### PR TITLE
[CARBONDATA-1373] Enhance update performance by increasing parallelism

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -539,6 +539,10 @@ public final class CarbonCommonConstants {
    */
   public static final String UNDERSCORE = "_";
   /**
+   * DASH
+   */
+  public static final String DASH = "-";
+  /**
    * POINT
    */
   public static final String POINT = ".";
@@ -1319,6 +1323,20 @@ public final class CarbonCommonConstants {
    * http://spark.apache.org/docs/latest/rdd-programming-guide.html#rdd-persistence.
    */
   public static final String CARBON_GLOBAL_SORT_RDD_STORAGE_LEVEL_DEFAULT = "MEMORY_ONLY";
+
+  /**
+   * property for configuring parallelism per segment when doing an update. Increase this
+   * value will avoid data screw problem for a large segment.
+   * Refer to CARBONDATA-1373 for more details.
+   */
+  @CarbonProperty
+  public static final String CARBON_UPDATE_SEGMENT_PARALLELISM =
+      "carbon.update.segment.parallelism";
+
+  /**
+   * In default we will not optimize the update
+   */
+  public static final String CARBON_UPDATE_SEGMENT_PARALLELISM_DEFAULT = "1";
 
   private CarbonCommonConstants() {
   }

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
@@ -894,6 +894,38 @@ public final class CarbonProperties {
   }
 
   /**
+   * Returns parallelism for segment update
+   * @return int
+   */
+  public int getParallelismForSegmentUpdate() {
+    int parallelism = Integer.parseInt(
+        CarbonCommonConstants.CARBON_UPDATE_SEGMENT_PARALLELISM_DEFAULT);
+    boolean isInvalidValue = false;
+    try {
+      String strParallelism = getProperty(CarbonCommonConstants.CARBON_UPDATE_SEGMENT_PARALLELISM,
+          CarbonCommonConstants.CARBON_UPDATE_SEGMENT_PARALLELISM_DEFAULT);
+      parallelism = Integer.parseInt(strParallelism);
+      if (parallelism <= 0 || parallelism > 1000) {
+        isInvalidValue = true;
+      }
+    } catch (NumberFormatException e) {
+      isInvalidValue = true;
+    }
+
+    if (isInvalidValue) {
+      LOGGER.error("The specified value for property "
+          + CarbonCommonConstants.CARBON_UPDATE_SEGMENT_PARALLELISM
+          + " is incorrect. Correct value should be in range of 0 - 1000."
+          + " Taking the default value: "
+          + CarbonCommonConstants.CARBON_UPDATE_SEGMENT_PARALLELISM_DEFAULT);
+      parallelism = Integer.parseInt(
+          CarbonCommonConstants.CARBON_UPDATE_SEGMENT_PARALLELISM_DEFAULT);
+    }
+
+    return parallelism;
+  }
+
+  /**
    * returns true if carbon property
    * @param key
    * @return

--- a/docs/configuration-parameters.md
+++ b/docs/configuration-parameters.md
@@ -74,7 +74,7 @@ This section provides the details of all the configurations required for CarbonD
 | carbon.horizontal.compaction.enable | true | This property is used to turn ON/OFF horizontal compaction. After every DELETE and UPDATE statement, horizontal compaction may occur in case the delta (DELETE/ UPDATE) files becomes more than specified threshold. |  |
 | carbon.horizontal.UPDATE.compaction.threshold | 1 | This property specifies the threshold limit on number of UPDATE delta files within a segment. In case the number of delta files goes beyond the threshold, the UPDATE delta files within the segment becomes eligible for horizontal compaction and compacted into single UPDATE delta file. | Values between 1 to 10000. |
 | carbon.horizontal.DELETE.compaction.threshold | 1 | This property specifies the threshold limit on number of DELETE delta files within a block of a segment. In case the number of delta files goes beyond the threshold, the DELETE delta files for the particular block of the segment becomes eligible for horizontal compaction and compacted into single DELETE delta file. | Values between 1 to 10000. |
-
+| carbon.update.segment.parallelism | 1 | This property specifies the parallelism for each segment during update. If there are segments that contain too many records to update and the spark job encounter data-spill related errors, it is better to increase this property value. It is recommended to set this value to a multiple of the number of executors for balance. | Values between 1 to 1000. |
   
 
 * **Query Configuration**

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/UpdateDataLoad.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/UpdateDataLoad.scala
@@ -28,6 +28,7 @@ import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.statusmanager.LoadMetadataDetails
 import org.apache.carbondata.processing.model.CarbonLoadModel
 import org.apache.carbondata.processing.newflow.DataLoadExecutor
+import org.apache.carbondata.spark.load.CarbonLoaderUtil
 
 /**
  * Data load in case of update command .
@@ -62,6 +63,8 @@ object UpdateDataLoad {
       case e: Exception =>
         LOGGER.error(e)
         throw e
+    } finally {
+      CarbonLoaderUtil.deleteLocalDataLoadFolderLocation(carbonLoadModel, false)
     }
   }
 

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -51,7 +51,7 @@ import org.apache.carbondata.core.metadata.schema.partition.PartitionType
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable
 import org.apache.carbondata.core.mutate.CarbonUpdateUtil
 import org.apache.carbondata.core.scan.partition.PartitionUtil
-import org.apache.carbondata.core.statusmanager.LoadMetadataDetails
+import org.apache.carbondata.core.statusmanager.{LoadMetadataDetails, SegmentStatusManager}
 import org.apache.carbondata.core.util.{ByteUtil, CarbonProperties}
 import org.apache.carbondata.core.util.path.CarbonStorePath
 import org.apache.carbondata.processing.csvload.{BlockDetails, CSVInputFormat, StringArrayWritable}
@@ -585,7 +585,7 @@ object CarbonDataRDDFactory {
       def loadDataFrameForUpdate(): Unit = {
         val segmentUpdateParallelism = CarbonProperties.getInstance().getParallelismForSegmentUpdate
 
-        def triggerDataLoadForSegment(key: String,
+        def triggerDataLoadForSegment(key: String, taskNo: Int,
             iter: Iterator[Row]): Iterator[(String, (LoadMetadataDetails, ExecutionErrors))] = {
           val rddResult = new updateResultImpl()
           val LOGGER = LogServiceFactory.getLogService(this.getClass.getName)
@@ -595,18 +595,8 @@ object CarbonDataRDDFactory {
             val executionErrors = new ExecutionErrors(FailureCauses.NONE, "")
             var uniqueLoadStatusId = ""
             try {
-              val (segId, suffix) = if (segmentUpdateParallelism > 1) {
-                val keyWithSuffix = key.split(CarbonCommonConstants.DASH)
-                (keyWithSuffix(0), keyWithSuffix(1).toInt)
-              } else {
-                (key, 0)
-              }
-
-              val taskNo = CarbonUpdateUtil
-                .getLatestTaskIdForSegment(segId,
-                  CarbonStorePath.getCarbonTablePath(carbonLoadModel.getStorePath,
-                    carbonTable.getCarbonTableIdentifier))
-              val index = taskNo + suffix + 1
+              val segId = key
+              val index = taskNo
               uniqueLoadStatusId = carbonLoadModel.getTableName +
                                    CarbonCommonConstants.UNDERSCORE +
                                    (index + "_0")
@@ -629,8 +619,6 @@ object CarbonDataRDDFactory {
 
               // storeLocation = CarbonDataLoadRDD.initialize(carbonLoadModel, index)
               loadMetadataDetails.setLoadStatus(CarbonCommonConstants.STORE_LOADSTATUS_SUCCESS)
-              val rddIteratorKey = CarbonCommonConstants.RDDUTIL_UPDATE_KEY +
-                                   UUID.randomUUID().toString
               UpdateDataLoad.DataLoadForUpdate(segId,
                 index,
                 iter,
@@ -665,19 +653,24 @@ object CarbonDataRDDFactory {
 
         val updateRdd = dataFrame.get.rdd
 
+        val loadMetadataDetails = SegmentStatusManager.readLoadMetadata(carbonTable.getStorePath)
+        val segmentIds = loadMetadataDetails.map(l => l.getLoadName)
+        val carbonTablePath = CarbonStorePath.getCarbonTablePath(carbonLoadModel.getStorePath,
+          carbonTable.getCarbonTableIdentifier)
+        val segmentId2maxTaskNo = segmentIds
+          .map(segId =>
+            (segId, CarbonUpdateUtil.getLatestTaskIdForSegment(segId, carbonTablePath)))
+          .toMap
+
         // splitting as (key, value) i.e., (segment, updatedRows)
-        val keyRDD = if (segmentUpdateParallelism > 1) {
-          // adding random suffix to increase the parallelism for one segment.
-          // use if-else to avoid unnecessary check for every record if there is no need to optimize
-          updateRdd.map(row =>
-            (row.get(row.size - 1).toString +
-             CarbonCommonConstants.DASH + Random.nextInt(segmentUpdateParallelism),
-              Row(row.toSeq.slice(0, row.size - 1): _*))
-          )
-        } else {
-          updateRdd.map(row =>
-            (row.get(row.size - 1).toString, Row(row.toSeq.slice(0, row.size - 1): _*)))
-        }
+        // appending random part to key to distribute records
+        val keyRDD = updateRdd.map(row => {
+          val segId = row.get(row.size - 1).toString
+          val newTaskNo = segmentId2maxTaskNo(segId) + Random.nextInt(segmentUpdateParallelism) + 1
+          (segId + CarbonCommonConstants.DASH + newTaskNo,
+            Row(row.toSeq.slice(0, row.size - 1): _*))
+        })
+
         val groupBySegmentRdd = keyRDD.groupByKey()
 
         val nodeNumOfData = groupBySegmentRdd.partitions.flatMap[String, Array[String]] { p =>
@@ -689,10 +682,11 @@ object CarbonDataRDDFactory {
           new UpdateCoalescedRDD[(String, scala.Iterable[Row])](groupBySegmentRdd,
             nodes.distinct.toArray)
 
-        res = groupBySegmentAndNodeRdd.map(x =>
-          triggerDataLoadForSegment(x._1, x._2.toIterator).toList
-        ).collect()
-
+        res = groupBySegmentAndNodeRdd.map(x => {
+          val segIdAndTaskNo = x._1.split(CarbonCommonConstants.DASH)
+          triggerDataLoadForSegment(segIdAndTaskNo(0), segIdAndTaskNo(1).toInt, x._2.toIterator)
+            .toList
+        }).collect()
       }
 
       def loadDataForPartitionTable(): Unit = {

--- a/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -51,7 +51,7 @@ import org.apache.carbondata.core.metadata.schema.partition.PartitionType
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable
 import org.apache.carbondata.core.mutate.CarbonUpdateUtil
 import org.apache.carbondata.core.scan.partition.PartitionUtil
-import org.apache.carbondata.core.statusmanager.LoadMetadataDetails
+import org.apache.carbondata.core.statusmanager.{LoadMetadataDetails, SegmentStatusManager}
 import org.apache.carbondata.core.util.{ByteUtil, CarbonProperties}
 import org.apache.carbondata.core.util.path.CarbonStorePath
 import org.apache.carbondata.processing.csvload.{BlockDetails, CSVInputFormat, StringArrayWritable}
@@ -597,7 +597,7 @@ object CarbonDataRDDFactory {
       def loadDataFrameForUpdate(): Unit = {
         val segmentUpdateParallelism = CarbonProperties.getInstance().getParallelismForSegmentUpdate
 
-        def triggerDataLoadForSegment(key: String,
+        def triggerDataLoadForSegment(key: String, taskNo: Int,
             iter: Iterator[Row]): Iterator[(String, (LoadMetadataDetails, ExecutionErrors))] = {
           val rddResult = new updateResultImpl()
           val LOGGER = LogServiceFactory.getLogService(this.getClass.getName)
@@ -607,18 +607,9 @@ object CarbonDataRDDFactory {
             val executionErrors = new ExecutionErrors(FailureCauses.NONE, "")
             var uniqueLoadStatusId = ""
             try {
-              val (segId, suffix) = if (segmentUpdateParallelism > 1) {
-                val keyWithSuffix = key.split(CarbonCommonConstants.DASH)
-                (keyWithSuffix(0), keyWithSuffix(1).toInt)
-              } else {
-                (key, 0)
-              }
+              val segId = key
+              val index = taskNo
 
-              val taskNo = CarbonUpdateUtil
-                .getLatestTaskIdForSegment(segId,
-                  CarbonStorePath.getCarbonTablePath(carbonLoadModel.getStorePath,
-                    carbonTable.getCarbonTableIdentifier))
-              val index = taskNo + suffix + 1
               uniqueLoadStatusId = carbonLoadModel.getTableName +
                                    CarbonCommonConstants.UNDERSCORE +
                                    (index + "_0")
@@ -641,8 +632,6 @@ object CarbonDataRDDFactory {
 
               // storeLocation = CarbonDataLoadRDD.initialize(carbonLoadModel, index)
               loadMetadataDetails.setLoadStatus(CarbonCommonConstants.STORE_LOADSTATUS_SUCCESS)
-              val rddIteratorKey = CarbonCommonConstants.RDDUTIL_UPDATE_KEY +
-                                   UUID.randomUUID().toString
               UpdateDataLoad.DataLoadForUpdate(segId,
                 index,
                 iter,
@@ -677,19 +666,24 @@ object CarbonDataRDDFactory {
 
         val updateRdd = dataFrame.get.rdd
 
+        val loadMetadataDetails = SegmentStatusManager.readLoadMetadata(carbonTable.getStorePath)
+        val segmentIds = loadMetadataDetails.map(l => l.getLoadName)
+        val carbonTablePath = CarbonStorePath.getCarbonTablePath(carbonLoadModel.getStorePath,
+          carbonTable.getCarbonTableIdentifier)
+        val segmentId2maxTaskNo = segmentIds
+          .map(segId =>
+            (segId, CarbonUpdateUtil.getLatestTaskIdForSegment(segId, carbonTablePath)))
+          .toMap
+
         // splitting as (key, value) i.e., (segment, updatedRows)
-        val keyRDD = if (segmentUpdateParallelism > 1) {
-          // adding random suffix to increase the parallelism for one segment.
-          // use if-else to avoid unnecessary check for every record if there is no need to optimize
-          updateRdd.map(row =>
-            (row.get(row.size - 1).toString +
-             CarbonCommonConstants.DASH + Random.nextInt(segmentUpdateParallelism),
-              Row(row.toSeq.slice(0, row.size - 1): _*))
-          )
-        } else {
-          updateRdd.map(row =>
-            (row.get(row.size - 1).toString, Row(row.toSeq.slice(0, row.size - 1): _*)))
-        }
+        // appending random part to key to distribute records
+        val keyRDD = updateRdd.map(row => {
+          val segId = row.get(row.size - 1).toString
+          val newTaskNo = segmentId2maxTaskNo(segId) + Random.nextInt(segmentUpdateParallelism) + 1
+          (segId + CarbonCommonConstants.DASH + newTaskNo,
+            Row(row.toSeq.slice(0, row.size - 1): _*))
+        })
+
         val groupBySegmentRdd = keyRDD.groupByKey()
 
         val nodeNumOfData = groupBySegmentRdd.partitions.flatMap[String, Array[String]] { p =>
@@ -701,10 +695,11 @@ object CarbonDataRDDFactory {
           new UpdateCoalescedRDD[(String, scala.Iterable[Row])](groupBySegmentRdd,
             nodes.distinct.toArray)
 
-        res = groupBySegmentAndNodeRdd.map(x =>
-          triggerDataLoadForSegment(x._1, x._2.toIterator).toList
-        ).collect()
-
+        res = groupBySegmentAndNodeRdd.map(x => {
+          val segIdAndTaskNo = x._1.split(CarbonCommonConstants.DASH)
+          triggerDataLoadForSegment(segIdAndTaskNo(0), segIdAndTaskNo(1).toInt, x._2.toIterator)
+            .toList
+        }).collect()
       }
 
       def loadDataForPartitionTable(): Unit = {

--- a/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -595,6 +595,8 @@ object CarbonDataRDDFactory {
       }
 
       def loadDataFrameForUpdate(): Unit = {
+        val segmentUpdateParallelism = CarbonProperties.getInstance().getParallelismForSegmentUpdate
+
         def triggerDataLoadForSegment(key: String,
             iter: Iterator[Row]): Iterator[(String, (LoadMetadataDetails, ExecutionErrors))] = {
           val rddResult = new updateResultImpl()
@@ -605,12 +607,18 @@ object CarbonDataRDDFactory {
             val executionErrors = new ExecutionErrors(FailureCauses.NONE, "")
             var uniqueLoadStatusId = ""
             try {
-              val segId = key
+              val (segId, suffix) = if (segmentUpdateParallelism > 1) {
+                val keyWithSuffix = key.split(CarbonCommonConstants.DASH)
+                (keyWithSuffix(0), keyWithSuffix(1).toInt)
+              } else {
+                (key, 0)
+              }
+
               val taskNo = CarbonUpdateUtil
                 .getLatestTaskIdForSegment(segId,
                   CarbonStorePath.getCarbonTablePath(carbonLoadModel.getStorePath,
                     carbonTable.getCarbonTableIdentifier))
-              val index = taskNo + 1
+              val index = taskNo + suffix + 1
               uniqueLoadStatusId = carbonLoadModel.getTableName +
                                    CarbonCommonConstants.UNDERSCORE +
                                    (index + "_0")
@@ -669,11 +677,19 @@ object CarbonDataRDDFactory {
 
         val updateRdd = dataFrame.get.rdd
 
-
-        val keyRDD = updateRdd.map(row =>
-          // splitting as (key, value) i.e., (segment, updatedRows)
-          (row.get(row.size - 1).toString, Row(row.toSeq.slice(0, row.size - 1): _*))
-        )
+        // splitting as (key, value) i.e., (segment, updatedRows)
+        val keyRDD = if (segmentUpdateParallelism > 1) {
+          // adding random suffix to increase the parallelism for one segment.
+          // use if-else to avoid unnecessary check for every record if there is no need to optimize
+          updateRdd.map(row =>
+            (row.get(row.size - 1).toString +
+             CarbonCommonConstants.DASH + Random.nextInt(segmentUpdateParallelism),
+              Row(row.toSeq.slice(0, row.size - 1): _*))
+          )
+        } else {
+          updateRdd.map(row =>
+            (row.get(row.size - 1).toString, Row(row.toSeq.slice(0, row.size - 1): _*)))
+        }
         val groupBySegmentRdd = keyRDD.groupByKey()
 
         val nodeNumOfData = groupBySegmentRdd.partitions.flatMap[String, Array[String]] { p =>


### PR DESCRIPTION
# Scenario

Recently I have tested the update feature provided in Carbondata and found its poor performance.

I had a table containing about 14 million records with about 370 columns(no dictionary columns) and the data files are about 3.8 GB in total. All the data files were in one segment.

I performed an update SQL which update a column for all the records and the SQL looked like `UPDATE myTable SET (col1)=(col1+1000) WHERE TRUE`. In my environment, the update job failed with 'executor lost errors'. And I found 'spill data' related messages in the container logs.

# Analyze

I've read about the implementation of update-delete in Carbondata in ISSUE#440. The update consists a delete and an insert operation. And the error occurred during the insert operation.

After studying the code, I have found that while doing inserting, the updated records are grouped by the `segmentId`, which means all the recoreds in one segment will be processed in only one task, thus will cause task failure when the amount of input data is quite large.

# Solution

We should improve the parallelism when doing update for a segment.

I append a random key to the `segmentId` to increase the partition number before doing the insertion stage and then remove the suffix when doing the real insertion.

# Modification

+ Increase parallelism while processing one segment in update
+ Add a property to configure the parallelism
+ Clean up local files after update (previous bugs)

# Notes

I have tested in my example and the job finished in about 13 minutes successfully. The records were updated as expected.