### PR TITLE
[CARBONDATA-840] improve limit query performance [Group By]

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/CarbonOptimizer.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/CarbonOptimizer.scala
@@ -87,11 +87,6 @@ class ResolveCarbonFunctions(relations: Seq[CarbonDecoderRelation])
       val recorder = CarbonTimeStatisticsFactory.createExecutorRecorder("")
       val queryStatistic = new QueryStatistic()
       val result = transformCarbonPlan(udfTransformedPlan, relations)
-      //val finalResult = if (!hasLimitOrFilter(logicalPlan))
-      //  result
-      //else{
-      //  pushDownLimitToScan(result)
-      //}
       queryStatistic.addStatistics("Time taken for Carbon Optimizer to optimize: ",
         System.currentTimeMillis)
       recorder.recordStatistics(queryStatistic)
@@ -806,20 +801,20 @@ case class CarbonDecoderRelation(
   }
 
   def contains(attr: Attribute): Boolean = {
-  val exists =
-  attributeMap.exists(entry => entry._1.name.equalsIgnoreCase(attr.name) &&
-  entry._1.exprId.equals(attr.exprId)) ||
-  extraAttrs.exists(entry => entry.name.equalsIgnoreCase(attr.name) &&
-  entry.exprId.equals(attr.exprId))
-  exists
-}
+    val exists =
+      attributeMap.exists(entry => entry._1.name.equalsIgnoreCase(attr.name) &&
+          entry._1.exprId.equals(attr.exprId)) ||
+          extraAttrs.exists(entry => entry.name.equalsIgnoreCase(attr.name) &&
+              entry.exprId.equals(attr.exprId))
+    exists
+  }
 
   def fillAttributeMap(attrMap: java.util.HashMap[AttributeReferenceWrapper,
-  CarbonDecoderRelation]): Unit = {
-  attributeMap.foreach { attr =>
-  attrMap.put(AttributeReferenceWrapper(attr._1), this)
-}
-}
+      CarbonDecoderRelation]): Unit = {
+    attributeMap.foreach { attr =>
+      attrMap.put(AttributeReferenceWrapper(attr._1), this)
+    }
+  }
 
   lazy val dictionaryMap = carbonRelation.carbonRelation.metaData.dictionaryMap
 }

