### PR TITLE
[CARBONDATA-1372]Update the documentation

### DIFF
--- a/docs/ddl-operation-on-carbondata.md
+++ b/docs/ddl-operation-on-carbondata.md
@@ -52,7 +52,7 @@ The following DDL operations are supported in CarbonData :
 |---------------|-----------------------------------------------------------------------------------------------------------------------------------------------|----------|
 | db_name | Name of the database. Database name should consist of alphanumeric characters and underscore(\_) special character. | Yes |
 | field_list | Comma separated List of fields with data type. The field names should consist of alphanumeric characters and underscore(\_) special character. | No |
-| table_name | The name of the table in Database. Table Name should consist of alphanumeric characters and underscore(\_) special character. | No |
+| table_name | The name of the table in Database. Table name should consist of alphanumeric characters and underscore(\_) special character. | No |
 | STORED BY | "org.apache.carbondata.format", identifies and creates a CarbonData table. | No |
 | TBLPROPERTIES | List of CarbonData table properties. |  |
 

--- a/docs/ddl-operation-on-carbondata.md
+++ b/docs/ddl-operation-on-carbondata.md
@@ -50,11 +50,11 @@ The following DDL operations are supported in CarbonData :
 
 | Parameter | Description | Optional |
 |---------------|-----------------------------------------------------------------------------------------------------------------------------------------------|----------|
-| db_name | Name of the database. Database name should consist of alphanumeric characters and underscore(\_) special character. | Yes |
-| field_list | Comma separated List of fields with data type. The field names should consist of alphanumeric characters and underscore(\_) special character. | No |
-| table_name | The name of the table in Database. Table name should consist of alphanumeric characters and underscore(\_) special character. | No |
-| STORED BY | "org.apache.carbondata.format", identifies and creates a CarbonData table. | No |
-| TBLPROPERTIES | List of CarbonData table properties. |  |
+| db_name | Name of the database. Database name should consist of alphanumeric characters and underscore(\_) special character. | YES |
+| field_list | Comma separated List of fields with data type. The field names should consist of alphanumeric characters and underscore(\_) special character. | NO |
+| table_name | The name of the table in Database. Table name should consist of alphanumeric characters and underscore(\_) special character. | NO |
+| STORED BY | "org.apache.carbondata.format", identifies and creates a CarbonData table. | NO |
+| TBLPROPERTIES | List of CarbonData table properties. | YES |
 
 ### Usage Guidelines
 
@@ -151,7 +151,7 @@ The following DDL operations are supported in CarbonData :
 ### Parameter Description
 | Parameter  | Description                                                                               | Optional |
 |------------|-------------------------------------------------------------------------------------------|----------|
-| IN db_Name | Name of the database. Required only if tables of this specific database are to be listed. | Yes      |
+| IN db_Name | Name of the database. Required only if tables of this specific database are to be listed. | YES      |
 
 ### Example:
 ```
@@ -170,11 +170,11 @@ This command is used to rename the existing table.
 ```
 
 #### Parameter Description
-| Parameter     | Description                                                                                   |
-|---------------|-----------------------------------------------------------------------------------------------|
-| db_Name       | Name of the database. If this parameter is left unspecified, the current database is selected.|
-|table_name     | Name of the existing table.                                                                   |
-|new_table_name | New table name for the existing table.                                                        |
+| Parameter     | Description                                                                                   | Optional |
+|---------------|-----------------------------------------------------------------------------------------------|----------|
+| db_Name       | Name of the database. If this parameter is left unspecified, the current database is selected.|   YES    |
+|table_name     | Name of the existing table.                                                                   |   NO     |
+|new_table_name | New table name for the existing table.                                                        |   NO     |
 
 #### Usage Guidelines
 
@@ -204,11 +204,11 @@ This command is used to add a new column to the existing table.
 ```
 
 #### Parameter Description
-| Parameter          | Description                                                                                               |
-|--------------------|-----------------------------------------------------------------------------------------------------------|
-| db_Name            | Name of the database. If this parameter is left unspecified, the current database is selected.            |
-| table_name         | Name of the existing table.                                                                               |
-| col_name data_type | Name of comma-separated column with data type. Column names contain letters, digits, and underscores (\_). |
+| Parameter        | Description                                                                                               |Optional|
+|------------------|-----------------------------------------------------------------------------------------------------------|------------|
+|db_Name           | Name of the database. If this parameter is left unspecified, the current database is selected.            |YES|
+|table_name        | Name of the existing table.                                                                               |NO |
+|col_name data_type| Name of comma-separated column with data type. Column names contain letters, digits, and underscores (\_). |NO |
 
 NOTE: Do not name the column after name, tupleId, PositionId, and PositionReference when creating Carbon tables because they are used internally by UPDATE, DELETE, and secondary index.
 
@@ -251,11 +251,11 @@ This command is used to delete a existing column or multiple columns in a table.
 ```
 
 #### Parameter Description
-| Parameter  | Description                                                                                              |
-|------------|----------------------------------------------------------------------------------------------------------|
-| db_Name    | Name of the database. If this parameter is left unspecified, the current database is selected.           |
-| table_name | Name of the existing table.                                                                              |
-| col_name   | Name of comma-separated column with data type. Column names contain letters, digits, and underscores (\_) |
+| Parameter  | Description                                                                                              | Optional |
+|------------|----------------------------------------------------------------------------------------------------------|----------|
+| db_Name    | Name of the database. If this parameter is left unspecified, the current database is selected.           |  YES     |
+| table_name | Name of the existing table.                                                                              |  NO      |
+| col_name   | Name of comma-separated column with data type. Column names contain letters, digits, and underscores (\_) | NO      |
 
 #### Usage Guidelines
 
