### PR TITLE
[CARBONDATA-1236] Support absolute path without scheme in loading - h…

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
@@ -696,13 +696,13 @@ public final class CarbonUtil {
    * @param filePath
    */
   public static String checkAndAppendHDFSUrl(String filePath) {
-    if (!filePath.startsWith("/")) {
-      filePath = "/" + filePath;
-    }
     String currentPath = filePath;
     if (null != filePath && filePath.length() != 0
         && FileFactory.getFileType(filePath) != FileFactory.FileType.HDFS
         && FileFactory.getFileType(filePath) != FileFactory.FileType.VIEWFS) {
+      if (!filePath.startsWith("/")) {
+        filePath = "/" + filePath;
+      }
       String baseDFSUrl = CarbonProperties.getInstance()
           .getProperty(CarbonCommonConstants.CARBON_DDL_BASE_HDFS_URL);
       String dfsUrl = conf.get(FS_DEFAULT_FS);


### PR DESCRIPTION
we should not check for the file type after adding a / in front. this PR will change the logic to first check the file type and then append a / if needed