### PR TITLE
[CARBONDATA-1062] Data load fails if a column specified as sort column is of numeric data type

### DIFF
--- a/integration/spark-common-test/src/test/resources/numeric_column_invalid_values.csv
+++ b/integration/spark-common-test/src/test/resources/numeric_column_invalid_values.csv
@@ -1,0 +1,6 @@
+1,Pallavi,25
+2,Rahul,24
+3,Prabhat,twenty six
+7,Neha,25
+2,Geetika,22
+3,Sangeeta,26

--- a/integration/spark-common-test/src/test/resources/restructure/data7.csv
+++ b/integration/spark-common-test/src/test/resources/restructure/data7.csv
@@ -1,0 +1,2 @@
+spark1,abc
+spark2,pqr

--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/restructure/vectorreader/AddColumnTestCases.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/restructure/vectorreader/AddColumnTestCases.scala
@@ -331,6 +331,32 @@ class AddColumnTestCases extends QueryTest with BeforeAndAfterAll {
     sql("DROP TABLE IF EXISTS carbon_table")
   }
 
+  test("test compaction with all dictionary columns") {
+    sql("DROP TABLE IF EXISTS alter_dict")
+    sql("CREATE TABLE alter_dict(stringField string,charField string) STORED BY 'carbondata'")
+    sql(s"LOAD DATA LOCAL INPATH '$resourcesPath/restructure/data7.csv' INTO TABLE alter_dict options('FILEHEADER'='stringField,charField')")
+    sql("Alter table alter_dict drop columns(charField)")
+    sql(s"LOAD DATA LOCAL INPATH '$resourcesPath/restructure/data7.csv' INTO TABLE alter_dict options('FILEHEADER'='stringField')")
+    sql("Alter table alter_dict compact 'major'")
+    checkExistence(sql("show segments for table alter_dict"), true, "0Compacted")
+    checkExistence(sql("show segments for table alter_dict"), true, "1Compacted")
+    checkExistence(sql("show segments for table alter_dict"), true, "0.1Success")
+    sql("DROP TABLE IF EXISTS alter_dict")
+  }
+
+  test("test compaction with all no dictionary columns") {
+    sql("DROP TABLE IF EXISTS alter_no_dict")
+    sql("CREATE TABLE alter_no_dict(stringField string,charField string) STORED BY 'carbondata' TBLPROPERTIES('DICTIONARY_EXCLUDE'='stringField,charField')")
+    sql(s"LOAD DATA LOCAL INPATH '$resourcesPath/restructure/data7.csv' INTO TABLE alter_no_dict options('FILEHEADER'='stringField,charField')")
+    sql("Alter table alter_no_dict drop columns(charField)")
+    sql(s"LOAD DATA LOCAL INPATH '$resourcesPath/restructure/data7.csv' INTO TABLE alter_no_dict options('FILEHEADER'='stringField')")
+    sql("Alter table alter_no_dict compact 'major'")
+    checkExistence(sql("show segments for table alter_no_dict"), true, "0Compacted")
+    checkExistence(sql("show segments for table alter_no_dict"), true, "1Compacted")
+    checkExistence(sql("show segments for table alter_no_dict"), true, "0.1Success")
+    sql("DROP TABLE IF EXISTS alter_no_dict")
+  }
+
   override def afterAll {
     sql("DROP TABLE IF EXISTS addcolumntest")
     sql("drop table if exists hivetable")

--- a/processing/src/main/java/org/apache/carbondata/processing/merger/CompactionResultSortProcessor.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/merger/CompactionResultSortProcessor.java
@@ -121,6 +121,10 @@ public class CompactionResultSortProcessor extends AbstractResultProcessor {
    * whether the allocated tasks has any record
    */
   private boolean isRecordFound;
+  /**
+   * intermediate sort merger
+   */
+  private SortIntermediateFileMerger intermediateFileMerger;
 
   /**
    * @param carbonLoadModel
@@ -266,6 +270,7 @@ public class CompactionResultSortProcessor extends AbstractResultProcessor {
    */
   private void readAndLoadDataFromSortTempFiles() throws Exception {
     try {
+      intermediateFileMerger.finish();
       finalMerger.startFinalMerge();
       while (finalMerger.hasNext()) {
         Object[] rowRead = finalMerger.next();
@@ -328,7 +333,7 @@ public class CompactionResultSortProcessor extends AbstractResultProcessor {
     }
     dimensionColumnCount = dimensions.size();
     SortParameters parameters = createSortParameters();
-    SortIntermediateFileMerger intermediateFileMerger = new SortIntermediateFileMerger(parameters);
+    intermediateFileMerger = new SortIntermediateFileMerger(parameters);
     // TODO: Now it is only supported onheap merge, but we can have unsafe merge
     // as well by using UnsafeSortDataRows.
     this.sortDataRows = new SortDataRows(parameters, intermediateFileMerger);
@@ -348,10 +353,10 @@ public class CompactionResultSortProcessor extends AbstractResultProcessor {
    */
   private SortParameters createSortParameters() {
     return SortParameters
-        .createSortParameters(carbonLoadModel.getDatabaseName(), tableName, dimensionColumnCount,
-            segmentProperties.getComplexDimensions().size(), measureCount, noDictionaryCount,
-            carbonLoadModel.getPartitionId(), segmentId, carbonLoadModel.getTaskNo(),
-            noDictionaryColMapping, true);
+        .createSortParameters(carbonTable, carbonLoadModel.getDatabaseName(), tableName,
+            dimensionColumnCount, segmentProperties.getComplexDimensions().size(), measureCount,
+            noDictionaryCount, carbonLoadModel.getPartitionId(), segmentId,
+            carbonLoadModel.getTaskNo(), noDictionaryColMapping, true);
   }
 
   /**

--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/converter/impl/NonDictionaryFieldConverterImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/converter/impl/NonDictionaryFieldConverterImpl.java
@@ -55,11 +55,12 @@ public class NonDictionaryFieldConverterImpl implements FieldConverter {
         row.update(DataTypeUtil
             .getBytesBasedOnDataTypeForNoDictionaryColumn(dimensionValue, dataType), index);
       } catch (Throwable ex) {
-        if (dimensionValue.length() != 0 || isEmptyBadRecord) {
+        if (dimensionValue.length() > 0 || isEmptyBadRecord) {
           logHolder.setReason(
               "The value " + " \"" + dimensionValue + "\"" + " with column name " + column
                   .getColName() + " and column data type " + dataType + " is not a valid "
                   + dataType + " type.");
+          row.update(CarbonCommonConstants.MEMBER_DEFAULT_VAL_ARRAY, index);
         } else {
           row.update(new byte[0], index);
         }


### PR DESCRIPTION
Fixes include: 
1. If a numeric data type column is specified as sort column and if it contains non numeric value then data load fails.
2. Intermediate merger thread is not shutdown before starting final merge sort during alter table compaction. This can lead to file not found exception.
3. During compaction after restructure operation, number of sort columns and number of no dictionary sort columns are not getting population during sorting which will lead to unsorted data being written to file and sometimes failure of compaction after restructure operation.

Fix: 
1. In case when bad records action is force and given value is invalid for a datatype update the row with default null value array.
2. Call finish on intermediate merger thread before starting final merge sort merge
3. Populate the number of sort and no sort columns from carbon table during compaction after restructure operation.
