### PR TITLE
[CARBONDATA-773] Fixed multiple DictionaryServer instances issue

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -700,6 +700,16 @@ public final class CarbonCommonConstants {
   public static final String DICTIONARY_ONE_CHUNK_SIZE = "carbon.dictionary.chunk.size";
 
   /**
+   *  Dictionary Server Worker Threads
+   */
+  public static final String DICTIONARY_WORKER_THREADS = "dictionary.worker.threads";
+
+  /**
+   *  Dictionary Server Worker Threads
+   */
+  public static final String DICTIONARY_WORKER_THREADS_DEFAULT = "1";
+
+  /**
    * dictionary chunk default size
    */
   public static final String DICTIONARY_ONE_CHUNK_SIZE_DEFAULT = "10000";

--- a/core/src/main/java/org/apache/carbondata/core/dictionary/client/DictionaryClient.java
+++ b/core/src/main/java/org/apache/carbondata/core/dictionary/client/DictionaryClient.java
@@ -49,8 +49,10 @@ public class DictionaryClient {
    * @param port
    */
   public void startClient(String address, int port) {
+    LOGGER.audit("Starting client on " + address + " " + port);
     long start = System.currentTimeMillis();
-    workerGroup = new NioEventLoopGroup();
+    // Create an Event with 1 thread.
+    workerGroup = new NioEventLoopGroup(1);
     Bootstrap clientBootstrap = new Bootstrap();
     clientBootstrap.group(workerGroup).channel(NioSocketChannel.class)
         .handler(new ChannelInitializer<SocketChannel>() {
@@ -58,7 +60,9 @@ public class DictionaryClient {
             ChannelPipeline pipeline = ch.pipeline();
             // Based on length provided at header, it collects all packets
             pipeline
-                .addLast("LengthDecoder", new LengthFieldBasedFrameDecoder(1048576, 0, 2, 0, 2));
+                .addLast("LengthDecoder",
+                    new LengthFieldBasedFrameDecoder(1048576, 0,
+                        2, 0, 2));
             pipeline.addLast("DictionaryClientHandler", dictionaryClientHandler);
           }
         });

--- a/core/src/main/java/org/apache/carbondata/core/dictionary/generator/ServerDictionaryGenerator.java
+++ b/core/src/main/java/org/apache/carbondata/core/dictionary/generator/ServerDictionaryGenerator.java
@@ -71,4 +71,9 @@ public class ServerDictionaryGenerator implements DictionaryGenerator<Integer, D
     }
   }
 
+  public void writeTableDictionaryData(String tableUniqueName) throws Exception {
+    TableDictionaryGenerator generator = tableMap.get(tableUniqueName);
+    generator.writeDictionaryData(tableUniqueName);
+  }
+
 }

