### PR TITLE
[CARBONDATA-1366]add an option 'carbon.global.sort.rdd.storage.level' to configure rdd storage level when sort_scope=global_sort

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -1308,7 +1308,8 @@ public final class CarbonCommonConstants {
    * Which storage level to persist rdd when sort_scope=global_sort
    */
   @CarbonProperty
-  public static final String CARBON_GLOBAL_SORT_RDD_STORAGE_LEVEL = "carbon.global.sort.rdd.storage.level";
+  public static final String CARBON_GLOBAL_SORT_RDD_STORAGE_LEVEL =
+      "carbon.global.sort.rdd.storage.level";
 
   /**
    * default value for carbon.global.sort.rdd.storage.level

--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -1312,7 +1312,11 @@ public final class CarbonCommonConstants {
       "carbon.global.sort.rdd.storage.level";
 
   /**
-   * default value for carbon.global.sort.rdd.storage.level
+   * The default value(MEMORY_ONLY) is designed for executors with big memory, if user's executor
+   * has less memory, set the CARBON_GLOBAL_SORT_RDD_STORAGE_LEVEL to MEMORY_AND_DISK_SER or
+   * other storage level to correspond to different environment.
+   * You can get more recommendations about storage level in spark website:
+   * http://spark.apache.org/docs/latest/rdd-programming-guide.html#rdd-persistence.
    */
   public static final String CARBON_GLOBAL_SORT_RDD_STORAGE_LEVEL_DEFAULT = "MEMORY_ONLY";
 

--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -1304,6 +1304,17 @@ public final class CarbonCommonConstants {
    */
   public static final String CARBON_USE_MULTI_TEMP_DIR_DEFAULT = "false";
 
+  /**
+   * Which storage level to persist rdd when sort_scope=global_sort
+   */
+  @CarbonProperty
+  public static final String CARBON_GLOBAL_SORT_RDD_STORAGE_LEVEL = "carbon.global.sort.rdd.storage.level";
+
+  /**
+   * default value for carbon.global.sort.rdd.storage.level
+   */
+  public static final String CARBON_GLOBAL_SORT_RDD_STORAGE_LEVEL_DEFAULT = "MEMORY_ONLY";
+
   private CarbonCommonConstants() {
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
@@ -867,7 +867,7 @@ public final class CarbonProperties {
         CarbonCommonConstants.CARBON_USE_MULTI_TEMP_DIR_DEFAULT);
     boolean validateBoolean = CarbonUtil.validateBoolean(usingMultiDirStr);
     if (!validateBoolean) {
-      LOGGER.info("The carbon.use.multiple.temp.dir configuration value is invalid."
+      LOGGER.error("The carbon.use.multiple.temp.dir configuration value is invalid."
           + "Configured value: \"" + usingMultiDirStr + "\"."
           + "Data Load will not use multiple temp directories.");
       usingMultiDirStr = CarbonCommonConstants.CARBON_USE_MULTI_TEMP_DIR_DEFAULT;
@@ -884,7 +884,7 @@ public final class CarbonProperties {
         CarbonCommonConstants.CARBON_GLOBAL_SORT_RDD_STORAGE_LEVEL_DEFAULT);
     boolean validateStorageLevel = CarbonUtil.isValidStorageLevel(storageLevel);
     if (!validateStorageLevel) {
-      LOGGER.info("The " + CarbonCommonConstants.CARBON_GLOBAL_SORT_RDD_STORAGE_LEVEL
+      LOGGER.error("The " + CarbonCommonConstants.CARBON_GLOBAL_SORT_RDD_STORAGE_LEVEL
           + " configuration value is invalid. It will use default storage level("
           + CarbonCommonConstants.CARBON_GLOBAL_SORT_RDD_STORAGE_LEVEL_DEFAULT
           + ") to persist rdd.");

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
@@ -876,6 +876,24 @@ public final class CarbonProperties {
   }
 
   /**
+   * Return valid storage level
+   * @return String
+   */
+  public String getGlobalSortRddStorageLevel() {
+    String storageLevel = getProperty(CarbonCommonConstants.CARBON_GLOBAL_SORT_RDD_STORAGE_LEVEL,
+        CarbonCommonConstants.CARBON_GLOBAL_SORT_RDD_STORAGE_LEVEL_DEFAULT);
+    boolean validateStorageLevel = CarbonUtil.isValidStorageLevel(storageLevel);
+    if (!validateStorageLevel) {
+      LOGGER.info("The " + CarbonCommonConstants.CARBON_GLOBAL_SORT_RDD_STORAGE_LEVEL
+          + " configuration value is invalid. It will use default storage level("
+          + CarbonCommonConstants.CARBON_GLOBAL_SORT_RDD_STORAGE_LEVEL_DEFAULT
+          + ") to persist rdd.");
+      storageLevel = CarbonCommonConstants.CARBON_GLOBAL_SORT_RDD_STORAGE_LEVEL_DEFAULT;
+    }
+    return storageLevel.toUpperCase();
+  }
+
+  /**
    * returns true if carbon property
    * @param key
    * @return

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
@@ -1724,27 +1724,16 @@ public final class CarbonUtil {
     }
     switch (storageLevel.toUpperCase()) {
       case "DISK_ONLY":
-        return true;
       case "DISK_ONLY_2":
-        return true;
       case "MEMORY_ONLY":
-        return true;
       case "MEMORY_ONLY_2":
-        return true;
       case "MEMORY_ONLY_SER":
-        return true;
       case "MEMORY_ONLY_SER_2":
-        return true;
       case "MEMORY_AND_DISK":
-        return true;
       case "MEMORY_AND_DISK_2":
-        return true;
       case "MEMORY_AND_DISK_SER":
-        return true;
       case "MEMORY_AND_DISK_SER_2":
-        return true;
       case "OFF_HEAP":
-        return true;
       case "NONE":
         return true;
       default:

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
@@ -1714,6 +1714,45 @@ public final class CarbonUtil {
   }
 
   /**
+   * validate the storage level
+   * @param storageLevel
+   * @return boolean
+   */
+  public static boolean isValidStorageLevel(String storageLevel) {
+    if (null == storageLevel || storageLevel.trim().equals("")) {
+      return false;
+    }
+    switch (storageLevel.toUpperCase()) {
+      case "DISK_ONLY":
+        return true;
+      case "DISK_ONLY_2":
+        return true;
+      case "MEMORY_ONLY":
+        return true;
+      case "MEMORY_ONLY_2":
+        return true;
+      case "MEMORY_ONLY_SER":
+        return true;
+      case "MEMORY_ONLY_SER_2":
+        return true;
+      case "MEMORY_AND_DISK":
+        return true;
+      case "MEMORY_AND_DISK_2":
+        return true;
+      case "MEMORY_AND_DISK_SER":
+        return true;
+      case "MEMORY_AND_DISK_SER_2":
+        return true;
+      case "OFF_HEAP":
+        return true;
+      case "NONE":
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  /**
    * validate teh batch size
    *
    * @param value

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/load/DataLoadProcessBuilderOnSpark.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/load/DataLoadProcessBuilderOnSpark.scala
@@ -32,6 +32,7 @@ import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.datastore.row.CarbonRow
 import org.apache.carbondata.core.statusmanager.LoadMetadataDetails
+import org.apache.carbondata.core.util.CarbonProperties
 import org.apache.carbondata.processing.csvload.{CSVInputFormat, StringArrayWritable}
 import org.apache.carbondata.processing.model.CarbonLoadModel
 import org.apache.carbondata.processing.newflow.DataLoadProcessBuilder
@@ -112,7 +113,8 @@ object DataLoadProcessBuilderOnSpark {
     // Because if the number of partitions greater than 1, there will be action operator(sample) in
     // sortBy operator. So here we cache the rdd to avoid do input and convert again.
     if (numPartitions > 1) {
-      convertRDD.persist(StorageLevel.MEMORY_AND_DISK_SER)
+      convertRDD.persist(StorageLevel.fromString(
+        CarbonProperties.getInstance().getGlobalSortRddStorageLevel()))
     }
 
     import scala.reflect.classTag

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/load/DataLoadProcessBuilderOnSpark.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/load/DataLoadProcessBuilderOnSpark.scala
@@ -112,7 +112,7 @@ object DataLoadProcessBuilderOnSpark {
     // Because if the number of partitions greater than 1, there will be action operator(sample) in
     // sortBy operator. So here we cache the rdd to avoid do input and convert again.
     if (numPartitions > 1) {
-      convertRDD.persist(StorageLevel.MEMORY_AND_DISK)
+      convertRDD.persist(StorageLevel.MEMORY_AND_DISK_SER)
     }
 
     import scala.reflect.classTag


### PR DESCRIPTION
My testing env and configs are as followings:

**Env:**
6 executors, 9G mem + 6 cores per executor 

**Configs:**
SINGLE_PASS=true
SORT_SCOPE=GLOBAL_SORT
spark.memory.fraction=0.5

if using 'convertRDD.persist(StorageLevel.MEMORY_AND_DISK_SER)' in method 'org.apache.carbondata.spark.load.DataLoadProcessBuilderOnSpark.loadDataUsingGlobalSort', it takes about **7.2** min to load 144136697 lines (10.9 G parquet files), and if using 'convertRDD.persist(StorageLevel.MEMORY_AND_DISK)', it takes about **9.5** min to load 144136697 lines.

So add an option 'carbon.global.sort.rdd.storage.level' for users to configure rdd storage level according to their different env, and the default value of this option is MEMORY_ONLY.