### PR TITLE
[CARBONDATA-1432] Fixed bug when column name in default.value property is not equal to column name in alter command

### DIFF
--- a/integration/spark-common-cluster-test/src/test/scala/org/apache/carbondata/cluster/sdv/generated/AlterTableTestCase.scala
+++ b/integration/spark-common-cluster-test/src/test/scala/org/apache/carbondata/cluster/sdv/generated/AlterTableTestCase.scala
@@ -450,11 +450,16 @@ class AlterTableTestCase extends QueryTest with BeforeAndAfterAll {
 
   //Check add column with option default value is given for an existing column
   test("ARID_AddColumn_001_14", Include) {
-    sql(s"""drop table if exists test1""").collect
-     sql(s"""create table test1 (name string) stored by 'carbondata'""").collect
-   sql(s"""insert into test1 select 'xx'""").collect
-    sql(s"""ALTER TABLE test1 ADD COLUMNS (Id int) TBLPROPERTIES('DICTIONARY_INCLUDE'='id','default.value.name'='yy')""").collect
-     sql(s"""drop table if exists test1""").collect
+    try {
+      sql(s"""drop table if exists test1""").collect
+      sql(s"""create table test1 (name string) stored by 'carbondata'""").collect
+      sql(s"""insert into test1 select 'xx'""").collect
+      sql(s"""ALTER TABLE test1 ADD COLUMNS (Id int) TBLPROPERTIES('DICTIONARY_INCLUDE'='id','default.value.name'='yy')""").collect
+      assert(false)
+      sql(s"""drop table if exists test1""").collect
+    } catch {
+      case _ => assert(true)
+    }
   }
 
 

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSpark2SqlParser.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSpark2SqlParser.scala
@@ -341,7 +341,12 @@ class CarbonSpark2SqlParser extends CarbonDDLSqlParser {
               throw new MalformedCarbonCommandException(
                 s"Unsupported Table property in add column: ${ f._1 }")
             } else if (f._1.toLowerCase.startsWith("default.value.")) {
-              f._1 -> f._2
+               if(fields.filter(field => checkFieldDefaultValue(field.column, f._1.toLowerCase)).size == 1) {
+                 f._1 -> f._2
+            } else {
+                 throw new MalformedCarbonCommandException(
+                s"Default.value property does not matches with the columns in ALTER command. Column name in property is: ${ f._1}")
+               }
             } else {
               f._1 -> f._2.toLowerCase
             })
@@ -367,6 +372,10 @@ class CarbonSpark2SqlParser extends CarbonDDLSqlParser {
           tableModel.highcardinalitydims.getOrElse(Seq.empty))
         AlterTableAddColumns(alterTableAddColumnsModel)
     }
+
+  private def checkFieldDefaultValue(fieldName: String, defaultValueColumnName: String): Boolean = {
+    defaultValueColumnName.equalsIgnoreCase("default.value."+fieldName)
+  }
 
   private def convertFieldNamesToLowercase(field: Field): Field = {
     val name = field.column.toLowerCase

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSpark2SqlParser.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSpark2SqlParser.scala
@@ -341,11 +341,13 @@ class CarbonSpark2SqlParser extends CarbonDDLSqlParser {
               throw new MalformedCarbonCommandException(
                 s"Unsupported Table property in add column: ${ f._1 }")
             } else if (f._1.toLowerCase.startsWith("default.value.")) {
-               if(fields.filter(field => checkFieldDefaultValue(field.column, f._1.toLowerCase)).size == 1) {
+              if (fields.count(field => checkFieldDefaultValue(field.column,
+                f._1.toLowerCase)) == 1) {
                  f._1 -> f._2
             } else {
                  throw new MalformedCarbonCommandException(
-                s"Default.value property does not matches with the columns in ALTER command. Column name in property is: ${ f._1}")
+                   s"Default.value property does not matches with the columns in ALTER command. " +
+                     s"Column name in property is: ${ f._1}")
                }
             } else {
               f._1 -> f._2.toLowerCase
@@ -374,7 +376,7 @@ class CarbonSpark2SqlParser extends CarbonDDLSqlParser {
     }
 
   private def checkFieldDefaultValue(fieldName: String, defaultValueColumnName: String): Boolean = {
-    defaultValueColumnName.equalsIgnoreCase("default.value."+fieldName)
+    defaultValueColumnName.equalsIgnoreCase("default.value." + fieldName)
   }
 
   private def convertFieldNamesToLowercase(field: Field): Field = {


### PR DESCRIPTION
Added exception case when column name in alter table command does not matches with the column name in default.value property.