### PR TITLE
[CARBONDATA-1364] Added the blocklet info to index file and make the datamap distributable with job

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -1347,6 +1347,10 @@ public final class CarbonCommonConstants {
    */
   public static final String CARBON_UPDATE_SEGMENT_PARALLELISM_DEFAULT = "1";
 
+  public static final String USE_DISTRIBUTED_DATAMAP = "carbon.enable.distributed.datamap";
+
+  public static final String USE_DISTRIBUTED_DATAMAP_DEFAULT = "false";
+
   private CarbonCommonConstants() {
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/datamap/DataMapDistributable.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/DataMapDistributable.java
@@ -16,18 +16,28 @@
  */
 package org.apache.carbondata.core.datamap;
 
+import java.io.IOException;
+import java.io.Serializable;
+
 import org.apache.carbondata.core.datastore.block.Distributable;
+
+import org.apache.hadoop.mapreduce.InputSplit;
 
 /**
  * Distributable class for datamap.
  */
-public abstract class DataMapDistributable implements Distributable {
+public abstract class DataMapDistributable extends InputSplit
+    implements Distributable, Serializable {
 
   private String tablePath;
 
   private String segmentId;
 
   private String dataMapName;
+
+  private String[] locations;
+
+  private String dataMapFactoryClass;
 
   public String getTablePath() {
     return tablePath;
@@ -53,4 +63,30 @@ public abstract class DataMapDistributable implements Distributable {
     this.dataMapName = dataMapName;
   }
 
+  public String getDataMapFactoryClass() {
+    return dataMapFactoryClass;
+  }
+
+  public void setDataMapFactoryClass(String dataMapFactoryClass) {
+    this.dataMapFactoryClass = dataMapFactoryClass;
+  }
+
+  public void setLocations(String[] locations) {
+    this.locations = locations;
+  }
+
+  @Override
+  public String[] getLocations() throws IOException {
+    return locations;
+  }
+
+  @Override
+  public int compareTo(Distributable o) {
+    return 0;
+  }
+
+  @Override
+  public long getLength() throws IOException, InterruptedException {
+    return 0;
+  }
 }

--- a/core/src/main/java/org/apache/carbondata/core/datamap/dev/DataMapFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/dev/DataMapFactory.java
@@ -51,6 +51,12 @@ public interface DataMapFactory {
   DataMap getDataMap(DataMapDistributable distributable);
 
   /**
+   * Get all distributable objects of a segmentid
+   * @return
+   */
+  List<DataMapDistributable> toDistributable(String segmentId);
+
+  /**
    *
    * @param event
    */

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/Blocklet.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/Blocklet.java
@@ -48,8 +48,8 @@ public class Blocklet implements Serializable {
     this.blockletId = blockletId;
   }
 
-  public Path getPath() {
-    return new Path(path);
+  public String getPath() {
+    return path;
   }
 
   public String getBlockletId() {
@@ -65,9 +65,9 @@ public class Blocklet implements Serializable {
   }
 
   public void updateLocations() throws IOException {
-    Path fspath = new Path(path);
-    FileSystem fs = fspath.getFileSystem(FileFactory.getConfiguration());
-    RemoteIterator<LocatedFileStatus> iter = fs.listLocatedStatus(fspath);
+    Path path = new Path(this.path);
+    FileSystem fs = path.getFileSystem(FileFactory.getConfiguration());
+    RemoteIterator<LocatedFileStatus> iter = fs.listLocatedStatus(path);
     LocatedFileStatus fileStatus = iter.next();
     location = fileStatus.getBlockLocations()[0].getHosts();
     length = fileStatus.getLen();

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMapDistributable.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMapDistributable.java
@@ -14,38 +14,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.carbondata.core.datamap.dev;
+package org.apache.carbondata.core.indexstore.blockletindex;
 
-import java.io.IOException;
-import java.util.List;
-
-import org.apache.carbondata.core.indexstore.Blocklet;
-import org.apache.carbondata.core.memory.MemoryException;
-import org.apache.carbondata.core.scan.filter.resolver.FilterResolverIntf;
+import org.apache.carbondata.core.datamap.DataMapDistributable;
 
 /**
- * Datamap is an entity which can store and retrieve index data.
+ * This class contains required information to make the Blocklet datamap distributable.
+ * Each distributable object can represents one datamap.
+ * Using this object job like spark/MR can be launched and execute each distributable object as
+ * one datamap task.
  */
-public interface DataMap {
+public class BlockletDataMapDistributable extends DataMapDistributable {
 
   /**
-   * It is called to load the data map to memory or to initialize it.
+   * Relative file path from the segment folder.
    */
-  void init(String filePath) throws MemoryException, IOException;
+  private String filePath;
 
-  /**
-   * Prune the datamap with filter expression. It returns the list of
-   * blocklets where these filters can exist.
-   *
-   * @param filterExp
-   * @return
-   */
-  List<Blocklet> prune(FilterResolverIntf filterExp);
+  public BlockletDataMapDistributable(String indexFileName) {
+    this.filePath = indexFileName;
+  }
 
-
-  /**
-   * Clear complete index table and release memory.
-   */
-  void clear();
-
+  public String getFilePath() {
+    return filePath;
+  }
 }

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonMetadataUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonMetadataUtil.java
@@ -273,9 +273,23 @@ public class CarbonMetadataUtil {
       blockIndex.setOffset(blockIndexInfo.getOffset());
       blockIndex.setFile_name(blockIndexInfo.getFileName());
       blockIndex.setBlock_index(getBlockletIndex(blockIndexInfo.getBlockletIndex()));
+      if (blockIndexInfo.getBlockletInfo() != null) {
+        blockIndex.setBlocklet_info(getBlocletInfo3(blockIndexInfo.getBlockletInfo()));
+      }
       thriftBlockIndexList.add(blockIndex);
     }
     return thriftBlockIndexList;
+  }
+
+  private static BlockletInfo3 getBlocletInfo3(
+      org.apache.carbondata.core.metadata.blocklet.BlockletInfo blockletInfo) {
+    List<Long> dimensionChunkOffsets = blockletInfo.getDimensionChunkOffsets();
+    dimensionChunkOffsets.addAll(blockletInfo.getMeasureChunkOffsets());
+    List<Integer> dimensionChunksLength = blockletInfo.getDimensionChunksLength();
+    dimensionChunksLength.addAll(blockletInfo.getMeasureChunksLength());
+    return new BlockletInfo3(blockletInfo.getNumberOfRows(), dimensionChunkOffsets,
+        dimensionChunksLength, blockletInfo.getDimensionOffset(), blockletInfo.getMeasureOffsets(),
+        blockletInfo.getNumberOfPages());
   }
 
   /**

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
@@ -932,6 +932,33 @@ public final class CarbonUtil {
   }
 
   /**
+   * Below method will be used to get the number of dimension column
+   * in carbon column schema
+   *
+   * @param columnSchemaList column schema list
+   * @return number of dimension column
+   */
+  public static int getNumberOfDimensionColumns(List<ColumnSchema> columnSchemaList) {
+    int numberOfDimensionColumns = 0;
+    int previousColumnGroupId = -1;
+    ColumnSchema columnSchema = null;
+    for (int i = 0; i < columnSchemaList.size(); i++) {
+      columnSchema = columnSchemaList.get(i);
+      if (columnSchema.isDimensionColumn() && columnSchema.isColumnar()) {
+        numberOfDimensionColumns++;
+      } else if (columnSchema.isDimensionColumn()) {
+        if (previousColumnGroupId != columnSchema.getColumnGroupId()) {
+          previousColumnGroupId = columnSchema.getColumnGroupId();
+          numberOfDimensionColumns++;
+        }
+      } else {
+        break;
+      }
+    }
+    return numberOfDimensionColumns;
+  }
+
+  /**
    * The method calculate the B-Tree metadata size.
    *
    * @param tableBlockInfo

--- a/core/src/main/java/org/apache/carbondata/core/util/DataFileFooterConverterV3.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/DataFileFooterConverterV3.java
@@ -76,7 +76,7 @@ public class DataFileFooterConverterV3 extends AbstractDataFileFooterConverter {
     List<BlockletInfo> blockletInfoList = new ArrayList<BlockletInfo>();
     for (int i = 0; i < leaf_node_infos_Thrift.size(); i++) {
       BlockletInfo blockletInfo = getBlockletInfo(leaf_node_infos_Thrift.get(i),
-          getNumberOfDimensionColumns(columnSchemaList));
+          CarbonUtil.getNumberOfDimensionColumns(columnSchemaList));
       blockletInfo.setBlockletIndex(blockletIndexList.get(i));
       blockletInfoList.add(blockletInfo);
     }
@@ -103,7 +103,7 @@ public class DataFileFooterConverterV3 extends AbstractDataFileFooterConverter {
    * @param blockletInfoThrift blocklet info of the thrift
    * @return blocklet info wrapper
    */
-  private BlockletInfo getBlockletInfo(
+  public BlockletInfo getBlockletInfo(
       org.apache.carbondata.format.BlockletInfo3 blockletInfoThrift, int numberOfDimensionColumns) {
     BlockletInfo blockletInfo = new BlockletInfo();
     List<Long> dimensionColumnChunkOffsets =
@@ -125,33 +125,6 @@ public class DataFileFooterConverterV3 extends AbstractDataFileFooterConverter {
     blockletInfo.setMeasureOffsets(blockletInfoThrift.getMeasure_offsets());
     blockletInfo.setNumberOfPages(blockletInfoThrift.getNumber_number_of_pages());
     return blockletInfo;
-  }
-
-  /**
-   * Below method will be used to get the number of dimension column
-   * in carbon column schema
-   *
-   * @param columnSchemaList column schema list
-   * @return number of dimension column
-   */
-  private int getNumberOfDimensionColumns(List<ColumnSchema> columnSchemaList) {
-    int numberOfDimensionColumns = 0;
-    int previousColumnGroupId = -1;
-    ColumnSchema columnSchema = null;
-    for (int i = 0; i < columnSchemaList.size(); i++) {
-      columnSchema = columnSchemaList.get(i);
-      if (columnSchema.isDimensionColumn() && columnSchema.isColumnar()) {
-        numberOfDimensionColumns++;
-      } else if (columnSchema.isDimensionColumn()) {
-        if (previousColumnGroupId != columnSchema.getColumnGroupId()) {
-          previousColumnGroupId = columnSchema.getColumnGroupId();
-          numberOfDimensionColumns++;
-        }
-      } else {
-        break;
-      }
-    }
-    return numberOfDimensionColumns;
   }
 
 }

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/DataMapJob.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/DataMapJob.java
@@ -14,38 +14,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.carbondata.core.datamap.dev;
+package org.apache.carbondata.hadoop.api;
 
-import java.io.IOException;
+import java.io.Serializable;
 import java.util.List;
 
 import org.apache.carbondata.core.indexstore.Blocklet;
-import org.apache.carbondata.core.memory.MemoryException;
 import org.apache.carbondata.core.scan.filter.resolver.FilterResolverIntf;
 
 /**
- * Datamap is an entity which can store and retrieve index data.
+ * Distributable datamap job to execute the #DistributableDataMapFormat in cluster. it prunes the
+ * datamaps distributably and returns the final blocklet list
  */
-public interface DataMap {
+public interface DataMapJob extends Serializable {
 
-  /**
-   * It is called to load the data map to memory or to initialize it.
-   */
-  void init(String filePath) throws MemoryException, IOException;
-
-  /**
-   * Prune the datamap with filter expression. It returns the list of
-   * blocklets where these filters can exist.
-   *
-   * @param filterExp
-   * @return
-   */
-  List<Blocklet> prune(FilterResolverIntf filterExp);
-
-
-  /**
-   * Clear complete index table and release memory.
-   */
-  void clear();
+  List<Blocklet> execute(DistributableDataMapFormat dataMapFormat, FilterResolverIntf resolverIntf);
 
 }

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/DistributableDataMapFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/DistributableDataMapFormat.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.hadoop.api;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.carbondata.core.datamap.DataMapDistributable;
+import org.apache.carbondata.core.datamap.DataMapStoreManager;
+import org.apache.carbondata.core.datamap.TableDataMap;
+import org.apache.carbondata.core.indexstore.Blocklet;
+import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
+import org.apache.carbondata.core.scan.filter.resolver.FilterResolverIntf;
+import org.apache.carbondata.hadoop.util.ObjectSerializationUtil;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
+
+/**
+ * Input format for datamaps, it makes the datamap pruning distributable.
+ */
+public class DistributableDataMapFormat extends FileInputFormat<Void, Blocklet> implements
+    Serializable {
+
+  private static final String FILTER_EXP = "mapreduce.input.distributed.datamap.filter";
+
+  private AbsoluteTableIdentifier identifier;
+
+  private String dataMapName;
+
+  private List<String> validSegments;
+
+  private String className;
+
+  public DistributableDataMapFormat(AbsoluteTableIdentifier identifier,
+      String dataMapName, List<String> validSegments, String className) {
+    this.identifier = identifier;
+    this.dataMapName = dataMapName;
+    this.validSegments = validSegments;
+    this.className = className;
+  }
+
+  public static void setFilterExp(Configuration configuration, FilterResolverIntf filterExp)
+      throws IOException {
+    if (filterExp != null) {
+      String string = ObjectSerializationUtil.convertObjectToString(filterExp);
+      configuration.set(FILTER_EXP, string);
+    }
+  }
+
+  private static FilterResolverIntf getFilterExp(Configuration configuration) throws IOException {
+    String filterString = configuration.get(FILTER_EXP);
+    if (filterString != null) {
+      Object toObject = ObjectSerializationUtil.convertStringToObject(filterString);
+      return (FilterResolverIntf) toObject;
+    }
+    return null;
+  }
+
+  @Override
+  public List<InputSplit> getSplits(JobContext job) throws IOException {
+    TableDataMap dataMap =
+        DataMapStoreManager.getInstance().getDataMap(identifier, dataMapName, className);
+    List<DataMapDistributable> distributables = dataMap.toDistributable(validSegments);
+    List<InputSplit> inputSplits = new ArrayList<>(distributables.size());
+    inputSplits.addAll(distributables);
+    return inputSplits;
+  }
+
+  @Override
+  public RecordReader<Void, Blocklet> createRecordReader(InputSplit inputSplit,
+      TaskAttemptContext taskAttemptContext) throws IOException, InterruptedException {
+    return new RecordReader<Void, Blocklet>() {
+      private Iterator<Blocklet> blockletIterator;
+      private Blocklet currBlocklet;
+
+      @Override
+      public void initialize(InputSplit inputSplit, TaskAttemptContext taskAttemptContext)
+          throws IOException, InterruptedException {
+        DataMapDistributable distributable = (DataMapDistributable)inputSplit;
+        AbsoluteTableIdentifier identifier =
+            AbsoluteTableIdentifier.fromTablePath(distributable.getTablePath());
+        TableDataMap dataMap = DataMapStoreManager.getInstance()
+            .getDataMap(identifier, distributable.getDataMapName(),
+                distributable.getDataMapFactoryClass());
+        blockletIterator =
+            dataMap.prune(distributable, getFilterExp(taskAttemptContext.getConfiguration()))
+                .iterator();
+      }
+
+      @Override
+      public boolean nextKeyValue() throws IOException, InterruptedException {
+        boolean hasNext = blockletIterator.hasNext();
+        if (hasNext) {
+          currBlocklet = blockletIterator.next();
+        }
+        return hasNext;
+      }
+
+      @Override
+      public Void getCurrentKey() throws IOException, InterruptedException {
+        return null;
+      }
+
+      @Override
+      public Blocklet getCurrentValue() throws IOException, InterruptedException {
+        return currBlocklet;
+      }
+
+      @Override
+      public float getProgress() throws IOException, InterruptedException {
+        return 0;
+      }
+
+      @Override
+      public void close() throws IOException {
+
+      }
+    };
+  }
+
+}

--- a/integration/spark-common-cluster-test/src/test/scala/org/apache/carbondata/cluster/sdv/generated/QueriesBasicTestCase.scala
+++ b/integration/spark-common-cluster-test/src/test/scala/org/apache/carbondata/cluster/sdv/generated/QueriesBasicTestCase.scala
@@ -5857,8 +5857,8 @@ class QueriesBasicTestCase extends QueryTest with BeforeAndAfterAll {
   //TC_025
   test("TC_025", Include) {
 
-    checkAnswer(s"""select channelsId, sum(channelsId+channelsId) Total from Carbon_automation group by  channelsId order by Total""",
-      s"""select channelsId, sum(channelsId+channelsId) Total from Carbon_automation_hive group by  channelsId order by Total""", "QueriesBasicTestCase_TC_025")
+    checkAnswer(s"""select channelsId, sum(channelsId+channelsId) Total from Carbon_automation group by  channelsId order by channelsId,Total""",
+      s"""select channelsId, sum(channelsId+channelsId) Total from Carbon_automation_hive group by  channelsId order by channelsId,Total""", "QueriesBasicTestCase_TC_025")
 
   }
 
@@ -7894,15 +7894,6 @@ class QueriesBasicTestCase extends QueryTest with BeforeAndAfterAll {
 
     checkAnswer(s"""select ActiveOperatorId, sum(imeiupdown) as total, count(distinct AMSize) as AMSize_count from (select AMSize, t1.gamePointId+t1.contractNumber as imeiupdown, if((t1.gamePointId+t1.contractNumber)>100, '>50', if((t1.gamePointId+t1.contractNumber)>100,'50~10',if((t1.gamePointId+t1.contractNumber)>100, '10~1','<1'))) as ActiveOperatorId from Carbon_automation t1) t2 group by ActiveOperatorId""",
       s"""select ActiveOperatorId, sum(imeiupdown) as total, count(distinct AMSize) as AMSize_count from (select AMSize, t1.gamePointId+t1.contractNumber as imeiupdown, if((t1.gamePointId+t1.contractNumber)>100, '>50', if((t1.gamePointId+t1.contractNumber)>100,'50~10',if((t1.gamePointId+t1.contractNumber)>100, '10~1','<1'))) as ActiveOperatorId from Carbon_automation_hive t1) t2 group by ActiveOperatorId""", "QueriesBasicTestCase_TC_312")
-
-  }
-
-
-  //TC_313
-  test("TC_313", Include) {
-
-    checkAnswer(s"""select ActiveOperatorId, sum(imeiupdown) as total, count(distinct AMSize) as AMSize_count from (select AMSize, t1.gamePointId+ t1.contractNumber as imeiupdown, if((t1.gamePointId+ t1.contractNumber)>100, '>50', if((t1.gamePointId+t1.contractNumber)>100,'50~10',if((t1.gamePointId+t1.contractNumber)>100, '10~1','<1'))) as ActiveOperatorId from Carbon_automation t1) t2 group by ActiveOperatorId""",
-      s"""select ActiveOperatorId, sum(imeiupdown) as total, count(distinct AMSize) as AMSize_count from (select AMSize, t1.gamePointId+ t1.contractNumber as imeiupdown, if((t1.gamePointId+ t1.contractNumber)>100, '>50', if((t1.gamePointId+t1.contractNumber)>100,'50~10',if((t1.gamePointId+t1.contractNumber)>100, '10~1','<1'))) as ActiveOperatorId from Carbon_automation_hive t1) t2 group by ActiveOperatorId""", "QueriesBasicTestCase_TC_313")
 
   }
 

--- a/integration/spark-common-cluster-test/src/test/scala/org/apache/carbondata/cluster/sdv/generated/QueriesIncludeDictionaryTestCase.scala
+++ b/integration/spark-common-cluster-test/src/test/scala/org/apache/carbondata/cluster/sdv/generated/QueriesIncludeDictionaryTestCase.scala
@@ -3068,8 +3068,8 @@ class QueriesIncludeDictionaryTestCase extends QueryTest with BeforeAndAfterAll 
   //VMALL_DICTIONARY_INCLUDE_371
   test("VMALL_DICTIONARY_INCLUDE_371", Include) {
 
-    checkAnswer(s"""select imei,deviceInformationId,MAC,deviceColor from VMALL_DICTIONARY_INCLUDE where  Latest_DAY  not like '1234567890123480.0000000000' order by deviceInformationId limit 5""",
-      s"""select imei,deviceInformationId,MAC,deviceColor from VMALL_DICTIONARY_INCLUDE_hive where  Latest_DAY  not like '1234567890123480.0000000000' order by deviceInformationId limit 5""", "QueriesIncludeDictionaryTestCase_VMALL_DICTIONARY_INCLUDE_371")
+    checkAnswer(s"""select imei,deviceInformationId,MAC,deviceColor from VMALL_DICTIONARY_INCLUDE where  Latest_DAY  not like '1234567890123480.0000000000' order by imei,deviceInformationId limit 5""",
+      s"""select imei,deviceInformationId,MAC,deviceColor from VMALL_DICTIONARY_INCLUDE_hive where  Latest_DAY  not like '1234567890123480.0000000000' order by imei,deviceInformationId limit 5""", "QueriesIncludeDictionaryTestCase_VMALL_DICTIONARY_INCLUDE_371")
 
   }
 

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datamap/DataMapWriterSuite.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datamap/DataMapWriterSuite.scala
@@ -52,6 +52,15 @@ class C2DataMapFactory() extends DataMapFactory {
   override def createWriter(segmentId: String): DataMapWriter = DataMapWriterSuite.dataMapWriterC2Mock
 
   override def getMeta: DataMapMeta = new DataMapMeta(List("c2").asJava, FilterType.EQUALTO)
+
+  /**
+   * Get all distributable objects of a segmentid
+   *
+   * @return
+   */
+  override def toDistributable(segmentId: String): util.List[DataMapDistributable] = {
+    ???
+  }
 }
 
 class DataMapWriterSuite extends QueryTest with BeforeAndAfterAll {
@@ -76,7 +85,7 @@ class DataMapWriterSuite extends QueryTest with BeforeAndAfterAll {
     // register datamap writer
     DataMapStoreManager.getInstance().createAndRegisterDataMap(
       AbsoluteTableIdentifier.from(storeLocation, "default", "carbon1"),
-      classOf[C2DataMapFactory],
+      classOf[C2DataMapFactory].getName,
       "test")
 
     val df = buildTestData(33000)
@@ -103,7 +112,7 @@ class DataMapWriterSuite extends QueryTest with BeforeAndAfterAll {
     // register datamap writer
     DataMapStoreManager.getInstance().createAndRegisterDataMap(
       AbsoluteTableIdentifier.from(storeLocation, "default", "carbon2"),
-      classOf[C2DataMapFactory],
+      classOf[C2DataMapFactory].getName,
       "test")
 
     CarbonProperties.getInstance()

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
@@ -275,6 +275,11 @@ class CarbonScanRDD(
       identifier.appendWithLocalPrefix(identifier.getTablePath))
     CarbonTableInputFormat.setFilterPredicates(conf, filterExpression)
     CarbonTableInputFormat.setColumnProjection(conf, columnProjection)
+    if (CarbonProperties.getInstance()
+      .getProperty(CarbonCommonConstants.USE_DISTRIBUTED_DATAMAP,
+        CarbonCommonConstants.USE_DISTRIBUTED_DATAMAP_DEFAULT).toBoolean) {
+      CarbonTableInputFormat.setDataMapJob(conf, new SparkDataMapJob)
+    }
     format
   }
 

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/SparkDataMapJob.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/SparkDataMapJob.scala
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.spark.rdd
+
+import java.text.SimpleDateFormat
+import java.util
+import java.util.Date
+
+import scala.collection.JavaConverters._
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.mapreduce.{InputSplit, Job, TaskAttemptID, TaskType}
+import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl
+import org.apache.spark.{Partition, SparkContext, TaskContext, TaskKilledException}
+
+import org.apache.carbondata.common.logging.LogServiceFactory
+import org.apache.carbondata.core.constants.CarbonCommonConstants
+import org.apache.carbondata.core.indexstore.Blocklet
+import org.apache.carbondata.core.scan.filter.resolver.FilterResolverIntf
+import org.apache.carbondata.hadoop.api.{DataMapJob, DistributableDataMapFormat}
+
+/**
+ * Spark job to execute datamap job and prune all the datamaps distributable
+ */
+class SparkDataMapJob extends DataMapJob {
+
+  override def execute(dataMapFormat: DistributableDataMapFormat,
+      resolverIntf: FilterResolverIntf): util.List[Blocklet] = {
+    new DataMapPruneRDD(SparkContext.getOrCreate(), dataMapFormat, resolverIntf).collect().toList
+      .asJava
+  }
+}
+
+class DataMapRDDPartition(rddId: Int, idx: Int, val inputSplit: InputSplit) extends Partition {
+  override def index: Int = idx
+
+  override def hashCode(): Int = 41 * (41 + rddId) + idx
+}
+
+/**
+ * RDD to prune the datamaps across spark cluster
+ * @param sc
+ * @param dataMapFormat
+ * @param resolverIntf
+ */
+class DataMapPruneRDD(sc: SparkContext,
+    dataMapFormat: DistributableDataMapFormat,
+    resolverIntf: FilterResolverIntf)
+  extends CarbonRDD[(Blocklet)](sc, Nil) {
+
+  private val jobTrackerId: String = {
+    val formatter = new SimpleDateFormat("yyyyMMddHHmm")
+    formatter.format(new Date())
+  }
+
+  override def internalCompute(split: Partition,
+      context: TaskContext): Iterator[Blocklet] = {
+    val LOGGER = LogServiceFactory.getLogService(this.getClass.getName)
+    val status = CarbonCommonConstants.STORE_LOADSTATUS_SUCCESS
+    val attemptId = new TaskAttemptID(jobTrackerId, id, TaskType.MAP, split.index, 0)
+    val attemptContext = new TaskAttemptContextImpl(new Configuration(), attemptId)
+    val inputSplit = split.asInstanceOf[DataMapRDDPartition].inputSplit
+    DistributableDataMapFormat.setFilterExp(attemptContext.getConfiguration, resolverIntf)
+    val reader = dataMapFormat.createRecordReader(inputSplit, attemptContext)
+    reader.initialize(inputSplit, attemptContext)
+    val iter = new Iterator[Blocklet] {
+
+      private var havePair = false
+      private var finished = false
+
+      override def hasNext: Boolean = {
+        if (context.isInterrupted) {
+          throw new TaskKilledException
+        }
+        if (!finished && !havePair) {
+          finished = !reader.nextKeyValue
+          havePair = !finished
+        }
+        !finished
+      }
+
+      override def next(): Blocklet = {
+        if (!hasNext) {
+          throw new java.util.NoSuchElementException("End of stream")
+        }
+        havePair = false
+        val value = reader.getCurrentValue
+        value
+      }
+    }
+    iter
+  }
+
+  override protected def getPartitions: Array[Partition] = {
+    val job = Job.getInstance(new Configuration())
+    val splits = dataMapFormat.getSplits(job)
+    splits.asScala.zipWithIndex.map(f => new DataMapRDDPartition(id, f._2, f._1)).toArray
+  }
+}


### PR DESCRIPTION
In this PR following tasks are completed.
1. Added the blocklet info to the carbonindex file, so datamap not required to read each carbondata file footer to the blocklet information. This makes the datamap loading faster.

2. Made the data map distributable and added the spark job. So datamap pruning could happen distributable and pruned blocklet list would be sent to driver.

This PR cannot compile as carbondata format changes are present.