### PR TITLE
[CARBONDATA-1486] Fixed issue of table status updation on insert overwrite failure and exception thrown while deletion of stale folders

### DIFF
--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/load/DataLoadProcessorStepOnSpark.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/load/DataLoadProcessorStepOnSpark.scala
@@ -136,7 +136,7 @@ object DataLoadProcessorStepOnSpark {
 
       override def next(): CarbonRow = {
         val row =
-          new CarbonRow(SortStepRowUtil.convertRow(rows.next().getData, sortParameters, true))
+          new CarbonRow(SortStepRowUtil.convertRow(rows.next().getData, sortParameters))
         rowCounter.add(1)
         row
       }

--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/sort/SortStepRowUtil.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/sort/SortStepRowUtil.java
@@ -21,8 +21,7 @@ import org.apache.carbondata.core.util.NonDictionaryUtil;
 import org.apache.carbondata.processing.sortandgroupby.sortdata.SortParameters;
 
 public class SortStepRowUtil {
-  public static Object[] convertRow(Object[] data, SortParameters parameters,
-      boolean needConvertDecimalToByte) {
+  public static Object[] convertRow(Object[] data, SortParameters parameters) {
     int measureCount = parameters.getMeasureColCount();
     int dimensionCount = parameters.getDimColCount();
     int complexDimensionCount = parameters.getComplexDimColCount();

--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/sort/unsafe/merger/UnsafeSingleThreadFinalSortFilesMerger.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/sort/unsafe/merger/UnsafeSingleThreadFinalSortFilesMerger.java
@@ -183,7 +183,7 @@ public class UnsafeSingleThreadFinalSortFilesMerger extends CarbonIterator<Objec
    * @return sorted row
    */
   public Object[] next() {
-    return SortStepRowUtil.convertRow(getSortedRecordFromFile(), parameters, false);
+    return SortStepRowUtil.convertRow(getSortedRecordFromFile(), parameters);
   }
 
   /**


### PR DESCRIPTION
Issues Fixed as part of this PR:

1. Fixed issue of HDFS file system throwing exception while deleting a non-existent folder. This happens because on multiple run of insert overwrite operation, same folder is getting added to the stale folder list even though it has been deleted during first time insert overwrite operation run and when the same folder is tried to be deleted again HDFS file system throws an IO exception.

2. Insert or Load operation should throw exception if:
     a. If insert overwrite is in progress and any other load or insert operation is triggered
     b. If load or insert into operation is in progress and insert overwrite operation is triggered

3. Fixed issue for table status not getting updated after failure of insert/load job. In case of insert overwrite job status in table status file is "Overwrite in Progress". In this case no other load for same table can run in parallel and if this status is not changes on success of failure jobs, the system will still assume that insert overwrite is in progress and fail all next insert/load jobs

4. Removed Unused Code