### PR TITLE
[WIP][CARBONDATA-844] Avoid to get useless splits

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/TableSegmentUniqueIdentifier.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/TableSegmentUniqueIdentifier.java
@@ -21,9 +21,9 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
-import org.apache.carbondata.core.datastore.block.TableBlockInfo;
 import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
 import org.apache.carbondata.core.metadata.CarbonTableIdentifier;
+import org.apache.carbondata.core.metadata.index.IndexInfo;
 
 /**
  * Class holds the absoluteTableIdentifier and segmentId to uniquely identify a segment
@@ -37,7 +37,7 @@ public class TableSegmentUniqueIdentifier {
   /**
    * segment to tableBlockInfo map
    */
-  Map<String, List<TableBlockInfo>> segmentToTableBlocksInfos;
+  Map<String, List<IndexInfo>> segmentToTableBlocksInfos;
 
   private String segmentId;
   private  boolean isSegmentUpdated;
@@ -54,7 +54,7 @@ public class TableSegmentUniqueIdentifier {
   }
 
   public TableSegmentUniqueIdentifier(AbsoluteTableIdentifier absoluteTableIdentifier,
-      Map<String, List<TableBlockInfo>> segmentToTableBlocksInfos, String segmentId) {
+      Map<String, List<IndexInfo>> segmentToTableBlocksInfos, String segmentId) {
     this.absoluteTableIdentifier = absoluteTableIdentifier;
     this.segmentToTableBlocksInfos = segmentToTableBlocksInfos;
     this.segmentId = segmentId;
@@ -76,7 +76,7 @@ public class TableSegmentUniqueIdentifier {
    *  returns the segment to tableBlockInfo map
    * @return
    */
-  public Map<String, List<TableBlockInfo>> getSegmentToTableBlocksInfos() {
+  public Map<String, List<IndexInfo>> getSegmentToTableBlocksInfos() {
     return segmentToTableBlocksInfos;
   }
 
@@ -85,7 +85,7 @@ public class TableSegmentUniqueIdentifier {
    * @param segmentToTableBlocksInfos
    */
   public void setSegmentToTableBlocksInfos(
-      Map<String, List<TableBlockInfo>> segmentToTableBlocksInfos) {
+      Map<String, List<IndexInfo>> segmentToTableBlocksInfos) {
     this.segmentToTableBlocksInfos = segmentToTableBlocksInfos;
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/datastore/block/TableBlockInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/block/TableBlockInfo.java
@@ -72,6 +72,11 @@ public class TableBlockInfo implements Distributable, Serializable {
   private Map<String, String> blockStorageIdMap =
           new HashMap<>(CarbonCommonConstants.DEFAULT_COLLECTION_SIZE);
 
+  public TableBlockInfo(String filePath, String segmentId) {
+    this.filePath = FileFactory.getUpdatedFilePath(filePath);
+    this.segmentId = segmentId;
+  }
+
   public TableBlockInfo(String filePath, long blockOffset, String segmentId, String[] locations,
       long blockLength, ColumnarFormatVersion version) {
     this.filePath = FileFactory.getUpdatedFilePath(filePath);
@@ -147,6 +152,10 @@ public class TableBlockInfo implements Distributable, Serializable {
    */
   public long getBlockLength() {
     return blockLength;
+  }
+
+  public long setBlockLength(long blockLength) {
+    return this.blockLength = blockLength;
   }
 
   /*
@@ -262,6 +271,10 @@ public class TableBlockInfo implements Distributable, Serializable {
 
   @Override public String[] getLocations() {
     return locations;
+  }
+
+  public String[] setLocations(String[] locations) {
+    return this.locations = this.locations;
   }
 
   /**

--- a/core/src/main/java/org/apache/carbondata/core/metadata/index/IndexInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/index/IndexInfo.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.core.metadata.index;
+
+public class IndexInfo {
+  private String filePath;
+
+  private String segmentId;
+
+  public IndexInfo(String filePath, String segmentId) {
+    this.filePath = filePath;
+    this.segmentId = segmentId;
+  }
+
+  /**
+   * @return the filePath
+   */
+  public String getFilePath() {
+    return filePath;
+  }
+
+  /**
+   * @return the segmentId
+   */
+  public String getSegmentId() {
+    return segmentId;
+  }
+}

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
@@ -58,6 +58,7 @@ import org.apache.carbondata.core.metadata.ValueEncoderMeta;
 import org.apache.carbondata.core.metadata.blocklet.DataFileFooter;
 import org.apache.carbondata.core.metadata.datatype.DataType;
 import org.apache.carbondata.core.metadata.encoder.Encoding;
+import org.apache.carbondata.core.metadata.index.IndexInfo;
 import org.apache.carbondata.core.metadata.schema.table.column.CarbonDimension;
 import org.apache.carbondata.core.metadata.schema.table.column.CarbonMeasure;
 import org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema;
@@ -974,23 +975,11 @@ public final class CarbonUtil {
   /**
    * The method returns the B-Tree for a particular taskId
    *
-   * @param taskId
-   * @param tableBlockInfoList
-   * @param absoluteTableIdentifier
+   * @param indexInfo
    */
-  public static long calculateDriverBTreeSize(String taskId, String bucketNumber,
-      List<TableBlockInfo> tableBlockInfoList, AbsoluteTableIdentifier absoluteTableIdentifier) {
-    // need to sort the  block info list based for task in ascending  order so
-    // it will be sinkup with block index read from file
-    Collections.sort(tableBlockInfoList);
-    CarbonTablePath carbonTablePath = CarbonStorePath
-        .getCarbonTablePath(absoluteTableIdentifier.getStorePath(),
-            absoluteTableIdentifier.getCarbonTableIdentifier());
+  public static long calculateDriverBTreeSize(IndexInfo indexInfo) {
     // geting the index file path
-    //TODO need to pass proper partition number when partiton will be supported
-    String carbonIndexFilePath = carbonTablePath
-        .getCarbonIndexFilePath(taskId, "0", tableBlockInfoList.get(0).getSegmentId(),
-            bucketNumber);
+    String carbonIndexFilePath = indexInfo.getFilePath();
     CarbonFile carbonFile = FileFactory
         .getCarbonFile(carbonIndexFilePath, FileFactory.getFileType(carbonIndexFilePath));
     // in case of carbonIndex file whole file is meta only so reading complete file.
@@ -1213,29 +1202,17 @@ public final class CarbonUtil {
   /**
    * Below method will be used to get all the block index info from index file
    *
-   * @param taskId                  task id of the file
-   * @param tableBlockInfoList      list of table block
-   * @param absoluteTableIdentifier absolute table identifier
+   * @param indexInfo      list of table block
    * @return list of block info
    * @throws IOException if any problem while reading
    */
-  public static List<DataFileFooter> readCarbonIndexFile(String taskId, String bucketNumber,
-      List<TableBlockInfo> tableBlockInfoList, AbsoluteTableIdentifier absoluteTableIdentifier)
+  public static List<DataFileFooter> readCarbonIndexFile(IndexInfo indexInfo)
       throws IOException {
-    // need to sort the  block info list based for task in ascending  order so
-    // it will be sinkup with block index read from file
-    Collections.sort(tableBlockInfoList);
-    CarbonTablePath carbonTablePath = CarbonStorePath
-        .getCarbonTablePath(absoluteTableIdentifier.getStorePath(),
-            absoluteTableIdentifier.getCarbonTableIdentifier());
     // geting the index file path
-    //TODO need to pass proper partition number when partiton will be supported
-    String carbonIndexFilePath = carbonTablePath
-        .getCarbonIndexFilePath(taskId, "0", tableBlockInfoList.get(0).getSegmentId(),
-            bucketNumber);
+    String carbonIndexFilePath = indexInfo.getFilePath();
     DataFileFooterConverter fileFooterConverter = new DataFileFooterConverter();
     // read the index info and return
-    return fileFooterConverter.getIndexInfo(carbonIndexFilePath, tableBlockInfoList);
+    return fileFooterConverter.getIndexInfo(carbonIndexFilePath, indexInfo);
   }
 
   /**

--- a/core/src/main/java/org/apache/carbondata/core/util/path/CarbonTablePath.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/path/CarbonTablePath.java
@@ -491,6 +491,20 @@ public class CarbonTablePath extends Path {
       return fileName.substring(startIndex, endIndex);
     }
 
+    public static String getTaskNoFromIndex(String carbonIndexFileName) {
+      // Get the file name from path
+      String fileName = getFileName(carbonIndexFileName);
+      return fileName.substring(0, fileName.indexOf("-"));
+    }
+
+    public static String getBucketNoFromIndex(String carbonIndexFileName) {
+      // Get the file name from path
+      String fileName = getFileName(carbonIndexFileName);
+      int startIndex = fileName.indexOf("-") + 1;
+      int endIndex = fileName.indexOf("-", startIndex + 1);
+      return fileName.substring(startIndex, endIndex);
+    }
+
     /**
      * Gets the file name from file path
      */

--- a/core/src/test/java/org/apache/carbondata/core/util/DataFileFooterConverterTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/util/DataFileFooterConverterTest.java
@@ -147,7 +147,7 @@ public class DataFileFooterConverterTest {
     List<TableBlockInfo> tableBlockInfoList = new ArrayList<>();
     tableBlockInfoList.add(tableBlockInfo);
     List<DataFileFooter> dataFileFooterList =
-        dataFileFooterConverter.getIndexInfo("indexfile", tableBlockInfoList);
+        dataFileFooterConverter.getIndexInfo("indexfile", null);
     byte[] exp = dataFileFooterList.get(0).getBlockletIndex().getBtreeIndex().getStartKey();
     byte[] res = "1".getBytes();
     for (int i = 0; i < exp.length; i++) {

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/internal/index/impl/InMemoryBTreeIndex.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/internal/index/impl/InMemoryBTreeIndex.java
@@ -112,7 +112,7 @@ class InMemoryBTreeIndex implements Index {
         List<TableBlockInfo> tableBlockInfoList = getTableBlockInfo(job);
         Map<String, List<TableBlockInfo>> segmentToTableBlocksInfos = new HashMap<>();
         segmentToTableBlocksInfos.put(segment.getId(), tableBlockInfoList);
-        segmentUniqueIdentifier.setSegmentToTableBlocksInfos(segmentToTableBlocksInfos);
+        segmentUniqueIdentifier.setSegmentToTableBlocksInfos(null);
         // TODO: loadAndGetTaskIdToSegmentsMap can be optimized, use tableBlockInfoList as input
         // get Btree blocks for given segment
         segmentTaskIndexWrapper = cacheClient.getSegmentAccessClient().get(segmentUniqueIdentifier);


### PR DESCRIPTION
In current implements of CarbonInputFormat.getDataBlocksOfSegment, 
1. Get all of the carbondata splits in segments directory.
2. Read the carbonindex and construct the B-tree.
3. Apply filter and get matching splits.

I think we get some useless splits and the operator of getSplits is expensive. So we'd better to do the getSplits after filter:
1. List the segment directory, and filter the path of carbonindex.
2. Read the carbonindex and construct the B-tree.
3. Apply filter and get matching blocks.
4. Get carbondata splits from filtered blocks.

TODOList:
- [ ] How to do something about IUD(isValidBlockBasedOnUpdateDetails)?
- [ ] Fix bug in suite

@jackylk @QiangCai Plz review the code when you have time.