### PR TITLE
[CARBONDATA-1470] csv data should not show in error log when data column length is greater than 100000 characters

### DIFF
--- a/processing/src/main/java/org/apache/carbondata/processing/csvload/CSVRecordReaderIterator.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/csvload/CSVRecordReaderIterator.java
@@ -19,8 +19,12 @@ package org.apache.carbondata.processing.csvload;
 
 import java.io.IOException;
 
+
 import org.apache.carbondata.common.CarbonIterator;
 import org.apache.carbondata.processing.newflow.exception.CarbonDataLoadingException;
+import org.apache.carbondata.processing.util.CarbonDataProcessorUtil;
+
+import com.univocity.parsers.common.TextParsingException;
 
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.mapreduce.InputSplit;
@@ -62,6 +66,10 @@ public class CSVRecordReaderIterator extends CarbonIterator<Object []> {
       }
       return true;
     } catch (Exception e) {
+      if (e instanceof TextParsingException) {
+        throw new CarbonDataLoadingException(
+            CarbonDataProcessorUtil.trimErrorMessage(e.getMessage()));
+      }
       throw new CarbonDataLoadingException(e);
     }
   }

--- a/processing/src/main/java/org/apache/carbondata/processing/util/CarbonDataProcessorUtil.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/util/CarbonDataProcessorUtil.java
@@ -610,4 +610,20 @@ public final class CarbonDataProcessorUtil {
     }
     return outArr;
   }
+
+  /**
+   * This method returns String if exception is TextParsingException
+   *
+   * @param input
+   * @return
+   */
+  public static String trimErrorMessage(String input) {
+    String errorMessage = input;
+    if (input != null) {
+      if (input.split("Hint").length > 0) {
+        errorMessage = input.split("Hint")[0];
+      }
+    }
+    return errorMessage;
+  }
 }


### PR DESCRIPTION
Added method to handle TextParsingException and stop the leak of the sensitive data in logs