### PR TITLE
[CARBONDATA-1083] Fixed Build failure issue on presto branch

### DIFF
--- a/integration/presto/pom.xml
+++ b/integration/presto/pom.xml
@@ -41,10 +41,11 @@
       <version>0.9.3</version>
     </dependency>
 
+    <!-- https://mvnrepository.com/artifact/org.apache.carbondata/carbondata-core -->
     <dependency>
       <groupId>org.apache.carbondata</groupId>
       <artifactId>carbondata-core</artifactId>
-      <version>${project.version}</version>
+      <version>1.1.0</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Updated carbondata-core version in presto's pom.xml as the previous version was causing compilation errors and build failures.