### PR TITLE
[CARBONDATA-1436] optimize concurrent control for datamap

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datamap/DataMapStoreManager.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/DataMapStoreManager.java
@@ -73,7 +73,7 @@ public final class DataMapStoreManager {
     } else {
       dataMap = getTableDataMap(dataMapName, tableDataMaps);
     }
-    
+
     if (dataMap == null) {
       throw new RuntimeException("Datamap does not exist");
     }


### PR DESCRIPTION
# Scenario

`DataMapStoreManager` provides a synchronized interface `getDataMap` to retrieve a table's `TableDataMap`. It will cause performance problems in current query scenario when all the queries have to wait the former query finished.

# Analyze

We can make the concurrent control in table scope instead of global scope.

# Modification

+ Synchronized by table.

+ Use double-checked locking to reduce lock overhead