### PR TITLE
[CARBONDATA-1109] Acquire semaphore before submit a producer in finish

### DIFF
--- a/processing/src/main/java/org/apache/carbondata/processing/store/CarbonFactDataHandlerColumnar.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/CarbonFactDataHandlerColumnar.java
@@ -488,13 +488,19 @@ public class CarbonFactDataHandlerColumnar implements CarbonFactHandler {
   public void finish() throws CarbonDataWriterException {
     // still some data is present in stores if entryCount is more
     // than 0
-    producerExecutorServiceTaskList.add(producerExecutorService
-        .submit(new Producer(blockletDataHolder, dataRows, ++writerTaskSequenceCounter, true)));
-    blockletProcessingCount.incrementAndGet();
-    processedDataCount += entryCount;
-    closeWriterExecutionService(producerExecutorService);
-    processWriteTaskSubmitList(producerExecutorServiceTaskList);
-    processingComplete = true;
+    try {
+      semaphore.acquire();
+      producerExecutorServiceTaskList.add(producerExecutorService
+          .submit(new Producer(blockletDataHolder, dataRows, ++writerTaskSequenceCounter, true)));
+      blockletProcessingCount.incrementAndGet();
+      processedDataCount += entryCount;
+      closeWriterExecutionService(producerExecutorService);
+      processWriteTaskSubmitList(producerExecutorServiceTaskList);
+      processingComplete = true;
+    } catch (InterruptedException e) {
+      LOGGER.error(e, e.getMessage());
+      throw new CarbonDataWriterException(e.getMessage(), e);
+    }
   }
 
   /**


### PR DESCRIPTION
# Problem
1. We use Producer-Consumer model in the write step, have n(default value is 2 and can be configured) producers and one consumer. The task of generate last page(less than 32000) is added to thread pool at the end, but can't be guaranteed to be finished and put to BlockletDataHolder at the end. Because we have n tasks running concurrently.
2. We can't guarantee consumer get the last page from BlockletDataHolder at the end.
3. We have 2 ways to invoke `writeDataToFile`, one is the size of `DataWriterHolder` reach the size of blocklet and two is the page is the last page.

So if the last page is not be consumed at the end, we lost the page which be consumed after last page.
# Solution
Acquire semaphore before submit a producer in finish.

cc @jackylk @ravipesala @kumarvishal09 