### PR TITLE
[CARBONDATA-1329] The first carbonindex file needs to be deleted during clean files operation

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/statusmanager/SegmentUpdateStatusManager.java
+++ b/core/src/main/java/org/apache/carbondata/core/statusmanager/SegmentUpdateStatusManager.java
@@ -984,10 +984,8 @@ public class SegmentUpdateStatusManager {
       }
 
       // get carbon index files of the block.
-      String taskNum = CarbonTablePath.DataFileUtil.getTaskNo(actualBlockName);
-      // String indexFileEndsWith = timestamp + CarbonTablePath.getCarbonIndexExtension();
-      if (eachFile.getName().endsWith(CarbonTablePath.getCarbonIndexExtension()) && eachFile
-          .getName().startsWith(taskNum)) {
+      String indexFileName = CarbonTablePath.getCarbonIndexFileName(actualBlockName);
+      if (eachFile.getName().equalsIgnoreCase(indexFileName)) {
         files.add(eachFile);
       }
 

--- a/core/src/main/java/org/apache/carbondata/core/util/path/CarbonTablePath.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/path/CarbonTablePath.java
@@ -733,4 +733,9 @@ public class CarbonTablePath extends Path {
   public static String addSegmentPrefix(String value) {
     return SEGMENT_PREFIX + value;
   }
+
+  public static String getCarbonIndexFileName(String actualBlockName) {
+    return DataFileUtil.getTaskNo(actualBlockName) + "-" + DataFileUtil.getBucketNo(actualBlockName)
+        + "-" + DataFileUtil.getTimeStampFromFileName(actualBlockName) + INDEX_FILE_EXT;
+  }
 }


### PR DESCRIPTION
No new test cases are required. Testing is carried out with clean operations on different type of IUD commands.
