### PR TITLE
[CARBONDATA-1093] During single pass load user data is printed in logs

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/dictionary/client/DictionaryClientHandler.java
+++ b/core/src/main/java/org/apache/carbondata/core/dictionary/client/DictionaryClientHandler.java
@@ -91,7 +91,14 @@ public class DictionaryClientHandler extends ChannelInboundHandlerAdapter {
     try {
       dictionaryMessage = responseMsgQueue.poll(100, TimeUnit.SECONDS);
       if (dictionaryMessage == null) {
-        throw new RuntimeException("Request timed out for key : " + key);
+        StringBuilder message = new StringBuilder();
+        message.append("DictionaryMessage { ColumnName: ")
+            .append(key.getColumnName())
+            .append(", DictionaryValue: ")
+            .append(key.getDictionaryValue())
+            .append(", type: ")
+            .append(key.getType());
+        throw new RuntimeException("Request timed out for key : " + message);
       }
       return dictionaryMessage;
     } catch (Exception e) {

--- a/core/src/test/java/org/apache/carbondata/core/dictionary/client/DictionaryClientTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/dictionary/client/DictionaryClientTest.java
@@ -19,6 +19,8 @@ package org.apache.carbondata.core.dictionary.client;
 
 import java.io.File;
 import java.util.Arrays;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.dictionary.generator.key.DictionaryMessage;
@@ -33,6 +35,8 @@ import org.apache.carbondata.core.metadata.schema.table.column.CarbonDimension;
 import org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema;
 import org.apache.carbondata.core.util.CarbonProperties;
 
+import mockit.Mock;
+import mockit.MockUp;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -158,6 +162,22 @@ public class DictionaryClientTest {
     client.shutDown();
 
     // Shutdown the server
+  }
+
+  @Test public void testToCheckIfCorrectTimeOutExceptionMessageIsThrown() {
+    new MockUp<LinkedBlockingQueue<DictionaryMessage>>() {
+      @SuppressWarnings("unused")
+      @Mock
+      DictionaryMessage poll(long timeout, TimeUnit unit) throws InterruptedException {
+        return null;
+      }
+    };
+    try {
+      testClient();
+      Assert.fail();
+    } catch (Exception e) {
+      Assert.assertFalse(e.getMessage().contains("data"));
+    }
   }
 
   @After public void tearDown() {


### PR DESCRIPTION
If the server fails to respond to the client then the client throws a timeout exception and the user data is printed in Executor logs.

Solution: Change the error message so that no sensitive data is printed.