### PR TITLE
[CARBONDATA-264]Fixed limit query scan time statistics issue

### DIFF
--- a/core/src/main/java/org/apache/carbondata/scan/executor/impl/AbstractQueryExecutor.java
+++ b/core/src/main/java/org/apache/carbondata/scan/executor/impl/AbstractQueryExecutor.java
@@ -435,6 +435,10 @@ public abstract class AbstractQueryExecutor<E> implements QueryExecutor<E> {
    * @throws QueryExecutionException
    */
   @Override public void finish() throws QueryExecutionException {
+    QueryStatistic statistic = new QueryStatistic();
+    statistic.addFixedTimeStatistic(QueryStatisticsConstants.SCAN_BLOCKS_TIME,
+        System.currentTimeMillis() - queryProperties.scanStartTime);
+    queryProperties.queryStatisticsRecorder.recordStatistics(statistic);
     if (null != queryProperties.executorService) {
       queryProperties.executorService.shutdownNow();
     }

--- a/core/src/main/java/org/apache/carbondata/scan/executor/impl/DetailQueryExecutor.java
+++ b/core/src/main/java/org/apache/carbondata/scan/executor/impl/DetailQueryExecutor.java
@@ -36,6 +36,7 @@ public class DetailQueryExecutor extends AbstractQueryExecutor {
   @Override public CarbonIterator<Object[]> execute(QueryModel queryModel)
       throws QueryExecutionException {
     List<BlockExecutionInfo> blockExecutionInfoList = getBlockExecutionInfos(queryModel);
+    queryProperties.scanStartTime=System.currentTimeMillis();
     return new DetailQueryResultIterator(blockExecutionInfoList, queryModel,
         queryProperties.executorService);
   }

--- a/core/src/main/java/org/apache/carbondata/scan/executor/impl/QueryExecutorProperties.java
+++ b/core/src/main/java/org/apache/carbondata/scan/executor/impl/QueryExecutorProperties.java
@@ -18,9 +18,7 @@
  */
 package org.apache.carbondata.scan.executor.impl;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ExecutorService;
 
 import org.apache.carbondata.core.cache.dictionary.Dictionary;
@@ -91,5 +89,10 @@ public class QueryExecutorProperties {
    * list of blocks in which query will be executed
    */
   protected List<AbstractIndex> dataBlocks;
+  /**
+   * start time scanning
+   *
+   * */
+  public long scanStartTime;
 
 }

--- a/core/src/main/java/org/apache/carbondata/scan/result/iterator/AbstractDetailQueryResultIterator.java
+++ b/core/src/main/java/org/apache/carbondata/scan/result/iterator/AbstractDetailQueryResultIterator.java
@@ -27,9 +27,6 @@ import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.carbon.datastore.DataRefNode;
 import org.apache.carbondata.core.carbon.datastore.DataRefNodeFinder;
 import org.apache.carbondata.core.carbon.datastore.impl.btree.BTreeDataRefNodeFinder;
-import org.apache.carbondata.core.carbon.querystatistics.QueryStatistic;
-import org.apache.carbondata.core.carbon.querystatistics.QueryStatisticsConstants;
-import org.apache.carbondata.core.carbon.querystatistics.QueryStatisticsRecorder;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.datastorage.store.FileHolder;
 import org.apache.carbondata.core.datastorage.store.impl.FileFactory;
@@ -63,18 +60,7 @@ public abstract class AbstractDetailQueryResultIterator extends CarbonIterator {
   protected FileHolder fileReader;
   protected AbstractDataBlockIterator dataBlockIterator;
   protected boolean nextBatch = false;
-  /**
-   * total time scan the blocks
-   */
-  protected long totalScanTime;
-  /**
-   * is the statistic recorded
-   */
-  protected boolean isStatisticsRecorded;
-  /**
-   * QueryStatisticsRecorder
-   */
-  protected QueryStatisticsRecorder recorder;
+
   /**
    * number of cores which can be used
    */
@@ -94,7 +80,6 @@ public abstract class AbstractDetailQueryResultIterator extends CarbonIterator {
     } else {
       batchSize = CarbonCommonConstants.DETAIL_QUERY_BATCH_SIZE_DEFAULT;
     }
-    this.recorder = queryModel.getStatisticsRecorder();
     this.blockExecutionInfos = infos;
     this.fileReader = FileFactory.getFileHolder(
         FileFactory.getFileType(queryModel.getAbsoluteTableIdentifier().getStorePath()));
@@ -103,7 +88,6 @@ public abstract class AbstractDetailQueryResultIterator extends CarbonIterator {
   }
 
   private void intialiseInfos() {
-    totalScanTime = System.currentTimeMillis();
     for (BlockExecutionInfo blockInfo : blockExecutionInfos) {
       DataRefNodeFinder finder = new BTreeDataRefNodeFinder(blockInfo.getEachColumnValueSize());
       DataRefNode startDataBlock = finder
@@ -130,13 +114,6 @@ public abstract class AbstractDetailQueryResultIterator extends CarbonIterator {
     } else if (blockExecutionInfos.size() > 0) {
       return true;
     } else {
-      if (!isStatisticsRecorded) {
-        QueryStatistic statistic = new QueryStatistic();
-        statistic.addFixedTimeStatistic(QueryStatisticsConstants.SCAN_BLOCKS_TIME,
-            System.currentTimeMillis() - totalScanTime);
-        recorder.recordStatistics(statistic);
-        isStatisticsRecorded = true;
-      }
       return false;
     }
   }

--- a/core/src/main/java/org/apache/carbondata/scan/result/iterator/DetailQueryResultIterator.java
+++ b/core/src/main/java/org/apache/carbondata/scan/result/iterator/DetailQueryResultIterator.java
@@ -58,7 +58,6 @@ public class DetailQueryResultIterator extends AbstractDetailQueryResultIterator
       } else {
         fileReader.finish();
       }
-      totalScanTime += System.currentTimeMillis() - startTime;
     } catch (Exception ex) {
       fileReader.finish();
       throw new RuntimeException(ex);

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
@@ -193,8 +193,8 @@ class CarbonScanRDD[V: ClassTag](
       try {
         context.addTaskCompletionListener(context => {
           clearDictionaryCache(queryModel.getColumnToDictionaryMapping)
-          logStatistics()
           queryExecutor.finish
+          logStatistics()
         })
         val carbonSparkPartition = thepartition.asInstanceOf[CarbonSparkPartition]
         if(!carbonSparkPartition.tableBlockInfos.isEmpty) {


### PR DESCRIPTION
Problem: Scan time is not logging in statistics in case of limit query 
Soluntion: Moved statistics recording from iterator to queryExecutor finish method as in case of limit query after consuming records call is not coming to hasNext method 
