### PR TITLE
[CARBONDATA-1038] Fixed exception in dictionary_exclude for string datatype

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/dataretention/DataRetentionConcurrencyTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/dataretention/DataRetentionConcurrencyTestCase.scala
@@ -67,7 +67,6 @@ class DataRetentionConcurrencyTestCase extends QueryTest with BeforeAndAfterAll 
   }
 
   test("DataRetention_Concurrency_load_date") {
-
     sql(
       s"LOAD DATA LOCAL INPATH '$resourcesPath/dataretention1.csv' INTO TABLE concurrent " +
       "OPTIONS('DELIMITER' =  ',')")

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/TableCreator.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/TableCreator.scala
@@ -39,7 +39,7 @@ object TableCreator {
 
   // detects whether datatype is part of dictionary_exclude
   def isDataTypeSupportedForDictionary_Exclude(columnDataType: String): Boolean = {
-    val dataTypes = Array("string")
+    val dataTypes = Array("stringtype")
     dataTypes.exists(x => x.equalsIgnoreCase(columnDataType))
   }
 


### PR DESCRIPTION
Analysis: 
1. The data type that could be added to the dictionary_exclude list was listed as "string" instead of "stringtype" which caused the exception.
2. If no table name is provided in the options while creating table then the default table name of "defalut_table" is taken. Which is not the expected result.

Solution: 
1. changed the datatype from "string" to "stringtype".
2. Throw exception instead of taking "default_table" as the table name if no name is provided.
