### PR TITLE
[CARBONDATA-1279] Push down for queries like "%xxx" , ends with are not working as expected in Spark 2.1

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonBoundReference.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonBoundReference.scala
@@ -29,6 +29,10 @@ case class CastExpr(expr: Expression) extends Filter {
   override def references: Array[String] = null
 }
 
+case class CarbonEndsWith(expr: Expression) extends Filter{
+  override def references: Array[String] = null
+}
+
 case class CarbonBoundReference(colExp: ColumnExpression, dataType: DataType, nullable: Boolean)
   extends LeafExpression with NamedExpression with CodegenFallback {
 

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/CarbonLateDecodeStrategy.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/CarbonLateDecodeStrategy.scala
@@ -509,6 +509,8 @@ private[sql] class CarbonLateDecodeStrategy extends SparkStrategy {
         CastExpressionOptimization.checkIfCastCanBeRemove(c)
       case StartsWith(a: Attribute, Literal(v, t)) =>
         Some(sources.StringStartsWith(a.name, v.toString))
+      case c@EndsWith(a: Attribute, Literal(v,t)) =>
+        Some(CarbonEndsWith(c))
       case others => None
     }
   }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/optimizer/CarbonFilters.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/optimizer/CarbonFilters.scala
@@ -20,11 +20,8 @@ package org.apache.carbondata.spark
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.execution.CastExpressionOptimization
 import org.apache.spark.sql.optimizer.AttributeReferenceWrapper
-import org.apache.spark.sql.CarbonBoundReference
-import org.apache.spark.sql.CastExpr
-import org.apache.spark.sql.sources
+import org.apache.spark.sql.{CarbonBoundReference, CarbonEndsWith, CastExpr, sources}
 import org.apache.spark.sql.types._
-
 import org.apache.carbondata.core.metadata.datatype.DataType
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable
 import org.apache.carbondata.core.metadata.schema.table.column.CarbonColumn
@@ -105,6 +102,12 @@ object CarbonFilters {
           val r = new LessThanExpression(
             getCarbonExpression(name), getCarbonLiteralExpression(name, maxValueLimit))
           Some(new AndExpression(l, r))
+        case CarbonEndsWith(expr: Expression) =>
+          Some(new SparkUnknownExpression(expr.transform {
+            case AttributeReference(name, dataType,_, _) =>
+            CarbonBoundReference(new CarbonColumnExpression(name.toString,
+              CarbonScalaUtil.convertSparkToCarbonDataType(dataType)), dataType, expr.nullable)
+          }))
         case CastExpr(expr: Expression) =>
           Some(transformExpression(expr))
         case _ => None
@@ -235,6 +238,8 @@ object CarbonFilters {
           CastExpressionOptimization.checkIfCastCanBeRemove(c)
         case StartsWith(a: Attribute, Literal(v, t)) =>
           Some(sources.StringStartsWith(a.name, v.toString))
+        case c@EndsWith(a:  Attribute, Literal(v,t)) =>
+          Some(CarbonEndsWith(c))
         case c@Cast(a: Attribute, _) =>
           Some(CastExpr(c))
         case others =>


### PR DESCRIPTION
Summary: Push down for some select queries not working as expected in Spark 2.1
                 Key: CARBONDATA-1279
                 URL: https://issues.apache.org/jira/browse/CARBONDATA-1279
             Project: CarbonData
          Issue Type: Bug
            Reporter: Pannerselvam Velmyl

Adding push down filter for select queries with like option. Push down for some select queries with like were not working as expected in Spark 2.1 similar to Spark 1.5