### PR TITLE
[CARBONDATA-1437] Fixed bug for incorrect exception message when loading to table having property 'bucketnumber' set to 0. 

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSpark2SqlParser.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSpark2SqlParser.scala
@@ -431,7 +431,7 @@ class CarbonSpark2SqlParser extends CarbonDDLSqlParser {
     }
     if (options.isBucketingEnabled) {
       if (options.bucketNumber.toString.contains("-") ||
-          options.bucketNumber.toString.contains("+")) {
+          options.bucketNumber.toString.contains("+") ||  options.bucketNumber == 0) {
         throw new MalformedCarbonCommandException("INVALID NUMBER OF BUCKETS SPECIFIED")
       }
       else {

--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/bucketing/TableBucketingTestCase.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/bucketing/TableBucketingTestCase.scala
@@ -44,6 +44,7 @@ class TableBucketingTestCase extends Spark2QueryTest with BeforeAndAfterAll {
     sql("DROP TABLE IF EXISTS t8")
     sql("DROP TABLE IF EXISTS t9")
     sql("DROP TABLE IF EXISTS t10")
+    sql("DROP TABLE IF EXISTS t11")
   }
 
   test("test create table with buckets") {
@@ -84,6 +85,29 @@ class TableBucketingTestCase extends Spark2QueryTest with BeforeAndAfterAll {
            USING org.apache.spark.sql.CarbonSource
            OPTIONS("bucketnumber"="-1", "bucketcolumns"="name", "tableName"="t9")
         """)
+      assert(false)
+    }
+    catch {
+      case malformedCarbonCommandException: MalformedCarbonCommandException => assert(true)
+    }
+  }
+
+  test("must unable to create table if number of buckets is 0") {
+    try{
+      sql(
+        """
+          |CREATE TABLE t11
+          |(ID Int,
+          | date Timestamp,
+          | country String,
+          | name String,
+          | phonetype String,
+          | serialname String,
+          | salary Int)
+          | STORED BY 'CARBONDATA'
+          | TBLPROPERTIES('bucketnumber'='0', 'bucketcolumns'='name')
+        """.stripMargin
+      )
       assert(false)
     }
     catch {


### PR DESCRIPTION
1. In this PR, Table creation would not be allowed, if the table property 'bucketnumber' is set to 0 in create command.
2. Added unit test case for it as well in class TableBucketingTestCase.scala
