### PR TITLE
[CARBONDATA-1337] fix error of 'Problem while intermediate merging' w…

### DIFF
--- a/processing/src/main/java/org/apache/carbondata/processing/sortandgroupby/sortdata/SortIntermediateFileMerger.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/sortandgroupby/sortdata/SortIntermediateFileMerger.java
@@ -17,6 +17,7 @@
 package org.apache.carbondata.processing.sortandgroupby.sortdata;
 
 import java.io.File;
+import java.util.Random;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -84,8 +85,10 @@ public class SortIntermediateFileMerger {
    * @param intermediateFiles
    */
   private void startIntermediateMerging(File[] intermediateFiles) {
+    int index = new Random().nextInt(parameters.getTempFileLocation().length);
+    String chosenTempDir = parameters.getTempFileLocation()[index];
     File file = new File(
-        parameters.getTempFileLocation() + File.separator + parameters.getTableName() + System
+        chosenTempDir + File.separator + parameters.getTableName() + System
             .nanoTime() + CarbonCommonConstants.MERGERD_EXTENSION);
     IntermediateFileMerger merger = new IntermediateFileMerger(parameters, intermediateFiles, file);
     executorService.submit(merger);

--- a/processing/src/main/java/org/apache/carbondata/processing/sortandgroupby/sortdata/SortIntermediateFileMerger.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/sortandgroupby/sortdata/SortIntermediateFileMerger.java
@@ -17,9 +17,9 @@
 package org.apache.carbondata.processing.sortandgroupby.sortdata;
 
 import java.io.File;
-import java.util.Random;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;


### PR DESCRIPTION
…hen loading data

With PR-1198(CARBONDATA-1281), when loading data, there was error occuring, as following:

`2017-07-28 13:10:49,443 - ERROR - org.apache.carbondata.common.logging.impl.StandardLogService.logErrorMessage(StandardLogService.java:143) - pool-17-thread-1 -pool-17-thread-1 Problem while intermediate merging
org.apache.carbondata.processing.sortandgroupby.exception.CarbonSortKeyAndGroupByException: Problem while getting the file
        at org.apache.carbondata.processing.sortandgroupby.sortdata.IntermediateFileMerger.initialize(IntermediateFileMerger.java:168)
        at org.apache.carbondata.processing.sortandgroupby.sortdata.IntermediateFileMerger.call(IntermediateFileMerger.java:110)
        at org.apache.carbondata.processing.sortandgroupby.sortdata.IntermediateFileMerger.call(IntermediateFileMerger.java:37)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
        at java.lang.Thread.run(Thread.java:745)
Caused by: java.io.FileNotFoundException: [Ljava.lang.String;@54218780/carbondata_hundred_million_pr11987419814281939480.merge (No such file or directory)
        at java.io.FileOutputStream.open0(Native Method)
        at java.io.FileOutputStream.open(FileOutputStream.java:270)
        at java.io.FileOutputStream.<init>(FileOutputStream.java:213)
        at java.io.FileOutputStream.<init>(FileOutputStream.java:162)
        at org.apache.carbondata.processing.sortandgroupby.sortdata.IntermediateFileMerger.initialize(IntermediateFileMerger.java:163)
        ... 6 more`

According to @xuchuanyin 's suggestion, it needs to fix the code of method SortIntermediateFileMerger.startIntermediateMerging.
