### PR TITLE
[CARBONDATA-1393] Avoid to throw NPE when execute 'freeMemory' of UnsafeMemoryManager/UnsafeSortMemoryManager.

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/memory/HeapMemoryAllocator.java
+++ b/core/src/main/java/org/apache/carbondata/core/memory/HeapMemoryAllocator.java
@@ -53,6 +53,8 @@ public class HeapMemoryAllocator implements MemoryAllocator {
             final MemoryBlock memory = blockReference.get();
             if (memory != null) {
               assert (memory.size() == size);
+              // reuse this MemoryBlock
+              memory.setFreedStatus(false);
               return memory;
             }
           }
@@ -76,5 +78,6 @@ public class HeapMemoryAllocator implements MemoryAllocator {
         pool.add(new WeakReference<>(memory));
       }
     }
+    memory.setFreedStatus(true);
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/memory/MemoryBlock.java
+++ b/core/src/main/java/org/apache/carbondata/core/memory/MemoryBlock.java
@@ -29,9 +29,15 @@ public class MemoryBlock extends MemoryLocation {
 
   private final long length;
 
+  /**
+   * whether freed or not
+   */
+  private boolean isFreed = false;
+
   public MemoryBlock(@Nullable Object obj, long offset, long length) {
     super(obj, offset);
     this.length = length;
+    this.isFreed = false;
   }
 
   /**
@@ -39,6 +45,14 @@ public class MemoryBlock extends MemoryLocation {
    */
   public long size() {
     return length;
+  }
+
+  public boolean isFreedStatus() {
+    return this.isFreed;
+  }
+
+  public void setFreedStatus(boolean freedStatus) {
+    this.isFreed = freedStatus;
   }
 
   /**

--- a/core/src/main/java/org/apache/carbondata/core/memory/UnsafeMemoryAllocator.java
+++ b/core/src/main/java/org/apache/carbondata/core/memory/UnsafeMemoryAllocator.java
@@ -36,5 +36,6 @@ public class UnsafeMemoryAllocator implements MemoryAllocator {
     assert (memory.obj == null) :
       "baseObject not null; are you trying to use the off-heap allocator to free on-heap memory?";
     CarbonUnsafe.getUnsafe().freeMemory(memory.offset);
+    memory.setFreedStatus(true);
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/memory/UnsafeMemoryManager.java
+++ b/core/src/main/java/org/apache/carbondata/core/memory/UnsafeMemoryManager.java
@@ -105,13 +105,15 @@ public class UnsafeMemoryManager {
   }
 
   public synchronized void freeMemory(long taskId, MemoryBlock memoryBlock) {
-    taskIdToMemoryBlockMap.get(taskId).remove(memoryBlock);
-    allocator.free(memoryBlock);
-    memoryUsed -= memoryBlock.size();
-    memoryUsed = memoryUsed < 0 ? 0 : memoryUsed;
-    LOGGER.info(
-        "Freeing memory of size: " + memoryBlock.size() + "available memory:  " + (totalMemory
-            - memoryUsed));
+    if (taskIdToMemoryBlockMap.containsKey(taskId)) {
+      taskIdToMemoryBlockMap.get(taskId).remove(memoryBlock);
+      allocator.free(memoryBlock);
+      memoryUsed -= memoryBlock.size();
+      memoryUsed = memoryUsed < 0 ? 0 : memoryUsed;
+      LOGGER.info(
+          "Freeing memory of size: " + memoryBlock.size() + "available memory:  " + (totalMemory
+              - memoryUsed));
+    }
   }
 
   public synchronized void freeMemoryAll(long taskId) {

--- a/core/src/main/java/org/apache/carbondata/core/memory/UnsafeMemoryManager.java
+++ b/core/src/main/java/org/apache/carbondata/core/memory/UnsafeMemoryManager.java
@@ -107,6 +107,8 @@ public class UnsafeMemoryManager {
   public synchronized void freeMemory(long taskId, MemoryBlock memoryBlock) {
     if (taskIdToMemoryBlockMap.containsKey(taskId)) {
       taskIdToMemoryBlockMap.get(taskId).remove(memoryBlock);
+    }
+    if (!memoryBlock.isFreedStatus()) {
       allocator.free(memoryBlock);
       memoryUsed -= memoryBlock.size();
       memoryUsed = memoryUsed < 0 ? 0 : memoryUsed;
@@ -125,8 +127,10 @@ public class UnsafeMemoryManager {
       MemoryBlock memoryBlock = null;
       while (iterator.hasNext()) {
         memoryBlock = iterator.next();
-        occuppiedMemory += memoryBlock.size();
-        allocator.free(memoryBlock);
+        if (!memoryBlock.isFreedStatus()) {
+          occuppiedMemory += memoryBlock.size();
+          allocator.free(memoryBlock);
+        }
       }
     }
     memoryUsed -= occuppiedMemory;

--- a/core/src/main/java/org/apache/carbondata/core/memory/UnsafeSortMemoryManager.java
+++ b/core/src/main/java/org/apache/carbondata/core/memory/UnsafeSortMemoryManager.java
@@ -135,14 +135,16 @@ public class UnsafeSortMemoryManager {
   }
 
   public synchronized void freeMemory(long taskId, MemoryBlock memoryBlock) {
-    allocator.free(memoryBlock);
-    taskIdToMemoryBlockMap.get(taskId).remove(memoryBlock);
-    memoryUsed -= memoryBlock.size();
-    memoryUsed = memoryUsed < 0 ? 0 : memoryUsed;
-    if (LOGGER.isDebugEnabled()) {
-      LOGGER.debug(
-          "Freeing memory of size: " + memoryBlock.size() + ": Current available memory is: " + (
-              totalMemory - memoryUsed));
+    if (taskIdToMemoryBlockMap.containsKey(taskId)) {
+      allocator.free(memoryBlock);
+      taskIdToMemoryBlockMap.get(taskId).remove(memoryBlock);
+      memoryUsed -= memoryBlock.size();
+      memoryUsed = memoryUsed < 0 ? 0 : memoryUsed;
+      if (LOGGER.isDebugEnabled()) {
+        LOGGER.debug(
+            "Freeing memory of size: " + memoryBlock.size() + ": Current available memory is: " + (
+                totalMemory - memoryUsed));
+      }
     }
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/memory/UnsafeSortMemoryManager.java
+++ b/core/src/main/java/org/apache/carbondata/core/memory/UnsafeSortMemoryManager.java
@@ -136,8 +136,10 @@ public class UnsafeSortMemoryManager {
 
   public synchronized void freeMemory(long taskId, MemoryBlock memoryBlock) {
     if (taskIdToMemoryBlockMap.containsKey(taskId)) {
-      allocator.free(memoryBlock);
       taskIdToMemoryBlockMap.get(taskId).remove(memoryBlock);
+    }
+    if (!memoryBlock.isFreedStatus()) {
+      allocator.free(memoryBlock);
       memoryUsed -= memoryBlock.size();
       memoryUsed = memoryUsed < 0 ? 0 : memoryUsed;
       if (LOGGER.isDebugEnabled()) {
@@ -163,8 +165,10 @@ public class UnsafeSortMemoryManager {
       MemoryBlock memoryBlock = null;
       while (iterator.hasNext()) {
         memoryBlock = iterator.next();
-        occuppiedMemory += memoryBlock.size();
-        allocator.free(memoryBlock);
+        if (!memoryBlock.isFreedStatus()) {
+          occuppiedMemory += memoryBlock.size();
+          allocator.free(memoryBlock);
+        }
       }
     }
     memoryUsed -= occuppiedMemory;


### PR DESCRIPTION
UnsafeMemoryManager.freeMemoryAll(long taskId) may run before freeMemory(long taskId, MemoryBlock memoryBlock), so taskIdToMemoryBlockMap.get(taskId) will return null and then throw NPE.