### PR TITLE
[CARBONDATA-1398] Support query from specified segments

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -50,6 +50,12 @@ public final class CarbonCommonConstants {
    * measure meta data file name
    */
   public static final String MEASURE_METADATA_FILE_NAME = "/msrMetaData_";
+
+  /**
+   * set the segment ids to query from the table
+   */
+  public static final String CARBON_INPUT_SEGMENTS = "carbon.input.segments.";
+
   /**
    * location of the carbon member, hierarchy and fact files
    */

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
@@ -54,6 +54,7 @@ import org.apache.carbondata.core.datastore.columnar.ColumnGroupModel;
 import org.apache.carbondata.core.datastore.columnar.UnBlockIndexer;
 import org.apache.carbondata.core.datastore.filesystem.CarbonFile;
 import org.apache.carbondata.core.datastore.impl.FileFactory;
+import org.apache.carbondata.core.exception.InvalidConfigurationException;
 import org.apache.carbondata.core.indexstore.BlockletDetailInfo;
 import org.apache.carbondata.core.keygenerator.mdkey.NumberCompressor;
 import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
@@ -2011,6 +2012,30 @@ public final class CarbonUtil {
     }
   }
 
+  public static boolean validateRangeOfSegmentList(String segmentId)
+      throws InvalidConfigurationException {
+    String[] values = segmentId.split(",");
+    try {
+      if (values.length == 0) {
+        throw new InvalidConfigurationException(
+            "carbon.input.segments.<database_name>.<table_name> value can't be empty.");
+      }
+      for (String value : values) {
+        if (!value.equalsIgnoreCase("*")) {
+          Float aFloatValue = Float.parseFloat(value);
+          if (aFloatValue < 0 || aFloatValue > Float.MAX_VALUE) {
+            throw new InvalidConfigurationException(
+                "carbon.input.segments.<database_name>.<table_name> value range should be greater "
+                    + "than 0 and less than " + Float.MAX_VALUE);
+          }
+        }
+      }
+    } catch (NumberFormatException nfe) {
+      throw new InvalidConfigurationException(
+          "carbon.input.segments.<database_name>.<table_name> value range is not valid");
+    }
+    return true;
+  }
   /**
    * Below method will be used to check whether bitset applied on previous filter
    * can be used to apply on next column filter

--- a/core/src/main/java/org/apache/carbondata/core/util/SessionParams.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/SessionParams.java
@@ -25,6 +25,7 @@ import org.apache.carbondata.common.constants.LoggerAction;
 import org.apache.carbondata.common.logging.LogService;
 import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.cache.CacheProvider;
+import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.exception.InvalidConfigurationException;
 
 import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_CUSTOM_BLOCK_DISTRIBUTION;
@@ -144,8 +145,15 @@ public class SessionParams implements Serializable {
         isValid = true;
         break;
       default:
-        throw new InvalidConfigurationException(
-            "The key " + key + " not supported for dynamic configuration.");
+        if (key.startsWith(CarbonCommonConstants.CARBON_INPUT_SEGMENTS)) {
+          isValid = CarbonUtil.validateRangeOfSegmentList(value);
+          if (!isValid) {
+            throw new InvalidConfigurationException("Invalid CARBON_INPUT_SEGMENT_IDs");
+          }
+        } else {
+          throw new InvalidConfigurationException(
+              "The key " + key + " not supported for dynamic configuration.");
+        }
     }
     return isValid;
   }

--- a/integration/spark-common-test/src/test/resources/data1.csv
+++ b/integration/spark-common-test/src/test/resources/data1.csv
@@ -1,0 +1,11 @@
+empno,empname,designation,doj,workgroupcategory,workgroupcategoryname,deptno,deptname,projectcode,projectjoindate,projectenddate,attendance,utilization,salary
+101,arvind,SE,17-01-2007,1,developer,10,network,928478,17-02-2007,29-11-2016,96,96,5040
+120,krithin,SSE,29-05-2008,1,developer,11,protocol,928378,29-06-2008,30-12-2016,85,95,7124
+103,madhan,TPL,07-07-2009,2,tester,10,network,928478,07-08-2009,30-12-2016,88,99,9054
+140,anandh,SA,29-12-2010,3,manager,11,protocol,928278,29-01-2011,29-06-2016,77,92,11248
+15,anu,SSA,09-11-2011,1,developer,12,security,928375,09-12-2011,29-05-2016,99,91,13245
+160,pramod,SE,14-10-2012,1,developer,13,configManagement,928478,14-11-2012,29-12-2016,86,93,5040
+107,gawrav,PL,22-09-2013,2,tester,12,security,928778,22-10-2013,15-11-2016,78,97,9574
+181,sibi,TL,15-08-2014,2,tester,14,Learning,928176,15-09-2014,29-05-2016,84,98,7245
+119,shivani,PL,12-05-2015,1,developer,10,network,928977,12-06-2015,12-11-2016,88,91,11254
+210,bill,PM,01-12-2015,3,manager,14,Learning,928479,01-01-2016,30-11-2016,75,94,13547

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/api/CarbonStore.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/api/CarbonStore.scala
@@ -66,11 +66,17 @@ object CarbonStore {
       loadMetadataDetailsSortedArray
           .filter(_.getVisibility.equalsIgnoreCase("true"))
           .map { load =>
+            val mergedTo = if (load.getMergedLoadName != null) {
+         load.getMergedLoadName
+       } else {
+         ""
+       }
             Row(
               load.getLoadName,
               load.getLoadStatus,
               new java.sql.Timestamp(load.getLoadStartTime),
-              new java.sql.Timestamp(load.getLoadEndTime)
+              new java.sql.Timestamp(load.getLoadEndTime),
+              mergedTo
             )
           }.toSeq
     } else {

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
@@ -349,6 +349,14 @@ class CarbonScanRDD(
         CarbonCommonConstants.USE_DISTRIBUTED_DATAMAP_DEFAULT).toBoolean) {
       CarbonTableInputFormat.setDataMapJob(conf, new SparkDataMapJob)
     }
+    val dbName = identifier.getCarbonTableIdentifier.getDatabaseName.toLowerCase
+    val tbName = identifier.getCarbonTableIdentifier.getTableName.toLowerCase
+    val segmentNumbersFromProperty = CarbonProperties.getInstance()
+      .getProperty(CarbonCommonConstants.CARBON_INPUT_SEGMENTS + dbName + "." + tbName, "*")
+    if (!segmentNumbersFromProperty.trim.equals("*")) {
+      CarbonTableInputFormat
+        .setSegmentsToAccess(conf, segmentNumbersFromProperty.split(",").toList.asJava)
+    }
     format
   }
 

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonCatalystOperators.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonCatalystOperators.scala
@@ -85,7 +85,8 @@ case class ShowLoadsCommand(
     Seq(AttributeReference("SegmentSequenceId", StringType, nullable = false)(),
       AttributeReference("Status", StringType, nullable = false)(),
       AttributeReference("Load Start Time", TimestampType, nullable = false)(),
-      AttributeReference("Load End Time", TimestampType, nullable = false)())
+      AttributeReference("Load End Time", TimestampType, nullable = false)(),
+      AttributeReference("Merged To", StringType, nullable = false)())
   }
 }
 

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/mutation/IUDCommonUtil.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/mutation/IUDCommonUtil.scala
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.command.mutation
+
+import org.apache.spark.sql._
+import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
+import org.apache.spark.sql.catalyst.plans.logical.{Filter, LogicalPlan}
+import org.apache.spark.sql.execution.datasources.LogicalRelation
+import org.apache.spark.sql.hive.HiveSessionCatalog
+
+import org.apache.carbondata.core.constants.CarbonCommonConstants
+import org.apache.carbondata.core.util.CarbonProperties
+import org.apache.carbondata.spark.exception.MalformedCarbonCommandException
+
+/**
+ * Util for IUD common function
+ */
+object IUDCommonUtil {
+
+  /**
+   * iterates the plan  and check whether CarbonCommonConstants.CARBON_INPUT_SEGMENTS set for any
+   * any table or not
+   * @param sparkSession
+   * @param logicalPlan
+   */
+  def checkIfSegmentListIsSet(sparkSession: SparkSession, logicalPlan: LogicalPlan): Unit = {
+    val carbonProperties = CarbonProperties.getInstance()
+    logicalPlan.foreach {
+      case unresolvedRelation: UnresolvedRelation =>
+        val dbAndTb =
+          sparkSession.sessionState.catalog.asInstanceOf[HiveSessionCatalog].getCurrentDatabase +
+          "." + unresolvedRelation.tableIdentifier.table
+        val segmentProperties = carbonProperties
+          .getProperty(CarbonCommonConstants.CARBON_INPUT_SEGMENTS + dbAndTb, "")
+        if (!(segmentProperties.equals("") || segmentProperties.trim.equals("*"))) {
+          throw new MalformedCarbonCommandException("carbon.input.segments." + dbAndTb +
+                                                    "should not be set for table used in DELETE " +
+                                                    "query. Please reset the property to carbon" +
+                                                    ".input.segments." +
+                                                    dbAndTb + "=*")
+        }
+      case logicalRelation: LogicalRelation if (logicalRelation.relation
+        .isInstanceOf[CarbonDatasourceHadoopRelation]) =>
+        val dbAndTb =
+          logicalRelation.relation.asInstanceOf[CarbonDatasourceHadoopRelation].carbonTable
+            .getDatabaseName + "." +
+          logicalRelation.relation.asInstanceOf[CarbonDatasourceHadoopRelation].carbonTable
+            .getFactTableName
+        val sementProperty = carbonProperties
+          .getProperty(CarbonCommonConstants.CARBON_INPUT_SEGMENTS + dbAndTb, "")
+        if (!(sementProperty.equals("") || sementProperty.trim.equals("*"))) {
+          throw new MalformedCarbonCommandException("carbon.input.segments." + dbAndTb +
+                                                    "should not be set for table used in UPDATE " +
+                                                    "query. Please reset the property to carbon" +
+                                                    ".input.segments." +
+                                                    dbAndTb + "=*")
+        }
+      case filter: Filter => filter.subqueries.toList
+        .foreach(subquery => checkIfSegmentListIsSet(sparkSession, subquery))
+      case _ =>
+    }
+  }
+}

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/mutation/ProjectForDeleteCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/mutation/ProjectForDeleteCommand.scala
@@ -42,6 +42,7 @@ private[sql] case class ProjectForDeleteCommand(
 
   override def processData(sparkSession: SparkSession): Seq[Row] = {
     val LOGGER = LogServiceFactory.getLogService(this.getClass.getName)
+      IUDCommonUtil.checkIfSegmentListIsSet(sparkSession, plan)
     val dataFrame = Dataset.ofRows(sparkSession, plan)
     //    dataFrame.show(truncate = false)
     //    dataFrame.collect().foreach(println)

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/mutation/ProjectForUpdateCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/mutation/ProjectForUpdateCommand.scala
@@ -43,6 +43,7 @@ private[sql] case class ProjectForUpdateCommand(
 
   override def processData(sparkSession: SparkSession): Seq[Row] = {
     val LOGGER = LogServiceFactory.getLogService(ProjectForUpdateCommand.getClass.getName)
+    IUDCommonUtil.checkIfSegmentListIsSet(sparkSession, plan)
     val res = plan find {
       case relation: LogicalRelation if relation.relation
         .isInstanceOf[CarbonDatasourceHadoopRelation] =>

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/hive/execution/command/CarbonHiveCommands.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/hive/execution/command/CarbonHiveCommands.scala
@@ -22,7 +22,9 @@ import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.execution.command._
 
+import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.util.{CarbonProperties, CarbonUtil}
+import org.apache.carbondata.spark.exception.MalformedCarbonCommandException
 
 case class CarbonDropDatabaseCommand(command: DropDatabaseCommand)
   extends RunnableCommand {
@@ -60,6 +62,16 @@ case class CarbonSetCommand(command: SetCommand)
         val isCarbonProperty: Boolean = CarbonProperties.getInstance().isCarbonProperty(key)
         if (isCarbonProperty) {
           sessionParms.addProperty(key, value)
+        }
+        else if (key.startsWith(CarbonCommonConstants.CARBON_INPUT_SEGMENTS)) {
+          if (key.split("\\.").length == 5) {
+            sessionParms.addProperty(key.toLowerCase(), value)
+          }
+          else {
+            throw new MalformedCarbonCommandException(
+              "property should be in \" carbon.input.segments.<database_name>" +
+              ".<table_name>=<seg_id list> \" format.")
+          }
         }
       case _ =>
 

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/internal/CarbonSqlConf.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/internal/CarbonSqlConf.scala
@@ -101,6 +101,11 @@ class CarbonSQLConf(sparkSession: SparkSession) {
         .doc("Property to configure data format for date type columns.")
         .stringConf
         .createWithDefault(CarbonLoadOptionConstants.CARBON_OPTIONS_DATEFORMAT_DEFAULT)
+    val CARBON_INPUT_SEGMENTS = SQLConfigBuilder(
+      "carbon.input.segments.<database_name>.<table_name>")
+      .doc("Property to configure the list of segments to query.").stringConf
+      .createWithDefault(carbonProperties
+        .getProperty("carbon.input.segments.<database_name>.<table_name>", "*"))
   }
 
   /**

--- a/integration/spark2/src/main/scala/org/apache/spark/util/ShowSegments.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/util/ShowSegments.scala
@@ -40,9 +40,9 @@ object ShowSegments {
   def showString(rows: Seq[Row]): String = {
     val sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.s")
     val sb = new StringBuilder
-    sb.append("+------------+------------------+----------------------+----------------------+\n")
-      .append("|SegmentId   |Status            |Load Start Time       |Load End Time         |\n")
-      .append("+------------+------------------+----------------------+----------------------+\n")
+    sb.append("+------------+------------------+----------------------+----------------------+----------------------+\n")
+      .append("|SegmentId   |Status            |Load Start Time       |Load End Time         |Merged To             |\n")
+      .append("+------------+------------------+----------------------+----------------------+----------------------+\n")
       rows.foreach{row =>
         sb.append("|")
           .append(StringUtils.rightPad(row.getString(0), 12))
@@ -52,9 +52,11 @@ object ShowSegments {
           .append(sdf.format(row.getAs[java.sql.Timestamp](2)))
           .append("|")
           .append(sdf.format(row.getAs[java.sql.Timestamp](3)))
+          .append("|")
+          .append(StringUtils.rightPad(row.getString(4), 18))
           .append("|\n")
       }
-    sb.append("+------------+------------------+----------------------+----------------------+\n")
+    sb.append("+------------+------------------+----------------------+----------------------+----------------------+\n")
     sb.toString
   }
 

--- a/integration/spark2/src/test/scala/org/apache/carbondata/spark/testsuite/segmentreading/TestSegmentReading.scala
+++ b/integration/spark2/src/test/scala/org/apache/carbondata/spark/testsuite/segmentreading/TestSegmentReading.scala
@@ -1,0 +1,352 @@
+package org.apache.carbondata.spark.testsuite.segmentreading
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.test.util.QueryTest
+import org.scalatest.BeforeAndAfterAll
+
+import org.apache.carbondata.spark.exception.MalformedCarbonCommandException
+
+/**
+ * Created by rahul on 19/9/17.
+ */
+class TestSegmentReading extends QueryTest with BeforeAndAfterAll {
+
+  override def beforeAll(): Unit = {
+    sql("drop table if exists carbon_table")
+    sql(
+      "create table carbon_table(empno int, empname String, designation String, doj Timestamp," +
+      "workgroupcategory int, workgroupcategoryname String, deptno int, deptname String," +
+      "projectcode int, projectjoindate Timestamp, projectenddate Timestamp,attendance int," +
+      "utilization int,salary int) STORED BY 'org.apache.carbondata.format'")
+    sql(
+      s"""LOAD DATA local inpath '$resourcesPath/data.csv' INTO TABLE carbon_table OPTIONS
+          |('DELIMITER'= ',', 'QUOTECHAR'= '\"')""".stripMargin)
+    sql(
+      s"""LOAD DATA local inpath '$resourcesPath/data1.csv' INTO TABLE carbon_table OPTIONS
+          |('DELIMITER'= ',', 'QUOTECHAR'= '\"')""".stripMargin)
+  }
+
+  test("test SET -V for segment reading property") {
+    try {
+      checkExistence(sql("SET -v"), true, "Property to configure the list of segments to query.")
+    }
+    finally {
+      sql("SET carbon.input.segments.default.carbon_table=*")
+    }
+  }
+  test("test count(*) for segment reading property") {
+    try {
+      sql("SET carbon.input.segments.default.carbon_table=1")
+      checkAnswer(sql("select count(*) from carbon_table"), Seq(Row(10)))
+    }
+    finally {
+      sql("SET carbon.input.segments.default.carbon_table=*")
+    }
+  }
+  test("test SET propertyname for segment reading property") {
+    try {
+      sql("SET carbon.input.segments.default.carbon_table=1")
+      checkAnswer(sql("SET carbon.input.segments.default.carbon_table"),
+        Seq(Row("carbon.input.segments.default.carbon_table", "1"))
+      )
+    }
+    finally {
+      sql("SET carbon.input.segments.default.carbon_table=*")
+    }
+  }
+  test("set valid segments and query from table") {
+    try {
+      checkAnswer(sql("select count(*) from carbon_table"), Seq(Row(20)))
+      sql("SET carbon.input.segments.default.carbon_table=1")
+      checkAnswer(sql("select count(*) from carbon_table"), Seq(Row(10)))
+      sql("SET carbon.input.segments.default.carbon_table=*")
+      checkAnswer(sql("select count(*) from carbon_table"), Seq(Row(20)))
+      sql("SET carbon.input.segments.default.carbon_table=0")
+      checkAnswer(sql("select count(*) from carbon_table"), Seq(Row(10)))
+    }
+    finally {
+      sql("SET carbon.input.segments.default.carbon_table=*")
+    }
+  }
+  test("test Multiple times set segment") {
+    try {
+      sql("SET carbon.input.segments.default.carbon_table=0")
+      checkAnswer(sql("select count(*) from carbon_table"), Seq(Row(10)))
+      sql("SET carbon.input.segments.default.carbon_table=1")
+      checkAnswer(sql("select count(*) from carbon_table"), Seq(Row(10)))
+      sql("SET carbon.input.segments.default.carbon_table=1,0,1")
+      checkAnswer(sql("select count(*) from carbon_table"), Seq(Row(20)))
+      sql("SET carbon.input.segments.default.carbon_table=2,0")
+      checkAnswer(sql("select count(*) from carbon_table"), Seq(Row(10)))
+      val trapped = intercept[Exception] {
+        sql("SET carbon.input.segments.default.carbon_table=2,a")
+      }
+      val trappedAgain = intercept[Exception] {
+        sql("SET carbon.input.segments.default.carbon_table=,")
+      }
+      assert(trapped.getMessage
+        .equalsIgnoreCase(
+          "carbon.input.segments.<database_name>.<table_name> value range is not valid"))
+      assert(trappedAgain.getMessage
+        .equalsIgnoreCase("carbon.input.segments.<database_name>.<table_name> value can't be empty."))
+    }
+    finally {
+      sql("SET carbon.input.segments.default.carbon_table=*")
+    }
+  }
+  test("test filter with segment reading"){
+    try {
+      sql("SET carbon.input.segments.default.carbon_table=*")
+      checkAnswer(sql("select count(empno) from carbon_table where empno = 15"),Seq(Row(2)))
+      sql("SET carbon.input.segments.default.carbon_table=1")
+      checkAnswer(sql("select count(empno) from carbon_table where empno = 15"),Seq(Row(1)))
+    }
+    finally {
+      sql("SET carbon.input.segments.default.carbon_table=*")
+    }
+  }
+  test("test group by with segment reading") {
+    try {
+      sql("SET carbon.input.segments.default.carbon_table=*")
+      checkAnswer(sql("select empno,count(empname) from carbon_table where empno = 15 group by empno"),Seq(Row(15,2)))
+      sql("SET carbon.input.segments.default.carbon_table=1")
+      checkAnswer(sql("select empno,count(empname) from carbon_table where empno = 15 group by empno"),Seq(Row(15,1)))
+    }
+    finally {
+      sql("SET carbon.input.segments.default.carbon_table=*")
+    }
+  }
+  test("test join with segment reading"){
+    try {
+      sql("SET carbon.input.segments.default.carbon_table=*")
+      sql("drop table if exists carbon_table_join")
+      sql(
+        "create table carbon_table_join(empno int, empname String, designation String, doj Timestamp," +
+        "workgroupcategory int, workgroupcategoryname String, deptno int, deptname String," +
+        "projectcode int, projectjoindate Timestamp, projectenddate Timestamp,attendance int," +
+        "utilization int,salary int) STORED BY 'org.apache.carbondata.format'")
+      sql("insert into carbon_table_join select * from carbon_table").show()
+      checkAnswer(sql("select count(a.empno) from carbon_table a inner join carbon_table_join b on a.empno = b.empno"),Seq(Row(22)))
+      sql("SET carbon.input.segments.default.carbon_table=1")
+      checkAnswer(sql("select count(a.empno) from carbon_table a inner join carbon_table_join b on a.empno = b.empno"),Seq(Row(11)))
+    }
+    finally {
+      sql("SET carbon.input.segments.default.carbon_table=*")
+    }
+  }
+  test("test aggregation with segment reading") {
+    try {
+      sql("SET carbon.input.segments.default.carbon_table=*")
+      checkAnswer(sql("select sum(empno) from carbon_table"), Seq(Row(1411)))
+      sql("SET carbon.input.segments.default.carbon_table=1")
+      checkAnswer(sql("select sum(empno) from carbon_table"), Seq(Row(1256)))
+    }
+    finally {
+      sql("SET carbon.input.segments.default.carbon_table=*")
+    }
+  }
+  test("test update query with segment reading"){
+    try {
+      sql("drop table if exists carbon_table_update")
+      sql(
+        "create table carbon_table_update(empno int, empname String, designation String, doj Timestamp," +
+        "workgroupcategory int, workgroupcategoryname String, deptno int, deptname String," +
+        "projectcode int, projectjoindate Timestamp, projectenddate Timestamp,attendance int," +
+        "utilization int,salary int) STORED BY 'org.apache.carbondata.format'")
+      sql(
+        s"""LOAD DATA local inpath '$resourcesPath/data.csv' INTO TABLE carbon_table_update OPTIONS
+            |('DELIMITER'= ',', 'QUOTECHAR'= '\"')""".stripMargin)
+      sql(
+        s"""LOAD DATA local inpath '$resourcesPath/data1.csv' INTO TABLE carbon_table_update OPTIONS
+            |('DELIMITER'= ',', 'QUOTECHAR'= '\"')""".stripMargin)
+      sql("SET carbon.input.segments.default.carbon_table=1")
+      intercept[MalformedCarbonCommandException]{
+        sql("update carbon_table_update a set(a.empname) = (select b.empname from carbon_table b where a.empno=b.empno)").show()
+      }
+      sql("SET carbon.input.segments.default.carbon_table=*")
+      sql("SET carbon.input.segments.default.carbon_table_update=1")
+      intercept[MalformedCarbonCommandException]{
+        sql("update carbon_table_update a set(a.empname) = (select b.empname from carbon_table b where a.empno=b.empno)").show()
+      }
+      sql("SET carbon.input.segments.default.carbon_table=*")
+      sql("SET carbon.input.segments.default.carbon_table_update=*")
+      checkAnswer(sql("select count(*) from carbon_table_update where empname='rahul'"), Seq(Row(0)))
+      sql("update carbon_table_update a set(a.empname) = ('rahul')").show()
+      checkAnswer(sql("select count(*) from carbon_table_update where empname='rahul'"), Seq(Row(20)))
+    }
+    finally {
+      sql("SET carbon.input.segments.default.carbon_table=*")
+    }
+  }
+  test("test delete query with segment reading"){
+    try {
+      sql("drop table if exists carbon_table_delete")
+      sql(
+        "create table carbon_table_delete(empno int, empname String, designation String, doj Timestamp," +
+        "workgroupcategory int, workgroupcategoryname String, deptno int, deptname String," +
+        "projectcode int, projectjoindate Timestamp, projectenddate Timestamp,attendance int," +
+        "utilization int,salary int) STORED BY 'org.apache.carbondata.format'")
+      sql(
+        s"""LOAD DATA local inpath '$resourcesPath/data.csv' INTO TABLE carbon_table_delete OPTIONS
+            |('DELIMITER'= ',', 'QUOTECHAR'= '\"')""".stripMargin)
+      sql(
+        s"""LOAD DATA local inpath '$resourcesPath/data.csv' INTO TABLE carbon_table_delete OPTIONS
+            |('DELIMITER'= ',', 'QUOTECHAR'= '\"')""".stripMargin)
+      sql("SET carbon.input.segments.default.carbon_table=*")
+      sql("SET carbon.input.segments.default.carbon_table=1")
+      intercept[MalformedCarbonCommandException]{
+        sql("delete from carbon_table_delete where empno IN (select empno from carbon_table where empname='ayushi')").show()
+      }
+      sql("SET carbon.input.segments.default.carbon_table_delete=1")
+      intercept[MalformedCarbonCommandException]{
+        sql("delete from carbon_table_delete where empno IN (select empno from carbon_table where empname='ayushi')").show()
+      }
+
+      sql("SET carbon.input.segments.default.carbon_table=*")
+      sql("SET carbon.input.segments.default.carbon_table_delete=*")
+      checkAnswer(sql("select count(*) from carbon_table_delete"), Seq(Row(20)))
+      sql("delete from carbon_table_delete where empno IN (select empno from carbon_table where empname='ayushi')").show()
+      checkAnswer(sql("select count(*) from carbon_table_delete"), Seq(Row(18)))
+    }
+    finally {
+      sql("SET carbon.input.segments.default.carbon_table=*")
+    }
+  }
+  test("test show segments"){
+    try {
+      sql("drop table if exists carbon_table_show_seg")
+      sql(
+        "create table carbon_table_show_seg(empno int, empname String, designation String, doj Timestamp," +
+        "workgroupcategory int, workgroupcategoryname String, deptno int, deptname String," +
+        "projectcode int, projectjoindate Timestamp, projectenddate Timestamp,attendance int," +
+        "utilization int,salary int) STORED BY 'org.apache.carbondata.format'")
+      sql(
+        s"""LOAD DATA local inpath '$resourcesPath/data.csv' INTO TABLE carbon_table_show_seg OPTIONS
+            |('DELIMITER'= ',', 'QUOTECHAR'= '\"')""".stripMargin)
+      sql(
+        s"""LOAD DATA local inpath '$resourcesPath/data.csv' INTO TABLE carbon_table_show_seg OPTIONS
+            |('DELIMITER'= ',', 'QUOTECHAR'= '\"')""".stripMargin)
+      sql("alter table carbon_table_show_seg compact 'major'")
+      sql(
+        s"""LOAD DATA local inpath '$resourcesPath/data.csv' INTO TABLE carbon_table_show_seg OPTIONS
+            |('DELIMITER'= ',', 'QUOTECHAR'= '\"')""".stripMargin)
+      val df = sql("SHOW SEGMENTS for table carbon_table_show_seg")
+      val col = df.collect().map{
+        row => Row(row.getString(0),row.getString(1),row.getString(4))
+      }.toSeq
+      assert(col.equals(Seq(Row("2","Success",""),
+        Row("1","Compacted","0.1"),
+        Row("0.1","Success",""),
+        Row("0","Compacted","0.1"))))
+    }
+    finally {
+      sql("SET carbon.input.segments.default.carbon_table=*")
+    }
+  }
+  test("test segment reading after compaction"){
+    sql("drop table if exists carbon_table_compact")
+    sql(
+      "create table carbon_table_compact(empno int, empname String, designation String, doj Timestamp," +
+      "workgroupcategory int, workgroupcategoryname String, deptno int, deptname String," +
+      "projectcode int, projectjoindate Timestamp, projectenddate Timestamp,attendance int," +
+      "utilization int,salary int) STORED BY 'org.apache.carbondata.format'")
+    sql(
+      s"""LOAD DATA local inpath '$resourcesPath/data.csv' INTO TABLE carbon_table_compact OPTIONS
+          |('DELIMITER'= ',', 'QUOTECHAR'= '\"')""".stripMargin)
+    sql(
+      s"""LOAD DATA local inpath '$resourcesPath/data.csv' INTO TABLE carbon_table_compact OPTIONS
+          |('DELIMITER'= ',', 'QUOTECHAR'= '\"')""".stripMargin)
+    sql("alter table carbon_table_compact compact 'major'")
+    sql(
+      s"""LOAD DATA local inpath '$resourcesPath/data.csv' INTO TABLE carbon_table_compact OPTIONS
+          |('DELIMITER'= ',', 'QUOTECHAR'= '\"')""".stripMargin)
+    checkAnswer(sql("select count(*) from carbon_table_compact"),Seq(Row(30)))
+    sql(" SET carbon.input.segments.default.carbon_table_compact=0.1")
+    checkAnswer(sql("select count(*) from carbon_table_compact"),Seq(Row(20)))
+  }
+  test("set segment id then alter table name and check select query") {
+    try {
+      sql("drop table if exists carbon_table_alter")
+      sql("drop table if exists carbon_table_alter_new")
+      sql(
+        "create table carbon_table_alter(empno int, empname String, designation String, doj " +
+        "Timestamp," +
+
+        "workgroupcategory int, workgroupcategoryname String, deptno int, deptname String," +
+        "projectcode int, projectjoindate Timestamp, projectenddate Timestamp,attendance int," +
+        "utilization int,salary int) STORED BY 'org.apache.carbondata.format'")
+      sql(
+        s"""LOAD DATA local inpath '$resourcesPath/data.csv' INTO TABLE carbon_table_alter OPTIONS
+            |('DELIMITER'= ',', 'QUOTECHAR'= '\"')""".
+          stripMargin)
+      sql(
+        s"""LOAD DATA local inpath '$resourcesPath/data.csv' INTO TABLE carbon_table_alter OPTIONS
+            |('DELIMITER'= ',', 'QUOTECHAR'= '\"')""".
+          stripMargin)
+      checkAnswer(sql("select count(*) from carbon_table_alter"),
+        Seq(Row(20)))
+      sql(
+        "SET carbon.input.segments.default.carbon_table_alter=1")
+      checkAnswer(sql(
+        "select count(*) from carbon_table_alter"), Seq(Row(10)))
+      sql(
+        "alter table carbon_table_alter rename to carbon_table_alter_new")
+      checkAnswer(sql(
+        "select count(*) from carbon_table_alter_new")
+        , Seq(Row(20)))
+    }
+    finally {
+      sql(
+        "SET carbon.input.segments.default.carbon_table=*")
+    }
+  }
+
+  test("drop and recreate table to check segment reading") {
+    try {
+      sql("drop table if exists carbon_table_recreate")
+      sql(
+        "create table carbon_table_recreate(empno int, empname String, designation String, doj " +
+        "Timestamp," +
+
+        "workgroupcategory int, workgroupcategoryname String, deptno int, deptname String," +
+        "projectcode int, projectjoindate Timestamp, projectenddate Timestamp,attendance int," +
+        "utilization int,salary int) STORED BY 'org.apache.carbondata.format'")
+      sql(
+        s"""LOAD DATA local inpath '$resourcesPath/data.csv' INTO TABLE carbon_table_recreate OPTIONS
+            |('DELIMITER'= ',', 'QUOTECHAR'= '\"')""".
+          stripMargin)
+      sql(
+        s"""LOAD DATA local inpath '$resourcesPath/data.csv' INTO TABLE carbon_table_recreate OPTIONS
+            |('DELIMITER'= ',', 'QUOTECHAR'= '\"')""".
+          stripMargin)
+      checkAnswer(sql("select count(*) from carbon_table_recreate"),
+        Seq(Row(20)))
+      sql(
+        "SET carbon.input.segments.default.carbon_table_recreate=1")
+      checkAnswer(sql(
+        "select count(*) from carbon_table_recreate"), Seq(Row(10)))
+      sql("drop table if exists carbon_table_recreate")
+      sql(
+        "create table carbon_table_recreate(empno int, empname String, designation String, doj " +
+        "Timestamp," +
+
+        "workgroupcategory int, workgroupcategoryname String, deptno int, deptname String," +
+        "projectcode int, projectjoindate Timestamp, projectenddate Timestamp,attendance int," +
+        "utilization int,salary int) STORED BY 'org.apache.carbondata.format'")
+      sql(
+        s"""LOAD DATA local inpath '$resourcesPath/data.csv' INTO TABLE carbon_table_recreate OPTIONS
+            |('DELIMITER'= ',', 'QUOTECHAR'= '\"')""".
+          stripMargin)
+      sql(
+        s"""LOAD DATA local inpath '$resourcesPath/data.csv' INTO TABLE carbon_table_recreate OPTIONS
+            |('DELIMITER'= ',', 'QUOTECHAR'= '\"')""".
+          stripMargin)
+      checkAnswer(sql(
+        "select count(*) from carbon_table_recreate"), Seq(Row(10)))
+    }
+    finally {
+      sql(
+        "SET carbon.input.segments.default.carbon_table=*")
+    }
+  }
+}


### PR DESCRIPTION
**1. **Objective**** : Support Query from specified segments.

**2. **Proposed Solution** :**
A new property will introduce to set the segment no.
User will  set property(carbon.input.segments. <database_name> .<table_name>) to specify segment no.
During CarbonScan data will be read from from specified segments only.
If property is not set, all segments will be caonsidered as default behavior.
_**For Update and delete this property is blocked .**_
**3. Syntax Used :** 
**To show all the segments.** 
		       It will display one new column at the end that will display the new segment-	           		       id of compacted segment.

> Syntax : SHOW SEGMENTS FOR TABLE <table_name>;

			`e.g. => show segments for table carbon_table;`

**TO set the segment ids.**
Segment ids to which we need to query, can be set to property carbon.input.segments (new) .

Following syntax can be used to set segment ids from client(BEELINE)

>  Syntax : SET carbon.input.segments.<databese_name>.<table_name> = **<list of segment ids>**;

`e.g => SET carbon.input.segments.default.carbontable=1,4,5;`

**To reset the segment id.**
Above property can be set to default behavior as follow.
Following syntax can be used to reset segment ids from client(BEELINE)

> Syntax : SET carbon.input.segments.<databese_name>.<table_name> = *;

`e.g => SET carbon.input.segments.default.carbontable=*`

**To reset all properties.**
It resets all the properties to default value. So it is recommended to use only when you want to reset all the different properties.

> Syntax : RESET;

`e.g => reset;`
