### PR TITLE
[CARBONDATA-833]load data from dataframe,generater data row may be error when delimiter…

### DIFF
--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/CarbonScalaUtil.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/CarbonScalaUtil.scala
@@ -168,9 +168,9 @@ object CarbonScalaUtil {
         case bs: Array[Byte] => new String(bs)
         case s: scala.collection.Seq[Any] =>
           val delimiter = if (level == 1) {
-            delimiterLevel1
+            delimiterLevel1.last
           } else {
-            delimiterLevel2
+            delimiterLevel2.last
           }
           val builder = new StringBuilder()
           s.foreach { x =>
@@ -182,9 +182,9 @@ object CarbonScalaUtil {
           throw new Exception("Unsupported data type: Map")
         case r: org.apache.spark.sql.Row =>
           val delimiter = if (level == 1) {
-            delimiterLevel1
+            delimiterLevel1.last
           } else {
-            delimiterLevel2
+            delimiterLevel2.last
           }
           val builder = new StringBuilder()
           for (i <- 0 until r.length) {


### PR DESCRIPTION
load data from dataframe,generater data row may be error by delimiterLevel1 or delimiterLevel2 is special character 
because delimiterLevel1 and delimiterLevel2 when carbonLoadModel is create by CarbonUtil.delimiterConverter(), CarbonScalaUtil.getString direct use carbonLoadModel.getComplexDelimiterLevel1 and carbonLoadModel.getComplexDelimiterLevel2 
val delimiter = if (level == 1)
{ delimiterLevel1 }
else
{ delimiterLevel2 }
val builder = new StringBuilder()
s.foreach
{ x => builder.append(getString(x, serializationNullFormat, delimiterLevel1, delimiterLevel2, timeStampFormat, dateFormat, level + 1)).append(delimiter) }
make primitive data added a more char \ when datatype is complex
code ：
 cc.sql( s"""CREATE TABLE carbon_test (
                 cookie string,
                  mid array<struct<id:string,
                              value:string>>,
                 global_meida array<string>)
              STORED BY 'org.apache.carbondata.format'
               TBLPROPERTIES ("DICTIONARY_EXCLUDE"="cookie")
               """)
val rdd =sc.textFile(args(0)).map(line => line.split("\t",-1)).map(x=>(x(0),x(1),x(20).split(",",-1))).map(item => Row.apply(item._1,item._2.split(",",-1).map(x=>{if(x!=null && x.split(":",-1).length==2) (x.split(":",-1)(0),x.split(":",-1)(1)) else ("","")}).toList,item._3))
    val schema = StructType( Seq(StructField("cookie", StringType), StructField("mid", ArrayType(StructType( Seq(StructField("id", StringType), StructField("value",StringType))))),StructField("global_meida", ArrayType(StringType))))
    val df = cc.createDataFrame(rdd,schema)
    df.write.format("carbondata").option("tableName", "carbon_test") .option("compress", "false")  .option("use_kettle", "false") .option("tempCSV", "false").option("complex_delimiter_level_1",args(1)).option("complex_delimiter_level_2",args(2)).mode(SaveMode.Append).save()
