### PR TITLE
[CARBONDATA-1119] Fixed database drop cascade in spark 2.1 and alter table in vector mode.

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestCreateTableWithDatabaseNameCaseChange.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestCreateTableWithDatabaseNameCaseChange.scala
@@ -51,6 +51,30 @@ class TestCreateTableWithDatabaseNameCaseChange extends QueryTest with BeforeAnd
     }
   }
 
+  test("test drop database cascade with case sensitive") {
+    // this test case will test the creation of table for different case for database name.
+    // In hive dbName folder is always created with small case in HDFS. Carbon should behave
+    // the same way. If table creation fails during second time creation it means in HDFS
+    // separate folders are created for the matching case in commands executed.
+    sql("drop database if exists AbCdEf cascade")
+    sql("create database AbCdEf")
+    sql("use AbCdEf")
+    sql("create table carbonTable(a int, b string)stored by 'carbondata'")
+    sql("use default")
+    sql("drop database if exists AbCdEf cascade")
+    sql("create database AbCdEf")
+    sql("use AbCdEf")
+    try {
+      sql("create table carbonTable(a int, b string)stored by 'carbondata'")
+      assert(true)
+    } catch {
+      case ex: Exception =>
+        assert(false)
+    }
+    sql("use default")
+    sql("drop database if exists AbCdEf cascade")
+  }
+
   override def afterAll {
     sql("use default")
     sql("drop database if exists dbCaseChange cascade")

--- a/integration/spark/src/main/scala/org/apache/spark/sql/test/SparkTestQueryExecutor.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/test/SparkTestQueryExecutor.scala
@@ -42,6 +42,7 @@ object SparkTestQueryExecutor {
     .addProperty(CarbonCommonConstants.STORE_LOCATION_TEMP_PATH,
       System.getProperty("java.io.tmpdir"))
     .addProperty(CarbonCommonConstants.LOCK_TYPE, CarbonCommonConstants.CARBON_LOCK_TYPE_LOCAL)
+    .addProperty(CarbonCommonConstants.STORE_LOCATION, TestQueryExecutor.storeLocation)
 
   val sc = new SparkContext(new SparkConf()
     .setAppName("CarbonSpark")

--- a/integration/spark2/src/main/java/org/apache/carbondata/spark/vectorreader/ColumnarVectorWrapper.java
+++ b/integration/spark2/src/main/java/org/apache/carbondata/spark/vectorreader/ColumnarVectorWrapper.java
@@ -60,7 +60,7 @@ class ColumnarVectorWrapper implements CarbonColumnVector {
     if (filteredRowsExist) {
       for (int i = 0; i < count; i++) {
         if (!filteredRows[rowId]) {
-          putShort(counter++, value);
+          columnVector.putShort(counter++, value);
         }
         rowId++;
       }
@@ -79,7 +79,7 @@ class ColumnarVectorWrapper implements CarbonColumnVector {
     if (filteredRowsExist) {
       for (int i = 0; i < count; i++) {
         if (!filteredRows[rowId]) {
-          putInt(counter++, value);
+          columnVector.putInt(counter++, value);
         }
         rowId++;
       }
@@ -98,7 +98,7 @@ class ColumnarVectorWrapper implements CarbonColumnVector {
     if (filteredRowsExist) {
       for (int i = 0; i < count; i++) {
         if (!filteredRows[rowId]) {
-          putLong(counter++, value);
+          columnVector.putLong(counter++, value);
         }
         rowId++;
       }
@@ -116,7 +116,7 @@ class ColumnarVectorWrapper implements CarbonColumnVector {
   @Override public void putDecimals(int rowId, int count, Decimal value, int precision) {
     for (int i = 0; i < count; i++) {
       if (!filteredRows[rowId]) {
-        putDecimal(counter++, value, precision);
+        columnVector.putDecimal(counter++, value, precision);
       }
       rowId++;
     }
@@ -132,7 +132,7 @@ class ColumnarVectorWrapper implements CarbonColumnVector {
     if (filteredRowsExist) {
       for (int i = 0; i < count; i++) {
         if (!filteredRows[rowId]) {
-          putDouble(counter++, value);
+          columnVector.putDouble(counter++, value);
         }
         rowId++;
       }
@@ -150,7 +150,7 @@ class ColumnarVectorWrapper implements CarbonColumnVector {
   @Override public void putBytes(int rowId, int count, byte[] value) {
     for (int i = 0; i < count; i++) {
       if (!filteredRows[rowId]) {
-        putBytes(counter++, value);
+        columnVector.putByteArray(counter++, value);
       }
       rowId++;
     }
@@ -172,7 +172,7 @@ class ColumnarVectorWrapper implements CarbonColumnVector {
     if (filteredRowsExist) {
       for (int i = 0; i < count; i++) {
         if (!filteredRows[rowId]) {
-          putNull(counter++);
+          columnVector.putNull(counter++);
         }
         rowId++;
       }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/CarbonHiveCommands.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/CarbonHiveCommands.scala
@@ -31,13 +31,12 @@ case class CarbonDropDatabaseCommand(command: DropDatabaseCommand)
     val rows = command.run(sparkSession)
     if (command.cascade) {
       val tablesInDB = CarbonEnv.getInstance(sparkSession).carbonMetastore.getAllTables()
-        .filterNot(_.database.exists(_.equalsIgnoreCase(dbName)))
+        .filter(_.database.exists(_.equalsIgnoreCase(dbName)))
       tablesInDB.foreach { tableName =>
-        CarbonDropTableCommand(true, Some(dbName), tableName.table).run(sparkSession)
+        CarbonDropTableCommand(true, tableName.database, tableName.table).run(sparkSession)
       }
     }
-    CarbonEnv.getInstance(sparkSession).carbonMetastore.dropDatabaseDirectory(dbName)
+    CarbonEnv.getInstance(sparkSession).carbonMetastore.dropDatabaseDirectory(dbName.toLowerCase)
     rows
   }
 }
-


### PR DESCRIPTION
Database drop cascade is not working in Spark 2.1 
And alter table not working when vector reader is enabled.