### PR TITLE
[CARBONDATA-1279] Push down for queries like "%xxx" , ends with are not working as expected in Spark 2.1 

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonBoundReference.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonBoundReference.scala
@@ -49,3 +49,11 @@ case class CarbonBoundReference(colExp: ColumnExpression, dataType: DataType, nu
   override def newInstance(): NamedExpression = throw new UnsupportedOperationException
 }
 
+case class CarbonEndsWith(expr: Expression) extends Filter {
+  override def references: Array[String] = null
+}
+
+case class CarbonContainsWith(expr: Expression) extends Filter {
+  override def references: Array[String] = null
+}
+

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/CarbonLateDecodeStrategy.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/CarbonLateDecodeStrategy.scala
@@ -512,6 +512,10 @@ private[sql] class CarbonLateDecodeStrategy extends SparkStrategy {
         CastExpressionOptimization.checkIfCastCanBeRemove(c)
       case StartsWith(a: Attribute, Literal(v, t)) =>
         Some(sources.StringStartsWith(a.name, v.toString))
+      case c@EndsWith(a: Attribute, Literal(v, t)) =>
+        Some(CarbonEndsWith(c))
+      case c@Contains(a: Attribute, Literal(v, t)) =>
+        Some(CarbonContainsWith(c))
       case others => None
     }
   }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/optimizer/CarbonFilters.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/optimizer/CarbonFilters.scala
@@ -24,6 +24,8 @@ import org.apache.spark.sql.CarbonBoundReference
 import org.apache.spark.sql.CastExpr
 import org.apache.spark.sql.sources
 import org.apache.spark.sql.types._
+import org.apache.spark.sql.CarbonContainsWith
+import org.apache.spark.sql.CarbonEndsWith
 
 import org.apache.carbondata.core.metadata.datatype.DataType
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable
@@ -105,6 +107,18 @@ object CarbonFilters {
           val r = new LessThanExpression(
             getCarbonExpression(name), getCarbonLiteralExpression(name, maxValueLimit))
           Some(new AndExpression(l, r))
+        case CarbonEndsWith(expr: Expression) =>
+          Some(new SparkUnknownExpression(expr.transform {
+            case AttributeReference(name, dataType, _, _) =>
+              CarbonBoundReference(new CarbonColumnExpression(name.toString,
+                CarbonScalaUtil.convertSparkToCarbonDataType(dataType)), dataType, expr.nullable)
+          }))
+        case CarbonContainsWith(expr: Expression) =>
+          Some(new SparkUnknownExpression(expr.transform {
+            case AttributeReference(name, dataType, _, _) =>
+              CarbonBoundReference(new CarbonColumnExpression(name.toString,
+                CarbonScalaUtil.convertSparkToCarbonDataType(dataType)), dataType, expr.nullable)
+          }))
         case CastExpr(expr: Expression) =>
           Some(transformExpression(expr))
         case _ => None
@@ -235,6 +249,10 @@ object CarbonFilters {
           CastExpressionOptimization.checkIfCastCanBeRemove(c)
         case StartsWith(a: Attribute, Literal(v, t)) =>
           Some(sources.StringStartsWith(a.name, v.toString))
+        case c@EndsWith(a: Attribute, Literal(v, t)) =>
+          Some(CarbonEndsWith(c))
+        case c@Contains(a: Attribute, Literal(v, t)) =>
+          Some(CarbonContainsWith(c))
         case c@Cast(a: Attribute, _) =>
           Some(CastExpr(c))
         case others =>


### PR DESCRIPTION
Summary: Push down for some select queries not working as expected in Spark 2.1
Key: CARBONDATA-1279
URL: https://issues.apache.org/jira/browse/CARBONDATA-1279
Project: CarbonData
Issue Type: Bug
Reporter: Pannerselvam Velmyl

Adding push down filter for select queries with like option. Push down for some select queries with like were not working as expected in Spark 2.1 similar to Spark 1.5

No new test cases are required.