### PR TITLE
[CARBONDATA-1306] Fixed carbondata crash after  using short-int datatype

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/UnsafeFixLengthColumnPage.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/UnsafeFixLengthColumnPage.java
@@ -358,7 +358,7 @@ public class UnsafeFixLengthColumnPage extends ColumnPage {
   public byte[] compress(Compressor compressor) throws MemoryException, IOException {
     if (UnsafeMemoryManager.isOffHeap()) {
       // use raw compression and copy to byte[]
-      int inputSize = pageSize << dataType.getSizeBits();
+      int inputSize = pageSize * dataType.getSizeInBytes();
       int compressedMaxSize = compressor.maxCompressedLength(inputSize);
       MemoryBlock compressed = UnsafeMemoryManager.allocateMemoryWithRetry(compressedMaxSize);
       long outSize = compressor.rawCompress(baseOffset, inputSize, compressed.getBaseOffset());

--- a/core/src/main/java/org/apache/carbondata/core/metadata/datatype/DataType.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/datatype/DataType.java
@@ -69,6 +69,9 @@ public enum DataType {
   }
 
   public int getSizeBits() {
+    if (this == SHORT_INT) {
+      throw new UnsupportedOperationException("Should not call this from datatype " + SHORT_INT);
+    }
     return (int) (Math.log(getSizeInBytes()) / Math.log(2));
   }
 }


### PR DESCRIPTION
It crashes since the size calculation of byte array of short-int datatype is wrong. It is fixed in this PR