### PR TITLE
[CARBONDATA-1239] Add validation for set command parameters

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonSessionInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonSessionInfo.java
@@ -58,14 +58,14 @@ public class CarbonSessionInfo implements Serializable, Cloneable {
     CarbonSessionInfo newObj = new CarbonSessionInfo();
     for (Map.Entry<String, String> entry : sessionParams.getAll().entrySet()) {
       try {
-        newObj.getSessionParams().addProperty(entry.getKey(), entry.getValue(), false);
+        newObj.getSessionParams().addProperty(entry.getKey(), entry.getValue(), false, true);
       } catch (InvalidConfigurationException ex) {
         ex.printStackTrace();
       }
     }
     for (Map.Entry<String, String> entry : threadParams.getAll().entrySet()) {
       try {
-        newObj.getThreadParams().addProperty(entry.getKey(), entry.getValue(), false);
+        newObj.getThreadParams().addProperty(entry.getKey(), entry.getValue(), false, false);
       } catch (InvalidConfigurationException ex) {
         ex.printStackTrace();
       }

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
@@ -1887,9 +1887,11 @@ public final class CarbonUtil {
   }
 
   /**
-   * is valid store path
+   * check weather path is valid
+   *
    * @param badRecordsLocation
-   * @return
+   * @return <false> if the badRecordsLocation is empty, null, or the configured
+   * path does not exists.
    */
   public static boolean isValidBadStorePath(String badRecordsLocation) {
     if (StringUtils.isEmpty(badRecordsLocation)) {
@@ -2205,6 +2207,31 @@ public final class CarbonUtil {
     return -1;
   }
 
+
+  /**
+   * This method validate the global_sort_partition range
+   *
+   * @param key
+   * @param minValue
+   * @param maxValue
+   */
+  public static boolean validateRange(String key, int minValue, int maxValue)
+      throws InvalidConfigurationException {
+    boolean isValid;
+    int value1;
+    try {
+      value1 = Integer.parseInt(key);
+    } catch (NumberFormatException nfe) {
+      throw new InvalidConfigurationException(
+          "The configured value for key " + key + " must be valid integer.");
+    }
+    isValid = value1 < minValue || value1 > maxValue;
+    if (isValid) {
+      throw new InvalidConfigurationException(
+          "'GLOBAL_SORT_PARTITIONS' should be greater " + "than 0.");
+    }
+    return isValid;
+  }
   /**
    * get the parent folder of old table path and returns the new tablePath by appending new
    * tableName to the parent

--- a/core/src/main/java/org/apache/carbondata/core/util/SessionParams.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/SessionParams.java
@@ -92,8 +92,9 @@ public class SessionParams implements Serializable {
    * @param key
    * @return properties value
    */
-  public SessionParams addProperty(String key, String value) throws InvalidConfigurationException {
-    return addProperty(key, value, true);
+  public SessionParams addProperty(String key, String value, boolean isSessionParams)
+      throws InvalidConfigurationException {
+    return addProperty(key, value, true, isSessionParams);
   }
 
   /**
@@ -102,9 +103,9 @@ public class SessionParams implements Serializable {
    * @param key
    * @return properties value
    */
-  public SessionParams addProperty(String key, String value, Boolean doAuditing)
-      throws InvalidConfigurationException {
-    boolean isValidConf = validateKeyValue(key, value);
+  public SessionParams addProperty(String key, String value, Boolean doAuditing,
+      boolean isSessionParams) throws InvalidConfigurationException {
+    boolean isValidConf = validateKeyValue(key, value, isSessionParams);
     if (isValidConf) {
       if (key.equals(CarbonLoadOptionConstants.CARBON_OPTIONS_BAD_RECORDS_ACTION)) {
         value = value.toUpperCase();
@@ -137,7 +138,8 @@ public class SessionParams implements Serializable {
    * @return
    * @throws InvalidConfigurationException
    */
-  private boolean validateKeyValue(String key, String value) throws InvalidConfigurationException {
+  private boolean validateKeyValue(String key, String value, boolean isSessionParams)
+      throws InvalidConfigurationException {
     boolean isValid = false;
     switch (key) {
       case ENABLE_UNSAFE_SORT:
@@ -187,7 +189,7 @@ public class SessionParams implements Serializable {
       case CARBON_OPTIONS_TIMESTAMPFORMAT:
         try {
           new SimpleDateFormat(value);
-          isValid = true;
+          isValid = !isSessionParams;
         } catch (Exception e) {
           throw new InvalidConfigurationException(
               "The value \"" + value + "\" configured for key " + key + " is invalid.");

--- a/core/src/main/java/org/apache/carbondata/core/util/SessionParams.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/SessionParams.java
@@ -18,6 +18,7 @@
 package org.apache.carbondata.core.util;
 
 import java.io.Serializable;
+import java.text.SimpleDateFormat;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -155,23 +156,26 @@ public class SessionParams implements Serializable {
           isValid = true;
         } catch (IllegalArgumentException iae) {
           throw new InvalidConfigurationException(
-              "The key " + key + " can have only either FORCE or IGNORE or REDIRECT.");
+              "The key " + key + " can have only either FORCE or IGNORE or REDIRECT or FAIL.");
         }
         break;
       case CARBON_OPTIONS_SORT_SCOPE:
         isValid = CarbonUtil.isValidSortOption(value);
         if (!isValid) {
           throw new InvalidConfigurationException("The sort scope " + key
-              + " can have only either BATCH_SORT or LOCAL_SORT or NO_SORT.");
+              + " can have only either BATCH_SORT or LOCAL_SORT or NO_SORT or GLOBAL_SORT.");
         }
         break;
       case CARBON_OPTIONS_BATCH_SORT_SIZE_INMB:
-      case CARBON_OPTIONS_GLOBAL_SORT_PARTITIONS:
         isValid = CarbonUtil.validateValidIntType(value);
         if (!isValid) {
           throw new InvalidConfigurationException(
               "The configured value for key " + key + " must be valid integer.");
         }
+        break;
+      case CARBON_OPTIONS_GLOBAL_SORT_PARTITIONS:
+
+        isValid = CarbonUtil.validateRange(value, 1, Integer.MAX_VALUE);
         break;
       case CARBON_OPTIONS_BAD_RECORD_PATH:
         isValid = CarbonUtil.isValidBadStorePath(value);
@@ -179,13 +183,15 @@ public class SessionParams implements Serializable {
           throw new InvalidConfigurationException("Invalid bad records location.");
         }
         break;
-      // no validation needed while set for CARBON_OPTIONS_DATEFORMAT
       case CARBON_OPTIONS_DATEFORMAT:
-        isValid = true;
-        break;
-      // no validation needed while set for CARBON_OPTIONS_TIMESTAMPFORMAT
       case CARBON_OPTIONS_TIMESTAMPFORMAT:
-        isValid = true;
+        try {
+          new SimpleDateFormat(value);
+          isValid = true;
+        } catch (Exception e) {
+          throw new InvalidConfigurationException(
+              "The value \"" + value + "\" configured for key " + key + " is invalid.");
+        }
         break;
       // no validation needed while set for CARBON_OPTIONS_SERIALIZATION_NULL_FORMAT
       case CARBON_OPTIONS_SERIALIZATION_NULL_FORMAT:

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableOutputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableOutputFormat.java
@@ -307,11 +307,11 @@ public class CarbonTableOutputFormat extends FileOutputFormat<NullWritable, Stri
     }
     model.setDateFormat(
         conf.get(
-            DATE_FORMAT, ""));
+            DATE_FORMAT, CarbonCommonConstants.CARBON_DATE_DEFAULT_FORMAT));
 
     model.setTimestampformat(
         conf.get(
-            TIMESTAMP_FORMAT, ""));
+            TIMESTAMP_FORMAT, CarbonCommonConstants.CARBON_TIMESTAMP_DEFAULT_FORMAT));
 
     model.setGlobalSortPartitions(
         conf.get(

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableOutputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableOutputFormat.java
@@ -307,11 +307,15 @@ public class CarbonTableOutputFormat extends FileOutputFormat<NullWritable, Stri
     }
     model.setDateFormat(
         conf.get(
-            DATE_FORMAT, CarbonCommonConstants.CARBON_DATE_DEFAULT_FORMAT));
+            DATE_FORMAT, carbonProperty.getProperty(
+                CarbonLoadOptionConstants.CARBON_OPTIONS_DATEFORMAT,
+                CarbonLoadOptionConstants.CARBON_OPTIONS_DATEFORMAT_DEFAULT)));
 
     model.setTimestampformat(
         conf.get(
-            TIMESTAMP_FORMAT, CarbonCommonConstants.CARBON_TIMESTAMP_DEFAULT_FORMAT));
+            TIMESTAMP_FORMAT, carbonProperty.getProperty(
+                CarbonLoadOptionConstants.CARBON_OPTIONS_TIMESTAMPFORMAT,
+                CarbonLoadOptionConstants.CARBON_OPTIONS_TIMESTAMPFORMAT_DEFAULT)));
 
     model.setGlobalSortPartitions(
         conf.get(

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableOutputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableOutputFormat.java
@@ -307,17 +307,11 @@ public class CarbonTableOutputFormat extends FileOutputFormat<NullWritable, Stri
     }
     model.setDateFormat(
         conf.get(
-            DATE_FORMAT,
-            carbonProperty.getProperty(
-                CarbonLoadOptionConstants.CARBON_OPTIONS_DATEFORMAT,
-                CarbonLoadOptionConstants.CARBON_OPTIONS_DATEFORMAT_DEFAULT)));
+            DATE_FORMAT, ""));
 
     model.setTimestampformat(
         conf.get(
-            TIMESTAMP_FORMAT,
-            carbonProperty.getProperty(
-                CarbonLoadOptionConstants.CARBON_OPTIONS_TIMESTAMPFORMAT,
-                CarbonLoadOptionConstants.CARBON_OPTIONS_TIMESTAMPFORMAT_DEFAULT)));
+            TIMESTAMP_FORMAT, ""));
 
     model.setGlobalSortPartitions(
         conf.get(

--- a/hadoop/src/test/java/org/apache/carbondata/hadoop/ft/CarbonTableInputFormatTest.java
+++ b/hadoop/src/test/java/org/apache/carbondata/hadoop/ft/CarbonTableInputFormatTest.java
@@ -60,8 +60,6 @@ import org.junit.Test;
 public class CarbonTableInputFormatTest {
   // changed setUp to static init block to avoid un wanted multiple time store creation
   static {
-    CarbonProperties.getInstance().
-        addProperty(CarbonCommonConstants.CARBON_BADRECORDS_LOC, "/tmp/carbon/badrecords");
     try {
       StoreCreator.createCarbonStore();
     } catch (Exception e) {

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/badrecordloger/BadRecordLoggerTest.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/badrecordloger/BadRecordLoggerTest.scala
@@ -242,7 +242,7 @@ class BadRecordLoggerTest extends QueryTest with BeforeAndAfterAll {
           + "('bad_records_action'='FORCA', 'DELIMITER'= ',', 'QUOTECHAR'= '\"')");
     } catch {
       case ex: Exception =>
-        assert("option BAD_RECORDS_ACTION can have only either FORCE or IGNORE or REDIRECT"
+        assert("option BAD_RECORDS_ACTION can have only either FORCE or IGNORE or REDIRECT or FAIL"
           .equals(ex.getMessage))
     }
   }

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestGlobalSortDataLoad.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestGlobalSortDataLoad.scala
@@ -30,6 +30,7 @@ import org.apache.spark.sql.test.TestQueryExecutor.projectPath
 import org.apache.spark.sql.test.util.QueryTest
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 
+import org.apache.carbondata.core.exception.InvalidConfigurationException
 import org.apache.carbondata.core.indexstore.blockletindex.SegmentIndexFileStore
 import org.apache.carbondata.core.metadata.CarbonMetadata
 import org.apache.carbondata.core.util.path.CarbonStorePath
@@ -143,12 +144,12 @@ class TestGlobalSortDataLoad extends QueryTest with BeforeAndAfterEach with Befo
   }
 
   test("Number of partitions should be greater than 0") {
-    intercept[MalformedCarbonCommandException] {
+    intercept[InvalidConfigurationException] {
       sql(s"LOAD DATA LOCAL INPATH '$filePath' INTO TABLE carbon_globalsort " +
         "OPTIONS('GLOBAL_SORT_PARTITIONS'='0')")
     }
 
-    intercept[MalformedCarbonCommandException] {
+    intercept[InvalidConfigurationException] {
       sql(s"LOAD DATA LOCAL INPATH '$filePath' INTO TABLE carbon_globalsort " +
         "OPTIONS('GLOBAL_SORT_PARTITIONS'='a')")
     }

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/load/ValidateUtil.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/load/ValidateUtil.scala
@@ -20,6 +20,7 @@ package org.apache.carbondata.spark.load
 import java.text.SimpleDateFormat
 
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable
+import org.apache.carbondata.core.util.CarbonUtil
 import org.apache.carbondata.processing.loading.sort.SortScopeOptions
 import org.apache.carbondata.spark.exception.MalformedCarbonCommandException
 
@@ -57,15 +58,7 @@ object ValidateUtil {
 
   def validateGlobalSortPartitions(globalSortPartitions: String): Unit = {
     if (globalSortPartitions != null) {
-      try {
-        val num = globalSortPartitions.toInt
-        if (num <= 0) {
-          throw new MalformedCarbonCommandException("'GLOBAL_SORT_PARTITIONS' should be greater " +
-            "than 0.")
-        }
-      } catch {
-        case e: NumberFormatException => throw new MalformedCarbonCommandException(e.getMessage)
-      }
+      CarbonUtil.validateRange(globalSortPartitions, 1, Integer.MAX_VALUE)
     }
   }
 }

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
@@ -948,7 +948,7 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
       catch {
         case _: IllegalArgumentException =>
           throw new MalformedCarbonCommandException(
-            "option BAD_RECORDS_ACTION can have only either FORCE or IGNORE or REDIRECT")
+            "option BAD_RECORDS_ACTION can have only either FORCE or IGNORE or REDIRECT or FAIL")
       }
     }
     if (options.exists(_._1.equalsIgnoreCase("IS_EMPTY_DATA_BAD_RECORD"))) {

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSession.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSession.scala
@@ -210,7 +210,7 @@ object CarbonSession {
       currentThreadSessionInfo = currentThreadSessionInfo.clone()
     }
     val threadParams = currentThreadSessionInfo.getThreadParams
-    CarbonSetCommand.validateAndSetValue(threadParams, key, value)
+    CarbonSetCommand.validateAndSetValue(threadParams, key, value, isSessionParams = false)
     ThreadLocalSessionInfo.setCarbonSessionInfo(currentThreadSessionInfo)
   }
 
@@ -245,7 +245,7 @@ object CarbonSession {
       val currentThreadSessionInfo = currentThreadSessionInfoOrig.clone()
       // copy all the thread parameters to apply to session parameters
       currentThreadSessionInfo.getThreadParams.getAll.asScala
-        .foreach(entry => carbonSessionInfo.getSessionParams.addProperty(entry._1, entry._2))
+        .foreach(entry => carbonSessionInfo.getSessionParams.addProperty(entry._1, entry._2, true))
       carbonSessionInfo.setThreadParams(currentThreadSessionInfo.getThreadParams)
     }
     // preserve thread parameters across call

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/hive/execution/command/CarbonHiveCommands.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/hive/execution/command/CarbonHiveCommands.scala
@@ -71,7 +71,7 @@ case class CarbonSetCommand(command: SetCommand)
     val sessionParms = CarbonEnv.getInstance(sparkSession).carbonSessionInfo.getSessionParams
     command.kv match {
       case Some((key, Some(value))) =>
-        CarbonSetCommand.validateAndSetValue(sessionParms, key, value)
+        CarbonSetCommand.validateAndSetValue(sessionParms, key, value, isSessionParams = true)
       case _ =>
 
     }
@@ -80,15 +80,16 @@ case class CarbonSetCommand(command: SetCommand)
 }
 
 object CarbonSetCommand {
-  def validateAndSetValue(sessionParams: SessionParams, key: String, value: String): Unit = {
+  def validateAndSetValue(sessionParams: SessionParams, key: String, value: String,
+      isSessionParams: Boolean = true): Unit = {
 
     val isCarbonProperty: Boolean = CarbonProperties.getInstance().isCarbonProperty(key)
     if (isCarbonProperty) {
-      sessionParams.addProperty(key, value)
+      sessionParams.addProperty(key, value, isSessionParams)
     }
     else if (key.startsWith(CarbonCommonConstants.CARBON_INPUT_SEGMENTS)) {
       if (key.split("\\.").length == 5) {
-        sessionParams.addProperty(key.toLowerCase(), value)
+        sessionParams.addProperty(key.toLowerCase(), value, isSessionParams)
       }
       else {
         throw new MalformedCarbonCommandException(
@@ -96,7 +97,7 @@ object CarbonSetCommand {
           ".<table_name>=<seg_id list> \" format.")
       }
     } else if (key.startsWith(CarbonCommonConstants.VALIDATE_CARBON_INPUT_SEGMENTS)) {
-      sessionParams.addProperty(key.toLowerCase(), value)
+      sessionParams.addProperty(key.toLowerCase(), value, isSessionParams)
     }
   }
 

--- a/integration/spark2/src/main/spark2.1/org/apache/spark/sql/hive/CarbonSQLConf.scala
+++ b/integration/spark2/src/main/spark2.1/org/apache/spark/sql/hive/CarbonSQLConf.scala
@@ -97,11 +97,6 @@ class CarbonSQLConf(sparkSession: SparkSession) {
         .createWithDefault(carbonProperties
           .getProperty(CarbonCommonConstants.LOAD_GLOBAL_SORT_PARTITIONS,
             CarbonCommonConstants.LOAD_GLOBAL_SORT_PARTITIONS_DEFAULT))
-    val DATEFORMAT =
-      SQLConfigBuilder(CarbonLoadOptionConstants.CARBON_OPTIONS_DATEFORMAT)
-        .doc("Property to configure data format for date type columns.")
-        .stringConf
-        .createWithDefault(CarbonLoadOptionConstants.CARBON_OPTIONS_DATEFORMAT_DEFAULT)
     val CARBON_INPUT_SEGMENTS = SQLConfigBuilder(
       "carbon.input.segments.<database_name>.<table_name>")
       .doc("Property to configure the list of segments to query.").stringConf
@@ -137,13 +132,8 @@ class CarbonSQLConf(sparkSession: SparkSession) {
     sparkSession.conf.set(CarbonLoadOptionConstants.CARBON_OPTIONS_BAD_RECORD_PATH,
       carbonProperties.getProperty(CarbonCommonConstants.CARBON_BADRECORDS_LOC,
         CarbonCommonConstants.CARBON_BADRECORDS_LOC_DEFAULT_VAL))
-    sparkSession.conf.set(CarbonLoadOptionConstants.CARBON_OPTIONS_BAD_RECORD_PATH,
-      carbonProperties.getProperty(CarbonCommonConstants.CARBON_BADRECORDS_LOC,
-        CarbonCommonConstants.CARBON_BADRECORDS_LOC_DEFAULT_VAL))
     sparkSession.conf.set(CarbonLoadOptionConstants.CARBON_OPTIONS_GLOBAL_SORT_PARTITIONS,
       carbonProperties.getProperty(CarbonCommonConstants.LOAD_GLOBAL_SORT_PARTITIONS,
         CarbonCommonConstants.LOAD_GLOBAL_SORT_PARTITIONS_DEFAULT))
-    sparkSession.conf.set(CarbonLoadOptionConstants.CARBON_OPTIONS_DATEFORMAT,
-      CarbonLoadOptionConstants.CARBON_OPTIONS_DATEFORMAT_DEFAULT)
   }
 }

--- a/integration/spark2/src/main/spark2.2/org/apache/spark/sql/hive/CarbonSqlConf.scala
+++ b/integration/spark2/src/main/spark2.2/org/apache/spark/sql/hive/CarbonSqlConf.scala
@@ -96,11 +96,6 @@ class CarbonSQLConf(sparkSession: SparkSession) {
         .createWithDefault(carbonProperties
           .getProperty(CarbonCommonConstants.LOAD_GLOBAL_SORT_PARTITIONS,
             CarbonCommonConstants.LOAD_GLOBAL_SORT_PARTITIONS_DEFAULT))
-    val DATEFORMAT =
-      buildConf(CarbonLoadOptionConstants.CARBON_OPTIONS_DATEFORMAT)
-        .doc("Property to configure data format for date type columns.")
-        .stringConf
-        .createWithDefault(CarbonLoadOptionConstants.CARBON_OPTIONS_DATEFORMAT_DEFAULT)
     val CARBON_INPUT_SEGMENTS = buildConf(
       "carbon.input.segments.<database_name>.<table_name>")
       .doc("Property to configure the list of segments to query.").stringConf
@@ -142,7 +137,5 @@ class CarbonSQLConf(sparkSession: SparkSession) {
     sparkSession.conf.set(CarbonLoadOptionConstants.CARBON_OPTIONS_GLOBAL_SORT_PARTITIONS,
       carbonProperties.getProperty(CarbonCommonConstants.LOAD_GLOBAL_SORT_PARTITIONS,
         CarbonCommonConstants.LOAD_GLOBAL_SORT_PARTITIONS_DEFAULT))
-    sparkSession.conf.set(CarbonLoadOptionConstants.CARBON_OPTIONS_DATEFORMAT,
-      CarbonLoadOptionConstants.CARBON_OPTIONS_DATEFORMAT_DEFAULT)
   }
 }


### PR DESCRIPTION
**Problem & solution**
1.Correct the validation message for carbon.options.bad.records.action param
2. Correct message for carbon.options.global.sort options
3. Add path validation for carbon.options.bad.record.path
4. Add range validation for carbon.options.global.sort.patitions
5. Remove carbon.options.dateformat from set option supported param.

- [X] Any interfaces changed?
 NA
 - [X] Any backward compatibility impacted?
 NA     
 - [X] Document update required?
NA 
 - [X] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       Fixed impacted Test case
 - [X] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
 NA
