### PR TITLE
[CARBONDATA-1291]:carbonData query performance improvement when numbe…

### DIFF
--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/CarbonInputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/CarbonInputFormat.java
@@ -460,21 +460,22 @@ public class CarbonInputFormat<T> extends FileInputFormat<Void, T> {
       for (DataRefNode dataRefNode : dataRefNodes) {
         BlockBTreeLeafNode leafNode = (BlockBTreeLeafNode) dataRefNode;
         TableBlockInfo tableBlockInfo = leafNode.getTableBlockInfo();
+        String[] deleteDeltaFilePath = null;
         if (isIUDTable) {
           // In case IUD is not performed in this table avoid searching for
           // invalidated blocks.
           if (CarbonUtil
-              .isInvalidTableBlock(tableBlockInfo.getSegmentId(), tableBlockInfo.getFilePath(),
-                  invalidBlockVOForSegmentId, updateStatusManager)) {
+                  .isInvalidTableBlock(tableBlockInfo.getSegmentId(), tableBlockInfo.getFilePath(),
+                          invalidBlockVOForSegmentId, updateStatusManager)) {
             continue;
           }
-        }
-        String[] deleteDeltaFilePath = null;
-        try {
-          deleteDeltaFilePath =
-              updateStatusManager.getDeleteDeltaFilePath(tableBlockInfo.getFilePath());
-        } catch (Exception e) {
-          throw new IOException(e);
+          // When iud is done then only get delete delta files for a block
+          try {
+            deleteDeltaFilePath =
+                    updateStatusManager.getDeleteDeltaFilePath(tableBlockInfo.getFilePath());
+          } catch (Exception e) {
+            throw new IOException(e);
+          }
         }
         result.add(new CarbonInputSplit(segmentNo, new Path(tableBlockInfo.getFilePath()),
             tableBlockInfo.getBlockOffset(), tableBlockInfo.getBlockLength(),

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableInputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableInputFormat.java
@@ -448,21 +448,22 @@ public class CarbonTableInputFormat<T> extends FileInputFormat<Void, T> {
         invalidBlockVOForSegmentId =
             updateStatusManager.getInvalidTimestampRange(inputSplit.getSegmentId());
       }
+      String[] deleteDeltaFilePath = null;
       if (isIUDTable) {
         // In case IUD is not performed in this table avoid searching for
         // invalidated blocks.
         if (CarbonUtil
-            .isInvalidTableBlock(inputSplit.getSegmentId(), inputSplit.getPath().toString(),
-                invalidBlockVOForSegmentId, updateStatusManager)) {
+                .isInvalidTableBlock(inputSplit.getSegmentId(), inputSplit.getPath().toString(),
+                        invalidBlockVOForSegmentId, updateStatusManager)) {
           continue;
         }
-      }
-      String[] deleteDeltaFilePath = null;
-      try {
-        deleteDeltaFilePath =
-            updateStatusManager.getDeleteDeltaFilePath(inputSplit.getPath().toString());
-      } catch (Exception e) {
-        throw new IOException(e);
+        // When iud is done then only get delete delta files for a block
+        try {
+          deleteDeltaFilePath =
+                  updateStatusManager.getDeleteDeltaFilePath(inputSplit.getPath().toString());
+        } catch (Exception e) {
+          throw new IOException(e);
+        }
       }
       inputSplit.setDeleteDeltaFiles(deleteDeltaFilePath);
       result.add(inputSplit);


### PR DESCRIPTION
…r of carbon blocks are high

Limit query performance is slow when one load is having around 8400 carbondata files using Spark Distribution 
This issue came, when number of blocks are high in that case for each block it is listing the delete delta file which is a expensive operation.
Solution- if IUD is done then only check for delete delta files

