### PR TITLE
[CARBONDATA-1076] Join Issue caused by dictionary and shuffle exchange

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/optimizer/CarbonLateDecodeRule.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/optimizer/CarbonLateDecodeRule.scala
@@ -180,7 +180,7 @@ class CarbonLateDecodeRule extends Rule[LogicalPlan] with PredicateHelper {
     def addTempDecoder(currentPlan: LogicalPlan): LogicalPlan = {
 
       def transformAggregateExpression(agg: Aggregate,
-          attrsOnGroup: util.HashSet[AttributeReferenceWrapper]  = null): LogicalPlan = {
+          attrsOnGroup: util.HashSet[AttributeReferenceWrapper] = null): LogicalPlan = {
         val attrsOndimAggs = new util.HashSet[AttributeReferenceWrapper]
         if (attrsOnGroup != null) {
           attrsOndimAggs.addAll(attrsOnGroup)


### PR DESCRIPTION
When under join aggregate plan is there then there is a high chance of having same partitioning so it will generate single exchange instead of two. So in that case better push down the decoder to aggregate rather than handling at join phase.