### PR TITLE
[CARBONDATA-1088] Added interfaces for Data Map frame work. 

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/events/ChangeEvent.java
+++ b/core/src/main/java/org/apache/carbondata/core/events/ChangeEvent.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.core.events;
+
+/**
+ * Change event for any updates in store.
+ */
+public interface ChangeEvent<T> {
+
+  EventType getEventType();
+
+  T getEventData();
+
+  void setEventData(T data);
+
+  enum EventType {
+    DELETE,UPDATE,REFERESH
+  }
+}
+
+

--- a/core/src/main/java/org/apache/carbondata/core/events/ChangeEvent.java
+++ b/core/src/main/java/org/apache/carbondata/core/events/ChangeEvent.java
@@ -28,7 +28,7 @@ public interface ChangeEvent<T> {
   void setEventData(T data);
 
   enum EventType {
-    DELETE,UPDATE,REFERESH
+    INSERT,DELETE,UPDATE,REFRESH
   }
 }
 

--- a/core/src/main/java/org/apache/carbondata/core/events/EventListener.java
+++ b/core/src/main/java/org/apache/carbondata/core/events/EventListener.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.core.events;
+
+/**
+ * Event listener
+ */
+public interface EventListener {
+
+  void fireEvent(ChangeEvent event);
+}

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/Blocklet.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/Blocklet.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.core.indexstore;
+
+import java.io.Serializable;
+
+/**
+ * Blocklet
+ */
+public class Blocklet implements Serializable {
+
+  private String path;
+
+  private String blockletId;
+
+  public Blocklet(String path, String blockletId) {
+    this.path = path;
+    this.blockletId = blockletId;
+  }
+
+  public String getPath() {
+    return path;
+  }
+
+  public String getBlockletId() {
+    return blockletId;
+  }
+}

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/DataMap.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/DataMap.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.core.indexstore;
+
+import java.util.List;
+
+import org.apache.carbondata.core.scan.filter.resolver.FilterResolverIntf;
+
+/**
+ * Interface for adding and retrieving index data.
+ */
+public interface DataMap {
+
+  /**
+   * Give the writer to write the data.
+   *
+   * @return
+   */
+  DataMapWriter getWriter();
+
+  /**
+   * It is called to load the data map to memory or to initialize it.
+   */
+  void init(String path);
+
+  /**
+   * Prune the datamap with filter expression. It returns the list of
+   * blocklets where these filters can exist.
+   *
+   * @param filterExp
+   * @return
+   */
+  List<Blocklet> prune(FilterResolverIntf filterExp);
+
+  /**
+   * Clear complete index table and release memory.
+   */
+  void clear();
+
+}

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/DataMapDistributable.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/DataMapDistributable.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.core.indexstore;
+
+import org.apache.carbondata.core.datastore.block.Distributable;
+
+/**
+ * Distributable class for datamap.
+ */
+public abstract class DataMapDistributable implements Distributable {
+
+  private String tablePath;
+
+  private String segmentId;
+
+  private String dataMapName;
+
+  public String getTablePath() {
+    return tablePath;
+  }
+
+  public void setTablePath(String tablePath) {
+    this.tablePath = tablePath;
+  }
+
+  public String getSegmentId() {
+    return segmentId;
+  }
+
+  public void setSegmentId(String segmentId) {
+    this.segmentId = segmentId;
+  }
+
+  public String getDataMapName() {
+    return dataMapName;
+  }
+
+  public void setDataMapName(String dataMapName) {
+    this.dataMapName = dataMapName;
+  }
+
+}

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/DataMapStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/DataMapStore.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.core.indexstore;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.carbondata.common.logging.LogService;
+import org.apache.carbondata.common.logging.LogServiceFactory;
+import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
+
+/**
+ * It maintains all the index tables in it.
+ */
+public class DataMapStore {
+
+  private static DataMapStore instance = new DataMapStore();
+
+  private Map<DataMapType, Map<String, TableDataMap>> dataMapMappping = new HashMap<>();
+
+  private static final LogService LOGGER =
+      LogServiceFactory.getLogService(DataMapStore.class.getName());
+
+  private DataMapStore() {
+
+  }
+
+  /**
+   * Get the datamap for reading data.
+   *
+   * @param dataMapName
+   * @param mapType
+   * @return
+   */
+  public TableDataMap getDataMap(AbsoluteTableIdentifier identifier, String dataMapName,
+      DataMapType mapType) {
+    Map<String, TableDataMap> map = dataMapMappping.get(mapType);
+    TableDataMap dataMap = null;
+    if (map == null) {
+      throw new RuntimeException("Datamap does not exist");
+    } else {
+      dataMap = map.get(dataMapName);
+      if (dataMap == null) {
+        throw new RuntimeException("Datamap does not exist");
+      }
+    }
+    // Initialize datamap
+    dataMap.init(identifier, dataMapName);
+    return dataMap;
+  }
+
+  /**
+   * Create new datamap instance using datamap type and path
+   *
+   * @param mapType
+   * @return
+   */
+  public TableDataMap createTableDataMap(AbsoluteTableIdentifier identifier, DataMapType mapType,
+      String dataMapName) {
+    Map<String, TableDataMap> map = dataMapMappping.get(mapType);
+    if (map == null) {
+      map = new HashMap<>();
+      dataMapMappping.put(mapType, map);
+    }
+    TableDataMap dataMap = map.get(dataMapName);
+    if (dataMap != null) {
+      throw new RuntimeException("Already datamap exists in that path with type " + mapType);
+    }
+
+    try {
+      //TODO create datamap using @mapType.getClassName())
+    } catch (Exception e) {
+      LOGGER.error(e);
+    }
+    dataMap.init(identifier, dataMapName);
+    map.put(dataMapName, dataMap);
+    return dataMap;
+  }
+
+  public void clearDataMap(String dataMapName, DataMapType mapType) {
+    Map<String, TableDataMap> map = dataMapMappping.get(mapType);
+    if (map != null && map.get(dataMapName) != null) {
+      map.remove(dataMapName).clear();
+    }
+  }
+
+  public static DataMapStore getInstance() {
+    return instance;
+  }
+
+}

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/DataMapStoreManager.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/DataMapStoreManager.java
@@ -26,16 +26,16 @@ import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
 /**
  * It maintains all the index tables in it.
  */
