### PR TITLE
[CARBONDATA-1475] fix default maven dependencies for Intellij Idea

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -50,11 +50,23 @@
       <groupId>org.apache.carbondata</groupId>
       <artifactId>carbondata-core</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.spark</groupId>
+          <artifactId>spark-sql_2.11</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.carbondata</groupId>
       <artifactId>carbondata-processing</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.spark</groupId>
+          <artifactId>spark-sql_2.11</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 
@@ -133,6 +145,20 @@
           <groupId>org.apache.carbondata</groupId>
           <artifactId>carbondata-spark</artifactId>
           <version>${project.version}</version>
+          <exclusions>
+            <exclusion>
+              <groupId>org.apache.spark</groupId>
+              <artifactId>spark-hive-thriftserver_2.11</artifactId>
+            </exclusion>
+            <exclusion>
+              <groupId>org.apache.spark</groupId>
+              <artifactId>spark-sql_2.11</artifactId>
+            </exclusion>
+            <exclusion>
+              <groupId>org.apache.spark</groupId>
+              <artifactId>spark-repl_2.11</artifactId>
+            </exclusion>
+          </exclusions>
         </dependency>
       </dependencies>
     </profile>
@@ -143,6 +169,20 @@
           <groupId>org.apache.carbondata</groupId>
           <artifactId>carbondata-spark</artifactId>
           <version>${project.version}</version>
+          <exclusions>
+            <exclusion>
+              <groupId>org.apache.spark</groupId>
+              <artifactId>spark-hive-thriftserver_2.11</artifactId>
+            </exclusion>
+            <exclusion>
+              <groupId>org.apache.spark</groupId>
+              <artifactId>spark-sql_2.11</artifactId>
+            </exclusion>
+            <exclusion>
+              <groupId>org.apache.spark</groupId>
+              <artifactId>spark-repl_2.11</artifactId>
+            </exclusion>
+          </exclusions>
         </dependency>
       </dependencies>
     </profile>
@@ -167,6 +207,20 @@
         <spark.deps.scope>compile</spark.deps.scope>
         <scala.deps.scope>compile</scala.deps.scope>
       </properties>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.spark</groupId>
+          <artifactId>spark-sql_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.spark</groupId>
+          <artifactId>spark-hive-thriftserver_${scala.binary.version}</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.spark</groupId>
+          <artifactId>spark-repl_${scala.binary.version}</artifactId>
+        </dependency>
+      </dependencies>
     </profile>
     <profile>
       <id>dist</id>

--- a/examples/flink/pom.xml
+++ b/examples/flink/pom.xml
@@ -47,18 +47,34 @@
     </dependency>
     <dependency>
       <groupId>org.apache.carbondata</groupId>
-      <artifactId>carbondata-hadoop</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.carbondata</groupId>
-      <artifactId>carbondata-spark</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.carbondata</groupId>
       <artifactId>carbondata-examples-spark</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.spark</groupId>
+          <artifactId>spark-hive-thriftserver_2.11</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.spark</groupId>
+          <artifactId>spark-repl_2.11</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.spark</groupId>
+          <artifactId>spark-sql_2.11</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-sql_${scala.binary.version}</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-hive-thriftserver_${scala.binary.version}</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-repl_${scala.binary.version}</artifactId>
     </dependency>
   </dependencies>
 

--- a/examples/spark/pom.xml
+++ b/examples/spark/pom.xml
@@ -38,6 +38,32 @@
       <groupId>org.apache.carbondata</groupId>
       <artifactId>carbondata-spark</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.spark</groupId>
+          <artifactId>spark-hive-thriftserver_2.11</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.spark</groupId>
+          <artifactId>spark-repl_2.11</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.spark</groupId>
+          <artifactId>spark-sql_2.11</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-sql_${scala.binary.version}</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-hive-thriftserver_${scala.binary.version}</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-repl_${scala.binary.version}</artifactId>
     </dependency>
   </dependencies>
 

