### PR TITLE
[CARBONDATA-1354]Remove the useless restriction of  'single_pass' can not be true when 'SORT_SCOPE'='GLOBAL_SORT'

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestGlobalSortDataLoad.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestGlobalSortDataLoad.scala
@@ -98,7 +98,7 @@ class TestGlobalSortDataLoad extends QueryTest with BeforeAndAfterEach with Befo
 
   // ----------------------------------- Single Pass -----------------------------------
   // Waiting for merge [CARBONDATA-1145]
-  ignore("Test GLOBAL_SORT with SINGLE_PASS") {
+  test("Test GLOBAL_SORT with SINGLE_PASS") {
     sql(s"LOAD DATA LOCAL INPATH '$filePath' INTO TABLE carbon_globalsort " +
       "OPTIONS('SORT_SCOPE'='GLOBAL_SORT', 'SINGLE_PASS'='TRUE')")
 

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchema.scala
@@ -537,10 +537,6 @@ case class LoadTable(
       val complex_delimeter_level2 = optionsFinal("complex_delimiter_level_2")
       val all_dictionary_path = optionsFinal("all_dictionary_path")
       val column_dict = optionsFinal("columndict")
-      if (sort_scope.equals("GLOBAL_SORT") &&
-          single_pass.equals("TRUE")) {
-        sys.error("Global_Sort can't be used with single_pass flow")
-      }
       ValidateUtil.validateDateFormat(dateFormat, table, tableName)
       ValidateUtil.validateSortScope(table, sort_scope)
 


### PR DESCRIPTION
Now when 'SORT_SCOPE'='GLOBAL_SORT', 'single_pass' can be 'true', so remove the useless restriction