-public class DataMapStore {
+public class DataMapStoreManager {
 
-  private static DataMapStore instance = new DataMapStore();
+  private static DataMapStoreManager instance = new DataMapStoreManager();
 
   private Map<DataMapType, Map<String, TableDataMap>> dataMapMappping = new HashMap<>();
 
   private static final LogService LOGGER =
-      LogServiceFactory.getLogService(DataMapStore.class.getName());
+      LogServiceFactory.getLogService(DataMapStoreManager.class.getName());
 
-  private DataMapStore() {
+  private DataMapStoreManager() {
 
   }
 
@@ -98,7 +98,7 @@ public class DataMapStore {
     }
   }
 
-  public static DataMapStore getInstance() {
+  public static DataMapStoreManager getInstance() {
     return instance;
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/DataMapType.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/DataMapType.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.core.indexstore;
+
+/**
+ * Datamap type
+ */
+public enum DataMapType {
+  BLOCKLET("org.apache.carbondata.datamap.BlockletDataMap");
+
+  private String className;
+
+  DataMapType(String className) {
+    this.className = className;
+  }
+
+  public String getClassName() {
+    return className;
+  }
+}

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/DataMapWriter.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/DataMapWriter.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.core.indexstore;
+
+import java.io.DataOutput;
+
+/**
+ * Data Map writer
+ */
+public interface DataMapWriter<T> {
+
+  /**
+   * Initialize the data map writer with output stream
+   *
+   * @param outStream
+   */
+  void init(DataOutput outStream);
+
+  /**
+   * Add the index row to the in-memory store.
+   */
+  void writeData(T data);
+
+  /**
+   * Get the added row count
+   *
+   * @return
+   */
+  int getRowCount();
+
+  /**
+   * Finish writing of data map table, otherwise it will not be allowed to read.
+   */
+  void finish();
+
+}

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/TableDataMap.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/TableDataMap.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.core.indexstore;
+
+import java.util.List;
+
+import org.apache.carbondata.core.events.EventListener;
+import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
+import org.apache.carbondata.core.scan.filter.resolver.FilterResolverIntf;
+
+/**
+ * DataMap at the table level, user can add any number of datamaps for one table. Depends
+ * on the filter condition it can prune the blocklets.
+ */
+public interface TableDataMap extends EventListener {
+
+  /**
+   * It is called to initialize and load the required table datamap metadata.
+   */
+  void init(AbsoluteTableIdentifier identifier, String dataMapName);
+
+  /**
+   * Gives the writer to write the metadata information of this datamap at table level.
+   *
+   * @return
+   */
+  DataMapWriter getWriter();
+
+  /**
+   * Create the datamap using the segmentid  and name.
+   *
+   * @param identifier
+   * @param segmentId
+   * @return
+   */
+  DataMap createDataMap(AbsoluteTableIdentifier identifier, String segmentId);
+
+  /**
+   * Pass the valid segments and prune the datamap using filter expression
+   *
+   * @param segmentIds
+   * @param filterExp
+   * @return
+   */
+  List<Blocklet> prune(List<String> segmentIds, FilterResolverIntf filterExp);
+
+  /**
+   * This is used for making the datamap distributable.
+   * It takes the valid segments and returns all the datamaps as distributable objects so that
+   * it can be distributed across machines.
+   *
+   * @return
+   */
+  List<DataMapDistributable> toDistributable(List<String> segmentIds);
+
+  /**
+   * This method is used from any machine after it is distributed. It takes the distributable object
+   * to prune the filters.
+   *
+   * @param distributable
+   * @param filterExp
+   * @return
+   */
+  List<Blocklet> prune(DataMapDistributable distributable, FilterResolverIntf filterExp);
+
+  /**
+   * This method checks whether the columns and the type of filters supported
+   * for this datamap or not
+   *
+   * @param filterExp
+   * @return
+   */
+  boolean isFiltersSupported(FilterResolverIntf filterExp);
+
+  /**
+   * Clears table level datamap
+   */
+  void clear();
+
+}


### PR DESCRIPTION
All Block index and blocklet indexes will be moved to this interface. And also the future secondary index also will be used the same interfaces. 

Interfaces for DataMap storage.
1.DataMapStore class which maintains all DataMap  existed in carbondata. So it can be worked as independent service as well.
2. DataMap interface has facility to add and retrieve index data. It is single point contact for index writing, and retrieving.
3.Here all the data added to above interface will be stored in unsafe offheap/onheap memory.


