### PR TITLE
[CARBONDATA-1446] Fixed Bug for error message on invalid partition id in alter partition command 

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/partition/TestDDLForPartitionTable.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/partition/TestDDLForPartitionTable.scala
@@ -139,17 +139,6 @@ class TestDDLForPartitionTable  extends QueryTest with BeforeAndAfterAll {
     intercept[Exception] { sql("alter table test drop columns(c)") }
   }
 
-  test("test exception if invalid partition id is provided in alter command") {
-    sql("drop table if exists test_invalid_partition_id")
-
-    sql("CREATE TABLE test_invalid_partition_id (CUST_NAME String,ACTIVE_EMUI_VERSION string,DOB Timestamp,DOJ timestamp, " +
-      "BIGINT_COLUMN1 bigint,BIGINT_COLUMN2 bigint,DECIMAL_COLUMN1 decimal(30,10), DECIMAL_COLUMN2 decimal(36,10)," +
-      "Double_COLUMN1 double, Double_COLUMN2 double,INTEGER_COLUMN1 int) PARTITIONED BY (CUST_ID int)" +
-      " STORED BY 'org.apache.carbondata.format' " +
-      "TBLPROPERTIES ('PARTITION_TYPE'='RANGE','RANGE_INFO'='9090,9500,9800',\"TABLE_BLOCKSIZE\"= \"256 MB\")")
-    intercept[IllegalArgumentException] { sql("ALTER TABLE test_invalid_partition_id SPLIT PARTITION(6) INTO ('9800','9900')") }
-  }
-
   test("test describe formatted for partition column") {
     sql("drop table if exists des")
     sql(

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/partition/TestDDLForPartitionTable.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/partition/TestDDLForPartitionTable.scala
@@ -139,6 +139,17 @@ class TestDDLForPartitionTable  extends QueryTest with BeforeAndAfterAll {
     intercept[Exception] { sql("alter table test drop columns(c)") }
   }
 
+  test("test exception if invalid partition id is provided in alter command") {
+    sql("drop table if exists test_invalid_partition_id")
+
+    sql("CREATE TABLE test_invalid_partition_id (CUST_NAME String,ACTIVE_EMUI_VERSION string,DOB Timestamp,DOJ timestamp, " +
+      "BIGINT_COLUMN1 bigint,BIGINT_COLUMN2 bigint,DECIMAL_COLUMN1 decimal(30,10), DECIMAL_COLUMN2 decimal(36,10)," +
+      "Double_COLUMN1 double, Double_COLUMN2 double,INTEGER_COLUMN1 int) PARTITIONED BY (CUST_ID int)" +
+      " STORED BY 'org.apache.carbondata.format' " +
+      "TBLPROPERTIES ('PARTITION_TYPE'='RANGE','RANGE_INFO'='9090,9500,9800',\"TABLE_BLOCKSIZE\"= \"256 MB\")")
+    intercept[IllegalArgumentException] { sql("ALTER TABLE test_invalid_partition_id SPLIT PARTITION(6) INTO ('9800','9900')") }
+  }
+
   test("test describe formatted for partition column") {
     sql("drop table if exists des")
     sql(

--- a/integration/spark-common/src/main/scala/org/apache/spark/util/PartitionUtils.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/util/PartitionUtils.scala
@@ -81,7 +81,8 @@ object PartitionUtils {
     val columnDataType = partitionInfo.getColumnSchemaList.get(0).getDataType
     val index = partitionIdList.indexOf(partitionId)
     if (index < 0) {
-      throw new IllegalArgumentException("Invalid Partition Id "+ partitionId + "\n Use show partitions table_name to get the list of valid partitions")
+      throw new IllegalArgumentException("Invalid Partition Id " + partitionId +
+        "\n Use show partitions table_name to get the list of valid partitions")
     }
     else {
       if (partitionInfo.getPartitionType == PartitionType.RANGE) {

--- a/integration/spark-common/src/main/scala/org/apache/spark/util/PartitionUtils.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/util/PartitionUtils.scala
@@ -84,39 +84,37 @@ object PartitionUtils {
       throw new IllegalArgumentException("Invalid Partition Id " + partitionId +
         "\n Use show partitions table_name to get the list of valid partitions")
     }
-    else {
-      if (partitionInfo.getPartitionType == PartitionType.RANGE) {
-        val rangeInfo = partitionInfo.getRangeInfo.asScala.toList
-        val newRangeInfo = partitionId match {
-          case 0 => rangeInfo ++ splitInfo
-          case _ => rangeInfo.take(index - 1) ++ splitInfo ++
-            rangeInfo.takeRight(rangeInfo.size - index)
-        }
-        CommonUtil.validateRangeInfo(newRangeInfo, columnDataType,
-          timestampFormatter, dateFormatter)
-        partitionInfo.setRangeInfo(newRangeInfo.asJava)
-      } else if (partitionInfo.getPartitionType == PartitionType.LIST) {
-        val originList = partitionInfo.getListInfo.asScala.map(_.asScala.toList).toList
-        if (partitionId != 0) {
-          val targetListInfo = partitionInfo.getListInfo.get(index - 1)
-          CommonUtil.validateSplitListInfo(targetListInfo.asScala.toList, splitInfo, originList)
-        } else {
-          CommonUtil.validateAddListInfo(splitInfo, originList)
-        }
-        val addListInfo = PartitionUtils.getListInfo(splitInfo.mkString(","))
-        val newListInfo = partitionId match {
-          case 0 => originList ++ addListInfo
-          case _ => originList.take(index - 1) ++ addListInfo ++
-            originList.takeRight(originList.size - index)
-        }
-        partitionInfo.setListInfo(newListInfo.map(_.asJava).asJava)
+    if (partitionInfo.getPartitionType == PartitionType.RANGE) {
+      val rangeInfo = partitionInfo.getRangeInfo.asScala.toList
+      val newRangeInfo = partitionId match {
+        case 0 => rangeInfo ++ splitInfo
+        case _ => rangeInfo.take(index - 1) ++ splitInfo ++
+          rangeInfo.takeRight(rangeInfo.size - index)
       }
-
-      if (partitionId == 0) {
-        partitionInfo.addPartition(splitInfo.size)
+      CommonUtil.validateRangeInfo(newRangeInfo, columnDataType,
+        timestampFormatter, dateFormatter)
+      partitionInfo.setRangeInfo(newRangeInfo.asJava)
+    } else if (partitionInfo.getPartitionType == PartitionType.LIST) {
+      val originList = partitionInfo.getListInfo.asScala.map(_.asScala.toList).toList
+      if (partitionId != 0) {
+        val targetListInfo = partitionInfo.getListInfo.get(index - 1)
+        CommonUtil.validateSplitListInfo(targetListInfo.asScala.toList, splitInfo, originList)
       } else {
-        partitionInfo.splitPartition(index, splitInfo.size)
+        CommonUtil.validateAddListInfo(splitInfo, originList)
       }
+      val addListInfo = PartitionUtils.getListInfo(splitInfo.mkString(","))
+      val newListInfo = partitionId match {
+        case 0 => originList ++ addListInfo
+        case _ => originList.take(index - 1) ++ addListInfo ++
+          originList.takeRight(originList.size - index)
+      }
+      partitionInfo.setListInfo(newListInfo.map(_.asJava).asJava)
+    }
+
+    if (partitionId == 0) {
+      partitionInfo.addPartition(splitInfo.size)
+    } else {
+      partitionInfo.splitPartition(index, splitInfo.size)
     }
   }
 

--- a/integration/spark-common/src/main/scala/org/apache/spark/util/PartitionUtils.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/util/PartitionUtils.scala
@@ -80,8 +80,11 @@ object PartitionUtils {
       dateFormatter: SimpleDateFormat): Unit = {
     val columnDataType = partitionInfo.getColumnSchemaList.get(0).getDataType
     val index = partitionIdList.indexOf(partitionId)
-    if (index >= 0) {
-        if (partitionInfo.getPartitionType == PartitionType.RANGE) {
+    if (index < 0) {
+      throw new IllegalArgumentException("Invalid Partition Id "+ partitionId + "\n Use show partitions table_name to get the list of valid partitions")
+    }
+    else {
+      if (partitionInfo.getPartitionType == PartitionType.RANGE) {
         val rangeInfo = partitionInfo.getRangeInfo.asScala.toList
         val newRangeInfo = partitionId match {
           case 0 => rangeInfo ++ splitInfo
@@ -113,9 +116,6 @@ object PartitionUtils {
       } else {
         partitionInfo.splitPartition(index, splitInfo.size)
       }
-    }
-    else {
-      throw new IllegalArgumentException("Invalid Partition Id")
     }
   }
 

--- a/integration/spark2/src/test/scala/org/apache/carbondata/spark/testsuite/partition/TestAlterPartitionTable.scala
+++ b/integration/spark2/src/test/scala/org/apache/carbondata/spark/testsuite/partition/TestAlterPartitionTable.scala
@@ -342,6 +342,17 @@ class TestAlterPartitionTable extends QueryTest with BeforeAndAfterAll {
     checkAnswer(result_after5, result_origin5)
   }
 
+  test("test exception if invalid partition id is provided in alter command") {
+    sql("drop table if exists test_invalid_partition_id")
+
+    sql("CREATE TABLE test_invalid_partition_id (CUST_NAME String,ACTIVE_EMUI_VERSION string,DOB Timestamp,DOJ timestamp, " +
+      "BIGINT_COLUMN1 bigint,BIGINT_COLUMN2 bigint,DECIMAL_COLUMN1 decimal(30,10), DECIMAL_COLUMN2 decimal(36,10)," +
+      "Double_COLUMN1 double, Double_COLUMN2 double,INTEGER_COLUMN1 int) PARTITIONED BY (CUST_ID int)" +
+      " STORED BY 'org.apache.carbondata.format' " +
+      "TBLPROPERTIES ('PARTITION_TYPE'='RANGE','RANGE_INFO'='9090,9500,9800',\"TABLE_BLOCKSIZE\"= \"256 MB\")")
+    intercept[IllegalArgumentException] { sql("ALTER TABLE test_invalid_partition_id SPLIT PARTITION(6) INTO ('9800','9900')") }
+  }
+
   test("Alter table split partition: List Partition") {
     sql("""ALTER TABLE list_table_country SPLIT PARTITION(4) INTO ('Canada', 'Russia', '(Good, NotGood)')""".stripMargin)
     val carbonTable = CarbonMetadata.getInstance().getCarbonTable("default_list_table_country")


### PR DESCRIPTION
1. In alter partition command, if the user has given invalid partition id ( that is, partition id which does not exist ), this case is not handled, and the invalid partition id results in inappropriate exception further in code.
2. In this PR, an appropriate exception is thrown for Invalid Partition Id.
3. Added test case for the same in class TestAlterPartitionTable.scala 