### PR TITLE
[CARBONDATA-530]Modified optimizer to place decoder on top of limit in case of sort and limt.

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/CarbonOptimizer.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/CarbonOptimizer.scala
@@ -156,6 +156,16 @@ class ResolveCarbonFunctions(relations: Seq[CarbonDecoderRelation])
 
     def addTempDecoder(currentPlan: LogicalPlan): LogicalPlan = {
       currentPlan match {
+        case limit@Limit(_, child: Sort) =>
+          if (!decoder) {
+            decoder = true
+            CarbonDictionaryTempDecoder(new util.HashSet[AttributeReferenceWrapper](),
+              new util.HashSet[AttributeReferenceWrapper](),
+              limit,
+              isOuter = true)
+          } else {
+            limit
+          }
         case sort: Sort if !sort.child.isInstanceOf[CarbonDictionaryTempDecoder] =>
           val attrsOnSort = new util.HashSet[AttributeReferenceWrapper]()
           sort.order.map { s =>

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/optimizer/CarbonLateDecodeRule.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/optimizer/CarbonLateDecodeRule.scala
@@ -139,6 +139,16 @@ class CarbonLateDecodeRule extends Rule[LogicalPlan] with PredicateHelper {
 
     def addTempDecoder(currentPlan: LogicalPlan): LogicalPlan = {
       currentPlan match {
+        case limit@GlobalLimit(_, LocalLimit(_, child: Sort)) =>
+          if (!decoder) {
+            decoder = true
+            CarbonDictionaryTempDecoder(new util.HashSet[AttributeReferenceWrapper](),
+              new util.HashSet[AttributeReferenceWrapper](),
+              limit,
+              isOuter = true)
+          } else {
+            limit
+          }
         case sort: Sort if !sort.child.isInstanceOf[CarbonDictionaryTempDecoder] =>
           val attrsOnSort = new util.HashSet[AttributeReferenceWrapper]()
           sort.order.map { s =>


### PR DESCRIPTION
**Problem**
While optimizing plan of query which is having order by and limit, we put outer decoder below limit. Because of this spark is not able to optimize the plan.

**Solution**
We need to optimize the plan in such a way that outer decoder comes on top of limit in above case. as given below

|== Physical Plan ==                                                                                                                                                                                                                                                                                                               |
|CarbonDictionaryDecoder [CarbonDecoderRelation(Map(name#3 -> name#3),CarbonDatasourceRelation(`default`.`dict`,None))], ExcludeProfile(ArrayBuffer(name#3)), CarbonAliasDecoderRelation()                                                                                                                                         |
| TakeOrderedAndProject(limit=2, orderBy=[name#3 ASC], output=[name#3])                                                                                                                                                                                                                                                            |
|  ConvertToSafe                                                                                                                                                                                                                                                                                                                   |
|   CarbonDictionaryDecoder [CarbonDecoderRelation(Map(name#3 -> name#3),CarbonDatasourceRelation(`default`.`dict`,None))], IncludeProfile(ArrayBuffer(name#3)), CarbonAliasDecoderRelation()                                                                                                                                      |
|    CarbonScan [name#3], (CarbonRelation default, dict, CarbonMetaData(ArrayBuffer(name),ArrayBuffer(default_dummy_measure),org.apache.carbondata.core.carbon.metadata.schema.table.CarbonTable@62b3dcd6,DictionaryMap(Map(name -> true))), org.apache.carbondata.spark.merger.TableMeta@e67983a, None), [(name#3 = hello)], false|
|                                                                                                                                                                                                                                                                                                                                  |
|Code Generation: true                                                                                                                                                                                                                                                                                                             |
+----------------------
