### PR TITLE
[CARBONDATA-1249] Wrong order of columns in redirected csv for bad records

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/row/CarbonRow.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/row/CarbonRow.java
@@ -27,10 +27,22 @@ public class CarbonRow implements Serializable {
 
   private Object[] data;
 
+  private Object[] rawData;
+
   public short bucketNumber;
 
   public CarbonRow(Object[] data) {
     this.data = data;
+  }
+
+  /**
+   *
+   * @param data contains column values for only schema columns
+   * @param rawData contains complete row of the rawData
+   */
+  public CarbonRow(Object[] data, Object[] rawData) {
+    this.data = data;
+    this.rawData = rawData;
   }
 
   public Object[] getData() {
@@ -61,14 +73,14 @@ public class CarbonRow implements Serializable {
     data[ordinal] = value;
   }
 
-  public CarbonRow getCopy() {
-    Object[] copy = new Object[data.length];
-    System.arraycopy(data, 0, copy, 0, copy.length);
-    return new CarbonRow(copy);
-  }
-
   @Override public String toString() {
     return Arrays.toString(data);
   }
 
+  public Object[] getRawData() {
+    return rawData;
+  }
+  public void setRawData(Object[] rawData) {
+    this.rawData = rawData;
+  }
 }

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/badrecordloger/BadRecordLoggerTest.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/badrecordloger/BadRecordLoggerTest.scala
@@ -17,14 +17,18 @@
 
 package org.apache.carbondata.spark.testsuite.badrecordloger
 
-import java.io.File
+import java.io.{File, FileFilter}
 
+import org.apache.commons.io.FileUtils
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.hive.HiveContext
 import org.scalatest.BeforeAndAfterAll
+
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.util.CarbonProperties
 import org.apache.spark.sql.test.util.QueryTest
+
+import org.apache.carbondata.core.datastore.impl.FileFactory
 
 /**
  * Test Class for detailed query on timestamp datatypes
@@ -46,6 +50,7 @@ class BadRecordLoggerTest extends QueryTest with BeforeAndAfterAll {
       sql("drop table IF EXISTS empty_timestamp")
       sql("drop table IF EXISTS empty_timestamp_false")
       sql("drop table IF EXISTS dataloadOptionTests")
+      sql("drop table IF EXISTS sales_test")
       sql(
         """CREATE TABLE IF NOT EXISTS sales(ID BigInt, date Timestamp, country String,
           actual_price Double, Quantity int, sold_price Decimal(19,2)) STORED BY 'carbondata'""")
@@ -247,8 +252,69 @@ class BadRecordLoggerTest extends QueryTest with BeforeAndAfterAll {
     }
   }
 
+  test("validate redirected data") {
+    cleanBadRecordPath("default", "sales_test")
+    val csvFilePath = s"$resourcesPath/badrecords/datasample.csv"
+    sql(
+      """CREATE TABLE IF NOT EXISTS sales_test(ID BigInt, date long, country int,
+          actual_price Double, Quantity String, sold_price Decimal(19,2)) STORED BY 'carbondata'""")
+
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, "yyyy/MM/dd")
+    try {
+      sql("LOAD DATA local inpath '" + csvFilePath + "' INTO TABLE sales_test OPTIONS" +
+          "('bad_records_logger_enable'='false','bad_records_action'='redirect', 'DELIMITER'=" +
+          " ',', 'QUOTECHAR'= '\"')");
+    } catch {
+      case e: Exception => {
+        assert(true)
+      }
+    }
+    val redirectCsvPath = getRedirectCsvPath("default", "sales_test", "0", "0")
+    assert(checkRedirectedCsvContentAvailableInSource(csvFilePath, redirectCsvPath))
+  }
+
+  def getRedirectCsvPath(dbName: String, tableName: String, segment: String, task: String) = {
+    var badRecordLocation = CarbonProperties.getInstance()
+      .getProperty(CarbonCommonConstants.CARBON_BADRECORDS_LOC)
+    badRecordLocation = badRecordLocation + "/" + dbName + "/" + tableName + "/" + segment + "/" +
+                        task
+    val listFiles = new File(badRecordLocation).listFiles(new FileFilter {
+      override def accept(pathname: File): Boolean = {
+        pathname.getPath.endsWith(".csv")
+      }
+    })
+    listFiles(0)
+  }
+
+  /**
+   *
+   * @param csvFilePath
+   * @param redirectCsvPath
+   */
+  def checkRedirectedCsvContentAvailableInSource(csvFilePath: String,
+      redirectCsvPath: File): Boolean = {
+    val origFileLineList = FileUtils.readLines(new File(csvFilePath))
+    val redirectedFileLineList = FileUtils.readLines(redirectCsvPath)
+    val iterator = redirectedFileLineList.iterator()
+    while (iterator.hasNext) {
+      if (!origFileLineList.contains(iterator.next())) {
+        return false;
+      }
+    }
+    return true
+  }
+
+  def cleanBadRecordPath(dbName: String, tableName: String) = {
+    var badRecordLocation = CarbonProperties.getInstance()
+      .getProperty(CarbonCommonConstants.CARBON_BADRECORDS_LOC)
+    badRecordLocation = badRecordLocation + "/" + dbName + "/" + tableName
+    FileFactory.deleteAllCarbonFilesOfDir(FileFactory.getCarbonFile(badRecordLocation))
+  }
+
   override def afterAll {
     sql("drop table sales")
+    sql("drop table sales_test")
     sql("drop table serializable_values")
     sql("drop table serializable_values_false")
     sql("drop table insufficientColumn")

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestDataLoadWithColumnsMoreThanSchema.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestDataLoadWithColumnsMoreThanSchema.scala
@@ -30,6 +30,10 @@ class TestDataLoadWithColumnsMoreThanSchema extends QueryTest with BeforeAndAfte
   override def beforeAll {
     sql("DROP TABLE IF EXISTS char_test")
     sql("DROP TABLE IF EXISTS hive_char_test")
+    sql("DROP TABLE IF EXISTS max_columns_value_test")
+    sql("DROP TABLE IF EXISTS boundary_max_columns_test")
+    sql("DROP TABLE IF EXISTS valid_max_columns_test")
+    sql("DROP TABLE IF EXISTS max_columns_test")
     sql("DROP TABLE IF EXISTS smart_500_DE")
     sql("CREATE TABLE char_test (imei string,age int,task bigint,num double,level decimal(10,3),productdate timestamp,mark int,name string)STORED BY 'org.apache.carbondata.format'")
     sql("CREATE TABLE hive_char_test (imei string,age int,task bigint,num double,level decimal(10,3),productdate timestamp,mark int,name string)row format delimited fields terminated by ','")

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/load/DataLoadProcessorStepOnSpark.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/load/DataLoadProcessorStepOnSpark.scala
@@ -37,7 +37,7 @@ import org.apache.carbondata.processing.loading.sort.SortStepRowUtil
 import org.apache.carbondata.processing.loading.steps.{DataConverterProcessorStepImpl, DataWriterProcessorStepImpl}
 import org.apache.carbondata.processing.sort.sortdata.SortParameters
 import org.apache.carbondata.processing.store.{CarbonFactHandler, CarbonFactHandlerFactory}
-import org.apache.carbondata.processing.util.CarbonLoaderUtil
+import org.apache.carbondata.processing.util.{CarbonDataProcessorUtil, CarbonLoaderUtil}
 import org.apache.carbondata.spark.rdd.{NewRddIterator, StringArrayRow}
 import org.apache.carbondata.spark.util.Util
 
@@ -69,7 +69,7 @@ object DataLoadProcessorStepOnSpark {
     val model: CarbonLoadModel = modelBroadcast.value.getCopyWithTaskNo(index.toString)
     val conf = DataLoadProcessBuilder.createConfiguration(model)
     val rowParser = new RowParserImpl(conf.getDataFields, conf)
-
+    val isRawDataRequired = CarbonDataProcessorUtil.isRawDataRequired(conf)
     TaskContext.get().addTaskFailureListener { (t: TaskContext, e: Throwable) =>
       wrapException(e, model)
     }
@@ -77,8 +77,16 @@ object DataLoadProcessorStepOnSpark {
     new Iterator[CarbonRow] {
       override def hasNext: Boolean = rows.hasNext
 
+
+
       override def next(): CarbonRow = {
-        val row = new CarbonRow(rowParser.parseRow(rows.next()))
+        var row : CarbonRow = null
+        if(isRawDataRequired) {
+          val rawRow = rows.next()
+           row = new CarbonRow(rowParser.parseRow(rawRow), rawRow)
+        } else {
+          row = new CarbonRow(rowParser.parseRow(rows.next()))
+        }
         rowCounter.add(1)
         row
       }

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/test/TestQueryExecutor.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/test/TestQueryExecutor.scala
@@ -62,7 +62,13 @@ object TestQueryExecutor {
       property
     }
   }
-
+  val badStorePath = s"$integrationPath/spark-common-test/target/badrecord";
+  try {
+    FileFactory.mkdirs(badStorePath, FileFactory.getFileType(badStorePath))
+  } catch {
+    case e : Exception =>
+      throw e;
+  }
   val hdfsUrl = {
     val property = System.getProperty("hdfs.url")
     if (property == null) {

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/converter/impl/RowConverterImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/converter/impl/RowConverterImpl.java
@@ -149,14 +149,12 @@ public class RowConverterImpl implements RowConverter {
 
   @Override
   public CarbonRow convert(CarbonRow row) throws CarbonDataLoadingException {
-    //TODO: only copy if it is bad record
-    CarbonRow copy = row.getCopy();
     logHolder.setLogged(false);
     logHolder.clear();
     for (int i = 0; i < fieldConverters.length; i++) {
       fieldConverters[i].convert(row, logHolder);
       if (!logHolder.isLogged() && logHolder.isBadRecordNotAdded()) {
-        badRecordLogger.addBadRecordsToBuilder(copy.getData(), logHolder.getReason());
+        badRecordLogger.addBadRecordsToBuilder(row.getRawData(), logHolder.getReason());
         if (badRecordLogger.isDataLoadFail()) {
           String error = "Data load failed due to bad record: " + logHolder.getReason() +
               "Please enable bad record logger to know the detail reason.";
@@ -169,6 +167,8 @@ public class RowConverterImpl implements RowConverter {
         }
       }
     }
+    // rawData will not be required after this so reset the entry to null.
+    row.setRawData(null);
     return row;
   }
 

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/model/CarbonLoadModel.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/model/CarbonLoadModel.java
@@ -422,6 +422,7 @@ public class CarbonLoadModel implements Serializable {
     copy.sortScope = sortScope;
     copy.batchSortSizeInMb = batchSortSizeInMb;
     copy.isAggLoadRequest = isAggLoadRequest;
+    copy.badRecordsLocation = badRecordsLocation;
     return copy;
   }
 

--- a/processing/src/main/java/org/apache/carbondata/processing/util/CarbonDataProcessorUtil.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/util/CarbonDataProcessorUtil.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.carbondata.common.constants.LoggerAction;
 import org.apache.carbondata.common.logging.LogService;
 import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
@@ -56,6 +57,7 @@ import org.apache.carbondata.processing.datatypes.PrimitiveDataType;
 import org.apache.carbondata.processing.datatypes.StructDataType;
 import org.apache.carbondata.processing.loading.CarbonDataLoadConfiguration;
 import org.apache.carbondata.processing.loading.DataField;
+import org.apache.carbondata.processing.loading.constants.DataLoadProcessorConstants;
 import org.apache.carbondata.processing.loading.model.CarbonDataLoadSchema;
 import org.apache.carbondata.processing.loading.sort.SortScopeOptions;
 
@@ -622,4 +624,30 @@ public final class CarbonDataProcessorUtil {
     }
     return errorMessage;
   }
+  /**
+   * The method returns true is either logger is enabled or action is redirect
+   * @param configuration
+   * @return
+   */
+  public static boolean isRawDataRequired(CarbonDataLoadConfiguration configuration) {
+    boolean isRawDataRequired = Boolean.parseBoolean(
+        configuration.getDataLoadProperty(DataLoadProcessorConstants.BAD_RECORDS_LOGGER_ENABLE)
+            .toString());
+    // if logger is disabled then check if action is redirect then raw data will be required.
+    if (!isRawDataRequired) {
+      Object bad_records_action =
+          configuration.getDataLoadProperty(DataLoadProcessorConstants.BAD_RECORDS_LOGGER_ACTION);
+      if (null != bad_records_action) {
+        LoggerAction loggerAction = null;
+        try {
+          loggerAction = LoggerAction.valueOf(bad_records_action.toString().toUpperCase());
+        } catch (IllegalArgumentException e) {
+          loggerAction = LoggerAction.FORCE;
+        }
+        isRawDataRequired = loggerAction == LoggerAction.REDIRECT;
+      }
+    }
+    return isRawDataRequired;
+  }
+
 }


### PR DESCRIPTION
Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

**Problem**:
Wrong order of columns in redirected csv for bad records
The RowParser rearrage the csv raw data based on the inputMapping & outputMapping.
So the converter step does not have actual raw csv record to log or redirect the bad record details.

**Steps to repprodcue:**

Create employee(Name string, age int, project string) stored by 'carbondata'

LOAD DATA LOCAL INPATH '$datafilepath' INTO table employee options('BAD_RECORDS_ACTION'='REDIRECT')
Data: 

Name,age,Project
Sam,27,Carbon
Ruhi,23x,Hadoop

The second record is bad record so it will be writtern to the csv file at the bad record loation.

Expected:

Ruhi,23x,Hadoop

Actual:

Ruhi,Hadoop,23x

 - [X] Any interfaces changed?
       Yes 
      1. Added one field rawData in the CarbonRow to pass the actual raw data to the converter step.
      2. The rawData will be populated only when logger is enabled or action is redirect
      3. Removed api making copy object of CarbonRow (public CarbonRow getCopy()) from CarbonRow 
 - [X] Any backward compatibility impacted?
       None
 - [X] Document update required?
    None
 - [X] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       Added test case to validate the redirected csv content with the source file.
 - [X] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
     None