### PR TITLE
[CARBONDATA-713] Make the store path in right priority

### DIFF
--- a/integration/spark-common/src/main/scala/org/apache/spark/util/FileUtils.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/util/FileUtils.scala
@@ -17,10 +17,13 @@
 
 package org.apache.spark.util
 
+import java.io.File
+
 import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.datastore.filesystem.CarbonFile
 import org.apache.carbondata.core.datastore.impl.FileFactory
+import org.apache.carbondata.core.util.CarbonProperties
 import org.apache.carbondata.processing.etl.DataLoadingException
 
 object FileUtils {
@@ -91,4 +94,24 @@ object FileUtils {
     }
   }
 
+  /*
+   * The store location of carbon comes from three places:
+   * 1. default location path in code(../carbon.store)
+   * 2. configurate "carbon.storelocation" in carbon.properties
+   * 3. pass the location as the parameter
+   * The priority is low to high.
+   */
+  def getHighestPriorityStorePath(storePathParameter: String): String = {
+    val storePathDefaultValue =
+      new File(CarbonCommonConstants.STORE_LOCATION_DEFAULT_VAL).getCanonicalPath
+    val storePathProperties = CarbonProperties.getInstance()
+      .getProperty(CarbonCommonConstants.STORE_LOCATION)
+    if (!storePathParameter.equals(storePathDefaultValue)) {
+      storePathParameter
+    } else if (null != storePathProperties) {
+      storePathProperties
+    } else {
+      storePathDefaultValue
+    }
+  }
 }

