### PR TITLE
[CARBONDATA-1261] Load data sql add 'header' option

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestLoadDataWithFileHeaderException.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestLoadDataWithFileHeaderException.scala
@@ -43,7 +43,7 @@ class TestLoadDataWithFileHeaderException extends QueryTest with BeforeAndAfterA
     }
   }
 
-  test("test load data ddl provided  wrong file header exception") {
+  test("test load data ddl provided wrong file header exception") {
     try {
       sql(s"""
            LOAD DATA LOCAL INPATH '$resourcesPath/source_without_header.csv' into table t3
@@ -54,6 +54,105 @@ class TestLoadDataWithFileHeaderException extends QueryTest with BeforeAndAfterA
       case e: Exception =>
         assert(e.getMessage.contains("CSV header in DDL is not proper. Column names in schema and CSV header are not the same"))
     }
+  }
+
+  test("test load data with wrong header , but without fileheader") {
+    try {
+      sql(s"""
+           LOAD DATA LOCAL INPATH '$resourcesPath/source.csv' into table t3
+           options('header'='abc')
+           """)
+      assert(false)
+    } catch {
+      case e: Exception =>
+        assert(e.getMessage.contains("'header' option should be either 'true' or 'false'"))
+    }
+  }
+
+  test("test load data with wrong header and fileheader") {
+    try {
+      sql(s"""
+         LOAD DATA LOCAL INPATH '$resourcesPath/source_without_header.csv' into table t3
+         options('header'='', 'fileheader'='ID,date,country,name,phonetype,serialname,salary')
+         """)
+      assert(false)
+    } catch {
+      case e: Exception =>
+        assert(e.getMessage.contains("'header' option should be either 'true' or 'false'"))
+    }
+  }
+
+  test("test load data with header=false, but without fileheader") {
+    sql(s"""
+         LOAD DATA LOCAL INPATH '$resourcesPath/source_without_header.csv' into table t3
+         options('header'='False')
+         """)
+  }
+
+  test("test load data with header=false and fileheader") {
+    sql(s"""
+         LOAD DATA LOCAL INPATH '$resourcesPath/source_without_header.csv' into table t3
+         options('header'='false', 'fileheader'='ID,date,country,name,phonetype,serialname,salary')
+         """)
+  }
+
+  test("test load data with header=false and wrong fileheader") {
+    try {
+      sql(s"""
+        LOAD DATA LOCAL INPATH '$resourcesPath/source_without_header.csv' into table t3
+        options('header'='false', 'fileheader'='ID1,date2,country,name,phonetype,serialname,salary')
+        """)
+      assert(false)
+    } catch {
+      case e: Exception =>
+        assert(e.getMessage.contains("CSV header in DDL is not proper. Column names in schema and CSV header are not the same"))
+    }
+  }
+
+  test("test load data with header=true, but without fileheader") {
+    sql(s"""
+         LOAD DATA LOCAL INPATH '$resourcesPath/source.csv' into table t3
+         options('header'='True')
+         """)
+  }
+
+  test("test load data with header=true and fileheader") {
+    try {
+      sql(s"""
+           LOAD DATA LOCAL INPATH '$resourcesPath/source.csv' into table t3
+           options('header'='true', 'fileheader'='ID,date,country,name,phonetype,serialname,salary')
+           """)
+      assert(false)
+    } catch {
+      case e: Exception =>
+        assert(e.getMessage.contains("When 'header' option is true, 'fileheader' option is not required."))
+    }
+  }
+
+  test("test load data with header=true and wrong fileheader") {
+    try {
+      sql(s"""
+           LOAD DATA LOCAL INPATH '$resourcesPath/source.csv' into table t3
+           options('header'='true', 'fileheader'='ID1,date1,country,name,phonetype,serialname,salary')
+           """)
+      assert(false)
+    } catch {
+      case e: Exception =>
+        assert(e.getMessage.contains("When 'header' option is true, 'fileheader' option is not required."))
+    }
+  }
+
+  test("test load data without header and fileheader") {
+    sql(s"""
+         LOAD DATA LOCAL INPATH '$resourcesPath/source.csv' into table t3
+         """)
+  }
+
+  test("test load data without header, but with fileheader") {
+    sql(s"""
+         LOAD DATA LOCAL INPATH '$resourcesPath/source_without_header.csv' into table t3
+         options('fileheader'='ID,date,country,name,phonetype,serialname,salary')
+         """)
   }
 
   override def afterAll {

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
@@ -839,7 +839,7 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
       "SERIALIZATION_NULL_FORMAT", "BAD_RECORDS_LOGGER_ENABLE", "BAD_RECORDS_ACTION",
       "ALL_DICTIONARY_PATH", "MAXCOLUMNS", "COMMENTCHAR", "DATEFORMAT", "BAD_RECORD_PATH",
       "SINGLE_PASS", "IS_EMPTY_DATA_BAD_RECORD", "SORT_SCOPE", "BATCH_SORT_SIZE_INMB",
-      "GLOBAL_SORT_PARTITIONS"
+      "GLOBAL_SORT_PARTITIONS", "HEADER"
     )
     var isSupported = true
     val invalidOptions = StringBuilder.newBuilder

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
@@ -538,6 +538,36 @@ case class LoadTable(
       carbonLoadModel.setEscapeChar(checkDefaultValue(optionsFinal.get("escapechar").get, "\\"))
       carbonLoadModel.setQuoteChar(checkDefaultValue(optionsFinal.get("quotechar").get, "\""))
       carbonLoadModel.setCommentChar(checkDefaultValue(optionsFinal.get("commentchar").get, "#"))
+
+      // if there isn't file header in csv file and load sql doesn't provide FILEHEADER option,
+      // we should use table schema to generate file header.
+      var fileHeader = optionsFinal.get("fileheader").get
+      val headerOption = options.get("header")
+      if (headerOption.isDefined) {
+        // whether the csv file has file header
+        // the default value is true
+        val header = try {
+          headerOption.get.toBoolean
+        } catch {
+          case ex: IllegalArgumentException =>
+            throw new MalformedCarbonCommandException(
+              "'header' option should be either 'true' or 'false'. " + ex.getMessage)
+        }
+        header match {
+          case true =>
+            if (fileHeader.nonEmpty) {
+              throw new MalformedCarbonCommandException(
+                "When 'header' option is true, 'fileheader' option is not required.")
+            }
+          case false =>
+            // generate file header
+            if (fileHeader.isEmpty) {
+              fileHeader = table.getCreateOrderColumn(table.getFactTableName)
+                .asScala.map(_.getColName).mkString(",")
+            }
+        }
+      }
+
       carbonLoadModel.setDateFormat(dateFormat)
       carbonLoadModel.setDefaultTimestampFormat(carbonProperty.getProperty(
         CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT,
@@ -583,7 +613,7 @@ case class LoadTable(
         LOGGER.info(s"Initiating Direct Load for the Table : ($dbName.$tableName)")
         carbonLoadModel.setFactFilePath(factPath)
         carbonLoadModel.setCsvDelimiter(CarbonUtil.unescapeChar(delimeter))
-        carbonLoadModel.setCsvHeader(optionsFinal.get("fileheader").get)
+        carbonLoadModel.setCsvHeader(fileHeader)
         carbonLoadModel.setColDictFilePath(column_dict)
         carbonLoadModel.setDirectLoad(true)
         carbonLoadModel.setCsvHeaderColumns(CommonUtil.getCsvHeaderColumns(carbonLoadModel))


### PR DESCRIPTION
When we load the CSV files without file header and the file header is the same with the table schema, add 'header'='false' to load data sql, no need to let user provide the file header.

maillist:
http://apache-carbondata-dev-mailing-list-archive.1130556.n5.nabble.com/Discussion-Add-HEADER-option-to-load-data-sql-td17080.html