### PR TITLE
[CarbonData-1134] Generate redundant folders under integration model when run test cases with mvn command in spark1.6

### DIFF
--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/test/TestQueryExecutor.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/test/TestQueryExecutor.scala
@@ -53,6 +53,7 @@ object TestQueryExecutor {
   val INSTANCE = lookupQueryExecutor.newInstance().asInstanceOf[TestQueryExecutorRegister]
   CarbonProperties.getInstance()
     .addProperty(CarbonCommonConstants.CARBON_BAD_RECORDS_ACTION, "FORCE")
+    .addProperty(CarbonCommonConstants.STORE_LOCATION, storeLocation)
   private def lookupQueryExecutor: Class[_] = {
     ServiceLoader.load(classOf[TestQueryExecutorRegister], Utils.getContextOrSparkClassLoader)
       .iterator().next().getClass


### PR DESCRIPTION
Background: 
When run mvn  -Pspark-1.6 -Dspark.version=1.6.3 clean package, it will generate redundant
folders under integration model.

Solution:
add carbon store path in carbon property.