### PR TITLE
[CARBONDATA-1101] Avoid widening between wrapper classes

### DIFF
--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/sort/unsafe/merger/UnsafeIntermediateFileMerger.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/sort/unsafe/merger/UnsafeIntermediateFileMerger.java
@@ -314,7 +314,7 @@ public class UnsafeIntermediateFileMerger implements Callable<Void> {
           case SHORT:
           case INT:
           case LONG:
-            rowData.putLong(size, (Long) value);
+            rowData.putLong(size, Long.valueOf(value.toString()));
             size += 8;
             break;
           case DOUBLE:


### PR DESCRIPTION
Modification reason:
Widening between wrapper classes throws ClassCastException