### PR TITLE
[CARBONDATA-612]throw exception when trying to use bucketing in spark 1.6

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
@@ -257,7 +257,8 @@ class CarbonSqlParser() extends CarbonDDLSqlParser {
             Token("TOK_TABCOLNAME", list)::numberOfBuckets) =>
               val cols = list.map(_.getText)
               if (cols != null) {
-                throw new MalformedCarbonCommandException("Bucketing Is not Supported in spark 1.6 ")
+                throw new MalformedCarbonCommandException (
+                  "Bucketing Is not Supported in spark 1.6 ")
                 bucketFields = Some(BucketFields(cols,
                   numberOfBuckets.head.getText.toInt))
               }

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
@@ -257,6 +257,7 @@ class CarbonSqlParser() extends CarbonDDLSqlParser {
             Token("TOK_TABCOLNAME", list)::numberOfBuckets) =>
               val cols = list.map(_.getText)
               if (cols != null) {
+                throw new MalformedCarbonCommandException("Bucketing Is not Supported in spark 1.6 ")
                 bucketFields = Some(BucketFields(cols,
                   numberOfBuckets.head.getText.toInt))
               }


### PR DESCRIPTION
in spark 1.6 when we try to create a bucketed table it do not give any exception but it should as bucketing is not supported in spark 1.6 in this pr this functionality is provided
