### PR TITLE
[CARBONDATA-757]Big decimal optimization

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/reader/measure/v3/CompressedMeasureChunkFileBasedReaderV3.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/reader/measure/v3/CompressedMeasureChunkFileBasedReaderV3.java
@@ -226,10 +226,12 @@ public class CompressedMeasureChunkFileBasedReaderV3 extends AbstractMeasureChun
     ByteBuffer rawData = measureRawColumnChunk.getRawData();
     rawData.position(copyPoint);
     rawData.get(data);
+    values.setFixedLength(dataChunk3.fixedLength);
     values.uncompress(compressionModel.getConvertedDataType()[0], data, 0,
         measureColumnChunk.data_page_length, compressionModel.getMantissa()[0],
         compressionModel.getMaxValue()[0], measureRawColumnChunk.getRowCount()[pageNumber]);
     CarbonReadDataHolder measureDataHolder = new CarbonReadDataHolder(values);
+    measureDataHolder.setLatestDecimalConverion(true);
     // set the data chunk
     datChunk.setMeasureDataHolder(measureDataHolder);
     // set the null value indexes

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/MeasureChunkStoreFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/MeasureChunkStoreFactory.java
@@ -57,6 +57,7 @@ public class MeasureChunkStoreFactory {
   private MeasureChunkStoreFactory() {
   }
 
+
   /**
    * Below method will be used to get the measure data chunk store based on data type
    *
@@ -65,6 +66,18 @@ public class MeasureChunkStoreFactory {
    * @return measure chunk store
    */
   public MeasureDataChunkStore getMeasureDataChunkStore(DataType dataType, int numberOfRows) {
+    return getMeasureDataChunkStore(dataType, numberOfRows, (short)-1);
+  }
+
+  /**
+   * Below method will be used to get the measure data chunk store based on data type
+   *
+   * @param dataType     data type
+   * @param numberOfRows number of rows
+   * @return measure chunk store
+   */
+  public MeasureDataChunkStore getMeasureDataChunkStore(DataType dataType, int numberOfRows,
+      short fixedLength) {
     if (!isUnsafe) {
       switch (dataType) {
         case DATA_BYTE:
@@ -76,7 +89,7 @@ public class MeasureChunkStoreFactory {
         case DATA_LONG:
           return new SafeLongMeasureChunkStore(numberOfRows);
         case DATA_BIGDECIMAL:
-          return new SafeBigDecimalMeasureChunkStore(numberOfRows);
+          return new SafeBigDecimalMeasureChunkStore(numberOfRows, fixedLength);
         case DATA_DOUBLE:
         default:
           return new SafeDoubleMeasureChunkStore(numberOfRows);
@@ -92,7 +105,7 @@ public class MeasureChunkStoreFactory {
         case DATA_LONG:
           return new UnsafeLongMeasureChunkStore(numberOfRows);
         case DATA_BIGDECIMAL:
-          return new UnsafeBigDecimalMeasureChunkStore(numberOfRows);
+          return new UnsafeBigDecimalMeasureChunkStore(numberOfRows, fixedLength);
         case DATA_DOUBLE:
         default:
           return new UnsafeDoubleMeasureChunkStore(numberOfRows);

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/MeasureDataChunkStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/MeasureDataChunkStore.java
@@ -17,8 +17,6 @@
 
 package org.apache.carbondata.core.datastore.chunk.store;
 
-import java.math.BigDecimal;
-
 /**
  * Responsibility is store the measure data in memory,
  * memory can be on heap or offheap based on the user configuration
@@ -73,12 +71,12 @@ public interface MeasureDataChunkStore<T> {
   double getDouble(int index);
 
   /**
-   * To get the bigdecimal value
+   * To get the backend array value
    *
    * @param index
    * @return bigdecimal value based on index
    */
-  BigDecimal getBigDecimal(int index);
+  byte[] getBigDecimalBackendArray(int index);
 
   /**
    * To free the occupied memory

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/safe/SafeAbstractMeasureDataChunkStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/safe/SafeAbstractMeasureDataChunkStore.java
@@ -17,8 +17,6 @@
 
 package org.apache.carbondata.core.datastore.chunk.store.impl.safe;
 
-import java.math.BigDecimal;
-
 import org.apache.carbondata.core.datastore.chunk.store.MeasureDataChunkStore;
 
 /**
@@ -97,8 +95,7 @@ public abstract class SafeAbstractMeasureDataChunkStore<T> implements
    * @param index
    * @return bigdecimal value based on index
    */
-  @Override
-  public BigDecimal getBigDecimal(int index) {
+  @Override public byte[] getBigDecimalBackendArray(int index) {
     throw new UnsupportedOperationException("Operation not supported");
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/unsafe/UnsafeAbstractMeasureDataChunkStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/unsafe/UnsafeAbstractMeasureDataChunkStore.java
@@ -17,8 +17,6 @@
 
 package org.apache.carbondata.core.datastore.chunk.store.impl.unsafe;
 
-import java.math.BigDecimal;
-
 import org.apache.carbondata.core.datastore.chunk.store.MeasureDataChunkStore;
 import org.apache.carbondata.core.memory.MemoryAllocatorFactory;
 import org.apache.carbondata.core.memory.MemoryBlock;
@@ -103,13 +101,7 @@ public abstract class UnsafeAbstractMeasureDataChunkStore<T> implements MeasureD
     throw new UnsupportedOperationException("Operation not supported");
   }
 
-  /**
-   * To get the bigdecimal value
-   *
-   * @param index
-   * @return bigdecimal value based on index
-   */
-  @Override public BigDecimal getBigDecimal(int index) {
+  @Override public byte[] getBigDecimalBackendArray(int index) {
     throw new UnsupportedOperationException("Operation not supported");
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/unsafe/UnsafeBigDecimalMeasureChunkStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/unsafe/UnsafeBigDecimalMeasureChunkStore.java
@@ -16,13 +16,11 @@
  */
 package org.apache.carbondata.core.datastore.chunk.store.impl.unsafe;
 
-import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.memory.CarbonUnsafe;
 import org.apache.carbondata.core.memory.MemoryAllocatorFactory;
-import org.apache.carbondata.core.util.DataTypeUtil;
 
 /**
  * Responsible for storing big decimal array data to memory. memory can be on heap or
@@ -35,8 +33,11 @@ public class UnsafeBigDecimalMeasureChunkStore extends UnsafeAbstractMeasureData
    */
   private long offsetStartPosition;
 
-  public UnsafeBigDecimalMeasureChunkStore(int numberOfRows) {
+  private short fixedLength;
+
+  public UnsafeBigDecimalMeasureChunkStore(int numberOfRows, short fixedLength) {
     super(numberOfRows);
+    this.fixedLength = fixedLength;
   }
 
   @Override public void putData(byte[] data) {
@@ -58,47 +59,49 @@ public class UnsafeBigDecimalMeasureChunkStore extends UnsafeAbstractMeasureData
     // to store this value we need to get the actual data length + 4 bytes used for storing the
     // length
     // start position will be used to store the current data position
-    int startOffset = 0;
-    // position from where offsets will start
-    long pointerOffsets = this.offsetStartPosition;
-    // as first position will be start from 4 byte as data is stored first in the memory block
-    // we need to skip first two bytes this is because first two bytes will be length of the data
-    // which we have to skip
-    CarbonUnsafe.unsafe.putInt(dataPageMemoryBlock.getBaseObject(),
-        dataPageMemoryBlock.getBaseOffset() + pointerOffsets,
-        CarbonCommonConstants.INT_SIZE_IN_BYTE);
-    // incrementing the pointers as first value is already filled and as we are storing as int
-    // we need to increment the 4 bytes to set the position of the next value to set
-    pointerOffsets += CarbonCommonConstants.INT_SIZE_IN_BYTE;
-    // creating a byte buffer which will wrap the length of the row
-    // using byte buffer as unsafe will return bytes in little-endian encoding
-    ByteBuffer buffer = ByteBuffer.allocate(CarbonCommonConstants.INT_SIZE_IN_BYTE);
-    // store length of data
-    byte[] length = new byte[CarbonCommonConstants.INT_SIZE_IN_BYTE];
-    // as first offset is already stored, we need to start from the 2nd row in data array
-    for (int i = 1; i < numberOfRows; i++) {
-      // first copy the length of previous row
-      CarbonUnsafe.unsafe.copyMemory(dataPageMemoryBlock.getBaseObject(),
-          dataPageMemoryBlock.getBaseOffset() + startOffset, length, CarbonUnsafe.BYTE_ARRAY_OFFSET,
-          CarbonCommonConstants.INT_SIZE_IN_BYTE);
-      buffer.put(length);
-      buffer.flip();
-      // so current row position will be
-      // previous row length + 4 bytes used for storing previous row data
-      startOffset += CarbonCommonConstants.INT_SIZE_IN_BYTE + buffer.getInt();
-      // as same byte buffer is used to avoid creating many byte buffer for each row
-      // we need to clear the byte buffer
-      buffer.clear();
-      // now put the offset of current row, here we need to add 4 more bytes as current will
-      // also have length part so we have to skip length
+    if (fixedLength <= 0) {
+      int startOffset = 0;
+      // position from where offsets will start
+      long pointerOffsets = this.offsetStartPosition;
+      // as first position will be start from 4 byte as data is stored first in the memory block
+      // we need to skip first two bytes this is because first two bytes will be length of the data
+      // which we have to skip
       CarbonUnsafe.unsafe.putInt(dataPageMemoryBlock.getBaseObject(),
           dataPageMemoryBlock.getBaseOffset() + pointerOffsets,
-          startOffset + CarbonCommonConstants.INT_SIZE_IN_BYTE);
+          CarbonCommonConstants.INT_SIZE_IN_BYTE);
       // incrementing the pointers as first value is already filled and as we are storing as int
       // we need to increment the 4 bytes to set the position of the next value to set
       pointerOffsets += CarbonCommonConstants.INT_SIZE_IN_BYTE;
+      // creating a byte buffer which will wrap the length of the row
+      // using byte buffer as unsafe will return bytes in little-endian encoding
+      ByteBuffer buffer = ByteBuffer.allocate(CarbonCommonConstants.INT_SIZE_IN_BYTE);
+      // store length of data
+      byte[] length = new byte[CarbonCommonConstants.INT_SIZE_IN_BYTE];
+      // as first offset is already stored, we need to start from the 2nd row in data array
+      for (int i = 1; i < numberOfRows; i++) {
+        // first copy the length of previous row
+        CarbonUnsafe.unsafe.copyMemory(dataPageMemoryBlock.getBaseObject(),
+            dataPageMemoryBlock.getBaseOffset() + startOffset, length,
+            CarbonUnsafe.BYTE_ARRAY_OFFSET, CarbonCommonConstants.INT_SIZE_IN_BYTE);
+        buffer.put(length);
+        buffer.flip();
+        // so current row position will be
+        // previous row length + 4 bytes used for storing previous row data
+        startOffset += CarbonCommonConstants.INT_SIZE_IN_BYTE + buffer.getInt();
+        // as same byte buffer is used to avoid creating many byte buffer for each row
+        // we need to clear the byte buffer
+        buffer.clear();
+        // now put the offset of current row, here we need to add 4 more bytes as current will
+        // also have length part so we have to skip length
+        CarbonUnsafe.unsafe.putInt(dataPageMemoryBlock.getBaseObject(),
+            dataPageMemoryBlock.getBaseOffset() + pointerOffsets,
+            startOffset + CarbonCommonConstants.INT_SIZE_IN_BYTE);
+        // incrementing the pointers as first value is already filled and as we are storing as int
+        // we need to increment the 4 bytes to set the position of the next value to set
+        pointerOffsets += CarbonCommonConstants.INT_SIZE_IN_BYTE;
 
-      this.isMemoryOccupied = true;
+        this.isMemoryOccupied = true;
+      }
     }
   }
 
@@ -108,33 +111,42 @@ public class UnsafeBigDecimalMeasureChunkStore extends UnsafeAbstractMeasureData
    * @param index
    * @return byte value based on index
    */
-  @Override public BigDecimal getBigDecimal(int index) {
-    // now to get the row from memory block we need to do following thing
-    // 1. first get the current offset
-    // 2. if it's not a last row- get the next row offset
-    // Subtract the current row offset + 4 bytes(to skip the data length) with next row offset
-    // else subtract the current row offset
-    // with complete data length get the offset of set of data
-    int currentDataOffset = CarbonUnsafe.unsafe.getInt(dataPageMemoryBlock.getBaseObject(),
-        dataPageMemoryBlock.getBaseOffset() + this.offsetStartPosition + (index
-            * CarbonCommonConstants.INT_SIZE_IN_BYTE));
-    int length = 0;
-    // calculating the length of data
-    if (index < numberOfRows - 1) {
-      int OffsetOfNextdata = CarbonUnsafe.unsafe.getInt(dataPageMemoryBlock.getBaseObject(),
-          dataPageMemoryBlock.getBaseOffset() + this.offsetStartPosition + ((index + 1)
-              * CarbonCommonConstants.INT_SIZE_IN_BYTE));
-      length =
-          (short) (OffsetOfNextdata - (currentDataOffset + CarbonCommonConstants.INT_SIZE_IN_BYTE));
+  @Override public byte[] getBigDecimalBackendArray(int index) {
+    if (fixedLength > 0) {
+      byte[] row = new byte[fixedLength];
+      CarbonUnsafe.unsafe.copyMemory(dataPageMemoryBlock.getBaseObject(),
+          dataPageMemoryBlock.getBaseOffset() + fixedLength * index, row,
+          CarbonUnsafe.BYTE_ARRAY_OFFSET, fixedLength);
+      return row;
     } else {
-      // for last record we need to subtract with data length
-      length = (short) (this.offsetStartPosition - currentDataOffset);
+
+      // now to get the row from memory block we need to do following thing
+      // 1. first get the current offset
+      // 2. if it's not a last row- get the next row offset
+      // Subtract the current row offset + 4 bytes(to skip the data length) with next row offset
+      // else subtract the current row offset
+      // with complete data length get the offset of set of data
+      int currentDataOffset = CarbonUnsafe.unsafe.getInt(dataPageMemoryBlock.getBaseObject(),
+          dataPageMemoryBlock.getBaseOffset() + this.offsetStartPosition + (index
+              * CarbonCommonConstants.INT_SIZE_IN_BYTE));
+      int length = 0;
+      // calculating the length of data
+      if (index < numberOfRows - 1) {
+        int OffsetOfNextdata = CarbonUnsafe.unsafe.getInt(dataPageMemoryBlock.getBaseObject(),
+            dataPageMemoryBlock.getBaseOffset() + this.offsetStartPosition + ((index + 1)
+                * CarbonCommonConstants.INT_SIZE_IN_BYTE));
+        length = (short) (OffsetOfNextdata - (currentDataOffset
+            + CarbonCommonConstants.INT_SIZE_IN_BYTE));
+      } else {
+        // for last record we need to subtract with data length
+        length = (short) (this.offsetStartPosition - currentDataOffset);
+      }
+      byte[] row = new byte[length];
+      CarbonUnsafe.unsafe.copyMemory(dataPageMemoryBlock.getBaseObject(),
+          dataPageMemoryBlock.getBaseOffset() + currentDataOffset, row,
+          CarbonUnsafe.BYTE_ARRAY_OFFSET, length);
+      return row;
     }
-    byte[] row = new byte[length];
-    CarbonUnsafe.unsafe.copyMemory(dataPageMemoryBlock.getBaseObject(),
-        dataPageMemoryBlock.getBaseOffset() + currentDataOffset, row,
-        CarbonUnsafe.BYTE_ARRAY_OFFSET, length);
-    return DataTypeUtil.byteToBigDecimal(row);
   }
 
 }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/compression/ValueCompressionHolder.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/compression/ValueCompressionHolder.java
@@ -92,6 +92,11 @@ public abstract class ValueCompressionHolder<T> {
     }
   }
 
+  public void setFixedLength(short fixedLength) {
+    // Nothing can be implemented here, only it is used for bigdecimal compression for now.
+    // so subclasses uses it.
+  }
+
   public abstract void setValue(T value);
 
   public abstract void setValue(T data, int numberOfRows, Object maxValueObject, int decimalPlaces);
@@ -114,6 +119,10 @@ public abstract class ValueCompressionHolder<T> {
   public abstract double getDoubleValue(int index);
 
   public abstract BigDecimal getBigDecimalValue(int index);
+
+  public byte[] getBackendByteArray(int index) {
+    throw new UnsupportedOperationException("it is not supported in this class " + getClass());
+  }
 
   public abstract void freeMemory();
 

--- a/core/src/main/java/org/apache/carbondata/core/datastore/compression/decimal/CompressByteArray.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/compression/decimal/CompressByteArray.java
@@ -40,6 +40,8 @@ public class CompressByteArray extends ValueCompressionHolder<byte[]> {
 
   private MeasureDataChunkStore<byte[]> measureChunkStore;
 
+  private short fixedLength;
+
   /**
    * value.
    */
@@ -91,7 +93,8 @@ public class CompressByteArray extends ValueCompressionHolder<byte[]> {
   }
 
   @Override public BigDecimal getBigDecimalValue(int index) {
-    return this.measureChunkStore.getBigDecimal(index);
+    throw new UnsupportedOperationException(
+        "Big decimal value is not defined for CompressionMaxMinDefault");
   }
 
   @Override public void freeMemory() {
@@ -101,7 +104,15 @@ public class CompressByteArray extends ValueCompressionHolder<byte[]> {
   @Override
   public void setValue(byte[] data, int numberOfRows, Object maxValueObject, int decimalPlaces) {
     this.measureChunkStore = MeasureChunkStoreFactory.INSTANCE
-        .getMeasureDataChunkStore(DataType.DATA_BIGDECIMAL, numberOfRows);
+        .getMeasureDataChunkStore(DataType.DATA_BIGDECIMAL, numberOfRows, fixedLength);
     this.measureChunkStore.putData(data);
+  }
+
+  @Override public void setFixedLength(short fixedLength) {
+    this.fixedLength = fixedLength;
+  }
+
+  @Override public byte[] getBackendByteArray(int index) {
+    return measureChunkStore.getBigDecimalBackendArray(index);
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/dataholder/CarbonReadDataHolder.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/dataholder/CarbonReadDataHolder.java
@@ -17,14 +17,14 @@
 
 package org.apache.carbondata.core.datastore.dataholder;
 
-import java.math.BigDecimal;
-
 import org.apache.carbondata.core.datastore.compression.ValueCompressionHolder;
 
 // This class is used with Uncompressor to hold the decompressed column chunk in memory
 public class CarbonReadDataHolder {
 
   private ValueCompressionHolder unCompressValue;
+
+  private boolean latestDecimalConverion;
 
   public CarbonReadDataHolder(ValueCompressionHolder unCompressValue) {
     this.unCompressValue = unCompressValue;
@@ -34,12 +34,20 @@ public class CarbonReadDataHolder {
     return this.unCompressValue.getLongValue(index);
   }
 
-  public BigDecimal getReadableBigDecimalValueByIndex(int index) {
-    return this.unCompressValue.getBigDecimalValue(index);
+  public byte[] getBigDecimalByteArrayByIndex(int index) {
+    return this.unCompressValue.getBackendByteArray(index);
   }
 
   public double getReadableDoubleValueByIndex(int index) {
     return this.unCompressValue.getDoubleValue(index);
+  }
+
+  public boolean isLatestDecimalConverion() {
+    return latestDecimalConverion;
+  }
+
+  public void setLatestDecimalConverion(boolean latestDecimalConverion) {
+    this.latestDecimalConverion = latestDecimalConverion;
   }
 
   public void freeMemory() {

--- a/core/src/main/java/org/apache/carbondata/core/metadata/datatype/DecimalConverterFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/datatype/DecimalConverterFactory.java
@@ -1,0 +1,234 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.core.metadata.datatype;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+
+import org.apache.carbondata.core.scan.result.vector.CarbonColumnVector;
+import org.apache.carbondata.core.util.DataTypeUtil;
+
+/**
+ * Decimal converter to keep the data compact.
+ */
+public final class DecimalConverterFactory {
+
+  public static DecimalConverterFactory INSTANCE = new DecimalConverterFactory();
+
+  private int[] minBytesForPrecision = minBytesForPrecision();
+
+  private byte[] decimalBuffer = new byte[minBytesForPrecision[38]];
+
+  private DecimalConverterFactory() {
+
+  }
+
+  private int computeMinBytesForPrecision(int precision) {
+    int numBytes = 1;
+    while (Math.pow(2.0, 8 * numBytes - 1) < Math.pow(10.0, precision)) {
+      numBytes += 1;
+    }
+    return numBytes;
+  }
+
+  private int[] minBytesForPrecision() {
+    int[] data = new int[39];
+    for (int i = 0; i < data.length; i++) {
+      data[i] = computeMinBytesForPrecision(i);
+    }
+    return data;
+  }
+
+  public interface DecimalConverter {
+
+    byte[] convert(BigDecimal decimal);
+
+    BigDecimal getDecimal(byte[] bytes);
+
+    void writeToColumnVector(byte[] bytes, CarbonColumnVector vector, int rowId);
+
+    int getSize();
+
+  }
+
+  public class DecimalIntConverter implements DecimalConverter {
+
+    private  ByteBuffer buffer = ByteBuffer.allocate(4);
+
+    private int precision;
+    private int scale;
+
+    public DecimalIntConverter(int precision, int scale) {
+      this.precision = precision;
+      this.scale = scale;
+    }
+
+    @Override public byte[] convert(BigDecimal decimal) {
+      long longValue = decimal.unscaledValue().longValue();
+      buffer.putInt(0, (int) longValue);
+      return buffer.array().clone();
+    }
+
+    @Override public BigDecimal getDecimal(byte[] bytes) {
+      long unscaled = getUnscaledLong(bytes);
+      return BigDecimal.valueOf(unscaled, scale);
+    }
+
+    @Override public void writeToColumnVector(byte[] bytes, CarbonColumnVector vector, int rowId) {
+      long unscaled = getUnscaledLong(bytes);
+      vector.putInt(rowId, (int) unscaled);
+    }
+
+    @Override public int getSize() {
+      return 4;
+    }
+  }
+
+  private long getUnscaledLong(byte[] bytes) {
+    long unscaled = 0L;
+    int i = 0;
+
+    while (i < bytes.length) {
+      unscaled = (unscaled << 8) | (bytes[i] & 0xff);
+      i += 1;
+    }
+
+    int bits = 8 * bytes.length;
+    unscaled = (unscaled << (64 - bits)) >> (64 - bits);
+    return unscaled;
+  }
+
+  public class DecimalLongConverter implements DecimalConverter {
+
+    private ByteBuffer buffer = ByteBuffer.allocate(8);
+
+    private int precision;
+    private int scale;
+
+    public DecimalLongConverter(int precision, int scale) {
+      this.precision = precision;
+      this.scale = scale;
+    }
+
+    @Override public byte[] convert(BigDecimal decimal) {
+      long longValue = decimal.unscaledValue().longValue();
+      buffer.putLong(0, longValue);
+      return buffer.array().clone();
+    }
+
+    @Override public BigDecimal getDecimal(byte[] bytes) {
+      long unscaled = getUnscaledLong(bytes);
+      return BigDecimal.valueOf(unscaled, scale);
+    }
+
+    @Override public void writeToColumnVector(byte[] bytes, CarbonColumnVector vector, int rowId) {
+      long unscaled = getUnscaledLong(bytes);
+      vector.putLong(rowId, unscaled);
+    }
+
+    @Override public int getSize() {
+      return 8;
+    }
+  }
+
+  public class DecimalUnscaledConverter implements DecimalConverter {
+
+    private int precision;
+    private int scale;
+
+    private int numBytes;
+
+    public DecimalUnscaledConverter(int precision, int scale) {
+      this.precision = precision;
+      this.scale = scale;
+      this.numBytes = minBytesForPrecision[precision];
+    }
+
+    @Override public byte[] convert(BigDecimal decimal) {
+      byte[] bytes = decimal.unscaledValue().toByteArray();
+      byte[] fixedLengthBytes = null;
+      if (bytes.length == numBytes) {
+        // If the length of the underlying byte array of the unscaled `BigInteger` happens to be
+        // `numBytes`, just reuse it, so that we don't bother copying it to `decimalBuffer`.
+        fixedLengthBytes = bytes;
+      } else {
+        // Otherwise, the length must be less than `numBytes`.  In this case we copy contents of
+        // the underlying bytes with padding sign bytes to `decimalBuffer` to form the result
+        // fixed-length byte array.
+        byte signByte = 0;
+        if (bytes[0] < 0) {
+          signByte = (byte) -1;
+        } else {
+          signByte = (byte) 0;
+        }
+        Arrays.fill(decimalBuffer, 0, numBytes - bytes.length, signByte);
+        System.arraycopy(bytes, 0, decimalBuffer, numBytes - bytes.length, bytes.length);
+        fixedLengthBytes = decimalBuffer;
+      }
+      byte[] value = new byte[numBytes];
+      System.arraycopy(fixedLengthBytes, 0, value, 0, numBytes);
+      return value;
+    }
+
+    @Override public BigDecimal getDecimal(byte[] bytes) {
+      BigInteger bigInteger = new BigInteger(bytes);
+      return new BigDecimal(bigInteger, scale);
+    }
+
+    @Override public void writeToColumnVector(byte[] bytes, CarbonColumnVector vector, int rowId) {
+      vector.putBytes(rowId, bytes);
+    }
+
+    @Override public int getSize() {
+      return numBytes;
+    }
+  }
+
+  public static class LegacyDecimalConverter implements DecimalConverter {
+
+    public static LegacyDecimalConverter INSTANCE = new LegacyDecimalConverter();
+
+    @Override public byte[] convert(BigDecimal decimal) {
+      return DataTypeUtil.bigDecimalToByte(decimal);
+    }
+
+    @Override public BigDecimal getDecimal(byte[] bytes) {
+      return DataTypeUtil.byteToBigDecimal(bytes);
+    }
+
+    @Override public void writeToColumnVector(byte[] bytes, CarbonColumnVector vector, int rowId) {
+      throw new UnsupportedOperationException("Unsupported in vector reading for legacy format");
+    }
+
+    @Override public int getSize() {
+      return -1;
+    }
+  }
+
+  public DecimalConverter getDecimalConverter(int precision, int scale) {
+    if (precision <= 9) {
+      return new DecimalIntConverter(precision, scale);
+    } else if (precision <= 18) {
+      return new DecimalLongConverter(precision, scale);
+    } else {
+      return new DecimalUnscaledConverter(precision, scale);
+    }
+  }
+
+}

--- a/core/src/main/java/org/apache/carbondata/core/scan/collector/impl/DictionaryBasedVectorResultCollector.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/collector/impl/DictionaryBasedVectorResultCollector.java
@@ -21,6 +21,8 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.apache.carbondata.core.keygenerator.directdictionary.DirectDictionaryKeyGeneratorFactory;
+import org.apache.carbondata.core.metadata.datatype.DataType;
+import org.apache.carbondata.core.metadata.datatype.DecimalConverterFactory;
 import org.apache.carbondata.core.metadata.encoder.Encoding;
 import org.apache.carbondata.core.scan.executor.infos.BlockExecutionInfo;
 import org.apache.carbondata.core.scan.model.QueryDimension;
@@ -91,6 +93,11 @@ public class DictionaryBasedVectorResultCollector extends AbstractScannedResultC
           .getMeasureVectorFiller(queryMeasures[i].getMeasure().getDataType());
       columnVectorInfo.ordinal = queryMeasures[i].getMeasure().getOrdinal();
       columnVectorInfo.measure = queryMeasures[i];
+      if (queryMeasures[i].getMeasure().getDataType().equals(DataType.DECIMAL)) {
+        columnVectorInfo.decimalConverter = DecimalConverterFactory.INSTANCE
+            .getDecimalConverter(queryMeasures[i].getMeasure().getPrecision(),
+                queryMeasures[i].getMeasure().getScale());
+      }
       measureInfo[i] = columnVectorInfo;
       allColumnInfo[queryMeasures[i].getQueryOrder()] = columnVectorInfo;
     }

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/resolver/RowLevelFilterResolverImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/resolver/RowLevelFilterResolverImpl.java
@@ -71,7 +71,7 @@ public class RowLevelFilterResolverImpl extends ConditionalFilterResolverImpl {
           msrColumnEvalutorInfo.setRowIndex(index++);
           msrColumnEvalutorInfo
               .setColumnIndex(columnExpression.getCarbonColumn().getOrdinal());
-          msrColumnEvalutorInfo.setType(columnExpression.getCarbonColumn().getDataType());
+          msrColumnEvalutorInfo.setColumn(columnExpression.getCarbonColumn());
           msrColEvalutorInfoList.add(msrColumnEvalutorInfo);
         }
       }

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/resolver/RowLevelRangeFilterResolverImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/resolver/RowLevelRangeFilterResolverImpl.java
@@ -193,7 +193,7 @@ public class RowLevelRangeFilterResolverImpl extends ConditionalFilterResolverIm
           msrColumnEvalutorInfo.setRowIndex(index++);
           msrColumnEvalutorInfo
               .setColumnIndex(columnExpression.getCarbonColumn().getOrdinal());
-          msrColumnEvalutorInfo.setType(columnExpression.getCarbonColumn().getDataType());
+          msrColumnEvalutorInfo.setColumn(columnExpression.getCarbonColumn());
           msrColEvalutorInfoList.add(msrColumnEvalutorInfo);
         }
       }

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/resolver/resolverinfo/MeasureColumnResolvedFilterInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/resolver/resolverinfo/MeasureColumnResolvedFilterInfo.java
@@ -19,6 +19,8 @@ package org.apache.carbondata.core.scan.filter.resolver.resolverinfo;
 
 import java.io.Serializable;
 
+import org.apache.carbondata.core.metadata.schema.table.column.CarbonColumn;
+
 public class MeasureColumnResolvedFilterInfo implements Serializable {
   /**
    *
@@ -31,7 +33,7 @@ public class MeasureColumnResolvedFilterInfo implements Serializable {
 
   private Object defaultValue;
 
-  private org.apache.carbondata.core.metadata.datatype.DataType type;
+  private CarbonColumn column;
 
   public int getColumnIndex() {
     return columnIndex;
@@ -49,12 +51,12 @@ public class MeasureColumnResolvedFilterInfo implements Serializable {
     this.rowIndex = rowIndex;
   }
 
-  public org.apache.carbondata.core.metadata.datatype.DataType getType() {
-    return type;
+  public CarbonColumn getColumn() {
+    return column;
   }
 
-  public void setType(org.apache.carbondata.core.metadata.datatype.DataType dataType) {
-    this.type = dataType;
+  public void setColumn(CarbonColumn column) {
+    this.column = column;
   }
 
   public boolean isMeasureExistsInCurrentSlice() {

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/AbstractScannedResult.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/AbstractScannedResult.java
@@ -19,7 +19,6 @@ package org.apache.carbondata.core.scan.result;
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
-import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.util.Map;
 
@@ -502,18 +501,6 @@ public abstract class AbstractScannedResult {
   protected double getDoubleMeasureValue(int ordinal, int rowIndex) {
     return measureDataChunks[ordinal][pageCounter].getMeasureDataHolder()
         .getReadableDoubleValueByIndex(rowIndex);
-  }
-
-  /**
-   * Below method will be used to get the measure type of big decimal data type
-   *
-   * @param ordinal  ordinal of the of the measure
-   * @param rowIndex row number
-   * @return measure of big decimal type
-   */
-  protected BigDecimal getBigDecimalMeasureValue(int ordinal, int rowIndex) {
-    return measureDataChunks[ordinal][pageCounter].getMeasureDataHolder()
-        .getReadableBigDecimalValueByIndex(rowIndex);
   }
 
   public int getRowCounter() {

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/vector/ColumnVectorInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/vector/ColumnVectorInfo.java
@@ -17,6 +17,7 @@
 package org.apache.carbondata.core.scan.result.vector;
 
 import org.apache.carbondata.core.keygenerator.directdictionary.DirectDictionaryGenerator;
+import org.apache.carbondata.core.metadata.datatype.DecimalConverterFactory;
 import org.apache.carbondata.core.scan.filter.GenericQueryType;
 import org.apache.carbondata.core.scan.model.QueryDimension;
 import org.apache.carbondata.core.scan.model.QueryMeasure;
@@ -28,6 +29,7 @@ public class ColumnVectorInfo implements Comparable<ColumnVectorInfo> {
   public int vectorOffset;
   public QueryDimension dimension;
   public QueryMeasure measure;
+  public DecimalConverterFactory.DecimalConverter decimalConverter;
   public int ordinal;
   public DirectDictionaryGenerator directDictionaryGenerator;
   public MeasureDataVectorProcessor.MeasureVectorFiller measureVectorFiller;

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonMetadataUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonMetadataUtil.java
@@ -804,6 +804,12 @@ public class CarbonMetadataUtil {
     dataChunk.setData_chunk_list(dataChunksList);
     dataChunk.setPage_length(pageLengths);
     dataChunk.setPage_offset(pageOffsets);
+    if (!isDimensionColumn && nodeHolderList.size() > 0) {
+      NodeHolder nodeHolder = nodeHolderList.get(0);
+      if (nodeHolder.getDecimalConverters()[index] != null) {
+        dataChunk.setFixedLength((short) nodeHolder.getDecimalConverters()[index].getSize());
+      }
+    }
     return dataChunk;
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/util/NodeHolder.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/NodeHolder.java
@@ -20,6 +20,7 @@ package org.apache.carbondata.core.util;
 import java.util.BitSet;
 
 import org.apache.carbondata.core.datastore.compression.WriterCompressModel;
+import org.apache.carbondata.core.metadata.datatype.DecimalConverterFactory;
 
 public class NodeHolder {
   /**
@@ -149,6 +150,8 @@ public class NodeHolder {
    * total length of all measure values
    */
   private int totalMeasureArrayLength;
+
+  private DecimalConverterFactory.DecimalConverter[] decimalConverters;
 
   /**
    * @return the keyArray
@@ -426,5 +429,13 @@ public class NodeHolder {
 
   public void setMeasureColumnMinData(byte[][] measureColumnMinData) {
     this.measureColumnMinData = measureColumnMinData;
+  }
+
+  public DecimalConverterFactory.DecimalConverter[] getDecimalConverters() {
+    return decimalConverters;
+  }
+
+  public void setDecimalConverters(DecimalConverterFactory.DecimalConverter[] decimalConverters) {
+    this.decimalConverters = decimalConverters;
   }
 }

--- a/format/src/main/thrift/carbondata.thrift
+++ b/format/src/main/thrift/carbondata.thrift
@@ -139,6 +139,7 @@ struct DataChunk3{
     1: required list<DataChunk2> data_chunk_list; // list of data chunk
     2: optional list<i32> page_offset; // offset of each chunk
     3: optional list<i32> page_length; // length of each chunk
+    4: optional i16 fixedLength // fixed length of the type, it is useful for decimal type and char(fixed length) types
    
  }
 /**

--- a/processing/src/main/java/org/apache/carbondata/processing/mdkeygen/MDKeyGenStep.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/mdkeygen/MDKeyGenStep.java
@@ -364,7 +364,7 @@ public class MDKeyGenStep extends BaseStep {
     String carbonDataDirectoryPath = getCarbonDataFolderLocation();
     finalMerger = new SingleThreadFinalSortFilesMerger(dataFolderLocation, tableName,
         dimensionCount - meta.getComplexDimsCount(), meta.getComplexDimsCount(), measureCount,
-        meta.getNoDictionaryCount(), aggType, isNoDictionaryDimension, true);
+        meta.getNoDictionaryCount(), aggType, null, isNoDictionaryDimension, true);
     CarbonFactDataHandlerModel carbonFactDataHandlerModel = getCarbonFactDataHandlerModel();
     carbonFactDataHandlerModel.setPrimitiveDimLens(simpleDimsLen);
     carbonFactDataHandlerModel.setCarbonDataFileAttributes(carbonDataFileAttributes);

--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/sort/impl/ParallelReadMergeSorterImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/sort/impl/ParallelReadMergeSorterImpl.java
@@ -80,9 +80,9 @@ public class ParallelReadMergeSorterImpl implements Sorter {
         storeLocation + File.separator + CarbonCommonConstants.SORT_TEMP_FILE_LOCATION;
     finalMerger =
         new SingleThreadFinalSortFilesMerger(dataFolderLocation, sortParameters.getTableName(),
-            sortParameters.getDimColCount(),
-            sortParameters.getComplexDimColCount(), sortParameters.getMeasureColCount(),
-            sortParameters.getNoDictionaryCount(), sortParameters.getAggType(),
+            sortParameters.getDimColCount(), sortParameters.getComplexDimColCount(),
+            sortParameters.getMeasureColCount(), sortParameters.getNoDictionaryCount(),
+            sortParameters.getAggType(), sortParameters.getDecimalConverters(),
             sortParameters.getNoDictionaryDimnesionColumn(), sortParameters.isUseKettle());
   }
 

--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/sort/impl/ParallelReadMergeSorterWithBucketingImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/sort/impl/ParallelReadMergeSorterWithBucketingImpl.java
@@ -139,8 +139,8 @@ public class ParallelReadMergeSorterWithBucketingImpl implements Sorter {
         new SingleThreadFinalSortFilesMerger(dataFolderLocation, sortParameters.getTableName(),
             sortParameters.getDimColCount(), sortParameters.getComplexDimColCount(),
             sortParameters.getMeasureColCount(), sortParameters.getNoDictionaryCount(),
-            sortParameters.getAggType(), sortParameters.getNoDictionaryDimnesionColumn(),
-            sortParameters.isUseKettle());
+            sortParameters.getAggType(), sortParameters.getDecimalConverters(),
+            sortParameters.getNoDictionaryDimnesionColumn(), sortParameters.isUseKettle());
     return finalMerger;
   }
 

--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/sort/unsafe/UnsafeSortDataRows.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/sort/unsafe/UnsafeSortDataRows.java
@@ -96,7 +96,8 @@ public class UnsafeSortDataRows {
   public void initialize() throws CarbonSortKeyAndGroupByException {
     MemoryBlock baseBlock = getMemoryBlock(inMemoryChunkSizeInMB * 1024 * 1024);
     this.rowPage = new UnsafeCarbonRowPage(parameters.getNoDictionaryDimnesionColumn(),
-        parameters.getDimColCount(), parameters.getMeasureColCount(), parameters.getAggType(),
+        parameters.getDimColCount() + parameters.getComplexDimColCount(),
+        parameters.getMeasureColCount(), parameters.getAggType(), parameters.getDecimalConverters(),
         baseBlock, !UnsafeMemoryManager.INSTANCE.isMemoryAvailable());
     // Delete if any older file exists in sort temp folder
     deleteSortLocationIfExists();
@@ -154,9 +155,9 @@ public class UnsafeSortDataRows {
             MemoryBlock memoryBlock = getMemoryBlock(inMemoryChunkSizeInMB * 1024 * 1024);
             boolean saveToDisk = !UnsafeMemoryManager.INSTANCE.isMemoryAvailable();
             rowPage = new UnsafeCarbonRowPage(parameters.getNoDictionaryDimnesionColumn(),
-                parameters.getDimColCount(), parameters.getMeasureColCount(),
-                parameters.getAggType(), memoryBlock,
-                saveToDisk);
+                parameters.getDimColCount() + parameters.getComplexDimColCount(),
+                parameters.getMeasureColCount(), parameters.getAggType(),
+                parameters.getDecimalConverters(), memoryBlock, saveToDisk);
             rowPage.addRow(rowBatch[i]);
           } catch (Exception e) {
             LOGGER.error(

--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/sort/unsafe/merger/UnsafeSingleThreadFinalSortFilesMerger.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/sort/unsafe/merger/UnsafeSingleThreadFinalSortFilesMerger.java
@@ -125,7 +125,8 @@ public class UnsafeSingleThreadFinalSortFilesMerger extends CarbonIterator<Objec
       for (final UnsafeCarbonRowPage rowPage : rowPages) {
 
         SortTempChunkHolder sortTempFileChunkHolder = new UnsafeInmemoryHolder(rowPage,
-            parameters.getDimColCount() + parameters.getMeasureColCount());
+            parameters.getDimColCount() + parameters.getComplexDimColCount() + parameters
+                .getMeasureColCount());
 
         // initialize
         sortTempFileChunkHolder.readRow();
@@ -137,7 +138,8 @@ public class UnsafeSingleThreadFinalSortFilesMerger extends CarbonIterator<Objec
 
         SortTempChunkHolder sortTempFileChunkHolder =
             new UnsafeFinalMergePageHolder(merger, parameters.getNoDictionaryDimnesionColumn(),
-                parameters.getDimColCount() + parameters.getMeasureColCount());
+                parameters.getDimColCount() + parameters.getComplexDimColCount() + parameters
+                    .getMeasureColCount());
 
         // initialize
         sortTempFileChunkHolder.readRow();

--- a/processing/src/main/java/org/apache/carbondata/processing/sortandgroupby/sortdata/SortParameters.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/sortandgroupby/sortdata/SortParameters.java
@@ -22,6 +22,7 @@ import org.apache.carbondata.common.logging.LogService;
 import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.metadata.CarbonTableIdentifier;
+import org.apache.carbondata.core.metadata.datatype.DecimalConverterFactory;
 import org.apache.carbondata.core.util.CarbonProperties;
 import org.apache.carbondata.processing.newflow.CarbonDataLoadConfiguration;
 import org.apache.carbondata.processing.schema.metadata.SortObserver;
@@ -119,6 +120,8 @@ public class SortParameters {
    */
   private boolean useKettle = true;
 
+  private DecimalConverterFactory.DecimalConverter[] decimalConverters;
+
   public SortParameters getCopy() {
     SortParameters parameters = new SortParameters();
     parameters.tempFileLocation = tempFileLocation;
@@ -144,6 +147,7 @@ public class SortParameters {
     parameters.noDictionaryDimnesionColumn = noDictionaryDimnesionColumn;
     parameters.numberOfCores = numberOfCores;
     parameters.useKettle = useKettle;
+    parameters.decimalConverters = decimalConverters;
     return parameters;
   }
 
@@ -331,6 +335,14 @@ public class SortParameters {
     this.useKettle = useKettle;
   }
 
+  public DecimalConverterFactory.DecimalConverter[] getDecimalConverters() {
+    return decimalConverters;
+  }
+
+  public void setDecimalConverters(DecimalConverterFactory.DecimalConverter[] decimalConverters) {
+    this.decimalConverters = decimalConverters;
+  }
+
   public static SortParameters createSortParameters(CarbonDataLoadConfiguration configuration) {
     SortParameters parameters = new SortParameters();
     CarbonTableIdentifier tableIdentifier =
@@ -433,6 +445,10 @@ public class SortParameters {
         .getAggType(parameters.getMeasureColCount(), parameters.getDatabaseName(),
             parameters.getTableName());
     parameters.setAggType(aggType);
+    DecimalConverterFactory.DecimalConverter[] decimalConverter = CarbonDataProcessorUtil
+        .getDecimalConverter(parameters.getMeasureColCount(), parameters.getDatabaseName(),
+            parameters.getTableName());
+    parameters.setDecimalConverters(decimalConverter);
     parameters.setUseKettle(false);
     return parameters;
   }
@@ -536,6 +552,10 @@ public class SortParameters {
         .getAggType(parameters.getMeasureColCount(), parameters.getDatabaseName(),
             parameters.getTableName());
     parameters.setAggType(aggType);
+    DecimalConverterFactory.DecimalConverter[] decimalConverter = CarbonDataProcessorUtil
+        .getDecimalConverter(parameters.getMeasureColCount(), parameters.getDatabaseName(),
+            parameters.getTableName());
+    parameters.setDecimalConverters(decimalConverter);
     return parameters;
   }
 

--- a/processing/src/main/java/org/apache/carbondata/processing/store/CarbonFactDataHandlerModel.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/CarbonFactDataHandlerModel.java
@@ -28,6 +28,7 @@ import org.apache.carbondata.core.datastore.block.SegmentProperties;
 import org.apache.carbondata.core.keygenerator.KeyGenerator;
 import org.apache.carbondata.core.metadata.CarbonMetadata;
 import org.apache.carbondata.core.metadata.CarbonTableIdentifier;
+import org.apache.carbondata.core.metadata.datatype.DecimalConverterFactory;
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
 import org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema;
 import org.apache.carbondata.core.util.CarbonProperties;
@@ -178,6 +179,8 @@ public class CarbonFactDataHandlerModel {
 
   private int bucketId = 0;
 
+  private DecimalConverterFactory.DecimalConverter[] decimalConverters;
+
   /**
    * Create the model using @{@link CarbonDataLoadConfiguration}
    * @param configuration
@@ -270,6 +273,9 @@ public class CarbonFactDataHandlerModel {
     carbonFactDataHandlerModel.setDataWritingRequest(true);
     carbonFactDataHandlerModel.setAggType(CarbonDataProcessorUtil
         .getAggType(measureCount, identifier.getDatabaseName(), identifier.getTableName()));
+    carbonFactDataHandlerModel.setDecimalConverters(CarbonDataProcessorUtil
+        .getDecimalConverter(measureCount, identifier.getDatabaseName(),
+            identifier.getTableName()));
     carbonFactDataHandlerModel.setFactDimLens(dimLens);
     carbonFactDataHandlerModel.setWrapperColumnSchema(wrapperColumnSchema);
     carbonFactDataHandlerModel.setPrimitiveDimLens(simpleDimsLen);
@@ -498,6 +504,14 @@ public class CarbonFactDataHandlerModel {
 
   public int getBucketId() {
     return bucketId;
+  }
+
+  public DecimalConverterFactory.DecimalConverter[] getDecimalConverters() {
+    return decimalConverters;
+  }
+
+  public void setDecimalConverters(DecimalConverterFactory.DecimalConverter[] decimalConverters) {
+    this.decimalConverters = decimalConverters;
   }
 }
 

--- a/processing/src/main/java/org/apache/carbondata/processing/store/SingleThreadFinalSortFilesMerger.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/SingleThreadFinalSortFilesMerger.java
@@ -30,6 +30,7 @@ import org.apache.carbondata.common.CarbonIterator;
 import org.apache.carbondata.common.logging.LogService;
 import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
+import org.apache.carbondata.core.metadata.datatype.DecimalConverterFactory;
 import org.apache.carbondata.core.util.CarbonProperties;
 import org.apache.carbondata.processing.sortandgroupby.exception.CarbonSortKeyAndGroupByException;
 import org.apache.carbondata.processing.sortandgroupby.sortdata.SortTempFileChunkHolder;
@@ -103,9 +104,12 @@ public class SingleThreadFinalSortFilesMerger extends CarbonIterator<Object[]> {
    */
   private boolean[] isNoDictionaryColumn;
 
+  private DecimalConverterFactory.DecimalConverter[] decimalConverters;
+
   public SingleThreadFinalSortFilesMerger(String tempFileLocation, String tableName,
       int dimensionCount, int complexDimensionCount, int measureCount, int noDictionaryCount,
-      char[] aggType, boolean[] isNoDictionaryColumn, boolean useKettle) {
+      char[] aggType, DecimalConverterFactory.DecimalConverter[] decimalConverters,
+      boolean[] isNoDictionaryColumn, boolean useKettle) {
     this.tempFileLocation = tempFileLocation;
     this.tableName = tableName;
     this.dimensionCount = dimensionCount;
@@ -115,6 +119,7 @@ public class SingleThreadFinalSortFilesMerger extends CarbonIterator<Object[]> {
     this.noDictionaryCount = noDictionaryCount;
     this.isNoDictionaryColumn = isNoDictionaryColumn;
     this.useKettle = useKettle;
+    this.decimalConverters = decimalConverters;
   }
 
   /**
@@ -183,8 +188,8 @@ public class SingleThreadFinalSortFilesMerger extends CarbonIterator<Object[]> {
           // create chunk holder
           SortTempFileChunkHolder sortTempFileChunkHolder =
               new SortTempFileChunkHolder(tempFile, dimensionCount, complexDimensionCount,
-                  measureCount, fileBufferSize, noDictionaryCount, aggType, isNoDictionaryColumn,
-                  useKettle);
+                  measureCount, fileBufferSize, noDictionaryCount, aggType, decimalConverters,
+                  isNoDictionaryColumn, useKettle);
 
           // initialize
           sortTempFileChunkHolder.initialize();

--- a/processing/src/main/java/org/apache/carbondata/processing/store/writer/v3/CarbonFactDataWriterImplV3.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/writer/v3/CarbonFactDataWriterImplV3.java
@@ -459,6 +459,7 @@ public class CarbonFactDataWriterImplV3 extends AbstractFactDataWriter<short[]> 
             < 0) {
           currentMaxValue[j] = maxValue.clone();
         }
+        measureIndex++;
       }
     }
     BlockletBTreeIndex btree =

--- a/processing/src/main/java/org/apache/carbondata/processing/util/CarbonDataProcessorUtil.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/util/CarbonDataProcessorUtil.java
@@ -39,6 +39,7 @@ import org.apache.carbondata.core.datastore.impl.FileFactory;
 import org.apache.carbondata.core.datastore.impl.FileFactory.FileType;
 import org.apache.carbondata.core.metadata.CarbonMetadata;
 import org.apache.carbondata.core.metadata.datatype.DataType;
+import org.apache.carbondata.core.metadata.datatype.DecimalConverterFactory;
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
 import org.apache.carbondata.core.metadata.schema.table.column.CarbonDimension;
 import org.apache.carbondata.core.metadata.schema.table.column.CarbonMeasure;
@@ -478,6 +479,26 @@ public final class CarbonDataProcessorUtil {
       aggType[i] = DataTypeUtil.getAggType(measures.get(i).getDataType());
     }
     return aggType;
+  }
+
+  /**
+   * get decimal converters.
+   */
+  public static DecimalConverterFactory.DecimalConverter[] getDecimalConverter(int measureCount,
+      String databaseName, String tableName) {
+    DecimalConverterFactory.DecimalConverter[] converters =
+        new DecimalConverterFactory.DecimalConverter[measureCount];
+    CarbonTable carbonTable = CarbonMetadata.getInstance()
+        .getCarbonTable(databaseName + CarbonCommonConstants.UNDERSCORE + tableName);
+    List<CarbonMeasure> measures = carbonTable.getMeasureByTableName(tableName);
+    for (int i = 0; i < converters.length; i++) {
+      CarbonMeasure carbonMeasure = measures.get(i);
+      if (carbonMeasure.getDataType().equals(DataType.DECIMAL)) {
+        converters[i] = DecimalConverterFactory.INSTANCE
+            .getDecimalConverter(carbonMeasure.getPrecision(), carbonMeasure.getScale());
+      }
+    }
+    return converters;
   }
 
   /**


### PR DESCRIPTION
Currently Decimal is converted to bytes and using LV (length + value) format to write to store. And while getting back read the bytes in LV format and convert back the bigdecimal.
We can do following operations to improve storage and processing.
1. if decimal precision is less than 9 then we can fit in int (4 bytes)
2. if decimal precision is less than 18 then we can fit in long (8 bytes)
3. if decimal precision is more than 18 then we can fit in fixed length bytes(the length bytes can vary depends on precision but it is always fixed length)
So in this approach we no need store bigdecimal in LV format, we can store in fixed format.It reduces the memory.

Carbondata format changes -> Added fixedLength in datachunk to know about the column length of big  decimal. This attribute can be used in case of char(fixedlength) or varchar(fixedlength) datatypes as well.