### PR TITLE
[CARBONDATA-1373] Enhance update performance by increasing parallelism

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -539,6 +539,10 @@ public final class CarbonCommonConstants {
    */
   public static final String UNDERSCORE = "_";
   /**
+   * DASH
+   */
+  public static final String DASH = "-";
+  /**
    * POINT
    */
   public static final String POINT = ".";
@@ -1324,6 +1328,20 @@ public final class CarbonCommonConstants {
    * http://spark.apache.org/docs/latest/rdd-programming-guide.html#rdd-persistence.
    */
   public static final String CARBON_GLOBAL_SORT_RDD_STORAGE_LEVEL_DEFAULT = "MEMORY_ONLY";
+
+  /**
+   * property for configuring parallelism per segment when doing an update. Increase this
+   * value will avoid data screw problem for a large segment.
+   * Refer to CARBONDATA-1373 for more details.
+   */
+  @CarbonProperty
+  public static final String CARBON_UPDATE_SEGMENT_PARALLELISM =
+      "carbon.update.segment.parallelism";
+
+  /**
+   * In default we will not optimize the update
+   */
+  public static final String CARBON_UPDATE_SEGMENT_PARALLELISM_DEFAULT = "1";
 
   private CarbonCommonConstants() {
   }

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
@@ -895,6 +895,38 @@ public final class CarbonProperties {
   }
 
   /**
+   * Returns parallelism for segment update
+   * @return int
+   */
+  public int getParallelismForSegmentUpdate() {
+    int parallelism = Integer.parseInt(
+        CarbonCommonConstants.CARBON_UPDATE_SEGMENT_PARALLELISM_DEFAULT);
+    boolean isInvalidValue = false;
+    try {
+      String strParallelism = getProperty(CarbonCommonConstants.CARBON_UPDATE_SEGMENT_PARALLELISM,
+          CarbonCommonConstants.CARBON_UPDATE_SEGMENT_PARALLELISM_DEFAULT);
+      parallelism = Integer.parseInt(strParallelism);
+      if (parallelism <= 0 || parallelism > 1000) {
+        isInvalidValue = true;
+      }
+    } catch (NumberFormatException e) {
+      isInvalidValue = true;
+    }
+
+    if (isInvalidValue) {
+      LOGGER.error("The specified value for property "
+          + CarbonCommonConstants.CARBON_UPDATE_SEGMENT_PARALLELISM
+          + " is incorrect. Correct value should be in range of 0 - 1000."
+          + " Taking the default value: "
+          + CarbonCommonConstants.CARBON_UPDATE_SEGMENT_PARALLELISM_DEFAULT);
+      parallelism = Integer.parseInt(
+          CarbonCommonConstants.CARBON_UPDATE_SEGMENT_PARALLELISM_DEFAULT);
+    }
+
+    return parallelism;
+  }
+
+  /**
    * returns true if carbon property
    * @param key
    * @return

--- a/docs/configuration-parameters.md
+++ b/docs/configuration-parameters.md
@@ -74,7 +74,7 @@ This section provides the details of all the configurations required for CarbonD
 | carbon.horizontal.compaction.enable | true | This property is used to turn ON/OFF horizontal compaction. After every DELETE and UPDATE statement, horizontal compaction may occur in case the delta (DELETE/ UPDATE) files becomes more than specified threshold. |  |
 | carbon.horizontal.UPDATE.compaction.threshold | 1 | This property specifies the threshold limit on number of UPDATE delta files within a segment. In case the number of delta files goes beyond the threshold, the UPDATE delta files within the segment becomes eligible for horizontal compaction and compacted into single UPDATE delta file. | Values between 1 to 10000. |
 | carbon.horizontal.DELETE.compaction.threshold | 1 | This property specifies the threshold limit on number of DELETE delta files within a block of a segment. In case the number of delta files goes beyond the threshold, the DELETE delta files for the particular block of the segment becomes eligible for horizontal compaction and compacted into single DELETE delta file. | Values between 1 to 10000. |
-
+| carbon.update.segment.parallelism | 1 | This property specifies the parallelism for each segment during update. If there are segments that contain too many records to update and the spark job encounter data-spill related errors, it is better to increase this property value. It is recommended to set this value to a multiple of the number of executors for balance. | Values between 1 to 1000. |
   
 
 * **Query Configuration**

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/UpdateDataLoad.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/UpdateDataLoad.scala
@@ -28,6 +28,7 @@ import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.statusmanager.LoadMetadataDetails
 import org.apache.carbondata.processing.model.CarbonLoadModel
 import org.apache.carbondata.processing.newflow.DataLoadExecutor
+import org.apache.carbondata.spark.load.CarbonLoaderUtil
 
 /**
  * Data load in case of update command .
@@ -62,6 +63,8 @@ object UpdateDataLoad {
       case e: Exception =>
         LOGGER.error(e)
         throw e
+    } finally {
+      CarbonLoaderUtil.deleteLocalDataLoadFolderLocation(carbonLoadModel, false, false)
     }
   }
 

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -19,7 +19,6 @@ package org.apache.carbondata.spark.rdd
 
 import java.text.SimpleDateFormat
 import java.util
-import java.util.UUID
 import java.util.concurrent._
 
 import scala.collection.JavaConverters._
@@ -32,8 +31,8 @@ import org.apache.hadoop.fs.Path
 import org.apache.hadoop.io.NullWritable
 import org.apache.hadoop.mapreduce.Job
 import org.apache.hadoop.mapreduce.lib.input.{FileInputFormat, FileSplit}
-import org.apache.spark.{SparkEnv, SparkException}
-import org.apache.spark.rdd.{DataLoadCoalescedRDD, DataLoadPartitionCoalescer, NewHadoopRDD, RDD, UpdateCoalescedRDD}
+import org.apache.spark.{SparkEnv, SparkException, TaskContext}
+import org.apache.spark.rdd.{DataLoadCoalescedRDD, DataLoadPartitionCoalescer, NewHadoopRDD, RDD}
 import org.apache.spark.sql.{CarbonEnv, DataFrame, Row, SQLContext}
 import org.apache.spark.sql.execution.command.{AlterTableModel, CompactionModel, ExecutionErrors, UpdateTableModel}
 import org.apache.spark.sql.hive.DistributionUtil
@@ -51,14 +50,14 @@ import org.apache.carbondata.core.metadata.schema.partition.PartitionType
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable
 import org.apache.carbondata.core.mutate.CarbonUpdateUtil
 import org.apache.carbondata.core.scan.partition.PartitionUtil
-import org.apache.carbondata.core.statusmanager.LoadMetadataDetails
+import org.apache.carbondata.core.statusmanager.{LoadMetadataDetails, SegmentStatusManager}
 import org.apache.carbondata.core.util.{ByteUtil, CarbonProperties}
 import org.apache.carbondata.core.util.path.CarbonStorePath
 import org.apache.carbondata.processing.csvload.{BlockDetails, CSVInputFormat, StringArrayWritable}
 import org.apache.carbondata.processing.etl.DataLoadingException
 import org.apache.carbondata.processing.merger.{CarbonCompactionUtil, CarbonDataMergerUtil, CompactionType}
 import org.apache.carbondata.processing.model.CarbonLoadModel
-import org.apache.carbondata.processing.newflow.exception.{BadRecordFoundException, CarbonDataLoadingException}
+import org.apache.carbondata.processing.newflow.exception.BadRecordFoundException
 import org.apache.carbondata.processing.newflow.DataLoadProcessBuilder
 import org.apache.carbondata.processing.newflow.exception.CarbonDataLoadingException
 import org.apache.carbondata.processing.newflow.sort.SortScopeOptions
@@ -583,7 +582,9 @@ object CarbonDataRDDFactory {
       }
 
       def loadDataFrameForUpdate(): Unit = {
-        def triggerDataLoadForSegment(key: String,
+        val segmentUpdateParallelism = CarbonProperties.getInstance().getParallelismForSegmentUpdate
+
+        def triggerDataLoadForSegment(key: String, taskNo: Int,
             iter: Iterator[Row]): Iterator[(String, (LoadMetadataDetails, ExecutionErrors))] = {
           val rddResult = new updateResultImpl()
           val LOGGER = LogServiceFactory.getLogService(this.getClass.getName)
@@ -594,11 +595,7 @@ object CarbonDataRDDFactory {
             var uniqueLoadStatusId = ""
             try {
               val segId = key
-              val taskNo = CarbonUpdateUtil
-                .getLatestTaskIdForSegment(segId,
-                  CarbonStorePath.getCarbonTablePath(carbonLoadModel.getStorePath,
-                    carbonTable.getCarbonTableIdentifier))
-              val index = taskNo + 1
+              val index = taskNo
               uniqueLoadStatusId = carbonLoadModel.getTableName +
                                    CarbonCommonConstants.UNDERSCORE +
                                    (index + "_0")
@@ -621,8 +618,6 @@ object CarbonDataRDDFactory {
 
               // storeLocation = CarbonDataLoadRDD.initialize(carbonLoadModel, index)
               loadMetadataDetails.setLoadStatus(CarbonCommonConstants.STORE_LOADSTATUS_SUCCESS)
-              val rddIteratorKey = CarbonCommonConstants.RDDUTIL_UPDATE_KEY +
-                                   UUID.randomUUID().toString
               UpdateDataLoad.DataLoadForUpdate(segId,
                 index,
                 iter,
@@ -657,26 +652,53 @@ object CarbonDataRDDFactory {
 
         val updateRdd = dataFrame.get.rdd
 
+        // return directly if no rows to update
+        val noRowsToUpdate = updateRdd.isEmpty()
+        if (noRowsToUpdate) {
+          res = Array[List[(String, (LoadMetadataDetails, ExecutionErrors))]]()
+          return
+        }
 
+        // splitting as (key, value) i.e., (segment, updatedRows)
         val keyRDD = updateRdd.map(row =>
-          // splitting as (key, value) i.e., (segment, updatedRows)
-          (row.get(row.size - 1).toString, Row(row.toSeq.slice(0, row.size - 1): _*))
-        )
-        val groupBySegmentRdd = keyRDD.groupByKey()
+          (row.get(row.size - 1).toString, Row(row.toSeq.slice(0, row.size - 1): _*)))
 
-        val nodeNumOfData = groupBySegmentRdd.partitions.flatMap[String, Array[String]] { p =>
-          DataLoadPartitionCoalescer.getPreferredLocs(groupBySegmentRdd, p).map(_.host)
-        }.distinct.size
-        val nodes = DistributionUtil.ensureExecutorsByNumberAndGetNodeList(nodeNumOfData,
-          sqlContext.sparkContext)
-        val groupBySegmentAndNodeRdd =
-          new UpdateCoalescedRDD[(String, scala.Iterable[Row])](groupBySegmentRdd,
-            nodes.distinct.toArray)
+        val loadMetadataDetails = SegmentStatusManager
+          .readLoadMetadata(carbonTable.getMetaDataFilepath)
+        val segmentIds = loadMetadataDetails.map(_.getLoadName)
+        val segmentIdIndex = segmentIds.zipWithIndex.toMap
+        val carbonTablePath = CarbonStorePath.getCarbonTablePath(carbonLoadModel.getStorePath,
+          carbonTable.getCarbonTableIdentifier)
+        val segmentId2maxTaskNo = segmentIds
+          .map(segId =>
+            (segId, CarbonUpdateUtil.getLatestTaskIdForSegment(segId, carbonTablePath)))
+          .toMap
 
-        res = groupBySegmentAndNodeRdd.map(x =>
-          triggerDataLoadForSegment(x._1, x._2.toIterator).toList
-        ).collect()
+        class SegmentPartitioner(segIdIndex: Map[String, Int], parallelism: Int)
+          extends org.apache.spark.Partitioner {
+          override def numPartitions: Int = segmentIdIndex.size * parallelism
 
+          override def getPartition(key: Any): Int = {
+            val segId = key.asInstanceOf[String]
+            // partitionId
+            segmentIdIndex(segId) * parallelism + Random.nextInt(parallelism)
+          }
+        }
+
+        val partitionByRdd = keyRDD
+          .partitionBy(new SegmentPartitioner(segmentIdIndex, segmentUpdateParallelism))
+
+        // because partitionId=segmentIdIndex*parallelism+RandomPart and RandomPart<parallelism,
+        // so segmentIdIndex=partitionId/parallelism, this has been verified.
+        res = partitionByRdd.map(_._2).mapPartitions(p => {
+          val partitionId = TaskContext.getPartitionId()
+          val segIdIndex = partitionId / segmentUpdateParallelism
+          val randomPart = partitionId - segIdIndex * segmentUpdateParallelism
+          val segId = segmentIds(segIdIndex)
+          val newTaskNo = segmentId2maxTaskNo(segId) + randomPart + 1
+
+          List(triggerDataLoadForSegment(segId, newTaskNo, p).toList).toIterator
+        }).collect()
       }
 
       def loadDataForPartitionTable(): Unit = {

--- a/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -762,16 +762,15 @@ object CarbonDataRDDFactory {
         val keyRDD = updateRdd.map(row =>
             (row.get(row.size - 1).toString, Row(row.toSeq.slice(0, row.size - 1): _*)))
 
-        val loadMetadataDetails = SegmentStatusManager
-          .readLoadMetadata(carbonTable.getMetaDataFilepath)
+        val loadMetadataDetails = SegmentStatusManager.readLoadMetadata(
+          carbonTable.getMetaDataFilepath)
         val segmentIds = loadMetadataDetails.map(_.getLoadName)
         val segmentIdIndex = segmentIds.zipWithIndex.toMap
         val carbonTablePath = CarbonStorePath.getCarbonTablePath(carbonLoadModel.getStorePath,
           carbonTable.getCarbonTableIdentifier)
-        val segmentId2maxTaskNo = segmentIds
-          .map(segId =>
-            (segId, CarbonUpdateUtil.getLatestTaskIdForSegment(segId, carbonTablePath)))
-          .toMap
+        val segmentId2maxTaskNo = segmentIds.map { segId =>
+          (segId, CarbonUpdateUtil.getLatestTaskIdForSegment(segId, carbonTablePath))
+        }.toMap
 
         class SegmentPartitioner(segIdIndex: Map[String, Int], parallelism: Int)
           extends org.apache.spark.Partitioner {
@@ -784,20 +783,20 @@ object CarbonDataRDDFactory {
           }
         }
 
-        val partitionByRdd = keyRDD
-          .partitionBy(new SegmentPartitioner(segmentIdIndex, segmentUpdateParallelism))
+        val partitionByRdd = keyRDD.partitionBy(new SegmentPartitioner(segmentIdIndex,
+          segmentUpdateParallelism))
 
         // because partitionId=segmentIdIndex*parallelism+RandomPart and RandomPart<parallelism,
         // so segmentIdIndex=partitionId/parallelism, this has been verified.
-        res = partitionByRdd.map(_._2).mapPartitions(p => {
+        res = partitionByRdd.map(_._2).mapPartitions { partition =>
           val partitionId = TaskContext.getPartitionId()
           val segIdIndex = partitionId / segmentUpdateParallelism
           val randomPart = partitionId - segIdIndex * segmentUpdateParallelism
           val segId = segmentIds(segIdIndex)
           val newTaskNo = segmentId2maxTaskNo(segId) + randomPart + 1
 
-          List(triggerDataLoadForSegment(segId, newTaskNo, p).toList).toIterator
-        }).collect()
+          List(triggerDataLoadForSegment(segId, newTaskNo, partition).toList).toIterator
+        }.collect()
       }
 
       def loadDataForPartitionTable(): Unit = {


### PR DESCRIPTION
# Scenario

Recently I have tested the update feature provided in Carbondata and found its poor performance.

I had a table containing about 14 million records with about 370 columns(no dictionary columns) and the data files are about 3.8 GB in total. All the data files were in one segment.

I performed an update SQL which update a column for all the records and the SQL looked like `UPDATE myTable SET (col1)=(col1+1000) WHERE TRUE`. In my environment, the update job failed with 'executor lost errors'. And I found 'spill data' related messages in the container logs.

# Analyze

I've read about the implementation of update-delete in Carbondata in ISSUE#440. The update consists a delete and an insert operation. And the error occurred during the insert operation.

After studying the code, I have found that while doing inserting, the updated records are grouped by the `segmentId`, which means all the recoreds in one segment will be processed in only one task, thus will cause task failure when the amount of input data is quite large.

# Solution

We should improve the parallelism when doing update for a segment.

~~I append a random key to the `segmentId` to increase the partition number before doing the insertion stage and then remove the suffix when doing the real insertion.~~

I customize a partitioner to distribute the records in one segment to multiple partitions, which will avoid a task to process to many records. And we use `partitionBy` to replace `groupByKey` to reduce shuffle overhead.

# Modification

+ Increase parallelism while processing one segment in update, this is achieved by distributing records to different partitions by using a customized partitioner.
+ Add a property to configure the parallelism.
+ Clean up local files after update (previous bugs)
+ Remove useless imports
+ Add tests
+ Add related documents

# Notes

I have tested in my example and the job finished in about 13 minutes successfully. The records were updated as expected.

Comparing to the previous implementation, the update performance has been enhanced:

Origin(Parallelism(1) + GroupBy): Update **FAILED**

Adding Parallelism(6) + GroupBy: Update **SUCCESSFULLY** using **13mins**

Parallelism(1) +  PartitionBy: Update **SUCCESSFULLY** using **21mins**

Adding Parallelism(6) + PartitionBy: Update **SUCCESSFULLY** using **5mins**
