### PR TITLE
[CARBONDATA-1263]Single pass load does not take default value false for blank or inval…

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
@@ -426,8 +426,14 @@ case class LoadTable(
           false
         }
       case illegal =>
-        LOGGER.error(s"Can't use single_pass, because illegal syntax found: [" + illegal + "] " +
-                     "Please set it as 'true' or 'false'")
+        if (StringUtils.isNotEmpty(optionsFinal.get("all_dictionary_path").get) ||
+            StringUtils.isNotEmpty(optionsFinal.get("columndict").get)) {
+          throw new MalformedCarbonCommandException(
+            "Can not use all_dictionary_path or columndict with Illegal Value:[" + illegal + "] " +
+            "of single_pass. Please set it to True")
+        }
+        LOGGER.info("Can't use single_pass, because illegal syntax found: [" + illegal + "] " +
+                     ",continuing with default value 'false'")
         false
     }
     optionsFinal.put("single_pass", useOnePass.toString)


### PR DESCRIPTION
Issue :- When Single pass value is given wrong (other than true/false) along with External Dictionary, Error is logged but Load is continue with Single pass=false . Which is not correct as for external  dictionary single pass must be true.

Solution :- Load is interrupted and  Error is thrown with proper error message. 