### PR TITLE
[CARBONDATA-921] resolved bug for unable to select outoforder columns in hive

### DIFF
--- a/integration/hive/src/main/java/org/apache/carbondata/hive/CarbonHiveRecordReader.java
+++ b/integration/hive/src/main/java/org/apache/carbondata/hive/CarbonHiveRecordReader.java
@@ -78,22 +78,21 @@ public class CarbonHiveRecordReader extends CarbonRecordReader<ArrayWritable>
     }
     List<TableBlockInfo> tableBlockInfoList = CarbonHiveInputSplit.createBlocks(splitList);
     queryModel.setTableBlockInfos(tableBlockInfoList);
-    readSupport.initialize(queryModel.getProjectionColumns(),
-        queryModel.getAbsoluteTableIdentifier());
+    readSupport.initialize(queryModel.getProjectionColumns(), queryModel.getAbsoluteTableIdentifier());
     try {
       carbonIterator = new ChunkRowIterator(queryExecutor.execute(queryModel));
     } catch (QueryExecutionException e) {
       throw new IOException(e.getMessage(), e.getCause());
     }
     if (valueObj == null) {
-      valueObj = new ArrayWritable(Writable.class,
-          new Writable[queryModel.getProjectionColumns().length]);
+      valueObj = new ArrayWritable(Writable.class, new Writable[queryModel.getProjectionColumns().length]);
     }
 
     final TypeInfo rowTypeInfo;
     final List<String> columnNames;
     List<TypeInfo> columnTypes;
     // Get column names and sort order
+    final String colIds = conf.get("hive.io.file.readcolumn.ids");
     final String columnNameProperty = conf.get("hive.io.file.readcolumn.names");
     final String columnTypeProperty = conf.get(serdeConstants.LIST_COLUMN_TYPES);
 
@@ -107,9 +106,15 @@ public class CarbonHiveRecordReader extends CarbonRecordReader<ArrayWritable>
     } else {
       columnTypes = TypeInfoUtils.getTypeInfosFromTypeString(columnTypeProperty);
     }
-    columnTypes = columnTypes.subList(0, columnNames.size());
+
+    String[] arraySelectedColId = colIds.split(",");
+    List<TypeInfo> reqColTypes = new ArrayList<TypeInfo>();
+
+    for (String anArrayColId : arraySelectedColId) {
+      reqColTypes.add(columnTypes.get(Integer.parseInt(anArrayColId)));
+    }
     // Create row related objects
-    rowTypeInfo = TypeInfoFactory.getStructTypeInfo(columnNames, columnTypes);
+    rowTypeInfo = TypeInfoFactory.getStructTypeInfo(columnNames, reqColTypes);
     this.objInspector = new CarbonObjectInspector((StructTypeInfo) rowTypeInfo);
   }
 

--- a/integration/hive/src/main/scala/org/apache/carbondata/hiveexample/HiveExample.scala
+++ b/integration/hive/src/main/scala/org/apache/carbondata/hiveexample/HiveExample.scala
@@ -175,6 +175,63 @@ object HiveExample {
       rowsFetched = rowsFetched + 1
     }
     println(s"******Total Number Of Rows Fetched ****** $rowsFetched")
+
+    logger.info("Fetching the Individual Columns ")
+    //fetching the seperate columns
+    var individualColRowsFetched = 0
+
+    val resultIndividualCol = stmt.executeQuery("SELECT NAME FROM HIVE_CARBON_EXAMPLE")
+
+    while(resultIndividualCol.next){
+      if (individualColRowsFetched == 0) {
+        println("+--------------+")
+        println("| NAME         |")
+
+        println("+---++---------+")
+
+        val resultName = resultIndividualCol.getString("name")
+
+        println(s"| $resultName    |")
+        println("+---+" + "+---------+")
+      }
+      else {
+        val resultName = resultIndividualCol.getString("NAME")
+
+        println(s"| $resultName      |" )
+        println("+---+" + "+---------+" )
+      }
+      individualColRowsFetched =  individualColRowsFetched +1
+    }
+    println(s" ********** Total Rows Fetched When Quering The Individual Column ********** $individualColRowsFetched")
+
+    logger.info("Fetching the Out Of Order Columns ")
+
+    val resultOutOfOrderCol = stmt.executeQuery("SELECT SALARY,ID,NAME FROM HIVE_CARBON_EXAMPLE")
+    var outOfOrderColFetched = 0
+    while (resultOutOfOrderCol.next()){
+      if (outOfOrderColFetched == 0) {
+        println("+---+" + "+-------+" + "+--------------+")
+        println("| Salary|" + "| ID |" + "| NAME        |")
+
+        println("+---+" + "+-------+" + "+--------------+")
+
+        val resultId = resultOutOfOrderCol.getString("id")
+        val resultName = resultOutOfOrderCol.getString("name")
+        val resultSalary = resultOutOfOrderCol.getString("salary")
+
+        println(s"| $resultSalary |" + s"| $resultId |" + s"| $resultName  |")
+        println("+---+" + "+-------+" + "+--------------+")
+      }
+      else {
+        val resultId = resultOutOfOrderCol.getString("ID")
+        val resultName = resultOutOfOrderCol.getString("NAME")
+        val resultSalary = resultOutOfOrderCol.getString("SALARY")
+
+        println(s"| $resultSalary |" + s"| $resultId |" + s"| $resultName   |")
+        println("+---+" + "+-------+" + "+--------------+")
+      }
+      outOfOrderColFetched =  outOfOrderColFetched +1
+    }
     hiveEmbeddedServer2.stop()
     System.exit(0)
   }


### PR DESCRIPTION
trying to select columns which are out of order always result in class cast exception

- added functionality for reading columns which are out of order in hive`
- tested manually with hive cli 
-added example for selecting columns out of order in hive in hive example
 
