### PR TITLE
[CARBONDATA-1282]Choose BatchedDatasource scan only if schema fits for codegen

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/CarbonLateDecodeStrategy.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/CarbonLateDecodeStrategy.scala
@@ -524,7 +524,9 @@ private[sql] class CarbonLateDecodeStrategy extends SparkStrategy {
           CarbonCommonConstants.ENABLE_VECTOR_READER_DEFAULT)
       }
     }
-    sqlContext.conf.wholeStageEnabled && vectorizedReader.toBoolean &&
+    val supportCodegen =
+      sqlContext.conf.wholeStageEnabled && sqlContext.conf.wholeStageMaxNumFields >= cols.size
+    supportCodegen && vectorizedReader.toBoolean &&
       cols.forall(_.dataType.isInstanceOf[AtomicType])
   }
 }


### PR DESCRIPTION
**Problem**
When table is having large no of column say 2000, then spark gives code generation issue during full scan query as size of generated code exceeds 64KB. 
**Solution**
As in code, we have two BatchedDataSourceScan and RowDataSourceScan to scan query. As per implementation BatchedDataSourceScan is used when code generation is supported else RowDataSourceScan . Spark checks the configuration spark.sql.codegen.wholeStage is enabled and also column size should not exceeds its configuration i.e spark.sql.codegen.maxFields. Hence we need to add one more check for spark.sql.codegen.maxFields.
**Testing**
Tested manually.
