### PR TITLE
[CARBONDATA-1368] Fix HDFS lock issue in SDV cluster

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/locks/HdfsFileLock.java
+++ b/core/src/main/java/org/apache/carbondata/core/locks/HdfsFileLock.java
@@ -73,6 +73,14 @@ public class HdfsFileLock extends AbstractCarbonLock {
   }
 
   /**
+   * @param lockFilePath
+   */
+  public HdfsFileLock(String lockFilePath) {
+    this.location = lockFilePath;
+    initRetry();
+  }
+
+  /**
    * @param tableIdentifier
    * @param lockFile
    */

--- a/integration/spark-common-cluster-test/src/test/scala/org/apache/carbondata/cluster/sdv/generated/AlterTableTestCase.scala
+++ b/integration/spark-common-cluster-test/src/test/scala/org/apache/carbondata/cluster/sdv/generated/AlterTableTestCase.scala
@@ -1073,7 +1073,7 @@ class AlterTableTestCase extends QueryTest with BeforeAndAfterAll {
     prop.addProperty("carbon.enable.auto.load.merge", "false")
     prop.addProperty("carbon.bad.records.action", "FORCE")
     prop.addProperty(CarbonCommonConstants.CARBON_BADRECORDS_LOC,
-      TestQueryExecutor.storeLocation+"/baaaaaaadrecords")
+      TestQueryExecutor.warehouse+"/baaaaaaadrecords")
   }
 
   override def afterAll: Unit = {

--- a/integration/spark-common-cluster-test/src/test/scala/org/apache/carbondata/cluster/sdv/generated/DataLoadingTestCase.scala
+++ b/integration/spark-common-cluster-test/src/test/scala/org/apache/carbondata/cluster/sdv/generated/DataLoadingTestCase.scala
@@ -1471,6 +1471,6 @@ class DataLoadingTestCase extends QueryTest with BeforeAndAfterAll {
   override protected def beforeAll(): Unit = {
     sql(s"""drop table if exists uniqdata""").collect
     CarbonProperties.getInstance().addProperty(CarbonCommonConstants.CARBON_BADRECORDS_LOC,
-      TestQueryExecutor.storeLocation+"/baaaaaaadrecords")
+      TestQueryExecutor.warehouse + "/baaaaaaadrecords")
   }
 }

--- a/integration/spark-common-cluster-test/src/test/scala/org/apache/spark/sql/common/util/QueryTest.scala
+++ b/integration/spark-common-cluster-test/src/test/scala/org/apache/spark/sql/common/util/QueryTest.scala
@@ -125,9 +125,7 @@ class QueryTest extends PlanTest with Suite {
 
   val sqlContext: SQLContext = TestQueryExecutor.INSTANCE.sqlContext
 
-  val storeLocation = TestQueryExecutor.storeLocation
   val resourcesPath = TestQueryExecutor.resourcesPath
-  val integrationPath = TestQueryExecutor.integrationPath
 }
 
 object QueryTest {

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/test/ResourceRegisterAndCopier.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/test/ResourceRegisterAndCopier.scala
@@ -47,7 +47,8 @@ object ResourceRegisterAndCopier {
     if (!file.exists()) {
       sys.error(s"""Provided path $hdfsPath does not exist""")
     }
-    val lock = new HdfsFileLock("", "resource.lock")
+    LOGGER.audit("Try downloading resource data")
+    val lock = new HdfsFileLock(hdfsPath + "/resource.lock")
     var bool = false
     try {
       bool = lockWithRetries(lock)

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/test/TestQueryExecutor.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/test/TestQueryExecutor.scala
@@ -71,10 +71,6 @@ object TestQueryExecutor {
   }
 
   val resourcesPath = if (hdfsUrl.startsWith("hdfs://")) {
-    System.setProperty(CarbonCommonConstants.HDFS_TEMP_LOCATION, hdfsUrl)
-    ResourceRegisterAndCopier.
-      copyResourcesifNotExists(hdfsUrl, s"$integrationPath/spark-common-test/src/test/resources",
-        s"$integrationPath//spark-common-cluster-test/src/test/resources/testdatafileslist.txt")
     hdfsUrl
   } else {
     s"$integrationPath/spark-common-test/src/test/resources"


### PR DESCRIPTION
HDFS lock issue in SDV cluster
All runs share the same lock so resulting some test fails randomly. This PR fix takes the lock from the corresponding store location.