### PR TITLE
[CARBONDATA-1407] Fix default end key bug for no-dictionary dimension

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/FilterUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/FilterUtil.java
@@ -1205,7 +1205,7 @@ public final class FilterUtil {
       startPoint++;
     }
     for (int i = 0; i < numberOfNoDictionaryDimension; i++) {
-      noDictionaryEndKeyBuffer.put((byte) 127);
+      noDictionaryEndKeyBuffer.put((byte) 0xFF);
     }
     return noDictionaryEndKeyBuffer.array();
   }
@@ -1460,7 +1460,7 @@ public final class FilterUtil {
         continue;
       }
       if (null == setOfStartKeyByteArray.get(dimension.getOrdinal())) {
-        setOfStartKeyByteArray.put(dimension.getOrdinal(), new byte[] { 127 });
+        setOfStartKeyByteArray.put(dimension.getOrdinal(), new byte[] { (byte) 0xFF });
       }
 
     }
@@ -1492,7 +1492,7 @@ public final class FilterUtil {
       if (CarbonUtil.hasEncoding(dimension.getEncoder(), Encoding.DICTIONARY)) {
         continue;
       }
-      setOfEndKeyByteArray.put(dimension.getOrdinal(), new byte[] { 127 });
+      setOfEndKeyByteArray.put(dimension.getOrdinal(), new byte[] { (byte) 0xFF });
     }
   }
 


### PR DESCRIPTION
Now the default end key of no-dictionary dimension is 127 (0xEF), it should be 0xFF.