### PR TITLE
[CARBONDATA-1452] Issue with loading timestamp data beyond cutoff

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/keygenerator/directdictionary/timestamp/TimeStampDirectDictionaryGenerator.java
+++ b/core/src/main/java/org/apache/carbondata/core/keygenerator/directdictionary/timestamp/TimeStampDirectDictionaryGenerator.java
@@ -210,15 +210,12 @@ public class TimeStampDirectDictionaryGenerator implements DirectDictionaryGener
   }
 
   private int generateKey(long timeValue) {
-    if (timeValue >= 0) {
-      long time = (timeValue - cutOffTimeStamp) / granularityFactor;
-      int keyValue = -1;
-      if (time <= (long) Integer.MAX_VALUE) {
-        keyValue = (int) time;
-      }
-      return keyValue < 0 ? 1 : keyValue + 2;
+    long time = (timeValue - cutOffTimeStamp) / granularityFactor;
+    int keyValue = -1;
+    if (time >= (long) Integer.MIN_VALUE && time <= (long) Integer.MAX_VALUE) {
+      keyValue = (int) time;
     }
-    return 1;
+    return keyValue < 0 ? 1 : keyValue + 2;
   }
 
   public void initialize() {


### PR DESCRIPTION
(1)Removed timeValue>=0 condition => this condition will restrict loading proper data when the **"CARBON_CUTOFF_TIMESTAMP"** is set before 1970. In this case timeValue will always be < 0 
(2) Added test case for the same