### PR TITLE
[CARBONDATA-1205] Use Spark 2.1 as default compilation in parent pom

### DIFF
--- a/integration/spark-common-test/pom.xml
+++ b/integration/spark-common-test/pom.xml
@@ -137,7 +137,6 @@
         <version>1.0</version>
         <!-- Note config is repeated in surefire config -->
         <configuration>
-          <skipTests>false</skipTests>
           <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
           <junitxml>.</junitxml>
           <filereports>CarbonTestSuite.txt</filereports>

--- a/integration/spark2/pom.xml
+++ b/integration/spark2/pom.xml
@@ -143,7 +143,6 @@
         <version>1.0</version>
         <!-- Note config is repeated in surefire config -->
         <configuration>
-          <skipTests>false</skipTests>
           <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
           <junitxml>.</junitxml>
           <filereports>CarbonTestSuite.txt</filereports>

--- a/pom.xml
+++ b/pom.xml
@@ -386,9 +386,6 @@
     </profile>
     <profile>
       <id>spark-1.6</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
       <properties>
         <spark.version>1.6.2</spark.version>
         <scala.binary.version>2.10</scala.binary.version>
@@ -401,6 +398,9 @@
     </profile>
     <profile>
       <id>spark-2.1</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
       <properties>
         <spark.version>2.1.0</spark.version>
         <scala.binary.version>2.11</scala.binary.version>


### PR DESCRIPTION
From 1.2.0, there are many features developing based on Spark 2.1, so use Spark2.1 as default compilation in parent pom.
