### PR TITLE
[CARBONDATA-1144] Fixed NullPointerException in partition column

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/CarbonTable.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/CarbonTable.java
@@ -169,13 +169,21 @@ public class CarbonTable implements Serializable {
     for (TableSchema aggTable : aggregateTableList) {
       this.aggregateTablesName.add(aggTable.getTableName());
       fillDimensionsAndMeasuresForTables(aggTable);
-      tableBucketMap.put(aggTable.getTableName(), aggTable.getBucketingInfo());
-      tablePartitionMap.put(aggTable.getTableName(), aggTable.getPartitionInfo());
+      if (aggTable.getBucketingInfo() != null) {
+        tableBucketMap.put(aggTable.getTableName(), aggTable.getBucketingInfo());
+      }
+      if (aggTable.getPartitionInfo() != null) {
+        tablePartitionMap.put(aggTable.getTableName(), aggTable.getPartitionInfo());
+      }
     }
-    tableBucketMap.put(tableInfo.getFactTable().getTableName(),
-        tableInfo.getFactTable().getBucketingInfo());
-    tablePartitionMap.put(tableInfo.getFactTable().getTableName(),
-        tableInfo.getFactTable().getPartitionInfo());
+    if (tableInfo.getFactTable().getBucketingInfo() != null) {
+      tableBucketMap.put(tableInfo.getFactTable().getTableName(),
+          tableInfo.getFactTable().getBucketingInfo());
+    }
+    if (tableInfo.getFactTable().getPartitionInfo() != null) {
+      tablePartitionMap.put(tableInfo.getFactTable().getTableName(),
+          tableInfo.getFactTable().getPartitionInfo());
+    }
   }
 
   /**

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/AlterTableCommands.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/AlterTableCommands.scala
@@ -282,15 +282,18 @@ private[sql] case class AlterTableDropColumns(
       carbonTable = CarbonEnv.getInstance(sparkSession).carbonMetastore
         .lookupRelation(Some(dbName), tableName)(sparkSession).asInstanceOf[CarbonRelation]
         .tableMeta.carbonTable
-      val columnNames = carbonTable.getPartitionInfo(tableName).getColumnSchemaList.asScala
-        .map(_.getColumnName)
-      // check each column existence in the table
-      val partitionColumns = alterTableDropColumnModel.columns.filter {
-        tableColumn => columnNames.contains(tableColumn)
-      }
-      if (partitionColumns.nonEmpty) {
-        throw new UnsupportedOperationException("Partition columns cannot be dropped: " +
-                                                s"$partitionColumns")
+      val partitionInfo = carbonTable.getPartitionInfo(tableName)
+      if (partitionInfo != null) {
+        val partitionColumnSchemaList = partitionInfo.getColumnSchemaList.asScala
+          .map(_.getColumnName)
+        // check each column existence in the table
+        val partitionColumns = alterTableDropColumnModel.columns.filter {
+          tableColumn => partitionColumnSchemaList.contains(tableColumn)
+        }
+        if (partitionColumns.nonEmpty) {
+          throw new UnsupportedOperationException("Partition columns cannot be dropped: " +
+                                                  s"$partitionColumns")
+        }
       }
       val tableColumns = carbonTable.getCreateOrderColumn(tableName).asScala
       var dictionaryColumns = Seq[org.apache.carbondata.core.metadata.schema.table.column

--- a/integration/spark2/src/test/scala/org/apache/spark/sql/common/util/QueryTest.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/sql/common/util/QueryTest.scala
@@ -23,7 +23,7 @@ import scala.collection.JavaConversions._
 
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.util._
-import org.apache.spark.sql.hive.{CarbonSessionState, HiveExternalCatalog}
+import org.apache.spark.sql.hive.CarbonSessionState
 import org.apache.spark.sql.test.TestQueryExecutor
 import org.apache.spark.sql.{DataFrame, Row}
 

--- a/integration/spark2/src/test/scala/org/apache/spark/sql/common/util/QueryTest.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/sql/common/util/QueryTest.scala
@@ -23,7 +23,7 @@ import scala.collection.JavaConversions._
 
 import org.apache.spark.sql.catalyst.plans._
 import org.apache.spark.sql.catalyst.util._
-import org.apache.spark.sql.hive.HiveExternalCatalog
+import org.apache.spark.sql.hive.{CarbonSessionState, HiveExternalCatalog}
 import org.apache.spark.sql.test.TestQueryExecutor
 import org.apache.spark.sql.{DataFrame, Row}
 
@@ -40,7 +40,8 @@ class QueryTest extends PlanTest {
 
   val sqlContext = TestQueryExecutor.INSTANCE.sqlContext
 
-  val hiveClient = sqlContext.sharedState.externalCatalog.asInstanceOf[HiveExternalCatalog].client
+  val hiveClient = sqlContext.sparkSession.sessionState.asInstanceOf[CarbonSessionState]
+    .metadataHive
 
   val resourcesPath = TestQueryExecutor.resourcesPath
 


### PR DESCRIPTION
Analysis: getColumnSchema on PartitionInfo was throwing null pointer exception

Solution: 
1. Added a null check 
2. Removed unnecessary entry for BucketingInfo and PartitionInfo if they do not exist