### PR TITLE
[CARBONDATA-998] Don't request executors when we use carbon distribution

### DIFF
--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
@@ -123,8 +123,8 @@ class CarbonScanRDD(
         // create a list of block based on split
         val blockList = splits.asScala.map(_.asInstanceOf[Distributable])
 
-        // get the list of executors and map blocks to executors based on locality
-        val activeNodes = DistributionUtil.ensureExecutorsAndGetNodeList(blockList, sparkContext)
+        // get the list of executors
+        val activeNodes = DistributionUtil.getNodeList(sparkContext)
 
         // divide the blocks among the tasks of the nodes as per the data locality
         val nodeBlockMapping = CarbonLoaderUtil.nodeBlockTaskMapping(blockList.asJava, -1,

--- a/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -580,8 +580,7 @@ object CarbonDataRDDFactory {
           }
           // group blocks to nodes, tasks
           val startTime = System.currentTimeMillis
-          val activeNodes = DistributionUtil
-              .ensureExecutorsAndGetNodeList(blockList, sqlContext.sparkContext)
+          val activeNodes = DistributionUtil.getNodeList(sqlContext.sparkContext).distinct
           val nodeBlockMapping =
             CarbonLoaderUtil
                 .nodeBlockMapping(blockList.toSeq.asJava, -1, activeNodes.toList.asJava).asScala
@@ -631,11 +630,7 @@ object CarbonDataRDDFactory {
         try {
           val rdd = dataFrame.get.rdd
 
-          val nodeNumOfData = rdd.partitions.flatMap[String, Array[String]]{ p =>
-            DataLoadPartitionCoalescer.getPreferredLocs(rdd, p).map(_.host)
-          }.distinct.size
-          val nodes = DistributionUtil.ensureExecutorsByNumberAndGetNodeList(nodeNumOfData,
-            sqlContext.sparkContext)
+          val nodes = DistributionUtil.getNodeList(sqlContext.sparkContext)
           val newRdd = new DataLoadCoalescedRDD[Row](rdd, nodes.toArray.distinct)
 
           status = new NewDataFrameLoaderRDD(sqlContext.sparkContext,


### PR DESCRIPTION
In the current implementation, carbon request executors if it need more executors. This brings the following questions:
1. Carbon interferes with spark dispatch to make request/remove executors confusedly.
2. Carbon will involk DistributionUtil.getDistinctNodesList and sleep some times to make sure the executors are assigned, it wastes a lot of time.

We'd better make the data scan and schedule independently.

### In CarbonData layout
Make one task scan multiple splits to make the input size of task larger and the number of tasks fewer.
### In Spark layout(dynamic allocation is enable)
Request executors if some resources are released by other apps and we won't reach the max number of executors.

Now, I only invoke DistributionUtil.getNodeList insteads of DistributionUtil.ensureExecutorsAndGetNodeList. We can talked about this idea here and then I can remove the useless code about DistributionUtil.ensureExecutorsAndGetNodeList.

cc @jackylk @QiangCai @kumarvishal09 