### PR TITLE
[CARBONDATA-1037] Changed dbname to lowercase in rename table

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/DDLStrategy.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/DDLStrategy.scala
@@ -39,11 +39,13 @@ class DDLStrategy(sparkSession: SparkSession) extends SparkStrategy {
         ExecutedCommandExec(LoadTable(identifier.database, identifier.table.toLowerCase, path,
           Seq(), Map(), isOverwrite)) :: Nil
       case alter@AlterTableRenameCommand(oldTableIdentifier, newTableIdentifier, _) =>
+        val dbOption = oldTableIdentifier.database.map(_.toLowerCase)
+        val tableIdentifier = TableIdentifier(oldTableIdentifier.table.toLowerCase(), dbOption)
         val isCarbonTable = CarbonEnv.getInstance(sparkSession).carbonMetastore
-          .tableExists(oldTableIdentifier)(
+          .tableExists(tableIdentifier)(
             sparkSession)
         if (isCarbonTable) {
-          val renameModel = AlterTableRenameModel(oldTableIdentifier, newTableIdentifier)
+          val renameModel = AlterTableRenameModel(tableIdentifier, newTableIdentifier)
           ExecutedCommandExec(AlterTableRenameTable(renameModel)) :: Nil
         } else {
           ExecutedCommandExec(alter) :: Nil

--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/restructure/AlterTableValidationTestCase.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/restructure/AlterTableValidationTestCase.scala
@@ -416,6 +416,14 @@ class AlterTableValidationTestCase extends QueryTest with BeforeAndAfterAll {
       .exists())
   }
 
+  test("table rename with dbname in Camel Case") {
+    sql("drop table if exists uniqdata")
+    sql("""CREATE TABLE uniqdata (CUST_ID int,CUST_NAME String) STORED BY 'org.apache.carbondata.format'""")
+    sql("""insert into table uniqdata values(1,"hello")""")
+    sql("alter table Default.uniqdata rename to uniqdata1")
+    checkAnswer(sql("select * from Default.uniqdata1"), Row(1,"hello"))
+  }
+
   override def afterAll {
     sql("DROP TABLE IF EXISTS restructure")
     sql("DROP TABLE IF EXISTS restructure_new")
@@ -423,5 +431,6 @@ class AlterTableValidationTestCase extends QueryTest with BeforeAndAfterAll {
     sql("DROP TABLE IF EXISTS restructure_bad")
     sql("DROP TABLE IF EXISTS restructure_badnew")
     sql("DROP TABLE IF EXISTS lock_rename")
+    sql("drop table if exists uniqdata")
   }
 }


### PR DESCRIPTION
Analysis: Database name was not being converted to lowercase which caused inconsistency in the rename process.

Solution: convert database and table name to lowercase