### PR TITLE
[CARBONDATA-1465] resolved bug for hive cant query carbon table when column name is in small letters

### DIFF
--- a/integration/hive/hive-guide.md
+++ b/integration/hive/hive-guide.md
@@ -91,7 +91,6 @@ $HIVE_HOME/bin/hive
 ### Query data from hive table
 
 ```
-alter table hive_carbon set location '<hdfs store path>/hive_carbon';
 set hive.mapred.supports.subdirectories=true;
 set mapreduce.input.fileinputformat.input.dir.recursive=true;
 

--- a/integration/hive/src/main/java/org/apache/carbondata/hive/MapredCarbonInputFormat.java
+++ b/integration/hive/src/main/java/org/apache/carbondata/hive/MapredCarbonInputFormat.java
@@ -172,7 +172,7 @@ public class MapredCarbonInputFormat extends CarbonInputFormat<ArrayWritable>
       //verify that the columns parsed by Hive exist in the table
       for (String col : columnNames) {
         //show columns command will return these data
-        if (carbonColumnNames.contains(col)) {
+        if (carbonColumnNames.contains(col) || carbonColumnNames.contains(col.toUpperCase())) {
           projectionColumns.append(col + ",");
         }
       }

--- a/integration/hive/src/main/java/org/apache/carbondata/hive/MapredCarbonInputFormat.java
+++ b/integration/hive/src/main/java/org/apache/carbondata/hive/MapredCarbonInputFormat.java
@@ -163,7 +163,7 @@ public class MapredCarbonInputFormat extends CarbonInputFormat<ArrayWritable>
     StringBuilder allColumns = new StringBuilder();
     StringBuilder projectionColumns = new StringBuilder();
     for (CarbonColumn column : carbonColumns) {
-      carbonColumnNames.add(column.getColName());
+      carbonColumnNames.add(column.getColName().toLowerCase());
       allColumns.append(column.getColName() + ",");
     }
 
@@ -172,7 +172,7 @@ public class MapredCarbonInputFormat extends CarbonInputFormat<ArrayWritable>
       //verify that the columns parsed by Hive exist in the table
       for (String col : columnNames) {
         //show columns command will return these data
-        if (carbonColumnNames.contains(col) || carbonColumnNames.contains(col.toUpperCase())) {
+        if (carbonColumnNames.contains(col.toLowerCase())) {
           projectionColumns.append(col + ",");
         }
       }


### PR DESCRIPTION
1.Resolved bug for hive can't query carbon when column name is in small letters
2.Corrected the hive guide there is no need  of alter table statement to alter location now it is done by CarbonHiveMetastore Event listener itself