### PR TITLE
[CARBONDATA-1350]Fix the bug of the verification of 'single_pass' when 'SORT_SCOPE'='GLOBAL_SORT'

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
@@ -537,7 +537,7 @@ case class LoadTable(
       val all_dictionary_path = optionsFinal("all_dictionary_path")
       val column_dict = optionsFinal("columndict")
       if (sort_scope.equals("GLOBAL_SORT") &&
-          single_pass.equals("TRUE")) {
+          single_pass.equalsIgnoreCase("true")) {
         sys.error("Global_Sort can't be used with single_pass flow")
       }
       ValidateUtil.validateDateFormat(dateFormat, table, tableName)


### PR DESCRIPTION
The value of option 'single_pass' is coverted to low case, but it uses 'single_pass.equals("TRUE")' to vericate, so it is invalid, and leading to load data unsuccessfully.


