### PR TITLE
[CARBONDATA-657]added support for shared dictionary columns in spark 2.1 

### DIFF
--- a/examples/spark/src/main/scala/org/apache/carbondata/examples/CarbonExample.scala
+++ b/examples/spark/src/main/scala/org/apache/carbondata/examples/CarbonExample.scala
@@ -31,45 +31,66 @@ object CarbonExample {
     CarbonProperties.getInstance()
       .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, "yyyy/MM/dd")
 
-    cc.sql("DROP TABLE IF EXISTS t3")
+    // Drop table
+
+    cc.sql("DROP TABLE IF EXISTS uniq_shared_dictionary ")
+
+    // Create table, with shared columns
+
+    cc.sql(
+      """ CREATE TABLE uniq_shared_dictionary (CUST_ID int,CUST_NAME String,
+      ACTIVE_EMUI_VERSION string, DOB timestamp, DOJ timestamp, BIGINT_COLUMN1 bigint,
+      BIGINT_COLUMN2 bigint,DECIMAL_COLUMN1 decimal(30,10), DECIMAL_COLUMN2 decimal(36,
+      10),Double_COLUMN1 double, Double_COLUMN2 double,INTEGER_COLUMN1 int) STORED BY
+    'org.apache.carbondata.format' TBLPROPERTIES('DICTIONARY_INCLUDE'='CUST_ID,
+    Double_COLUMN2,DECIMAL_COLUMN2','columnproperties.CUST_ID.shared_column'='shared.CUST_ID',
+    'columnproperties.decimal_column2.shared_column'='shared.decimal_column2')"""
+        .stripMargin).show
+
+    cc.sql("select * from uniq_shared_dictionary").show()
 
     // Create table, 6 dimensions, 1 measure
-    cc.sql("""
+    cc.sql(
+      """
            CREATE TABLE IF NOT EXISTS t3
            (ID Int, date Timestamp, country String,
            name String, phonetype String, serialname char(10), salary Int)
            STORED BY 'carbondata'
-           """)
+      """)
 
     // Currently there are two data loading flows in CarbonData, one uses Kettle as ETL tool
     // in each node to do data loading, another uses a multi-thread framework without Kettle (See
     // AbstractDataLoadProcessorStep)
     // Load data with Kettle
