### PR TITLE
[CARBONDATA-1351]Fix NPE of 'ThreadLocalTaskInfo.getCarbonTaskInfo()' When 'SORT_SCOPE'='GLOBAL_SORT' and 'enable.unsafe.columnpage'='true'

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/indexstore/UnsafeMemoryDMStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/UnsafeMemoryDMStore.java
@@ -48,8 +48,7 @@ public class UnsafeMemoryDMStore {
 
   private int rowCount;
 
-  private final long taskId = null != ThreadLocalTaskInfo.getCarbonTaskInfo() ?
-      ThreadLocalTaskInfo.getCarbonTaskInfo().getTaskId() : System.nanoTime();
+  private final long taskId = ThreadLocalTaskInfo.getCarbonTaskInfo().getTaskId();
 
   public UnsafeMemoryDMStore(DataMapSchema[] schema) throws MemoryException {
     this.schema = schema;

--- a/core/src/main/java/org/apache/carbondata/core/util/ThreadLocalTaskInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/ThreadLocalTaskInfo.java
@@ -28,6 +28,11 @@ public class ThreadLocalTaskInfo {
   }
 
   public static CarbonTaskInfo getCarbonTaskInfo() {
+    if (null == threadLocal.get()) {
+      CarbonTaskInfo carbonTaskInfo = new CarbonTaskInfo();
+      carbonTaskInfo.setTaskId(System.nanoTime());
+      ThreadLocalTaskInfo.setCarbonTaskInfo(carbonTaskInfo);
+    }
     return threadLocal.get();
   }
 }


### PR DESCRIPTION
When 'SORT_SCOPE'='GLOBAL_SORT' and 'enable.unsafe.columnpage'='true', it uses native RDD of Spark to load data, the method of 'ThreadLocalTaskInfo.setCarbonTaskInfo(carbonTaskInfo)' in ‘CarbonRDD.compute’ does not be called, so 'ThreadLocalTaskInfo.getCarbonTaskInfo()' will return null in some unsafe related classes, such as: UnsafeFixLengthColumnPage, UnsafeVarLengthColumnPage, UnsafeMemoryDMStore and so on.

Solution: Set the CarbonTaskInfo in the method of 'ThreadLocalTaskInfo.getCarbonTaskInfo()' when 'threadLocal.get()' is null.

