### PR TITLE
[CARBONDATA-1183] Update CarbonPartitionExample because partition columns should not be specified in schema

### DIFF
--- a/examples/spark2/src/main/scala/org/apache/carbondata/examples/CarbonPartitionExample.scala
+++ b/examples/spark2/src/main/scala/org/apache/carbondata/examples/CarbonPartitionExample.scala
@@ -119,7 +119,7 @@ object CarbonPartitionExample {
     spark.sql("DROP TABLE IF EXISTS t3")
 
     spark.close()
-    
+
   }
 
 }

--- a/examples/spark2/src/main/scala/org/apache/carbondata/examples/CarbonPartitionExample.scala
+++ b/examples/spark2/src/main/scala/org/apache/carbondata/examples/CarbonPartitionExample.scala
@@ -100,7 +100,8 @@ object CarbonPartitionExample {
     spark.sql("DROP TABLE IF EXISTS t5")
 
     spark.sql("""
-       | CREATE TABLE IF NOT EXISTS t5(
+       | CREATE TABLE IF NOT EXISTS t5
+       | (
        | vin String,
        | logdate Timestamp,
        | phonenumber Long,

--- a/examples/spark2/src/main/scala/org/apache/carbondata/examples/CarbonPartitionExample.scala
+++ b/examples/spark2/src/main/scala/org/apache/carbondata/examples/CarbonPartitionExample.scala
@@ -75,7 +75,7 @@ object CarbonPartitionExample {
                 | PARTITIONED BY (logdate TIMESTAMP)
                 | STORED BY 'carbondata'
                 | TBLPROPERTIES('PARTITION_TYPE'='RANGE',
-                | 'RANGE_INFO'='2014/01/01, 2015/01/01 ,2016/01/01')
+                | 'RANGE_INFO'='2014/01/01, 2015/01/01, 2016/01/01')
               """.stripMargin)
 
     // hash partition

--- a/examples/spark2/src/main/scala/org/apache/carbondata/examples/CarbonPartitionExample.scala
+++ b/examples/spark2/src/main/scala/org/apache/carbondata/examples/CarbonPartitionExample.scala
@@ -53,11 +53,11 @@ object CarbonPartitionExample {
 
     spark.sql("""
                 | CREATE TABLE IF NOT EXISTS t0(
-                | vin STRING,
-                | logdate TIMESTAMP,
-                | phonenumber LONG,
-                | country STRING,
-                | area STRING
+                | vin String,
+                | logdate Timestamp,
+                | phonenumber Long,
+                | country String,
+                | area String
                 | )
                 | STORED BY 'carbondata'
               """.stripMargin)
@@ -67,43 +67,43 @@ object CarbonPartitionExample {
 
     spark.sql("""
                 | CREATE TABLE IF NOT EXISTS t1(
-                | vin STRING,
-                | phonenumber LONG,
-                | country STRING,
-                | area STRING
+                | vin String,
+                | phonenumber Long,
+                | country String,
+                | area String
                 | )
-                | PARTITIONED BY (logdate TIMESTAMP)
+                | PARTITIONED BY (logdate Timestamp)
                 | STORED BY 'carbondata'
                 | TBLPROPERTIES('PARTITION_TYPE'='RANGE',
                 | 'RANGE_INFO'='2014/01/01, 2015/01/01, 2016/01/01')
               """.stripMargin)
 
     // hash partition
-    spark.sql("DROP TABLE IF EXISTS t2")
+    spark.sql("DROP TABLE IF EXISTS t3")
 
     spark.sql("""
-                | CREATE TABLE IF NOT EXISTS t2(
-                | logdate TIMESTAMP,
-                | phonenumber LONG,
-                | country STRING,
-                | area STRING
+                | CREATE TABLE IF NOT EXISTS t3(
+                | logdate Timestamp,
+                | phonenumber Long,
+                | country String,
+                | area String
                 | )
-                | PARTITIONED BY (vin STRING)
+                | PARTITIONED BY (vin String)
                 | STORED BY 'carbondata'
                 | TBLPROPERTIES('PARTITION_TYPE'='HASH','NUM_PARTITIONS'='5')
                 """.stripMargin)
 
     // list partition
-    spark.sql("DROP TABLE IF EXISTS t3")
+    spark.sql("DROP TABLE IF EXISTS t5")
 
     spark.sql("""
-       | CREATE TABLE IF NOT EXISTS t3(
-       | vin STRING,
-       | logdate TIMESTAMP,
-       | phonenumber LONG,
-       | area STRING
+       | CREATE TABLE IF NOT EXISTS t5(
+       | vin String,
+       | logdate Timestamp,
+       | phonenumber Long,
+       | area String
        |)
-       | PARTITIONED BY (country STRING)
+       | PARTITIONED BY (country String)
        | STORED BY 'carbondata'
        | TBLPROPERTIES('PARTITION_TYPE'='LIST',
        | 'LIST_INFO'='(China,United States),UK ,japan,(Canada,Russia), South Korea')
@@ -115,8 +115,8 @@ object CarbonPartitionExample {
     // drop table
     spark.sql("DROP TABLE IF EXISTS t0")
     spark.sql("DROP TABLE IF EXISTS t1")
-    spark.sql("DROP TABLE IF EXISTS t2")
     spark.sql("DROP TABLE IF EXISTS t3")
+    spark.sql("DROP TABLE IF EXISTS t5")
 
     spark.close()
 

--- a/examples/spark2/src/main/scala/org/apache/carbondata/examples/CarbonPartitionExample.scala
+++ b/examples/spark2/src/main/scala/org/apache/carbondata/examples/CarbonPartitionExample.scala
@@ -117,7 +117,6 @@ object CarbonPartitionExample {
     spark.sql("DROP TABLE IF EXISTS t1")
     spark.sql("DROP TABLE IF EXISTS t2")
     spark.sql("DROP TABLE IF EXISTS t3")
-    
   }
 
 }

--- a/examples/spark2/src/main/scala/org/apache/carbondata/examples/CarbonPartitionExample.scala
+++ b/examples/spark2/src/main/scala/org/apache/carbondata/examples/CarbonPartitionExample.scala
@@ -109,10 +109,10 @@ object CarbonPartitionExample {
        | 'LIST_INFO'='(China,United States),UK ,japan,(Canada,Russia), South Korea ')
        """.stripMargin)
 
-    // Show tables
+    // show tables
     spark.sql("SHOW TABLES").show()
 
-    // Drop table
+    // drop table
     spark.sql("DROP TABLE IF EXISTS t0")
     spark.sql("DROP TABLE IF EXISTS t1")
     spark.sql("DROP TABLE IF EXISTS t2")

--- a/examples/spark2/src/main/scala/org/apache/carbondata/examples/CarbonPartitionExample.scala
+++ b/examples/spark2/src/main/scala/org/apache/carbondata/examples/CarbonPartitionExample.scala
@@ -68,12 +68,11 @@ object CarbonPartitionExample {
     spark.sql("""
                 | CREATE TABLE IF NOT EXISTS t1(
                 | vin STRING,
-                | logdate TIMESTAMP,
                 | phonenumber LONG,
                 | country STRING,
                 | area STRING
                 | )
-                | PARTITIONED BY (timestampField TIMESTAMP)
+                | PARTITIONED BY (logdate TIMESTAMP)
                 | STORED BY 'carbondata'
                 | TBLPROPERTIES('PARTITION_TYPE'='RANGE',
                 | 'RANGE_INFO'='2014/01/01, 2015/01/01 ,2016/01/01')
@@ -84,13 +83,12 @@ object CarbonPartitionExample {
 
     spark.sql("""
                 | CREATE TABLE IF NOT EXISTS t2(
-                | vin STRING,
                 | logdate TIMESTAMP,
                 | phonenumber LONG,
                 | country STRING,
                 | area STRING
                 | )
-                | PARTITIONED BY (stringField STRING)
+                | PARTITIONED BY (vin STRING)
                 | STORED BY 'carbondata'
                 | TBLPROPERTIES('PARTITION_TYPE'='HASH','NUM_PARTITIONS'='5')
                 """.stripMargin)
@@ -103,10 +101,9 @@ object CarbonPartitionExample {
        | vin STRING,
        | logdate TIMESTAMP,
        | phonenumber LONG,
-       | country STRING,
        | area STRING
        |)
-       | PARTITIONED BY (stringField STRING)
+       | PARTITIONED BY (country STRING)
        | STORED BY 'carbondata'
        | TBLPROPERTIES('PARTITION_TYPE'='LIST',
        | 'LIST_INFO'='(China,United States),UK ,japan,(Canada,Russia), South Korea ')

--- a/examples/spark2/src/main/scala/org/apache/carbondata/examples/CarbonPartitionExample.scala
+++ b/examples/spark2/src/main/scala/org/apache/carbondata/examples/CarbonPartitionExample.scala
@@ -110,7 +110,7 @@ object CarbonPartitionExample {
        | PARTITIONED BY (country String)
        | STORED BY 'carbondata'
        | TBLPROPERTIES('PARTITION_TYPE'='LIST',
-       | 'LIST_INFO'='(China,United States),UK ,japan,(Canada,Russia), South Korea')
+       | 'LIST_INFO'='(China,United States),UK ,japan,(Canada,Russia), South Korea ')
        """.stripMargin)
 
     // show tables

--- a/examples/spark2/src/main/scala/org/apache/carbondata/examples/CarbonPartitionExample.scala
+++ b/examples/spark2/src/main/scala/org/apache/carbondata/examples/CarbonPartitionExample.scala
@@ -52,7 +52,8 @@ object CarbonPartitionExample {
     spark.sql("DROP TABLE IF EXISTS t0")
 
     spark.sql("""
-                | CREATE TABLE IF NOT EXISTS t0(
+                | CREATE TABLE IF NOT EXISTS t0
+                | (
                 | vin String,
                 | logdate Timestamp,
                 | phonenumber Long,
@@ -66,7 +67,8 @@ object CarbonPartitionExample {
     spark.sql("DROP TABLE IF EXISTS t1")
 
     spark.sql("""
-                | CREATE TABLE IF NOT EXISTS t1(
+                | CREATE TABLE IF NOT EXISTS t1
+                | (
                 | vin String,
                 | phonenumber Long,
                 | country String,
@@ -82,7 +84,8 @@ object CarbonPartitionExample {
     spark.sql("DROP TABLE IF EXISTS t3")
 
     spark.sql("""
-                | CREATE TABLE IF NOT EXISTS t3(
+                | CREATE TABLE IF NOT EXISTS t3
+                | (
                 | logdate Timestamp,
                 | phonenumber Long,
                 | country String,

--- a/examples/spark2/src/main/scala/org/apache/carbondata/examples/CarbonPartitionExample.scala
+++ b/examples/spark2/src/main/scala/org/apache/carbondata/examples/CarbonPartitionExample.scala
@@ -117,6 +117,8 @@ object CarbonPartitionExample {
     spark.sql("DROP TABLE IF EXISTS t1")
     spark.sql("DROP TABLE IF EXISTS t2")
     spark.sql("DROP TABLE IF EXISTS t3")
+
+    spark.close()
   }
 
 }

--- a/examples/spark2/src/main/scala/org/apache/carbondata/examples/CarbonPartitionExample.scala
+++ b/examples/spark2/src/main/scala/org/apache/carbondata/examples/CarbonPartitionExample.scala
@@ -117,6 +117,7 @@ object CarbonPartitionExample {
     spark.sql("DROP TABLE IF EXISTS t1")
     spark.sql("DROP TABLE IF EXISTS t2")
     spark.sql("DROP TABLE IF EXISTS t3")
+    
   }
 
 }

--- a/examples/spark2/src/main/scala/org/apache/carbondata/examples/CarbonPartitionExample.scala
+++ b/examples/spark2/src/main/scala/org/apache/carbondata/examples/CarbonPartitionExample.scala
@@ -119,6 +119,7 @@ object CarbonPartitionExample {
     spark.sql("DROP TABLE IF EXISTS t3")
 
     spark.close()
+    
   }
 
 }

--- a/examples/spark2/src/main/scala/org/apache/carbondata/examples/CarbonPartitionExample.scala
+++ b/examples/spark2/src/main/scala/org/apache/carbondata/examples/CarbonPartitionExample.scala
@@ -52,13 +52,12 @@ object CarbonPartitionExample {
     spark.sql("DROP TABLE IF EXISTS t0")
 
     spark.sql("""
-                | CREATE TABLE IF NOT EXISTS t0
-                | (
-                | vin String,
-                | logdate Timestamp,
-                | phonenumber Long,
-                | country String,
-                | area String
+                | CREATE TABLE IF NOT EXISTS t0(
+                | vin STRING,
+                | logdate TIMESTAMP,
+                | phonenumber LONG,
+                | country STRING,
+                | area STRING
                 | )
                 | STORED BY 'carbondata'
               """.stripMargin)
@@ -67,65 +66,60 @@ object CarbonPartitionExample {
     spark.sql("DROP TABLE IF EXISTS t1")
 
     spark.sql("""
-                | CREATE TABLE IF NOT EXISTS t1
-                | (
-                | vin String,
-                | logdate Timestamp,
-                | phonenumber Long,
-                | country String,
-                | area String
+                | CREATE TABLE IF NOT EXISTS t1(
+                | vin STRING,
+                | logdate TIMESTAMP,
+                | phonenumber LONG,
+                | country STRING,
+                | area STRING
                 | )
-                | PARTITIONED BY (logdate Timestamp)
+                | PARTITIONED BY (timestampField TIMESTAMP)
                 | STORED BY 'carbondata'
                 | TBLPROPERTIES('PARTITION_TYPE'='RANGE',
-                | 'RANGE_INFO'='20140101, 2015/01/01 ,2016-01-01, ')
+                | 'RANGE_INFO'='2014/01/01, 2015/01/01 ,2016/01/01')
               """.stripMargin)
 
     // hash partition
-    spark.sql("DROP TABLE IF EXISTS t3")
+    spark.sql("DROP TABLE IF EXISTS t2")
 
     spark.sql("""
-                | CREATE TABLE IF NOT EXISTS t3
-                | (
-                | vin String,
-                | logdate Timestamp,
-                | phonenumber Long,
-                | country String,
-                | area String
+                | CREATE TABLE IF NOT EXISTS t2(
+                | vin STRING,
+                | logdate TIMESTAMP,
+                | phonenumber LONG,
+                | country STRING,
+                | area STRING
                 | )
-                | PARTITIONED BY (vin String)
+                | PARTITIONED BY (stringField STRING)
                 | STORED BY 'carbondata'
                 | TBLPROPERTIES('PARTITION_TYPE'='HASH','NUM_PARTITIONS'='5')
                 """.stripMargin)
 
     // list partition
-    spark.sql("DROP TABLE IF EXISTS t5")
+    spark.sql("DROP TABLE IF EXISTS t3")
 
     spark.sql("""
-       | CREATE TABLE IF NOT EXISTS t5
-       | (
-       | vin String,
-       | logdate Timestamp,
-       | phonenumber Long,
-       | country String,
-       | area String
+       | CREATE TABLE IF NOT EXISTS t3(
+       | vin STRING,
+       | logdate TIMESTAMP,
+       | phonenumber LONG,
+       | country STRING,
+       | area STRING
        |)
-       | PARTITIONED BY (country string)
+       | PARTITIONED BY (stringField STRING)
        | STORED BY 'carbondata'
        | TBLPROPERTIES('PARTITION_TYPE'='LIST',
        | 'LIST_INFO'='(China,United States),UK ,japan,(Canada,Russia), South Korea ')
        """.stripMargin)
 
-    // spark.sql(s"""
-    //   LOAD DATA LOCAL INPATH '$testData' into table t3
-    // options('BAD_RECORDS_ACTION'='FORCE')
-    //   """)
-
-    // spark.sql("select vin, count(*) from t3 group by vin
-    // order by count(*) desc").show(50)
+    // Show tables
+    spark.sql("SHOW TABLES").show()
 
     // Drop table
-    // spark.sql("DROP TABLE IF EXISTS t3")
+    spark.sql("DROP TABLE IF EXISTS t0")
+    spark.sql("DROP TABLE IF EXISTS t1")
+    spark.sql("DROP TABLE IF EXISTS t2")
+    spark.sql("DROP TABLE IF EXISTS t3")
   }
 
 }

--- a/examples/spark2/src/main/scala/org/apache/carbondata/examples/CarbonPartitionExample.scala
+++ b/examples/spark2/src/main/scala/org/apache/carbondata/examples/CarbonPartitionExample.scala
@@ -106,7 +106,7 @@ object CarbonPartitionExample {
        | PARTITIONED BY (country STRING)
        | STORED BY 'carbondata'
        | TBLPROPERTIES('PARTITION_TYPE'='LIST',
-       | 'LIST_INFO'='(China,United States),UK ,japan,(Canada,Russia), South Korea ')
+       | 'LIST_INFO'='(China,United States),UK ,japan,(Canada,Russia), South Korea')
        """.stripMargin)
 
     // show tables


### PR DESCRIPTION
Background:
CarbonPartitionTable fail in lastest master branch.

Root Cause:
Now partition column should not be specified in schema, otherwise operation will fail in parser stage.

Solution:
Update CarbonPartitionTable.
