### PR TITLE
[CARBONDATA-1246] fix null pointer exception by changing null to empty array

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/AlluxioCarbonFile.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/AlluxioCarbonFile.java
@@ -74,7 +74,7 @@ public class AlluxioCarbonFile extends AbstractDFSCarbonFile {
         Path path = fileStatus.getPath();
         listStatus = path.getFileSystem(FileFactory.getConfiguration()).listStatus(path);
       } else {
-        return null;
+        return new CarbonFile[0];
       }
     } catch (IOException e) {
       LOGGER.error("Exception occured: " + e.getMessage());

--- a/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/HDFSCarbonFile.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/HDFSCarbonFile.java
@@ -72,7 +72,7 @@ public class HDFSCarbonFile extends AbstractDFSCarbonFile {
         Path path = fileStatus.getPath();
         listStatus = path.getFileSystem(FileFactory.getConfiguration()).listStatus(path);
       } else {
-        return null;
+        return new CarbonFile[0];
       }
     } catch (IOException e) {
       LOGGER.error("Exception occured: " + e.getMessage());

--- a/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/LocalCarbonFile.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/LocalCarbonFile.java
@@ -123,7 +123,7 @@ public class LocalCarbonFile implements CarbonFile {
   @Override public CarbonFile[] listFiles() {
 
     if (!file.isDirectory()) {
-      return null;
+      return new CarbonFile[0];
     }
     File[] files = file.listFiles();
     if (files == null) {

--- a/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/ViewFSCarbonFile.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/ViewFSCarbonFile.java
@@ -71,7 +71,7 @@ public class ViewFSCarbonFile extends AbstractDFSCarbonFile {
         Path path = fileStatus.getPath();
         listStatus = path.getFileSystem(FileFactory.getConfiguration()).listStatus(path);
       } else {
-        return null;
+        return new CarbonFile[0];
       }
     } catch (IOException ex) {
       LOGGER.error("Exception occured" + ex.getMessage());

--- a/core/src/test/java/org/apache/carbondata/core/datastore/filesystem/AlluxioCarbonFileTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/datastore/filesystem/AlluxioCarbonFileTest.java
@@ -35,6 +35,7 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -90,7 +91,7 @@ public class AlluxioCarbonFileTest {
     @Test
     public void testListFilesWithOutDirectoryPermission() {
         alluxioCarbonFile = new AlluxioCarbonFile(fileStatusWithOutDirectoryPermission);
-        assertTrue(alluxioCarbonFile.listFiles() == null);
+        assertArrayEquals(alluxioCarbonFile.listFiles(), new CarbonFile[0]);
     }
 
     @Test

--- a/core/src/test/java/org/apache/carbondata/core/datastore/filesystem/HDFSCarbonFileTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/datastore/filesystem/HDFSCarbonFileTest.java
@@ -39,6 +39,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -132,7 +133,7 @@ public class HDFSCarbonFileTest {
             }
 
         };
-        assertEquals(hdfsCarbonFile.listFiles(), null);
+        assertArrayEquals(hdfsCarbonFile.listFiles(), new CarbonFile[0]);
     }
 
     @Test

--- a/core/src/test/java/org/apache/carbondata/core/datastore/filesystem/LocalCarbonFileTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/datastore/filesystem/LocalCarbonFileTest.java
@@ -30,6 +30,7 @@ import java.io.*;
 import java.nio.channels.ReadableByteChannel;
 import java.util.Objects;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -102,7 +103,7 @@ public class LocalCarbonFileTest {
                 return false;
             }
         };
-        assertTrue(localCarbonFile.listFiles() == null);
+        assertArrayEquals(localCarbonFile.listFiles(), new CarbonFile[0]);
     }
 
     @Test

--- a/core/src/test/java/org/apache/carbondata/core/datastore/filesystem/ViewFsCarbonFileTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/datastore/filesystem/ViewFsCarbonFileTest.java
@@ -35,6 +35,7 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -91,7 +92,7 @@ public class ViewFsCarbonFileTest {
     @Test
     public void testListFilesWithOutDirectoryPermission() {
         viewFSCarbonFile = new ViewFSCarbonFile(fileStatusWithOutDirectoryPermission);
-        assertTrue(viewFSCarbonFile.listFiles() == null);
+        assertArrayEquals(viewFSCarbonFile.listFiles(), new CarbonFile[0]);
     }
 
     @Test


### PR DESCRIPTION
In presto integration, `CarbonFile.listFiles()` function will return null when the specified `fileStatus` is not a directory or is null. This will incur a `NullPointerException` when called by `CarbonTableReader.updateTableList()` function.
Change the `listFiles()` function to return an empty array, instead of a null value.