### PR TITLE
[CARBONDATA-1135] Added partition column info in describe formatted

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/partition/TestDDLForPartitionTable.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/partition/TestDDLForPartitionTable.scala
@@ -122,6 +122,14 @@ class TestDDLForPartitionTable  extends QueryTest with BeforeAndAfterAll {
     intercept[Exception] { sql("alter table test drop columns(c)") }
   }
 
+  test("test describe formatted for partition column") {
+    sql(
+      """create table desc(a int, b string) partitioned by (c string) stored by 'carbondata'
+        |tblproperties ('partition_type'='list','list_info'='1,2')""".stripMargin)
+    checkExistence(sql("describe formatted desc"),true, "Partition Columns")
+    sql("drop table desc")
+  }
+
   override def afterAll = {
     dropTable
   }
@@ -130,6 +138,7 @@ class TestDDLForPartitionTable  extends QueryTest with BeforeAndAfterAll {
     sql("drop table if exists hashTable")
     sql("drop table if exists rangeTable")
     sql("drop table if exists listTable")
+    sql("drop table test")
   }
 
 }

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/partition/TestDDLForPartitionTable.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/partition/TestDDLForPartitionTable.scala
@@ -127,7 +127,7 @@ class TestDDLForPartitionTable  extends QueryTest with BeforeAndAfterAll {
       """create table desc(a int, b string) partitioned by (c string) stored by 'carbondata'
         |tblproperties ('partition_type'='list','list_info'='1,2')""".stripMargin)
     checkExistence(sql("describe formatted desc"),true, "Partition Columns")
-    sql("drop table desc")
+    sql("drop table if exists desc")
   }
 
   override def afterAll = {
@@ -138,7 +138,7 @@ class TestDDLForPartitionTable  extends QueryTest with BeforeAndAfterAll {
     sql("drop table if exists hashTable")
     sql("drop table if exists rangeTable")
     sql("drop table if exists listTable")
-    sql("drop table test")
+    sql("drop table if exists test")
   }
 
 }

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/partition/TestDDLForPartitionTable.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/partition/TestDDLForPartitionTable.scala
@@ -124,10 +124,10 @@ class TestDDLForPartitionTable  extends QueryTest with BeforeAndAfterAll {
 
   test("test describe formatted for partition column") {
     sql(
-      """create table desc(a int, b string) partitioned by (c string) stored by 'carbondata'
+      """create table des(a int, b string) partitioned by (c string) stored by 'carbondata'
         |tblproperties ('partition_type'='list','list_info'='1,2')""".stripMargin)
-    checkExistence(sql("describe formatted desc"),true, "Partition Columns")
-    sql("drop table if exists desc")
+    checkExistence(sql("describe formatted des"),true, "Partition Columns")
+    sql("drop table if exists des")
   }
 
   override def afterAll = {

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
@@ -834,6 +834,11 @@ private[sql] case class DescribeCommandFormatted(
     val dimension = carbonTable
       .getDimensionByTableName(relation.tableMeta.carbonTableIdentifier.getTableName)
     results ++= getColumnGroups(dimension.asScala.toList)
+    if (carbonTable.getPartitionInfo(carbonTable.getFactTableName) != null) {
+      results ++=
+      Seq(("Partition Columns: ", carbonTable.getPartitionInfo(carbonTable.getFactTableName)
+        .getColumnSchemaList.asScala.map(_.getColumnName).mkString(","), ""))
+    }
     results.map { case (name, dataType, comment) =>
       Row(f"$name%-36s $dataType%-80s $comment%-72s")
     }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
@@ -865,6 +865,11 @@ private[sql] case class DescribeCommandFormatted(
     val dimension = carbonTable
       .getDimensionByTableName(relation.tableMeta.carbonTableIdentifier.getTableName)
     results ++= getColumnGroups(dimension.asScala.toList)
+    if (carbonTable.getPartitionInfo(carbonTable.getFactTableName) != null) {
+      results ++=
+      Seq(("Partition Columns: ", carbonTable.getPartitionInfo(carbonTable.getFactTableName)
+        .getColumnSchemaList.asScala.map(_.getColumnName).mkString(","), ""))
+    }
     results.map { case (name, dataType, comment) =>
       Row(f"$name%-36s", f"$dataType%-80s", f"$comment%-72s")
     }


### PR DESCRIPTION
Currently the partition columns are not listed in describe formatted command.

This PR will enable the listing of the same