--- a/integration/spark-common/src/main/scala/org/apache/spark/util/FileUtils.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/util/FileUtils.scala
@@ -101,13 +101,13 @@ object FileUtils {
    * 3. pass the location as the parameter
    * The priority is low to high.
    */
-  def getHighestPriorityStorePath(storePathParameter: String): String = {
+  def getHighestPriorityStorePath(storePathParameter: Option[String]): String = {
     val storePathDefaultValue =
       new File(CarbonCommonConstants.STORE_LOCATION_DEFAULT_VAL).getCanonicalPath
     val storePathProperties = CarbonProperties.getInstance()
       .getProperty(CarbonCommonConstants.STORE_LOCATION)
-    if (!storePathParameter.equals(storePathDefaultValue)) {
-      storePathParameter
+    if (storePathParameter.isDefined) {
+      storePathParameter.get
     } else if (null != storePathProperties) {
       storePathProperties
     } else {

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonContext.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonContext.scala
@@ -30,6 +30,7 @@ import org.apache.spark.sql.execution.ExtractPythonUDFs
 import org.apache.spark.sql.execution.datasources.{PreInsertCastAndRename, PreWriteCheck}
 import org.apache.spark.sql.hive._
 import org.apache.spark.sql.optimizer.CarbonOptimizer
+import org.apache.spark.util.FileUtils
 
 import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.core.constants.CarbonCommonConstants
@@ -66,9 +67,10 @@ class CarbonContext(
 
   @transient
   override lazy val catalog = {
+    val highestPriorityStorePath = FileUtils.getHighestPriorityStorePath(storePath)
     CarbonProperties.getInstance()
-      .addProperty(CarbonCommonConstants.STORE_LOCATION, storePath)
-    new CarbonMetastore(this, storePath, metadataHive, queryId) with OverrideCatalog
+      .addProperty(CarbonCommonConstants.STORE_LOCATION, highestPriorityStorePath)
+    new CarbonMetastore(this, highestPriorityStorePath, metadataHive, queryId) with OverrideCatalog
   }
 
   @transient

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonContext.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonContext.scala
@@ -39,20 +39,29 @@ import org.apache.carbondata.core.util.{CarbonProperties, CarbonTimeStatisticsFa
 
 class CarbonContext(
     val sc: SparkContext,
-    val storePath: String,
+    val storePathInParam: Option[String] = None,
     metaStorePath: String) extends HiveContext(sc) {
   self =>
 
+  val storePath = storePathInParam
+    .getOrElse(new File(CarbonCommonConstants.STORE_LOCATION_DEFAULT_VAL).getCanonicalPath)
+
   def this(sc: SparkContext) = {
     this(sc,
-      new File(CarbonCommonConstants.STORE_LOCATION_DEFAULT_VAL).getCanonicalPath,
+      None,
       new File(CarbonCommonConstants.METASTORE_LOCATION_DEFAULT_VAL).getCanonicalPath)
   }
 
-  def this(sc: SparkContext, storePath: String) = {
+  def this(sc: SparkContext, storePathInParam: String) = {
     this(sc,
-      storePath,
+      Option(storePathInParam),
       new File(CarbonCommonConstants.METASTORE_LOCATION_DEFAULT_VAL).getCanonicalPath)
+  }
+
+  def this(sc: SparkContext, storePathInParam: String, metaStorePath: String) = {
+    this(sc,
+      Option(storePathInParam),
+      metaStorePath)
   }
 
   CarbonContext.addInstance(sc, this)
@@ -67,7 +76,7 @@ class CarbonContext(
 
   @transient
   override lazy val catalog = {
-    val highestPriorityStorePath = FileUtils.getHighestPriorityStorePath(storePath)
+    val highestPriorityStorePath = FileUtils.getHighestPriorityStorePath(storePathInParam)
     CarbonProperties.getInstance()
       .addProperty(CarbonCommonConstants.STORE_LOCATION, highestPriorityStorePath)
     new CarbonMetastore(this, highestPriorityStorePath, metadataHive, queryId) with OverrideCatalog

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
@@ -42,7 +42,7 @@ object CarbonEnv {
   def init(sqlContext: SQLContext): Unit = {
     if (!initialized) {
       val cc = sqlContext.asInstanceOf[CarbonContext]
-      val highestPriorityStorePath = FileUtils.getHighestPriorityStorePath(cc.storePath)
+      val highestPriorityStorePath = FileUtils.getHighestPriorityStorePath(cc.storePathInParam)
       val catalog = new CarbonMetastore(cc, highestPriorityStorePath, cc.hiveClientInterface, "")
       carbonEnv = CarbonEnv(catalog)
       CarbonIUDAnalysisRule.init(sqlContext)

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
@@ -17,8 +17,11 @@
 
 package org.apache.spark.sql
 
+import java.io.File
+
 import org.apache.spark.scheduler.cluster.CoarseGrainedSchedulerBackend
 import org.apache.spark.sql.hive.{CarbonIUDAnalysisRule, CarbonMetastore}
+import org.apache.spark.util.FileUtils
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.util.CarbonProperties
@@ -39,7 +42,8 @@ object CarbonEnv {
   def init(sqlContext: SQLContext): Unit = {
     if (!initialized) {
       val cc = sqlContext.asInstanceOf[CarbonContext]
-      val catalog = new CarbonMetastore(cc, cc.storePath, cc.hiveClientInterface, "")
+      val highestPriorityStorePath = FileUtils.getHighestPriorityStorePath(cc.storePath)
+      val catalog = new CarbonMetastore(cc, highestPriorityStorePath, cc.hiveClientInterface, "")
       carbonEnv = CarbonEnv(catalog)
       CarbonIUDAnalysisRule.init(sqlContext)
       initialized = true

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSession.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSession.scala
@@ -24,6 +24,7 @@ import org.apache.spark.scheduler.{SparkListener, SparkListenerApplicationEnd}
 import org.apache.spark.sql.SparkSession.Builder
 import org.apache.spark.sql.hive.CarbonSessionState
 import org.apache.spark.sql.internal.{SessionState, SharedState}
+import org.apache.spark.util.FileUtils
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.util.CarbonProperties
@@ -141,8 +142,9 @@ object CarbonSession {
           sc
         }
 
+        val highestPriorityStorePath = FileUtils.getHighestPriorityStorePath(storePath)
         CarbonProperties.getInstance()
-          .addProperty(CarbonCommonConstants.STORE_LOCATION, storePath)
+          .addProperty(CarbonCommonConstants.STORE_LOCATION, highestPriorityStorePath)
         session = new CarbonSession(sparkContext)
         options.foreach { case (k, v) => session.sessionState.conf.setConfString(k, v) }
         SparkSession.setDefaultSession(session)

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSession.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSession.scala
@@ -67,17 +67,23 @@ object CarbonSession {
 
     def getOrCreateCarbonSession(): SparkSession = {
       getOrCreateCarbonSession(
-        new File(CarbonCommonConstants.STORE_LOCATION_DEFAULT_VAL).getCanonicalPath,
+        None,
         new File(CarbonCommonConstants.METASTORE_LOCATION_DEFAULT_VAL).getCanonicalPath)
     }
 
     def getOrCreateCarbonSession(storePath: String): SparkSession = {
       getOrCreateCarbonSession(
-        storePath,
+        Option(storePath),
         new File(CarbonCommonConstants.METASTORE_LOCATION_DEFAULT_VAL).getCanonicalPath)
     }
 
-    def getOrCreateCarbonSession(storePath: String,
+    def getOrCreateCarbonSession(storePath: String, metaStorePath: String): SparkSession = {
+      getOrCreateCarbonSession(
+        Option(storePath),
+        metaStorePath)
+    }
+
+    def getOrCreateCarbonSession(storePath: Option[String],
         metaStorePath: String): SparkSession = synchronized {
       builder.enableHiveSupport()
       val options =


### PR DESCRIPTION
The store location of carbon comes from three places:
* default location path in code(../carbon.store)
* configurate "carbon.storelocation" in carbon.properties
* pass the location as the parameter

The priority is low to high.