### PR TITLE
[CARBONDATA-1367] Change module dependency from spark1 to spark2

### DIFF
--- a/examples/flink/pom.xml
+++ b/examples/flink/pom.xml
@@ -52,12 +52,12 @@
     </dependency>
     <dependency>
       <groupId>org.apache.carbondata</groupId>
-      <artifactId>carbondata-spark</artifactId>
+      <artifactId>carbondata-spark2</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.carbondata</groupId>
-      <artifactId>carbondata-examples-spark</artifactId>
+      <artifactId>carbondata-examples-spark2</artifactId>
       <version>${project.version}</version>
     </dependency>
   </dependencies>

--- a/examples/spark2/src/main/scala/org/apache/carbondata/examples/util/ExampleUtils.scala
+++ b/examples/spark2/src/main/scala/org/apache/carbondata/examples/util/ExampleUtils.scala
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.examples.util
+
+import java.io.File
+
+import org.apache.spark.SparkConf
+import org.apache.spark.SparkContext
+import org.apache.spark.sql.CarbonSession
+import org.apache.spark.sql.SaveMode
+import org.apache.spark.sql.SparkSession
+
+import org.apache.carbondata.core.util.CarbonProperties
+
+// scalastyle:off println
+
+object ExampleUtils {
+
+  def currentPath: String = new File(this.getClass.getResource("/").getPath + "../../")
+      .getCanonicalPath
+  val storeLocation = currentPath + "/target/store"
+
+
+  /**
+   * compatible for carbondata-examples-spark
+   * @param appName
+   * @return
+   */
+  def createCarbonContext(appName: String): CarbonSession = {
+    val sc = new SparkContext(new SparkConf()
+        .setAppName(appName)
+        .setMaster("local[2]"))
+    sc.setLogLevel("ERROR")
+
+    println(s"Starting $appName using spark version ${sc.version}")
+
+    val warehouse = s"$currentPath/target/warehouse"
+    val metastoreDb = s"$currentPath/target/carbonmetastore"
+    import org.apache.spark.sql.CarbonSession._
+    val cc = SparkSession
+      .builder()
+      .master("local[2]")
+      .appName(appName)
+      .config("spark.sql.warehouse.dir", warehouse)
+      .config("spark.driver.host", "localhost")
+      .getOrCreateCarbonSession(storeLocation, metastoreDb)
+      .asInstanceOf[CarbonSession]
+
+    CarbonProperties.getInstance()
+      .addProperty("carbon.storelocation", storeLocation)
+    cc
+  }
+
+  /**
+   * This func will write a sample CarbonData file containing following schema:
+   * c1: String, c2: String, c3: Double
+   * Returns table path
+   */
+  def writeSampleCarbonFile(cc: CarbonSession, tableName: String, numRows: Int = 1000): String = {
+    cc.sql(s"DROP TABLE IF EXISTS $tableName")
+    writeDataframe(cc, tableName, numRows, SaveMode.Overwrite)
+    s"$storeLocation/default/$tableName"
+  }
+
+  /**
+   * This func will append data to the CarbonData file
+   * Returns table path
+   */
+  def appendSampleCarbonFile(cc: CarbonSession, tableName: String, numRows: Int = 1000): String = {
+    writeDataframe(cc, tableName, numRows, SaveMode.Append)
+    s"$storeLocation/default/$tableName"
+  }
+
+  /**
+   * create a new dataframe and write to CarbonData file, based on save mode
+   */
+  private def writeDataframe(
+      cc: CarbonSession, tableName: String, numRows: Int, mode: SaveMode): Unit = {
+
+    val rdd = cc.sparkContext.parallelize(1 to numRows, 2).map(x => ("a", "b", x))
+    val df = cc.sqlContext.createDataFrame(rdd)
+
+    // save dataframe directl to carbon file without tempCSV
+    df.write
+      .format("carbondata")
+      .option("tableName", tableName)
+      .option("compress", "true")
+      .option("tempCSV", "false")
+      .mode(mode)
+      .save()
+  }
+
+  def cleanSampleCarbonFile(cc: CarbonSession, tableName: String): Unit = {
+    cc.sql(s"DROP TABLE IF EXISTS $tableName")
+  }
+}
+// scalastyle:on println
+


### PR DESCRIPTION
# Problems
When compiling Carbondata with profile spark-2.1, `carbondata-examples-flink` will be compiled too. But this module depends on `carbondata-example-spark` and `sparkdata-spark` which will be compiled with profile-1.6, so we need to fix it.

# Solution
+ Change module dependency from spark1 to spark2.

+ Copy the `ExampleUtils.scala` from `carbondata-examples-spark` to ``carbondata-examples-spark2` and replace `CarbonContext` with `CarbonSession`.