--- a/core/src/main/java/org/apache/carbondata/core/dictionary/generator/key/DictionaryMessageType.java
+++ b/core/src/main/java/org/apache/carbondata/core/dictionary/generator/key/DictionaryMessageType.java
@@ -24,7 +24,8 @@ public enum DictionaryMessageType {
   DICT_GENERATION((byte) 1),
   TABLE_INTIALIZATION((byte) 2),
   SIZE((byte) 3),
-  WRITE_DICTIONARY((byte) 4);
+  WRITE_DICTIONARY((byte) 4),
+  WRITE_TABLE_DICTIONARY((byte) 5);
 
   final byte type;
 

--- a/core/src/main/java/org/apache/carbondata/core/dictionary/server/DictionaryServer.java
+++ b/core/src/main/java/org/apache/carbondata/core/dictionary/server/DictionaryServer.java
@@ -18,8 +18,10 @@ package org.apache.carbondata.core.dictionary.server;
 
 import org.apache.carbondata.common.logging.LogService;
 import org.apache.carbondata.common.logging.LogServiceFactory;
+import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.dictionary.generator.key.DictionaryMessage;
 import org.apache.carbondata.core.dictionary.generator.key.DictionaryMessageType;
+import org.apache.carbondata.core.util.CarbonProperties;
 
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.ChannelInitializer;
@@ -43,41 +45,88 @@ public class DictionaryServer {
 
   private EventLoopGroup boss;
   private EventLoopGroup worker;
+  private int port;
+  private static Object lock = new Object();
+  private static DictionaryServer INSTANCE = null;
+
+  private DictionaryServer(int port) {
+    startServer(port);
+  }
+
+  public static DictionaryServer getInstance(int port) {
+    if (INSTANCE == null) {
+      synchronized (lock) {
+        if (INSTANCE == null) {
+          INSTANCE = new DictionaryServer(port);
+        }
+      }
+    }
+    return INSTANCE;
+  }
 
   /**
    * start dictionary server
    *
    * @param port
-   * @throws Exception
    */
-  public void startServer(int port) {
-    long start = System.currentTimeMillis();
+  private void startServer(int port) {
     dictionaryServerHandler = new DictionaryServerHandler();
-    boss = new NioEventLoopGroup();
-    worker = new NioEventLoopGroup();
+    String workerThreads = CarbonProperties.getInstance()
+        .getProperty(CarbonCommonConstants.DICTIONARY_WORKER_THREADS,
+            CarbonCommonConstants.DICTIONARY_WORKER_THREADS_DEFAULT);
+    boss = new NioEventLoopGroup(1);
+    worker = new NioEventLoopGroup(Integer.parseInt(workerThreads));
     // Configure the server.
-    try {
-      ServerBootstrap bootstrap = new ServerBootstrap();
-      bootstrap.group(boss, worker);
-      bootstrap.channel(NioServerSocketChannel.class);
+    bindToPort(port);
+  }
 
-      bootstrap.childHandler(new ChannelInitializer<SocketChannel>() {
-        @Override public void initChannel(SocketChannel ch) throws Exception {
-          ChannelPipeline pipeline = ch.pipeline();
-          // Based on length provided at header, it collects all packets
-          pipeline.addLast("LengthDecoder", new LengthFieldBasedFrameDecoder(1048576, 0, 2, 0, 2));
-          pipeline.addLast("DictionaryServerHandler", dictionaryServerHandler);
+  /**
+   * Binds dictionary server to an available port.
+   *
+   * @param port
+   */
+  private void bindToPort(int port) {
+    long start = System.currentTimeMillis();
+    // Configure the server.
+    int i = 0;
+    while (i < 10) {
+      int newPort = port + i;
+      try {
+        ServerBootstrap bootstrap = new ServerBootstrap();
+        bootstrap.group(boss, worker);
+        bootstrap.channel(NioServerSocketChannel.class);
+        bootstrap.childHandler(new ChannelInitializer<SocketChannel>() {
+          @Override public void initChannel(SocketChannel ch) throws Exception {
+            ChannelPipeline pipeline = ch.pipeline();
+            pipeline
+                .addLast("LengthDecoder",
+                    new LengthFieldBasedFrameDecoder(1048576, 0,
+                        2, 0, 2));
+            pipeline.addLast("DictionaryServerHandler", dictionaryServerHandler);
+          }
+        });
+        bootstrap.childOption(ChannelOption.SO_KEEPALIVE, true);
+        bootstrap.bind(newPort).sync();
+        LOGGER.audit("Dictionary Server started, Time spent " + (System.currentTimeMillis() - start)
+            + " Listening on port " + newPort);
+        this.port = newPort;
+        break;
+      } catch (Exception e) {
+        LOGGER.error(e, "Dictionary Server Failed to bind to port:");
+        if (i == 9) {
+          throw new RuntimeException("Dictionary Server Could not bind to any port");
         }
-      });
-      bootstrap.childOption(ChannelOption.SO_KEEPALIVE, true);
-      bootstrap.bind(port).sync();
-
-      LOGGER.info("Dictionary Server started, Time spent " + (System.currentTimeMillis() - start)
-          + " Listening on port " + port);
-    } catch (Exception e) {
-      LOGGER.error(e, "Dictionary Server Start Failed");
-      throw new RuntimeException(e);
+      }
+      i++;
     }
+  }
+
+  /**
+   *
+   * @return Port on which the DictionaryServer has started.
+   */
+  public int getPort() {
+    return port;
   }
 
   /**
@@ -93,6 +142,8 @@ public class DictionaryServer {
     worker.terminationFuture().sync();
   }
 
+
+
   /**
    * Write dictionary to the store.
    * @throws Exception
@@ -100,6 +151,18 @@ public class DictionaryServer {
   public void writeDictionary() throws Exception {
     DictionaryMessage key = new DictionaryMessage();
     key.setType(DictionaryMessageType.WRITE_DICTIONARY);
+    dictionaryServerHandler.processMessage(key);
+  }
+
+  /**
+   *  Write Dictionary for one table.
+   * @throws Exception
+   */
+
+  public void writeTableDictionary(String uniqueTableName) throws Exception {
+    DictionaryMessage key = new DictionaryMessage();
+    key.setTableUniqueName(uniqueTableName);
+    key.setType(DictionaryMessageType.WRITE_TABLE_DICTIONARY);
     dictionaryServerHandler.processMessage(key);
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/dictionary/server/DictionaryServerHandler.java
+++ b/core/src/main/java/org/apache/carbondata/core/dictionary/server/DictionaryServerHandler.java
@@ -101,6 +101,9 @@ public class DictionaryServerHandler extends ChannelInboundHandlerAdapter {
       case WRITE_DICTIONARY :
         generatorForServer.writeDictionaryData();
         return 0;
+      case WRITE_TABLE_DICTIONARY:
+        generatorForServer.writeTableDictionaryData(key.getTableUniqueName());
+        return 0;
       default:
         return -1;
     }

--- a/core/src/test/java/org/apache/carbondata/core/dictionary/client/DictionaryClientTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/dictionary/client/DictionaryClientTest.java
@@ -91,8 +91,7 @@ public class DictionaryClientTest {
     metadata.addCarbonTable(carbonTable);
 
     // Start the server for testing the client
-    server = new DictionaryServer();
-    server.startServer(5678);
+    server = DictionaryServer.getInstance(5678);
   }
 
   @Test public void testClient() throws Exception {
@@ -159,7 +158,6 @@ public class DictionaryClientTest {
     client.shutDown();
 
     // Shutdown the server
-    server.shutdown();
   }
 
   @After public void tearDown() {


### PR DESCRIPTION
In the earlier flow multiple instances of dictionary server were being created when parallel load requests were fired. This caused the later request to fail because a server was already running on the defined port.
Now only one instance of the dictionary server would be created on a load request and any consecutive requests would use the already created server.
Also removed the java future and instead we now use netty future for multithreading.
