### PR TITLE
[Release]Add dependency of spark-sql-2.1 to presto as it fails when building using spark-1.6 version.

### DIFF
--- a/integration/presto/pom.xml
+++ b/integration/presto/pom.xml
@@ -438,7 +438,11 @@
         </exclusion>
       </exclusions>
     </dependency>
-
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-sql_2.11</artifactId>
+      <version>2.1.0</version>
+    </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-network-common_2.11</artifactId>


### PR DESCRIPTION
Spark 2.1 dependency got added to presto in the PR https://github.com/apache/carbondata/pull/1307 .
So when using build-all profile using 1.6 profile to build carbon, presto fails as it only depends on spark 2.1 package.