### PR TITLE
[CARBONDATA-1145] Fix single-pass issue for multi-task loading

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/dictionary/generator/ServerDictionaryGenerator.java
+++ b/core/src/main/java/org/apache/carbondata/core/dictionary/generator/ServerDictionaryGenerator.java
@@ -55,6 +55,8 @@ public class ServerDictionaryGenerator implements DictionaryGenerator<Integer, D
       synchronized (tableMap) {
         if (tableMap.get(key.getTableUniqueName()) == null) {
           tableMap.put(key.getTableUniqueName(), new TableDictionaryGenerator(dimension));
+        } else {
+          tableMap.get(key.getTableUniqueName()).updateGenerator(dimension);
         }
       }
     } else {

--- a/core/src/main/java/org/apache/carbondata/core/dictionary/generator/ServerDictionaryGenerator.java
+++ b/core/src/main/java/org/apache/carbondata/core/dictionary/generator/ServerDictionaryGenerator.java
@@ -52,7 +52,11 @@ public class ServerDictionaryGenerator implements DictionaryGenerator<Integer, D
             key.getTableUniqueName(), key.getColumnName());
     // initialize TableDictionaryGenerator first
     if (tableMap.get(key.getTableUniqueName()) == null) {
-      tableMap.put(key.getTableUniqueName(), new TableDictionaryGenerator(dimension));
+      synchronized (tableMap) {
+        if (tableMap.get(key.getTableUniqueName()) == null) {
+          tableMap.put(key.getTableUniqueName(), new TableDictionaryGenerator(dimension));
+        }
+      }
     } else {
       tableMap.get(key.getTableUniqueName()).updateGenerator(dimension);
     }

--- a/core/src/main/java/org/apache/carbondata/core/dictionary/generator/TableDictionaryGenerator.java
+++ b/core/src/main/java/org/apache/carbondata/core/dictionary/generator/TableDictionaryGenerator.java
@@ -115,7 +115,14 @@ public class TableDictionaryGenerator
   }
 
   public void updateGenerator(CarbonDimension dimension) {
-    columnMap.put(dimension.getColumnId(),
-            new IncrementalColumnDictionaryGenerator(dimension, 1));
+    // reuse dictionary generator
+    if (null == columnMap.get(dimension.getColumnId())) {
+      synchronized (columnMap) {
+        if (null == columnMap.get(dimension.getColumnId())) {
+          columnMap.put(dimension.getColumnId(),
+              new IncrementalColumnDictionaryGenerator(dimension, 1));
+        }
+      }
+    }
   }
 }

--- a/core/src/test/java/org/apache/carbondata/core/dictionary/generator/TableDictionaryGeneratorTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/dictionary/generator/TableDictionaryGeneratorTest.java
@@ -65,8 +65,8 @@ public class TableDictionaryGeneratorTest {
     empDimension = new CarbonDimension(empColumnSchema, 0, 0, 0, 0, 0);
 
     ageColumnSchema = new ColumnSchema();
-    ageColumnSchema.setColumnName("empNameCol");
-    ageColumnSchema.setColumnUniqueId("empNameCol");
+    ageColumnSchema.setColumnName("ageNameCol");
+    ageColumnSchema.setColumnUniqueId("ageNameCol");
     ageColumnSchema.setDimensionColumn(true);
     ageColumnSchema.setEncodingList(Arrays.asList(Encoding.DICTIONARY));
     ageDimension = new CarbonDimension(ageColumnSchema, 0, 0, 0, 0, 0);

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/partition/TestDataLoadingForPartitionTable.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/partition/TestDataLoadingForPartitionTable.scala
@@ -16,16 +16,17 @@
  */
 package org.apache.carbondata.spark.testsuite.partition
 
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.common.util.QueryTest
 import org.apache.spark.sql.test.TestQueryExecutor
 import org.scalatest.BeforeAndAfterAll
+
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.datastore.filesystem.{CarbonFile, CarbonFileFilter}
 import org.apache.carbondata.core.datastore.impl.FileFactory
 import org.apache.carbondata.core.metadata.CarbonMetadata
 import org.apache.carbondata.core.util.CarbonProperties
 import org.apache.carbondata.core.util.path.CarbonTablePath
-import org.apache.spark.sql.Row
 
 class TestDataLoadingForPartitionTable extends QueryTest with BeforeAndAfterAll {
 


### PR DESCRIPTION
**Issue**
The single-pass loading of partition table lost incremental dictionary. The query result of dictionary column is null.

**Analyze**
During the single-pass loading, the executor will send many initial message to server to initialize the dictionary generator. for each initial message, it will update the generator, will lead to lost some incremental dictionary.

**Solution**
Reuse the dictionary generator, no need to update it if exists.