### PR TITLE
[CARBONDATA-1236] Support absolute path without scheme in loading

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
@@ -692,14 +692,20 @@ public final class CarbonUtil {
    * @param filePath
    */
   public static String checkAndAppendHDFSUrl(String filePath) {
+    if (!filePath.startsWith("/")) {
+      filePath = "/" + filePath;
+    }
     String currentPath = filePath;
     if (null != filePath && filePath.length() != 0
         && FileFactory.getFileType(filePath) != FileFactory.FileType.HDFS
         && FileFactory.getFileType(filePath) != FileFactory.FileType.VIEWFS) {
       String baseDFSUrl = CarbonProperties.getInstance()
           .getProperty(CarbonCommonConstants.CARBON_DDL_BASE_HDFS_URL);
+      String dfsUrl = conf.get(FS_DEFAULT_FS);
       if (null != baseDFSUrl) {
-        String dfsUrl = conf.get(FS_DEFAULT_FS);
+        if (!baseDFSUrl.startsWith("/")) {
+          baseDFSUrl = "/" + baseDFSUrl;
+        }
         if (null != dfsUrl && (dfsUrl.startsWith(HDFS_PREFIX) || dfsUrl
             .startsWith(VIEWFS_PREFIX))) {
           baseDFSUrl = dfsUrl + baseDFSUrl;
@@ -707,10 +713,9 @@ public final class CarbonUtil {
         if (baseDFSUrl.endsWith("/")) {
           baseDFSUrl = baseDFSUrl.substring(0, baseDFSUrl.length() - 1);
         }
-        if (!filePath.startsWith("/")) {
-          filePath = "/" + filePath;
-        }
         currentPath = baseDFSUrl + filePath;
+      } else {
+        currentPath = dfsUrl + filePath;
       }
     }
     return currentPath;

--- a/core/src/test/java/org/apache/carbondata/core/util/CarbonUtilTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/util/CarbonUtilTest.java
@@ -342,7 +342,7 @@ public class CarbonUtilTest {
       }
     };
     String hdfsURL = CarbonUtil.checkAndAppendHDFSUrl("../core/src/test/resources/testDatabase");
-    assertEquals(hdfsURL, "BASE_URL/../core/src/test/resources/testDatabase");
+    assertEquals(hdfsURL, "/BASE_URL/../core/src/test/resources/testDatabase");
   }
 
   @Test public void testToCheckAndAppendHDFSUrlWithBlackSlash() {
@@ -357,7 +357,7 @@ public class CarbonUtilTest {
       }
     };
     String hdfsURL = CarbonUtil.checkAndAppendHDFSUrl("../core/src/test/resources/testDatabase");
-    assertEquals(hdfsURL, "BASE_URL/../core/src/test/resources/testDatabase");
+    assertEquals(hdfsURL, "/BASE_URL/../core/src/test/resources/testDatabase");
   }
 
   @Test public void testToCheckAndAppendHDFSUrlWithNull() {
@@ -372,7 +372,7 @@ public class CarbonUtilTest {
       }
     };
     String hdfsURL = CarbonUtil.checkAndAppendHDFSUrl("../core/src/test/resources/testDatabase");
-    assertEquals(hdfsURL, "../core/src/test/resources/testDatabase");
+    assertEquals(hdfsURL, "file:////../core/src/test/resources/testDatabase");
   }
 
   @Test public void testForisFileExists() {

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/GlobalDictionaryUtil.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/GlobalDictionaryUtil.scala
@@ -441,7 +441,9 @@ object GlobalDictionaryUtil {
                                        " should be columnName:columnPath, please check")
       }
       setPredefineDict(carbonLoadModel, dimensions, table, colNameWithPath(0),
-        FileUtils.getPaths(colPathMapTrim.substring(colNameWithPath(0).length + 1)))
+        FileUtils
+          .getPaths(CarbonUtil
+            .checkAndAppendHDFSUrl(colPathMapTrim.substring(colNameWithPath(0).length + 1))))
     }
   }
 
@@ -773,7 +775,8 @@ object GlobalDictionaryUtil {
       dimensions: Array[CarbonDimension],
       allDictionaryPath: String): Unit = {
     LOGGER.info("Generate global dictionary from dictionary files!")
-    val isNonempty = validateAllDictionaryPath(allDictionaryPath)
+    val allDictionaryPathAppended = CarbonUtil.checkAndAppendHDFSUrl(allDictionaryPath)
+    val isNonempty = validateAllDictionaryPath(allDictionaryPathAppended)
     if (isNonempty) {
       var headers = carbonLoadModel.getCsvHeaderColumns
       headers = headers.map(headerName => headerName.trim)
@@ -786,7 +789,7 @@ object GlobalDictionaryUtil {
         val accumulator = sqlContext.sparkContext.accumulator(0)
         // read local dictionary file, and group by key
         val allDictionaryRdd = readAllDictionaryFiles(sqlContext, headers,
-          requireColumnNames, allDictionaryPath, accumulator)
+          requireColumnNames, allDictionaryPathAppended, accumulator)
         // read exist dictionary and combine
         val inputRDD = new CarbonAllDictionaryCombineRDD(allDictionaryRdd, model)
           .partitionBy(new ColumnPartitioner(model.primDimensions.length))


### PR DESCRIPTION
While giving the raw data in LOAD command, the path should be with the scheme like hdfs:// , viewfs:// etc. with this improvement the data path can be absolute path without the scheme. data path for load data and pre-created dictionary data are improved here.