### PR TITLE
[CARBONDATA-1285] resolved compilation error in hiveembedded server2 when running hiveexample

### DIFF
--- a/integration/hive/pom.xml
+++ b/integration/hive/pom.xml
@@ -94,6 +94,21 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.apache.hive</groupId>
+            <artifactId>hive-service</artifactId>
+            <version>1.2.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hive</groupId>
+            <artifactId>hive-jdbc</artifactId>
+            <version>1.2.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-hive_2.11</artifactId>
+            <version>${spark.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-sql_${scala.binary.version}</artifactId>
         </dependency>
@@ -178,7 +193,7 @@
                     <includes>
                         <include>**/*.java</include>
                         <include>**/*.scala</include>
-                       <include>**/Test*.java</include>
+                        <include>**/Test*.java</include>
                         <include>**/*Test.java</include>
                         <include>**/*TestCase.java</include>
                         <include>**/*Suite.java</include>


### PR DESCRIPTION
This Pr Will  Resolved Compilation error in HiveEmbedded Server2

 - corrected the pom to use hiveserver2 b y adding hive-service and hive-jdbc dependency
 - Tested by Running HIve Example

