### PR TITLE
[CARBONDATA-1281] Support multiple temp dirs for writing temp files while loading

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -1308,6 +1308,18 @@ public final class CarbonCommonConstants {
   public static final String CARBON_LEASE_RECOVERY_RETRY_INTERVAL =
       "carbon.lease.recovery.retry.interval";
 
+  /**
+   * whether to use multi directories when loading data,
+   * the main purpose is to avoid single-disk-hot-spot
+   */
+  @CarbonProperty
+  public static final String CARBON_USING_MULTI_TEMP_DIR = "carbon.using.multi.temp.dir";
+
+  /**
+   * default value for multi temp dir
+   */
+  public static final String CARBON_SUING_MULTI_TEMP_DIR_DEFAULT = "false";
+
   private CarbonCommonConstants() {
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonMergerUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonMergerUtil.java
@@ -46,4 +46,20 @@ public class CarbonMergerUtil {
     return localCardinality;
   }
 
+  /**
+   * read from the first non-empty level metadata
+   * @param paths paths
+   * @param tableName table name
+   * @return cardinality
+   */
+  public static int[] getCardinalityFromLevelMetadata(String[] paths, String tableName) {
+    int[] localCardinality = null;
+    for (String path : paths) {
+      localCardinality = getCardinalityFromLevelMetadata(path, tableName);
+      if (null != localCardinality) {
+        break;
+      }
+    }
+    return localCardinality;
+  }
 }

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
@@ -892,6 +892,15 @@ public final class CarbonProperties {
   }
 
   /**
+   * Returns whether to use multi temp dirs
+   * @return boolean
+   */
+  public boolean isUseMultiTempDir() {
+    String value = getProperty(CarbonCommonConstants.CARBON_USING_MULTI_TEMP_DIR, "false");
+    return value.equalsIgnoreCase("true");
+  }
+
+  /**
    * returns true if carbon property
    * @param key
    * @return

--- a/core/src/main/java/org/apache/carbondata/core/util/path/CarbonTablePath.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/path/CarbonTablePath.java
@@ -385,7 +385,7 @@ public class CarbonTablePath extends Path {
    * @param factUpdateTimeStamp unique identifier to identify an update
    * @return gets data file name only with out path
    */
-  public String getCarbonDataFileName(Integer filePartNo, Integer taskNo, int bucketNumber,
+  public static String getCarbonDataFileName(Integer filePartNo, Integer taskNo, int bucketNumber,
       int batchNo, String factUpdateTimeStamp) {
     return DATA_PART_PREFIX + filePartNo + "-" + taskNo + BATCH_PREFIX + batchNo + "-"
         + bucketNumber + "-" + factUpdateTimeStamp + CARBON_DATA_EXT;
@@ -398,7 +398,7 @@ public class CarbonTablePath extends Path {
    * @param factUpdatedTimeStamp time stamp
    * @return filename
    */
-  public String getCarbonIndexFileName(int taskNo, int bucketNumber, int batchNo,
+  public static String getCarbonIndexFileName(int taskNo, int bucketNumber, int batchNo,
       String factUpdatedTimeStamp) {
     return taskNo + BATCH_PREFIX + batchNo + "-" + bucketNumber + "-" + factUpdatedTimeStamp
         + INDEX_FILE_EXT;

--- a/hadoop/src/test/java/org/apache/carbondata/hadoop/test/util/StoreCreator.java
+++ b/hadoop/src/test/java/org/apache/carbondata/hadoop/test/util/StoreCreator.java
@@ -413,7 +413,7 @@ public class StoreCreator {
 
     CSVRecordReaderIterator readerIterator = new CSVRecordReaderIterator(recordReader, blockDetails, hadoopAttemptContext);
     new DataLoadExecutor().execute(loadModel,
-        storeLocation,
+        new String[] {storeLocation},
         new CarbonIterator[]{readerIterator});
 
     info.setDatabaseName(databaseName);

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/load/DataLoadProcessorStepOnSpark.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/load/DataLoadProcessorStepOnSpark.scala
@@ -154,7 +154,7 @@ object DataLoadProcessorStepOnSpark {
 
     try {
       model = modelBroadcast.value.getCopyWithTaskNo(index.toString)
-      val storeLocation = getTempStoreLocation(index)
+      val storeLocation = Array(getTempStoreLocation(index))
       val conf = DataLoadProcessBuilder.createConfiguration(model, storeLocation)
 
       tableName = model.getTableName

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/NewCarbonDataLoadRDD.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/NewCarbonDataLoadRDD.scala
@@ -17,7 +17,7 @@
 
 package org.apache.carbondata.spark.rdd
 
-import java.io.{IOException, ObjectInputStream, ObjectOutputStream}
+import java.io.{File, IOException, ObjectInputStream, ObjectOutputStream}
 import java.nio.ByteBuffer
 import java.text.SimpleDateFormat
 import java.util.{Date, UUID}
@@ -124,7 +124,7 @@ class SparkPartitionLoader(model: CarbonLoadModel,
     loadMetadataDetails: LoadMetadataDetails) {
   private val LOGGER = LogServiceFactory.getLogService(this.getClass.getCanonicalName)
 
-  var storeLocation: String = ""
+  var storeLocation: Array[String] = Array[String]()
 
   def initialize(): Unit = {
     val carbonPropertiesFilePath = System.getProperty("carbon.properties.filepath", null)
@@ -144,22 +144,34 @@ class SparkPartitionLoader(model: CarbonLoadModel,
 
     // this property is used to determine whether temp location for carbon is inside
     // container temp dir or is yarn application directory.
-    val carbonUseLocalDir = CarbonProperties.getInstance()
-      .getProperty("carbon.use.local.dir", "false")
-    if (carbonUseLocalDir.equalsIgnoreCase("true")) {
-      val storeLocations = CarbonLoaderUtil.getConfiguredLocalDirs(SparkEnv.get.conf)
-      if (null != storeLocations && storeLocations.nonEmpty) {
-        storeLocation = storeLocations(Random.nextInt(storeLocations.length))
-      }
-      if (storeLocation == null) {
-        storeLocation = System.getProperty("java.io.tmpdir")
+    val isCarbonUseLocalDir = CarbonProperties.getInstance()
+      .getProperty("carbon.use.local.dir", "false").equalsIgnoreCase("true")
+
+    val isCarbonUseMultiDir = CarbonProperties.getInstance().isUseMultiTempDir
+
+
+    if (isCarbonUseLocalDir) {
+      val yarnStoreLocations = CarbonLoaderUtil.getConfiguredLocalDirs(SparkEnv.get.conf)
+
+      if (!isCarbonUseMultiDir && null != yarnStoreLocations && yarnStoreLocations.nonEmpty) {
+        // use single dir
+        storeLocation = storeLocation :+
+            (yarnStoreLocations(Random.nextInt(yarnStoreLocations.length)) + tmpLocationSuffix)
+        if (storeLocation == null || storeLocation.isEmpty) {
+          storeLocation = storeLocation :+
+              (System.getProperty("java.io.tmpdir") + tmpLocationSuffix)
+        }
+      } else {
+        // use all the yarn dirs
+        storeLocation = yarnStoreLocations.map(_ + tmpLocationSuffix)
       }
     } else {
-      storeLocation = System.getProperty("java.io.tmpdir")
+      storeLocation = storeLocation :+ (System.getProperty("java.io.tmpdir") + tmpLocationSuffix)
     }
-    storeLocation = storeLocation + '/' + System.nanoTime() + '/' + splitIndex
+    LOGGER.info("Temp location for loading data: " + storeLocation.mkString(","))
   }
 
+  private def tmpLocationSuffix = File.separator + System.nanoTime() + File.separator + splitIndex
 }
 
 /**

--- a/processing/src/main/java/org/apache/carbondata/processing/merger/CompactionResultSortProcessor.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/merger/CompactionResultSortProcessor.java
@@ -100,7 +100,7 @@ public class CompactionResultSortProcessor extends AbstractResultProcessor {
   /**
    * temp store location to be sued during data load
    */
-  private String tempStoreLocation;
+  private String[] tempStoreLocation;
   /**
    * table name
    */
@@ -178,10 +178,12 @@ public class CompactionResultSortProcessor extends AbstractResultProcessor {
    */
   private void deleteTempStoreLocation() {
     if (null != tempStoreLocation) {
-      try {
-        CarbonUtil.deleteFoldersAndFiles(new File[] { new File(tempStoreLocation) });
-      } catch (IOException | InterruptedException e) {
-        LOGGER.error("Problem deleting local folders during compaction: " + e.getMessage());
+      for (String tempLoc : tempStoreLocation) {
+        try {
+          CarbonUtil.deleteFoldersAndFiles(new File(tempLoc));
+        } catch (IOException | InterruptedException e) {
+          LOGGER.error("Problem deleting local folders during compaction: " + e.getMessage());
+        }
       }
     }
   }
@@ -358,8 +360,6 @@ public class CompactionResultSortProcessor extends AbstractResultProcessor {
    * sort temp files
    */
   private void initializeFinalThreadMergerForMergeSort() {
-    String sortTempFileLocation = tempStoreLocation + CarbonCommonConstants.FILE_SEPARATOR
-        + CarbonCommonConstants.SORT_TEMP_FILE_LOCATION;
     boolean[] noDictionarySortColumnMapping = null;
     if (noDictionaryColMapping.length == this.segmentProperties.getNumberOfSortColumns()) {
       noDictionarySortColumnMapping = noDictionaryColMapping;
@@ -367,6 +367,12 @@ public class CompactionResultSortProcessor extends AbstractResultProcessor {
       noDictionarySortColumnMapping = new boolean[this.segmentProperties.getNumberOfSortColumns()];
       System.arraycopy(noDictionaryColMapping, 0,
           noDictionarySortColumnMapping, 0, noDictionarySortColumnMapping.length);
+    }
+
+    String[] sortTempFileLocation = new String[tempStoreLocation.length];
+    for (int i = 0; i < tempStoreLocation.length; i++) {
+      sortTempFileLocation[i] = tempStoreLocation[i] + CarbonCommonConstants.FILE_SEPARATOR
+          + CarbonCommonConstants.SORT_TEMP_FILE_LOCATION;
     }
     finalMerger =
         new SingleThreadFinalSortFilesMerger(sortTempFileLocation, tableName, dimensionColumnCount,

--- a/processing/src/main/java/org/apache/carbondata/processing/merger/RowResultMergerProcessor.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/merger/RowResultMergerProcessor.java
@@ -57,12 +57,15 @@ public class RowResultMergerProcessor extends AbstractResultProcessor {
       LogServiceFactory.getLogService(RowResultMergerProcessor.class.getName());
 
   public RowResultMergerProcessor(String databaseName,
-      String tableName, SegmentProperties segProp, String tempStoreLocation,
+      String tableName, SegmentProperties segProp, String[] tempStoreLocation,
       CarbonLoadModel loadModel, CompactionType compactionType) {
     this.segprop = segProp;
-    if (!new File(tempStoreLocation).mkdirs()) {
-      LOGGER.error("Error while new File(tempStoreLocation).mkdirs() ");
+    for (String temLoc : tempStoreLocation) {
+      if (!new File(temLoc).mkdirs()) {
+        LOGGER.error("Error while new File(tempStoreLocation).mkdirs() ");
+      }
     }
+
     CarbonTable carbonTable = CarbonMetadata.getInstance()
             .getCarbonTable(databaseName + CarbonCommonConstants.UNDERSCORE + tableName);
     CarbonFactDataHandlerModel carbonFactDataHandlerModel = CarbonFactDataHandlerModel

--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/DataLoadExecutor.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/DataLoadExecutor.java
@@ -33,7 +33,7 @@ public class DataLoadExecutor {
   private static final LogService LOGGER =
       LogServiceFactory.getLogService(DataLoadExecutor.class.getName());
 
-  public void execute(CarbonLoadModel loadModel, String storeLocation,
+  public void execute(CarbonLoadModel loadModel, String[] storeLocation,
       CarbonIterator<Object[]>[] inputIterators) throws Exception {
     AbstractDataLoadProcessorStep loadProcessorStep = null;
     try {

--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/DataLoadProcessBuilder.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/DataLoadProcessBuilder.java
@@ -47,6 +47,8 @@ import org.apache.carbondata.processing.newflow.steps.InputProcessorStepImpl;
 import org.apache.carbondata.processing.newflow.steps.SortProcessorStepImpl;
 import org.apache.carbondata.processing.util.CarbonDataProcessorUtil;
 
+import org.apache.commons.lang3.StringUtils;
+
 /**
  * It builds the pipe line of steps for loading data to carbon.
  */
@@ -55,7 +57,7 @@ public final class DataLoadProcessBuilder {
   private static final LogService LOGGER =
       LogServiceFactory.getLogService(DataLoadProcessBuilder.class.getName());
 
-  public AbstractDataLoadProcessorStep build(CarbonLoadModel loadModel, String storeLocation,
+  public AbstractDataLoadProcessorStep build(CarbonLoadModel loadModel, String[] storeLocation,
       CarbonIterator[] inputIterators) throws Exception {
     CarbonDataLoadConfiguration configuration = createConfiguration(loadModel, storeLocation);
     SortScopeOptions.SortScope sortScope = CarbonDataProcessorUtil.getSortScope(configuration);
@@ -134,16 +136,19 @@ public final class DataLoadProcessBuilder {
   }
 
   public static CarbonDataLoadConfiguration createConfiguration(CarbonLoadModel loadModel,
-      String storeLocation) {
-    if (!new File(storeLocation).mkdirs()) {
-      LOGGER.error("Error while creating the temp store path: " + storeLocation);
+      String[] storeLocation) {
+    for (String s : storeLocation) {
+      if (!new File(s).mkdirs()) {
+        LOGGER.error("Error while creating the temp store path: " + s);
+      }
     }
 
     String databaseName = loadModel.getDatabaseName();
     String tableName = loadModel.getTableName();
     String tempLocationKey = CarbonDataProcessorUtil
         .getTempStoreLocationKey(databaseName, tableName, loadModel.getTaskNo(), false);
-    CarbonProperties.getInstance().addProperty(tempLocationKey, storeLocation);
+    CarbonProperties.getInstance().addProperty(tempLocationKey,
+        StringUtils.join(storeLocation, File.pathSeparator));
     CarbonProperties.getInstance()
         .addProperty(CarbonCommonConstants.STORE_LOCATION_HDFS, loadModel.getStorePath());
 

--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/sort/impl/ParallelReadMergeSorterImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/sort/impl/ParallelReadMergeSorterImpl.java
@@ -68,16 +68,19 @@ public class ParallelReadMergeSorterImpl extends AbstractMergeSorter {
   public void initialize(SortParameters sortParameters) {
     this.sortParameters = sortParameters;
     intermediateFileMerger = new SortIntermediateFileMerger(sortParameters);
-    String storeLocation =
+    String[] storeLocations =
         CarbonDataProcessorUtil.getLocalDataFolderLocation(
             sortParameters.getDatabaseName(), sortParameters.getTableName(),
             String.valueOf(sortParameters.getTaskNo()), sortParameters.getPartitionID(),
             sortParameters.getSegmentId() + "", false);
     // Set the data file location
-    String dataFolderLocation =
-        storeLocation + File.separator + CarbonCommonConstants.SORT_TEMP_FILE_LOCATION;
+    String[] dataFolderLocations = new String[storeLocations.length];
+    for (int i = 0; i < storeLocations.length; i++) {
+      dataFolderLocations[i] = storeLocations[i]  + File.separator
+          + CarbonCommonConstants.SORT_TEMP_FILE_LOCATION;
+    }
     finalMerger =
-        new SingleThreadFinalSortFilesMerger(dataFolderLocation, sortParameters.getTableName(),
+        new SingleThreadFinalSortFilesMerger(dataFolderLocations, sortParameters.getTableName(),
             sortParameters.getDimColCount(),
             sortParameters.getComplexDimColCount(), sortParameters.getMeasureColCount(),
             sortParameters.getNoDictionaryCount(), sortParameters.getMeasureDataType(),

--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/sort/impl/ParallelReadMergeSorterWithBucketingImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/sort/impl/ParallelReadMergeSorterWithBucketingImpl.java
@@ -134,13 +134,16 @@ public class ParallelReadMergeSorterWithBucketingImpl extends AbstractMergeSorte
   }
 
   private SingleThreadFinalSortFilesMerger getFinalMerger(String bucketId) {
-    String storeLocation = CarbonDataProcessorUtil
+    String[] storeLocation = CarbonDataProcessorUtil
         .getLocalDataFolderLocation(sortParameters.getDatabaseName(), sortParameters.getTableName(),
             String.valueOf(sortParameters.getTaskNo()), bucketId,
             sortParameters.getSegmentId() + "", false);
     // Set the data file location
-    String dataFolderLocation =
-        storeLocation + File.separator + CarbonCommonConstants.SORT_TEMP_FILE_LOCATION;
+    String[] dataFolderLocation = new String[storeLocation.length];
+    for (int i = 0; i < storeLocation.length; i++) {
+      dataFolderLocation[i] = storeLocation[i] + File.separator
+          + CarbonCommonConstants.SORT_TEMP_FILE_LOCATION;
+    }
     return new SingleThreadFinalSortFilesMerger(dataFolderLocation, sortParameters.getTableName(),
             sortParameters.getDimColCount(), sortParameters.getComplexDimColCount(),
             sortParameters.getMeasureColCount(), sortParameters.getNoDictionaryCount(),
@@ -185,12 +188,17 @@ public class ParallelReadMergeSorterWithBucketingImpl extends AbstractMergeSorte
   }
 
   private void setTempLocation(SortParameters parameters) {
-    String carbonDataDirectoryPath = CarbonDataProcessorUtil
+    String[] carbonDataDirectoryPath = CarbonDataProcessorUtil
         .getLocalDataFolderLocation(parameters.getDatabaseName(),
             parameters.getTableName(), parameters.getTaskNo(),
             parameters.getPartitionID(), parameters.getSegmentId(), false);
-    parameters.setTempFileLocation(
-        carbonDataDirectoryPath + File.separator + CarbonCommonConstants.SORT_TEMP_FILE_LOCATION);
+    String[] tmpLocs = new String[carbonDataDirectoryPath.length];
+    for (int i = 0; i < carbonDataDirectoryPath.length; i++)
+    {
+      tmpLocs[i] = carbonDataDirectoryPath[i] + File.separator
+          + CarbonCommonConstants.SORT_TEMP_FILE_LOCATION;
+    }
+    parameters.setTempFileLocation(tmpLocs);
   }
 
   /**

--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/sort/impl/UnsafeBatchParallelReadMergeSorterImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/sort/impl/UnsafeBatchParallelReadMergeSorterImpl.java
@@ -221,12 +221,16 @@ public class UnsafeBatchParallelReadMergeSorterImpl extends AbstractMergeSorter 
     }
 
     private void setTempLocation(SortParameters parameters) {
-      String carbonDataDirectoryPath = CarbonDataProcessorUtil
+      String[] carbonDataDirectoryPath = CarbonDataProcessorUtil
           .getLocalDataFolderLocation(parameters.getDatabaseName(),
             parameters.getTableName(), parameters.getTaskNo(), batchCount + "",
             parameters.getSegmentId(), false);
-      parameters.setTempFileLocation(
-          carbonDataDirectoryPath + File.separator + CarbonCommonConstants.SORT_TEMP_FILE_LOCATION);
+      String[] tempDirs = new String[carbonDataDirectoryPath.length];
+      for (int i = 0; i < carbonDataDirectoryPath.length; i++) {
+        tempDirs[i] = carbonDataDirectoryPath[i] + File.separator
+            + CarbonCommonConstants.SORT_TEMP_FILE_LOCATION;
+      }
+      parameters.setTempFileLocation(tempDirs);
     }
 
     @Override public UnsafeSingleThreadFinalSortFilesMerger next() {

--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/sort/impl/UnsafeParallelReadMergeSorterImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/sort/impl/UnsafeParallelReadMergeSorterImpl.java
@@ -16,7 +16,6 @@
  */
 package org.apache.carbondata.processing.newflow.sort.impl;
 
-import java.io.File;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -28,7 +27,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.apache.carbondata.common.CarbonIterator;
 import org.apache.carbondata.common.logging.LogService;
 import org.apache.carbondata.common.logging.LogServiceFactory;
-import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.datastore.exception.CarbonDataWriterException;
 import org.apache.carbondata.core.datastore.row.CarbonRow;
 import org.apache.carbondata.core.memory.MemoryException;
@@ -43,7 +41,6 @@ import org.apache.carbondata.processing.newflow.sort.unsafe.merger.UnsafeInterme
 import org.apache.carbondata.processing.newflow.sort.unsafe.merger.UnsafeSingleThreadFinalSortFilesMerger;
 import org.apache.carbondata.processing.sortandgroupby.exception.CarbonSortKeyAndGroupByException;
 import org.apache.carbondata.processing.sortandgroupby.sortdata.SortParameters;
-import org.apache.carbondata.processing.util.CarbonDataProcessorUtil;
 
 /**
  * It parallely reads data from array of iterates and do merge sort.
@@ -70,13 +67,7 @@ public class UnsafeParallelReadMergeSorterImpl extends AbstractMergeSorter {
   @Override public void initialize(SortParameters sortParameters) {
     this.sortParameters = sortParameters;
     unsafeIntermediateFileMerger = new UnsafeIntermediateMerger(sortParameters);
-    String storeLocation = CarbonDataProcessorUtil
-        .getLocalDataFolderLocation(sortParameters.getDatabaseName(), sortParameters.getTableName(),
-            String.valueOf(sortParameters.getTaskNo()), sortParameters.getPartitionID(),
-            sortParameters.getSegmentId() + "", false);
-    // Set the data file location
-    String dataFolderLocation =
-        storeLocation + File.separator + CarbonCommonConstants.SORT_TEMP_FILE_LOCATION;
+
     finalMerger = new UnsafeSingleThreadFinalSortFilesMerger(sortParameters,
         sortParameters.getTempFileLocation());
   }

--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/sort/impl/UnsafeParallelReadMergeSorterWithBucketingImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/sort/impl/UnsafeParallelReadMergeSorterWithBucketingImpl.java
@@ -124,13 +124,16 @@ public class UnsafeParallelReadMergeSorterWithBucketingImpl implements Sorter {
   }
 
   private UnsafeSingleThreadFinalSortFilesMerger getFinalMerger(String bucketId) {
-    String storeLocation = CarbonDataProcessorUtil
+    String[] storeLocation = CarbonDataProcessorUtil
         .getLocalDataFolderLocation(sortParameters.getDatabaseName(), sortParameters.getTableName(),
             String.valueOf(sortParameters.getTaskNo()), bucketId,
             sortParameters.getSegmentId() + "", false);
     // Set the data file location
-    String dataFolderLocation =
-        storeLocation + File.separator + CarbonCommonConstants.SORT_TEMP_FILE_LOCATION;
+    String[] dataFolderLocation = new String[storeLocation.length];
+    for (int i = 0; i < storeLocation.length; i++) {
+      dataFolderLocation[i] = storeLocation[i] + File.separator
+          + CarbonCommonConstants.SORT_TEMP_FILE_LOCATION;
+    }
     return new UnsafeSingleThreadFinalSortFilesMerger(sortParameters, dataFolderLocation);
   }
 
@@ -168,11 +171,15 @@ public class UnsafeParallelReadMergeSorterWithBucketingImpl implements Sorter {
   }
 
   private void setTempLocation(SortParameters parameters) {
-    String carbonDataDirectoryPath = CarbonDataProcessorUtil
+    String[] carbonDataDirectoryPath = CarbonDataProcessorUtil
         .getLocalDataFolderLocation(parameters.getDatabaseName(), parameters.getTableName(),
             parameters.getTaskNo(), parameters.getPartitionID(), parameters.getSegmentId(), false);
-    parameters.setTempFileLocation(
-        carbonDataDirectoryPath + File.separator + CarbonCommonConstants.SORT_TEMP_FILE_LOCATION);
+    String[] tmpLoc = new String[carbonDataDirectoryPath.length];
+    for (int i = 0; i < carbonDataDirectoryPath.length; i++) {
+      tmpLoc[i] = carbonDataDirectoryPath[i] + File.separator
+          + CarbonCommonConstants.SORT_TEMP_FILE_LOCATION;
+    }
+    parameters.setTempFileLocation(tmpLoc);
   }
 
   /**

--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/sort/unsafe/UnsafeSortDataRows.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/sort/unsafe/UnsafeSortDataRows.java
@@ -22,6 +22,7 @@ import java.io.DataOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.Random;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -125,8 +126,10 @@ public class UnsafeSortDataRows {
     deleteSortLocationIfExists();
 
     // create new sort temp directory
-    if (!new File(parameters.getTempFileLocation()).mkdirs()) {
-      LOGGER.info("Sort Temp Location Already Exists");
+    for (String tmpLoc : parameters.getTempFileLocation()) {
+      if (!new File(tmpLoc).mkdirs()) {
+        LOGGER.info("Sort Temp Location Already Exists: " + tmpLoc);
+      }
     }
     this.dataSorterAndWriterExecutorService =
         Executors.newFixedThreadPool(parameters.getNumberOfCores());
@@ -286,7 +289,9 @@ public class UnsafeSortDataRows {
    * This method will be used to delete sort temp location is it is exites
    */
   public void deleteSortLocationIfExists() {
-    CarbonDataProcessorUtil.deleteSortLocationIfExists(parameters.getTempFileLocation());
+    for (String loc : parameters.getTempFileLocation()) {
+      CarbonDataProcessorUtil.deleteSortLocationIfExists(loc);
+    }
   }
 
   /**
@@ -345,9 +350,12 @@ public class UnsafeSortDataRows {
         }
         if (rowPage.isSaveToDisk()) {
           // create a new file every time
+          // create a new file and pick a temp directory randomly every time
+          String tmpDir = parameters.getTempFileLocation()[
+              new Random().nextInt(parameters.getTempFileLocation().length)];
           File sortTempFile = new File(
-              parameters.getTempFileLocation() + File.separator + parameters.getTableName() + System
-                  .nanoTime() + CarbonCommonConstants.SORT_TEMP_FILE_EXT);
+              tmpDir + File.separator + parameters.getTableName()
+                  + System.nanoTime() + CarbonCommonConstants.SORT_TEMP_FILE_EXT);
           writeData(page, sortTempFile);
           LOGGER.info("Time taken to sort row page with size" + page.getBuffer().getActualSize()
               + " and write is: " + (System.currentTimeMillis() - startTime));

--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/sort/unsafe/merger/UnsafeIntermediateMerger.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/sort/unsafe/merger/UnsafeIntermediateMerger.java
@@ -19,6 +19,7 @@ package org.apache.carbondata.processing.newflow.sort.unsafe.merger;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -106,8 +107,12 @@ public class UnsafeIntermediateMerger {
    * @param intermediateFiles
    */
   private void startIntermediateMerging(File[] intermediateFiles) {
+    //pick a temp location randomly
+    String[] tempFileLocations = parameters.getTempFileLocation();
+    String targetLocation = tempFileLocations[new Random().nextInt(tempFileLocations.length)];
+
     File file = new File(
-        parameters.getTempFileLocation() + File.separator + parameters.getTableName() + System
+        targetLocation + File.separator + parameters.getTableName() + System
             .nanoTime() + CarbonCommonConstants.MERGERD_EXTENSION);
     UnsafeIntermediateFileMerger merger =
         new UnsafeIntermediateFileMerger(parameters, intermediateFiles, file);

--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/steps/CarbonRowDataWriterProcessorStepImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/steps/CarbonRowDataWriterProcessorStepImpl.java
@@ -89,12 +89,15 @@ public class CarbonRowDataWriterProcessorStepImpl extends AbstractDataLoadProces
     child.initialize();
   }
 
-  private String getStoreLocation(CarbonTableIdentifier tableIdentifier, String partitionId) {
-    String storeLocation = CarbonDataProcessorUtil
+  private String[] getStoreLocation(CarbonTableIdentifier tableIdentifier, String partitionId) {
+    String[] storeLocation = CarbonDataProcessorUtil
         .getLocalDataFolderLocation(tableIdentifier.getDatabaseName(),
             tableIdentifier.getTableName(), String.valueOf(configuration.getTaskNo()), partitionId,
             configuration.getSegmentId() + "", false);
-    new File(storeLocation).mkdirs();
+    for (String loc : storeLocation)
+    {
+      new File(loc).mkdirs();
+    }
     return storeLocation;
   }
 
@@ -112,9 +115,11 @@ public class CarbonRowDataWriterProcessorStepImpl extends AbstractDataLoadProces
       isNoDictionaryDimensionColumn =
           CarbonDataProcessorUtil.getNoDictionaryMapping(configuration.getDataFields());
       measureDataType = configuration.getMeasureDataType();
+      //choose a tmp location randomly
+      String[] storeLocation = getStoreLocation(tableIdentifier, String.valueOf(0));
       CarbonFactDataHandlerModel dataHandlerModel = CarbonFactDataHandlerModel
           .createCarbonFactDataHandlerModel(configuration,
-              getStoreLocation(tableIdentifier, String.valueOf(0)), 0, 0);
+              storeLocation, 0, 0);
       measureCount = dataHandlerModel.getMeasureCount();
       outputLength = measureCount + (this.noDictWithComplextCount > 0 ? 1 : 0) + 1;
       CarbonTimeStatisticsFactory.getLoadStatisticsInstance()
@@ -148,9 +153,10 @@ public class CarbonRowDataWriterProcessorStepImpl extends AbstractDataLoadProces
   }
 
   private void doExecute(Iterator<CarbonRowBatch> iterator, int partitionId, int iteratorIndex) {
-    String storeLocation = getStoreLocation(tableIdentifier, String.valueOf(partitionId));
+    String[] storeLocation = getStoreLocation(tableIdentifier, String.valueOf(partitionId));
     CarbonFactDataHandlerModel model = CarbonFactDataHandlerModel
-        .createCarbonFactDataHandlerModel(configuration, storeLocation, partitionId, iteratorIndex);
+        .createCarbonFactDataHandlerModel(configuration, storeLocation, partitionId,
+            iteratorIndex);
     CarbonFactHandler dataHandler = null;
     boolean rowsNotExist = true;
     while (iterator.hasNext()) {

--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/steps/DataWriterBatchProcessorStepImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/steps/DataWriterBatchProcessorStepImpl.java
@@ -58,12 +58,14 @@ public class DataWriterBatchProcessorStepImpl extends AbstractDataLoadProcessorS
     child.initialize();
   }
 
-  private String getStoreLocation(CarbonTableIdentifier tableIdentifier, String partitionId) {
-    String storeLocation = CarbonDataProcessorUtil
+  private String[] getStoreLocation(CarbonTableIdentifier tableIdentifier, String partitionId) {
+    String[] storeLocation = CarbonDataProcessorUtil
         .getLocalDataFolderLocation(tableIdentifier.getDatabaseName(),
             tableIdentifier.getTableName(), String.valueOf(configuration.getTaskNo()), partitionId,
             configuration.getSegmentId() + "", false);
-    new File(storeLocation).mkdirs();
+    for (String loc : storeLocation) {
+      new File(loc).mkdirs();
+    }
     return storeLocation;
   }
 
@@ -78,7 +80,7 @@ public class DataWriterBatchProcessorStepImpl extends AbstractDataLoadProcessorS
               System.currentTimeMillis());
       int i = 0;
       for (Iterator<CarbonRowBatch> iterator : iterators) {
-        String storeLocation = getStoreLocation(tableIdentifier, String.valueOf(i));
+        String[] storeLocation = getStoreLocation(tableIdentifier, String.valueOf(i));
         int k = 0;
         while (iterator.hasNext()) {
           CarbonRowBatch next = iterator.next();

--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/steps/DataWriterProcessorStepImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/steps/DataWriterProcessorStepImpl.java
@@ -65,19 +65,22 @@ public class DataWriterProcessorStepImpl extends AbstractDataLoadProcessorStep {
     child.initialize();
   }
 
-  private String getStoreLocation(CarbonTableIdentifier tableIdentifier, String partitionId) {
-    String storeLocation = CarbonDataProcessorUtil
+  private String[] getStoreLocation(CarbonTableIdentifier tableIdentifier, String partitionId) {
+    String[] storeLocation = CarbonDataProcessorUtil
         .getLocalDataFolderLocation(tableIdentifier.getDatabaseName(),
             tableIdentifier.getTableName(), String.valueOf(configuration.getTaskNo()), partitionId,
             configuration.getSegmentId() + "", false);
-    new File(storeLocation).mkdirs();
+    for (String loc : storeLocation)
+    {
+      new File(loc).mkdirs();
+    }
     return storeLocation;
   }
 
   public CarbonFactDataHandlerModel getDataHandlerModel(int partitionId) {
     CarbonTableIdentifier tableIdentifier =
         configuration.getTableIdentifier().getCarbonTableIdentifier();
-    String storeLocation = getStoreLocation(tableIdentifier, String.valueOf(partitionId));
+    String[] storeLocation = getStoreLocation(tableIdentifier, String.valueOf(partitionId));
     CarbonFactDataHandlerModel model = CarbonFactDataHandlerModel
         .createCarbonFactDataHandlerModel(configuration, storeLocation, partitionId, 0);
     return model;
@@ -94,7 +97,8 @@ public class DataWriterProcessorStepImpl extends AbstractDataLoadProcessorStep {
               System.currentTimeMillis());
       int i = 0;
       for (Iterator<CarbonRowBatch> iterator : iterators) {
-        String storeLocation = getStoreLocation(tableIdentifier, String.valueOf(i));
+        String[] storeLocation = getStoreLocation(tableIdentifier, String.valueOf(i));
+
         CarbonFactDataHandlerModel model = CarbonFactDataHandlerModel
             .createCarbonFactDataHandlerModel(configuration, storeLocation, i, 0);
         CarbonFactHandler dataHandler = null;

--- a/processing/src/main/java/org/apache/carbondata/processing/sortandgroupby/sortdata/SortDataRows.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/sortandgroupby/sortdata/SortDataRows.java
@@ -24,6 +24,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.Arrays;
+import java.util.Random;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -101,8 +102,10 @@ public class SortDataRows {
     deleteSortLocationIfExists();
 
     // create new sort temp directory
-    if (!new File(parameters.getTempFileLocation()).mkdirs()) {
-      LOGGER.info("Sort Temp Location Already Exists");
+    for (String loc : parameters.getTempFileLocation()) {
+      if (!new File(loc).mkdirs()) {
+        LOGGER.info("Sort Temp Location Already Exists: " + loc);
+      }
     }
     this.dataSorterAndWriterExecutorService =
         Executors.newFixedThreadPool(parameters.getNumberOfCores());
@@ -204,9 +207,11 @@ public class SortDataRows {
       }
       recordHolderList = toSort;
 
-      // create new file
+      // create new file and choose folder randomly
+      String[] tmpLocation = parameters.getTempFileLocation();
+      String locationChosen = tmpLocation[new Random().nextInt(tmpLocation.length)];
       File file = new File(
-          parameters.getTempFileLocation() + File.separator + parameters.getTableName() +
+          locationChosen + File.separator + parameters.getTableName() +
               System.nanoTime() + CarbonCommonConstants.SORT_TEMP_FILE_EXT);
       writeDataTofile(recordHolderList, this.entryCount, file);
 
@@ -347,7 +352,9 @@ public class SortDataRows {
    * @throws CarbonSortKeyAndGroupByException
    */
   public void deleteSortLocationIfExists() throws CarbonSortKeyAndGroupByException {
-    CarbonDataProcessorUtil.deleteSortLocationIfExists(parameters.getTempFileLocation());
+    for (String loc : parameters.getTempFileLocation()) {
+      CarbonDataProcessorUtil.deleteSortLocationIfExists(loc);
+    }
   }
 
   /**
@@ -406,9 +413,11 @@ public class SortDataRows {
               new NewRowComparatorForNormalDims(parameters.getNumberOfSortColumns()));
         }
 
-        // create a new file every time
+        // create a new file and choose folder randomly every time
+        String[] tmpFileLocation = parameters.getTempFileLocation();
+        String locationChosen = tmpFileLocation[new Random().nextInt(tmpFileLocation.length)];
         File sortTempFile = new File(
-            parameters.getTempFileLocation() + File.separator + parameters.getTableName() + System
+            locationChosen + File.separator + parameters.getTableName() + System
                 .nanoTime() + CarbonCommonConstants.SORT_TEMP_FILE_EXT);
         writeDataTofile(recordHolderArray, recordHolderArray.length, sortTempFile);
         // add sort temp filename to and arrayList. When the list size reaches 20 then

--- a/processing/src/main/java/org/apache/carbondata/processing/sortandgroupby/sortdata/SortParameters.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/sortandgroupby/sortdata/SortParameters.java
@@ -30,6 +30,8 @@ import org.apache.carbondata.processing.newflow.CarbonDataLoadConfiguration;
 import org.apache.carbondata.processing.schema.metadata.SortObserver;
 import org.apache.carbondata.processing.util.CarbonDataProcessorUtil;
 
+import org.apache.commons.lang3.StringUtils;
+
 public class SortParameters implements Serializable {
 
   private static final LogService LOGGER =
@@ -37,7 +39,7 @@ public class SortParameters implements Serializable {
   /**
    * tempFileLocation
    */
-  private String tempFileLocation;
+  private String[] tempFileLocation;
   /**
    * sortBufferSize
    */
@@ -156,11 +158,11 @@ public class SortParameters implements Serializable {
     return parameters;
   }
 
-  public String getTempFileLocation() {
+  public String[] getTempFileLocation() {
     return tempFileLocation;
   }
 
-  public void setTempFileLocation(String tempFileLocation) {
+  public void setTempFileLocation(String[] tempFileLocation) {
     this.tempFileLocation = tempFileLocation;
   }
 
@@ -407,13 +409,18 @@ public class SortParameters implements Serializable {
 
     LOGGER.info("File Buffer Size: " + parameters.getFileBufferSize());
 
-    String carbonDataDirectoryPath = CarbonDataProcessorUtil
+    String[] carbonDataDirectoryPath = CarbonDataProcessorUtil
         .getLocalDataFolderLocation(tableIdentifier.getDatabaseName(),
             tableIdentifier.getTableName(), configuration.getTaskNo(),
             configuration.getPartitionId(), configuration.getSegmentId(), false);
-    parameters.setTempFileLocation(
-        carbonDataDirectoryPath + File.separator + CarbonCommonConstants.SORT_TEMP_FILE_LOCATION);
-    LOGGER.info("temp file location" + parameters.getTempFileLocation());
+    String[] sortTempDirs = new String[carbonDataDirectoryPath.length];
+    for (int i = 0; i < carbonDataDirectoryPath.length; i++) {
+      sortTempDirs[i] = carbonDataDirectoryPath[i] + File.separator
+          + CarbonCommonConstants.SORT_TEMP_FILE_LOCATION;
+    }
+
+    parameters.setTempFileLocation(sortTempDirs);
+    LOGGER.info("temp file location: " + StringUtils.join(parameters.getTempFileLocation(), ","));
 
     int numberOfCores;
     try {
@@ -528,12 +535,16 @@ public class SortParameters implements Serializable {
 
     LOGGER.info("File Buffer Size: " + parameters.getFileBufferSize());
 
-    String carbonDataDirectoryPath = CarbonDataProcessorUtil
+    String[] carbonDataDirectoryPath = CarbonDataProcessorUtil
         .getLocalDataFolderLocation(databaseName, tableName, taskNo, partitionID, segmentId,
             isCompactionFlow);
-    parameters.setTempFileLocation(
-        carbonDataDirectoryPath + File.separator + CarbonCommonConstants.SORT_TEMP_FILE_LOCATION);
-    LOGGER.info("temp file location" + parameters.getTempFileLocation());
+    String[] sortTempDirs = new String[carbonDataDirectoryPath.length];
+    for (int i = 0; i < carbonDataDirectoryPath.length; i++) {
+      sortTempDirs[i] = carbonDataDirectoryPath[i] + File.separator
+          + CarbonCommonConstants.SORT_TEMP_FILE_LOCATION;
+    }
+    parameters.setTempFileLocation(sortTempDirs);
+    LOGGER.info("temp file location: " + StringUtils.join(parameters.getTempFileLocation(), ","));
 
     int numberOfCores;
     try {

--- a/processing/src/main/java/org/apache/carbondata/processing/store/CarbonFactDataHandlerColumnar.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/CarbonFactDataHandlerColumnar.java
@@ -304,7 +304,8 @@ public class CarbonFactDataHandlerColumnar implements CarbonFactHandler {
    */
   public void initialise() throws CarbonDataWriterException {
     fileManager = new FileManager();
-    fileManager.setName(new File(model.getStoreLocation()).getName());
+    // todo: the fileManager seems to be useless, remove it later
+    fileManager.setName(new File(model.getStoreLocation()[0]).getName());
     setWritingConfiguration();
   }
 

--- a/processing/src/main/java/org/apache/carbondata/processing/store/CarbonFactDataHandlerModel.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/CarbonFactDataHandlerModel.java
@@ -77,7 +77,7 @@ public class CarbonFactDataHandlerModel {
   /**
    * local store location
    */
-  private String storeLocation;
+  private String[] storeLocation;
   /**
    * flag to check whether use inverted index
    */
@@ -163,7 +163,7 @@ public class CarbonFactDataHandlerModel {
    * Create the model using @{@link CarbonDataLoadConfiguration}
    */
   public static CarbonFactDataHandlerModel createCarbonFactDataHandlerModel(
-      CarbonDataLoadConfiguration configuration, String storeLocation, int bucketId,
+      CarbonDataLoadConfiguration configuration, String[] storeLocation, int bucketId,
       int taskExtension) {
     CarbonTableIdentifier identifier =
         configuration.getTableIdentifier().getCarbonTableIdentifier();
@@ -265,7 +265,7 @@ public class CarbonFactDataHandlerModel {
    */
   public static CarbonFactDataHandlerModel getCarbonFactDataHandlerModel(CarbonLoadModel loadModel,
       CarbonTable carbonTable, SegmentProperties segmentProperties, String tableName,
-      String tempStoreLocation) {
+      String[] tempStoreLocation) {
     CarbonFactDataHandlerModel carbonFactDataHandlerModel = new CarbonFactDataHandlerModel();
     carbonFactDataHandlerModel.setSchemaUpdatedTimeStamp(carbonTable.getTableLastUpdatedTime());
     carbonFactDataHandlerModel.setDatabaseName(loadModel.getDatabaseName());
@@ -375,11 +375,11 @@ public class CarbonFactDataHandlerModel {
     this.measureCount = measureCount;
   }
 
-  public String getStoreLocation() {
+  public String[] getStoreLocation() {
     return storeLocation;
   }
 
-  public void setStoreLocation(String storeLocation) {
+  public void setStoreLocation(String[] storeLocation) {
     this.storeLocation = storeLocation;
   }
 

--- a/processing/src/main/java/org/apache/carbondata/processing/store/SingleThreadFinalSortFilesMerger.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/SingleThreadFinalSortFilesMerger.java
@@ -20,6 +20,9 @@ package org.apache.carbondata.processing.store;
 import java.io.File;
 import java.io.FileFilter;
 import java.util.AbstractQueue;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.PriorityQueue;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
@@ -92,7 +95,7 @@ public class SingleThreadFinalSortFilesMerger extends CarbonIterator<Object[]> {
   /**
    * tempFileLocation
    */
-  private String tempFileLocation;
+  private String[] tempFileLocation;
 
   private DataType[] measureDataType;
 
@@ -104,7 +107,7 @@ public class SingleThreadFinalSortFilesMerger extends CarbonIterator<Object[]> {
 
   private boolean[] isNoDictionarySortColumn;
 
-  public SingleThreadFinalSortFilesMerger(String tempFileLocation, String tableName,
+  public SingleThreadFinalSortFilesMerger(String[] tempFileLocation, String tableName,
       int dimensionCount, int complexDimensionCount, int measureCount, int noDictionaryCount,
       DataType[] type, boolean[] isNoDictionaryColumn, boolean[] isNoDictionarySortColumn) {
     this.tempFileLocation = tempFileLocation;
@@ -124,19 +127,35 @@ public class SingleThreadFinalSortFilesMerger extends CarbonIterator<Object[]> {
    * @throws CarbonSortKeyAndGroupByException
    */
   public void startFinalMerge() throws CarbonDataWriterException {
-    // get all the merged files
-    File file = new File(tempFileLocation);
+    List<File> filesToMerge = getFilesToMergeSort();
+    if (filesToMerge.size() == 0)
+    {
+      LOGGER.info("No file to merge in final merge stage");
+      return;
+    }
 
-    File[] fileList = file.listFiles(new FileFilter() {
+    startSorting(filesToMerge);
+  }
+
+  private List<File> getFilesToMergeSort() {
+    FileFilter fileFilter = new FileFilter() {
       public boolean accept(File pathname) {
         return pathname.getName().startsWith(tableName);
       }
-    });
+    };
 
-    if (null == fileList || fileList.length == 0) {
-      return;
+    // get all the merged files
+    List<File> files = new ArrayList<File>(tempFileLocation.length);
+    for (String tempLoc : tempFileLocation)
+    {
+      File[] subFiles = new File(tempLoc).listFiles(fileFilter);
+      if (null != subFiles && subFiles.length > 0)
+      {
+        files.addAll(Arrays.asList(subFiles));
+      }
     }
-    startSorting(fileList);
+
+    return files;
   }
 
   /**
@@ -147,8 +166,8 @@ public class SingleThreadFinalSortFilesMerger extends CarbonIterator<Object[]> {
    *
    * @throws CarbonSortKeyAndGroupByException
    */
-  private void startSorting(File[] files) throws CarbonDataWriterException {
-    this.fileCounter = files.length;
+  private void startSorting(List<File> files) throws CarbonDataWriterException {
+    this.fileCounter = files.size();
     if (fileCounter == 0) {
       LOGGER.info("No files to merge sort");
       return;
@@ -162,7 +181,7 @@ public class SingleThreadFinalSortFilesMerger extends CarbonIterator<Object[]> {
     LOGGER.info("File Buffer Size: " + this.fileBufferSize);
 
     // create record holder heap
-    createRecordHolderQueue(files);
+    createRecordHolderQueue();
 
     // iterate over file list and create chunk holder and add to heap
     LOGGER.info("Started adding first record from each file");
@@ -215,12 +234,10 @@ public class SingleThreadFinalSortFilesMerger extends CarbonIterator<Object[]> {
   /**
    * This method will be used to create the heap which will be used to hold
    * the chunk of data
-   *
-   * @param listFiles list of temp files
    */
-  private void createRecordHolderQueue(File[] listFiles) {
+  private void createRecordHolderQueue() {
     // creating record holder heap
-    this.recordHolderHeapLocal = new PriorityQueue<SortTempFileChunkHolder>(listFiles.length);
+    this.recordHolderHeapLocal = new PriorityQueue<SortTempFileChunkHolder>(fileCounter);
   }
 
   /**

--- a/processing/src/main/java/org/apache/carbondata/processing/store/writer/CarbonDataWriterVo.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/writer/CarbonDataWriterVo.java
@@ -28,7 +28,7 @@ import org.apache.carbondata.processing.store.file.IFileManagerComposite;
  */
 public class CarbonDataWriterVo {
 
-  private String storeLocation;
+  private String[] storeLocation;
 
   private int measureCount;
 
@@ -67,14 +67,14 @@ public class CarbonDataWriterVo {
   /**
    * @return the storeLocation
    */
-  public String getStoreLocation() {
+  public String[] getStoreLocation() {
     return storeLocation;
   }
 
   /**
    * @param storeLocation the storeLocation to set
    */
-  public void setStoreLocation(String storeLocation) {
+  public void setStoreLocation(String[] storeLocation) {
     this.storeLocation = storeLocation;
   }
 

--- a/processing/src/test/java/org/apache/carbondata/processing/StoreCreator.java
+++ b/processing/src/test/java/org/apache/carbondata/processing/StoreCreator.java
@@ -404,8 +404,9 @@ public class StoreCreator {
         format.createRecordReader(blockDetails, hadoopAttemptContext);
 
     CSVRecordReaderIterator readerIterator = new CSVRecordReaderIterator(recordReader, blockDetails, hadoopAttemptContext);
+    String[] storeLocationArray = new String[] {storeLocation};
     new DataLoadExecutor().execute(loadModel,
-        storeLocation,
+        storeLocationArray,
         new CarbonIterator[]{readerIterator});
 
     info.setDatabaseName(databaseName);


### PR DESCRIPTION
# Modifications
This feature mainly focus on avoiding disk hot-spot in single massive data loading, changes are made in two parts: 

1. randomly choose a yarn local folder to write sort temp file in sort-process;

2.randomly choose a yarn local folder to write carbondata file in write-process.

# Usage

To enable this feature, user should enable `carbon.using.multi.temp.dir=true` and `carbon.use.local.dir=true`.

# Performance
In my case, this feature improves the loading performance from 35M/s/node to 70+M/s/node
