### PR TITLE
[CARBONDATA-1169] Support input read bytes size / Record metrics in the UI

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/BlockIndexStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/BlockIndexStore.java
@@ -47,6 +47,7 @@ import org.apache.carbondata.core.mutate.CarbonUpdateUtil;
 import org.apache.carbondata.core.mutate.UpdateVO;
 import org.apache.carbondata.core.scan.model.QueryModel;
 import org.apache.carbondata.core.util.CarbonProperties;
+import org.apache.carbondata.core.util.TaskMetricsMap;
 
 /**
  * This class is used to load the B-Tree in Executor LRU Cache
@@ -290,8 +291,15 @@ public class BlockIndexStore<K, V> extends AbstractBlockIndexStoreCache<K, V> {
     }
 
     @Override public AbstractIndex call() throws Exception {
-      // load and return the loaded blocks
-      return get(tableBlockUniqueIdentifier);
+      try {
+        //register thread callback for calculating metrics
+        TaskMetricsMap.getInstance().registerThreadCallback();
+        // load and return the loaded blocks
+        return get(tableBlockUniqueIdentifier);
+      } finally {
+        // update read bytes metrics for this thread
+        TaskMetricsMap.getInstance().updateReadBytes(Thread.currentThread().getId());
+      }
     }
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/util/TaskMetricsMap.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/TaskMetricsMap.java
@@ -1,0 +1,207 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.core.util;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.apache.carbondata.common.logging.LogService;
+import org.apache.carbondata.common.logging.LogServiceFactory;
+
+import org.apache.hadoop.fs.FileSystem;
+
+/**
+ * This class maintains task level metrics info for all spawned child threads and parent task thread
+ */
+public class TaskMetricsMap {
+
+  private static final LogService LOGGER =
+      LogServiceFactory.getLogService(TaskMetricsMap.class.getName());
+
+  public static final InheritableThreadLocal<Long> threadLocal = new InheritableThreadLocal<>();
+  /**
+   * In this map we are maintaining all spawned child threads callback info for each parent thread
+   * here key = parent thread id & values =  list of spawned child threads callbacks
+   */
+  public static Map<Long, List<CarbonFSBytesReadOnThreadCallback>> metricMap =
+      new ConcurrentHashMap<>();
+
+  public static TaskMetricsMap taskMetricsMap = new TaskMetricsMap();
+
+  public static TaskMetricsMap getInstance() {
+    return taskMetricsMap;
+  }
+
+  /**
+   * registers current thread callback using parent thread id
+   *
+   * @return
+   */
+  public void registerThreadCallback() {
+    // parent thread id should not be null as we are setting the same for all RDDs
+    if (null != threadLocal.get()) {
+      long parentThreadId = threadLocal.get();
+      new CarbonFSBytesReadOnThreadCallback(parentThreadId);
+    }
+  }
+
+  /**
+   * removes parent thread entry from map.
+   *
+   * @param threadId
+   */
+  public void removeEntry(long threadId) {
+    metricMap.remove(threadId);
+  }
+
+  /**
+   * returns all spawned child threads callback list of given parent thread
+   *
+   * @param threadId
+   * @return
+   */
+  public List<CarbonFSBytesReadOnThreadCallback> getCallbackList(long threadId) {
+    return metricMap.get(threadId);
+  }
+
+  public boolean isCallbackEmpty(long threadId) {
+    List<CarbonFSBytesReadOnThreadCallback> callbackList = getCallbackList(threadId);
+    if (null == callbackList) {
+      return true;
+    }
+    return callbackList.isEmpty();
+  }
+
+  /**
+   * This function updates read bytes of given thread
+   * After completing the task, each spawned child thread should update current read bytes,
+   * by calling this function.
+   *
+   * @param callbackThreadId
+   */
+  public void updateReadBytes(long callbackThreadId) {
+    // parent thread id should not be null as we are setting the same for all RDDs
+    if (null != threadLocal.get()) {
+      long parentThreadId = threadLocal.get();
+      List<CarbonFSBytesReadOnThreadCallback> callbackList = getCallbackList(parentThreadId);
+      if (null != callbackList) {
+        for (CarbonFSBytesReadOnThreadCallback callback : callbackList) {
+          if (callback.threadId == callbackThreadId) {
+            callback.updatedReadBytes += callback.readbytes();
+            break;
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * returns total task read bytes, by summing all parent & spawned threads readbytes
+   *
+   * @param threadName
+   * @return
+   */
+  public long getReadBytesSum(long threadName) {
+    List<CarbonFSBytesReadOnThreadCallback> callbacks = getCallbackList(threadName);
+    long sum = 0;
+    if (null != callbacks) {
+      for (CarbonFSBytesReadOnThreadCallback callback : callbacks) {
+        sum += callback.getReadBytes();
+      }
+    }
+    return sum;
+  }
+
+  public void clear() {
+    metricMap.clear();
+  }
+
+  /**
+   * adds spawaned thread callback entry in metricmap using parentThreadId
+   *
+   * @param parentThreadId
+   * @param callback
+   */
+  private void addEntry(long parentThreadId, CarbonFSBytesReadOnThreadCallback callback) {
+    List<CarbonFSBytesReadOnThreadCallback> callbackList = getCallbackList(parentThreadId);
+    if (null == callbackList) {
+      //create new list
+      List<CarbonFSBytesReadOnThreadCallback> list = new CopyOnWriteArrayList<>();
+      list.add(callback);
+      metricMap.put(parentThreadId, list);
+    } else {
+      // add to existing list
+      callbackList.add(callback);
+    }
+  }
+
+  /**
+   * This class maintains getReadBytes info of each thread
+   */
+  class CarbonFSBytesReadOnThreadCallback {
+    long baseline = 0;
+    long updatedReadBytes = 0;
+    long threadId = Thread.currentThread().getId();
+
+    CarbonFSBytesReadOnThreadCallback(long parentThread) {
+      // reads current thread readBytes
+      this.baseline = readbytes();
+      addEntry(parentThread, this);
+    }
+
+    /**
+     * returns current thread readbytes from FileSystem Statistics
+     *
+     * @return
+     */
+    public long readbytes() {
+      List<FileSystem.Statistics> statisticsList = FileSystem.getAllStatistics();
+      long sum = 0;
+      try {
+        for (FileSystem.Statistics statistics : statisticsList) {
+          Class statisticsClass = Class.forName(statistics.getClass().getName());
+          Method getThreadStatisticsMethod =
+              statisticsClass.getDeclaredMethod("getThreadStatistics");
+          Class statisticsDataClass =
+              Class.forName("org.apache.hadoop.fs.FileSystem$Statistics$StatisticsData");
+          Method getBytesReadMethod = statisticsDataClass.getDeclaredMethod("getBytesRead");
+          sum += (Long) getBytesReadMethod
+              .invoke(statisticsDataClass.cast(getThreadStatisticsMethod.invoke(statistics, null)),
+                  null);
+        }
+      } catch (Exception ex) {
+        LOGGER.debug(ex.getLocalizedMessage());
+      }
+      return sum;
+    }
+
+    /**
+     * After completing task, each child thread should update corresponding
+     * read bytes using updatedReadBytes method.
+     * if updatedReadBytes > 0 then return updatedReadBytes (i.e thread read bytes).
+     *
+     * @return
+     */
+    public long getReadBytes() {
+      return updatedReadBytes - baseline;
+    }
+  }
+}

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/CarbonRecordReader.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/CarbonRecordReader.java
@@ -47,6 +47,13 @@ public class CarbonRecordReader<T> extends AbstractRecordReader<T> {
   protected CarbonIterator<Object[]> carbonIterator;
 
   protected QueryExecutor queryExecutor;
+  private InputMetricsStats inputMetricsStats;
+
+  public CarbonRecordReader(QueryModel queryModel, CarbonReadSupport<T> readSupport,
+      InputMetricsStats inputMetricsStats) {
+    this(queryModel, readSupport);
+    this.inputMetricsStats = inputMetricsStats;
+  }
 
   public CarbonRecordReader(QueryModel queryModel, CarbonReadSupport<T> readSupport) {
     this.queryModel = queryModel;
@@ -92,6 +99,9 @@ public class CarbonRecordReader<T> extends AbstractRecordReader<T> {
 
   @Override public T getCurrentValue() throws IOException, InterruptedException {
     rowCount += 1;
+    if (null != inputMetricsStats) {
+      inputMetricsStats.incrementRecordRead(1L);
+    }
     return readSupport.readRow(carbonIterator.next());
   }
 

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/InputMetricsStats.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/InputMetricsStats.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.hadoop;
+
+import java.io.Serializable;
+import java.lang.Long;
+
+/**
+ * It gives statistics of number of bytes and record read
+ */
+public interface InputMetricsStats extends Serializable {
+
+  /**
+   * increment if record is read
+   */
+  void incrementRecordRead(Long recordRead);
+
+  /**
+   * update hdfs byte read
+   */
+  void updateAndClose();
+
+}

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/InitInputMetrics.java
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/InitInputMetrics.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.spark;
+
+import org.apache.carbondata.hadoop.CarbonMultiBlockSplit;
+import org.apache.carbondata.hadoop.InputMetricsStats;
+
+import org.apache.spark.TaskContext;
+
+
+/**
+ * Initializes bytes read call back
+ */
+public interface InitInputMetrics extends InputMetricsStats {
+
+  void initBytesReadCallback(TaskContext context, CarbonMultiBlockSplit carbonMultiBlockSplit);
+}

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonRDD.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonRDD.scala
@@ -26,7 +26,7 @@ import org.apache.spark.{Dependency, OneToOneDependency, Partition, SparkContext
 import org.apache.spark.rdd.RDD
 
 import org.apache.carbondata.core.metadata.schema.table.TableInfo
-import org.apache.carbondata.core.util.{CarbonProperties, CarbonSessionInfo, CarbonTaskInfo, SessionParams, ThreadLocalSessionInfo, ThreadLocalTaskInfo}
+import org.apache.carbondata.core.util.{CarbonProperties, CarbonSessionInfo, CarbonTaskInfo, SessionParams, TaskMetricsMap, ThreadLocalSessionInfo, ThreadLocalTaskInfo}
 
 /**
  * This RDD maintains session level ThreadLocal
@@ -53,6 +53,7 @@ abstract class CarbonRDD[T: ClassTag](@transient sc: SparkContext,
 
   final def compute(split: Partition, context: TaskContext): Iterator[T] = {
     ThreadLocalSessionInfo.setCarbonSessionInfo(carbonSessionInfo)
+    TaskMetricsMap.threadLocal.set(Thread.currentThread().getId)
     val carbonTaskInfo = new CarbonTaskInfo
     carbonTaskInfo.setTaskId(System.nanoTime)
     ThreadLocalTaskInfo.setCarbonTaskInfo(carbonTaskInfo)

--- a/integration/spark/src/main/scala/org/apache/spark/CarbonInputMetrics.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/CarbonInputMetrics.scala
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark
+
+import java.lang.Long
+
+import org.apache.spark.deploy.SparkHadoopUtil
+import org.apache.spark.executor.{DataReadMethod, InputMetrics}
+
+import org.apache.carbondata.common.logging.LogServiceFactory
+import org.apache.carbondata.hadoop.{CarbonMultiBlockSplit, InputMetricsStats}
+import org.apache.carbondata.spark.InitInputMetrics
+
+/**
+ * It gives statistics of number of bytes and record read
+ */
+class CarbonInputMetrics extends InitInputMetrics {
+  @transient val LOGGER = LogServiceFactory.getLogService(this.getClass.getName)
+  var inputMetrics: InputMetrics = _
+  var bytesReadCallback: Option[() => scala.Long] = _
+  var carbonMultiBlockSplit: CarbonMultiBlockSplit = _
+
+  def initBytesReadCallback(context: TaskContext,
+                            carbonMultiBlockSplit: CarbonMultiBlockSplit) {
+    inputMetrics = context.taskMetrics().getInputMetricsForReadMethod(DataReadMethod.Hadoop)
+    this.carbonMultiBlockSplit = carbonMultiBlockSplit;
+    bytesReadCallback = carbonMultiBlockSplit match {
+      case _: CarbonMultiBlockSplit =>
+        SparkHadoopUtil.get.getFSBytesReadOnThreadCallback()
+      case _ => None
+    }
+  }
+
+  def incrementRecordRead(recordRead: Long) {
+    inputMetrics.incRecordsRead(recordRead)
+  }
+
+  def updateAndClose() {
+    if (bytesReadCallback.isDefined) {
+      inputMetrics.updateBytesRead()
+    } else if (carbonMultiBlockSplit.isInstanceOf[CarbonMultiBlockSplit]) {
+      // If we can't get the bytes read from the FS stats, fall back to the split size,
+      // which may be inaccurate.
+      try {
+        inputMetrics.incBytesRead(carbonMultiBlockSplit.getLength)
+      } catch {
+        case e: java.io.IOException =>
+          LOGGER.warn("Unable to get input size to set InputMetrics for task:" + e.getMessage)
+      }
+    }
+  }
+}

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonScan.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonScan.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 
+import org.apache.spark.CarbonInputMetrics
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions._
@@ -27,7 +28,7 @@ import org.apache.spark.sql.execution.LeafNode
 import org.apache.spark.sql.hive.CarbonMetastore
 
 import org.apache.carbondata.core.scan.model._
-import org.apache.carbondata.hadoop.CarbonProjection
+import org.apache.carbondata.hadoop.{CarbonProjection, InputMetricsStats}
 import org.apache.carbondata.spark.CarbonFilters
 import org.apache.carbondata.spark.rdd.CarbonScanRDD
 
@@ -122,14 +123,14 @@ case class CarbonScan(
     columnProjection.foreach { attr =>
       projection.addColumn(attr.name)
     }
-
+    val inputMetricsStats: CarbonInputMetrics = new CarbonInputMetrics
     new CarbonScanRDD(
       ocRaw.sparkContext,
       projection,
       buildCarbonPlan.getFilterExpression,
       carbonTable.getAbsoluteTableIdentifier,
       carbonTable.getTableInfo.serialize(),
-      carbonTable.getTableInfo
+      carbonTable.getTableInfo, inputMetricsStats
     )
   }
 

--- a/integration/spark2/src/main/scala/org/apache/spark/CarbonInputMetrics.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/CarbonInputMetrics.scala
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark
+
+import java.lang.Long
+
+import org.apache.spark.deploy.SparkHadoopUtil
+import org.apache.spark.executor.InputMetrics
+
+import org.apache.carbondata.common.logging.LogServiceFactory
+import org.apache.carbondata.core.util.TaskMetricsMap
+import org.apache.carbondata.hadoop.CarbonMultiBlockSplit
+import org.apache.carbondata.spark.InitInputMetrics
+
+
+/**
+ * It gives statistics of number of bytes and record read
+ */
+class CarbonInputMetrics extends InitInputMetrics{
+  @transient val LOGGER = LogServiceFactory.getLogService(this.getClass.getName)
+    var inputMetrics: InputMetrics = _
+    // bytes read before compute by other map rdds in lineage
+    var existingBytesRead: Long = _
+    var carbonMultiBlockSplit: CarbonMultiBlockSplit = _
+
+  def initBytesReadCallback(context: TaskContext,
+      carbonMultiBlockSplit: CarbonMultiBlockSplit) {
+    inputMetrics = context.taskMetrics().inputMetrics
+    existingBytesRead = inputMetrics.bytesRead
+    this.carbonMultiBlockSplit = carbonMultiBlockSplit;
+  }
+
+  def incrementRecordRead(recordRead: Long) {
+    val value : scala.Long = recordRead
+    inputMetrics.incRecordsRead(value)
+    if (inputMetrics.recordsRead % SparkHadoopUtil.UPDATE_INPUT_METRICS_INTERVAL_RECORDS == 0) {
+      updateBytesRead()
+    }
+  }
+
+  def updateBytesRead(): Unit = {
+    inputMetrics
+      .setBytesRead(existingBytesRead
+                    + TaskMetricsMap.getInstance().getReadBytesSum(Thread.currentThread().getId))
+  }
+
+  def updateAndClose() {
+    // if metrics supported file system ex: hdfs
+    if (!TaskMetricsMap.getInstance().isCallbackEmpty(Thread.currentThread().getId)) {
+      updateBytesRead()
+     // after update clear parent thread entry from map.
+      TaskMetricsMap.getInstance().removeEntry(Thread.currentThread().getId)
+    } else if (carbonMultiBlockSplit.isInstanceOf[CarbonMultiBlockSplit]) {
+      // If we can't get the bytes read from the FS stats, fall back to the split size,
+      // which may be inaccurate.
+      try {
+        inputMetrics.incBytesRead(carbonMultiBlockSplit.getLength)
+      } catch {
+        case e: java.io.IOException =>
+          LOGGER.warn("Unable to get input size to set InputMetrics for task:" + e.getMessage)
+      }
+    }
+  }
+}

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonDatasourceHadoopRelation.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonDatasourceHadoopRelation.scala
@@ -21,6 +21,7 @@ import java.io.{ByteArrayOutputStream, DataOutputStream}
 
 import scala.collection.mutable.ArrayBuffer
 
+import org.apache.spark.CarbonInputMetrics
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.execution.command.LoadTableByInsert
@@ -34,7 +35,7 @@ import org.apache.carbondata.core.metadata.schema.table.CarbonTable
 import org.apache.carbondata.core.scan.expression.Expression
 import org.apache.carbondata.core.scan.expression.logical.AndExpression
 import org.apache.carbondata.core.util.{CarbonSessionInfo, ThreadLocalSessionInfo}
-import org.apache.carbondata.hadoop.CarbonProjection
+import org.apache.carbondata.hadoop.{CarbonProjection, InputMetricsStats}
 import org.apache.carbondata.spark.CarbonFilters
 import org.apache.carbondata.spark.rdd.CarbonScanRDD
 
@@ -71,14 +72,14 @@ case class CarbonDatasourceHadoopRelation(
 
     val projection = new CarbonProjection
     requiredColumns.foreach(projection.addColumn)
-
+    val inputMetricsStats: CarbonInputMetrics = new CarbonInputMetrics
     new CarbonScanRDD(
       sqlContext.sparkContext,
       projection,
       filterExpression.orNull,
       identifier,
       carbonTable.getTableInfo.serialize(),
-      carbonTable.getTableInfo)
+      carbonTable.getTableInfo, inputMetricsStats)
   }
 
   override def unhandledFilters(filters: Array[Filter]): Array[Filter] = new Array[Filter](0)


### PR DESCRIPTION
**Requirement** : Support store input size / Record metrics for carbon UI

**Solution** : Adding input read bytes size / Records details in carbon UI
**Example** :  Execute any query (select * query etc., )and check input size/ Records details in the UI

**Input size metrics** : We can use Hadoop FileSystem statistics  but it is based on thread local variables, this is ok if the RDD computation chain is running on the same thread, but in carbon we are spawning multiple threads for computating Btree load, dictionary, read block etc.,. So we need to maintain one global map to track readbytes for all spawned threads & return total task readbytes, by summing all parent and spawned thread readbytes.

**Record metrics:** increment record count for each row