-    cc.sql(s"""
+    cc.sql(
+      s"""
            LOAD DATA LOCAL INPATH '$testData' into table t3
            """)
 
     // Perform a query
-    cc.sql("""
+    cc.sql(
+      """
            SELECT country, count(salary) AS amount
            FROM t3
            WHERE country IN ('china','france')
            GROUP BY country
-           """).show()
+      """).show()
 
     // Load data without kettle
-    cc.sql(s"""
+    cc.sql(
+      s"""
            LOAD DATA LOCAL INPATH '$testData' into table t3
            OPTIONS('USE_KETTLE'='false')
            """)
 
     // Perform a query
-    cc.sql("""
+    cc.sql(
+      """
            SELECT country, count(salary) AS amount
            FROM t3
            WHERE country IN ('china','france')
            GROUP BY country
-           """).show()
+      """).show()
 
     // Drop table
     cc.sql("DROP TABLE IF EXISTS t3")

--- a/examples/spark2/src/main/scala/org/apache/carbondata/examples/CarbonSessionExample.scala
+++ b/examples/spark2/src/main/scala/org/apache/carbondata/examples/CarbonSessionExample.scala
@@ -48,7 +48,21 @@ object CarbonSessionExample {
 
     spark.sparkContext.setLogLevel("WARN")
 
-    spark.sql("DROP TABLE IF EXISTS carbon_table")
+    // Drop table
+
+    spark.sql("DROP TABLE IF EXISTS uniq_shared_dictionary")
+
+    // Create table, with shared columns
+
+    spark.sql(
+      """ CREATE TABLE uniq_shared_dictionary (CUST_ID int,CUST_NAME String,
+      ACTIVE_EMUI_VERSION string, DOB timestamp, DOJ timestamp, BIGINT_COLUMN1 bigint,
+      BIGINT_COLUMN2 bigint,DECIMAL_COLUMN1 decimal(30,10), DECIMAL_COLUMN2 decimal(36,
+      10),Double_COLUMN1 double, Double_COLUMN2 double,INTEGER_COLUMN1 int) STORED BY
+    'org.apache.carbondata.format' TBLPROPERTIES('DICTIONARY_INCLUDE'='CUST_ID,
+    Double_COLUMN2,DECIMAL_COLUMN2','columnproperties.CUST_ID.shared_column'='shared.CUST_ID',
+    'columnproperties.decimal_column2.shared_column'='shared.decimal_column2')"""
+        .stripMargin).show
 
     // Create table
     spark.sql(

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/CommonUtil.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/CommonUtil.scala
@@ -176,7 +176,7 @@ object CommonUtil {
     if (!key.startsWith(CarbonCommonConstants.COLUMN_PROPERTIES)) {
       return true
     }
-    val columnPropertyKey = CarbonCommonConstants.COLUMN_PROPERTIES + "." + column + "."
+    val columnPropertyKey = CarbonCommonConstants.COLUMN_PROPERTIES + "." + column.toLowerCase + "."
     if (key.startsWith(columnPropertyKey)) {
       true
     } else {


### PR DESCRIPTION
in spark 1.6 shared columns works fine

0: jdbc:hive2://localhost:10000> CREATE TABLE uniq_shared_dictionary (CUST_ID int,CUST_NAME String,ACTIVE_EMUI_VERSION string, DOB timestamp, DOJ timestamp, BIGINT_COLUMN1 bigint,BIGINT_COLUMN2 bigint,DECIMAL_COLUMN1 decimal(30,10), DECIMAL_COLUMN2 decimal(36,10),Double_COLUMN1 double, Double_COLUMN2 double,INTEGER_COLUMN1 int) STORED BY 'org.apache.carbondata.format' TBLPROPERTIES('DICTIONARY_INCLUDE'='CUST_ID,Double_COLUMN2,DECIMAL_COLUMN2','columnproperties.CUST_ID.shared_column'='shared.CUST_ID','columnproperties.decimal_column2.shared_column'='shared.decimal_column2');
+---------+--+
| Result  |
+---------+--+
+---------+--+

but in spark 2.1 it gives exception

0: jdbc:hive2://hadoop-master:10000> CREATE TABLE uniq_shared_dictionary (CUST_ID int,CUST_NAME String,ACTIVE_EMUI_VERSION string, DOB timestamp, DOJ timestamp, BIGINT_COLUMN1 bigint,BIGINT_COLUMN2 bigint,DECIMAL_COLUMN1 decimal(30,10), DECIMAL_COLUMN2 decimal(36,10),Double_COLUMN1 double, Double_COLUMN2 double,INTEGER_COLUMN1 int) STORED BY 'org.apache.carbondata.format' TBLPROPERTIES('DICTIONARY_INCLUDE'='CUST_ID,Double_COLUMN2,DECIMAL_COLUMN2','columnproperties.CUST_ID.shared_column'='shared.CUST_ID','columnproperties.decimal_column2.shared_column'='shared.decimal_column2');
Error: org.apache.carbondata.spark.exception.MalformedCarbonCommandException: Invalid table properties columnproperties.cust_id.shared_column (state=,code=0)
LOGS
ERROR 18-01 13:31:18,147 - Error executing query, currentState RUNNING, 
org.apache.carbondata.spark.exception.MalformedCarbonCommandException: Invalid table properties columnproperties.cust_id.shared_column

but if we give column name in  lower case it works fine

CREATE TABLE uniq_shared_dictionary (cust_id int,CUST_NAME String,ACTIVE_EMUI_VERSION string, DOB timestamp, DOJ timestamp, BIGINT_COLUMN1 bigint,BIGINT_COLUMN2 bigint,DECIMAL_COLUMN1 decimal(30,10), decimal_column2 decimal(36,10),Double_COLUMN1 double, Double_COLUMN2 double,INTEGER_COLUMN1 int) STORED BY 'org.apache.carbondata.format' TBLPROPERTIES('DICTIONARY_INCLUDE'='CUST_ID,Double_COLUMN2,DECIMAL_COLUMN2','columnproperties.cust_id.shared_column'='shared.cust_id','columnproperties.decimal_column2.shared_column'='shared.decimal_column2');
+---------+--+
| Result  |
+---------+--+
+---------+--+
No rows selected (2.644 seconds)

with this pr user will be able to create shared columns in spark 2.1 in both case
