### PR TITLE
[CARBONDATA-1463] CompareTest should validate result size

### DIFF
--- a/examples/spark2/src/main/scala/org/apache/carbondata/examples/CompareTest.scala
+++ b/examples/spark2/src/main/scala/org/apache/carbondata/examples/CompareTest.scala
@@ -320,7 +320,10 @@ object CompareTest {
 
   private def printErrorIfNotMatch(index: Int, table1: String, result1: Array[Row],
       table2: String, result2: Array[Row]): Unit = {
-    if (!result1.sameElements(result2)) {
+    // check result size instead of result value, because some test case include
+    // aggregation on double column which will give different result since carbon
+    // records are sorted
+    if (result1.length != result2.length) {
       val num = index + 1
       println(s"$table1 result for query $num: ")
       println(s"""${result1.mkString(",")}""")


### PR DESCRIPTION
CompareTest for spark2.1 should only validate result size instead of result value, because some test case include aggregation on double column which will give different result since carbon records are sorted