### PR TITLE
[CARBONDATA-1335] Remove duplicated time-consuming method call

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonSessionState.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonSessionState.scala
@@ -80,7 +80,8 @@ class CarbonSessionCatalog(
    */
   override def lookupRelation(name: TableIdentifier,
       alias: Option[String]): LogicalPlan = {
-    super.lookupRelation(name, alias) match {
+    val rtnRelation = super.lookupRelation(name, alias)
+    rtnRelation match {
       case SubqueryAlias(_,
           LogicalRelation(carbonDatasourceHadoopRelation: CarbonDatasourceHadoopRelation, _, _),
           _) =>
@@ -89,11 +90,13 @@ class CarbonSessionCatalog(
         refreshRelationFromCache(name, alias, carbonDatasourceHadoopRelation)
       case relation => relation
     }
+
+    rtnRelation
   }
 
   private def refreshRelationFromCache(name: TableIdentifier,
       alias: Option[String],
-      carbonDatasourceHadoopRelation: CarbonDatasourceHadoopRelation): LogicalPlan = {
+      carbonDatasourceHadoopRelation: CarbonDatasourceHadoopRelation): Unit = {
     carbonEnv.carbonMetastore.
       checkSchemasModifiedTimeAndReloadTables(CarbonEnv.getInstance(sparkSession).storePath)
     carbonEnv.carbonMetastore
@@ -106,7 +109,6 @@ class CarbonSessionCatalog(
         }
       case _ =>
     }
-    super.lookupRelation(name, alias)
   }
 }
 


### PR DESCRIPTION
# Scenario

Currently we did a concurrent  14 queries on Carbondata. The queries are the same, but on different tables. We have noticed the following scene:

+ A single query took about 5s;
+ In concurrent scenario, each query took about 15s;

By adding checkpoint in the log, we found that there was great latency in starting query jobs in spark.

# Analyze

When we fire a query, Carbondata firstly do some job in the client side, including parse/analyze plans and prepare filtered blocks and inputSplits. Then Carbondata start to submit query job to spark. 

We found in the first step, Carbondata took about 7s in current scenario, but it only took about <1s in single scenario.
By studying the related code, we found the most time consuming method call was  `CarbonSessionCatalog.lookupRelation`. In side this method, it called `super.lookupRelation` twice, which consumed about 3s each time.

# Solution

Carbondata only needs to call the `super.lookupRelation` only once, we need to remove the useless duplicated method call.

I've tested in my environment and it works well. In concurrent scenario, each query takes about 12s (3s saved for the improvement).