### PR TITLE
[CARBONDATA-1199] support dynamically enabling unsafe column page 

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/ColumnPage.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/ColumnPage.java
@@ -54,10 +54,6 @@ public abstract class ColumnPage {
 
   protected DecimalConverterFactory.DecimalConverter decimalConverter;
 
-  protected static final boolean unsafe = Boolean.parseBoolean(CarbonProperties.getInstance()
-      .getProperty(CarbonCommonConstants.ENABLE_UNSAFE_COLUMN_PAGE_LOADING,
-          CarbonCommonConstants.ENABLE_UNSAFE_COLUMN_PAGE_LOADING_DEFAULT));
-
   protected ColumnPage(DataType dataType, int pageSize, int scale, int precision) {
     this.dataType = dataType;
     this.pageSize = pageSize;
@@ -84,6 +80,9 @@ public abstract class ColumnPage {
 
   private static ColumnPage createVarLengthPage(DataType dataType, int pageSize, int scale,
       int precision) {
+    boolean unsafe = Boolean.parseBoolean(CarbonProperties.getInstance()
+        .getProperty(CarbonCommonConstants.ENABLE_UNSAFE_COLUMN_PAGE_LOADING,
+            CarbonCommonConstants.ENABLE_UNSAFE_COLUMN_PAGE_LOADING_DEFAULT));
     if (unsafe) {
       try {
         return new UnsafeVarLengthColumnPage(dataType, pageSize, scale, precision);
@@ -97,6 +96,9 @@ public abstract class ColumnPage {
 
   private static ColumnPage createFixLengthPage(DataType dataType, int pageSize, int scale,
       int precision) {
+    boolean unsafe = Boolean.parseBoolean(CarbonProperties.getInstance()
+        .getProperty(CarbonCommonConstants.ENABLE_UNSAFE_COLUMN_PAGE_LOADING,
+            CarbonCommonConstants.ENABLE_UNSAFE_COLUMN_PAGE_LOADING_DEFAULT));
     if (unsafe) {
       try {
         return new UnsafeFixLengthColumnPage(dataType, pageSize, scale, precision);
@@ -122,6 +124,9 @@ public abstract class ColumnPage {
 
   private static ColumnPage newVarLengthPage(DataType dataType, int pageSize, int scale,
       int precision) {
+    boolean unsafe = Boolean.parseBoolean(CarbonProperties.getInstance()
+        .getProperty(CarbonCommonConstants.ENABLE_UNSAFE_COLUMN_PAGE_LOADING,
+            CarbonCommonConstants.ENABLE_UNSAFE_COLUMN_PAGE_LOADING_DEFAULT));
     if (unsafe) {
       try {
         return new UnsafeVarLengthColumnPage(dataType, pageSize, scale, precision);
@@ -139,6 +144,9 @@ public abstract class ColumnPage {
   public static ColumnPage newPage(DataType dataType, int pageSize, int scale, int precision)
       throws MemoryException {
     ColumnPage instance;
+    boolean unsafe = Boolean.parseBoolean(CarbonProperties.getInstance()
+        .getProperty(CarbonCommonConstants.ENABLE_UNSAFE_COLUMN_PAGE_LOADING,
+            CarbonCommonConstants.ENABLE_UNSAFE_COLUMN_PAGE_LOADING_DEFAULT));
     if (unsafe) {
       switch (dataType) {
         case BYTE:
@@ -375,7 +383,6 @@ public abstract class ColumnPage {
    * Set byte array from offset to length at rowId
    */
   public abstract void putBytes(int rowId, byte[] bytes, int offset, int length);
-
 
   /**
    * Set null at rowId

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/VarLengthColumnPageBase.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/VarLengthColumnPageBase.java
@@ -20,10 +20,12 @@ package org.apache.carbondata.core.datastore.page;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.memory.MemoryException;
 import org.apache.carbondata.core.metadata.datatype.DataType;
 import org.apache.carbondata.core.metadata.datatype.DecimalConverterFactory;
 import org.apache.carbondata.core.util.ByteUtil;
+import org.apache.carbondata.core.util.CarbonProperties;
 
 import static org.apache.carbondata.core.metadata.datatype.DataType.DECIMAL;
 
@@ -159,6 +161,9 @@ public abstract class VarLengthColumnPageBase extends ColumnPage {
 
     VarLengthColumnPageBase page;
     int inputDataLength = offset;
+    boolean unsafe = Boolean.parseBoolean(CarbonProperties.getInstance()
+        .getProperty(CarbonCommonConstants.ENABLE_UNSAFE_COLUMN_PAGE_LOADING,
+            CarbonCommonConstants.ENABLE_UNSAFE_COLUMN_PAGE_LOADING_DEFAULT));
     if (unsafe) {
       page = new UnsafeVarLengthColumnPage(DECIMAL, numRows, inputDataLength, scale, precision);
     } else {


### PR DESCRIPTION
Currently unsafe column page configuration is a static config, it should support dynamic configuration