### PR TITLE
[CARBONDATA-1412] - Fixed bug related to incorrect behavior of delete functionality while using segment.starttime before '<any_date_value>'

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/statusmanager/LoadMetadataDetails.java
+++ b/core/src/main/java/org/apache/carbondata/core/statusmanager/LoadMetadataDetails.java
@@ -52,7 +52,7 @@ public class LoadMetadataDetails implements Serializable {
 
   // dont remove static as the write will fail.
   private static final SimpleDateFormat parser =
-      new SimpleDateFormat(CarbonCommonConstants.CARBON_TIMESTAMP);
+      new SimpleDateFormat(CarbonCommonConstants.CARBON_TIMESTAMP_MILLIS);
   /**
    * Segment modification or deletion time stamp
    */

--- a/hadoop/src/test/java/org/apache/carbondata/hadoop/test/util/StoreCreator.java
+++ b/hadoop/src/test/java/org/apache/carbondata/hadoop/test/util/StoreCreator.java
@@ -144,7 +144,7 @@ public class StoreCreator {
       loadModel.setDateFormat(null);
       loadModel.setDefaultTimestampFormat(CarbonProperties.getInstance().getProperty(
           CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT,
-          CarbonCommonConstants.CARBON_TIMESTAMP_DEFAULT_FORMAT));
+          CarbonCommonConstants.CARBON_TIMESTAMP_MILLIS));
       loadModel.setDefaultDateFormat(CarbonProperties.getInstance().getProperty(
           CarbonCommonConstants.CARBON_DATE_FORMAT,
           CarbonCommonConstants.CARBON_DATE_DEFAULT_FORMAT));
@@ -495,7 +495,7 @@ public class StoreCreator {
   }
 
   public static String readCurrentTime() {
-    SimpleDateFormat sdf = new SimpleDateFormat(CarbonCommonConstants.CARBON_TIMESTAMP);
+    SimpleDateFormat sdf = new SimpleDateFormat(CarbonCommonConstants.CARBON_TIMESTAMP_MILLIS);
     String date = null;
 
     date = sdf.format(new Date());


### PR DESCRIPTION
segment.starttime before <any_date_value_containing_milliseconds> was giving incorrect behavior. As during fetching of the segment details timestamp data is in  "dd-MM-yyyy HH:mm:ss:SSS"  format while during internal conversions it was getting converted into "dd-MM-yyyy HH:mm:ss" format in which milliseconds data was getting lost.

Also when you perform query "show segments for table <tablename>" It provide details in "dd-MM-yyyy HH:mm:ss:SSS"  format. 

But when you apply segment.starttime before '2017-09-07 12:01:09.693' it gets converted to 2017-09-07 12:01:09 and hence segment with the provided starttime is also deleted.

To resolve the issue: I have used "dd-MM-yyyy HH:mm:ss:SSS" format at the time of fetching the segment time details.(this is the same format in which segment starttime is stored at the time of load.)