### PR TITLE
[CARBONDATA-1064] Updated null check for right expression in not in expression

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/scan/expression/conditional/NotInExpression.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/expression/conditional/NotInExpression.java
@@ -42,7 +42,7 @@ public class NotInExpression extends BinaryConditionalExpression {
     if (setOfExprResult == null) {
       ExpressionResult val = null;
       ExpressionResult rightRsult = right.evaluate(value);
-      // Both left and right results need to be checked for null because NotInExpression is basically
+      // Both left and right result need to be checked for null because NotInExpression is basically
       // an And Operation on the list of predicates that are provided.
       // Example: x in (1,2,null) would be converted to x=1 AND x=2 AND x=null.
       // If any of the predicates is null then the result is unknown for all the predicates thus

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/detailquery/ExpressionWithNullTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/detailquery/ExpressionWithNullTestCase.scala
@@ -38,6 +38,7 @@ class ExpressionWithNullTestCase extends QueryTest with BeforeAndAfterAll {
   }
 
   test("test to check in expression with null values") {
+    checkAnswer(sql("select * from expression_test where id in (1,2,'', NULL, ' ')"), sql("select * from expression_test_hive where id in (1,2,' ', NULL, ' ')"))
     checkAnswer(sql("select * from expression_test where id in (1,2,'')"), sql("select * from expression_test_hive where id in (1,2,'')"))
     checkAnswer(sql("select * from expression_test where id in ('')"), sql("select * from expression_test_hive where id in ('')"))
     checkAnswer(sql("select * from expression_test where number in (null)"), sql("select * from expression_test_hive where number in (null)"))
@@ -54,6 +55,7 @@ class ExpressionWithNullTestCase extends QueryTest with BeforeAndAfterAll {
   }
 
   test("test to check not in expression with null values") {
+    checkAnswer(sql("select * from expression_test where id not in (1,2,'', NULL, ' ')"), sql("select * from expression_test_hive where id not in (1,2,' ', NULL, ' ')"))
     checkAnswer(sql("select * from expression_test where id not in (1,2,'')"), sql("select * from expression_test_hive where id not in (1,2,'')"))
     checkAnswer(sql("select * from expression_test where id not in ('')"), sql("select * from expression_test_hive where id not in ('')"))
     checkAnswer(sql("select * from expression_test where number not in (null)"), sql("select * from expression_test_hive where number not in (null)"))


### PR DESCRIPTION
Analysis: Right expression value was null in NotInExpression which cased the select query to throw NullPointerException

Solution: Move the null check at the beginning