### PR TITLE
[CARBONDATA-1408]:Data loading with globalSort is failing in long run…

### DIFF
--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/load/DataLoadProcessorStepOnSpark.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/load/DataLoadProcessorStepOnSpark.scala
@@ -225,7 +225,7 @@ object DataLoadProcessorStepOnSpark {
     } else {
       storeLocation = System.getProperty("java.io.tmpdir")
     }
-    storeLocation = storeLocation + '/' + System.nanoTime() + '/' + index
+    storeLocation = storeLocation + '/' + System.nanoTime() + '_' + index
     storeLocation
   }
 

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonMergerRDD.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonMergerRDD.scala
@@ -101,7 +101,7 @@ class CarbonMergerRDD[K, V](
       } else {
         storeLocation = System.getProperty("java.io.tmpdir")
       }
-      storeLocation = storeLocation + '/' + System.nanoTime() + '/' + theSplit.index
+      storeLocation = storeLocation + '/' + System.nanoTime() + '_' + theSplit.index
       var mergeStatus = false
       var mergeNumber = ""
       var exec: CarbonCompactionExecutor = null

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/NewCarbonDataLoadRDD.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/NewCarbonDataLoadRDD.scala
@@ -169,7 +169,7 @@ class SparkPartitionLoader(model: CarbonLoadModel,
     LOGGER.info("Temp location for loading data: " + storeLocation.mkString(","))
   }
 
-  private def tmpLocationSuffix = File.separator + System.nanoTime() + File.separator + splitIndex
+  private def tmpLocationSuffix = File.separator + System.nanoTime() + "_" + splitIndex
 }
 
 /**


### PR DESCRIPTION
After 437 load, data loading getting failed.
On analyzing the root cause it concluded that any new folder is not getting created in temp location.
There's a certain limit based on OS in folder creation. Thus in long run data loading case the folder creation limit reaches its maximum due to which any new folder is not getting created in temp folder, and thus the data loading is getting failed.
Solution:- Need to delete the created folder from temp folder once data loading is completed.