### PR TITLE
[CARBONDATA-1488] JVM crashes when unsafe columnpage is enabled

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/UnsafeVarLengthColumnPage.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/UnsafeVarLengthColumnPage.java
@@ -42,18 +42,6 @@ public class UnsafeVarLengthColumnPage extends VarLengthColumnPageBase {
     baseOffset = memoryBlock.getBaseOffset();
   }
 
-  /**
-   * create a page with initial capacity
-   */
-  UnsafeVarLengthColumnPage(TableSpec.ColumnSpec columnSpec, DataType dataType, int pageSize,
-      int capacity) throws MemoryException {
-    super(columnSpec, dataType, pageSize);
-    this.capacity = capacity;
-    memoryBlock = UnsafeMemoryManager.allocateMemoryWithRetry(taskId, (long)(capacity));
-    baseAddress = memoryBlock.getBaseObject();
-    baseOffset = memoryBlock.getBaseOffset();
-  }
-
   @Override
   public void freeMemory() {
     if (memoryBlock != null) {

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/VarLengthColumnPageBase.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/VarLengthColumnPageBase.java
@@ -363,7 +363,7 @@ public abstract class VarLengthColumnPageBase extends ColumnPage {
    */
   protected void ensureMemory(int requestSize) throws MemoryException {
     if (totalLength + requestSize > capacity) {
-      int newSize = 2 * capacity;
+      int newSize = Math.max(2 * capacity, totalLength + requestSize);
       MemoryBlock newBlock = UnsafeMemoryManager.allocateMemoryWithRetry(taskId, newSize);
       CarbonUnsafe.getUnsafe().copyMemory(baseAddress, baseOffset,
           newBlock.getBaseObject(), newBlock.getBaseOffset(), capacity);

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/CarbonVectorizedRecordReader.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/CarbonVectorizedRecordReader.java
@@ -72,7 +72,7 @@ class CarbonVectorizedRecordReader extends AbstractRecordReader<Object> {
   /**
    * The default config on whether columnarBatch should be offheap.
    */
-  private static final MemoryMode DEFAULT_MEMORY_MODE = MemoryMode.ON_HEAP;
+  private static final MemoryMode DEFAULT_MEMORY_MODE = MemoryMode.OFF_HEAP;
 
   private QueryModel queryModel;
 

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/CarbonVectorizedRecordReader.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/CarbonVectorizedRecordReader.java
@@ -72,7 +72,7 @@ class CarbonVectorizedRecordReader extends AbstractRecordReader<Object> {
   /**
    * The default config on whether columnarBatch should be offheap.
    */
-  private static final MemoryMode DEFAULT_MEMORY_MODE = MemoryMode.OFF_HEAP;
+  private static final MemoryMode DEFAULT_MEMORY_MODE = MemoryMode.ON_HEAP;
 
   private QueryModel queryModel;
 

--- a/integration/spark2/src/main/java/org/apache/carbondata/spark/vectorreader/VectorizedCarbonRecordReader.java
+++ b/integration/spark2/src/main/java/org/apache/carbondata/spark/vectorreader/VectorizedCarbonRecordReader.java
@@ -72,9 +72,9 @@ class VectorizedCarbonRecordReader extends AbstractRecordReader<Object> {
   private boolean returnColumnarBatch;
 
   /**
-   * The default config on whether columnarBatch should be offheap.
+   * The default config on whether columnarBatch should be onheap.
    */
-  private static final MemoryMode DEFAULT_MEMORY_MODE = MemoryMode.OFF_HEAP;
+  private static final MemoryMode DEFAULT_MEMORY_MODE = MemoryMode.ON_HEAP;
 
   private QueryModel queryModel;
 


### PR DESCRIPTION
The test case `BadRecordEmptyDataTest.test load multiple loads- pne with valid record and one with invalid` crashes when unsafe columnpage is enabled
It is because of capacity size calculation in unsafe var page.
Fixed capacity size calculation when column value size is larger than initial capacity in this PR.

