### PR TITLE
[CARBONDATA-1376] Fix warn message when setting LOCK_TYPE to HDFSLOCK

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
@@ -166,7 +166,7 @@ public final class CarbonProperties {
         && !CarbonCommonConstants.CARBON_LOCK_TYPE_HDFS.equalsIgnoreCase(lockTypeConfigured)) {
       LOGGER.warn("The value \"" + lockTypeConfigured + "\" configured for key "
           + CarbonCommonConstants.LOCK_TYPE + " is invalid for current file system. "
-              + "Use the default value \"" + CarbonCommonConstants.CARBON_LOCK_TYPE_HDFS + " instead.");
+          + "Use the default value " + CarbonCommonConstants.CARBON_LOCK_TYPE_HDFS + " instead.");
       carbonProperties.setProperty(CarbonCommonConstants.LOCK_TYPE,
           CarbonCommonConstants.CARBON_LOCK_TYPE_HDFS);
     } else if (null != defaultFs && defaultFs.startsWith(CarbonCommonConstants.LOCAL_FILE_PREFIX)
@@ -175,7 +175,7 @@ public final class CarbonProperties {
           CarbonCommonConstants.CARBON_LOCK_TYPE_LOCAL);
       LOGGER.warn("The value \"" + lockTypeConfigured + "\" configured for key "
           + CarbonCommonConstants.LOCK_TYPE + " is invalid for current file system. "
-          + "Use the default value \"" + CarbonCommonConstants.CARBON_LOCK_TYPE_LOCAL + " instead.");
+          + "Use the default value " + CarbonCommonConstants.CARBON_LOCK_TYPE_LOCAL + " instead.");
     }
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
@@ -165,8 +165,8 @@ public final class CarbonProperties {
         .startsWith(CarbonCommonConstants.ALLUXIOURL_PREFIX))
         && !CarbonCommonConstants.CARBON_LOCK_TYPE_HDFS.equalsIgnoreCase(lockTypeConfigured)) {
       LOGGER.warn("The value \"" + lockTypeConfigured + "\" configured for key "
-          + CarbonCommonConstants.LOCK_TYPE + "\" is invalid for current file system. "
-              + "Will use the default value \"" + CarbonCommonConstants.CARBON_LOCK_TYPE_HDFS + " instead");
+          + CarbonCommonConstants.LOCK_TYPE + " is invalid for current file system. "
+              + "Use the default value \"" + CarbonCommonConstants.CARBON_LOCK_TYPE_HDFS + " instead.");
       carbonProperties.setProperty(CarbonCommonConstants.LOCK_TYPE,
           CarbonCommonConstants.CARBON_LOCK_TYPE_HDFS);
     } else if (null != defaultFs && defaultFs.startsWith(CarbonCommonConstants.LOCAL_FILE_PREFIX)
@@ -174,8 +174,8 @@ public final class CarbonProperties {
       carbonProperties.setProperty(CarbonCommonConstants.LOCK_TYPE,
           CarbonCommonConstants.CARBON_LOCK_TYPE_LOCAL);
       LOGGER.warn("The value \"" + lockTypeConfigured + "\" configured for key "
-          + CarbonCommonConstants.LOCK_TYPE + "\" is invalid for current file system. "
-          + "Will use the default value \"" + CarbonCommonConstants.CARBON_LOCK_TYPE_LOCAL + " instead");
+          + CarbonCommonConstants.LOCK_TYPE + " is invalid for current file system. "
+          + "Use the default value \"" + CarbonCommonConstants.CARBON_LOCK_TYPE_LOCAL + " instead.");
     }
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
@@ -165,8 +165,8 @@ public final class CarbonProperties {
         .startsWith(CarbonCommonConstants.ALLUXIOURL_PREFIX))
         && !CarbonCommonConstants.CARBON_LOCK_TYPE_HDFS.equalsIgnoreCase(lockTypeConfigured)) {
       LOGGER.warn("The value \"" + lockTypeConfigured + "\" configured for key "
-          + CarbonCommonConstants.LOCK_TYPE + "\" is invalid. Using the default value \""
-          + CarbonCommonConstants.CARBON_LOCK_TYPE_HDFS);
+          + CarbonCommonConstants.LOCK_TYPE + "\" is invalid for current file system. "
+              + "Will use the default value \"" + CarbonCommonConstants.CARBON_LOCK_TYPE_HDFS + " instead");
       carbonProperties.setProperty(CarbonCommonConstants.LOCK_TYPE,
           CarbonCommonConstants.CARBON_LOCK_TYPE_HDFS);
     } else if (null != defaultFs && defaultFs.startsWith(CarbonCommonConstants.LOCAL_FILE_PREFIX)
@@ -174,9 +174,8 @@ public final class CarbonProperties {
       carbonProperties.setProperty(CarbonCommonConstants.LOCK_TYPE,
           CarbonCommonConstants.CARBON_LOCK_TYPE_LOCAL);
       LOGGER.warn("The value \"" + lockTypeConfigured + "\" configured for key "
-          + CarbonCommonConstants.LOCK_TYPE
-          + "\" is invalid. Using the default value \""
-          + CarbonCommonConstants.CARBON_LOCK_TYPE_LOCAL);
+          + CarbonCommonConstants.LOCK_TYPE + "\" is invalid for current file system. "
+          + "Will use the default value \"" + CarbonCommonConstants.CARBON_LOCK_TYPE_LOCAL + " instead");
     }
   }
 


### PR DESCRIPTION
Modify Reason:
The below warn message is not correct, need to optimize. Users may confused by this warn message, now the default value "LOCALLOCK" will be set before validate and configure lock, so it will not be null any more, change this warn message just for better understanding.