@@ -295,12 +295,12 @@ This command is used to change the data type from INT to BIGINT or decimal preci
 ```
 
 #### Parameter Description
-| Parameter           | Description                                                                                               |
-|---------------------|-----------------------------------------------------------------------------------------------------------|
-| db_Name             | Name of the database. If this parameter is left unspecified, the current database is selected.            |
-| table_name          | Name of the existing table.                                                                               |
-| col_name            | Name of comma-separated column with data type. Column names contain letters, digits, and underscores (\_). |
-| changed_column_type | The change in the data type.                                                                              |
+| Parameter           | Description                                                                                               |Optional|
+|---------------------|-----------------------------------------------------------------------------------------------------------|-------|
+| db_Name             | Name of the database. If this parameter is left unspecified, the current database is selected.            |  YES  |
+| table_name          | Name of the existing table.                                                                               |  NO |
+| col_name            | Name of comma-separated column with data type. Column names contain letters, digits, and underscores (\_). | NO |
+| changed_column_type | The change in the data type.                                                                              |  NO |
 
 #### Usage Guidelines
 

--- a/docs/ddl-operation-on-carbondata.md
+++ b/docs/ddl-operation-on-carbondata.md
@@ -281,12 +281,9 @@ If the table contains 4 columns namely a1, b1, c1, and d1.
 - **To delete multiple columns:**
 
 ```
-   ALTER TABLE carbon DROP COLUMNS (b1,c1);
+   ALTER TABLE carbon DROP COLUMNS (c1,d1);
 ```
 
-```
-   ALTER TABLE carbon DROP COLUMNS (b1,c1);
-```
 
 ### **CHANGE DATA TYPE**
 

--- a/docs/dml-operation-on-carbondata.md
+++ b/docs/dml-operation-on-carbondata.md
@@ -478,7 +478,7 @@ column1 = 'USA');
 ```
 
 ```
-DELETE FROM columncarbonTable1 WHERE column2 >= 4
+DELETE FROM columncarbonTable1 WHERE column2 >= 4;
 ```
 
 **The Status Success/Failure shall be captured in the driver log and the client.**

--- a/docs/dml-operation-on-carbondata.md
+++ b/docs/dml-operation-on-carbondata.md
@@ -305,7 +305,7 @@ SHOW SEGMENTS FOR Table [db_name.]table_name LIMIT number_of_segments
 After you retrieve the segment ID of the segment that you want to delete, execute the following command to delete the selected segment.
 
 ```
-DELETE FROM TABLE [db_name.]table_name WHERE SEGMENT.ID IN (segment_id1, segments_id2, ....)
+DELETE FROM TABLE [db_name.]table_name WHERE SEGMENT.ID IN (segment_id1, segments_id2, ...)
 ```
 
 ### Parameter Description
@@ -356,7 +356,7 @@ This command will allow to update the carbon table based on the column expressio
 ```
  UPDATE <table_name>
  SET (column_name1, column_name2, ... column_name n) =
- (column1_expression , column2_expression . .. column n_expression )
+ (column1_expression , column2_expression, ... column n_expression )
  [ WHERE { <filter_condition> } ];
 ```
 
@@ -364,7 +364,7 @@ alternatively the following the command can also be used for updating the Carbon
 
 ```
 UPDATE <table_name>
-SET (column_name1, column_name2,) =
+SET (column_name1, column_name2) =
 (select sourceColumn1, sourceColumn2 from sourceTable
 [ WHERE { <filter_condition> } ] )
 [ WHERE { <filter_condition> } ];

--- a/docs/installation-guide.md
+++ b/docs/installation-guide.md
@@ -96,7 +96,7 @@ To get started with CarbonData : [Quick Start](quick-start-guide.md), [DDL Opera
 
 2. Copy the `./conf/carbon.properties.template` file from CarbonData repository to `$SPARK_HOME/conf/` folder and rename the file to `carbon.properties`.
 
-3. Create `tar,gz` file of carbonlib folder and move it inside the carbonlib folder.
+3. Create `tar.gz` file of carbonlib folder and move it inside the carbonlib folder.
 
 ```
 cd $SPARK_HOME

--- a/docs/quick-start-guide.md
+++ b/docs/quick-start-guide.md
@@ -84,7 +84,7 @@ scala>carbon.sql("CREATE TABLE
 ###### Loading Data to a Table
 
 ```
-scala>carbon.sql("LOAD DATA INPATH 'sample.csv file path'
+scala>carbon.sql("LOAD DATA INPATH '/path/to/sample.csv'
                   INTO TABLE test_table")
 ```
 **NOTE**: Please provide the real file path of `sample.csv` for the above script.

--- a/docs/quick-start-guide.md
+++ b/docs/quick-start-guide.md
@@ -153,7 +153,7 @@ scala>cc.sql("LOAD DATA INPATH 'sample.csv file path'
 ```
 **NOTE**: Please provide the real file path of `sample.csv` for the above script.
 
-###### Query Data from a Table
+###### Querying Data from a Table
 
 ```
 scala>cc.sql("SELECT * FROM test_table").show()


### PR DESCRIPTION
1.   rename file path
I rename sample.csv file path in the example of documentation.   
It is more easily for users to replace the file path with their real file path of sample.csv

2. keep consistency in documentation   
Query=>Querying   
keep consistency with creating and loading