### PR TITLE
[CARBONDATA-757] Big decimal optimization

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/TableSpec.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/TableSpec.java
@@ -188,18 +188,27 @@ public class TableSpec {
     // data type of each measure, in schema order
     private DataType[] types;
 
+    private int[] scale;
+
+    private int[] precision;
+
     MeasureSpec(List<CarbonMeasure> measures) {
       fieldName = new String[measures.size()];
       types = new DataType[measures.size()];
+      scale = new int[measures.size()];
+      precision = new int[measures.size()];
       int i = 0;
       for (CarbonMeasure measure: measures) {
-        add(i++, measure.getColName(), measure.getDataType());
+        add(i++, measure.getColName(), measure.getDataType(), measure.getScale(),
+            measure.getPrecision());
       }
     }
 
-    private void add(int index, String name, DataType type) {
+    private void add(int index, String name, DataType type, int scale, int precision) {
       fieldName[index] = name;
       types[index] = type;
+      this.scale[index] = scale;
+      this.precision[index] = precision;
     }
 
     /**
@@ -208,6 +217,16 @@ public class TableSpec {
     public DataType getType(int index) {
       assert (index >= 0 && index < types.length);
       return types[index];
+    }
+
+    public int getScale(int index) {
+      assert (index >= 0 && index < precision.length);
+      return scale[index];
+    }
+
+    public int getPrecision(int index) {
+      assert (index >= 0 && index < precision.length);
+      return precision[index];
     }
 
     /**

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/reader/measure/v1/CompressedMeasureChunkFileBasedReaderV1.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/reader/measure/v1/CompressedMeasureChunkFileBasedReaderV1.java
@@ -98,7 +98,7 @@ public class CompressedMeasureChunkFileBasedReaderV1 extends AbstractMeasureChun
     DataChunk dataChunk = measureColumnChunks.get(blockIndex);
     ValueEncoderMeta meta = dataChunk.getValueEncoderMeta().get(0);
 
-    ColumnPageCodec codec = strategy.createCodec(meta);
+    ColumnPageCodec codec = strategy.createCodec(meta, -1, -1);
     ColumnPage page = codec.decode(measureRawColumnChunk.getRawData().array(),
         measureRawColumnChunk.getOffSet(), dataChunk.getDataPageLength());
 

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/ColumnPage.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/ColumnPage.java
@@ -116,7 +116,11 @@ public abstract class ColumnPage {
     }
   }
 
-  public static ColumnPage newVarLengthPath(DataType dataType, int pageSize, int scale,
+  public static ColumnPage newVarLengthPage(DataType dataType, int pageSize) {
+    return newVarLengthPage(dataType, pageSize, -1, -1);
+  }
+
+  private static ColumnPage newVarLengthPage(DataType dataType, int pageSize, int scale,
       int precision) {
     if (unsafe) {
       try {

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/LazyColumnPage.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/LazyColumnPage.java
@@ -138,6 +138,16 @@ public class LazyColumnPage extends ColumnPage {
   }
 
   @Override
+  public void putDecimal(int rowId, BigDecimal decimal) {
+    throw new UnsupportedOperationException("internal error");
+  }
+
+  @Override
+  public byte[] getDecimalPage() {
+    throw new UnsupportedOperationException("internal error");
+  }
+
+  @Override
   public byte[] getFlattenedBytePage() {
     throw new UnsupportedOperationException("internal error");
   }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/LazyColumnPage.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/LazyColumnPage.java
@@ -32,7 +32,8 @@ public class LazyColumnPage extends ColumnPage {
   private PrimitiveCodec codec;
 
   private LazyColumnPage(ColumnPage columnPage, PrimitiveCodec codec) {
-    super(columnPage.getDataType(), columnPage.getPageSize());
+    super(columnPage.getDataType(), columnPage.getPageSize(), columnPage.scale,
+        columnPage.precision);
     this.columnPage = columnPage;
     this.codec = codec;
   }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/SafeFixLengthColumnPage.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/SafeFixLengthColumnPage.java
@@ -99,11 +99,13 @@ public class SafeFixLengthColumnPage extends ColumnPage {
     throw new UnsupportedOperationException("invalid data type: " + dataType);
   }
 
-  @Override public void putDecimal(int rowId, BigDecimal decimal) {
+  @Override
+  public void putDecimal(int rowId, BigDecimal decimal) {
     throw new UnsupportedOperationException("invalid data type: " + dataType);
   }
 
-  @Override public byte[] getDecimalPage() {
+  @Override
+  public byte[] getDecimalPage() {
     throw new UnsupportedOperationException("invalid data type: " + dataType);
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/SafeFixLengthColumnPage.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/SafeFixLengthColumnPage.java
@@ -36,8 +36,8 @@ public class SafeFixLengthColumnPage extends ColumnPage {
   private double[] doubleData;
   private byte[] shortIntData;
 
-  SafeFixLengthColumnPage(DataType dataType, int pageSize) {
-    super(dataType, pageSize);
+  SafeFixLengthColumnPage(DataType dataType, int pageSize, int scale, int precision) {
+    super(dataType, pageSize, scale, precision);
   }
 
   /**
@@ -96,6 +96,14 @@ public class SafeFixLengthColumnPage extends ColumnPage {
 
   @Override
   public void putBytes(int rowId, byte[] bytes, int offset, int length) {
+    throw new UnsupportedOperationException("invalid data type: " + dataType);
+  }
+
+  @Override public void putDecimal(int rowId, BigDecimal decimal) {
+    throw new UnsupportedOperationException("invalid data type: " + dataType);
+  }
+
+  @Override public byte[] getDecimalPage() {
     throw new UnsupportedOperationException("invalid data type: " + dataType);
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/SafeVarLengthColumnPage.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/SafeVarLengthColumnPage.java
@@ -20,15 +20,14 @@ package org.apache.carbondata.core.datastore.page;
 import java.math.BigDecimal;
 
 import org.apache.carbondata.core.metadata.datatype.DataType;
-import org.apache.carbondata.core.util.DataTypeUtil;
 
 public class SafeVarLengthColumnPage extends VarLengthColumnPageBase {
 
   // for string and decimal data
   private byte[][] byteArrayData;
 
-  SafeVarLengthColumnPage(DataType dataType, int pageSize) {
-    super(dataType, pageSize);
+  SafeVarLengthColumnPage(DataType dataType, int pageSize, int scale, int precision) {
+    super(dataType, pageSize, scale, precision);
     byteArrayData = new byte[pageSize][];
   }
 
@@ -47,10 +46,14 @@ public class SafeVarLengthColumnPage extends VarLengthColumnPageBase {
     System.arraycopy(bytes, offset, byteArrayData[rowId], 0, length);
   }
 
+  @Override public void putDecimal(int rowId, BigDecimal decimal) {
+    putBytes(rowId, decimalConverter.convert(decimal));
+  }
+
   @Override
   public BigDecimal getDecimal(int rowId) {
     byte[] bytes = byteArrayData[rowId];
-    return DataTypeUtil.byteToBigDecimal(bytes);
+    return decimalConverter.getDecimal(bytes);
   }
 
   @Override

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/UnsafeFixLengthColumnPage.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/UnsafeFixLengthColumnPage.java
@@ -49,8 +49,9 @@ public class UnsafeFixLengthColumnPage extends ColumnPage {
   private static final int floatBits = DataType.FLOAT.getSizeBits();
   private static final int doubleBits = DataType.DOUBLE.getSizeBits();
 
-  UnsafeFixLengthColumnPage(DataType dataType, int pageSize) throws MemoryException {
-    super(dataType, pageSize);
+  UnsafeFixLengthColumnPage(DataType dataType, int pageSize, int scale, int precision)
+      throws MemoryException {
+    super(dataType, pageSize, scale, precision);
     switch (dataType) {
       case BYTE:
       case SHORT:
@@ -124,6 +125,10 @@ public class UnsafeFixLengthColumnPage extends ColumnPage {
     throw new UnsupportedOperationException("invalid data type: " + dataType);
   }
 
+  @Override public void putDecimal(int rowId, BigDecimal decimal) {
+    throw new UnsupportedOperationException("invalid data type: " + dataType);
+  }
+
   @Override
   public byte getByte(int rowId) {
     long offset = rowId << byteBits;
@@ -172,6 +177,10 @@ public class UnsafeFixLengthColumnPage extends ColumnPage {
 
   @Override
   public BigDecimal getDecimal(int rowId) {
+    throw new UnsupportedOperationException("invalid data type: " + dataType);
+  }
+
+  @Override public byte[] getDecimalPage() {
     throw new UnsupportedOperationException("invalid data type: " + dataType);
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/UnsafeVarLengthColumnPage.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/UnsafeVarLengthColumnPage.java
@@ -24,7 +24,6 @@ import org.apache.carbondata.core.memory.MemoryBlock;
 import org.apache.carbondata.core.memory.MemoryException;
 import org.apache.carbondata.core.memory.UnsafeMemoryManager;
 import org.apache.carbondata.core.metadata.datatype.DataType;
-import org.apache.carbondata.core.util.DataTypeUtil;
 
 // This extension uses unsafe memory to store page data, for variable length data type (string,
 // decimal)
@@ -52,10 +51,11 @@ public class UnsafeVarLengthColumnPage extends VarLengthColumnPageBase {
    * @param dataType data type
    * @param pageSize number of row
    */
-  UnsafeVarLengthColumnPage(DataType dataType, int pageSize) throws MemoryException {
-    super(dataType, pageSize);
+  UnsafeVarLengthColumnPage(DataType dataType, int pageSize, int scale, int precision)
+      throws MemoryException {
+    super(dataType, pageSize, scale, precision);
     capacity = (int) (pageSize * DEFAULT_ROW_SIZE * FACTOR);
-    memoryBlock = UnsafeMemoryManager.allocateMemoryWithRetry((long)(capacity));
+    memoryBlock = UnsafeMemoryManager.allocateMemoryWithRetry((long) (capacity));
     baseAddress = memoryBlock.getBaseObject();
     baseOffset = memoryBlock.getBaseOffset();
   }
@@ -117,6 +117,10 @@ public class UnsafeVarLengthColumnPage extends VarLengthColumnPageBase {
         baseAddress, baseOffset + rowOffset[rowId], length);
   }
 
+  @Override public void putDecimal(int rowId, BigDecimal decimal) {
+    putBytes(rowId, decimalConverter.convert(decimal));
+  }
+
   @Override
   public BigDecimal getDecimal(int rowId) {
     int length = rowOffset[rowId + 1] - rowOffset[rowId];
@@ -124,7 +128,7 @@ public class UnsafeVarLengthColumnPage extends VarLengthColumnPageBase {
     CarbonUnsafe.unsafe.copyMemory(baseAddress, baseOffset + rowOffset[rowId],
         bytes, CarbonUnsafe.BYTE_ARRAY_OFFSET, length);
 
-    return DataTypeUtil.byteToBigDecimal(bytes);
+    return decimalConverter.getDecimal(bytes);
   }
 
   @Override

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/UnsafeVarLengthColumnPage.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/UnsafeVarLengthColumnPage.java
@@ -66,8 +66,9 @@ public class UnsafeVarLengthColumnPage extends VarLengthColumnPageBase {
    * @param pageSize number of row
    * @param capacity initial capacity of the page, in bytes
    */
-  UnsafeVarLengthColumnPage(DataType dataType, int pageSize, int capacity) throws MemoryException {
-    super(dataType, pageSize);
+  UnsafeVarLengthColumnPage(DataType dataType, int pageSize, int capacity,
+      int scale, int precision) throws MemoryException {
+    super(dataType, pageSize, scale, precision);
     this.capacity = capacity;
     memoryBlock = UnsafeMemoryManager.allocateMemoryWithRetry((long)(capacity));
     baseAddress = memoryBlock.getBaseObject();

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/VarLengthColumnPageBase.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/VarLengthColumnPageBase.java
@@ -90,7 +90,7 @@ public abstract class VarLengthColumnPageBase extends ColumnPage {
         DecimalConverterFactory.INSTANCE.getDecimalConverter(precision, scale);
     int size = decimalConverter.getSize();
     if (size < 0) {
-      return getLegacyColumnPage(lvEncodedBytes, scale, precision, DataType.DECIMAL);
+      return getLVBytesColumnPage(lvEncodedBytes, scale, precision, DataType.DECIMAL);
     } else {
       // Here the size is always fixed.
       return getDecimalColumnPage(lvEncodedBytes, scale, precision, size);
@@ -102,7 +102,7 @@ public abstract class VarLengthColumnPageBase extends ColumnPage {
    */
   static ColumnPage newVarLengthColumnPage(byte[] lvEncodedBytes, int scale, int precision)
       throws MemoryException {
-    return getLegacyColumnPage(lvEncodedBytes, scale, precision, DataType.BYTE_ARRAY);
+    return getLVBytesColumnPage(lvEncodedBytes, scale, precision, DataType.BYTE_ARRAY);
   }
 
   private static ColumnPage getDecimalColumnPage(byte[] lvEncodedBytes, int scale, int precision,
@@ -135,7 +135,7 @@ public abstract class VarLengthColumnPageBase extends ColumnPage {
     return page;
   }
 
-  private static ColumnPage getLegacyColumnPage(byte[] lvEncodedBytes, int scale,
+  private static ColumnPage getLVBytesColumnPage(byte[] lvEncodedBytes, int scale,
       int precision, DataType dataType) throws MemoryException {
     // extract length and data, set them to rowOffset and unsafe memory correspondingly
     int rowId = 0;
@@ -295,7 +295,8 @@ public abstract class VarLengthColumnPageBase extends ColumnPage {
     throw new UnsupportedOperationException("invalid data type: " + dataType);
   }
 
-  @Override public byte[] getDecimalPage() {
+  @Override
+  public byte[] getDecimalPage() {
     // output LV encoded byte array
     int offset = 0;
     byte[] data = new byte[totalLength];

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/VarLengthColumnPageBase.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/VarLengthColumnPageBase.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import org.apache.carbondata.core.memory.MemoryException;
 import org.apache.carbondata.core.metadata.datatype.DataType;
+import org.apache.carbondata.core.metadata.datatype.DecimalConverterFactory;
 import org.apache.carbondata.core.util.ByteUtil;
 
 import static org.apache.carbondata.core.metadata.datatype.DataType.DECIMAL;
@@ -33,6 +34,8 @@ public abstract class VarLengthColumnPageBase extends ColumnPage {
 
   // the length of bytes added in the page
   int totalLength;
+
+  protected DecimalConverterFactory.DecimalConverter decimalConverter;
 
   VarLengthColumnPageBase(DataType dataType, int pageSize) {
     super(dataType, pageSize);
@@ -240,6 +243,10 @@ public abstract class VarLengthColumnPageBase extends ColumnPage {
   @Override
   public double[] getDoublePage() {
     throw new UnsupportedOperationException("invalid data type: " + dataType);
+  }
+
+  public void setDecimalConverter(DecimalConverterFactory.DecimalConverter decimalConverter) {
+    this.decimalConverter = decimalConverter;
   }
 
   /**

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/AdaptiveIntegerCodec.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/AdaptiveIntegerCodec.java
@@ -52,7 +52,8 @@ class AdaptiveIntegerCodec extends AdaptiveCompressionCodec {
 
   @Override
   public byte[] encode(ColumnPage input) throws MemoryException, IOException {
-    encodedPage = ColumnPage.newPage(targetDataType, input.getPageSize());
+    encodedPage = ColumnPage
+        .newPage(targetDataType, input.getPageSize(), stats.getScale(), stats.getPrecision());
     input.encode(codec);
     byte[] result = encodedPage.compress(compressor);
     encodedPage.freeMemory();
@@ -62,9 +63,13 @@ class AdaptiveIntegerCodec extends AdaptiveCompressionCodec {
   @Override
   public ColumnPage decode(byte[] input, int offset, int length) throws MemoryException {
     if (srcDataType.equals(targetDataType)) {
-      return ColumnPage.decompress(compressor, targetDataType, input, offset, length);
+      return ColumnPage
+          .decompress(compressor, targetDataType, input, offset, length, stats.getScale(),
+              stats.getPrecision());
     } else {
-      ColumnPage page = ColumnPage.decompress(compressor, targetDataType, input, offset, length);
+      ColumnPage page = ColumnPage
+          .decompress(compressor, targetDataType, input, offset, length, stats.getScale(),
+              stats.getPrecision());
       return LazyColumnPage.newPage(page, codec);
     }
   }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/DefaultEncodingStrategy.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/DefaultEncodingStrategy.java
@@ -79,7 +79,7 @@ public class DefaultEncodingStrategy extends EncodingStrategy {
     if (Math.min(adaptiveDataType.getSizeInBytes(), deltaDataType.getSizeInBytes()) ==
         srcDataType.getSizeInBytes()) {
       // no effect to use adaptive or delta, use compression only
-      return DirectCompressCodec.newInstance(srcDataType, compressor);
+      return DirectCompressCodec.newInstance(stats, compressor);
     }
     if (adaptiveDataType.getSizeInBytes() <= deltaDataType.getSizeInBytes()) {
       // choose adaptive encoding
@@ -93,17 +93,17 @@ public class DefaultEncodingStrategy extends EncodingStrategy {
 
   @Override
   ColumnPageCodec newCodecForFloatingType(ColumnPageStatsVO stats) {
-    return DirectCompressCodec.newInstance(stats.getDataType(), compressor);
+    return DirectCompressCodec.newInstance(stats, compressor);
   }
 
   // for decimal, currently it is a very basic implementation
   @Override
   ColumnPageCodec newCodecForDecimalType(ColumnPageStatsVO stats) {
-    return DirectCompressCodec.newInstance(stats.getDataType(), compressor);
+    return DirectCompressCodec.newInstance(stats, compressor);
   }
 
   @Override
   ColumnPageCodec newCodecForByteArrayType(ColumnPageStatsVO stats) {
-    return DirectCompressCodec.newInstance(stats.getDataType(), compressor);
+    return DirectCompressCodec.newInstance(stats, compressor);
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/DeltaIntegerCodec.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/DeltaIntegerCodec.java
@@ -67,7 +67,8 @@ public class DeltaIntegerCodec extends AdaptiveCompressionCodec {
 
   @Override
   public byte[] encode(ColumnPage input) throws MemoryException, IOException {
-    encodedPage = ColumnPage.newPage(targetDataType, input.getPageSize());
+    encodedPage = ColumnPage
+        .newPage(targetDataType, input.getPageSize(), stats.getScale(), stats.getPrecision());
     input.encode(codec);
     byte[] result = encodedPage.compress(compressor);
     encodedPage.freeMemory();
@@ -77,9 +78,13 @@ public class DeltaIntegerCodec extends AdaptiveCompressionCodec {
   @Override
   public ColumnPage decode(byte[] input, int offset, int length) throws MemoryException {
     if (srcDataType.equals(targetDataType)) {
-      return ColumnPage.decompress(compressor, targetDataType, input, offset, length);
+      return ColumnPage
+          .decompress(compressor, targetDataType, input, offset, length, stats.getScale(),
+              stats.getPrecision());
     } else {
-      ColumnPage page = ColumnPage.decompress(compressor, targetDataType, input, offset, length);
+      ColumnPage page = ColumnPage
+          .decompress(compressor, targetDataType, input, offset, length, stats.getScale(),
+              stats.getPrecision());
       return LazyColumnPage.newPage(page, codec);
     }
   }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/DirectCompressCodec.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/DirectCompressCodec.java
@@ -21,8 +21,8 @@ import java.io.IOException;
 
 import org.apache.carbondata.core.datastore.compression.Compressor;
 import org.apache.carbondata.core.datastore.page.ColumnPage;
+import org.apache.carbondata.core.datastore.page.statistics.ColumnPageStatsVO;
 import org.apache.carbondata.core.memory.MemoryException;
-import org.apache.carbondata.core.metadata.datatype.DataType;
 
 /**
  * This codec directly apply compression on the input data
@@ -30,15 +30,15 @@ import org.apache.carbondata.core.metadata.datatype.DataType;
 public class DirectCompressCodec implements ColumnPageCodec {
 
   private Compressor compressor;
-  private DataType dataType;
+  private ColumnPageStatsVO stats;
 
-  private DirectCompressCodec(DataType dataType, Compressor compressor) {
+  private DirectCompressCodec(ColumnPageStatsVO stats, Compressor compressor) {
     this.compressor = compressor;
-    this.dataType = dataType;
+    this.stats = stats;
   }
 
-  public static DirectCompressCodec newInstance(DataType dataType, Compressor compressor) {
-    return new DirectCompressCodec(dataType, compressor);
+  public static DirectCompressCodec newInstance(ColumnPageStatsVO stats, Compressor compressor) {
+    return new DirectCompressCodec(stats, compressor);
   }
 
   @Override
@@ -53,6 +53,8 @@ public class DirectCompressCodec implements ColumnPageCodec {
 
   @Override
   public ColumnPage decode(byte[] input, int offset, int length) throws MemoryException {
-    return ColumnPage.decompress(compressor, dataType, input, offset, length);
+    return ColumnPage
+        .decompress(compressor, stats.getDataType(), input, offset, length, stats.getScale(),
+            stats.getPrecision());
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/EncodingStrategy.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/EncodingStrategy.java
@@ -51,8 +51,8 @@ public abstract class EncodingStrategy {
   /**
    * create codec based on the page data type and statistics contained by ValueEncoderMeta
    */
-  public ColumnPageCodec createCodec(ValueEncoderMeta meta) {
-    ColumnPageStatsVO stats = ColumnPageStatsVO.copyFrom(meta);
+  public ColumnPageCodec createCodec(ValueEncoderMeta meta, int scale, int precision) {
+    ColumnPageStatsVO stats = ColumnPageStatsVO.copyFrom(meta, scale, precision);
     return createCodec(stats);
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/statistics/ColumnPageStatsVO.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/statistics/ColumnPageStatsVO.java
@@ -40,6 +40,10 @@ public class ColumnPageStatsVO {
   /** decimal count of the measures */
   private int decimal;
 
+  private int scale;
+
+  private int precision;
+
   public ColumnPageStatsVO(DataType dataType) {
     this.dataType = dataType;
     switch (dataType) {
@@ -64,12 +68,14 @@ public class ColumnPageStatsVO {
     decimal = 0;
   }
 
-  public static ColumnPageStatsVO copyFrom(ValueEncoderMeta meta) {
+  public static ColumnPageStatsVO copyFrom(ValueEncoderMeta meta, int scale, int precision) {
     ColumnPageStatsVO instance = new ColumnPageStatsVO(meta.getType());
     instance.min = meta.getMinValue();
     instance.max = meta.getMaxValue();
     instance.decimal = meta.getDecimal();
     instance.nonExistValue = meta.getUniqueValue();
+    instance.scale = scale;
+    instance.precision = precision;
     return instance;
   }
 
@@ -213,6 +219,14 @@ public class ColumnPageStatsVO {
 
   public DataType getDataType() {
     return dataType;
+  }
+
+  public int getScale() {
+    return scale;
+  }
+
+  public int getPrecision() {
+    return precision;
   }
 
   @Override

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/statistics/ColumnPageStatsVO.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/statistics/ColumnPageStatsVO.java
@@ -107,7 +107,7 @@ public class ColumnPageStatsVO {
         nonExistValue = (double) min - 1;
         break;
       case DECIMAL:
-        BigDecimal decimalValue = DataTypeUtil.byteToBigDecimal((byte[]) value);
+        BigDecimal decimalValue = (BigDecimal) value;
         decimal = decimalValue.scale();
         BigDecimal val = (BigDecimal) min;
         nonExistValue = (val.subtract(new BigDecimal(1.0)));

--- a/core/src/main/java/org/apache/carbondata/core/metadata/datatype/DecimalConverterFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/datatype/DecimalConverterFactory.java
@@ -1,0 +1,234 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.core.metadata.datatype;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+
+import org.apache.carbondata.core.scan.result.vector.CarbonColumnVector;
+import org.apache.carbondata.core.util.DataTypeUtil;
+
+/**
+ * Decimal converter to keep the data compact.
+ */
+public final class DecimalConverterFactory {
+
+  public static DecimalConverterFactory INSTANCE = new DecimalConverterFactory();
+
+  private int[] minBytesForPrecision = minBytesForPrecision();
+
+  private byte[] decimalBuffer = new byte[minBytesForPrecision[38]];
+
+  private DecimalConverterFactory() {
+
+  }
+
+  private int computeMinBytesForPrecision(int precision) {
+    int numBytes = 1;
+    while (Math.pow(2.0, 8 * numBytes - 1) < Math.pow(10.0, precision)) {
+      numBytes += 1;
+    }
+    return numBytes;
+  }
+
+  private int[] minBytesForPrecision() {
+    int[] data = new int[39];
+    for (int i = 0; i < data.length; i++) {
+      data[i] = computeMinBytesForPrecision(i);
+    }
+    return data;
+  }
+
+  public interface DecimalConverter {
+
+    byte[] convert(BigDecimal decimal);
+
+    BigDecimal getDecimal(byte[] bytes);
+
+    void writeToColumnVector(byte[] bytes, CarbonColumnVector vector, int rowId);
+
+    int getSize();
+
+  }
+
+  public class DecimalIntConverter implements DecimalConverter {
+
+    private ByteBuffer buffer = ByteBuffer.allocate(4);
+
+    private int precision;
+    private int scale;
+
+    public DecimalIntConverter(int precision, int scale) {
+      this.precision = precision;
+      this.scale = scale;
+    }
+
+    @Override public byte[] convert(BigDecimal decimal) {
+      long longValue = decimal.unscaledValue().longValue();
+      buffer.putInt(0, (int) longValue);
+      return buffer.array().clone();
+    }
+
+    @Override public BigDecimal getDecimal(byte[] bytes) {
+      long unscaled = getUnscaledLong(bytes);
+      return BigDecimal.valueOf(unscaled, scale);
+    }
+
+    @Override public void writeToColumnVector(byte[] bytes, CarbonColumnVector vector, int rowId) {
+      long unscaled = getUnscaledLong(bytes);
+      vector.putInt(rowId, (int) unscaled);
+    }
+
+    @Override public int getSize() {
+      return 4;
+    }
+  }
+
+  private long getUnscaledLong(byte[] bytes) {
+    long unscaled = 0L;
+    int i = 0;
+
+    while (i < bytes.length) {
+      unscaled = (unscaled << 8) | (bytes[i] & 0xff);
+      i += 1;
+    }
+
+    int bits = 8 * bytes.length;
+    unscaled = (unscaled << (64 - bits)) >> (64 - bits);
+    return unscaled;
+  }
+
+  public class DecimalLongConverter implements DecimalConverter {
+
+    private ByteBuffer buffer = ByteBuffer.allocate(8);
+
+    private int precision;
+    private int scale;
+
+    public DecimalLongConverter(int precision, int scale) {
+      this.precision = precision;
+      this.scale = scale;
+    }
+
+    @Override public byte[] convert(BigDecimal decimal) {
+      long longValue = decimal.unscaledValue().longValue();
+      buffer.putLong(0, longValue);
+      return buffer.array().clone();
+    }
+
+    @Override public BigDecimal getDecimal(byte[] bytes) {
+      long unscaled = getUnscaledLong(bytes);
+      return BigDecimal.valueOf(unscaled, scale);
+    }
+
+    @Override public void writeToColumnVector(byte[] bytes, CarbonColumnVector vector, int rowId) {
+      long unscaled = getUnscaledLong(bytes);
+      vector.putLong(rowId, unscaled);
+    }
+
+    @Override public int getSize() {
+      return 8;
+    }
+  }
+
+  public class DecimalUnscaledConverter implements DecimalConverter {
+
+    private int precision;
+    private int scale;
+
+    private int numBytes;
+
+    public DecimalUnscaledConverter(int precision, int scale) {
+      this.precision = precision;
+      this.scale = scale;
+      this.numBytes = minBytesForPrecision[precision];
+    }
+
+    @Override public byte[] convert(BigDecimal decimal) {
+      byte[] bytes = decimal.unscaledValue().toByteArray();
+      byte[] fixedLengthBytes = null;
+      if (bytes.length == numBytes) {
+        // If the length of the underlying byte array of the unscaled `BigInteger` happens to be
+        // `numBytes`, just reuse it, so that we don't bother copying it to `decimalBuffer`.
+        fixedLengthBytes = bytes;
+      } else {
+        // Otherwise, the length must be less than `numBytes`.  In this case we copy contents of
+        // the underlying bytes with padding sign bytes to `decimalBuffer` to form the result
+        // fixed-length byte array.
+        byte signByte = 0;
+        if (bytes[0] < 0) {
+          signByte = (byte) -1;
+        } else {
+          signByte = (byte) 0;
+        }
+        Arrays.fill(decimalBuffer, 0, numBytes - bytes.length, signByte);
+        System.arraycopy(bytes, 0, decimalBuffer, numBytes - bytes.length, bytes.length);
+        fixedLengthBytes = decimalBuffer;
+      }
+      byte[] value = new byte[numBytes];
+      System.arraycopy(fixedLengthBytes, 0, value, 0, numBytes);
+      return value;
+    }
+
+    @Override public BigDecimal getDecimal(byte[] bytes) {
+      BigInteger bigInteger = new BigInteger(bytes);
+      return new BigDecimal(bigInteger, scale);
+    }
+
+    @Override public void writeToColumnVector(byte[] bytes, CarbonColumnVector vector, int rowId) {
+      vector.putBytes(rowId, bytes);
+    }
+
+    @Override public int getSize() {
+      return numBytes;
+    }
+  }
+
+  public static class LegacyDecimalConverter implements DecimalConverter {
+
+    public static LegacyDecimalConverter INSTANCE = new LegacyDecimalConverter();
+
+    @Override public byte[] convert(BigDecimal decimal) {
+      return DataTypeUtil.bigDecimalToByte(decimal);
+    }
+
+    @Override public BigDecimal getDecimal(byte[] bytes) {
+      return DataTypeUtil.byteToBigDecimal(bytes);
+    }
+
+    @Override public void writeToColumnVector(byte[] bytes, CarbonColumnVector vector, int rowId) {
+      throw new UnsupportedOperationException("Unsupported in vector reading for legacy format");
+    }
+
+    @Override public int getSize() {
+      return -1;
+    }
+  }
+
+  public DecimalConverter getDecimalConverter(int precision, int scale) {
+    if (precision <= 9) {
+      return new DecimalIntConverter(precision, scale);
+    } else if (precision <= 18) {
+      return new DecimalLongConverter(precision, scale);
+    } else {
+      return new DecimalUnscaledConverter(precision, scale);
+    }
+  }
+
+}

--- a/core/src/main/java/org/apache/carbondata/core/metadata/datatype/DecimalConverterFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/datatype/DecimalConverterFactory.java
@@ -201,9 +201,9 @@ public final class DecimalConverterFactory {
     }
   }
 
-  public static class LegacyDecimalConverter implements DecimalConverter {
+  public static class LVBytesDecimalConverter implements DecimalConverter {
 
-    public static LegacyDecimalConverter INSTANCE = new LegacyDecimalConverter();
+    public static LVBytesDecimalConverter INSTANCE = new LVBytesDecimalConverter();
 
     @Override public byte[] convert(BigDecimal decimal) {
       return DataTypeUtil.bigDecimalToByte(decimal);
@@ -224,7 +224,7 @@ public final class DecimalConverterFactory {
 
   public DecimalConverter getDecimalConverter(int precision, int scale) {
     if (precision < 0) {
-      return new LegacyDecimalConverter();
+      return new LVBytesDecimalConverter();
     } else if (precision <= 9) {
       return new DecimalIntConverter(precision, scale);
     } else if (precision <= 18) {

--- a/core/src/main/java/org/apache/carbondata/core/metadata/datatype/DecimalConverterFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/datatype/DecimalConverterFactory.java
@@ -33,8 +33,6 @@ public final class DecimalConverterFactory {
 
   private int[] minBytesForPrecision = minBytesForPrecision();
 
-  private byte[] decimalBuffer = new byte[minBytesForPrecision[38]];
-
   private DecimalConverterFactory() {
 
   }
@@ -150,9 +148,12 @@ public final class DecimalConverterFactory {
   public class DecimalUnscaledConverter implements DecimalConverter {
 
     private int precision;
+
     private int scale;
 
     private int numBytes;
+
+    private byte[] decimalBuffer = new byte[minBytesForPrecision[38]];
 
     public DecimalUnscaledConverter(int precision, int scale) {
       this.precision = precision;
@@ -222,7 +223,9 @@ public final class DecimalConverterFactory {
   }
 
   public DecimalConverter getDecimalConverter(int precision, int scale) {
-    if (precision <= 9) {
+    if (precision < 0) {
+      return new LegacyDecimalConverter();
+    } else if (precision <= 9) {
       return new DecimalIntConverter(precision, scale);
     } else if (precision <= 18) {
       return new DecimalLongConverter(precision, scale);

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonMetadataUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonMetadataUtil.java
@@ -24,6 +24,7 @@ import java.io.ObjectOutputStream;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.carbondata.common.logging.LogService;
@@ -431,6 +432,28 @@ public class CarbonMetadataUtil {
     return false;
   }
 
+  private static ByteBuffer writeInfoIfDecimal(int blockIndex,
+      SegmentProperties segmentProperties) {
+    Map<Integer, Integer> blockMapping = segmentProperties.getMeasuresOrdinalToBlockMapping();
+    List<CarbonMeasure> measures = segmentProperties.getMeasures();
+    CarbonMeasure selectedMeasure = null;
+    for (CarbonMeasure measure : measures) {
+      Integer blockId = blockMapping.get(measure.getOrdinal());
+      selectedMeasure = measure;
+      if (blockId == blockIndex) {
+        break;
+      }
+    }
+    assert (selectedMeasure != null);
+    if (selectedMeasure.getDataType() == DataType.DECIMAL) {
+      ByteBuffer buffer = ByteBuffer.allocate(8);
+      buffer.putInt(selectedMeasure.getScale());
+      buffer.putInt(selectedMeasure.getPrecision());
+      return buffer;
+    }
+    return null;
+  }
+
   private static byte[] serializeEncoderMeta(ValueEncoderMeta encoderMeta) throws IOException {
     // TODO : should remove the unnecessary fields.
     ByteArrayOutputStream aos = new ByteArrayOutputStream();
@@ -788,6 +811,10 @@ public class CarbonMetadataUtil {
         List<ByteBuffer> encoderMetaList = new ArrayList<ByteBuffer>();
         encoderMetaList.add(ByteBuffer.wrap(serializeEncodeMetaUsingByteBuffer(
             createValueEncoderMeta(nodeHolder.getStats(), index))));
+        ByteBuffer decimalMeta = writeInfoIfDecimal(index, segmentProperties);
+        if (decimalMeta != null) {
+          encoderMetaList.add(decimalMeta);
+        }
         dataChunk.setEncoder_meta(encoderMetaList);
         dataChunk.min_max
             .addToMax_values(ByteBuffer.wrap(nodeHolder.getMeasureColumnMaxData()[index]));

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonMetadataUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonMetadataUtil.java
@@ -449,6 +449,7 @@ public class CarbonMetadataUtil {
       ByteBuffer buffer = ByteBuffer.allocate(8);
       buffer.putInt(selectedMeasure.getScale());
       buffer.putInt(selectedMeasure.getPrecision());
+      buffer.flip();
       return buffer;
     }
     return null;

--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/sort/SortStepRowUtil.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/sort/SortStepRowUtil.java
@@ -17,10 +17,6 @@
 
 package org.apache.carbondata.processing.newflow.sort;
 
-import java.math.BigDecimal;
-
-import org.apache.carbondata.core.metadata.datatype.DataType;
-import org.apache.carbondata.core.util.DataTypeUtil;
 import org.apache.carbondata.processing.sortandgroupby.sortdata.SortParameters;
 import org.apache.carbondata.processing.util.NonDictionaryUtil;
 
@@ -60,21 +56,10 @@ public class SortStepRowUtil {
 
       index = 0;
 
-      DataType[] measureDataType = parameters.getMeasureDataType();
       // read measure values
       for (int i = 0; i < measureCount; i++) {
         if (needConvertDecimalToByte) {
-          Object value = data[allCount];
-          if (null != value) {
-            if (measureDataType[i] == DataType.DECIMAL) {
-              BigDecimal decimal = (BigDecimal) value;
-              measures[index++] = DataTypeUtil.bigDecimalToByte(decimal);
-            } else {
-              measures[index++] = value;
-            }
-          } else {
-            measures[index++] = null;
-          }
+          measures[index++] = data[allCount];
         } else {
           measures[index++] = data[allCount];
         }

--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/sort/unsafe/UnsafeCarbonRowPage.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/sort/unsafe/UnsafeCarbonRowPage.java
@@ -230,7 +230,7 @@ public class UnsafeCarbonRowPage {
             CarbonUnsafe.unsafe.copyMemory(baseObject, address + size, bigDecimalInBytes,
                 CarbonUnsafe.BYTE_ARRAY_OFFSET, bigDecimalInBytes.length);
             size += bigDecimalInBytes.length;
-            rowToFill[dimensionSize + mesCount] = bigDecimalInBytes;
+            rowToFill[dimensionSize + mesCount] = DataTypeUtil.byteToBigDecimal(bigDecimalInBytes);
             break;
         }
       } else {

--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/sort/unsafe/holder/UnsafeSortTempFileChunkHolder.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/sort/unsafe/holder/UnsafeSortTempFileChunkHolder.java
@@ -35,6 +35,7 @@ import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.metadata.datatype.DataType;
 import org.apache.carbondata.core.util.CarbonProperties;
 import org.apache.carbondata.core.util.CarbonUtil;
+import org.apache.carbondata.core.util.DataTypeUtil;
 import org.apache.carbondata.processing.newflow.sort.unsafe.UnsafeCarbonRowPage;
 import org.apache.carbondata.processing.sortandgroupby.exception.CarbonSortKeyAndGroupByException;
 import org.apache.carbondata.processing.sortandgroupby.sortdata.NewRowComparator;
@@ -341,7 +342,7 @@ public class UnsafeSortTempFileChunkHolder implements SortTempChunkHolder {
               short aShort = stream.readShort();
               byte[] bigDecimalInBytes = new byte[aShort];
               stream.readFully(bigDecimalInBytes);
-              row[dimensionCount + mesCount] = bigDecimalInBytes;
+              row[dimensionCount + mesCount] = DataTypeUtil.byteToBigDecimal(bigDecimalInBytes);
               break;
           }
         }

--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/steps/CarbonRowDataWriterProcessorStepImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/steps/CarbonRowDataWriterProcessorStepImpl.java
@@ -18,7 +18,6 @@ package org.apache.carbondata.processing.newflow.steps;
 
 import java.io.File;
 import java.io.IOException;
-import java.math.BigDecimal;
 import java.util.Iterator;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -33,7 +32,6 @@ import org.apache.carbondata.core.keygenerator.KeyGenException;
 import org.apache.carbondata.core.metadata.CarbonTableIdentifier;
 import org.apache.carbondata.core.metadata.datatype.DataType;
 import org.apache.carbondata.core.util.CarbonTimeStatisticsFactory;
-import org.apache.carbondata.core.util.DataTypeUtil;
 import org.apache.carbondata.processing.newflow.AbstractDataLoadProcessorStep;
 import org.apache.carbondata.processing.newflow.CarbonDataLoadConfiguration;
 import org.apache.carbondata.processing.newflow.DataField;
@@ -257,17 +255,7 @@ public class CarbonRowDataWriterProcessorStepImpl extends AbstractDataLoadProces
 
     Object[] measures = new Object[outputLength];
     for (int i = 0; i < this.measureCount; i++) {
-      Object value = row.getObject(i + this.dimensionWithComplexCount);
-      if (null != value) {
-        if (measureDataType[i] == DataType.DECIMAL) {
-          BigDecimal val = (BigDecimal) value;
-          measures[i] = DataTypeUtil.bigDecimalToByte(val);
-        } else {
-          measures[i] = value;
-        }
-      } else {
-        measures[i] = null;
-      }
+      measures[i] = row.getObject(i + this.dimensionWithComplexCount);
     }
 
     return WriteStepRowUtil.fromColumnCategory(dim, nonDicArray, measures);

--- a/processing/src/main/java/org/apache/carbondata/processing/sortandgroupby/sortdata/SortTempFileChunkHolder.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/sortandgroupby/sortdata/SortTempFileChunkHolder.java
@@ -35,6 +35,7 @@ import org.apache.carbondata.core.metadata.datatype.DataType;
 import org.apache.carbondata.core.util.ByteUtil.UnsafeComparer;
 import org.apache.carbondata.core.util.CarbonProperties;
 import org.apache.carbondata.core.util.CarbonUtil;
+import org.apache.carbondata.core.util.DataTypeUtil;
 import org.apache.carbondata.processing.sortandgroupby.exception.CarbonSortKeyAndGroupByException;
 import org.apache.carbondata.processing.util.NonDictionaryUtil;
 
@@ -356,7 +357,7 @@ public class SortTempFileChunkHolder implements Comparable<SortTempFileChunkHold
               int len = stream.readInt();
               byte[] buff = new byte[len];
               stream.readFully(buff);
-              measures[index++] = buff;
+              measures[index++] = DataTypeUtil.byteToBigDecimal(buff);
               break;
           }
         } else {

--- a/processing/src/main/java/org/apache/carbondata/processing/store/TablePage.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/TablePage.java
@@ -68,11 +68,11 @@ public class TablePage {
     int numDictDimension = model.getMDKeyGenerator().getDimCount();
     dictDimensionPage = new ColumnPage[numDictDimension];
     for (int i = 0; i < dictDimensionPage.length; i++) {
-      dictDimensionPage[i] = ColumnPage.newVarLengthPath(DataType.BYTE_ARRAY, pageSize, -1, -1);
+      dictDimensionPage[i] = ColumnPage.newVarLengthPage(DataType.BYTE_ARRAY, pageSize);
     }
     noDictDimensionPage = new ColumnPage[model.getNoDictionaryCount()];
     for (int i = 0; i < noDictDimensionPage.length; i++) {
-      noDictDimensionPage[i] = ColumnPage.newVarLengthPath(DataType.BYTE_ARRAY, pageSize, -1, -1);
+      noDictDimensionPage[i] = ColumnPage.newVarLengthPage(DataType.BYTE_ARRAY, pageSize);
     }
     complexDimensionPage = new ComplexColumnPage[model.getComplexColumnCount()];
     for (int i = 0; i < complexDimensionPage.length; i++) {

--- a/processing/src/main/java/org/apache/carbondata/processing/store/TablePage.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/TablePage.java
@@ -20,12 +20,12 @@ package org.apache.carbondata.processing.store;
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
-import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.carbondata.core.datastore.GenericDataType;
+import org.apache.carbondata.core.datastore.TableSpec;
 import org.apache.carbondata.core.datastore.exception.CarbonDataWriterException;
 import org.apache.carbondata.core.datastore.page.ColumnPage;
 import org.apache.carbondata.core.datastore.page.ComplexColumnPage;
@@ -35,7 +35,6 @@ import org.apache.carbondata.core.datastore.row.WriteStepRowUtil;
 import org.apache.carbondata.core.keygenerator.KeyGenException;
 import org.apache.carbondata.core.memory.MemoryException;
 import org.apache.carbondata.core.metadata.datatype.DataType;
-import org.apache.carbondata.core.util.DataTypeUtil;
 
 import org.apache.spark.sql.types.Decimal;
 
@@ -69,11 +68,11 @@ public class TablePage {
     int numDictDimension = model.getMDKeyGenerator().getDimCount();
     dictDimensionPage = new ColumnPage[numDictDimension];
     for (int i = 0; i < dictDimensionPage.length; i++) {
-      dictDimensionPage[i] = ColumnPage.newVarLengthPath(DataType.BYTE_ARRAY, pageSize);
+      dictDimensionPage[i] = ColumnPage.newVarLengthPath(DataType.BYTE_ARRAY, pageSize, -1, -1);
     }
     noDictDimensionPage = new ColumnPage[model.getNoDictionaryCount()];
     for (int i = 0; i < noDictDimensionPage.length; i++) {
-      noDictDimensionPage[i] = ColumnPage.newVarLengthPath(DataType.BYTE_ARRAY, pageSize);
+      noDictDimensionPage[i] = ColumnPage.newVarLengthPath(DataType.BYTE_ARRAY, pageSize, -1, -1);
     }
     complexDimensionPage = new ComplexColumnPage[model.getComplexColumnCount()];
     for (int i = 0; i < complexDimensionPage.length; i++) {
@@ -83,8 +82,10 @@ public class TablePage {
     }
     measurePage = new ColumnPage[model.getMeasureCount()];
     DataType[] dataTypes = model.getMeasureDataType();
+    TableSpec.MeasureSpec measureSpec = model.getTableSpec().getMeasureSpec();
     for (int i = 0; i < measurePage.length; i++) {
-      measurePage[i] = ColumnPage.newPage(dataTypes[i], pageSize);
+      measurePage[i] = ColumnPage
+          .newPage(dataTypes[i], pageSize, measureSpec.getScale(i), measureSpec.getPrecision(i));
     }
   }
 
@@ -132,8 +133,7 @@ public class TablePage {
       if (measurePage[i].getDataType() == DataType.DECIMAL &&
           model.isCompactionFlow() &&
           value != null) {
-        BigDecimal bigDecimal = ((Decimal) value).toJavaBigDecimal();
-        value = DataTypeUtil.bigDecimalToByte(bigDecimal);
+        value = ((Decimal) value).toJavaBigDecimal();
       }
       measurePage[i].putData(rowId, value);
     }


### PR DESCRIPTION
Currently Decimal is converted to bytes and using LV (length + value) format to write to store. And while getting back read the bytes in LV format and convert back the bigdecimal.
We can do following operations to improve storage and processing.

1. if decimal precision is less than 9 then we can fit in int (4 bytes)
2. if decimal precision is less than 18 then we can fit in long (8 bytes)
3. if decimal precision is more than 18 then we can fit in fixed length bytes(the length bytes can vary depends on precision but it is always fixed length)

So in this approach we no need store bigdecimal in LV format, we can store in fixed format.It reduces the memory.
Carbondata format changes -> Added fixedLength in datachunk to know about the column length of big decimal. This attribute can be used in case of char(fixedlength) or varchar(fixedlength) datatypes as well.