--- a/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/CarbonOptimizer.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/CarbonOptimizer.scala
@@ -176,7 +176,7 @@ class ResolveCarbonFunctions(relations: Seq[CarbonDecoderRelation])
     } isDefined
   }
   def readyForLimitOptimization(plan: LogicalPlan): Boolean = {
-    if(hasLimit(plan) && hasAggregate(plan) && !hasSort(plan) && !hasFilter(plan)) true
+    if (hasLimit(plan) && hasAggregate(plan) && !hasSort(plan) && !hasFilter(plan)) true
     else false
   }
   def isOptimized(plan: LogicalPlan): Boolean = {
@@ -583,7 +583,8 @@ class ResolveCarbonFunctions(relations: Seq[CarbonDecoderRelation])
             val newFilters = LimitQueryOptimizer.
               getFilters(limit_num, groupingExpressions, relations, agg.child).getOrElse(null)
             if (newFilters != null) {
-              val new_agg = new Aggregate(agg.groupingExpressions, agg.aggregateExpressions, newFilters)
+              val new_agg = new Aggregate(agg.groupingExpressions, agg.aggregateExpressions,
+                newFilters)
               addDecoder(new_agg)
             } else {
               addDecoder(agg)

--- a/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/LimitQueryOptimizer.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/LimitQueryOptimizer.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.spark.sql.optimizer
 
 import org.apache.carbondata.core.cache.dictionary.{Dictionary, DictionaryColumnUniqueIdentifier}
@@ -8,9 +25,6 @@ import org.apache.spark.sql.catalyst.plans.logical.Filter
 
 import scala.collection.mutable.ArrayBuffer
 
-/**
-  * Created by lucao on 3/23/17.
-  */
 class LimitQueryOptimizer(limit_num: Int,
                           groupingExpressions: Seq[Expression],
                           originFilters: Filter,
@@ -42,7 +56,8 @@ class LimitQueryOptimizer(limit_num: Int,
                     count_arr(i) += 1
                     total_count = count_arr.product
                 }
-                val left = Literal.create(col.name, col.dataType)
+                //val left = Literal.create(col.name, col.dataType)
+                val left = col
                 if(value_arr.size > 1){
                     val inExpression = In(left , value_arr)
                     expr_arr += inExpression

--- a/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/LimitQueryOptimizer.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/LimitQueryOptimizer.scala
@@ -1,0 +1,97 @@
+package org.apache.spark.sql.optimizer
+
+import org.apache.carbondata.core.cache.dictionary.{Dictionary, DictionaryColumnUniqueIdentifier}
+import org.apache.carbondata.spark.load.CarbonLoaderUtil
+import org.apache.spark.sql.CarbonRelation
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.plans.logical.Filter
+
+import scala.collection.mutable.ArrayBuffer
+
+/**
+  * Created by lucao on 3/23/17.
+  */
+class LimitQueryOptimizer(limit_num: Int,
+                          groupingExpressions: Seq[Expression],
+                          originFilters: Filter,
+                          relations: Seq[CarbonDecoderRelation]){
+    def getNewFilters(): Filter = {
+        val cols = groupingExpressions.reverse.map(_.asInstanceOf[AttributeReference])
+        val count_arr = ArrayBuffer[Int]()
+        val expr_arr = ArrayBuffer[Expression]()
+        var total_count : Int = 0
+
+        for( i <- 0 until cols.size ) {
+            val col = cols(i)
+            val value_arr = ArrayBuffer[Literal]()
+            count_arr += 0
+            val relation = getTableRelation(col)
+            val dictExist = relation.metaData.dictionaryMap.get(col.name).get
+            if (total_count < limit_num && dictExist){
+                val dict = LimitQueryOptimizer.getDictionaryValue(col, relation).get
+                /** Get distinct value list of current grouping column **/
+                var index: Int = 2
+                var distinctValue = dict.getDictionaryValueForKey(index)
+                value_arr += (Literal(distinctValue))
+                count_arr(i) += 1
+                total_count = count_arr.product
+                while (total_count < limit_num && distinctValue != null) {
+                    index += 1
+                    distinctValue = dict.getDictionaryValueForKey(index)
+                    value_arr += (Literal(distinctValue))
+                    count_arr(i) += 1
+                    total_count = count_arr.product
+                }
+                val left = Literal.create(col.name, col.dataType)
+                if(value_arr.size > 1){
+                    val inExpression = In(left , value_arr)
+                    expr_arr += inExpression
+                }else if(value_arr.size == 1){
+                    val equalExpression = EqualTo(left, value_arr.head)
+                    expr_arr += equalExpression
+                }
+            }
+        }
+        val origin_expr = originFilters.condition
+        var new_expr : And = null
+        var index = 0
+        for(expression <- expr_arr) {
+            if(index == 0){
+                new_expr = new And(origin_expr, expression)
+            }else{
+                new_expr = new And(new_expr, expression)
+            }
+            index += 1
+        }
+       new Filter(new_expr, originFilters.child)
+    }
+    def getTableRelation(col: AttributeReference) : CarbonRelation = {
+        val tableName = col.qualifiers.head
+        val relation = relations.filter(_.carbonRelation.getTable() == tableName).head
+        val carbonRelation = relation.carbonRelation.carbonRelation
+        carbonRelation
+    }
+}
+
+object LimitQueryOptimizer {
+    def apply(limit_num: Int,
+              groupingExpressions: Seq[Expression],
+              originFilters: Filter,
+              relations: Seq[CarbonDecoderRelation])
+      = new LimitQueryOptimizer(limit_num: Int,
+        groupingExpressions: Seq[Expression],
+        originFilters: Filter,
+        relations: Seq[CarbonDecoderRelation])
+
+    def getDictionaryValue(col: AttributeReference, relation: CarbonRelation) : Option[Dictionary] = {
+        val tableName = col.qualifiers.head
+        val carbonTable = relation.tableMeta.carbonTable
+        val dimension = carbonTable.getDimensionByName(tableName.toLowerCase(), col.name)
+        val carbonTableIdentifier = carbonTable.getCarbonTableIdentifier
+        val columnIdentifier = new DictionaryColumnUniqueIdentifier(carbonTableIdentifier,
+            dimension.getColumnIdentifier, dimension.getDataType)
+        val path = relation.metaData.carbonTable.getStorePath
+        val dict = CarbonLoaderUtil.getDictionary(columnIdentifier, path)
+        Some(dict)
+    }
+}

--- a/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/LimitQueryOptimizer.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/LimitQueryOptimizer.scala
@@ -56,13 +56,11 @@ class LimitQueryOptimizer(limit_num: Int,
                     count_arr(i) += 1
                     total_count = count_arr.product
                 }
-                //val left = Literal.create(col.name, col.dataType)
-                val left = col
                 if(value_arr.size > 1){
-                    val inExpression = In(left , value_arr)
+                    val inExpression = In(col , value_arr)
                     expr_arr += inExpression
                 }else if(value_arr.size == 1){
-                    val equalExpression = EqualTo(left, value_arr.head)
+                    val equalExpression = EqualTo(col, value_arr.head)
                     expr_arr += equalExpression
                 }
             }


### PR DESCRIPTION
Currently limit query will still scan all data first and limit in the last step. In carbon we can convert limit to filters with dictionary distinct value list...