### PR TITLE
[CARBONDATA-1342] Fixed bugs for spark conf property and debugging in windows

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/locks/ZooKeeperLocking.java
+++ b/core/src/main/java/org/apache/carbondata/core/locks/ZooKeeperLocking.java
@@ -17,7 +17,6 @@
 
 package org.apache.carbondata.core.locks;
 
-import java.io.File;
 import java.util.Collections;
 import java.util.List;
 
@@ -70,8 +69,8 @@ public class ZooKeeperLocking extends AbstractCarbonLock {
   private String lockTypeFolder;
 
   public ZooKeeperLocking(CarbonTableIdentifier tableIdentifier, String lockFile) {
-    this(tableIdentifier.getDatabaseName() + File.separator + tableIdentifier.getTableName(),
-        lockFile);
+    this(tableIdentifier.getDatabaseName() + CarbonCommonConstants.FILE_SEPARATOR + tableIdentifier
+        .getTableName(), lockFile);
   }
 
   /**
@@ -123,7 +122,7 @@ public class ZooKeeperLocking extends AbstractCarbonLock {
   private void createRecursivly(String path) throws KeeperException, InterruptedException {
     try {
       if (zk.exists(path, true) == null && path.length() > 0) {
-        String temp = path.substring(0, path.lastIndexOf(File.separator));
+        String temp = path.substring(0, path.lastIndexOf(CarbonCommonConstants.FILE_SEPARATOR));
         createRecursivly(temp);
         zk.create(path, null, Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
       } else {

--- a/core/src/main/java/org/apache/carbondata/core/metadata/AbsoluteTableIdentifier.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/AbsoluteTableIdentifier.java
@@ -16,7 +16,6 @@
  */
 package org.apache.carbondata.core.metadata;
 
-import java.io.File;
 import java.io.Serializable;
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
@@ -99,8 +98,9 @@ public class AbsoluteTableIdentifier implements Serializable {
   }
 
   public String getTablePath() {
-    return getStorePath() + File.separator + getCarbonTableIdentifier().getDatabaseName() +
-        File.separator + getCarbonTableIdentifier().getTableName();
+    return getStorePath() + CarbonCommonConstants.FILE_SEPARATOR + getCarbonTableIdentifier()
+        .getDatabaseName() + CarbonCommonConstants.FILE_SEPARATOR + getCarbonTableIdentifier()
+        .getTableName();
   }
 
   public String appendWithLocalPrefix(String path) {

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/CommonUtil.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/CommonUtil.scala
@@ -713,13 +713,9 @@ object CommonUtil {
    * @param sparkContext
    */
   def cleanInProgressSegments(storePath: String, sparkContext: SparkContext): Unit = {
-    val prop = CarbonProperties.getInstance().
-      getProperty(CarbonCommonConstants.DATA_MANAGEMENT_DRIVER)
-    if (prop != null) {
-      sparkContext.getConf.set(CarbonCommonConstants.DATA_MANAGEMENT_DRIVER, prop)
-    }
-    val loaderDriver = sparkContext.getConf.get(CarbonCommonConstants.DATA_MANAGEMENT_DRIVER,
-      CarbonCommonConstants.DATA_MANAGEMENT_DRIVER_DEFAULT).toBoolean
+    val loaderDriver = CarbonProperties.getInstance().
+      getProperty(CarbonCommonConstants.DATA_MANAGEMENT_DRIVER,
+        CarbonCommonConstants.DATA_MANAGEMENT_DRIVER_DEFAULT).toBoolean
     if (!loaderDriver) {
       return
     }

--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/steps/DataConverterProcessorStepImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/steps/DataConverterProcessorStepImpl.java
@@ -211,8 +211,9 @@ public class DataConverterProcessorStepImpl extends AbstractDataLoadProcessorSte
       CarbonTableIdentifier identifier =
           configuration.getTableIdentifier().getCarbonTableIdentifier();
       CarbonDataProcessorUtil.renameBadRecordsFromInProgressToNormal(configuration,
-          identifier.getDatabaseName() + File.separator + identifier.getTableName() + File.separator
-              + configuration.getSegmentId() + File.separator + configuration.getTaskNo());
+          identifier.getDatabaseName() + CarbonCommonConstants.FILE_SEPARATOR + identifier
+              .getTableName() + CarbonCommonConstants.FILE_SEPARATOR + configuration.getSegmentId()
+              + CarbonCommonConstants.FILE_SEPARATOR + configuration.getTaskNo());
     }
   }
 

--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/steps/DataConverterProcessorStepImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/steps/DataConverterProcessorStepImpl.java
@@ -180,7 +180,7 @@ public class DataConverterProcessorStepImpl extends AbstractDataLoadProcessorSte
     if (!closed) {
       if (null != badRecordLogger) {
         badRecordLogger.closeStreams();
-        renameBadRecord(configuration);
+        renameBadRecord(badRecordLogger, configuration);
       }
       super.close();
       if (converters != null) {
@@ -195,21 +195,25 @@ public class DataConverterProcessorStepImpl extends AbstractDataLoadProcessorSte
       configuration, RowConverter converter) {
     if (badRecordLogger != null) {
       badRecordLogger.closeStreams();
-      renameBadRecord(configuration);
+      renameBadRecord(badRecordLogger, configuration);
     }
     if (converter != null) {
       converter.finish();
     }
   }
 
-  private static void renameBadRecord(CarbonDataLoadConfiguration configuration) {
-    // rename the bad record in progress to normal
-    CarbonTableIdentifier identifier =
-        configuration.getTableIdentifier().getCarbonTableIdentifier();
-    CarbonDataProcessorUtil.renameBadRecordsFromInProgressToNormal(configuration,
-        identifier.getDatabaseName() + File.separator + identifier.getTableName()
-            + File.separator + configuration.getSegmentId() + File.separator + configuration
-            .getTaskNo());
+  private static void renameBadRecord(BadRecordsLogger badRecordLogger,
+      CarbonDataLoadConfiguration configuration) {
+    // rename operation should be performed only in case either bad reccords loggers is enabled
+    // or bad records redirect is enabled
+    if (badRecordLogger.isBadRecordLoggerEnable() || badRecordLogger.isBadRecordsLogRedirect()) {
+      // rename the bad record in progress to normal
+      CarbonTableIdentifier identifier =
+          configuration.getTableIdentifier().getCarbonTableIdentifier();
+      CarbonDataProcessorUtil.renameBadRecordsFromInProgressToNormal(configuration,
+          identifier.getDatabaseName() + File.separator + identifier.getTableName() + File.separator
+              + configuration.getSegmentId() + File.separator + configuration.getTaskNo());
+    }
   }
 
   @Override protected String getStepName() {

--- a/processing/src/main/java/org/apache/carbondata/processing/surrogatekeysgenerator/csvbased/BadRecordsLogger.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/surrogatekeysgenerator/csvbased/BadRecordsLogger.java
@@ -259,6 +259,14 @@ public class BadRecordsLogger {
     return isDataLoadFail;
   }
 
+  public boolean isBadRecordLoggerEnable() {
+    return badRecordLoggerEnable;
+  }
+
+  public boolean isBadRecordsLogRedirect() {
+    return badRecordsLogRedirect;
+  }
+
   /**
    * closeStreams void
    */


### PR DESCRIPTION
Fixes include:
1. In spark 2, spark conf once set in spark context cannot be modified with the same context again. Therefore removed setting property in spark conf and directly getting the property from carbon properties.
2. Fixed bug of running CarbonSessionExample in windows by removing File.Separator
3. Removed call of namenode after completion of each data load for renaming bad folders