### PR TITLE
[WIP] Test CI's stability and fix issues

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
@@ -475,6 +475,15 @@ public final class CarbonProperties {
     return this;
   }
 
+  /**
+   * This method will be used to remove the key property
+   * @param key
+   */
+  public CarbonProperties removeProperty(String key) {
+    carbonProperties.remove(key);
+    return this;
+  }
+
   private ColumnarFormatVersion getDefaultFormatVersion() {
     return ColumnarFormatVersion.valueOf(CarbonCommonConstants.CARBON_DATA_FILE_DEFAULT_VERSION);
   }

--- a/core/src/test/java/org/apache/carbondata/core/cache/CacheProviderTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/cache/CacheProviderTest.java
@@ -33,6 +33,7 @@ import org.apache.carbondata.core.datastore.block.TableBlockUniqueIdentifier;
 import org.apache.carbondata.core.util.CarbonProperties;
 
 import org.apache.avro.Schema;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -48,10 +49,16 @@ public class CacheProviderTest {
   @Before public void setUp() throws Exception {
     // enable lru cache by setting cache size
     CarbonProperties.getInstance()
-        .addProperty(CarbonCommonConstants.CARBON_MAX_DRIVER_LRU_CACHE_SIZE, "10");
+        .addProperty(CarbonCommonConstants.CARBON_MAX_DRIVER_LRU_CACHE_SIZE, "10")
     // enable lru cache by setting cache size
-    CarbonProperties.getInstance()
         .addProperty(CarbonCommonConstants.CARBON_MAX_EXECUTOR_LRU_CACHE_SIZE, "20");
+  }
+
+  @After public void tearDown() {
+    CarbonProperties.getInstance()
+        .removeProperty(CarbonCommonConstants.CARBON_MAX_DRIVER_LRU_CACHE_SIZE)
+        .removeProperty(CarbonCommonConstants.CARBON_MAX_EXECUTOR_LRU_CACHE_SIZE)
+        .removeProperty(CarbonCommonConstants.IS_DRIVER_INSTANCE);
   }
 
   @Test public void getInstance() throws Exception {

--- a/core/src/test/java/org/apache/carbondata/core/cache/dictionary/ForwardDictionaryCacheTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/cache/dictionary/ForwardDictionaryCacheTest.java
@@ -63,6 +63,8 @@ public class ForwardDictionaryCacheTest extends AbstractDictionaryCacheTest {
     carbonTableIdentifier = null;
     forwardDictionaryCache = null;
     deleteStorePath();
+    CarbonProperties.getInstance()
+        .removeProperty(CarbonCommonConstants.CARBON_MAX_DRIVER_LRU_CACHE_SIZE);
   }
 
   private void createDictionaryCacheObject() {

--- a/core/src/test/java/org/apache/carbondata/core/cache/dictionary/ReverseDictionaryCacheTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/cache/dictionary/ReverseDictionaryCacheTest.java
@@ -66,6 +66,8 @@ public class ReverseDictionaryCacheTest extends AbstractDictionaryCacheTest {
     carbonTableIdentifier = null;
     reverseDictionaryCache = null;
     deleteStorePath();
+    CarbonProperties.getInstance()
+        .removeProperty(CarbonCommonConstants.CARBON_MAX_DRIVER_LRU_CACHE_SIZE);
   }
 
   private void createDictionaryCacheObject() {

--- a/core/src/test/java/org/apache/carbondata/core/dictionary/client/DictionaryClientTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/dictionary/client/DictionaryClientTest.java
@@ -184,6 +184,8 @@ public class DictionaryClientTest {
     // Cleanup created files
     CarbonMetadata.getInstance().removeTable(tableInfo.getTableUniqueName());
     cleanUpDirectory(new File(storePath));
+    CarbonProperties.getInstance()
+            .removeProperty(CarbonCommonConstants.CARBON_MAX_DRIVER_LRU_CACHE_SIZE);
   }
 
   private void cleanUpDirectory(File path) {

--- a/core/src/test/java/org/apache/carbondata/core/dictionary/generator/IncrementalColumnDictionaryGeneratorTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/dictionary/generator/IncrementalColumnDictionaryGeneratorTest.java
@@ -29,6 +29,7 @@ import org.apache.carbondata.core.metadata.schema.table.column.CarbonDimension;
 import org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema;
 import org.apache.carbondata.core.util.CarbonProperties;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -45,6 +46,11 @@ public class IncrementalColumnDictionaryGeneratorTest {
     // enable lru cache by setting cache size
     CarbonProperties.getInstance()
         .addProperty(CarbonCommonConstants.CARBON_MAX_DRIVER_LRU_CACHE_SIZE, "10");
+  }
+
+  @After public void tearDown() {
+    CarbonProperties.getInstance()
+        .removeProperty(CarbonCommonConstants.CARBON_MAX_DRIVER_LRU_CACHE_SIZE);
   }
 
   @Test public void generateKeyOnce() throws Exception {

--- a/core/src/test/java/org/apache/carbondata/core/dictionary/generator/ServerDictionaryGeneratorTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/dictionary/generator/ServerDictionaryGeneratorTest.java
@@ -199,6 +199,8 @@ public class ServerDictionaryGeneratorTest {
 
   @After public void tearDown() {
     cleanUpDirectory(new File(storePath));
+    CarbonProperties.getInstance()
+        .removeProperty(CarbonCommonConstants.CARBON_MAX_DRIVER_LRU_CACHE_SIZE);
   }
 
   private void cleanUpDirectory(File path) {

--- a/core/src/test/java/org/apache/carbondata/core/dictionary/generator/TableDictionaryGeneratorTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/dictionary/generator/TableDictionaryGeneratorTest.java
@@ -217,6 +217,8 @@ public class TableDictionaryGeneratorTest {
   @After public void tearDown() {
     CarbonMetadata.getInstance().removeTable(tableInfo.getTableUniqueName());
     cleanUpDirectory(new File(storePath));
+    CarbonProperties.getInstance()
+        .removeProperty(CarbonCommonConstants.CARBON_MAX_DRIVER_LRU_CACHE_SIZE);
   }
 
   private void cleanUpDirectory(File path) {

--- a/core/src/test/java/org/apache/carbondata/core/writer/CarbonDictionaryWriterImplTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/writer/CarbonDictionaryWriterImplTest.java
@@ -104,6 +104,8 @@ public class CarbonDictionaryWriterImplTest {
   @After public void tearDown() throws Exception {
     carbonTableIdentifier = null;
     deleteStorePath();
+    CarbonProperties.getInstance()
+        .removeProperty(CarbonCommonConstants.DICTIONARY_ONE_CHUNK_SIZE);
   }
 
   /**

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestGlobalSortDataLoad.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestGlobalSortDataLoad.scala
@@ -233,11 +233,11 @@ class TestGlobalSortDataLoad extends QueryTest with BeforeAndAfterEach with Befo
         | STORED BY 'org.apache.carbondata.format'
       """.stripMargin)
     sql(s"LOAD DATA LOCAL INPATH '$filePath' INTO TABLE carbon_localsort_delete")
-    sql("DELETE FROM carbon_localsort_delete WHERE id = 1")
+    sql("DELETE FROM carbon_localsort_delete WHERE id = 1").show
 
     sql(s"LOAD DATA LOCAL INPATH '$filePath' INTO TABLE carbon_globalsort " +
       "OPTIONS('SORT_SCOPE'='GLOBAL_SORT')")
-    sql("DELETE FROM carbon_globalsort WHERE id = 1")
+    sql("DELETE FROM carbon_globalsort WHERE id = 1").show
 
     assert(getIndexFileCount("carbon_globalsort") === 3)
     checkAnswer(sql("SELECT COUNT(*) FROM carbon_globalsort"), Seq(Row(11)))
@@ -269,7 +269,7 @@ class TestGlobalSortDataLoad extends QueryTest with BeforeAndAfterEach with Befo
   test("INSERT INTO") {
     CarbonProperties.getInstance().addProperty(CarbonCommonConstants.LOAD_SORT_SCOPE, "GLOBAL_SORT")
     CarbonProperties.getInstance().addProperty(CarbonCommonConstants.LOAD_GLOBAL_SORT_PARTITIONS, "2")
-    sql(s"INSERT INTO TABLE carbon_globalsort SELECT * FROM carbon_localsort_once")
+    sql(s"INSERT INTO TABLE carbon_globalsort SELECT * FROM carbon_localsort_once").show
 
     assert(getIndexFileCount("carbon_globalsort") === 2)
     checkAnswer(sql("SELECT COUNT(*) FROM carbon_globalsort"), Seq(Row(12)))
@@ -283,9 +283,9 @@ class TestGlobalSortDataLoad extends QueryTest with BeforeAndAfterEach with Befo
     sql(
       s"""
          | CREATE TABLE carbon_localsort_difftypes(
-         | shortField SHORT,
+         | shortField smallint,
          | intField INT,
-         | bigintField LONG,
+         | bigintField bigint,
          | doubleField DOUBLE,
          | stringField STRING,
          | timestampField TIMESTAMP,
@@ -306,9 +306,9 @@ class TestGlobalSortDataLoad extends QueryTest with BeforeAndAfterEach with Befo
     sql(
       s"""
          | CREATE TABLE carbon_globalsort_difftypes(
-         | shortField SHORT,
+         | shortField smallint,
          | intField INT,
-         | bigintField LONG,
+         | bigintField bigint,
          | doubleField DOUBLE,
          | stringField STRING,
          | timestampField TIMESTAMP,

--- a/integration/spark/src/main/scala/org/apache/spark/sql/test/SparkTestQueryExecutor.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/test/SparkTestQueryExecutor.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.test
 
 import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.sql.{CarbonContext, DataFrame, SQLContext}
+import org.apache.spark.sql.test.TestQueryExecutor
 
 import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.core.constants.CarbonCommonConstants

--- a/integration/spark/src/test/scala/org/apache/carbondata/integration/spark/testsuite/complexType/TestComplexPrimitiveTimestampDirectDictionary.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/integration/spark/testsuite/complexType/TestComplexPrimitiveTimestampDirectDictionary.scala
@@ -18,6 +18,7 @@
 package org.apache.carbondata.integration.spark.testsuite.complexType
 
 import org.apache.spark.sql.common.util.QueryTest
+import org.apache.spark.sql.test.TestQueryExecutor
 import org.scalatest.BeforeAndAfterAll
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants
@@ -61,5 +62,7 @@ class TestComplexPrimitiveTimestampDirectDictionary extends QueryTest with Befor
   override def afterAll {
 	  sql("drop table if exists complexcarbontimestamptable")
     sql("drop table if exists complexhivetimestamptable")
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, TestQueryExecutor.timestampFormat)
   }
 }

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/allqueries/AllDataTypesTestCaseAggregate.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/allqueries/AllDataTypesTestCaseAggregate.scala
@@ -18,6 +18,7 @@
 package org.apache.carbondata.spark.testsuite.allqueries
 
 import org.apache.spark.sql.common.util.QueryTest
+import org.apache.spark.sql.test.TestQueryExecutor
 import org.apache.spark.sql.{Row, SaveMode}
 import org.scalatest.BeforeAndAfterAll
 
@@ -46,7 +47,7 @@ class AllDataTypesTestCaseAggregate extends QueryTest with BeforeAndAfterAll {
   override def afterAll {
     clean
     CarbonProperties.getInstance()
-      .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, "dd-MM-yyyy")
+      .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, TestQueryExecutor.timestampFormat)
   }
 
 

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/allqueries/InsertIntoCarbonTableSpark1TestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/allqueries/InsertIntoCarbonTableSpark1TestCase.scala
@@ -17,6 +17,7 @@
 package org.apache.carbondata.spark.testsuite.allqueries
 
 import org.apache.spark.sql.common.util.QueryTest
+import org.apache.spark.sql.test.TestQueryExecutor
 import org.scalatest.BeforeAndAfterAll
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants
@@ -77,5 +78,8 @@ class InsertIntoCarbonTableSpark1TestCase extends QueryTest with BeforeAndAfterA
     sql("drop table if exists inser")
     sql("DROP TABLE IF EXISTS THive")
     sql("DROP TABLE IF EXISTS TCarbon")
+
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, TestQueryExecutor.timestampFormat)
   }
 }

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/badrecordloger/BadRecordLoggerSharedDictionaryTest.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/badrecordloger/BadRecordLoggerSharedDictionaryTest.scala
@@ -25,6 +25,7 @@ import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.util.CarbonProperties
 import org.apache.spark.sql.common.util.QueryTest
 import org.apache.spark.sql.hive.HiveContext
+import org.apache.spark.sql.test.TestQueryExecutor
 import org.scalatest.BeforeAndAfterAll
 
 
@@ -78,7 +79,9 @@ class BadRecordLoggerSharedDictionaryTest extends QueryTest with BeforeAndAfterA
 
   override def afterAll {
     sql("drop table IF EXISTS testdrive")
+
     CarbonProperties.getInstance()
-      .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, timestamp_format)
+      .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, TestQueryExecutor.timestampFormat)
+      .removeProperty(CarbonCommonConstants.CARBON_BADRECORDS_LOC)
   }
 }

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/CompactionSystemLockFeatureTest.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/CompactionSystemLockFeatureTest.scala
@@ -19,6 +19,7 @@ package org.apache.carbondata.spark.testsuite.datacompaction
 import scala.collection.JavaConverters._
 
 import org.apache.spark.sql.common.util.QueryTest
+import org.apache.spark.sql.test.TestQueryExecutor
 import org.scalatest.BeforeAndAfterAll
 
 import org.apache.carbondata.core.util.path.{CarbonStorePath, CarbonTablePath}
@@ -134,10 +135,13 @@ class CompactionSystemLockFeatureTest extends QueryTest with BeforeAndAfterAll {
   }
 
   override def afterAll {
-    CarbonProperties.getInstance()
-      .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, "dd-MM-yyyy")
     sql("drop table if exists  table1")
     sql("drop table if exists  table2")
+
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, TestQueryExecutor.timestampFormat)
+      .removeProperty("carbon.compaction.level.threshold")
+      .removeProperty(CarbonCommonConstants.ENABLE_CONCURRENT_COMPACTION)
   }
 
 }

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/DataCompactionMinorThresholdTest.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/DataCompactionMinorThresholdTest.scala
@@ -19,6 +19,7 @@ package org.apache.carbondata.spark.testsuite.datacompaction
 import scala.collection.JavaConverters._
 
 import org.apache.spark.sql.common.util.QueryTest
+import org.apache.spark.sql.test.TestQueryExecutor
 import org.scalatest.BeforeAndAfterAll
 
 import org.apache.carbondata.core.metadata.{AbsoluteTableIdentifier, CarbonTableIdentifier}
@@ -94,10 +95,8 @@ class DataCompactionMinorThresholdTest extends QueryTest with BeforeAndAfterAll 
   override def afterAll {
     sql("drop table if exists  minorthreshold")
     CarbonProperties.getInstance()
-      .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, "dd-MM-yyyy")
-    CarbonProperties.getInstance()
-      .addProperty(CarbonCommonConstants.COMPACTION_SEGMENT_LEVEL_THRESHOLD,
-        CarbonCommonConstants.DEFAULT_SEGMENT_LEVEL_THRESHOLD)
+      .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, TestQueryExecutor.timestampFormat)
+      .removeProperty(CarbonCommonConstants.COMPACTION_SEGMENT_LEVEL_THRESHOLD)
   }
 
 }

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/DataCompactionNoDictionaryTest.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/DataCompactionNoDictionaryTest.scala
@@ -20,6 +20,7 @@ import scala.collection.JavaConverters._
 
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.common.util.QueryTest
+import org.apache.spark.sql.test.TestQueryExecutor
 import org.scalatest.BeforeAndAfterAll
 
 import org.apache.carbondata.core.metadata.{AbsoluteTableIdentifier, CarbonTableIdentifier}
@@ -166,8 +167,8 @@ class DataCompactionNoDictionaryTest extends QueryTest with BeforeAndAfterAll {
   override def afterAll {
     sql("DROP TABLE IF EXISTS nodictionaryCompaction")
     CarbonProperties.getInstance()
-      .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, "dd-MM-yyyy")
-    CarbonProperties.getInstance().addProperty(CarbonCommonConstants.ENABLE_AUTO_LOAD_MERGE, "false")
+      .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, TestQueryExecutor.timestampFormat)
+      .removeProperty(CarbonCommonConstants.ENABLE_AUTO_LOAD_MERGE)
   }
 
 }

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/DataCompactionTest.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/DataCompactionTest.scala
@@ -20,6 +20,7 @@ import scala.collection.JavaConverters._
 
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.common.util.QueryTest
+import org.apache.spark.sql.test.TestQueryExecutor
 import org.scalatest.BeforeAndAfterAll
 
 import org.apache.carbondata.core.metadata.{AbsoluteTableIdentifier, CarbonTableIdentifier}
@@ -217,8 +218,8 @@ class DataCompactionTest extends QueryTest with BeforeAndAfterAll {
     sql("drop table if exists normalcompaction")
     sql("drop table if exists cardinalityUpdatetest")
     CarbonProperties.getInstance()
-      .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, "dd-MM-yyyy")
-    CarbonProperties.getInstance().addProperty(CarbonCommonConstants.ENABLE_AUTO_LOAD_MERGE, "false")
+      .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, TestQueryExecutor.timestampFormat)
+      .removeProperty(CarbonCommonConstants.ENABLE_AUTO_LOAD_MERGE)
   }
 
 }

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/filterexpr/GrtLtFilterProcessorTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/filterexpr/GrtLtFilterProcessorTestCase.scala
@@ -19,6 +19,7 @@ package org.apache.carbondata.spark.testsuite.filterexpr
 
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.common.util.QueryTest
+import org.apache.spark.sql.test.TestQueryExecutor
 import org.scalatest.BeforeAndAfterAll
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants
@@ -59,6 +60,6 @@ class GrtLtFilterProcessorTestCase extends QueryTest with BeforeAndAfterAll {
   override def afterAll {
     sql("drop table if exists a12_allnull")
     CarbonProperties.getInstance()
-      .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, "dd-MM-yyyy")
+      .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, TestQueryExecutor.timestampFormat)
   }
 }

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/util/GlobalDictionaryUtilConcurrentTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/util/GlobalDictionaryUtilConcurrentTestCase.scala
@@ -151,8 +151,8 @@ class GlobalDictionaryUtilConcurrentTestCase extends QueryTest with BeforeAndAft
 
   override def afterAll {
     sql("drop table if exists employee")
-    CarbonProperties.getInstance.addProperty(CarbonCommonConstants.MAX_QUERY_EXECUTION_TIME,
-        Integer.toString(CarbonCommonConstants.DEFAULT_MAX_QUERY_EXECUTION_TIME))
+    CarbonProperties.getInstance
+      .removeProperty(CarbonCommonConstants.MAX_QUERY_EXECUTION_TIME)
   }
 
   class DictGenerator(loadModel: CarbonLoadModel) extends Callable[String] {

--- a/integration/spark2/src/test/scala/org/apache/carbondata/spark/util/AllDictionaryTestCase.scala
+++ b/integration/spark2/src/test/scala/org/apache/carbondata/spark/util/AllDictionaryTestCase.scala
@@ -156,5 +156,8 @@ class AllDictionaryTestCase extends QueryTest with BeforeAndAfterAll {
   override def afterAll {
     sql("drop table sample")
     sql("drop table complextypes")
+
+    CarbonProperties.getInstance()
+      .removeProperty("carbon.custom.distribution")
   }
 }

--- a/integration/spark2/src/test/scala/org/apache/carbondata/spark/util/ExternalColumnDictionaryTestCase.scala
+++ b/integration/spark2/src/test/scala/org/apache/carbondata/spark/util/ExternalColumnDictionaryTestCase.scala
@@ -285,5 +285,8 @@ class ExternalColumnDictionaryTestCase extends QueryTest with BeforeAndAfterAll 
 
   override def afterAll: Unit = {
     cleanAllTables
+
+    CarbonProperties.getInstance()
+      .removeProperty("carbon.custom.distribution")
   }
 }

--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/DataLoadFailAllTypeSortTest.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/DataLoadFailAllTypeSortTest.scala
@@ -21,6 +21,7 @@ import java.io.File
 
 import org.apache.spark.sql.common.util.QueryTest
 import org.apache.spark.sql.hive.HiveContext
+import org.apache.spark.sql.test.TestQueryExecutor
 import org.scalatest.BeforeAndAfterAll
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants
@@ -34,6 +35,8 @@ import org.apache.carbondata.core.util.CarbonProperties
 class DataLoadFailAllTypeSortTest extends QueryTest with BeforeAndAfterAll {
   var hiveContext: HiveContext = _
 
+  var originAction: String = _
+
   override def beforeAll: Unit = {
     sql("drop table IF EXISTS data_pm")
     sql("drop table IF EXISTS data_um")
@@ -41,6 +44,9 @@ class DataLoadFailAllTypeSortTest extends QueryTest with BeforeAndAfterAll {
     sql("drop table IF EXISTS data_bmf")
     sql("drop table IF EXISTS data_tbm")
     sql("drop table IF EXISTS data_bm_no_good_data")
+
+    originAction = CarbonProperties.getInstance()
+      .getProperty(CarbonCommonConstants.CARBON_BAD_RECORDS_ACTION)
   }
 
   test("dataload with parallel merge with bad_records_action='FAIL'") {
@@ -248,6 +254,10 @@ class DataLoadFailAllTypeSortTest extends QueryTest with BeforeAndAfterAll {
     sql("drop table IF EXISTS data_tbm")
     sql("drop table IF EXISTS data_bm_no_good_data")
     CarbonProperties.getInstance()
-      .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, "dd-MM-yyyy")
+      .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, TestQueryExecutor.timestampFormat)
+      .removeProperty(CarbonCommonConstants.CARBON_BADRECORDS_LOC)
+      .removeProperty(CarbonCommonConstants.ENABLE_UNSAFE_SORT)
+      .removeProperty(CarbonCommonConstants.LOAD_SORT_SCOPE)
+      .addProperty(CarbonCommonConstants.CARBON_BAD_RECORDS_ACTION, originAction)
   }
 }

--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/bucketing/TableBucketingTestCase.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/bucketing/TableBucketingTestCase.scala
@@ -20,6 +20,7 @@ package org.apache.spark.carbondata.bucketing
 import org.apache.spark.sql.common.util.QueryTest
 import org.apache.spark.sql.execution.command.LoadTable
 import org.apache.spark.sql.execution.exchange.ShuffleExchange
+import org.apache.spark.sql.test.TestQueryExecutor
 import org.scalatest.BeforeAndAfterAll
 
 import org.apache.carbondata.core.metadata.CarbonMetadata
@@ -240,5 +241,9 @@ class TableBucketingTestCase extends QueryTest with BeforeAndAfterAll {
     sql("DROP TABLE IF EXISTS t9")
     sql("DROP TABLE IF EXISTS t10")
     sqlContext.setConf("spark.sql.autoBroadcastJoinThreshold", threshold.toString)
+
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, TestQueryExecutor.timestampFormat)
+      .removeProperty(CarbonCommonConstants.ENABLE_UNSAFE_SORT)
   }
 }

--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/datatype/NumericDimensionBadRecordTest.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/datatype/NumericDimensionBadRecordTest.scala
@@ -22,6 +22,7 @@ import java.io.File
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.common.util.QueryTest
 import org.apache.spark.sql.hive.HiveContext
+import org.apache.spark.sql.test.TestQueryExecutor
 import org.scalatest.BeforeAndAfterAll
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants
@@ -177,6 +178,7 @@ class NumericDimensionBadRecordTest extends QueryTest with BeforeAndAfterAll {
     sql("drop table if exists num_dic")
     sql("drop table if exists num_dicc")
     CarbonProperties.getInstance()
-      .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, "dd-MM-yyyy")
+      .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, TestQueryExecutor.timestampFormat)
+      .removeProperty(CarbonCommonConstants.CARBON_BADRECORDS_LOC)
   }
 }

--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/query/TestNotEqualToFilter.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/query/TestNotEqualToFilter.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.carbondata.query
 
 import org.apache.spark.sql.common.util.QueryTest
+import org.apache.spark.sql.test.TestQueryExecutor
 import org.scalatest.BeforeAndAfterAll
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants
@@ -86,5 +87,8 @@ class TestNotEqualToFilter extends QueryTest with BeforeAndAfterAll {
   override def afterAll {
     sql("drop table if exists test_not_equal_to_carbon")
     sql("drop table if exists test_not_equal_to_hive")
+
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, TestQueryExecutor.timestampFormat)
   }
 }

--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/restructure/AlterTableValidationTestCase.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/restructure/AlterTableValidationTestCase.scala
@@ -432,5 +432,8 @@ class AlterTableValidationTestCase extends QueryTest with BeforeAndAfterAll {
     sql("DROP TABLE IF EXISTS restructure_badnew")
     sql("DROP TABLE IF EXISTS lock_rename")
     sql("drop table if exists uniqdata")
+
+    CarbonProperties.getInstance()
+      .removeProperty(CarbonCommonConstants.CARBON_BADRECORDS_LOC)
   }
 }

--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/vectorreader/VectorReaderTestCase.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/vectorreader/VectorReaderTestCase.scala
@@ -21,6 +21,7 @@ import org.apache.spark.sql.Row
 import org.apache.spark.sql.common.util.QueryTest
 import org.apache.spark.sql.execution.command.LoadTable
 import org.apache.spark.sql.execution.{BatchedDataSourceScanExec, RowDataSourceScanExec}
+import org.apache.spark.sql.test.TestQueryExecutor
 import org.scalatest.BeforeAndAfterAll
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants
@@ -77,5 +78,8 @@ class VectorReaderTestCase extends QueryTest with BeforeAndAfterAll {
 
   override def afterAll {
     sql("DROP TABLE IF EXISTS vectorreader")
+
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, TestQueryExecutor.timestampFormat)
   }
 }

--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/sort/SortStepRowUtil.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/sort/SortStepRowUtil.java
@@ -64,7 +64,7 @@ public class SortStepRowUtil {
       for (int i = 0; i < measureCount; i++) {
         Object value = data[allCount];
         if (null != value) {
-          if (measureDataType[i] == DataType.DECIMAL) {
+          if (measureDataType[i] == DataType.DECIMAL && value instanceof BigDecimal) {
             BigDecimal decimal = (BigDecimal) value;
             measures[index++] = DataTypeUtil.bigDecimalToByte(decimal);
           } else {

--- a/processing/src/test/java/org/apache/carbondata/carbon/datastore/BlockIndexStoreTest.java
+++ b/processing/src/test/java/org/apache/carbondata/carbon/datastore/BlockIndexStoreTest.java
@@ -52,14 +52,11 @@ public class BlockIndexStoreTest extends TestCase {
   // private BlockIndexStore indexStore;
   BlockIndexStore<TableBlockUniqueIdentifier, AbstractIndex> cache;
 
-  private String property;
-
   private static final LogService LOGGER =
           LogServiceFactory.getLogService(BlockIndexStoreTest.class.getName());
 
   @BeforeClass public void setUp() {
-	property = CarbonProperties.getInstance().getProperty(CarbonCommonConstants.CARBON_DATA_FILE_VERSION);
-	
+
 	CarbonProperties.getInstance().addProperty(CarbonCommonConstants.CARBON_DATA_FILE_VERSION, "1");
     StoreCreator.createCarbonStore();
     CarbonProperties.getInstance().
@@ -69,11 +66,10 @@ public class BlockIndexStoreTest extends TestCase {
   }
   
   @AfterClass public void tearDown() {
-	    if(null!=property) {
-		CarbonProperties.getInstance().addProperty(CarbonCommonConstants.CARBON_DATA_FILE_VERSION, property);
-	    }else {
-	    	CarbonProperties.getInstance().addProperty(CarbonCommonConstants.CARBON_DATA_FILE_VERSION, CarbonCommonConstants.CARBON_DATA_FILE_DEFAULT_VERSION);
-	    }
+		  CarbonProperties.getInstance()
+          .removeProperty(CarbonCommonConstants.CARBON_DATA_FILE_VERSION)
+          .removeProperty(CarbonCommonConstants.CARBON_MAX_DRIVER_LRU_CACHE_SIZE);
+
 	  }
 
   @Test public void testLoadAndGetTaskIdToSegmentsMapForSingleSegment()

--- a/processing/src/test/java/org/apache/carbondata/lcm/locks/LocalFileLockTest.java
+++ b/processing/src/test/java/org/apache/carbondata/lcm/locks/LocalFileLockTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
  */
 public class LocalFileLockTest {
 
+  String originStoreLocation = null;
   /**
    * @throws java.lang.Exception
    */
@@ -39,6 +40,7 @@ public class LocalFileLockTest {
     String rootPath = new File(this.getClass().getResource("/").getPath()
         + "../../..").getCanonicalPath();
     String storeLocation = rootPath + "/target/store";
+    originStoreLocation = CarbonProperties.getInstance().getProperty("carbon.storelocation");
     CarbonProperties.getInstance()
         .addProperty("carbon.storelocation", storeLocation);
   }
@@ -47,6 +49,8 @@ public class LocalFileLockTest {
    * @throws java.lang.Exception
    */
   @After public void tearDown() throws Exception {
+    CarbonProperties.getInstance()
+        .addProperty("carbon.storelocation", originStoreLocation);
   }
 
   @Test public void testingLocalFileLockingByAcquiring2Locks() {


### PR DESCRIPTION
During test running:
1. keep following properties
CarbonCommonConstants.CARBON_BAD_RECORDS_ACTION, "FORCE"
CarbonCommonConstants.STORE_LOCATION, storeLocation
CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, TestQueryExecutor.timestampFormat
CarbonCommonConstants.STORE_LOCATION_TEMP_PATH, System.getProperty("java.io.tmpdir")
CarbonCommonConstants.LOCK_TYPE, CarbonCommonConstants.CARBON_LOCK_TYPE_LOCAL
CarbonCommonConstants.CARBON_BAD_RECORDS_ACTION, "FORCE"

2.  remove other properties which added by test cases
add removeProperty(String key) method

3. fix test case issue 
TestGlobalSortDataLoad.scala on spark-1.6