### PR TITLE
[CARBONDATA-1222] Residual files created from Update are not deleted after clean operation

### DIFF
--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/DataManagementFunc.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/DataManagementFunc.scala
@@ -361,7 +361,7 @@ object DataManagementFunc {
         LOGGER.info("Clean files lock has been successfully acquired.")
         deleteLoadsAndUpdateMetadata(dbName, tableName, storePath,
           isForceDeletion = true, carbonTable)
-        CarbonUpdateUtil.cleanUpDeltaFiles(carbonTable,true)
+        CarbonUpdateUtil.cleanUpDeltaFiles(carbonTable, true)
       } else {
         val errorMsg = "Clean files request is failed for " +
             s"$dbName.$tableName" +

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/DataManagementFunc.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/DataManagementFunc.scala
@@ -361,6 +361,7 @@ object DataManagementFunc {
         LOGGER.info("Clean files lock has been successfully acquired.")
         deleteLoadsAndUpdateMetadata(dbName, tableName, storePath,
           isForceDeletion = true, carbonTable)
+        CarbonUpdateUtil.cleanUpDeltaFiles(carbonTable,true)
       } else {
         val errorMsg = "Clean files request is failed for " +
             s"$dbName.$tableName" +


### PR DESCRIPTION
No new unit test cases are required. I have tested it and the residual files are deleted after the clean command.