--- a/examples/spark2/pom.xml
+++ b/examples/spark2/pom.xml
@@ -38,32 +38,6 @@
       <groupId>org.apache.carbondata</groupId>
       <artifactId>carbondata-spark2</artifactId>
       <version>${project.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.spark</groupId>
-          <artifactId>spark-hive-thriftserver_2.10</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.spark</groupId>
-          <artifactId>spark-repl_2.10</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.spark</groupId>
-          <artifactId>spark-sql_2.10</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.spark</groupId>
-      <artifactId>spark-sql_${scala.binary.version}</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.spark</groupId>
-      <artifactId>spark-hive-thriftserver_${scala.binary.version}</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.spark</groupId>
-      <artifactId>spark-repl_${scala.binary.version}</artifactId>
     </dependency>
   </dependencies>
 

--- a/hadoop/pom.xml
+++ b/hadoop/pom.xml
@@ -38,6 +38,16 @@
       <groupId>org.apache.carbondata</groupId>
       <artifactId>carbondata-processing</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.spark</groupId>
+          <artifactId>spark-sql_2.11</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-sql_${scala.binary.version}</artifactId>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/integration/hive/pom.xml
+++ b/integration/hive/pom.xml
@@ -70,15 +70,15 @@
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.spark</groupId>
-                    <artifactId>spark-hive-thriftserver_2.10</artifactId>
+                    <artifactId>spark-hive-thriftserver_2.11</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>org.apache.spark</groupId>
-                    <artifactId>spark-repl_2.10</artifactId>
+                    <artifactId>spark-repl_2.11</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>org.apache.spark</groupId>
-                    <artifactId>spark-sql_2.10</artifactId>
+                    <artifactId>spark-sql_2.11</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -119,7 +119,7 @@
             <exclusions>
               <exclusion>
                 <groupId>org.apache.spark</groupId>
-                <artifactId>spark-sql_2.10</artifactId>
+                <artifactId>spark-sql_2.11</artifactId>
               </exclusion>
             </exclusions>
         </dependency>

--- a/integration/hive/pom.xml
+++ b/integration/hive/pom.xml
@@ -67,20 +67,6 @@
             <groupId>org.apache.carbondata</groupId>
             <artifactId>carbondata-spark2</artifactId>
             <version>${project.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.spark</groupId>
-                    <artifactId>spark-hive-thriftserver_2.11</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.spark</groupId>
-                    <artifactId>spark-repl_2.11</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.spark</groupId>
-                    <artifactId>spark-sql_2.11</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.hive</groupId>
@@ -116,12 +102,6 @@
             <groupId>org.apache.carbondata</groupId>
             <artifactId>carbondata-hadoop</artifactId>
             <version>${project.version}</version>
-            <exclusions>
-              <exclusion>
-                <groupId>org.apache.spark</groupId>
-                <artifactId>spark-sql_2.11</artifactId>
-              </exclusion>
-            </exclusions>
         </dependency>
     </dependencies>
 

--- a/integration/spark-common-cluster-test/pom.xml
+++ b/integration/spark-common-cluster-test/pom.xml
@@ -43,7 +43,7 @@
       <exclusions>
         <exclusion>
           <groupId>org.apache.spark</groupId>
-          <artifactId>spark-hive-thriftserver_2.10</artifactId>
+          <artifactId>spark-hive-thriftserver_2.11</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -170,11 +170,11 @@
           <exclusions>
             <exclusion>
               <groupId>org.apache.spark</groupId>
-              <artifactId>spark-hive-thriftserver_2.10</artifactId>
+              <artifactId>spark-hive-thriftserver_2.11</artifactId>
             </exclusion>
             <exclusion>
               <groupId>org.apache.spark</groupId>
-              <artifactId>spark-repl_2.10</artifactId>
+              <artifactId>spark-repl_2.11</artifactId>
             </exclusion>
           </exclusions>
         </dependency>
@@ -191,11 +191,11 @@
           <exclusions>
             <exclusion>
               <groupId>org.apache.spark</groupId>
-              <artifactId>spark-hive-thriftserver_2.10</artifactId>
+              <artifactId>spark-hive-thriftserver_2.11</artifactId>
             </exclusion>
             <exclusion>
               <groupId>org.apache.spark</groupId>
-              <artifactId>spark-repl_2.10</artifactId>
+              <artifactId>spark-repl_2.11</artifactId>
             </exclusion>
           </exclusions>
         </dependency>
@@ -215,11 +215,11 @@
           <exclusions>
             <exclusion>
               <groupId>org.apache.spark</groupId>
-              <artifactId>spark-hive-thriftserver_2.10</artifactId>
+              <artifactId>spark-hive-thriftserver_2.11</artifactId>
             </exclusion>
             <exclusion>
               <groupId>org.apache.spark</groupId>
-              <artifactId>spark-repl_2.10</artifactId>
+              <artifactId>spark-repl_2.11</artifactId>
             </exclusion>
           </exclusions>
         </dependency>

--- a/integration/spark-common-test/pom.xml
+++ b/integration/spark-common-test/pom.xml
@@ -94,7 +94,11 @@
       <exclusions>
         <exclusion>
           <groupId>org.apache.spark</groupId>
-          <artifactId>spark-hive-thriftserver_2.10</artifactId>
+          <artifactId>spark-hive-thriftserver_2.11</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.spark</groupId>
+          <artifactId>spark-sql_2.11</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -344,11 +348,11 @@
           <exclusions>
             <exclusion>
               <groupId>org.apache.spark</groupId>
-              <artifactId>spark-hive-thriftserver_2.10</artifactId>
+              <artifactId>spark-hive-thriftserver_2.11</artifactId>
             </exclusion>
             <exclusion>
               <groupId>org.apache.spark</groupId>
-              <artifactId>spark-repl_2.10</artifactId>
+              <artifactId>spark-repl_2.11</artifactId>
             </exclusion>
           </exclusions>
         </dependency>
@@ -365,11 +369,11 @@
           <exclusions>
             <exclusion>
               <groupId>org.apache.spark</groupId>
-              <artifactId>spark-hive-thriftserver_2.10</artifactId>
+              <artifactId>spark-hive-thriftserver_2.11</artifactId>
             </exclusion>
             <exclusion>
               <groupId>org.apache.spark</groupId>
-              <artifactId>spark-repl_2.10</artifactId>
+              <artifactId>spark-repl_2.11</artifactId>
             </exclusion>
           </exclusions>
         </dependency>
@@ -389,11 +393,11 @@
           <exclusions>
             <exclusion>
               <groupId>org.apache.spark</groupId>
-              <artifactId>spark-hive-thriftserver_2.10</artifactId>
+              <artifactId>spark-hive-thriftserver_2.11</artifactId>
             </exclusion>
             <exclusion>
               <groupId>org.apache.spark</groupId>
-              <artifactId>spark-repl_2.10</artifactId>
+              <artifactId>spark-repl_2.11</artifactId>
             </exclusion>
           </exclusions>
         </dependency>

--- a/integration/spark-common/pom.xml
+++ b/integration/spark-common/pom.xml
@@ -36,23 +36,14 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.carbondata</groupId>
-      <artifactId>carbondata-processing</artifactId>
+      <artifactId>carbondata-hadoop</artifactId>
       <version>${project.version}</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.spark</groupId>
-          <artifactId>spark-hive-thriftserver_2.10</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.spark</groupId>
-          <artifactId>spark-sql_2.10</artifactId>
+          <artifactId>spark-sql_2.11</artifactId>
         </exclusion>
       </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.carbondata</groupId>
-      <artifactId>carbondata-hadoop</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.scala-lang</groupId>

--- a/integration/spark/pom.xml
+++ b/integration/spark/pom.xml
@@ -36,28 +36,18 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.carbondata</groupId>
-      <artifactId>carbondata-common</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.carbondata</groupId>
-      <artifactId>carbondata-core</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.carbondata</groupId>
-      <artifactId>carbondata-processing</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.carbondata</groupId>
-      <artifactId>carbondata-hadoop</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.carbondata</groupId>
       <artifactId>carbondata-spark-common</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.spark</groupId>
+          <artifactId>spark-hive-thriftserver_2.11</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.spark</groupId>
+          <artifactId>spark-sql_2.11</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.scala-lang</groupId>

--- a/integration/spark2/pom.xml
+++ b/integration/spark2/pom.xml
@@ -38,16 +38,6 @@
       <groupId>org.apache.carbondata</groupId>
       <artifactId>carbondata-spark-common</artifactId>
       <version>${project.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.spark</groupId>
-          <artifactId>spark-hive-thriftserver_2.10</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.spark</groupId>
-          <artifactId>spark-sql_2.10</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>

--- a/processing/pom.xml
+++ b/processing/pom.xml
@@ -41,7 +41,7 @@
       <exclusions>
         <exclusion>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-sql_2.10</artifactId>
+            <artifactId>spark-sql_2.11</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
When we choose spark-1.6, Intellij Idea dependency scala-2.11.
This PR will fix this issue.
![selection_007](https://user-images.githubusercontent.com/15495227/30332946-4af1482c-97a1-11e7-9337-300346292aeb.png)
