### PR TITLE
[CARBONDATA-1339] CarbonTableInputFormat should use serialized TableInfo 

### DIFF
--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableInputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableInputFormat.java
@@ -17,6 +17,8 @@
 
 package org.apache.carbondata.hadoop.api;
 
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.util.ArrayList;
@@ -115,7 +117,7 @@ public class CarbonTableInputFormat<T> extends FileInputFormat<Void, T> {
   public static void setTableInfo(Configuration configuration, TableInfo tableInfo)
       throws IOException {
     if (null != tableInfo) {
-      configuration.set(TABLE_INFO, ObjectSerializationUtil.convertObjectToString(tableInfo));
+      configuration.set(TABLE_INFO, ObjectSerializationUtil.encodeToString(tableInfo.serialize()));
     }
   }
 
@@ -124,7 +126,16 @@ public class CarbonTableInputFormat<T> extends FileInputFormat<Void, T> {
    */
   private TableInfo getTableInfo(Configuration configuration) throws IOException {
     String tableInfoStr = configuration.get(TABLE_INFO);
-    return (TableInfo) ObjectSerializationUtil.convertStringToObject(tableInfoStr);
+    if (tableInfoStr == null) {
+      return null;
+    } else {
+      TableInfo output = new TableInfo();
+      output.readFields(
+          new DataInputStream(
+              new ByteArrayInputStream(
+                  ObjectSerializationUtil.decodeStringToBytes(tableInfoStr))));
+      return output;
+    }
   }
 
   /**


### PR DESCRIPTION
When setting TableInfo, CarbonTableInputFormat should use serialized TableInfo. Otherwise it will fail because TableInfo contains Scala list