### PR TITLE
[CARBONDATA-1211] Implicit Column Fix

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/scan/result/AbstractScannedResult.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/AbstractScannedResult.java
@@ -304,7 +304,7 @@ public abstract class AbstractScannedResult {
               j :
               rowMapping[pageCounter][j]);
         }
-        vector.putBytes(vectorOffset++, offset, data.length(), data.getBytes());
+        vector.putBytes(vectorOffset++, data.getBytes());
       }
     }
   }


### PR DESCRIPTION
Projection on implicit column is failing with garbage values when vector read is enabled. 

Select getTupleId as tupleId from table; 
