### PR TITLE
[carbondata-1149] Fix issue of mismatch type of partition column when specify partition info

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/util/DataTypeUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/DataTypeUtil.java
@@ -284,17 +284,6 @@ public final class DataTypeUtil {
             return null;
           }
           return Long.parseLong(data);
-        case BYTE:
-          if (data.isEmpty()) {
-            return null;
-          }
-          return Byte.parseByte(data);
-        case BOOLEAN:
-          if (data.isEmpty() || !(data.equalsIgnoreCase("false")
-              || data.equalsIgnoreCase("true"))) {
-            return null;
-          }
-          return Boolean.parseBoolean(data);
         case DATE:
           if (data.isEmpty()) {
             return null;

--- a/core/src/main/java/org/apache/carbondata/core/util/DataTypeUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/DataTypeUtil.java
@@ -269,6 +269,11 @@ public final class DataTypeUtil {
             return null;
           }
           return Short.parseShort(data);
+        case FLOAT:
+          if (data.isEmpty()) {
+            return null;
+          }
+          return Long.parseLong(data);
         case DOUBLE:
           if (data.isEmpty()) {
             return null;
@@ -279,6 +284,17 @@ public final class DataTypeUtil {
             return null;
           }
           return Long.parseLong(data);
+        case BYTE:
+          if (data.isEmpty()) {
+            return null;
+          }
+          return Byte.parseByte(data);
+        case BOOLEAN:
+          if (data.isEmpty() || !(data.equalsIgnoreCase("false")
+              || data.equalsIgnoreCase("true"))) {
+            return null;
+          }
+          return Boolean.parseBoolean(data);
         case DATE:
           if (data.isEmpty()) {
             return null;

--- a/core/src/main/java/org/apache/carbondata/core/util/DataTypeUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/DataTypeUtil.java
@@ -273,7 +273,7 @@ public final class DataTypeUtil {
           if (data.isEmpty()) {
             return null;
           }
-          return Long.parseLong(data);
+          return Float.parseFloat(data);
         case DOUBLE:
           if (data.isEmpty()) {
             return null;

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/partition/TestDDLForPartitionTable.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/partition/TestDDLForPartitionTable.scala
@@ -31,6 +31,9 @@ import org.apache.carbondata.core.util.CarbonProperties
 class TestDDLForPartitionTable  extends QueryTest with BeforeAndAfterAll {
 
   override def beforeAll = {
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, "yyyy-MM-dd HH:mm:ss")
+      .addProperty(CarbonCommonConstants.CARBON_DATE_FORMAT, "yyyy-MM-dd")
     dropTable
     CarbonProperties.getInstance()
       .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, "dd-MM-yyyy")
@@ -68,7 +71,7 @@ class TestDDLForPartitionTable  extends QueryTest with BeforeAndAfterAll {
         | PARTITIONED BY (doj Timestamp)
         | STORED BY 'org.apache.carbondata.format'
         | TBLPROPERTIES('PARTITION_TYPE'='RANGE',
-        |  'RANGE_INFO'='01-01-2010, 01-01-2015, 01-04-2015, 01-07-2015')
+        |  'RANGE_INFO'='2017-06-11 00:00:02, 2017-06-13 23:59:59')
       """.stripMargin)
 
     val carbonTable = CarbonMetadata.getInstance().getCarbonTable("default_rangeTable")
@@ -81,11 +84,9 @@ class TestDDLForPartitionTable  extends QueryTest with BeforeAndAfterAll {
     assert(partitionInfo.getColumnSchemaList.get(0).getEncodingList.get(1) == Encoding.DIRECT_DICTIONARY)
     assert(partitionInfo.getColumnSchemaList.get(0).getEncodingList.get(2) == Encoding.INVERTED_INDEX)
     assert(partitionInfo.getPartitionType == PartitionType.RANGE)
-    assert(partitionInfo.getRangeInfo.size == 4)
-    assert(partitionInfo.getRangeInfo.get(0).equals("01-01-2010"))
-    assert(partitionInfo.getRangeInfo.get(1).equals("01-01-2015"))
-    assert(partitionInfo.getRangeInfo.get(2).equals("01-04-2015"))
-    assert(partitionInfo.getRangeInfo.get(3).equals("01-07-2015"))
+    assert(partitionInfo.getRangeInfo.size == 2)
+    assert(partitionInfo.getRangeInfo.get(0).equals("2017-06-11 00:00:02"))
+    assert(partitionInfo.getRangeInfo.get(1).equals("2017-06-13 23:59:59"))
   }
 
   test("create partition table: list partition") {
@@ -175,205 +176,183 @@ class TestDDLForPartitionTable  extends QueryTest with BeforeAndAfterAll {
 
 
   test("test exception when values in list_info can not match partition column type") {
-    sql("DROP TABLE IF EXISTS test_list_1")
-    val exception_test_list_1: Exception = intercept[Exception] {
+    sql("DROP TABLE IF EXISTS test_list_int")
+    val exception_test_list_int: Exception = intercept[Exception] {
       sql(
         """
-          | CREATE TABLE test_list_1(col1 INT, col2 STRING)
+          | CREATE TABLE test_list_int(col1 INT, col2 STRING)
           | PARTITIONED BY (col3 INT) STORED BY 'carbondata'
           | TBLPROPERTIES('PARTITION_TYPE'='LIST', 'LIST_INFO'='abc,def')
         """.stripMargin)
     }
-    assert(exception_test_list_1.getMessage.contains("Invalid partition definition"))
+    assert(exception_test_list_int.getMessage.contains("Invalid partition definition"))
 
-    sql("DROP TABLE IF EXISTS test_list_2")
-    val exception_test_list_2: Exception = intercept[Exception] {
+    sql("DROP TABLE IF EXISTS test_list_small")
+    val exception_test_list_small: Exception = intercept[Exception] {
       sql(
         """
-          | CREATE TABLE test_list_2(col1 INT, col2 STRING)
+          | CREATE TABLE test_list_small(col1 INT, col2 STRING)
           | PARTITIONED BY (col3 SMALLINT) STORED BY 'carbondata'
           | TBLPROPERTIES('PARTITION_TYPE'='LIST', 'LIST_INFO'='abc,def')
         """.stripMargin)
     }
-    assert(exception_test_list_2.getMessage.contains("Invalid partition definition"))
+    assert(exception_test_list_small.getMessage.contains("Invalid partition definition"))
 
-    sql("DROP TABLE IF EXISTS test_list_3")
-    val exception_test_list_3: Exception = intercept[Exception] {
+    sql("DROP TABLE IF EXISTS test_list_float")
+    val exception_test_list_float: Exception = intercept[Exception] {
       sql(
         """
-          | CREATE TABLE test_list_3(col1 INT, col2 STRING)
+          | CREATE TABLE test_list_float(col1 INT, col2 STRING)
           | PARTITIONED BY (col3 FLOAT) STORED BY 'carbondata'
           | TBLPROPERTIES('PARTITION_TYPE'='LIST', 'LIST_INFO'='abc,def')
         """.stripMargin)
     }
-    assert(exception_test_list_3.getMessage.contains("Invalid partition definition"))
+    assert(exception_test_list_float.getMessage.contains("Invalid partition definition"))
 
-    sql("DROP TABLE IF EXISTS test_list_4")
-    val exception_test_list_4: Exception = intercept[Exception] {
+    sql("DROP TABLE IF EXISTS test_list_double")
+    val exception_test_list_double: Exception = intercept[Exception] {
       sql(
         """
-          | CREATE TABLE test_list_4(col1 INT, col2 STRING)
+          | CREATE TABLE test_list_double(col1 INT, col2 STRING)
           | PARTITIONED BY (col3 DOUBLE) STORED BY 'carbondata'
           | TBLPROPERTIES('PARTITION_TYPE'='LIST', 'LIST_INFO'='abc,def')
         """.stripMargin)
     }
-    assert(exception_test_list_4.getMessage.contains("Invalid partition definition"))
+    assert(exception_test_list_double.getMessage.contains("Invalid partition definition"))
 
-    sql("DROP TABLE IF EXISTS test_list_5")
-    val exception_test_list_5: Exception = intercept[Exception] {
+    sql("DROP TABLE IF EXISTS test_list_bigint")
+    val exception_test_list_bigint: Exception = intercept[Exception] {
       sql(
         """
-          | CREATE TABLE test_list_5(col1 INT, col2 STRING)
+          | CREATE TABLE test_list_bigint(col1 INT, col2 STRING)
           | PARTITIONED BY (col3 BIGINT) STORED BY 'carbondata'
           | TBLPROPERTIES('PARTITION_TYPE'='LIST', 'LIST_INFO'='abc,def')
         """.stripMargin)
     }
-    assert(exception_test_list_5.getMessage.contains("Invalid partition definition"))
+    assert(exception_test_list_bigint.getMessage.contains("Invalid partition definition"))
 
-    sql("DROP TABLE IF EXISTS test_list_6")
-    val exception_test_list_6: Exception = intercept[Exception] {
+    sql("DROP TABLE IF EXISTS test_list_date")
+    val exception_test_list_date: Exception = intercept[Exception] {
       sql(
         """
-          | CREATE TABLE test_list_6(col1 INT, col2 STRING)
-          | PARTITIONED BY (col3 BOOLEAN) STORED BY 'carbondata'
-          | TBLPROPERTIES('PARTITION_TYPE'='LIST', 'LIST_INFO'='abc,def')
-        """.stripMargin)
-    }
-    assert(exception_test_list_6.getMessage.contains("Invalid partition definition"))
-
-    sql("DROP TABLE IF EXISTS test_list_7")
-    val exception_test_list_7: Exception = intercept[Exception] {
-      sql(
-        """
-          | CREATE TABLE test_list_7(col1 INT, col2 STRING)
+          | CREATE TABLE test_list_date(col1 INT, col2 STRING)
           | PARTITIONED BY (col3 DATE) STORED BY 'carbondata'
           | TBLPROPERTIES('PARTITION_TYPE'='LIST', 'LIST_INFO'='abc,def')
         """.stripMargin)
     }
-    assert(exception_test_list_7.getMessage.contains("Invalid partition definition"))
+    assert(exception_test_list_date.getMessage.contains("Invalid partition definition"))
 
-    sql("DROP TABLE IF EXISTS test_list_8")
-    val exception_test_list_8: Exception = intercept[Exception] {
+    sql("DROP TABLE IF EXISTS test_list_timestamp")
+    val exception_test_list_timestamp: Exception = intercept[Exception] {
       sql(
         """
-          | CREATE TABLE test_list_8(col1 INT, col2 STRING)
+          | CREATE TABLE test_list_timestamp(col1 INT, col2 STRING)
           | PARTITIONED BY (col3 TIMESTAMP) STORED BY 'carbondata'
           | TBLPROPERTIES('PARTITION_TYPE'='LIST', 'LIST_INFO'='abc,def')
         """.stripMargin)
     }
-    assert(exception_test_list_8.getMessage.contains("Invalid partition definition"))
+    assert(exception_test_list_timestamp.getMessage.contains("Invalid partition definition"))
 
-    sql("DROP TABLE IF EXISTS test_list_9")
-    val exception_test_list_9: Exception = intercept[Exception] {
+    sql("DROP TABLE IF EXISTS test_list_decimal")
+    val exception_test_list_decimal: Exception = intercept[Exception] {
       sql(
         """
-          | CREATE TABLE test_list_9(col1 INT, col2 STRING)
+          | CREATE TABLE test_list_decimal(col1 INT, col2 STRING)
           | PARTITIONED BY (col3 DECIMAL(25, 4)) STORED BY 'carbondata'
-          | TBLPROPERTIES('PARTITION_TYPE'='LIST', 'LIST_INFO'='abc,def')
+          | TBLPROPERTIES('PARTITION_TYPE'='LIST', 'LIST_INFO'='23.23111,2.32')
         """.stripMargin)
     }
-    assert(exception_test_list_9.getMessage.contains("Invalid partition definition"))
+    assert(exception_test_list_decimal.getMessage.contains("Invalid partition definition"))
   }
 
   test("test exception when values in range_info can not match partition column type") {
-    sql("DROP TABLE IF EXISTS test_range_1")
-    val exception_test_range_1: Exception = intercept[Exception] {
+    sql("DROP TABLE IF EXISTS test_range_int")
+    val exception_test_range_int: Exception = intercept[Exception] {
       sql(
         """
-          | CREATE TABLE test_range_1(col1 INT, col2 STRING)
+          | CREATE TABLE test_range_int(col1 INT, col2 STRING)
           | PARTITIONED BY (col3 INT) STORED BY 'carbondata'
           | TBLPROPERTIES('PARTITION_TYPE'='RANGE', 'RANGE_INFO'='abc,def')
         """.stripMargin)
     }
-    assert(exception_test_range_1.getMessage.contains("Invalid partition definition"))
+    assert(exception_test_range_int.getMessage.contains("Invalid partition definition"))
 
-    sql("DROP TABLE IF EXISTS test_range_2")
-    val exception_test_range_2: Exception = intercept[Exception] {
+    sql("DROP TABLE IF EXISTS test_range_smallint")
+    val exception_test_range_smallint: Exception = intercept[Exception] {
       sql(
         """
-          | CREATE TABLE test_range_2(col1 INT, col2 STRING)
+          | CREATE TABLE test_range_smallint(col1 INT, col2 STRING)
           | PARTITIONED BY (col3 SMALLINT) STORED BY 'carbondata'
           | TBLPROPERTIES('PARTITION_TYPE'='RANGE', 'RANGE_INFO'='abc,def')
         """.stripMargin)
     }
-    assert(exception_test_range_2.getMessage.contains("Invalid partition definition"))
+    assert(exception_test_range_smallint.getMessage.contains("Invalid partition definition"))
 
-    sql("DROP TABLE IF EXISTS test_range_3")
-    val exception_test_range_3: Exception = intercept[Exception] {
+    sql("DROP TABLE IF EXISTS test_range_float")
+    val exception_test_range_float: Exception = intercept[Exception] {
       sql(
         """
-          | CREATE TABLE test_range_3(col1 INT, col2 STRING)
+          | CREATE TABLE test_range_float(col1 INT, col2 STRING)
           | PARTITIONED BY (col3 FLOAT) STORED BY 'carbondata'
           | TBLPROPERTIES('PARTITION_TYPE'='RANGE', 'RANGE_INFO'='abc,def')
         """.stripMargin)
     }
-    assert(exception_test_range_3.getMessage.contains("Invalid partition definition"))
+    assert(exception_test_range_float.getMessage.contains("Invalid partition definition"))
 
-    sql("DROP TABLE IF EXISTS test_range_4")
-    val exception_test_range_4: Exception = intercept[Exception] {
+    sql("DROP TABLE IF EXISTS test_range_double")
+    val exception_test_range_double: Exception = intercept[Exception] {
       sql(
         """
-          | CREATE TABLE test_range_4(col1 INT, col2 STRING)
+          | CREATE TABLE test_range_double(col1 INT, col2 STRING)
           | PARTITIONED BY (col3 DOUBLE) STORED BY 'carbondata'
           | TBLPROPERTIES('PARTITION_TYPE'='RANGE', 'RANGE_INFO'='abc,def')
         """.stripMargin)
     }
-    assert(exception_test_range_4.getMessage.contains("Invalid partition definition"))
+    assert(exception_test_range_double.getMessage.contains("Invalid partition definition"))
 
-    sql("DROP TABLE IF EXISTS test_range_5")
-    val exception_test_range_5: Exception = intercept[Exception] {
+    sql("DROP TABLE IF EXISTS test_range_bigint")
+    val exception_test_range_bigint: Exception = intercept[Exception] {
       sql(
         """
-          | CREATE TABLE test_range_5(col1 INT, col2 STRING)
+          | CREATE TABLE test_range_bigint(col1 INT, col2 STRING)
           | PARTITIONED BY (col3 BIGINT) STORED BY 'carbondata'
           | TBLPROPERTIES('PARTITION_TYPE'='RANGE', 'RANGE_INFO'='abc,def')
         """.stripMargin)
     }
-    assert(exception_test_range_5.getMessage.contains("Invalid partition definition"))
+    assert(exception_test_range_bigint.getMessage.contains("Invalid partition definition"))
 
-    sql("DROP TABLE IF EXISTS test_range_6")
-    val exception_test_range_6: Exception = intercept[Exception] {
+    sql("DROP TABLE IF EXISTS test_range_date")
+    val exception_test_range_date: Exception = intercept[Exception] {
       sql(
         """
-          | CREATE TABLE test_range_6(col1 INT, col2 STRING)
-          | PARTITIONED BY (col3 BOOLEAN) STORED BY 'carbondata'
+          | CREATE TABLE test_range_date(col1 INT, col2 STRING)
+          | PARTITIONED BY (col3 DATE) STORED BY 'carbondata'
           | TBLPROPERTIES('PARTITION_TYPE'='RANGE', 'RANGE_INFO'='abc,def')
         """.stripMargin)
     }
-    assert(exception_test_range_6.getMessage.contains("Invalid partition definition"))
+    assert(exception_test_range_date.getMessage.contains("Invalid partition definition"))
 
-    sql("DROP TABLE IF EXISTS test_range_7")
-    val exception_test_range_7: Exception = intercept[Exception] {
+    sql("DROP TABLE IF EXISTS test_range_timestamp")
+    val exception_test_range_timestamp: Exception = intercept[Exception] {
       sql(
         """
-          | CREATE TABLE test_range_7(col1 INT, col2 STRING)
-          | PARTITIONED BY (col3 BOOLEAN) STORED BY 'carbondata'
-          | TBLPROPERTIES('PARTITION_TYPE'='RANGE', 'RANGE_INFO'='abc,def')
-        """.stripMargin)
-    }
-    assert(exception_test_range_7.getMessage.contains("Invalid partition definition"))
-
-    sql("DROP TABLE IF EXISTS test_range_8")
-    val exception_test_range_8: Exception = intercept[Exception] {
-      sql(
-        """
-          | CREATE TABLE test_range_8(col1 INT, col2 STRING)
+          | CREATE TABLE test_range_timestamp(col1 INT, col2 STRING)
           | PARTITIONED BY (col3 TIMESTAMP) STORED BY 'carbondata'
           | TBLPROPERTIES('PARTITION_TYPE'='RANGE', 'RANGE_INFO'='abc,def')
         """.stripMargin)
     }
-    assert(exception_test_range_8.getMessage.contains("Invalid partition definition"))
+    assert(exception_test_range_timestamp.getMessage.contains("Invalid partition definition"))
 
-    sql("DROP TABLE IF EXISTS test_range_9")
-    val exception_test_range_9: Exception = intercept[Exception] {
+    sql("DROP TABLE IF EXISTS test_range_decimal")
+    val exception_test_range_decimal: Exception = intercept[Exception] {
       sql(
         """
-          | CREATE TABLE test_range_8(col1 INT, col2 STRING)
+          | CREATE TABLE test_range_decimal(col1 INT, col2 STRING)
           | PARTITIONED BY (col3 DECIMAL(25, 4)) STORED BY 'carbondata'
           | TBLPROPERTIES('PARTITION_TYPE'='RANGE', 'RANGE_INFO'='abc,def')
         """.stripMargin)
     }
-    assert(exception_test_range_9.getMessage.contains("Invalid partition definition"))
+    assert(exception_test_range_decimal.getMessage.contains("Invalid partition definition"))
 
   }
 
@@ -388,6 +367,25 @@ class TestDDLForPartitionTable  extends QueryTest with BeforeAndAfterAll {
     sql("drop table if exists rangeTable")
     sql("drop table if exists listTable")
     sql("drop table if exists test")
+    sql("DROP TABLE IF EXISTS test_hash_1")
+    sql("DROP TABLE IF EXISTS test_hash_2")
+    sql("DROP TABLE IF EXISTS test_hash_3")
+    sql("DROP TABLE IF EXISTS test_list_int")
+    sql("DROP TABLE IF EXISTS test_list_smallint")
+    sql("DROP TABLE IF EXISTS test_list_bigint")
+    sql("DROP TABLE IF EXISTS test_list_float")
+    sql("DROP TABLE IF EXISTS test_list_double")
+    sql("DROP TABLE IF EXISTS test_list_date")
+    sql("DROP TABLE IF EXISTS test_list_timestamp")
+    sql("DROP TABLE IF EXISTS test_list_decimal")
+    sql("DROP TABLE IF EXISTS test_range_int")
+    sql("DROP TABLE IF EXISTS test_range_smallint")
+    sql("DROP TABLE IF EXISTS test_range_bigint")
+    sql("DROP TABLE IF EXISTS test_range_float")
+    sql("DROP TABLE IF EXISTS test_range_double")
+    sql("DROP TABLE IF EXISTS test_range_date")
+    sql("DROP TABLE IF EXISTS test_range_timestamp")
+    sql("DROP TABLE IF EXISTS test_range_decimal")
   }
 
 }

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/partition/TestDDLForPartitionTable.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/partition/TestDDLForPartitionTable.scala
@@ -131,8 +131,250 @@ class TestDDLForPartitionTable  extends QueryTest with BeforeAndAfterAll {
     sql(
       """create table des(a int, b string) partitioned by (c string) stored by 'carbondata'
         |tblproperties ('partition_type'='list','list_info'='1,2')""".stripMargin)
-    checkExistence(sql("describe formatted des"),true, "Partition Columns")
+    checkExistence(sql("describe formatted des"), true, "Partition Columns")
     sql("drop table if exists des")
+  }
+
+  test("test exception if hash number is invalid") {
+    sql("DROP TABLE IF EXISTS test_hash_1")
+    val exception_test_hash_1: Exception = intercept[Exception] {
+      sql(
+        """
+          | CREATE TABLE test_hash_1(col1 INT, col2 STRING)
+          | PARTITIONED BY (col3 INT) STORED BY 'carbondata'
+          | TBLPROPERTIES('PARTITION_TYPE'='HASH', 'NUM_PARTITIONS'='2.1')
+        """.stripMargin
+      )
+    }
+    assert(exception_test_hash_1.getMessage.contains("Invalid partition definition"))
+
+    sql("DROP TABLE IF EXISTS test_hash_2")
+    val exception_test_hash_2: Exception = intercept[Exception] {
+      sql(
+        """
+          | CREATE TABLE test_hash_2(col1 INT, col2 STRING)
+          | PARTITIONED BY (col3 INT) STORED BY 'carbondata'
+          | TBLPROPERTIES('PARTITION_TYPE'='HASH', 'NUM_PARTITIONS'='abc')
+        """.stripMargin
+      )
+    }
+    assert(exception_test_hash_2.getMessage.contains("Invalid partition definition"))
+
+    sql("DROP TABLE IF EXISTS test_hash_3")
+    val exception_test_hash_3: Exception = intercept[Exception] {
+      sql(
+        """
+          | CREATE TABLE test_hash_3(col1 INT, col2 STRING)
+          | PARTITIONED BY (col3 INT) STORED BY 'carbondata'
+          | TBLPROPERTIES('PARTITION_TYPE'='HASH', 'NUM_PARTITIONS'='-2.1')
+        """.stripMargin
+      )
+    }
+    assert(exception_test_hash_3.getMessage.contains("Invalid partition definition"))
+  }
+
+
+  test("test exception when values in list_info can not match partition column type") {
+    sql("DROP TABLE IF EXISTS test_list_1")
+    val exception_test_list_1: Exception = intercept[Exception] {
+      sql(
+        """
+          | CREATE TABLE test_list_1(col1 INT, col2 STRING)
+          | PARTITIONED BY (col3 INT) STORED BY 'carbondata'
+          | TBLPROPERTIES('PARTITION_TYPE'='LIST', 'LIST_INFO'='abc,def')
+        """.stripMargin)
+    }
+    assert(exception_test_list_1.getMessage.contains("Invalid partition definition"))
+
+    sql("DROP TABLE IF EXISTS test_list_2")
+    val exception_test_list_2: Exception = intercept[Exception] {
+      sql(
+        """
+          | CREATE TABLE test_list_2(col1 INT, col2 STRING)
+          | PARTITIONED BY (col3 SHORT) STORED BY 'carbondata'
+          | TBLPROPERTIES('PARTITION_TYPE'='LIST', 'LIST_INFO'='abc,def')
+        """.stripMargin)
+    }
+    assert(exception_test_list_2.getMessage.contains("Invalid partition definition"))
+
+    sql("DROP TABLE IF EXISTS test_list_3")
+    val exception_test_list_3: Exception = intercept[Exception] {
+      sql(
+        """
+          | CREATE TABLE test_list_3(col1 INT, col2 STRING)
+          | PARTITIONED BY (col3 FLOAT) STORED BY 'carbondata'
+          | TBLPROPERTIES('PARTITION_TYPE'='LIST', 'LIST_INFO'='abc,def')
+        """.stripMargin)
+    }
+    assert(exception_test_list_3.getMessage.contains("Invalid partition definition"))
+
+    sql("DROP TABLE IF EXISTS test_list_4")
+    val exception_test_list_4: Exception = intercept[Exception] {
+      sql(
+        """
+          | CREATE TABLE test_list_4(col1 INT, col2 STRING)
+          | PARTITIONED BY (col3 DOUBLE) STORED BY 'carbondata'
+          | TBLPROPERTIES('PARTITION_TYPE'='LIST', 'LIST_INFO'='abc,def')
+        """.stripMargin)
+    }
+    assert(exception_test_list_4.getMessage.contains("Invalid partition definition"))
+
+    sql("DROP TABLE IF EXISTS test_list_5")
+    val exception_test_list_5: Exception = intercept[Exception] {
+      sql(
+        """
+          | CREATE TABLE test_list_5(col1 INT, col2 STRING)
+          | PARTITIONED BY (col3 LONG) STORED BY 'carbondata'
+          | TBLPROPERTIES('PARTITION_TYPE'='LIST', 'LIST_INFO'='abc,def')
+        """.stripMargin)
+    }
+    assert(exception_test_list_5.getMessage.contains("Invalid partition definition"))
+
+    sql("DROP TABLE IF EXISTS test_list_7")
+    val exception_test_list_7: Exception = intercept[Exception] {
+      sql(
+        """
+          | CREATE TABLE test_list_7(col1 INT, col2 STRING)
+          | PARTITIONED BY (col3 BYTE) STORED BY 'carbondata'
+          | TBLPROPERTIES('PARTITION_TYPE'='LIST', 'LIST_INFO'='abc,def')
+        """.stripMargin)
+    }
+    assert(exception_test_list_7.getMessage.contains("Invalid partition definition"))
+
+    sql("DROP TABLE IF EXISTS test_list_8")
+    val exception_test_list_8: Exception = intercept[Exception] {
+      sql(
+        """
+          | CREATE TABLE test_list_8(col1 INT, col2 STRING)
+          | PARTITIONED BY (col3 BOOLEAN) STORED BY 'carbondata'
+          | TBLPROPERTIES('PARTITION_TYPE'='LIST', 'LIST_INFO'='abc,def')
+        """.stripMargin)
+    }
+    assert(exception_test_list_8.getMessage.contains("Invalid partition definition"))
+
+    sql("DROP TABLE IF EXISTS test_list_9")
+    val exception_test_list_9: Exception = intercept[Exception] {
+      sql(
+        """
+          | CREATE TABLE test_list_9(col1 INT, col2 STRING)
+          | PARTITIONED BY (col3 DATE) STORED BY 'carbondata'
+          | TBLPROPERTIES('PARTITION_TYPE'='LIST', 'LIST_INFO'='abc,def')
+        """.stripMargin)
+    }
+    assert(exception_test_list_9.getMessage.contains("Invalid partition definition"))
+
+    sql("DROP TABLE IF EXISTS test_list_10")
+    val exception_test_list_10: Exception = intercept[Exception] {
+      sql(
+        """
+          | CREATE TABLE test_list_10(col1 INT, col2 STRING)
+          | PARTITIONED BY (col3 TIMESTAMP) STORED BY 'carbondata'
+          | TBLPROPERTIES('PARTITION_TYPE'='LIST', 'LIST_INFO'='abc,def')
+        """.stripMargin)
+    }
+    assert(exception_test_list_10.getMessage.contains("Invalid partition definition"))
+  }
+
+  test("test exception when values in range_info can not match partition column type") {
+    sql("DROP TABLE IF EXISTS test_range_1")
+    val exception_test_range_1: Exception = intercept[Exception] {
+      sql(
+        """
+          | CREATE TABLE test_range_1(col1 INT, col2 STRING)
+          | PARTITIONED BY (col3 INT) STORED BY 'carbondata'
+          | TBLPROPERTIES('PARTITION_TYPE'='RANGE', 'RANGE_INFO'='abc,def')
+        """.stripMargin)
+    }
+    assert(exception_test_range_1.getMessage.contains("Invalid partition definition"))
+
+    sql("DROP TABLE IF EXISTS test_range_2")
+    val exception_test_range_2: Exception = intercept[Exception] {
+      sql(
+        """
+          | CREATE TABLE test_range_2(col1 INT, col2 STRING)
+          | PARTITIONED BY (col3 SHORT) STORED BY 'carbondata'
+          | TBLPROPERTIES('PARTITION_TYPE'='RANGE', 'RANGE_INFO'='abc,def')
+        """.stripMargin)
+    }
+    assert(exception_test_range_2.getMessage.contains("Invalid partition definition"))
+
+    sql("DROP TABLE IF EXISTS test_range_3")
+    val exception_test_range_3: Exception = intercept[Exception] {
+      sql(
+        """
+          | CREATE TABLE test_range_3(col1 INT, col2 STRING)
+          | PARTITIONED BY (col3 FLOAT) STORED BY 'carbondata'
+          | TBLPROPERTIES('PARTITION_TYPE'='RANGE', 'RANGE_INFO'='abc,def')
+        """.stripMargin)
+    }
+    assert(exception_test_range_3.getMessage.contains("Invalid partition definition"))
+
+    sql("DROP TABLE IF EXISTS test_range_4")
+    val exception_test_range_4: Exception = intercept[Exception] {
+      sql(
+        """
+          | CREATE TABLE test_range_4(col1 INT, col2 STRING)
+          | PARTITIONED BY (col3 DOUBLE) STORED BY 'carbondata'
+          | TBLPROPERTIES('PARTITION_TYPE'='RANGE', 'RANGE_INFO'='abc,def')
+        """.stripMargin)
+    }
+    assert(exception_test_range_4.getMessage.contains("Invalid partition definition"))
+
+    sql("DROP TABLE IF EXISTS test_range_5")
+    val exception_test_range_5: Exception = intercept[Exception] {
+      sql(
+        """
+          | CREATE TABLE test_range_5(col1 INT, col2 STRING)
+          | PARTITIONED BY (col3 LONG) STORED BY 'carbondata'
+          | TBLPROPERTIES('PARTITION_TYPE'='RANGE', 'RANGE_INFO'='abc,def')
+        """.stripMargin)
+    }
+    assert(exception_test_range_5.getMessage.contains("Invalid partition definition"))
+
+    sql("DROP TABLE IF EXISTS test_range_7")
+    val exception_test_range_7: Exception = intercept[Exception] {
+      sql(
+        """
+          | CREATE TABLE test_range_7(col1 INT, col2 STRING)
+          | PARTITIONED BY (col3 BYTE) STORED BY 'carbondata'
+          | TBLPROPERTIES('PARTITION_TYPE'='RANGE', 'RANGE_INFO'='abc,def')
+        """.stripMargin)
+    }
+    assert(exception_test_range_7.getMessage.contains("Invalid partition definition"))
+
+    sql("DROP TABLE IF EXISTS test_range_8")
+    val exception_test_range_8: Exception = intercept[Exception] {
+      sql(
+        """
+          | CREATE TABLE test_range_8(col1 INT, col2 STRING)
+          | PARTITIONED BY (col3 BOOLEAN) STORED BY 'carbondata'
+          | TBLPROPERTIES('PARTITION_TYPE'='RANGE', 'RANGE_INFO'='abc,def')
+        """.stripMargin)
+    }
+    assert(exception_test_range_8.getMessage.contains("Invalid partition definition"))
+
+    sql("DROP TABLE IF EXISTS test_range_9")
+    val exception_test_range_9: Exception = intercept[Exception] {
+      sql(
+        """
+          | CREATE TABLE test_range_9(col1 INT, col2 STRING)
+          | PARTITIONED BY (col3 BOOLEAN) STORED BY 'carbondata'
+          | TBLPROPERTIES('PARTITION_TYPE'='RANGE', 'RANGE_INFO'='abc,def')
+        """.stripMargin)
+    }
+    assert(exception_test_range_9.getMessage.contains("Invalid partition definition"))
+
+    sql("DROP TABLE IF EXISTS test_range_10")
+    val exception_test_range_10: Exception = intercept[Exception] {
+      sql(
+        """
+          | CREATE TABLE test_range_10(col1 INT, col2 STRING)
+          | PARTITIONED BY (col3 TIMESTAMP) STORED BY 'carbondata'
+          | TBLPROPERTIES('PARTITION_TYPE'='RANGE', 'RANGE_INFO'='abc,def')
+        """.stripMargin)
+    }
+    assert(exception_test_range_10.getMessage.contains("Invalid partition definition"))
+
   }
 
   override def afterAll = {

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/partition/TestDDLForPartitionTable.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/partition/TestDDLForPartitionTable.scala
@@ -191,7 +191,7 @@ class TestDDLForPartitionTable  extends QueryTest with BeforeAndAfterAll {
       sql(
         """
           | CREATE TABLE test_list_2(col1 INT, col2 STRING)
-          | PARTITIONED BY (col3 SHORT) STORED BY 'carbondata'
+          | PARTITIONED BY (col3 SMALLINT) STORED BY 'carbondata'
           | TBLPROPERTIES('PARTITION_TYPE'='LIST', 'LIST_INFO'='abc,def')
         """.stripMargin)
     }
@@ -224,18 +224,29 @@ class TestDDLForPartitionTable  extends QueryTest with BeforeAndAfterAll {
       sql(
         """
           | CREATE TABLE test_list_5(col1 INT, col2 STRING)
-          | PARTITIONED BY (col3 LONG) STORED BY 'carbondata'
+          | PARTITIONED BY (col3 BIGINT) STORED BY 'carbondata'
           | TBLPROPERTIES('PARTITION_TYPE'='LIST', 'LIST_INFO'='abc,def')
         """.stripMargin)
     }
     assert(exception_test_list_5.getMessage.contains("Invalid partition definition"))
+
+    sql("DROP TABLE IF EXISTS test_list_6")
+    val exception_test_list_6: Exception = intercept[Exception] {
+      sql(
+        """
+          | CREATE TABLE test_list_6(col1 INT, col2 STRING)
+          | PARTITIONED BY (col3 BOOLEAN) STORED BY 'carbondata'
+          | TBLPROPERTIES('PARTITION_TYPE'='LIST', 'LIST_INFO'='abc,def')
+        """.stripMargin)
+    }
+    assert(exception_test_list_6.getMessage.contains("Invalid partition definition"))
 
     sql("DROP TABLE IF EXISTS test_list_7")
     val exception_test_list_7: Exception = intercept[Exception] {
       sql(
         """
           | CREATE TABLE test_list_7(col1 INT, col2 STRING)
-          | PARTITIONED BY (col3 BYTE) STORED BY 'carbondata'
+          | PARTITIONED BY (col3 DATE) STORED BY 'carbondata'
           | TBLPROPERTIES('PARTITION_TYPE'='LIST', 'LIST_INFO'='abc,def')
         """.stripMargin)
     }
@@ -246,33 +257,11 @@ class TestDDLForPartitionTable  extends QueryTest with BeforeAndAfterAll {
       sql(
         """
           | CREATE TABLE test_list_8(col1 INT, col2 STRING)
-          | PARTITIONED BY (col3 BOOLEAN) STORED BY 'carbondata'
-          | TBLPROPERTIES('PARTITION_TYPE'='LIST', 'LIST_INFO'='abc,def')
-        """.stripMargin)
-    }
-    assert(exception_test_list_8.getMessage.contains("Invalid partition definition"))
-
-    sql("DROP TABLE IF EXISTS test_list_9")
-    val exception_test_list_9: Exception = intercept[Exception] {
-      sql(
-        """
-          | CREATE TABLE test_list_9(col1 INT, col2 STRING)
-          | PARTITIONED BY (col3 DATE) STORED BY 'carbondata'
-          | TBLPROPERTIES('PARTITION_TYPE'='LIST', 'LIST_INFO'='abc,def')
-        """.stripMargin)
-    }
-    assert(exception_test_list_9.getMessage.contains("Invalid partition definition"))
-
-    sql("DROP TABLE IF EXISTS test_list_10")
-    val exception_test_list_10: Exception = intercept[Exception] {
-      sql(
-        """
-          | CREATE TABLE test_list_10(col1 INT, col2 STRING)
           | PARTITIONED BY (col3 TIMESTAMP) STORED BY 'carbondata'
           | TBLPROPERTIES('PARTITION_TYPE'='LIST', 'LIST_INFO'='abc,def')
         """.stripMargin)
     }
-    assert(exception_test_list_10.getMessage.contains("Invalid partition definition"))
+    assert(exception_test_list_8.getMessage.contains("Invalid partition definition"))
   }
 
   test("test exception when values in range_info can not match partition column type") {
@@ -292,7 +281,7 @@ class TestDDLForPartitionTable  extends QueryTest with BeforeAndAfterAll {
       sql(
         """
           | CREATE TABLE test_range_2(col1 INT, col2 STRING)
-          | PARTITIONED BY (col3 SHORT) STORED BY 'carbondata'
+          | PARTITIONED BY (col3 SMALLINT) STORED BY 'carbondata'
           | TBLPROPERTIES('PARTITION_TYPE'='RANGE', 'RANGE_INFO'='abc,def')
         """.stripMargin)
     }
@@ -325,18 +314,29 @@ class TestDDLForPartitionTable  extends QueryTest with BeforeAndAfterAll {
       sql(
         """
           | CREATE TABLE test_range_5(col1 INT, col2 STRING)
-          | PARTITIONED BY (col3 LONG) STORED BY 'carbondata'
+          | PARTITIONED BY (col3 BIGINT) STORED BY 'carbondata'
           | TBLPROPERTIES('PARTITION_TYPE'='RANGE', 'RANGE_INFO'='abc,def')
         """.stripMargin)
     }
     assert(exception_test_range_5.getMessage.contains("Invalid partition definition"))
+
+    sql("DROP TABLE IF EXISTS test_range_6")
+    val exception_test_range_6: Exception = intercept[Exception] {
+      sql(
+        """
+          | CREATE TABLE test_range_6(col1 INT, col2 STRING)
+          | PARTITIONED BY (col3 BOOLEAN) STORED BY 'carbondata'
+          | TBLPROPERTIES('PARTITION_TYPE'='RANGE', 'RANGE_INFO'='abc,def')
+        """.stripMargin)
+    }
+    assert(exception_test_range_6.getMessage.contains("Invalid partition definition"))
 
     sql("DROP TABLE IF EXISTS test_range_7")
     val exception_test_range_7: Exception = intercept[Exception] {
       sql(
         """
           | CREATE TABLE test_range_7(col1 INT, col2 STRING)
-          | PARTITIONED BY (col3 BYTE) STORED BY 'carbondata'
+          | PARTITIONED BY (col3 BOOLEAN) STORED BY 'carbondata'
           | TBLPROPERTIES('PARTITION_TYPE'='RANGE', 'RANGE_INFO'='abc,def')
         """.stripMargin)
     }
@@ -347,34 +347,11 @@ class TestDDLForPartitionTable  extends QueryTest with BeforeAndAfterAll {
       sql(
         """
           | CREATE TABLE test_range_8(col1 INT, col2 STRING)
-          | PARTITIONED BY (col3 BOOLEAN) STORED BY 'carbondata'
-          | TBLPROPERTIES('PARTITION_TYPE'='RANGE', 'RANGE_INFO'='abc,def')
-        """.stripMargin)
-    }
-    assert(exception_test_range_8.getMessage.contains("Invalid partition definition"))
-
-    sql("DROP TABLE IF EXISTS test_range_9")
-    val exception_test_range_9: Exception = intercept[Exception] {
-      sql(
-        """
-          | CREATE TABLE test_range_9(col1 INT, col2 STRING)
-          | PARTITIONED BY (col3 BOOLEAN) STORED BY 'carbondata'
-          | TBLPROPERTIES('PARTITION_TYPE'='RANGE', 'RANGE_INFO'='abc,def')
-        """.stripMargin)
-    }
-    assert(exception_test_range_9.getMessage.contains("Invalid partition definition"))
-
-    sql("DROP TABLE IF EXISTS test_range_10")
-    val exception_test_range_10: Exception = intercept[Exception] {
-      sql(
-        """
-          | CREATE TABLE test_range_10(col1 INT, col2 STRING)
           | PARTITIONED BY (col3 TIMESTAMP) STORED BY 'carbondata'
           | TBLPROPERTIES('PARTITION_TYPE'='RANGE', 'RANGE_INFO'='abc,def')
         """.stripMargin)
     }
-    assert(exception_test_range_10.getMessage.contains("Invalid partition definition"))
-
+    assert(exception_test_range_8.getMessage.contains("Invalid partition definition"))
   }
 
   override def afterAll = {

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/partition/TestDDLForPartitionTable.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/partition/TestDDLForPartitionTable.scala
@@ -262,6 +262,17 @@ class TestDDLForPartitionTable  extends QueryTest with BeforeAndAfterAll {
         """.stripMargin)
     }
     assert(exception_test_list_8.getMessage.contains("Invalid partition definition"))
+
+    sql("DROP TABLE IF EXISTS test_list_9")
+    val exception_test_list_9: Exception = intercept[Exception] {
+      sql(
+        """
+          | CREATE TABLE test_list_9(col1 INT, col2 STRING)
+          | PARTITIONED BY (col3 DECIMAL(25, 4)) STORED BY 'carbondata'
+          | TBLPROPERTIES('PARTITION_TYPE'='LIST', 'LIST_INFO'='abc,def')
+        """.stripMargin)
+    }
+    assert(exception_test_list_9.getMessage.contains("Invalid partition definition"))
   }
 
   test("test exception when values in range_info can not match partition column type") {
@@ -352,6 +363,18 @@ class TestDDLForPartitionTable  extends QueryTest with BeforeAndAfterAll {
         """.stripMargin)
     }
     assert(exception_test_range_8.getMessage.contains("Invalid partition definition"))
+
+    sql("DROP TABLE IF EXISTS test_range_9")
+    val exception_test_range_9: Exception = intercept[Exception] {
+      sql(
+        """
+          | CREATE TABLE test_range_8(col1 INT, col2 STRING)
+          | PARTITIONED BY (col3 DECIMAL(25, 4)) STORED BY 'carbondata'
+          | TBLPROPERTIES('PARTITION_TYPE'='RANGE', 'RANGE_INFO'='abc,def')
+        """.stripMargin)
+    }
+    assert(exception_test_range_9.getMessage.contains("Invalid partition definition"))
+
   }
 
   override def afterAll = {

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/partition/TestDDLForPartitionTable.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/partition/TestDDLForPartitionTable.scala
@@ -353,7 +353,6 @@ class TestDDLForPartitionTable  extends QueryTest with BeforeAndAfterAll {
         """.stripMargin)
     }
     assert(exception_test_range_decimal.getMessage.contains("Invalid partition definition"))
-
   }
 
   override def afterAll = {

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/CommonUtil.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/CommonUtil.scala
@@ -265,7 +265,7 @@ object CommonUtil {
         scala.util.Try(value.toLong).isSuccess
       case "float" =>
         scala.util.Try(value.toFloat).isSuccess
-      case "doubletype" =>
+      case "double" =>
         scala.util.Try(value.toDouble).isSuccess
       case "numeric" =>
         scala.util.Try(value.toDouble).isSuccess

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/CommonUtil.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/CommonUtil.scala
@@ -227,19 +227,11 @@ object CommonUtil {
       case "timestamptype" =>
         val timeStampFormat = new SimpleDateFormat(CarbonProperties.getInstance()
           .getProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT))
-        if (scala.util.Try(timeStampFormat.parse(value)).isSuccess) {
-          true
-        } else {
-          false
-        }
+        scala.util.Try(timeStampFormat.parse(value)).isSuccess
       case "datetype" =>
         val dateFormat = new SimpleDateFormat(CarbonProperties.getInstance()
           .getProperty(CarbonCommonConstants.CARBON_DATE_FORMAT))
-        if (scala.util.Try(dateFormat.parse(value)).isSuccess) {
-          true
-        } else {
-          false
-        }
+        scala.util.Try(dateFormat.parse(value)).isSuccess
       case others =>
        if (others != null && others.startsWith("char")) {
          scala.util.Try(value.toString).isSuccess

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/CommonUtil.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/CommonUtil.scala
@@ -233,15 +233,13 @@ object CommonUtil {
         DataTypeUtil.getDataBasedOnDataType(value.trim, DataType.INT)
       case Some("string") =>
         DataTypeUtil.getDataBasedOnDataType(value.trim, DataType.STRING)
-      case Some("long") =>
+      case Some("bigint") =>
         DataTypeUtil.getDataBasedOnDataType(value.trim, DataType.LONG)
       case Some("float") =>
         DataTypeUtil.getDataBasedOnDataType(value.trim, DataType.FLOAT)
       case Some("double") =>
         DataTypeUtil.getDataBasedOnDataType(value.trim, DataType.DOUBLE)
-      case Some("byte") =>
-        DataTypeUtil.getDataBasedOnDataType(value.trim, DataType.BYTE)
-      case Some("short") =>
+      case Some("smallint") =>
         DataTypeUtil.getDataBasedOnDataType(value.trim, DataType.SHORT)
       case Some("boolean") =>
         DataTypeUtil.getDataBasedOnDataType(value.trim, DataType.BOOLEAN)

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/CommonUtil.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/CommonUtil.scala
@@ -27,13 +27,13 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat
 import org.apache.spark.SparkContext
 import org.apache.spark.sql.execution.command.{ColumnProperty, Field, PartitionerField}
-import org.apache.spark.sql.types.StructField
 import org.apache.spark.util.FileUtils
 
 import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.core.constants.CarbonCommonConstants
+import org.apache.carbondata.core.metadata.datatype.DataType
 import org.apache.carbondata.core.statusmanager.SegmentStatusManager
-import org.apache.carbondata.core.util.{CarbonProperties, CarbonUtil}
+import org.apache.carbondata.core.util.{CarbonProperties, CarbonUtil, DataTypeUtil}
 import org.apache.carbondata.processing.csvload.CSVInputFormat
 import org.apache.carbondata.processing.model.CarbonLoadModel
 import org.apache.carbondata.processing.newflow.exception.CarbonDataLoadingException
@@ -167,9 +167,23 @@ object CommonUtil {
       isValid = false
     } else {
       partitionType.get.toUpperCase() match {
-        case "HASH" => if (!numPartitions.isDefined) isValid = false
-        case "LIST" => if (!listInfo.isDefined) isValid = false
-        case "RANGE" => if (!rangeInfo.isDefined) isValid = false
+        case "HASH" => if (!numPartitions.isDefined
+        || scala.util.Try(numPartitions.get.toInt).isFailure
+        || numPartitions.get.toInt <= 0) {
+          isValid = false
+        }
+        case "LIST" => if (!listInfo.isDefined) {
+          isValid = false
+        } else {
+          listInfo.get.replace("(", "").replace(")", "").split(",").foreach(
+            isValid &= validateTypeConvert(partitionerFields(0).dataType, _))
+        }
+        case "RANGE" => if (!rangeInfo.isDefined) {
+          isValid = false
+        } else {
+          rangeInfo.get.split(CarbonCommonConstants.COMMA).foreach(
+            isValid &= validateTypeConvert(partitionerFields(0).dataType, _))
+        }
         case "RANGE_INTERVAL" => isValid = false
         case _ => isValid = false
       }
@@ -177,6 +191,70 @@ object CommonUtil {
       if (partitionerFields.length > 1) isValid = false
     }
     isValid
+  }
+
+  def validateTypeConvert(desType: Option[String], value: String): Boolean = {
+    var flag = true
+    val result = desType match {
+      case Some("IntegerType") =>
+        DataTypeUtil.getDataBasedOnDataType(value.trim, DataType.INT)
+      case Some("StringType") =>
+        DataTypeUtil.getDataBasedOnDataType(value.trim, DataType.STRING)
+      case Some("LongType") =>
+        DataTypeUtil.getDataBasedOnDataType(value.trim, DataType.LONG)
+      case Some("FloatType") =>
+        DataTypeUtil.getDataBasedOnDataType(value.trim, DataType.FLOAT)
+      case Some("DoubleType") =>
+        DataTypeUtil.getDataBasedOnDataType(value.trim, DataType.DOUBLE)
+      case Some("ByteType") =>
+        DataTypeUtil.getDataBasedOnDataType(value.trim, DataType.BYTE)
+      case Some("ShortType") =>
+        DataTypeUtil.getDataBasedOnDataType(value.trim, DataType.SHORT)
+      case Some("BooleanType") =>
+        DataTypeUtil.getDataBasedOnDataType(value.trim, DataType.BOOLEAN)
+      case Some("DecimalType") =>
+        DataTypeUtil.getDataBasedOnDataType(value.trim, DataType.DECIMAL)
+      case Some("TimestampType") =>
+        DataTypeUtil.getDataBasedOnDataType(value.trim, DataType.TIMESTAMP)
+      case Some("DateType") =>
+        DataTypeUtil.getDataBasedOnDataType(value.trim, DataType.DATE)
+      case _ =>
+        validateTypeConvertExt(desType, value)
+    }
+    if (result == null) {
+      flag = false
+    }
+    flag
+  }
+
+  def validateTypeConvertExt(desType: Option[String], value: String): Object = {
+    val resultExt = desType match {
+      case Some("int") =>
+        DataTypeUtil.getDataBasedOnDataType(value.trim, DataType.INT)
+      case Some("string") =>
+        DataTypeUtil.getDataBasedOnDataType(value.trim, DataType.STRING)
+      case Some("long") =>
+        DataTypeUtil.getDataBasedOnDataType(value.trim, DataType.LONG)
+      case Some("float") =>
+        DataTypeUtil.getDataBasedOnDataType(value.trim, DataType.FLOAT)
+      case Some("double") =>
+        DataTypeUtil.getDataBasedOnDataType(value.trim, DataType.DOUBLE)
+      case Some("byte") =>
+        DataTypeUtil.getDataBasedOnDataType(value.trim, DataType.BYTE)
+      case Some("short") =>
+        DataTypeUtil.getDataBasedOnDataType(value.trim, DataType.SHORT)
+      case Some("boolean") =>
+        DataTypeUtil.getDataBasedOnDataType(value.trim, DataType.BOOLEAN)
+      case Some("decimal") =>
+        DataTypeUtil.getDataBasedOnDataType(value.trim, DataType.DECIMAL)
+      case Some("timestamp") =>
+        DataTypeUtil.getDataBasedOnDataType(value.trim, DataType.TIMESTAMP)
+      case Some("date") =>
+        DataTypeUtil.getDataBasedOnDataType(value.trim, DataType.DATE)
+      case _ =>
+        throw new MalformedCarbonCommandException("UnSupported partition type: " + desType)
+    }
+    resultExt
   }
 
   def validateFields(key: String, fields: Seq[Field]): Boolean = {

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/CommonUtil.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/CommonUtil.scala
@@ -221,8 +221,8 @@ object CommonUtil {
         val parField = partitionerField.dataType.get.split(",")
         val precision = parField(0).substring(12).toInt
         val scale = parField(1).substring(0, parField(1).length - 1).toInt
-        val pattern = "^([-]?[0-9]{0," +(precision - scale) +
-                      "})([.][0-9]{1," +scale +"})?$"
+        val pattern = "^([-]?[0-9]{0," + (precision - scale) +
+                      "})([.][0-9]{1," + scale + "})?$"
         value.matches(pattern)
       case "timestamptype" =>
         val timeStampFormat = new SimpleDateFormat(CarbonProperties.getInstance()
@@ -279,8 +279,8 @@ object CommonUtil {
         val parField = partitionerField.dataType.get.split(",")
         val precision = parField(0).substring(8).toInt
         val scale = parField(1).substring(0, parField(1).length - 1).toInt
-        val pattern = "^([-]?[0-9]{0," +(precision - scale) +
-                      "})([.][0-9]{1," +scale +"})?$"
+        val pattern = "^([-]?[0-9]{0," + (precision - scale) +
+                      "})([.][0-9]{1," + scale + "})?$"
         value.matches(pattern)
       case "timestamp" =>
         val timeStampFormat = new SimpleDateFormat(CarbonProperties.getInstance()

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSqlParser.scala
@@ -294,7 +294,7 @@ class CarbonSqlParser() extends CarbonDDLSqlParser {
 
           if (partitionCols.nonEmpty) {
             if (!CommonUtil.validatePartitionColumns(tableProperties, partitionCols)) {
-              throw new MalformedCarbonCommandException("Invalid table properties")
+              throw new MalformedCarbonCommandException("Invalid partition definition")
             }
             // partition columns should not be part of the schema
             val colNames = fields.map(_.column)


### PR DESCRIPTION
Background:
Create a partition table with invalid partition info (numPartitions, range info and list info) will success. Actually, create table operation should failed as expected.

Root cause:
There is no check mechanism for partition info when create a partition table.

Solution:
Add check mechanism for partition info when create a partition table. If the partition info is invalid, an exception will be throwed and create table operation will fail.

