### PR TITLE
fix timestamp format issue for range partitioned table

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/partition/PartitionFilterUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/partition/PartitionFilterUtil.java
@@ -18,6 +18,7 @@
 package org.apache.carbondata.core.scan.filter.partition;
 
 import java.math.BigDecimal;
+import java.text.DateFormat;
 import java.util.BitSet;
 import java.util.Comparator;
 import java.util.List;
@@ -116,7 +117,8 @@ public class PartitionFilterUtil {
    * @return
    */
   public static BitSet getPartitionMapForRangeFilter(PartitionInfo partitionInfo,
-      ListPartitioner partitioner, Object filterValue,  boolean isGreaterThan, boolean isEqualTo) {
+      ListPartitioner partitioner, Object filterValue,  boolean isGreaterThan, boolean isEqualTo,
+      DateFormat timestampFormatter, DateFormat dateFormatter) {
 
     List<List<String>> values = partitionInfo.getListInfo();
     DataType partitionColumnDataType = partitionInfo.getColumnSchemaList().get(0).getDataType();
@@ -135,7 +137,8 @@ public class PartitionFilterUtil {
         outer1:
         for (int i = 0; i < partitions; i++) {
           for (String value : values.get(i)) {
-            Object listValue = PartitionUtil.getDataBasedOnDataType(value, partitionColumnDataType);
+            Object listValue = PartitionUtil.getDataBasedOnDataType(value, partitionColumnDataType,
+                timestampFormatter, dateFormatter);
             if (comparator.compare(listValue, filterValue) >= 0) {
               partitionMap.set(i);
               continue outer1;
@@ -147,7 +150,8 @@ public class PartitionFilterUtil {
         outer2:
         for (int i = 0; i < partitions; i++) {
           for (String value : values.get(i)) {
-            Object listValue = PartitionUtil.getDataBasedOnDataType(value, partitionColumnDataType);
+            Object listValue = PartitionUtil.getDataBasedOnDataType(value, partitionColumnDataType,
+                timestampFormatter, dateFormatter);
             if (comparator.compare(listValue, filterValue) > 0) {
               partitionMap.set(i);
               continue outer2;
@@ -161,7 +165,8 @@ public class PartitionFilterUtil {
         outer3:
         for (int i = 0; i < partitions; i++) {
           for (String value : values.get(i)) {
-            Object listValue = PartitionUtil.getDataBasedOnDataType(value, partitionColumnDataType);
+            Object listValue = PartitionUtil.getDataBasedOnDataType(value, partitionColumnDataType,
+                timestampFormatter, dateFormatter);
             if (comparator.compare(listValue, filterValue) <= 0) {
               partitionMap.set(i);
               continue outer3;
@@ -173,7 +178,8 @@ public class PartitionFilterUtil {
         outer4:
         for (int i = 0; i < partitions; i++) {
           for (String value : values.get(i)) {
-            Object listValue = PartitionUtil.getDataBasedOnDataType(value, partitionColumnDataType);
+            Object listValue = PartitionUtil.getDataBasedOnDataType(value, partitionColumnDataType,
+                timestampFormatter, dateFormatter);
             if (comparator.compare(listValue, filterValue) < 0) {
               partitionMap.set(i);
               continue outer4;
@@ -196,7 +202,8 @@ public class PartitionFilterUtil {
    * @return
    */
   public static BitSet getPartitionMapForRangeFilter(PartitionInfo partitionInfo,
-      RangePartitioner partitioner, Object filterValue, boolean isGreaterThan, boolean isEqualTo) {
+      RangePartitioner partitioner, Object filterValue, boolean isGreaterThan, boolean isEqualTo,
+      DateFormat timestampFormatter, DateFormat dateFormatter) {
 
     List<String> values = partitionInfo.getRangeInfo();
     DataType partitionColumnDataType = partitionInfo.getColumnSchemaList().get(0).getDataType();
@@ -213,7 +220,7 @@ public class PartitionFilterUtil {
     // find the partition of filter value
     for (; partitionIndex < numPartitions; partitionIndex++) {
       result = comparator.compare(filterValue, PartitionUtil.getDataBasedOnDataType(
-          values.get(partitionIndex), partitionColumnDataType));
+          values.get(partitionIndex), partitionColumnDataType, timestampFormatter, dateFormatter));
       if (result <= 0) {
         break;
       }

--- a/core/src/main/java/org/apache/carbondata/core/scan/partition/ListPartitioner.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/partition/ListPartitioner.java
@@ -17,16 +17,27 @@
 
 package org.apache.carbondata.core.scan.partition;
 
+import java.text.SimpleDateFormat;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.metadata.datatype.DataType;
 import org.apache.carbondata.core.metadata.schema.PartitionInfo;
+import org.apache.carbondata.core.util.CarbonProperties;
 
 /**
  * List Partitioner
  */
 public class ListPartitioner implements Partitioner {
+
+  private SimpleDateFormat timestampFormatter = new SimpleDateFormat(CarbonProperties.getInstance()
+      .getProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT,
+          CarbonCommonConstants.CARBON_TIMESTAMP_DEFAULT_FORMAT));
+
+  private SimpleDateFormat dateFormatter = new SimpleDateFormat(CarbonProperties.getInstance()
+      .getProperty(CarbonCommonConstants.CARBON_DATE_FORMAT,
+          CarbonCommonConstants.CARBON_DATE_DEFAULT_FORMAT));
 
   /**
    * map the value of ListPartition to partition id.
@@ -41,7 +52,8 @@ public class ListPartitioner implements Partitioner {
     numPartitions = values.size();
     for (int i = 0; i < numPartitions; i++) {
       for (String value : values.get(i)) {
-        map.put(PartitionUtil.getDataBasedOnDataType(value, partitionColumnDataType), i);
+        map.put(PartitionUtil.getDataBasedOnDataType(value, partitionColumnDataType,
+            timestampFormatter, dateFormatter), i);
       }
     }
   }

--- a/core/src/main/java/org/apache/carbondata/core/scan/partition/PartitionUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/partition/PartitionUtil.java
@@ -19,37 +19,14 @@ package org.apache.carbondata.core.scan.partition;
 
 import java.math.BigDecimal;
 import java.text.DateFormat;
-import java.text.SimpleDateFormat;
 import java.util.BitSet;
 
-import org.apache.carbondata.common.logging.LogService;
-import org.apache.carbondata.common.logging.LogServiceFactory;
-import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.metadata.datatype.DataType;
 import org.apache.carbondata.core.metadata.schema.PartitionInfo;
-import org.apache.carbondata.core.util.CarbonProperties;
 
 import org.apache.commons.lang.StringUtils;
 
 public class PartitionUtil {
-
-  private static LogService LOGGER = LogServiceFactory.getLogService(PartitionUtil.class.getName());
-
-  private static final ThreadLocal<DateFormat> timestampFormatter = new ThreadLocal<DateFormat>() {
-    @Override protected DateFormat initialValue() {
-      return new SimpleDateFormat(CarbonProperties.getInstance()
-          .getProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT,
-              CarbonCommonConstants.CARBON_TIMESTAMP_DEFAULT_FORMAT));
-    }
-  };
-
-  private static final ThreadLocal<DateFormat> dateFormatter = new ThreadLocal<DateFormat>() {
-    @Override protected DateFormat initialValue() {
-      return new SimpleDateFormat(CarbonProperties.getInstance()
-          .getProperty(CarbonCommonConstants.CARBON_DATE_FORMAT,
-              CarbonCommonConstants.CARBON_DATE_DEFAULT_FORMAT));
-    }
-  };
 
   public static Partitioner getPartitioner(PartitionInfo partitionInfo) {
     switch (partitionInfo.getPartitionType()) {
@@ -65,7 +42,8 @@ public class PartitionUtil {
     }
   }
 
-  public static Object getDataBasedOnDataType(String data, DataType actualDataType) {
+  public static Object getDataBasedOnDataType(String data, DataType actualDataType,
+      DateFormat timestampFormatter, DateFormat dateFormatter) {
     if (data == null) {
       return null;
     }
@@ -85,9 +63,9 @@ public class PartitionUtil {
         case LONG:
           return Long.parseLong(data);
         case DATE:
-          return PartitionUtil.dateFormatter.get().parse(data).getTime();
+          return dateFormatter.parse(data).getTime();
         case TIMESTAMP:
-          return PartitionUtil.timestampFormatter.get().parse(data).getTime();
+          return timestampFormatter.parse(data).getTime();
         case DECIMAL:
           return new BigDecimal(data);
         default:

--- a/core/src/main/java/org/apache/carbondata/core/scan/partition/RangePartitioner.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/partition/RangePartitioner.java
@@ -19,11 +19,14 @@ package org.apache.carbondata.core.scan.partition;
 
 import java.io.Serializable;
 import java.math.BigDecimal;
+import java.text.SimpleDateFormat;
 import java.util.List;
 
+import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.metadata.datatype.DataType;
 import org.apache.carbondata.core.metadata.schema.PartitionInfo;
 import org.apache.carbondata.core.util.ByteUtil;
+import org.apache.carbondata.core.util.CarbonProperties;
 
 /**
  * Range Partitioner
@@ -33,6 +36,14 @@ public class RangePartitioner implements Partitioner {
   private int numPartitions;
   private Object[] bounds;
   private SerializableComparator comparator;
+
+  private SimpleDateFormat timestampFormatter = new SimpleDateFormat(CarbonProperties.getInstance()
+      .getProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT,
+          CarbonCommonConstants.CARBON_TIMESTAMP_DEFAULT_FORMAT));
+
+  private SimpleDateFormat dateFormatter = new SimpleDateFormat(CarbonProperties.getInstance()
+      .getProperty(CarbonCommonConstants.CARBON_DATE_FORMAT,
+          CarbonCommonConstants.CARBON_DATE_DEFAULT_FORMAT));
 
   public RangePartitioner(PartitionInfo partitionInfo) {
     List<String> values = partitionInfo.getRangeInfo();
@@ -45,7 +56,8 @@ public class RangePartitioner implements Partitioner {
       }
     } else {
       for (int i = 0; i < numPartitions; i++) {
-        bounds[i] = PartitionUtil.getDataBasedOnDataType(values.get(i), partitionColumnDataType);
+        bounds[i] = PartitionUtil.getDataBasedOnDataType(values.get(i), partitionColumnDataType,
+            timestampFormatter, dateFormatter);
       }
     }
 
@@ -75,6 +87,7 @@ public class RangePartitioner implements Partitioner {
   /**
    * number of partitions
    * add extra default partition
+   *
    * @return
    */
   @Override public int numPartitions() {

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/partition/TestAllDataTypeForPartitionTable.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/partition/TestAllDataTypeForPartitionTable.scala
@@ -23,13 +23,11 @@ import org.apache.carbondata.core.util.CarbonProperties
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.common.util.QueryTest
 import org.scalatest.BeforeAndAfterAll
-
 import scala.collection.mutable
 
-class TestAllDataTypeForPartitionTable extends QueryTest with BeforeAndAfterAll {
+import org.apache.spark.sql.test.TestQueryExecutor
 
-  val defaultTimestampFormat = CarbonProperties.getInstance()
-    .getProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT)
+class TestAllDataTypeForPartitionTable extends QueryTest with BeforeAndAfterAll {
 
   override def beforeAll {
     CarbonProperties.getInstance()
@@ -41,7 +39,7 @@ class TestAllDataTypeForPartitionTable extends QueryTest with BeforeAndAfterAll 
 
   override def afterAll = {
     CarbonProperties.getInstance()
-      .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, CarbonCommonConstants.CARBON_TIMESTAMP_DEFAULT_FORMAT)
+      .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, TestQueryExecutor.timestampFormat)
       .addProperty(CarbonCommonConstants.CARBON_DATE_FORMAT, CarbonCommonConstants.CARBON_DATE_DEFAULT_FORMAT)
 
     dropTable

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/partition/TestDDLForPartitionTable.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/partition/TestDDLForPartitionTable.scala
@@ -18,17 +18,22 @@
 package org.apache.carbondata.spark.testsuite.partition
 
 import org.apache.spark.sql.common.util.QueryTest
+import org.apache.spark.sql.test.TestQueryExecutor
 import org.scalatest.BeforeAndAfterAll
 
+import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.metadata.CarbonMetadata
 import org.apache.carbondata.core.metadata.datatype.DataType
 import org.apache.carbondata.core.metadata.encoder.Encoding
 import org.apache.carbondata.core.metadata.schema.partition.PartitionType
+import org.apache.carbondata.core.util.CarbonProperties
 
 class TestDDLForPartitionTable  extends QueryTest with BeforeAndAfterAll {
 
   override def beforeAll = {
     dropTable
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, "dd-MM-yyyy")
   }
 
   test("create partition table: hash partition") {
@@ -132,6 +137,8 @@ class TestDDLForPartitionTable  extends QueryTest with BeforeAndAfterAll {
 
   override def afterAll = {
     dropTable
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, TestQueryExecutor.timestampFormat)
   }
 
   def dropTable = {

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/partition/TestDataLoadingForPartitionTable.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/partition/TestDataLoadingForPartitionTable.scala
@@ -17,6 +17,7 @@
 package org.apache.carbondata.spark.testsuite.partition
 
 import org.apache.spark.sql.common.util.QueryTest
+import org.apache.spark.sql.test.TestQueryExecutor
 import org.scalatest.BeforeAndAfterAll
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants
@@ -27,9 +28,6 @@ import org.apache.carbondata.core.util.CarbonProperties
 import org.apache.carbondata.core.util.path.CarbonTablePath
 
 class TestDataLoadingForPartitionTable extends QueryTest with BeforeAndAfterAll {
-
-  val defaultTimestampFormat = CarbonProperties.getInstance()
-    .getProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT)
 
   override def beforeAll {
     dropTable
@@ -283,14 +281,8 @@ class TestDataLoadingForPartitionTable extends QueryTest with BeforeAndAfterAll 
 
   override def afterAll = {
     dropTable
-    if (defaultTimestampFormat == null) {
-      CarbonProperties.getInstance()
-        .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT,
-          CarbonCommonConstants.CARBON_TIMESTAMP_DEFAULT_FORMAT)
-    } else {
-      CarbonProperties.getInstance()
-        .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, defaultTimestampFormat)
-    }
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, TestQueryExecutor.timestampFormat)
   }
 
   def dropTable = {

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/partition/TestQueryForPartitionTable.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/partition/TestQueryForPartitionTable.scala
@@ -18,6 +18,7 @@
 package org.apache.carbondata.spark.testsuite.partition
 
 import org.apache.spark.sql.common.util.QueryTest
+import org.apache.spark.sql.test.TestQueryExecutor
 import org.scalatest.BeforeAndAfterAll
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants
@@ -141,6 +142,8 @@ class TestQueryForPartitionTable  extends QueryTest with BeforeAndAfterAll {
 
   override def afterAll = {
     dropTable
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, TestQueryExecutor.timestampFormat)
   }
 
   def dropTable = {

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -1013,15 +1013,28 @@ object CarbonDataRDDFactory {
     if (partitionColumnIndex == -1) {
       throw new DataLoadingException("Partition column not found.")
     }
+
+    val dateFormatMap = CarbonDataProcessorUtil.getDateFormatMap(carbonLoadModel.getDateFormat())
+    val specificFormat = Option(dateFormatMap.get(partitionColumn.toLowerCase))
+    val timeStampFormat = if (specificFormat.isDefined) {
+      new SimpleDateFormat(specificFormat.get)
+    } else {
+      val timestampFormatString = CarbonProperties.getInstance().getProperty(CarbonCommonConstants
+        .CARBON_TIMESTAMP_FORMAT, CarbonCommonConstants.CARBON_TIMESTAMP_DEFAULT_FORMAT)
+      new SimpleDateFormat(timestampFormatString)
+    }
+
+    val dateFormat = if (specificFormat.isDefined) {
+      new SimpleDateFormat(specificFormat.get)
+    } else {
+      val dateFormatString = CarbonProperties.getInstance().getProperty(CarbonCommonConstants
+        .CARBON_DATE_FORMAT, CarbonCommonConstants.CARBON_DATE_DEFAULT_FORMAT)
+      new SimpleDateFormat(dateFormatString)
+    }
+
     // generate RDD[(K, V)] to use the partitionBy method of PairRDDFunctions
     val inputRDD: RDD[(String, Row)] = if (dataFrame.isDefined) {
       // input data from DataFrame
-      val timestampFormatString = CarbonProperties.getInstance().getProperty(CarbonCommonConstants
-        .CARBON_TIMESTAMP_FORMAT, CarbonCommonConstants.CARBON_TIMESTAMP_DEFAULT_FORMAT)
-      val timeStampFormat = new SimpleDateFormat(timestampFormatString)
-      val dateFormatString = CarbonProperties.getInstance().getProperty(CarbonCommonConstants
-        .CARBON_DATE_FORMAT, CarbonCommonConstants.CARBON_DATE_DEFAULT_FORMAT)
-      val dateFormat = new SimpleDateFormat(dateFormatString)
       val delimiterLevel1 = carbonLoadModel.getComplexDelimiterLevel1
       val delimiterLevel2 = carbonLoadModel.getComplexDelimiterLevel2
       val serializationNullFormat =
@@ -1060,7 +1073,8 @@ object CarbonDataRDDFactory {
       }
     } else {
       inputRDD.map { row =>
-        (PartitionUtil.getDataBasedOnDataType(row._1, partitionColumnDataType), row._2)
+        (PartitionUtil.getDataBasedOnDataType(row._1, partitionColumnDataType, timeStampFormat,
+          dateFormat), row._2)
       }
         .partitionBy(partitioner)
         .map(_._2)


### PR DESCRIPTION
the format of Timestamp/Date use a static variable, it is not proper.

the format of Timestamp/Date:
during dataloading,  if load sql specific datefromat, use it. if not, use carbon property.

during query, use spark/hive dateformat.

during create table, use carbon property.