### PR TITLE
[CARBONDATA-1098] change PageStatistics to use exact type

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/ColumnPage.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/ColumnPage.java
@@ -145,18 +145,6 @@ public class ColumnPage {
     return columnPage;
   }
 
-  protected void updateStatisticsLong(long value) {
-    stats.updateLong(value);
-  }
-
-  protected void updateStatisticsDouble(double value) {
-    stats.updateDouble(value);
-  }
-
-  protected void updateStatisticsDecimal(byte[] value) {
-    stats.updateDecimal(value);
-  }
-
   protected static ColumnPage newVarLengthPage(byte[][] stringData) {
     ColumnPage columnPage = new ColumnPage(BYTE_ARRAY, stringData.length);
     columnPage.byteArrayData = stringData;

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/ColumnPage.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/ColumnPage.java
@@ -145,6 +145,18 @@ public class ColumnPage {
     return columnPage;
   }
 
+  protected void updateStatisticsLong(long value) {
+    stats.updateLong(value);
+  }
+
+  protected void updateStatisticsDouble(double value) {
+    stats.updateDouble(value);
+  }
+
+  protected void updateStatisticsDecimal(byte[] value) {
+    stats.updateDecimal(value);
+  }
+
   protected static ColumnPage newVarLengthPage(byte[][] stringData) {
     ColumnPage columnPage = new ColumnPage(BYTE_ARRAY, stringData.length);
     columnPage.byteArrayData = stringData;
@@ -173,21 +185,27 @@ public class ColumnPage {
       case BYTE:
         // TODO: change sort step to store as exact data type
         putByte(rowId, (byte) value);
+        stats.updateLong((byte) value);
         break;
       case SHORT:
         putShort(rowId, (short) value);
+        stats.updateLong((short) value);
         break;
       case INT:
         putInt(rowId, (int) value);
+        stats.updateLong((int) value);
         break;
       case LONG:
         putLong(rowId, (long) value);
+        stats.updateLong((long) value);
         break;
       case DOUBLE:
         putDouble(rowId, (double) value);
+        stats.updateDouble((double) value);
         break;
       case DECIMAL:
         putDecimalBytes(rowId, (byte[]) value);
+        stats.updateDecimal((byte[]) value);
         break;
       case BYTE_ARRAY:
         putBytes(rowId, (byte[]) value);
@@ -195,7 +213,6 @@ public class ColumnPage {
       default:
         throw new RuntimeException("unsupported data type: " + dataType);
     }
-    stats.update(value);
   }
 
   /**

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/PrimitiveCodec.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/PrimitiveCodec.java
@@ -20,19 +20,32 @@ package org.apache.carbondata.core.datastore.page;
 // Transformation type that can be applied to ColumnPage
 public interface PrimitiveCodec {
   void encode(int rowId, byte value);
+
   void encode(int rowId, short value);
+
   void encode(int rowId, int value);
+
   void encode(int rowId, long value);
+
   void encode(int rowId, float value);
+
   void encode(int rowId, double value);
 
   long decodeLong(byte value);
+
   long decodeLong(short value);
+
   long decodeLong(int value);
+
   double decodeDouble(byte value);
+
   double decodeDouble(short value);
+
   double decodeDouble(int value);
+
   double decodeDouble(long value);
+
   double decodeDouble(float value);
+
   double decodeDouble(double value);
 }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/statistics/ColumnPageStatsVO.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/statistics/ColumnPageStatsVO.java
@@ -28,14 +28,13 @@ import org.apache.carbondata.core.util.DataTypeUtil;
 public class ColumnPageStatsVO {
   private DataType dataType;
 
-  /** min and max value of the measures */
-  private Object min, max;
-
   /**
-   * the unique value is the non-exist value in the row,
-   * and will be used as storage key for null values of measures
+   * min and max value of the measures, only one of following will be used.
+   * non-exist value will be used as storage key for null values of measures
    */
-  private Object nonExistValue;
+  private long minLong, maxLong;
+  private double minDouble, maxDouble;
+  private BigDecimal minDecimal, maxDecimal;
 
   /** decimal count of the measures */
   private int decimal;
@@ -46,19 +45,16 @@ public class ColumnPageStatsVO {
       case SHORT:
       case INT:
       case LONG:
-        max = Long.MIN_VALUE;
-        min = Long.MAX_VALUE;
-        nonExistValue = Long.MIN_VALUE;
+        maxLong = Long.MIN_VALUE;
+        minLong = Long.MAX_VALUE;
         break;
       case DOUBLE:
-        max = Double.MIN_VALUE;
-        min = Double.MAX_VALUE;
-        nonExistValue = Double.MIN_VALUE;
+        maxDouble = Double.MIN_VALUE;
+        minDouble = Double.MAX_VALUE;
         break;
       case DECIMAL:
-        max = new BigDecimal(Double.MIN_VALUE);
-        min = new BigDecimal(Double.MAX_VALUE);
-        nonExistValue = new BigDecimal(Double.MIN_VALUE);
+        maxDecimal = new BigDecimal(Double.MIN_VALUE);
+        minDecimal = new BigDecimal(Double.MAX_VALUE);
         break;
     }
     decimal = 0;
@@ -66,86 +62,86 @@ public class ColumnPageStatsVO {
 
   public static ColumnPageStatsVO copyFrom(ValueEncoderMeta meta) {
     ColumnPageStatsVO instance = new ColumnPageStatsVO(meta.getType());
-    instance.min = meta.getMinValue();
-    instance.max = meta.getMaxValue();
-    instance.decimal = meta.getDecimal();
-    instance.nonExistValue = meta.getUniqueValue();
+    switch (meta.getType()) {
+      case BYTE:
+      case SHORT:
+      case INT:
+      case LONG:
+        instance.minLong = (long) meta.getMinValue();
+        instance.maxLong = (long) meta.getMaxValue();
+        instance.decimal = meta.getDecimal();
+        break;
+      case DOUBLE:
+        instance.minDouble = (double) meta.getMinValue();
+        instance.maxDouble = (double) meta.getMaxValue();
+        instance.decimal = meta.getDecimal();
+        break;
+      case DECIMAL:
+        instance.minDecimal = (BigDecimal) meta.getMinValue();
+        instance.maxDecimal = (BigDecimal) meta.getMaxValue();
+        instance.decimal = meta.getDecimal();
+        break;
+    }
     return instance;
   }
 
   /**
-   * update the statistics for the input row
+   * update the statistics for the null
    */
-  public void update(Object value) {
-    switch (dataType) {
-      case SHORT:
-        max = ((long) max > ((Short) value).longValue()) ? max : ((Short) value).longValue();
-        min = ((long) min < ((Short) value).longValue()) ? min : ((Short) value).longValue();
-        nonExistValue = (long) min - 1;
-        break;
-      case INT:
-        max = ((long) max > ((Integer) value).longValue()) ? max : ((Integer) value).longValue();
-        min = ((long) min  < ((Integer) value).longValue()) ? min : ((Integer) value).longValue();
-        nonExistValue = (long) min - 1;
-        break;
-      case LONG:
-        max = ((long) max > (long) value) ? max : value;
-        min = ((long) min < (long) value) ? min : value;
-        nonExistValue = (long) min - 1;
-        break;
-      case DOUBLE:
-        max = ((double) max > (double) value) ? max : value;
-        min = ((double) min < (double) value) ? min : value;
-        int num = getDecimalCount((double) value);
-        decimal = decimal > num ? decimal : num;
-        nonExistValue = (double) min - 1;
-        break;
-      case DECIMAL:
-        BigDecimal decimalValue = DataTypeUtil.byteToBigDecimal((byte[]) value);
-        decimal = decimalValue.scale();
-        BigDecimal val = (BigDecimal) min;
-        nonExistValue = (val.subtract(new BigDecimal(1.0)));
-        break;
-      case ARRAY:
-      case STRUCT:
-        // for complex type column, writer is not going to use stats, so, do nothing
+  public void updateNull() {
+//    switch (dataType) {
+//      case BYTE:
+//      case SHORT:
+//      case INT:
+//      case LONG:
+//        maxLong = (max > 0) ? max : 0L;
+//        min = ((long) min < 0) ? min : 0L;
+//        nonExistValue = (long) min - 1;
+//        break;
+//      case DOUBLE:
+//        max = ((double) max > 0d) ? max : 0d;
+//        min = ((double) min < 0d) ? min : 0d;
+//        int num = getDecimalCount(0d);
+//        decimal = decimal > num ? decimal : num;
+//        nonExistValue = (double) min - 1;
+//        break;
+//      case DECIMAL:
+//        BigDecimal decimalValue = BigDecimal.ZERO;
+//        decimal = decimalValue.scale();
+//        BigDecimal val = (BigDecimal) min;
+//        nonExistValue = (val.subtract(new BigDecimal(1.0)));
+//        break;
+//      case ARRAY:
+//      case STRUCT:
+//        // for complex type column, writer is not going to use stats, so, do nothing
+//
+//    }
+  }
+
+  public void updateLong(long value) {
+    maxLong = Math.max(maxLong, value);
+    minLong = Math.min(minLong, value);
+  }
+
+  public void updateDouble(double value) {
+    maxDouble = Math.max(maxDouble, value);
+    minDouble = Math.min(minDouble, value);
+    int num = getDecimalCount(value);
+    if (decimal < num) {
+      decimal = num;
     }
   }
 
-  public void updateNull() {
-    switch (dataType) {
-      case SHORT:
-        max = ((long) max > 0) ? max : 0L;
-        min = ((long) min < 0) ? min : 0L;
-        nonExistValue = (long) min - 1;
-        break;
-      case INT:
-        max = ((long) max > 0) ? max : 0L;
-        min = ((long) min  < 0) ? min : 0L;
-        nonExistValue = (long) min - 1;
-        break;
-      case LONG:
-        max = ((long) max > 0) ? max : 0L;
-        min = ((long) min < 0) ? min : 0L;
-        nonExistValue = (long) min - 1;
-        break;
-      case DOUBLE:
-        max = ((double) max > 0d) ? max : 0d;
-        min = ((double) min < 0d) ? min : 0d;
-        int num = getDecimalCount(0d);
-        decimal = decimal > num ? decimal : num;
-        nonExistValue = (double) min - 1;
-        break;
-      case DECIMAL:
-        BigDecimal decimalValue = BigDecimal.ZERO;
-        decimal = decimalValue.scale();
-        BigDecimal val = (BigDecimal) min;
-        nonExistValue = (val.subtract(new BigDecimal(1.0)));
-        break;
-      case ARRAY:
-      case STRUCT:
-        // for complex type column, writer is not going to use stats, so, do nothing
+  public void updateDecimal(byte[] value) {
+    //TODO: optimization it when changing format of output in sort step. do not create decimal
+    BigDecimal decimalValue = DataTypeUtil.byteToBigDecimal(value);
+    if (maxDecimal.compareTo(decimalValue) < 0) {
+      maxDecimal = decimalValue;
     }
+    if (minDecimal.compareTo(decimalValue) > 0) {
+      minDecimal = decimalValue;
+    }
+    decimal = decimalValue.scale();
   }
 
   /**
@@ -175,16 +171,17 @@ public class ColumnPageStatsVO {
   private byte[] getValueAsBytes(Object value) {
     ByteBuffer b;
     switch (dataType) {
+      case BYTE:
+      case SHORT:
+      case INT:
+      case LONG:
+        b = ByteBuffer.allocate(8);
+        b.putLong((Long) value);
+        b.flip();
+        return b.array();
       case DOUBLE:
         b = ByteBuffer.allocate(8);
         b.putDouble((Double) value);
-        b.flip();
-        return b.array();
-      case LONG:
-      case INT:
-      case SHORT:
-        b = ByteBuffer.allocate(8);
-        b.putLong((Long) value);
         b.flip();
         return b.array();
       case DECIMAL:
@@ -195,15 +192,36 @@ public class ColumnPageStatsVO {
   }
 
   public Object getMin() {
-    return min;
+    switch (dataType) {
+      case BYTE:
+      case SHORT:
+      case INT:
+      case LONG:
+        return minLong;
+      case FLOAT:
+      case DOUBLE:
+        return minDouble;
+      case DECIMAL:
+        return minDecimal;
+      default:
+        return null;
+    }
   }
 
   public Object getMax() {
-    return max;
-  }
-
-  public Object nonExistValue() {
-    return nonExistValue;
+    switch (dataType) {
+      case SHORT:
+      case INT:
+      case LONG:
+        return maxLong;
+      case FLOAT:
+      case DOUBLE:
+        return maxDouble;
+      case DECIMAL:
+        return maxDecimal;
+      default:
+        return null;
+    }
   }
 
   public int getDecimal() {
@@ -216,6 +234,19 @@ public class ColumnPageStatsVO {
 
   @Override
   public String toString() {
-    return String.format("min: %s, max: %s, decimal: %s ", min, max, decimal);
+    switch (dataType) {
+      case BYTE:
+      case SHORT:
+      case INT:
+      case LONG:
+        return String.format("min: %s, max: %s, decimal: %s ", minLong, maxLong, decimal);
+      case FLOAT:
+      case DOUBLE:
+        return String.format("min: %s, max: %s, decimal: %s ", minDouble, maxDouble, decimal);
+      case DECIMAL:
+        return String.format("min: %s, max: %s, decimal: %s ", minDecimal, maxDecimal, decimal);
+      default:
+        throw new RuntimeException("internal error, type: " + dataType);
+    }
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/statistics/MeasurePageStatsVO.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/statistics/MeasurePageStatsVO.java
@@ -23,7 +23,7 @@ import org.apache.carbondata.core.metadata.datatype.DataType;
 
 public class MeasurePageStatsVO {
   // statistics of each measure column
-  private Object[] min, max, nonExistValue;
+  private Object[] min, max;
   private int[] decimal;
 
   private DataType[] dataType;
@@ -32,35 +32,33 @@ public class MeasurePageStatsVO {
   private MeasurePageStatsVO() {
   }
 
-  public MeasurePageStatsVO(ColumnPage[] measurePages) {
-    min = new Object[measurePages.length];
-    max = new Object[measurePages.length];
-    nonExistValue = new Object[measurePages.length];
-    decimal = new int[measurePages.length];
-    dataType = new DataType[measurePages.length];
-    selectedDataType = new byte[measurePages.length];
+  public static MeasurePageStatsVO build(ColumnPage[] measurePages) {
+    MeasurePageStatsVO stats = new MeasurePageStatsVO();
+    stats.min = new Object[measurePages.length];
+    stats.max = new Object[measurePages.length];
+    stats.decimal = new int[measurePages.length];
+    stats.dataType = new DataType[measurePages.length];
+    stats.selectedDataType = new byte[measurePages.length];
     for (int i = 0; i < measurePages.length; i++) {
-      ColumnPageStatsVO stats = measurePages[i].getStatistics();
-      min[i] = stats.getMin();
-      max[i] = stats.getMax();
-      nonExistValue[i] = stats.nonExistValue();
-      decimal[i] = stats.getDecimal();
-      dataType[i] = measurePages[i].getDataType();
+      ColumnPageStatsVO vo = measurePages[i].getStatistics();
+      stats.min[i] = vo.getMin();
+      stats.max[i] = vo.getMax();
+      stats.decimal[i] = vo.getDecimal();
+      stats.dataType[i] = measurePages[i].getDataType();
     }
+    return stats;
   }
 
   public static MeasurePageStatsVO build(ValueEncoderMeta[] encoderMetas) {
     Object[] max = new Object[encoderMetas.length];
     Object[] min = new Object[encoderMetas.length];
     int[] decimal = new int[encoderMetas.length];
-    Object[] nonExistValue = new Object[encoderMetas.length];
     DataType[] dataType = new DataType[encoderMetas.length];
     byte[] selectedDataType = new byte[encoderMetas.length];
     for (int i = 0; i < encoderMetas.length; i++) {
       max[i] = encoderMetas[i].getMaxValue();
       min[i] = encoderMetas[i].getMinValue();
       decimal[i] = encoderMetas[i].getDecimal();
-      nonExistValue[i] = encoderMetas[i].getUniqueValue();
       dataType[i] = encoderMetas[i].getType();
       selectedDataType[i] = encoderMetas[i].getDataTypeSelected();
     }
@@ -70,7 +68,6 @@ public class MeasurePageStatsVO {
     stats.selectedDataType = selectedDataType;
     stats.min = min;
     stats.max = max;
-    stats.nonExistValue = nonExistValue;
     stats.decimal = decimal;
     return stats;
   }
@@ -91,13 +88,7 @@ public class MeasurePageStatsVO {
     return decimal[measureIndex];
   }
 
-  public Object getNonExistValue(int measureIndex) {
-    return nonExistValue[measureIndex];
-  }
-
   public byte getDataTypeSelected(int measureIndex) {
     return selectedDataType[measureIndex];
   }
-
-
 }

--- a/core/src/main/java/org/apache/carbondata/core/metadata/ValueEncoderMeta.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/ValueEncoderMeta.java
@@ -38,11 +38,6 @@ public class ValueEncoderMeta implements Serializable {
    */
   private Object minValue;
 
-  /**
-   * uniqueValue
-   */
-  private Object uniqueValue;
-
   private int decimal;
 
   private char type;
@@ -63,14 +58,6 @@ public class ValueEncoderMeta implements Serializable {
 
   public void setMinValue(Object minValue) {
     this.minValue = minValue;
-  }
-
-  public Object getUniqueValue() {
-    return uniqueValue;
-  }
-
-  public void setUniqueValue(Object uniqueValue) {
-    this.uniqueValue = uniqueValue;
   }
 
   public int getDecimal() {

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonMetadataUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonMetadataUtil.java
@@ -448,7 +448,6 @@ public class CarbonMetadataUtil {
     encoderMeta.setDataTypeSelected(stats.getDataTypeSelected(index));
     encoderMeta.setDecimal(stats.getDecimal(index));
     encoderMeta.setType(getTypeInChar(stats.getDataType(index)));
-    encoderMeta.setUniqueValue(stats.getNonExistValue(index));
     return encoderMeta;
   }
 
@@ -834,7 +833,7 @@ public class CarbonMetadataUtil {
         buffer.putChar(valueEncoderMeta.getTypeInChar());
         buffer.putLong((Long) valueEncoderMeta.getMaxValue());
         buffer.putLong((Long) valueEncoderMeta.getMinValue());
-        buffer.putLong((Long) valueEncoderMeta.getUniqueValue());
+        buffer.putLong(0L); // unique value, deprecated
         break;
       case DOUBLE:
         buffer = ByteBuffer.allocate(
@@ -843,7 +842,7 @@ public class CarbonMetadataUtil {
         buffer.putChar(valueEncoderMeta.getTypeInChar());
         buffer.putDouble((Double) valueEncoderMeta.getMaxValue());
         buffer.putDouble((Double) valueEncoderMeta.getMinValue());
-        buffer.putDouble((Double) valueEncoderMeta.getUniqueValue());
+        buffer.putDouble(0d); // unique value, deprecated
         break;
       case DECIMAL:
         buffer = ByteBuffer.allocate(CarbonCommonConstants.INT_SIZE_IN_BYTE + 3);

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
@@ -26,6 +26,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.ObjectInputStream;
+import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.security.PrivilegedExceptionAction;
@@ -1421,17 +1422,15 @@ public final class CarbonUtil {
       case CarbonCommonConstants.DOUBLE_MEASURE:
         valueEncoderMeta.setMaxValue(buffer.getDouble());
         valueEncoderMeta.setMinValue(buffer.getDouble());
-        valueEncoderMeta.setUniqueValue(buffer.getDouble());
+        buffer.getDouble(); // unique value, deprecated. this is for backward compatibility
         break;
       case CarbonCommonConstants.BIG_DECIMAL_MEASURE:
-        valueEncoderMeta.setMaxValue(0.0);
-        valueEncoderMeta.setMinValue(0.0);
-        valueEncoderMeta.setUniqueValue(0.0);
+        valueEncoderMeta.setMaxValue(BigDecimal.ZERO); // unused, decimal is encoded as byte array
+        valueEncoderMeta.setMinValue(BigDecimal.ZERO); // unused, decimal is encoded as byte array
         break;
       case CarbonCommonConstants.BIG_INT_MEASURE:
         valueEncoderMeta.setMaxValue(buffer.getLong());
         valueEncoderMeta.setMinValue(buffer.getLong());
-        valueEncoderMeta.setUniqueValue(buffer.getLong());
         break;
       default:
         throw new IllegalArgumentException("invalid measure type");

--- a/core/src/test/java/org/apache/carbondata/core/util/CarbonMetadataUtilTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/util/CarbonMetadataUtilTest.java
@@ -57,7 +57,6 @@ public class CarbonMetadataUtilTest {
   static int[] objDecimal;
 
   @BeforeClass public static void setUp() {
-    Long lngObj = new Long("11221");
     byte byt = 1;
     objMaxArr = new Long[6];
     objMaxArr[0] = new Long("111111");
@@ -117,7 +116,6 @@ public class CarbonMetadataUtilTest {
     valueEncoderMeta.setDecimal(5);
     valueEncoderMeta.setMinValue(objMinArr);
     valueEncoderMeta.setMaxValue(objMaxArr);
-    valueEncoderMeta.setUniqueValue(lngObj);
     valueEncoderMeta.setType('a');
     valueEncoderMeta.setDataTypeSelected(byt);
 
@@ -202,7 +200,6 @@ public class CarbonMetadataUtilTest {
       metas[i] = new ValueEncoderMeta();
       metas[i].setMinValue(objMinArr[i]);
       metas[i].setMaxValue(objMaxArr[i]);
-      metas[i].setUniqueValue(objMinArr[i]);
       metas[i].setDecimal(objDecimal[i]);
       metas[i].setType(CarbonCommonConstants.BIG_INT_MEASURE);
       metas[i].setDataTypeSelected(byteArr[i]);

--- a/core/src/test/java/org/apache/carbondata/core/util/CarbonUtilTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/util/CarbonUtilTest.java
@@ -654,7 +654,6 @@ public class CarbonUtilTest {
     ValueEncoderMeta valueEncoderMeta = new ValueEncoderMeta();
     valueEncoderMeta.setMaxValue(5.0);
     valueEncoderMeta.setMinValue(1.0);
-    valueEncoderMeta.setUniqueValue(2.0);
     valueEncoderMeta.setType('n');
     valueEncoderMeta.setDataTypeSelected((byte) 'v');
     valueEncoderMetas.add(valueEncoderMeta);

--- a/core/src/test/java/org/apache/carbondata/core/writer/CarbonFooterWriterTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/writer/CarbonFooterWriterTest.java
@@ -186,14 +186,12 @@ public class CarbonFooterWriterTest extends TestCase{
     metas[0] = new ValueEncoderMeta();
     metas[0].setMinValue(0);
     metas[0].setMaxValue(44d);
-    metas[0].setUniqueValue(0d);
     metas[0].setDecimal(0);
     metas[0].setType(CarbonCommonConstants.DOUBLE_MEASURE);
     metas[0].setDataTypeSelected((byte)0);
     metas[1] = new ValueEncoderMeta();
     metas[1].setMinValue(0);
     metas[1].setMaxValue(55d);
-    metas[1].setUniqueValue(0d);
     metas[1].setDecimal(0);
     metas[1].setType(CarbonCommonConstants.DOUBLE_MEASURE);
     metas[1].setDataTypeSelected((byte)0);

--- a/processing/src/main/java/org/apache/carbondata/processing/store/TablePage.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/TablePage.java
@@ -138,7 +138,7 @@ public class TablePage {
 
     // update statistics if it is last row
     if (rowId + 1 == pageSize) {
-      this.measurePageStatistics = new MeasurePageStatsVO(measurePage);
+      this.measurePageStatistics = MeasurePageStatsVO.build(measurePage);
     }
   }
 


### PR DESCRIPTION
Currently page statistics uses Object internally, which requires boxing/unboxing when processing it. 
This PR changes it to use exact type as schema defines
