### PR TITLE
[CARBONDATA-1213] Removed rowCountPercentage check and fixed IUD data load issue

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -834,13 +834,6 @@ public final class CarbonCommonConstants {
   public static final int HIGH_CARDINALITY_THRESHOLD_MIN = 10000;
 
   /**
-   * percentage of cardinality in row count
-   */
-  public static final String HIGH_CARDINALITY_IN_ROW_COUNT_PERCENTAGE =
-      "high.cardinality.row.count.percentage";
-  public static final String HIGH_CARDINALITY_IN_ROW_COUNT_PERCENTAGE_DEFAULT = "80";
-
-  /**
    * 16 mb size
    */
   public static final long CARBON_16MB = 16 * 1024 * 1024;

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
@@ -82,7 +82,6 @@ public final class CarbonProperties {
     validateBadRecordsLocation();
     validateHighCardinalityIdentify();
     validateHighCardinalityThreshold();
-    validateHighCardinalityInRowCountPercentage();
     validateCarbonDataFileVersion();
     validateExecutorStartUpTime();
     validatePrefetchBufferSize();
@@ -342,29 +341,6 @@ public final class CarbonProperties {
           + CarbonCommonConstants.HIGH_CARDINALITY_THRESHOLD_DEFAULT);
       carbonProperties.setProperty(CarbonCommonConstants.HIGH_CARDINALITY_THRESHOLD,
           CarbonCommonConstants.HIGH_CARDINALITY_THRESHOLD_DEFAULT);
-    }
-  }
-
-  private void validateHighCardinalityInRowCountPercentage() {
-    String highcardPercentageStr = carbonProperties
-        .getProperty(CarbonCommonConstants.HIGH_CARDINALITY_IN_ROW_COUNT_PERCENTAGE,
-            CarbonCommonConstants.HIGH_CARDINALITY_IN_ROW_COUNT_PERCENTAGE_DEFAULT);
-    try {
-      double highcardPercentage = Double.parseDouble(highcardPercentageStr);
-      if (highcardPercentage <= 0) {
-        LOGGER.info(
-            "The percentage of high cardinality in row count value \"" + highcardPercentageStr
-                + "\" is invalid. Using the default value \""
-                + CarbonCommonConstants.HIGH_CARDINALITY_IN_ROW_COUNT_PERCENTAGE_DEFAULT);
-        carbonProperties.setProperty(CarbonCommonConstants.HIGH_CARDINALITY_IN_ROW_COUNT_PERCENTAGE,
-            CarbonCommonConstants.HIGH_CARDINALITY_IN_ROW_COUNT_PERCENTAGE_DEFAULT);
-      }
-    } catch (NumberFormatException e) {
-      LOGGER.info("The percentage of high cardinality in row count value \"" + highcardPercentageStr
-          + "\" is invalid. Using the default value \""
-          + CarbonCommonConstants.HIGH_CARDINALITY_IN_ROW_COUNT_PERCENTAGE_DEFAULT);
-      carbonProperties.setProperty(CarbonCommonConstants.HIGH_CARDINALITY_IN_ROW_COUNT_PERCENTAGE,
-          CarbonCommonConstants.HIGH_CARDINALITY_IN_ROW_COUNT_PERCENTAGE_DEFAULT);
     }
   }
 

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonGlobalDictionaryRDD.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonGlobalDictionaryRDD.scala
@@ -155,7 +155,6 @@ case class DictionaryLoadModel(table: CarbonTableIdentifier,
     delimiters: Array[String],
     highCardIdentifyEnable: Boolean,
     highCardThreshold: Int,
-    rowCountPercentage: Double,
     columnIdentifier: Array[ColumnIdentifier],
     isFirstLoad: Boolean,
     hdfsTempLocation: String,
@@ -382,7 +381,7 @@ class CarbonGlobalDictionaryGenerateRDD(
                 && !model.isComplexes(split.index)
                 && model.primDimensions(split.index).isColumnar) {
               isHighCardinalityColumn = GlobalDictionaryUtil.isHighCardinalityColumn(
-                valuesBuffer.size, rowCount, model)
+                valuesBuffer.size, model)
               if (isHighCardinalityColumn) {
                 break
               }

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/GlobalDictionaryUtil.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/GlobalDictionaryUtil.scala
@@ -279,11 +279,8 @@ object GlobalDictionaryUtil {
   }
 
   def isHighCardinalityColumn(columnCardinality: Int,
-      rowCount: Long,
       model: DictionaryLoadModel): Boolean = {
-    (columnCardinality > model.highCardThreshold) &&
-    (rowCount > 0) &&
-    (columnCardinality.toDouble / rowCount * 100 > model.rowCountPercentage)
+    columnCardinality > model.highCardThreshold
   }
 
   /**
@@ -329,9 +326,6 @@ object GlobalDictionaryUtil {
     val highCardThreshold = CarbonProperties.getInstance().getProperty(
       CarbonCommonConstants.HIGH_CARDINALITY_THRESHOLD,
       CarbonCommonConstants.HIGH_CARDINALITY_THRESHOLD_DEFAULT).toInt
-    val rowCountPercentage = CarbonProperties.getInstance().getProperty(
-      CarbonCommonConstants.HIGH_CARDINALITY_IN_ROW_COUNT_PERCENTAGE,
-      CarbonCommonConstants.HIGH_CARDINALITY_IN_ROW_COUNT_PERCENTAGE_DEFAULT).toDouble
 
     val serializationNullFormat =
       carbonLoadModel.getSerializationNullFormat.split(CarbonCommonConstants.COMMA, 2)(1)
@@ -350,7 +344,6 @@ object GlobalDictionaryUtil {
       carbonLoadModel.getDelimiters,
       highCardIdentifyEnable,
       highCardThreshold,
-      rowCountPercentage,
       columnIdentifier,
       carbonLoadModel.getLoadMetadataDetails.size() == 0,
       hdfsTempLocation,

--- a/processing/src/main/java/org/apache/carbondata/processing/util/CarbonDataProcessorUtil.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/util/CarbonDataProcessorUtil.java
@@ -32,6 +32,7 @@ import java.util.Set;
 import org.apache.carbondata.common.logging.LogService;
 import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
+import org.apache.carbondata.core.datastore.DimensionType;
 import org.apache.carbondata.core.datastore.GenericDataType;
 import org.apache.carbondata.core.datastore.filesystem.CarbonFile;
 import org.apache.carbondata.core.datastore.filesystem.CarbonFileFilter;
@@ -515,6 +516,19 @@ public final class CarbonDataProcessorUtil {
   public static String prepareFailureReason(String columnName, DataType dataType) {
     return "The value with column name " + columnName + " and column data type " + dataType
         .getName() + " is not a valid " + dataType + " type.";
+  }
+
+  /**
+   * This method will return a flag based on whether a column is applicable for RLE encoding
+   *
+   * @param dimensionType
+   * @return
+   */
+  public static boolean isRleApplicableForColumn(DimensionType dimensionType) {
+    if (dimensionType == DimensionType.GLOBAL_DICTIONARY) {
+      return true;
+    }
+    return false;
   }
 
 }


### PR DESCRIPTION
Problems:
1. Row count percentage not required with high cardinality threshold check
2. IUD returning incorrect results in case of update on high cardinality column

Analysis:
1. In case a column is identified as high cardinality column still it is not getting converted to no dictionary column because of another parameter check called rowCountPercentage. Default value of rowCountPercentage is 80%. Due to this even though high cardinality column is identified, if it is less than 80% of the total number of rows it will be treated as dictionary column. This can still lead to executor lost failure due to memory constraints.
2. RLE on a column is not being set correctly and due to incorrect code design RLE applicable on a column is decided by a different part of code from the one which is actually applying the RLE on a column. Because of this Footer is getting filled with incorrect RLE information and query is failing.

Fix:
1. Remove an unwanted check for rowCountPercentage.
2. RLE applicability on a column should be decided from a common place in the code.