### PR TITLE
[WIP] Support object storage by S3 interface

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/cache/CacheProvider.java
+++ b/core/src/main/java/org/apache/carbondata/core/cache/CacheProvider.java
@@ -34,6 +34,8 @@ import org.apache.carbondata.core.datastore.block.TableBlockUniqueIdentifier;
 import org.apache.carbondata.core.indexstore.BlockletDataMapIndexStore;
 import org.apache.carbondata.core.util.CarbonProperties;
 
+import org.apache.hadoop.conf.Configuration;
+
 /**
  * Cache provider class which will create a cache based on given type
  */
@@ -89,7 +91,8 @@ public class CacheProvider {
    * @param <V>
    * @return
    */
-  public <K, V> Cache<K, V> createCache(CacheType cacheType, String carbonStorePath) {
+  public <K, V> Cache<K, V> createCache(CacheType cacheType, String carbonStorePath,
+      Configuration configuration) {
     //check if lru cache is null, if null create one
     //check if cache is null for given cache type, if null create one
     if (!dictionaryCacheAlreadyExists(cacheType)) {
@@ -98,7 +101,7 @@ public class CacheProvider {
           if (null == carbonLRUCache) {
             createLRULevelCacheInstance(cacheType);
           }
-          createDictionaryCacheForGivenType(cacheType, carbonStorePath);
+          createDictionaryCacheForGivenType(cacheType, carbonStorePath, configuration);
         }
       }
     }
@@ -111,24 +114,22 @@ public class CacheProvider {
    * @param cacheType       type of cache
    * @param carbonStorePath store path
    */
-  private void createDictionaryCacheForGivenType(CacheType cacheType, String carbonStorePath) {
+  private void createDictionaryCacheForGivenType(CacheType cacheType, String carbonStorePath,
+      Configuration configuration) {
     Cache cacheObject = null;
     if (cacheType.equals(CacheType.REVERSE_DICTIONARY)) {
-      cacheObject =
-          new ReverseDictionaryCache<DictionaryColumnUniqueIdentifier, Dictionary>(carbonStorePath,
-              carbonLRUCache);
+      cacheObject = new ReverseDictionaryCache<DictionaryColumnUniqueIdentifier, Dictionary>(
+          configuration, carbonStorePath, carbonLRUCache);
     } else if (cacheType.equals(CacheType.FORWARD_DICTIONARY)) {
-      cacheObject =
-          new ForwardDictionaryCache<DictionaryColumnUniqueIdentifier, Dictionary>(carbonStorePath,
-              carbonLRUCache);
+      cacheObject = new ForwardDictionaryCache<DictionaryColumnUniqueIdentifier, Dictionary>(
+              configuration, carbonStorePath, carbonLRUCache);
     } else if (cacheType.equals(cacheType.EXECUTOR_BTREE)) {
-      cacheObject = new BlockIndexStore<TableBlockUniqueIdentifier, AbstractIndex>(carbonStorePath,
-          carbonLRUCache);
+      cacheObject = new BlockIndexStore<TableBlockUniqueIdentifier, AbstractIndex>(
+          configuration, carbonStorePath, carbonLRUCache);
     } else if (cacheType.equals(cacheType.DRIVER_BTREE)) {
-      cacheObject =
-          new SegmentTaskIndexStore(carbonStorePath, carbonLRUCache);
+      cacheObject = new SegmentTaskIndexStore(configuration, carbonStorePath, carbonLRUCache);
     } else if (cacheType.equals(cacheType.DRIVER_BLOCKLET_DATAMAP)) {
-      cacheObject = new BlockletDataMapIndexStore(carbonStorePath, carbonLRUCache);
+      cacheObject = new BlockletDataMapIndexStore(configuration, carbonStorePath, carbonLRUCache);
     }
     cacheTypeToCacheMap.put(cacheType, cacheObject);
   }

--- a/core/src/main/java/org/apache/carbondata/core/cache/dictionary/DictionaryCacheLoaderImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/cache/dictionary/DictionaryCacheLoaderImpl.java
@@ -31,6 +31,8 @@ import org.apache.carbondata.core.service.CarbonCommonFactory;
 import org.apache.carbondata.core.service.DictionaryService;
 import org.apache.carbondata.core.util.CarbonUtil;
 
+import org.apache.hadoop.conf.Configuration;
+
 /**
  * This class is responsible for loading the dictionary data for given columns
  */
@@ -48,15 +50,19 @@ public class DictionaryCacheLoaderImpl implements DictionaryCacheLoader {
    */
   private String carbonStorePath;
 
+  private Configuration configuration;
+
   /**
    * @param carbonTableIdentifier fully qualified table name
    * @param carbonStorePath       hdfs store path
    */
   public DictionaryCacheLoaderImpl(CarbonTableIdentifier carbonTableIdentifier,
-      String carbonStorePath, DictionaryColumnUniqueIdentifier dictionaryColumnUniqueIdentifier) {
+      String carbonStorePath, DictionaryColumnUniqueIdentifier dictionaryColumnUniqueIdentifier,
+      Configuration configuration) {
     this.carbonTableIdentifier = carbonTableIdentifier;
     this.carbonStorePath = carbonStorePath;
     this.dictionaryColumnUniqueIdentifier = dictionaryColumnUniqueIdentifier;
+    this.configuration = configuration;
   }
 
   /**
@@ -167,7 +173,7 @@ public class DictionaryCacheLoaderImpl implements DictionaryCacheLoader {
       DictionaryColumnUniqueIdentifier dictionaryColumnUniqueIdentifier) {
     DictionaryService dictService = CarbonCommonFactory.getDictionaryService();
     return dictService.getDictionaryReader(carbonTableIdentifier, dictionaryColumnUniqueIdentifier,
-        carbonStorePath);
+        carbonStorePath, configuration);
   }
 
   /**
@@ -179,6 +185,6 @@ public class DictionaryCacheLoaderImpl implements DictionaryCacheLoader {
     DictionaryService dictService = CarbonCommonFactory.getDictionaryService();
     return dictService
         .getDictionarySortIndexReader(carbonTableIdentifier, dictionaryColumnUniqueIdentifier,
-            carbonStorePath);
+            carbonStorePath, configuration);
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/cache/dictionary/ForwardDictionaryCache.java
+++ b/core/src/main/java/org/apache/carbondata/core/cache/dictionary/ForwardDictionaryCache.java
@@ -37,6 +37,8 @@ import org.apache.carbondata.core.util.CarbonUtil;
 import org.apache.carbondata.core.util.ObjectSizeCalculator;
 import org.apache.carbondata.core.util.TaskMetricsMap;
 
+import org.apache.hadoop.conf.Configuration;
+
 /**
  * This class implements methods to create dictionary cache which will hold
  * dictionary chunks for look up of surrogate keys and values
@@ -62,8 +64,9 @@ public class ForwardDictionaryCache<K extends
    * @param carbonStorePath
    * @param carbonLRUCache
    */
-  public ForwardDictionaryCache(String carbonStorePath, CarbonLRUCache carbonLRUCache) {
-    super(carbonStorePath, carbonLRUCache);
+  public ForwardDictionaryCache(Configuration configuration, String carbonStorePath,
+      CarbonLRUCache carbonLRUCache) {
+    super(configuration, carbonStorePath, carbonLRUCache);
   }
 
   /**

--- a/core/src/main/java/org/apache/carbondata/core/cache/dictionary/ReverseDictionaryCache.java
+++ b/core/src/main/java/org/apache/carbondata/core/cache/dictionary/ReverseDictionaryCache.java
@@ -35,6 +35,8 @@ import org.apache.carbondata.core.reader.CarbonDictionaryColumnMetaChunk;
 import org.apache.carbondata.core.util.CarbonUtil;
 import org.apache.carbondata.core.util.ObjectSizeCalculator;
 
+import org.apache.hadoop.conf.Configuration;
+
 /**
  * This class implements methods to create dictionary cache which will hold
  * dictionary chunks for look up of surrogate keys and values
@@ -67,8 +69,9 @@ public class ReverseDictionaryCache<K extends DictionaryColumnUniqueIdentifier,
    * @param carbonStorePath
    * @param carbonLRUCache
    */
-  public ReverseDictionaryCache(String carbonStorePath, CarbonLRUCache carbonLRUCache) {
-    super(carbonStorePath, carbonLRUCache);
+  public ReverseDictionaryCache(Configuration configuration, String carbonStorePath,
+      CarbonLRUCache carbonLRUCache) {
+    super(configuration, carbonStorePath, carbonLRUCache);
   }
 
   /**

--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -144,6 +144,14 @@ public final class CarbonCommonConstants {
    * ALLUXIO_PREFIX
    */
   public static final String ALLUXIOURL_PREFIX = "alluxio://";
+
+  /**
+   * S3_PREFIX
+   */
+  public static final String S3_PREFIX = "s3://";
+  public static final String S3A_PREFIX = "s3a://";
+  public static final String S3N_PREFIX = "s3n://";
+
   /**
    * FS_DEFAULT_FS
    */

--- a/core/src/main/java/org/apache/carbondata/core/datamap/DataMapStoreManager.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/DataMapStoreManager.java
@@ -26,6 +26,8 @@ import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.datamap.dev.DataMapFactory;
 import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
 
+import org.apache.hadoop.conf.Configuration;
+
 /**
  * It maintains all the DataMaps in it.
  */
@@ -57,7 +59,7 @@ public final class DataMapStoreManager {
    * @return
    */
   public TableDataMap getDataMap(AbsoluteTableIdentifier identifier,
-      String dataMapName, String factoryClass) {
+      String dataMapName, String factoryClass, Configuration configuration) {
     String table = identifier.uniqueName();
     List<TableDataMap> tableDataMaps = allDataMaps.get(table);
     TableDataMap dataMap;
@@ -65,7 +67,7 @@ public final class DataMapStoreManager {
       synchronized (table.intern()) {
         tableDataMaps = allDataMaps.get(table);
         if (tableDataMaps == null) {
-          dataMap = createAndRegisterDataMap(identifier, factoryClass, dataMapName);
+          dataMap = createAndRegisterDataMap(identifier, factoryClass, dataMapName, configuration);
         } else {
           dataMap = getTableDataMap(dataMapName, tableDataMaps);
         }
@@ -85,7 +87,7 @@ public final class DataMapStoreManager {
    * The datamap is created using datamap name, datamap factory class and table identifier.
    */
   public TableDataMap createAndRegisterDataMap(AbsoluteTableIdentifier identifier,
-      String factoryClassName, String dataMapName) {
+      String factoryClassName, String dataMapName, Configuration configuration) {
     String table = identifier.uniqueName();
     List<TableDataMap> tableDataMaps = allDataMaps.get(table);
     if (tableDataMaps == null) {
@@ -100,8 +102,8 @@ public final class DataMapStoreManager {
       Class<? extends DataMapFactory> factoryClass =
           (Class<? extends DataMapFactory>) Class.forName(factoryClassName);
       DataMapFactory dataMapFactory = factoryClass.newInstance();
-      dataMapFactory.init(identifier, dataMapName);
-      dataMap = new TableDataMap(identifier, dataMapName, dataMapFactory);
+      dataMapFactory.init(configuration, identifier, dataMapName);
+      dataMap = new TableDataMap(identifier, dataMapName, dataMapFactory, configuration);
     } catch (Exception e) {
       LOGGER.error(e);
       throw new RuntimeException(e);

--- a/core/src/main/java/org/apache/carbondata/core/datamap/TableDataMap.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/TableDataMap.java
@@ -28,6 +28,8 @@ import org.apache.carbondata.core.indexstore.Blocklet;
 import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
 import org.apache.carbondata.core.scan.filter.resolver.FilterResolverIntf;
 
+import org.apache.hadoop.conf.Configuration;
+
 /**
  * DataMap at the table level, user can add any number of datamaps for one table. Depends
  * on the filter condition it can prune the blocklets.
@@ -40,14 +42,17 @@ public final class TableDataMap implements EventListener {
 
   private DataMapFactory dataMapFactory;
 
+  private Configuration configuration;
+
   /**
    * It is called to initialize and load the required table datamap metadata.
    */
   public TableDataMap(AbsoluteTableIdentifier identifier,
-      String dataMapName, DataMapFactory dataMapFactory) {
+      String dataMapName, DataMapFactory dataMapFactory, Configuration configuration) {
     this.identifier = identifier;
     this.dataMapName = dataMapName;
     this.dataMapFactory = dataMapFactory;
+    this.configuration = configuration;
   }
 
   /**
@@ -61,7 +66,7 @@ public final class TableDataMap implements EventListener {
       throws IOException {
     List<Blocklet> blocklets = new ArrayList<>();
     for (String segmentId : segmentIds) {
-      List<DataMap> dataMaps = dataMapFactory.getDataMaps(segmentId);
+      List<DataMap> dataMaps = dataMapFactory.getDataMaps(configuration, segmentId);
       for (DataMap dataMap : dataMaps) {
         List<Blocklet> pruneBlocklets = dataMap.prune(filterExp);
         blocklets.addAll(addSegmentId(pruneBlocklets, segmentId));
@@ -87,7 +92,7 @@ public final class TableDataMap implements EventListener {
   public List<DataMapDistributable> toDistributable(List<String> segmentIds) throws IOException {
     List<DataMapDistributable> distributables = new ArrayList<>();
     for (String segmentsId : segmentIds) {
-      List<DataMapDistributable> list = dataMapFactory.toDistributable(segmentsId);
+      List<DataMapDistributable> list = dataMapFactory.toDistributable(configuration, segmentsId);
       for (DataMapDistributable distributable: list) {
         distributable.setDataMapName(dataMapName);
         distributable.setSegmentId(segmentsId);

--- a/core/src/main/java/org/apache/carbondata/core/datamap/dev/DataMap.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/dev/DataMap.java
@@ -23,6 +23,8 @@ import org.apache.carbondata.core.indexstore.Blocklet;
 import org.apache.carbondata.core.memory.MemoryException;
 import org.apache.carbondata.core.scan.filter.resolver.FilterResolverIntf;
 
+import org.apache.hadoop.conf.Configuration;
+
 /**
  * Datamap is an entity which can store and retrieve index data.
  */
@@ -31,7 +33,7 @@ public interface DataMap {
   /**
    * It is called to load the data map to memory or to initialize it.
    */
-  void init(String filePath) throws MemoryException, IOException;
+  void init(Configuration configuration, String filePath) throws MemoryException, IOException;
 
   /**
    * Prune the datamap with filter expression. It returns the list of

--- a/core/src/main/java/org/apache/carbondata/core/datamap/dev/DataMapFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/dev/DataMapFactory.java
@@ -25,6 +25,8 @@ import org.apache.carbondata.core.datamap.dev.DataMap;
 import org.apache.carbondata.core.events.ChangeEvent;
 import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
 
+import org.apache.hadoop.conf.Configuration;
+
 /**
  * Interface for datamap factory, it is responsible for creating the datamap.
  */
@@ -33,7 +35,7 @@ public interface DataMapFactory {
   /**
    * Initialization of Datamap factory with the identifier and datamap name
    */
-  void init(AbsoluteTableIdentifier identifier, String dataMapName);
+  void init(Configuration configuration, AbsoluteTableIdentifier identifier, String dataMapName);
 
   /**
    * Return a new write for this datamap
@@ -43,7 +45,7 @@ public interface DataMapFactory {
   /**
    * Get the datamap for segmentid
    */
-  List<DataMap> getDataMaps(String segmentId) throws IOException;
+  List<DataMap> getDataMaps(Configuration configuration, String segmentId) throws IOException;
 
   /**
    * Get datamap for distributable object.
@@ -54,7 +56,7 @@ public interface DataMapFactory {
    * Get all distributable objects of a segmentid
    * @return
    */
-  List<DataMapDistributable> toDistributable(String segmentId);
+  List<DataMapDistributable> toDistributable(Configuration configuration, String segmentId);
 
   /**
    *

--- a/core/src/main/java/org/apache/carbondata/core/datastore/AbstractBlockIndexStoreCache.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/AbstractBlockIndexStoreCache.java
@@ -34,6 +34,8 @@ import org.apache.carbondata.core.metadata.blocklet.DataFileFooter;
 import org.apache.carbondata.core.util.CarbonUtil;
 import org.apache.carbondata.core.util.ObjectSizeCalculator;
 
+import org.apache.hadoop.conf.Configuration;
+
 /**
  * This class validate and load the B-Tree in the executor lru cache
  * @param <K> cache key
@@ -67,8 +69,11 @@ public abstract class AbstractBlockIndexStoreCache<K, V>
    */
   protected Map<String, Object> segmentIDLock;
 
-  public AbstractBlockIndexStoreCache(CarbonLRUCache lruCache) {
+  protected Configuration configuration;
+
+  public AbstractBlockIndexStoreCache(CarbonLRUCache lruCache, Configuration configuration) {
     this.lruCache = lruCache;
+    this.configuration = configuration;
     blockInfoLock = new ConcurrentHashMap<BlockInfo, Object>();
     segmentIDLock = new ConcurrentHashMap<String, Object>();
     segmentIdToBlockListMap = new ConcurrentHashMap<>();
@@ -87,11 +92,11 @@ public abstract class AbstractBlockIndexStoreCache<K, V>
       throws IOException {
     // calculate the required size is
     TableBlockInfo blockInfo = tableBlockUniqueIdentifier.getTableBlockInfo();
-    long requiredMetaSize = CarbonUtil.calculateMetaSize(blockInfo);
+    long requiredMetaSize = CarbonUtil.calculateMetaSize(blockInfo, configuration);
     if (requiredMetaSize > 0) {
       // load table blocks data
       // getting the data file meta data of the block
-      DataFileFooter footer = CarbonUtil.readMetadatFile(blockInfo);
+      DataFileFooter footer = CarbonUtil.readMetadatFile(blockInfo, configuration);
       footer.setBlockInfo(new BlockInfo(blockInfo));
       // building the block
       tableBlock.buildIndex(Collections.singletonList(footer));

--- a/core/src/main/java/org/apache/carbondata/core/datastore/BlockIndexStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/BlockIndexStore.java
@@ -49,6 +49,8 @@ import org.apache.carbondata.core.scan.model.QueryModel;
 import org.apache.carbondata.core.util.CarbonProperties;
 import org.apache.carbondata.core.util.TaskMetricsMap;
 
+import org.apache.hadoop.conf.Configuration;
+
 /**
  * This class is used to load the B-Tree in Executor LRU Cache
  */
@@ -59,8 +61,9 @@ public class BlockIndexStore<K, V> extends AbstractBlockIndexStoreCache<K, V> {
    */
   private static final LogService LOGGER =
       LogServiceFactory.getLogService(BlockIndexStore.class.getName());
-  public BlockIndexStore(String carbonStorePath, CarbonLRUCache lruCache) {
-    super(lruCache);
+  public BlockIndexStore(Configuration configuration, String carbonStorePath,
+      CarbonLRUCache lruCache) {
+    super(lruCache, configuration);
   }
 
   /**

--- a/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/AlluxioCarbonFile.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/AlluxioCarbonFile.java
@@ -23,8 +23,8 @@ import java.util.List;
 
 import org.apache.carbondata.common.logging.LogService;
 import org.apache.carbondata.common.logging.LogServiceFactory;
-import org.apache.carbondata.core.datastore.impl.FileFactory;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -39,16 +39,16 @@ public class AlluxioCarbonFile extends AbstractDFSCarbonFile {
   private static final LogService LOGGER =
       LogServiceFactory.getLogService(AlluxioCarbonFile.class.getName());
 
-  public AlluxioCarbonFile(String filePath) {
-    super(filePath);
+  public AlluxioCarbonFile(Configuration configuration, String filePath) {
+    super(configuration, filePath);
   }
 
-  public AlluxioCarbonFile(Path path) {
-    super(path);
+  public AlluxioCarbonFile(Configuration configuration, Path path) {
+    super(configuration, path);
   }
 
-  public AlluxioCarbonFile(FileStatus fileStatus) {
-    super(fileStatus);
+  public AlluxioCarbonFile(Configuration configuration, FileStatus fileStatus) {
+    super(configuration, fileStatus);
   }
 
   /**
@@ -61,7 +61,7 @@ public class AlluxioCarbonFile extends AbstractDFSCarbonFile {
     }
     CarbonFile[] files = new CarbonFile[listStatus.length];
     for (int i = 0; i < files.length; i++) {
-      files[i] = new AlluxioCarbonFile(listStatus[i]);
+      files[i] = new AlluxioCarbonFile(configuration, listStatus[i]);
     }
     return files;
   }
@@ -72,7 +72,7 @@ public class AlluxioCarbonFile extends AbstractDFSCarbonFile {
     try {
       if (null != fileStatus && fileStatus.isDirectory()) {
         Path path = fileStatus.getPath();
-        listStatus = path.getFileSystem(FileFactory.getConfiguration()).listStatus(path);
+        listStatus = path.getFileSystem(configuration).listStatus(path);
       } else {
         return new CarbonFile[0];
       }
@@ -105,14 +105,14 @@ public class AlluxioCarbonFile extends AbstractDFSCarbonFile {
   @Override
   public CarbonFile getParentFile() {
     Path parent = fileStatus.getPath().getParent();
-    return null == parent ? null : new AlluxioCarbonFile(parent);
+    return null == parent ? null : new AlluxioCarbonFile(configuration, parent);
   }
 
   @Override
   public boolean renameForce(String changetoName) {
     FileSystem fs;
     try {
-      fs = fileStatus.getPath().getFileSystem(FileFactory.getConfiguration());
+      fs = fileStatus.getPath().getFileSystem(configuration);
       if (fs instanceof DistributedFileSystem) {
         ((DistributedFileSystem) fs).rename(fileStatus.getPath(), new Path(changetoName),
             org.apache.hadoop.fs.Options.Rename.OVERWRITE);

--- a/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/LocalCarbonFile.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/LocalCarbonFile.java
@@ -167,13 +167,13 @@ public class LocalCarbonFile implements CarbonFile {
     try {
       CarbonFile tempFile = null;
       // delete temporary file if it already exists at a given path
-      if (FileFactory.isFileExist(tempWriteFilePath, fileType)) {
-        tempFile = FileFactory.getCarbonFile(tempWriteFilePath, fileType);
+      if (FileFactory.isFileExist(null, tempWriteFilePath, fileType)) {
+        tempFile = FileFactory.getCarbonFile(null, tempWriteFilePath, fileType);
         tempFile.delete();
       }
       // create new temporary file
-      FileFactory.createNewFile(tempWriteFilePath, fileType);
-      tempFile = FileFactory.getCarbonFile(tempWriteFilePath, fileType);
+      FileFactory.createNewFile(null, tempWriteFilePath, fileType);
+      tempFile = FileFactory.getCarbonFile(null, tempWriteFilePath, fileType);
       source = new FileInputStream(fileName).getChannel();
       destination = new FileOutputStream(tempWriteFilePath).getChannel();
       long read = destination.transferFrom(source, 0, validDataEndOffset);

--- a/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/ViewFSCarbonFile.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/ViewFSCarbonFile.java
@@ -22,8 +22,8 @@ import java.util.List;
 
 import org.apache.carbondata.common.logging.LogService;
 import org.apache.carbondata.common.logging.LogServiceFactory;
-import org.apache.carbondata.core.datastore.impl.FileFactory;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -36,16 +36,16 @@ public class ViewFSCarbonFile extends AbstractDFSCarbonFile {
   private static final LogService LOGGER =
       LogServiceFactory.getLogService(ViewFSCarbonFile.class.getName());
 
-  public ViewFSCarbonFile(String filePath) {
-    super(filePath);
+  public ViewFSCarbonFile(Configuration configuration, String filePath) {
+    super(configuration, filePath);
   }
 
-  public ViewFSCarbonFile(Path path) {
-    super(path);
+  public ViewFSCarbonFile(Configuration configuration, Path path) {
+    super(configuration, path);
   }
 
-  public ViewFSCarbonFile(FileStatus fileStatus) {
-    super(fileStatus);
+  public ViewFSCarbonFile(Configuration configuration, FileStatus fileStatus) {
+    super(configuration, fileStatus);
   }
 
   /**
@@ -58,7 +58,7 @@ public class ViewFSCarbonFile extends AbstractDFSCarbonFile {
     }
     CarbonFile[] files = new CarbonFile[listStatus.length];
     for (int i = 0; i < files.length; i++) {
-      files[i] = new ViewFSCarbonFile(listStatus[i]);
+      files[i] = new ViewFSCarbonFile(configuration, listStatus[i]);
     }
     return files;
   }
@@ -69,7 +69,7 @@ public class ViewFSCarbonFile extends AbstractDFSCarbonFile {
     try {
       if (null != fileStatus && fileStatus.isDirectory()) {
         Path path = fileStatus.getPath();
-        listStatus = path.getFileSystem(FileFactory.getConfiguration()).listStatus(path);
+        listStatus = path.getFileSystem(configuration).listStatus(path);
       } else {
         return new CarbonFile[0];
       }
@@ -101,14 +101,14 @@ public class ViewFSCarbonFile extends AbstractDFSCarbonFile {
 
   @Override public CarbonFile getParentFile() {
     Path parent = fileStatus.getPath().getParent();
-    return null == parent ? null : new ViewFSCarbonFile(parent);
+    return null == parent ? null : new ViewFSCarbonFile(configuration, parent);
   }
 
   @Override
   public boolean renameForce(String changetoName) {
     FileSystem fs;
     try {
-      fs = fileStatus.getPath().getFileSystem(FileFactory.getConfiguration());
+      fs = fileStatus.getPath().getFileSystem(configuration);
       if (fs instanceof ViewFileSystem) {
         fs.delete(new Path(changetoName), true);
         fs.rename(fileStatus.getPath(), new Path(changetoName));

--- a/core/src/main/java/org/apache/carbondata/core/datastore/impl/DFSFileHolderImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/impl/DFSFileHolderImpl.java
@@ -27,6 +27,7 @@ import java.util.Map.Entry;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.datastore.FileHolder;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -39,10 +40,12 @@ public class DFSFileHolderImpl implements FileHolder {
 
   private String queryId;
 
+  private Configuration configuration;
 
-  public DFSFileHolderImpl() {
+  public DFSFileHolderImpl(Configuration configuration) {
     this.fileNameAndStreamCache =
         new HashMap<String, FSDataInputStream>(CarbonCommonConstants.DEFAULT_COLLECTION_SIZE);
+    this.configuration = configuration;
   }
 
   @Override public byte[] readByteArray(String filePath, long offset, int length)
@@ -63,7 +66,7 @@ public class DFSFileHolderImpl implements FileHolder {
     FSDataInputStream fileChannel = fileNameAndStreamCache.get(filePath);
     if (null == fileChannel) {
       Path pt = new Path(filePath);
-      FileSystem fs = pt.getFileSystem(FileFactory.getConfiguration());
+      FileSystem fs = pt.getFileSystem(configuration);
       fileChannel = fs.open(pt);
       fileNameAndStreamCache.put(filePath, fileChannel);
     }

--- a/core/src/main/java/org/apache/carbondata/core/dictionary/generator/ServerDictionaryGenerator.java
+++ b/core/src/main/java/org/apache/carbondata/core/dictionary/generator/ServerDictionaryGenerator.java
@@ -24,6 +24,8 @@ import org.apache.carbondata.core.devapi.DictionaryGenerator;
 import org.apache.carbondata.core.dictionary.generator.key.DictionaryMessage;
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
 
+import org.apache.hadoop.conf.Configuration;
+
 /**
  * This is the dictionary generator for all tables. It generates dictionary
  * based on @{@link DictionaryMessage}.
@@ -43,14 +45,14 @@ public class ServerDictionaryGenerator implements DictionaryGenerator<Integer, D
     return generator.generateKey(value);
   }
 
-  public void initializeGeneratorForTable(CarbonTable carbonTable) {
+  public void initializeGeneratorForTable(CarbonTable carbonTable, Configuration configuration) {
     // initialize TableDictionaryGenerator first
     String tableId = carbonTable.getCarbonTableIdentifier().getTableId();
     if (tableMap.get(tableId) == null) {
       synchronized (tableMap) {
         if (tableMap.get(tableId) == null) {
           tableMap.put(tableId,
-              new TableDictionaryGenerator(carbonTable));
+              new TableDictionaryGenerator(carbonTable, configuration));
         }
       }
     }

--- a/core/src/main/java/org/apache/carbondata/core/dictionary/generator/TableDictionaryGenerator.java
+++ b/core/src/main/java/org/apache/carbondata/core/dictionary/generator/TableDictionaryGenerator.java
@@ -34,6 +34,8 @@ import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
 import org.apache.carbondata.core.metadata.schema.table.column.CarbonDimension;
 import org.apache.carbondata.core.util.CarbonProperties;
 
+import org.apache.hadoop.conf.Configuration;
+
 /**
  * Dictionary generation for table.
  */
@@ -49,8 +51,11 @@ public class TableDictionaryGenerator
    */
   private Map<String, DictionaryGenerator<Integer, String>> columnMap = new ConcurrentHashMap<>();
 
-  public TableDictionaryGenerator(CarbonTable carbonTable) {
+  private Configuration configuration;
+
+  public TableDictionaryGenerator(CarbonTable carbonTable, Configuration configuration) {
     this.carbonTable = carbonTable;
+    this.configuration = configuration;
   }
 
   @Override
@@ -102,8 +107,8 @@ public class TableDictionaryGenerator
     if (null == columnMap.get(dimension.getColumnId())) {
       synchronized (columnMap) {
         if (null == columnMap.get(dimension.getColumnId())) {
-          columnMap.put(dimension.getColumnId(),
-              new IncrementalColumnDictionaryGenerator(dimension, 1, carbonTable));
+          columnMap.put(dimension.getColumnId(), new IncrementalColumnDictionaryGenerator(
+              dimension, 1, carbonTable, configuration));
         }
       }
     }

--- a/core/src/main/java/org/apache/carbondata/core/dictionary/server/DictionaryServer.java
+++ b/core/src/main/java/org/apache/carbondata/core/dictionary/server/DictionaryServer.java
@@ -33,6 +33,7 @@ import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
+import org.apache.hadoop.conf.Configuration;
 
 /**
  * Dictionary Server to generate dictionary keys.
@@ -54,7 +55,8 @@ public class DictionaryServer {
     startServer(port);
   }
 
-  public static DictionaryServer getInstance(int port, CarbonTable carbonTable) throws Exception {
+  public static DictionaryServer getInstance(int port, CarbonTable carbonTable,
+      Configuration configuration) throws Exception {
     if (INSTANCE == null) {
       synchronized (lock) {
         if (INSTANCE == null) {
@@ -62,7 +64,7 @@ public class DictionaryServer {
         }
       }
     }
-    INSTANCE.initializeDictionaryGenerator(carbonTable);
+    INSTANCE.initializeDictionaryGenerator(carbonTable, configuration);
     return INSTANCE;
   }
 
@@ -142,8 +144,9 @@ public class DictionaryServer {
     boss.shutdownGracefully();
   }
 
-  public void initializeDictionaryGenerator(CarbonTable carbonTable) throws Exception {
-    dictionaryServerHandler.initializeTable(carbonTable);
+  public void initializeDictionaryGenerator(CarbonTable carbonTable,
+      Configuration configuration) throws Exception {
+    dictionaryServerHandler.initializeTable(carbonTable, configuration);
   }
 
   /**

--- a/core/src/main/java/org/apache/carbondata/core/dictionary/server/DictionaryServerHandler.java
+++ b/core/src/main/java/org/apache/carbondata/core/dictionary/server/DictionaryServerHandler.java
@@ -26,6 +26,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import org.apache.hadoop.conf.Configuration;
 
 /**
  * Handler for Dictionary server.
@@ -102,8 +103,8 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
     }
   }
 
-  void initializeTable(CarbonTable carbonTable) {
-    generatorForServer.initializeGeneratorForTable(carbonTable);
+  void initializeTable(CarbonTable carbonTable, Configuration configuration) {
+    generatorForServer.initializeGeneratorForTable(carbonTable, configuration);
   }
 
 }

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/Blocklet.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/Blocklet.java
@@ -19,8 +19,7 @@ package org.apache.carbondata.core.indexstore;
 import java.io.IOException;
 import java.io.Serializable;
 
-import org.apache.carbondata.core.datastore.impl.FileFactory;
-
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
@@ -64,9 +63,9 @@ public class Blocklet implements Serializable {
     this.detailInfo = detailInfo;
   }
 
-  public void updateLocations() throws IOException {
+  public void updateLocations(Configuration configuration) throws IOException {
     Path path = new Path(this.path);
-    FileSystem fs = path.getFileSystem(FileFactory.getConfiguration());
+    FileSystem fs = path.getFileSystem(configuration);
     RemoteIterator<LocatedFileStatus> iter = fs.listLocatedStatus(path);
     LocatedFileStatus fileStatus = iter.next();
     location = fileStatus.getBlockLocations()[0].getHosts();

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/BlockletDataMapIndexStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/BlockletDataMapIndexStore.java
@@ -29,6 +29,8 @@ import org.apache.carbondata.core.cache.CarbonLRUCache;
 import org.apache.carbondata.core.indexstore.blockletindex.BlockletDataMap;
 import org.apache.carbondata.core.memory.MemoryException;
 
+import org.apache.hadoop.conf.Configuration;
+
 /**
  * Class to handle loading, unloading,clearing,storing of the table
  * blocks
@@ -54,13 +56,17 @@ public class BlockletDataMapIndexStore
    */
   private Map<String, Object> segmentLockMap;
 
+  private Configuration configuration;
+
   /**
    * constructor to initialize the SegmentTaskIndexStore
    *
    * @param carbonStorePath
    * @param lruCache
    */
-  public BlockletDataMapIndexStore(String carbonStorePath, CarbonLRUCache lruCache) {
+  public BlockletDataMapIndexStore(Configuration configuration, String carbonStorePath,
+      CarbonLRUCache lruCache) {
+    this.configuration = configuration;
     this.carbonStorePath = carbonStorePath;
     this.lruCache = lruCache;
     segmentLockMap = new ConcurrentHashMap<String, Object>();
@@ -141,7 +147,7 @@ public class BlockletDataMapIndexStore
     BlockletDataMap dataMap = null;
     synchronized (lock) {
       dataMap = new BlockletDataMap();
-      dataMap.init(tableSegmentUniqueIdentifier.getFilePath());
+      dataMap.init(configuration, tableSegmentUniqueIdentifier.getFilePath());
       lruCache.put(tableSegmentUniqueIdentifier.getUniqueTableSegmentIdentifier(), dataMap,
           dataMap.getMemorySize());
     }

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/IndexWrapper.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/IndexWrapper.java
@@ -25,16 +25,18 @@ import org.apache.carbondata.core.datastore.block.TableBlockInfo;
 import org.apache.carbondata.core.metadata.blocklet.DataFileFooter;
 import org.apache.carbondata.core.util.CarbonUtil;
 
+import org.apache.hadoop.conf.Configuration;
+
 /**
  * Wrapper of abstract index
  * TODO it could be removed after refactor
  */
 public class IndexWrapper extends AbstractIndex {
 
-  public IndexWrapper(List<TableBlockInfo> blockInfos) {
+  public IndexWrapper(List<TableBlockInfo> blockInfos, Configuration configuration) {
     DataFileFooter fileFooter = null;
     try {
-      fileFooter = CarbonUtil.readMetadatFile(blockInfos.get(0));
+      fileFooter = CarbonUtil.readMetadatFile(blockInfos.get(0), configuration);
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/core/src/main/java/org/apache/carbondata/core/locks/AbstractCarbonLock.java
+++ b/core/src/main/java/org/apache/carbondata/core/locks/AbstractCarbonLock.java
@@ -21,6 +21,8 @@ import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.datastore.impl.FileFactory;
 import org.apache.carbondata.core.util.CarbonProperties;
 
+import org.apache.hadoop.conf.Configuration;
+
 /**
  * This is the abstract class of the lock implementations.This handles the
  * retrying part of the locking.
@@ -73,9 +75,9 @@ public abstract class AbstractCarbonLock implements ICarbonLock {
 
   }
 
-  public boolean releaseLockManually(String lockFile) {
+  public boolean releaseLockManually(Configuration configuration, String lockFile) {
     try {
-      return FileFactory.deleteFile(lockFile, FileFactory.getFileType(lockFile));
+      return FileFactory.deleteFile(configuration, lockFile, FileFactory.getFileType(lockFile));
     } catch (Exception e) {
       return false;
     }

--- a/core/src/main/java/org/apache/carbondata/core/locks/CarbonLockFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/locks/CarbonLockFactory.java
@@ -23,6 +23,8 @@ import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.metadata.CarbonTableIdentifier;
 import org.apache.carbondata.core.util.CarbonProperties;
 
+import org.apache.hadoop.conf.Configuration;
+
 /**
  * This class is a Lock factory class which is used to provide lock objects.
  * Using this lock object client can request the lock and unlock.
@@ -51,7 +53,7 @@ public class CarbonLockFactory {
    * @return
    */
   public static ICarbonLock getCarbonLockObj(CarbonTableIdentifier tableIdentifier,
-      String lockFile) {
+      String lockFile, Configuration configuration) {
     switch (lockTypeConfigured) {
       case CarbonCommonConstants.CARBON_LOCK_TYPE_LOCAL:
         return new LocalFileLock(tableIdentifier, lockFile);
@@ -60,7 +62,7 @@ public class CarbonLockFactory {
         return new ZooKeeperLocking(tableIdentifier, lockFile);
 
       case CarbonCommonConstants.CARBON_LOCK_TYPE_HDFS:
-        return new HdfsFileLock(tableIdentifier, lockFile);
+        return new HdfsFileLock(configuration, tableIdentifier, lockFile);
 
       default:
         throw new UnsupportedOperationException("Not supported the lock type");
@@ -73,7 +75,8 @@ public class CarbonLockFactory {
    * @param lockFile
    * @return carbon lock
    */
-  public static ICarbonLock getCarbonLockObj(String locFileLocation, String lockFile) {
+  public static ICarbonLock getCarbonLockObj(String locFileLocation, String lockFile,
+      Configuration configuration) {
     switch (lockTypeConfigured) {
       case CarbonCommonConstants.CARBON_LOCK_TYPE_LOCAL:
         return new LocalFileLock(locFileLocation, lockFile);
@@ -82,7 +85,7 @@ public class CarbonLockFactory {
         return new ZooKeeperLocking(locFileLocation, lockFile);
 
       case CarbonCommonConstants.CARBON_LOCK_TYPE_HDFS:
-        return new HdfsFileLock(locFileLocation, lockFile);
+        return new HdfsFileLock(configuration, locFileLocation, lockFile);
 
       default:
         throw new UnsupportedOperationException("Not supported the lock type");

--- a/core/src/main/java/org/apache/carbondata/core/locks/CarbonLockUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/locks/CarbonLockUtil.java
@@ -21,6 +21,8 @@ import org.apache.carbondata.common.logging.LogService;
 import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.metadata.CarbonTableIdentifier;
 
+import org.apache.hadoop.conf.Configuration;
+
 /**
  * This class contains all carbon lock utilities
  */
@@ -70,8 +72,10 @@ public class CarbonLockUtil {
    * @param lockType
    * @return
    */
-  public static ICarbonLock getLockObject(CarbonTableIdentifier identifier, String lockType) {
-    ICarbonLock carbonLock = CarbonLockFactory.getCarbonLockObj(identifier, lockType);
+  public static ICarbonLock getLockObject(CarbonTableIdentifier identifier, String lockType,
+      Configuration configuration) {
+    ICarbonLock carbonLock =
+        CarbonLockFactory.getCarbonLockObj(identifier, lockType, configuration);
     LOGGER.info("Trying to acquire lock: " + carbonLock);
     if (carbonLock.lockWithRetries()) {
       LOGGER.info("Successfully acquired the lock " + carbonLock);

--- a/core/src/main/java/org/apache/carbondata/core/locks/ICarbonLock.java
+++ b/core/src/main/java/org/apache/carbondata/core/locks/ICarbonLock.java
@@ -17,6 +17,8 @@
 
 package org.apache.carbondata.core.locks;
 
+import org.apache.hadoop.conf.Configuration;
+
 /**
  * Carbon Lock Interface which handles the locking and unlocking.
  */
@@ -42,6 +44,6 @@ public interface ICarbonLock {
    * @param lockFile The path of the lock file.
    * @return True if the lock file is deleted, false otherwise.
    */
-  boolean releaseLockManually(String lockFile);
+  boolean releaseLockManually(Configuration configuration, String lockFile);
 
 }

--- a/core/src/main/java/org/apache/carbondata/core/locks/LocalFileLock.java
+++ b/core/src/main/java/org/apache/carbondata/core/locks/LocalFileLock.java
@@ -103,13 +103,13 @@ public class LocalFileLock extends AbstractCarbonLock {
    */
   @Override public boolean lock() {
     try {
-      if (!FileFactory.isFileExist(location, FileFactory.getFileType(tmpPath))) {
-        FileFactory.mkdirs(location, FileFactory.getFileType(tmpPath));
+      if (!FileFactory.isFileExist(null, location, FileFactory.getFileType(tmpPath))) {
+        FileFactory.mkdirs(null, location, FileFactory.getFileType(tmpPath));
       }
       lockFilePath = location + CarbonCommonConstants.FILE_SEPARATOR +
           lockFile;
-      if (!FileFactory.isFileExist(lockFilePath, FileFactory.getFileType(location))) {
-        FileFactory.createNewLockFile(lockFilePath, FileFactory.getFileType(location));
+      if (!FileFactory.isFileExist(null, lockFilePath, FileFactory.getFileType(location))) {
+        FileFactory.createNewLockFile(null, lockFilePath, FileFactory.getFileType(location));
       }
 
       fileOutputStream = new FileOutputStream(lockFilePath);
@@ -151,7 +151,7 @@ public class LocalFileLock extends AbstractCarbonLock {
           fileOutputStream.close();
           // deleting the lock file after releasing the lock.
           CarbonFile lockFile = FileFactory
-                  .getCarbonFile(lockFilePath, FileFactory.getFileType(lockFilePath));
+                  .getCarbonFile(null, lockFilePath, FileFactory.getFileType(lockFilePath));
           if (!lockFile.exists() || lockFile.delete()) {
             LOGGER.info("Successfully deleted the lock file " + lockFilePath);
           } else {

--- a/core/src/main/java/org/apache/carbondata/core/mutate/data/BlockletDeleteDeltaCacheLoader.java
+++ b/core/src/main/java/org/apache/carbondata/core/mutate/data/BlockletDeleteDeltaCacheLoader.java
@@ -26,6 +26,8 @@ import org.apache.carbondata.core.datastore.DataRefNode;
 import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
 import org.apache.carbondata.core.statusmanager.SegmentUpdateStatusManager;
 
+import org.apache.hadoop.conf.Configuration;
+
 /**
  * This class is responsible for loading delete delta file cache based on
  * blocklet id of a particular block
@@ -34,14 +36,16 @@ public class BlockletDeleteDeltaCacheLoader implements DeleteDeltaCacheLoaderInt
   private String blockletID;
   private DataRefNode blockletNode;
   private AbsoluteTableIdentifier absoluteIdentifier;
+  private Configuration configuration;
   private static final LogService LOGGER =
       LogServiceFactory.getLogService(BlockletDeleteDeltaCacheLoader.class.getName());
 
   public BlockletDeleteDeltaCacheLoader(String blockletID, DataRefNode blockletNode,
-      AbsoluteTableIdentifier absoluteIdentifier) {
+      AbsoluteTableIdentifier absoluteIdentifier, Configuration configuration) {
     this.blockletID = blockletID;
     this.blockletNode = blockletNode;
     this.absoluteIdentifier = absoluteIdentifier;
+    this.configuration = configuration;
   }
 
   /**
@@ -50,7 +54,7 @@ public class BlockletDeleteDeltaCacheLoader implements DeleteDeltaCacheLoaderInt
    */
   public void loadDeleteDeltaFileDataToCache() {
     SegmentUpdateStatusManager segmentUpdateStatusManager =
-        new SegmentUpdateStatusManager(absoluteIdentifier);
+        new SegmentUpdateStatusManager(absoluteIdentifier, configuration);
     Map<Integer, Integer[]> deleteDeltaFileData = null;
     BlockletLevelDeleteDeltaDataCache deleteDeltaDataCache = null;
     if (null == blockletNode.getDeleteDeltaDataCache()) {

--- a/core/src/main/java/org/apache/carbondata/core/reader/CarbonDeleteDeltaFileReaderImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/reader/CarbonDeleteDeltaFileReaderImpl.java
@@ -33,6 +33,7 @@ import org.apache.carbondata.core.mutate.DeleteDeltaBlockDetails;
 import org.apache.carbondata.core.util.CarbonUtil;
 
 import com.google.gson.Gson;
+import org.apache.hadoop.conf.Configuration;
 
 /**
  * This class perform the functionality of reading the delete delta file
@@ -52,6 +53,8 @@ public class CarbonDeleteDeltaFileReaderImpl implements CarbonDeleteDeltaFileRea
   private DataInputStream dataInputStream = null;
 
   private InputStreamReader inputStream = null;
+
+  private Configuration configuration;
 
   private static final int DEFAULT_BUFFER_SIZE = 258;
 
@@ -78,7 +81,7 @@ public class CarbonDeleteDeltaFileReaderImpl implements CarbonDeleteDeltaFileRea
     // Configure Buffer based on our requirement
     char[] buffer = new char[DEFAULT_BUFFER_SIZE];
     StringWriter sw = new StringWriter();
-    dataInputStream = FileFactory.getDataInputStream(filePath, fileType);
+    dataInputStream = FileFactory.getDataInputStream(configuration, filePath, fileType);
     inputStream = new InputStreamReader(dataInputStream,
         CarbonCommonConstants.CARBON_DEFAULT_STREAM_ENCODEFORMAT);
     int n = 0;
@@ -100,10 +103,10 @@ public class CarbonDeleteDeltaFileReaderImpl implements CarbonDeleteDeltaFileRea
     InputStreamReader inStream = null;
     DeleteDeltaBlockDetails deleteDeltaBlockDetails;
     AtomicFileOperations fileOperation =
-        new AtomicFileOperationsImpl(filePath, FileFactory.getFileType(filePath));
+        new AtomicFileOperationsImpl(configuration, filePath, FileFactory.getFileType(filePath));
 
     try {
-      if (!FileFactory.isFileExist(filePath, FileFactory.getFileType(filePath))) {
+      if (!FileFactory.isFileExist(configuration, filePath, FileFactory.getFileType(filePath))) {
         return new DeleteDeltaBlockDetails("");
       }
       dataInputStream = fileOperation.openForRead();

--- a/core/src/main/java/org/apache/carbondata/core/reader/CarbonDictionaryMetadataReaderImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/reader/CarbonDictionaryMetadataReaderImpl.java
@@ -29,6 +29,7 @@ import org.apache.carbondata.core.service.PathService;
 import org.apache.carbondata.core.util.path.CarbonTablePath;
 import org.apache.carbondata.format.ColumnDictionaryChunkMeta;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.thrift.TBase;
 
 /**
@@ -61,6 +62,8 @@ public class CarbonDictionaryMetadataReaderImpl implements CarbonDictionaryMetad
    */
   private ThriftReader dictionaryMetadataFileReader;
 
+  private Configuration configuration;
+
   /**
    * Constructor
    *
@@ -70,10 +73,12 @@ public class CarbonDictionaryMetadataReaderImpl implements CarbonDictionaryMetad
    */
   public CarbonDictionaryMetadataReaderImpl(String storePath,
       CarbonTableIdentifier carbonTableIdentifier,
-      DictionaryColumnUniqueIdentifier dictionaryColumnUniqueIdentifier) {
+      DictionaryColumnUniqueIdentifier dictionaryColumnUniqueIdentifier,
+      Configuration configuration) {
     this.storePath = storePath;
     this.carbonTableIdentifier = carbonTableIdentifier;
     this.dictionaryColumnUniqueIdentifier = dictionaryColumnUniqueIdentifier;
+    this.configuration = configuration;
     initFileLocation();
   }
 
@@ -170,9 +175,8 @@ public class CarbonDictionaryMetadataReaderImpl implements CarbonDictionaryMetad
    */
   protected void initFileLocation() {
     PathService pathService = CarbonCommonFactory.getPathService();
-    CarbonTablePath carbonTablePath = pathService
-        .getCarbonTablePath(this.storePath, carbonTableIdentifier,
-            dictionaryColumnUniqueIdentifier);
+    CarbonTablePath carbonTablePath = pathService.getCarbonTablePath(this.storePath,
+        carbonTableIdentifier, dictionaryColumnUniqueIdentifier, configuration);
     this.columnDictionaryMetadataFilePath = carbonTablePath.getDictionaryMetaFilePath(
         dictionaryColumnUniqueIdentifier.getColumnIdentifier().getColumnId());
   }
@@ -187,7 +191,8 @@ public class CarbonDictionaryMetadataReaderImpl implements CarbonDictionaryMetad
     // dictionary thrift object contains a list of byte buffer
     if (null == dictionaryMetadataFileReader) {
       dictionaryMetadataFileReader =
-          new ThriftReader(this.columnDictionaryMetadataFilePath, new ThriftReader.TBaseCreator() {
+          new ThriftReader(configuration, this.columnDictionaryMetadataFilePath,
+              new ThriftReader.TBaseCreator() {
             @Override public TBase create() {
               return new ColumnDictionaryChunkMeta();
             }

--- a/core/src/main/java/org/apache/carbondata/core/reader/CarbonDictionaryReaderImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/reader/CarbonDictionaryReaderImpl.java
@@ -31,6 +31,7 @@ import org.apache.carbondata.core.service.PathService;
 import org.apache.carbondata.core.util.path.CarbonTablePath;
 import org.apache.carbondata.format.ColumnDictionaryChunk;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.thrift.TBase;
 
 /**
@@ -64,6 +65,8 @@ public class CarbonDictionaryReaderImpl implements CarbonDictionaryReader {
    */
   private ThriftReader dictionaryFileReader;
 
+  private Configuration configuration;
+
   /**
    * Constructor
    *
@@ -72,10 +75,12 @@ public class CarbonDictionaryReaderImpl implements CarbonDictionaryReader {
    * @param dictionaryColumnUniqueIdentifier      column unique identifier
    */
   public CarbonDictionaryReaderImpl(String storePath, CarbonTableIdentifier carbonTableIdentifier,
-      DictionaryColumnUniqueIdentifier dictionaryColumnUniqueIdentifier) {
+      DictionaryColumnUniqueIdentifier dictionaryColumnUniqueIdentifier,
+      Configuration configuration) {
     this.storePath = storePath;
     this.carbonTableIdentifier = carbonTableIdentifier;
     this.dictionaryColumnUniqueIdentifier = dictionaryColumnUniqueIdentifier;
+    this.configuration = configuration;
     initFileLocation();
   }
 
@@ -218,7 +223,7 @@ public class CarbonDictionaryReaderImpl implements CarbonDictionaryReader {
     PathService pathService = CarbonCommonFactory.getPathService();
     CarbonTablePath carbonTablePath = pathService
         .getCarbonTablePath(this.storePath, carbonTableIdentifier,
-            dictionaryColumnUniqueIdentifier);
+            dictionaryColumnUniqueIdentifier, configuration);
     this.columnDictionaryFilePath = carbonTablePath.getDictionaryFilePath(
         dictionaryColumnUniqueIdentifier.getColumnIdentifier().getColumnId());
   }
@@ -304,7 +309,7 @@ public class CarbonDictionaryReaderImpl implements CarbonDictionaryReader {
    */
   protected CarbonDictionaryMetadataReader getDictionaryMetadataReader() {
     return new CarbonDictionaryMetadataReaderImpl(this.storePath, carbonTableIdentifier,
-        this.dictionaryColumnUniqueIdentifier);
+        this.dictionaryColumnUniqueIdentifier, configuration);
   }
 
   /**
@@ -317,7 +322,8 @@ public class CarbonDictionaryReaderImpl implements CarbonDictionaryReader {
       // initialise dictionary file reader which will return dictionary thrift object
       // dictionary thrift object contains a list of byte buffer
       dictionaryFileReader =
-          new ThriftReader(this.columnDictionaryFilePath, new ThriftReader.TBaseCreator() {
+          new ThriftReader(configuration, this.columnDictionaryFilePath,
+              new ThriftReader.TBaseCreator() {
             @Override public TBase create() {
               return new ColumnDictionaryChunk();
             }

--- a/core/src/main/java/org/apache/carbondata/core/reader/CarbonFooterReader.java
+++ b/core/src/main/java/org/apache/carbondata/core/reader/CarbonFooterReader.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 
 import org.apache.carbondata.format.FileFooter;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.thrift.TBase;
 
 /**
@@ -34,8 +35,10 @@ public class CarbonFooterReader {
   //From which offset of file this metadata should be read
   private long offset;
 
-  public CarbonFooterReader(String filePath, long offset) {
+  private Configuration configuration;
 
+  public CarbonFooterReader(Configuration configuration, String filePath, long offset) {
+    this.configuration = configuration;
     this.filePath = filePath;
     this.offset = offset;
   }
@@ -65,7 +68,7 @@ public class CarbonFooterReader {
    */
   private ThriftReader openThriftReader(String filePath) {
 
-    return new ThriftReader(filePath, new ThriftReader.TBaseCreator() {
+    return new ThriftReader(configuration, filePath, new ThriftReader.TBaseCreator() {
       @Override public TBase create() {
         return new FileFooter();
       }

--- a/core/src/main/java/org/apache/carbondata/core/reader/CarbonFooterReaderV3.java
+++ b/core/src/main/java/org/apache/carbondata/core/reader/CarbonFooterReaderV3.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 
 import org.apache.carbondata.format.FileFooter3;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.thrift.TBase;
 
 /**
@@ -35,7 +36,10 @@ public class CarbonFooterReaderV3 {
   //start offset of the file footer
   private long footerOffset;
 
-  public CarbonFooterReaderV3(String filePath, long offset) {
+  private Configuration configuration;
+
+  public CarbonFooterReaderV3(Configuration configuration, String filePath, long offset) {
+    this.configuration = configuration;
     this.filePath = filePath;
     this.footerOffset = offset;
   }
@@ -65,7 +69,7 @@ public class CarbonFooterReaderV3 {
    */
   private ThriftReader openThriftReader(String filePath) {
 
-    return new ThriftReader(filePath, new ThriftReader.TBaseCreator() {
+    return new ThriftReader(configuration, filePath, new ThriftReader.TBaseCreator() {
       @Override public TBase create() {
         return new FileFooter3();
       }

--- a/core/src/main/java/org/apache/carbondata/core/reader/CarbonHeaderReader.java
+++ b/core/src/main/java/org/apache/carbondata/core/reader/CarbonHeaderReader.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 
 import org.apache.carbondata.format.FileHeader;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.thrift.TBase;
 
 /**
@@ -31,7 +32,10 @@ public class CarbonHeaderReader {
   //Fact file path
   private String filePath;
 
-  public CarbonHeaderReader(String filePath) {
+  private Configuration configuration;
+
+  public CarbonHeaderReader(Configuration configuration, String filePath) {
+    this.configuration = configuration;
     this.filePath = filePath;
   }
 
@@ -58,7 +62,7 @@ public class CarbonHeaderReader {
    */
   private ThriftReader openThriftReader(String filePath) {
 
-    return new ThriftReader(filePath, new ThriftReader.TBaseCreator() {
+    return new ThriftReader(configuration, filePath, new ThriftReader.TBaseCreator() {
       @Override public TBase create() {
         return new FileHeader();
       }

--- a/core/src/main/java/org/apache/carbondata/core/reader/CarbonIndexFileReader.java
+++ b/core/src/main/java/org/apache/carbondata/core/reader/CarbonIndexFileReader.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import org.apache.carbondata.format.BlockIndex;
 import org.apache.carbondata.format.IndexHeader;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.thrift.TBase;
 
 /**
@@ -74,8 +75,8 @@ public class CarbonIndexFileReader {
    * @param filePath
    * @throws IOException
    */
-  public void openThriftReader(String filePath) throws IOException {
-    thriftReader = new ThriftReader(filePath);
+  public void openThriftReader(Configuration configuration, String filePath) throws IOException {
+    thriftReader = new ThriftReader(configuration, filePath);
     thriftReader.open();
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/reader/ThriftReader.java
+++ b/core/src/main/java/org/apache/carbondata/core/reader/ThriftReader.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import org.apache.carbondata.core.datastore.impl.FileFactory;
 import org.apache.carbondata.core.util.CarbonUtil;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.thrift.TBase;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TCompactProtocol;
@@ -54,10 +55,13 @@ public class ThriftReader {
    */
   private TProtocol binaryIn;
 
+  private Configuration configuration;
+
   /**
    * Constructor.
    */
-  public ThriftReader(String fileName, TBaseCreator creator) {
+  public ThriftReader(Configuration configuration, String fileName, TBaseCreator creator) {
+    this.configuration = configuration;
     this.fileName = fileName;
     this.creator = creator;
   }
@@ -65,7 +69,8 @@ public class ThriftReader {
   /**
    * Constructor.
    */
-  public ThriftReader(String fileName) {
+  public ThriftReader(Configuration configuration, String fileName) {
+    this.configuration = configuration;
     this.fileName = fileName;
   }
 
@@ -74,7 +79,8 @@ public class ThriftReader {
    */
   public void open() throws IOException {
     FileFactory.FileType fileType = FileFactory.getFileType(fileName);
-    dataInputStream = FileFactory.getDataInputStream(fileName, fileType, bufferSize);
+    dataInputStream =
+        FileFactory.getDataInputStream(configuration, fileName, fileType, bufferSize);
     binaryIn = new TCompactProtocol(new TIOStreamTransport(dataInputStream));
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/FilterProcessor.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/FilterProcessor.java
@@ -29,6 +29,8 @@ import org.apache.carbondata.core.scan.expression.Expression;
 import org.apache.carbondata.core.scan.expression.exception.FilterUnsupportedException;
 import org.apache.carbondata.core.scan.filter.resolver.FilterResolverIntf;
 
+import org.apache.hadoop.conf.Configuration;
+
 public interface FilterProcessor {
 
   /**
@@ -41,8 +43,8 @@ public interface FilterProcessor {
    * @throws FilterUnsupportedException
    */
   FilterResolverIntf getFilterResolver(Expression expressionTree,
-      AbsoluteTableIdentifier tableIdentifier, TableProvider tableProvider)
-      throws FilterUnsupportedException, IOException;
+      AbsoluteTableIdentifier tableIdentifier, TableProvider tableProvider,
+      Configuration configuration) throws FilterUnsupportedException, IOException;
 
   /**
    * This API is exposed inorder to get the required block reference node
@@ -53,7 +55,8 @@ public interface FilterProcessor {
    * @return list of DataRefNode.
    */
   List<DataRefNode> getFilterredBlocks(DataRefNode dataRefNode, FilterResolverIntf filterResolver,
-      AbstractIndex segmentIndexBuilder, AbsoluteTableIdentifier tableIdentifier);
+      AbstractIndex segmentIndexBuilder, AbsoluteTableIdentifier tableIdentifier,
+      Configuration configuration);
 
   /**
    * This API will get the map of required partitions.

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RowLevelFilterExecuterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RowLevelFilterExecuterImpl.java
@@ -62,6 +62,8 @@ import org.apache.carbondata.core.util.BitSetGroup;
 import org.apache.carbondata.core.util.CarbonUtil;
 import org.apache.carbondata.core.util.DataTypeUtil;
 
+import org.apache.hadoop.conf.Configuration;
+
 public class RowLevelFilterExecuterImpl implements FilterExecuter {
 
   private static final LogService LOGGER =
@@ -100,11 +102,14 @@ public class RowLevelFilterExecuterImpl implements FilterExecuter {
    */
   protected boolean isNaturalSorted;
 
+  protected Configuration configuration;
+
   public RowLevelFilterExecuterImpl(List<DimColumnResolvedFilterInfo> dimColEvaluatorInfoList,
       List<MeasureColumnResolvedFilterInfo> msrColEvalutorInfoList, Expression exp,
       AbsoluteTableIdentifier tableIdentifier, SegmentProperties segmentProperties,
-      Map<Integer, GenericQueryType> complexDimensionInfoMap) {
+      Map<Integer, GenericQueryType> complexDimensionInfoMap, Configuration configuration) {
     this.segmentProperties = segmentProperties;
+    this.configuration = configuration;
     if (null == dimColEvaluatorInfoList) {
       this.dimColEvaluatorInfoList = new ArrayList<>(CarbonCommonConstants.DEFAULT_COLLECTION_SIZE);
     } else {
@@ -429,8 +434,8 @@ public class RowLevelFilterExecuterImpl implements FilterExecuter {
   private String getFilterActualValueFromDictionaryValue(
       DimColumnResolvedFilterInfo dimColumnEvaluatorInfo, int dictionaryValue) throws IOException {
     String memberString;
-    Dictionary forwardDictionary = FilterUtil
-        .getForwardDictionaryCache(tableIdentifier, dimColumnEvaluatorInfo.getDimension());
+    Dictionary forwardDictionary = FilterUtil.getForwardDictionaryCache(tableIdentifier,
+        dimColumnEvaluatorInfo.getDimension(), configuration);
 
     memberString = forwardDictionary.getDictionaryValueForKey(dictionaryValue);
     if (null != memberString) {

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RowLevelRangeGrtThanFiterExecuterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RowLevelRangeGrtThanFiterExecuterImpl.java
@@ -44,6 +44,8 @@ import org.apache.carbondata.core.util.DataTypeUtil;
 import org.apache.carbondata.core.util.comparator.Comparator;
 import org.apache.carbondata.core.util.comparator.SerializableComparator;
 
+import org.apache.hadoop.conf.Configuration;
+
 public class RowLevelRangeGrtThanFiterExecuterImpl extends RowLevelFilterExecuterImpl {
   private byte[][] filterRangeValues;
   private Object[] msrFilterRangeValues;
@@ -60,9 +62,10 @@ public class RowLevelRangeGrtThanFiterExecuterImpl extends RowLevelFilterExecute
       List<MeasureColumnResolvedFilterInfo> msrColEvalutorInfoList, Expression exp,
       AbsoluteTableIdentifier tableIdentifier, byte[][] filterRangeValues,
       Object[] msrFilterRangeValues,
-      SegmentProperties segmentProperties) {
+      SegmentProperties segmentProperties,
+      Configuration configuration) {
     super(dimColEvaluatorInfoList, msrColEvalutorInfoList, exp, tableIdentifier, segmentProperties,
-        null);
+        null, configuration);
     this.filterRangeValues = filterRangeValues;
     this.msrFilterRangeValues = msrFilterRangeValues;
     lastDimensionColOrdinal = segmentProperties.getLastDimensionColOrdinal();

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RowLevelRangeGrtrThanEquaToFilterExecuterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RowLevelRangeGrtrThanEquaToFilterExecuterImpl.java
@@ -44,6 +44,8 @@ import org.apache.carbondata.core.util.DataTypeUtil;
 import org.apache.carbondata.core.util.comparator.Comparator;
 import org.apache.carbondata.core.util.comparator.SerializableComparator;
 
+import org.apache.hadoop.conf.Configuration;
+
 public class RowLevelRangeGrtrThanEquaToFilterExecuterImpl extends RowLevelFilterExecuterImpl {
 
   protected byte[][] filterRangeValues;
@@ -59,9 +61,10 @@ public class RowLevelRangeGrtrThanEquaToFilterExecuterImpl extends RowLevelFilte
       List<DimColumnResolvedFilterInfo> dimColEvaluatorInfoList,
       List<MeasureColumnResolvedFilterInfo> msrColEvalutorInfoList, Expression exp,
       AbsoluteTableIdentifier tableIdentifier, byte[][] filterRangeValues,
-      Object[] msrFilterRangeValues, SegmentProperties segmentProperties) {
+      Object[] msrFilterRangeValues, SegmentProperties segmentProperties,
+      Configuration configuration) {
     super(dimColEvaluatorInfoList, msrColEvalutorInfoList, exp, tableIdentifier, segmentProperties,
-        null);
+        null, configuration);
     this.filterRangeValues = filterRangeValues;
     this.msrFilterRangeValues = msrFilterRangeValues;
     lastDimensionColOrdinal = segmentProperties.getLastDimensionColOrdinal();

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RowLevelRangeLessThanEqualFilterExecuterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RowLevelRangeLessThanEqualFilterExecuterImpl.java
@@ -46,6 +46,8 @@ import org.apache.carbondata.core.util.DataTypeUtil;
 import org.apache.carbondata.core.util.comparator.Comparator;
 import org.apache.carbondata.core.util.comparator.SerializableComparator;
 
+import org.apache.hadoop.conf.Configuration;
+
 public class RowLevelRangeLessThanEqualFilterExecuterImpl extends RowLevelFilterExecuterImpl {
   protected byte[][] filterRangeValues;
   protected Object[] msrFilterRangeValues;
@@ -60,9 +62,10 @@ public class RowLevelRangeLessThanEqualFilterExecuterImpl extends RowLevelFilter
       List<DimColumnResolvedFilterInfo> dimColEvaluatorInfoList,
       List<MeasureColumnResolvedFilterInfo> msrColEvalutorInfoList, Expression exp,
       AbsoluteTableIdentifier tableIdentifier, byte[][] filterRangeValues,
-      Object[] msrFilterRangeValues, SegmentProperties segmentProperties) {
+      Object[] msrFilterRangeValues, SegmentProperties segmentProperties,
+      Configuration configuration) {
     super(dimColEvaluatorInfoList, msrColEvalutorInfoList, exp, tableIdentifier, segmentProperties,
-        null);
+        null, configuration);
     lastDimensionColOrdinal = segmentProperties.getLastDimensionColOrdinal();
     this.filterRangeValues = filterRangeValues;
     this.msrFilterRangeValues = msrFilterRangeValues;

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RowLevelRangeLessThanFiterExecuterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RowLevelRangeLessThanFiterExecuterImpl.java
@@ -46,6 +46,8 @@ import org.apache.carbondata.core.util.DataTypeUtil;
 import org.apache.carbondata.core.util.comparator.Comparator;
 import org.apache.carbondata.core.util.comparator.SerializableComparator;
 
+import org.apache.hadoop.conf.Configuration;
+
 public class RowLevelRangeLessThanFiterExecuterImpl extends RowLevelFilterExecuterImpl {
   private byte[][] filterRangeValues;
   private Object[] msrFilterRangeValues;
@@ -60,9 +62,10 @@ public class RowLevelRangeLessThanFiterExecuterImpl extends RowLevelFilterExecut
       List<DimColumnResolvedFilterInfo> dimColEvaluatorInfoList,
       List<MeasureColumnResolvedFilterInfo> msrColEvalutorInfoList, Expression exp,
       AbsoluteTableIdentifier tableIdentifier, byte[][] filterRangeValues,
-      Object[] msrFilterRangeValues, SegmentProperties segmentProperties) {
+      Object[] msrFilterRangeValues, SegmentProperties segmentProperties,
+      Configuration configuration) {
     super(dimColEvaluatorInfoList, msrColEvalutorInfoList, exp, tableIdentifier, segmentProperties,
-        null);
+        null, configuration);
     this.filterRangeValues = filterRangeValues;
     this.msrFilterRangeValues = msrFilterRangeValues;
     lastDimensionColOrdinal = segmentProperties.getLastDimensionColOrdinal();

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RowLevelRangeTypeExecuterFacory.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RowLevelRangeTypeExecuterFacory.java
@@ -21,6 +21,8 @@ import org.apache.carbondata.core.scan.filter.intf.FilterExecuterType;
 import org.apache.carbondata.core.scan.filter.resolver.FilterResolverIntf;
 import org.apache.carbondata.core.scan.filter.resolver.RowLevelRangeFilterResolverImpl;
 
+import org.apache.hadoop.conf.Configuration;
+
 public class RowLevelRangeTypeExecuterFacory {
 
   private RowLevelRangeTypeExecuterFacory() {
@@ -37,7 +39,7 @@ public class RowLevelRangeTypeExecuterFacory {
    */
   public static RowLevelFilterExecuterImpl getRowLevelRangeTypeExecuter(
       FilterExecuterType filterExecuterType, FilterResolverIntf filterExpressionResolverTree,
-      SegmentProperties segmentProperties) {
+      SegmentProperties segmentProperties, Configuration configuration) {
     switch (filterExecuterType) {
 
       case ROWLEVEL_LESSTHAN:
@@ -51,7 +53,7 @@ public class RowLevelRangeTypeExecuterFacory {
             ((RowLevelRangeFilterResolverImpl) filterExpressionResolverTree)
                 .getFilterRangeValues(segmentProperties),
             ((RowLevelRangeFilterResolverImpl) filterExpressionResolverTree)
-            .getMeasureFilterRangeValues(), segmentProperties);
+            .getMeasureFilterRangeValues(), segmentProperties, configuration);
       case ROWLEVEL_LESSTHAN_EQUALTO:
         return new RowLevelRangeLessThanEqualFilterExecuterImpl(
             ((RowLevelRangeFilterResolverImpl) filterExpressionResolverTree)
@@ -63,7 +65,7 @@ public class RowLevelRangeTypeExecuterFacory {
             ((RowLevelRangeFilterResolverImpl) filterExpressionResolverTree)
                 .getFilterRangeValues(segmentProperties),
             ((RowLevelRangeFilterResolverImpl) filterExpressionResolverTree)
-                .getMeasureFilterRangeValues(), segmentProperties);
+                .getMeasureFilterRangeValues(), segmentProperties, configuration);
       case ROWLEVEL_GREATERTHAN_EQUALTO:
         return new RowLevelRangeGrtrThanEquaToFilterExecuterImpl(
             ((RowLevelRangeFilterResolverImpl) filterExpressionResolverTree)
@@ -75,7 +77,7 @@ public class RowLevelRangeTypeExecuterFacory {
             ((RowLevelRangeFilterResolverImpl) filterExpressionResolverTree)
                 .getFilterRangeValues(segmentProperties),
             ((RowLevelRangeFilterResolverImpl) filterExpressionResolverTree)
-                .getMeasureFilterRangeValues(), segmentProperties);
+                .getMeasureFilterRangeValues(), segmentProperties, configuration);
       case ROWLEVEL_GREATERTHAN:
         return new RowLevelRangeGrtThanFiterExecuterImpl(
             ((RowLevelRangeFilterResolverImpl) filterExpressionResolverTree)
@@ -87,7 +89,7 @@ public class RowLevelRangeTypeExecuterFacory {
             ((RowLevelRangeFilterResolverImpl) filterExpressionResolverTree)
                 .getFilterRangeValues(segmentProperties),
             ((RowLevelRangeFilterResolverImpl) filterExpressionResolverTree)
-                .getMeasureFilterRangeValues(), segmentProperties);
+                .getMeasureFilterRangeValues(), segmentProperties, configuration);
       default:
         // Scenario wont come logic must break
         return null;

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/resolver/RowLevelFilterResolverImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/resolver/RowLevelFilterResolverImpl.java
@@ -30,6 +30,8 @@ import org.apache.carbondata.core.scan.filter.intf.FilterExecuterType;
 import org.apache.carbondata.core.scan.filter.resolver.resolverinfo.DimColumnResolvedFilterInfo;
 import org.apache.carbondata.core.scan.filter.resolver.resolverinfo.MeasureColumnResolvedFilterInfo;
 
+import org.apache.hadoop.conf.Configuration;
+
 public class RowLevelFilterResolverImpl extends ConditionalFilterResolverImpl {
 
   private static final long serialVersionUID = 176122729713729929L;
@@ -39,8 +41,9 @@ public class RowLevelFilterResolverImpl extends ConditionalFilterResolverImpl {
   private AbsoluteTableIdentifier tableIdentifier;
 
   public RowLevelFilterResolverImpl(Expression exp, boolean isExpressionResolve,
-      boolean isIncludeFilter, AbsoluteTableIdentifier tableIdentifier) {
-    super(exp, isExpressionResolve, isIncludeFilter, tableIdentifier, false);
+      boolean isIncludeFilter, AbsoluteTableIdentifier tableIdentifier,
+      Configuration configuration) {
+    super(exp, isExpressionResolve, isIncludeFilter, tableIdentifier, false, configuration);
     dimColEvaluatorInfoList =
         new ArrayList<DimColumnResolvedFilterInfo>(CarbonCommonConstants.DEFAULT_COLLECTION_SIZE);
     msrColEvalutorInfoList = new ArrayList<MeasureColumnResolvedFilterInfo>(

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/resolver/RowLevelRangeFilterResolverImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/resolver/RowLevelRangeFilterResolverImpl.java
@@ -49,6 +49,8 @@ import org.apache.carbondata.core.util.ByteUtil;
 import org.apache.carbondata.core.util.CarbonProperties;
 import org.apache.carbondata.core.util.DataTypeUtil;
 
+import org.apache.hadoop.conf.Configuration;
+
 public class RowLevelRangeFilterResolverImpl extends ConditionalFilterResolverImpl {
 
   /**
@@ -60,8 +62,9 @@ public class RowLevelRangeFilterResolverImpl extends ConditionalFilterResolverIm
   private AbsoluteTableIdentifier tableIdentifier;
 
   public RowLevelRangeFilterResolverImpl(Expression exp, boolean isExpressionResolve,
-      boolean isIncludeFilter, AbsoluteTableIdentifier tableIdentifier) {
-    super(exp, isExpressionResolve, isIncludeFilter, tableIdentifier, false);
+      boolean isIncludeFilter, AbsoluteTableIdentifier tableIdentifier,
+      Configuration configuration) {
+    super(exp, isExpressionResolve, isIncludeFilter, tableIdentifier, false, configuration);
     dimColEvaluatorInfoList =
         new ArrayList<DimColumnResolvedFilterInfo>(CarbonCommonConstants.DEFAULT_COLLECTION_SIZE);
     msrColEvalutorInfoList = new ArrayList<MeasureColumnResolvedFilterInfo>(

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/resolver/resolverinfo/TrueConditionalResolverImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/resolver/resolverinfo/TrueConditionalResolverImpl.java
@@ -23,14 +23,17 @@ import org.apache.carbondata.core.scan.filter.TableProvider;
 import org.apache.carbondata.core.scan.filter.intf.FilterExecuterType;
 import org.apache.carbondata.core.scan.filter.resolver.ConditionalFilterResolverImpl;
 
+import org.apache.hadoop.conf.Configuration;
+
 /* The expression with If TRUE will be resolved setting all bits to TRUE. */
 
 public class TrueConditionalResolverImpl extends ConditionalFilterResolverImpl {
 
   public TrueConditionalResolverImpl(Expression exp, boolean isExpressionResolve,
-      boolean isIncludeFilter, AbsoluteTableIdentifier tableIdentifier) {
+      boolean isIncludeFilter, AbsoluteTableIdentifier tableIdentifier,
+      Configuration configuration) {
 
-    super(exp, isExpressionResolve, isIncludeFilter, tableIdentifier, false);
+    super(exp, isExpressionResolve, isIncludeFilter, tableIdentifier, false, configuration);
   }
 
   @Override public void resolve(AbsoluteTableIdentifier absoluteTableIdentifier,

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/resolver/resolverinfo/visitor/DictionaryColumnVisitor.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/resolver/resolverinfo/visitor/DictionaryColumnVisitor.java
@@ -29,7 +29,15 @@ import org.apache.carbondata.core.scan.filter.resolver.metadata.FilterResolverMe
 import org.apache.carbondata.core.scan.filter.resolver.resolverinfo.ColumnResolvedFilterInfo;
 import org.apache.carbondata.core.scan.filter.resolver.resolverinfo.DimColumnResolvedFilterInfo;
 
+import org.apache.hadoop.conf.Configuration;
+
 public class DictionaryColumnVisitor implements ResolvedFilterInfoVisitorIntf {
+
+  protected Configuration configuration;
+
+  public DictionaryColumnVisitor(Configuration configuration) {
+    this.configuration = configuration;
+  }
 
   /**
    * This Visitor method is used to populate the visitableObj with direct dictionary filter details
@@ -53,9 +61,9 @@ public class DictionaryColumnVisitor implements ResolvedFilterInfoVisitorIntf {
       } catch (FilterIllegalMemberException e) {
         throw new FilterUnsupportedException(e);
       }
-      resolvedFilterObject = FilterUtil
-          .getFilterValues(metadata.getTableIdentifier(), metadata.getColumnExpression(),
-              evaluateResultListFinal, metadata.isIncludeFilter(), metadata.getTableProvider());
+      resolvedFilterObject = FilterUtil.getFilterValues(metadata.getTableIdentifier(),
+          metadata.getColumnExpression(), evaluateResultListFinal, metadata.isIncludeFilter(),
+          metadata.getTableProvider(), configuration);
       if (!metadata.isIncludeFilter() && null != resolvedFilterObject) {
         // Adding default surrogate key of null member inorder to not display the same while
         // displaying the report as per hive compatibility.

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/resolver/resolverinfo/visitor/FilterInfoTypeVisitorFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/resolver/resolverinfo/visitor/FilterInfoTypeVisitorFactory.java
@@ -21,6 +21,8 @@ import org.apache.carbondata.core.scan.expression.ColumnExpression;
 import org.apache.carbondata.core.scan.expression.Expression;
 import org.apache.carbondata.core.scan.expression.logical.RangeExpression;
 
+import org.apache.hadoop.conf.Configuration;
+
 public class FilterInfoTypeVisitorFactory {
 
   /**
@@ -31,14 +33,14 @@ public class FilterInfoTypeVisitorFactory {
    * @return
    */
   public static ResolvedFilterInfoVisitorIntf getResolvedFilterInfoVisitor(
-      ColumnExpression columnExpression, Expression exp) {
+      ColumnExpression columnExpression, Expression exp, Configuration configuration) {
     if (exp instanceof RangeExpression) {
       if (columnExpression.getDimension().hasEncoding(Encoding.DIRECT_DICTIONARY)) {
         return new RangeDirectDictionaryVisitor();
       } else if (!columnExpression.getDimension().hasEncoding(Encoding.DICTIONARY)) {
         return new RangeNoDictionaryTypeVisitor();
       } else if (columnExpression.getDimension().hasEncoding(Encoding.DICTIONARY)) {
-        return new RangeDictionaryColumnVisitor();
+        return new RangeDictionaryColumnVisitor(configuration);
       }
     }
     else {
@@ -48,7 +50,7 @@ public class FilterInfoTypeVisitorFactory {
         } else if (!columnExpression.getDimension().hasEncoding(Encoding.DICTIONARY)) {
           return new NoDictionaryTypeVisitor();
         } else if (columnExpression.getDimension().hasEncoding(Encoding.DICTIONARY)) {
-          return new DictionaryColumnVisitor();
+          return new DictionaryColumnVisitor(configuration);
         }
       } else if (columnExpression.getMeasure().isMeasure()) {
         return new MeasureColumnVisitor();

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/resolver/resolverinfo/visitor/RangeDictionaryColumnVisitor.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/resolver/resolverinfo/visitor/RangeDictionaryColumnVisitor.java
@@ -29,8 +29,14 @@ import org.apache.carbondata.core.scan.filter.resolver.metadata.FilterResolverMe
 import org.apache.carbondata.core.scan.filter.resolver.resolverinfo.ColumnResolvedFilterInfo;
 import org.apache.carbondata.core.scan.filter.resolver.resolverinfo.DimColumnResolvedFilterInfo;
 
+import org.apache.hadoop.conf.Configuration;
+
 public class RangeDictionaryColumnVisitor extends DictionaryColumnVisitor
     implements ResolvedFilterInfoVisitorIntf {
+  public RangeDictionaryColumnVisitor(Configuration configuration) {
+    super(configuration);
+  }
+
   /**
    * This Visitor method is used to populate the visitableObj with direct dictionary filter details
    * where the filters values will be resolve using dictionary cache.
@@ -51,7 +57,7 @@ public class RangeDictionaryColumnVisitor extends DictionaryColumnVisitor
       resolvedFilterObject = FilterUtil
           .getFilterListForAllValues(metadata.getTableIdentifier(), metadata.getExpression(),
               metadata.getColumnExpression(), metadata.isIncludeFilter(),
-              metadata.getTableProvider());
+              metadata.getTableProvider(), configuration);
 
       if (!metadata.isIncludeFilter() && null != resolvedFilterObject) {
         // Adding default surrogate key of null member inorder to not display the same while

--- a/core/src/main/java/org/apache/carbondata/core/scan/model/QueryModel.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/model/QueryModel.java
@@ -41,6 +41,8 @@ import org.apache.carbondata.core.stats.QueryStatisticsRecorder;
 import org.apache.carbondata.core.util.CarbonUtil;
 import org.apache.carbondata.core.util.DataTypeConverter;
 
+import org.apache.hadoop.conf.Configuration;
+
 /**
  * Query model which will have all the detail
  * about the query, This will be sent from driver to executor '
@@ -108,6 +110,8 @@ public class QueryModel implements Serializable {
   private List<String> invalidSegmentIds;
   private Map<String, UpdateVO> invalidSegmentBlockIdMap =
       new HashMap<>(CarbonCommonConstants.DEFAULT_COLLECTION_SIZE);
+
+  private transient Configuration configuration;
 
   public QueryModel() {
     tableBlockInfos = new ArrayList<TableBlockInfo>();
@@ -377,5 +381,13 @@ public class QueryModel implements Serializable {
 
   public void setConverter(DataTypeConverter converter) {
     this.converter = converter;
+  }
+
+  public Configuration getConfiguration() {
+    return configuration;
+  }
+
+  public void setConfiguration(Configuration configuration) {
+    this.configuration = configuration;
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/iterator/AbstractDetailQueryResultIterator.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/iterator/AbstractDetailQueryResultIterator.java
@@ -105,7 +105,7 @@ public abstract class AbstractDetailQueryResultIterator<E> extends CarbonIterato
     }
     this.recorder = queryModel.getStatisticsRecorder();
     this.blockExecutionInfos = infos;
-    this.fileReader = FileFactory.getFileHolder(
+    this.fileReader = FileFactory.getFileHolder(queryModel.getConfiguration(),
         FileFactory.getFileType(queryModel.getAbsoluteTableIdentifier().getStorePath()));
     this.fileReader.setQueryId(queryModel.getQueryId());
     this.execService = execService;

--- a/core/src/main/java/org/apache/carbondata/core/service/DictionaryService.java
+++ b/core/src/main/java/org/apache/carbondata/core/service/DictionaryService.java
@@ -24,6 +24,8 @@ import org.apache.carbondata.core.reader.sortindex.CarbonDictionarySortIndexRead
 import org.apache.carbondata.core.writer.CarbonDictionaryWriter;
 import org.apache.carbondata.core.writer.sortindex.CarbonDictionarySortIndexWriter;
 
+import org.apache.hadoop.conf.Configuration;
+
 /**
  * Dictionary service to get writer and reader
  */
@@ -38,7 +40,8 @@ public interface DictionaryService {
    * @return
    */
   CarbonDictionaryWriter getDictionaryWriter(CarbonTableIdentifier carbonTableIdentifier,
-      DictionaryColumnUniqueIdentifier dictionaryColumnUniqueIdentifier, String carbonStorePath);
+      DictionaryColumnUniqueIdentifier dictionaryColumnUniqueIdentifier, String carbonStorePath,
+      Configuration configuration);
 
   /**
    * get dictionary sort index writer
@@ -50,7 +53,8 @@ public interface DictionaryService {
    */
   CarbonDictionarySortIndexWriter getDictionarySortIndexWriter(
       CarbonTableIdentifier carbonTableIdentifier,
-      DictionaryColumnUniqueIdentifier dictionaryColumnUniqueIdentifier, String carbonStorePath);
+      DictionaryColumnUniqueIdentifier dictionaryColumnUniqueIdentifier, String carbonStorePath,
+      Configuration configuration);
 
   /**
    * get dictionary metadata reader
@@ -62,7 +66,8 @@ public interface DictionaryService {
    */
   CarbonDictionaryMetadataReader getDictionaryMetadataReader(
       CarbonTableIdentifier carbonTableIdentifier,
-      DictionaryColumnUniqueIdentifier dictionaryColumnUniqueIdentifier, String carbonStorePath);
+      DictionaryColumnUniqueIdentifier dictionaryColumnUniqueIdentifier, String carbonStorePath,
+      Configuration configuration);
 
   /**
    * get dictionary reader
@@ -73,7 +78,8 @@ public interface DictionaryService {
    * @return
    */
   CarbonDictionaryReader getDictionaryReader(CarbonTableIdentifier carbonTableIdentifier,
-      DictionaryColumnUniqueIdentifier dictionaryColumnUniqueIdentifier, String carbonStorePath);
+      DictionaryColumnUniqueIdentifier dictionaryColumnUniqueIdentifier, String carbonStorePath,
+      Configuration configuration);
 
   /**
    * get dictionary sort index reader
@@ -85,6 +91,7 @@ public interface DictionaryService {
    */
   CarbonDictionarySortIndexReader getDictionarySortIndexReader(
       CarbonTableIdentifier carbonTableIdentifier,
-      DictionaryColumnUniqueIdentifier dictionaryColumnUniqueIdentifier, String carbonStorePath);
+      DictionaryColumnUniqueIdentifier dictionaryColumnUniqueIdentifier, String carbonStorePath,
+      Configuration configuration);
 
 }

--- a/core/src/main/java/org/apache/carbondata/core/service/impl/DictionaryFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/service/impl/DictionaryFactory.java
@@ -30,6 +30,8 @@ import org.apache.carbondata.core.writer.CarbonDictionaryWriterImpl;
 import org.apache.carbondata.core.writer.sortindex.CarbonDictionarySortIndexWriter;
 import org.apache.carbondata.core.writer.sortindex.CarbonDictionarySortIndexWriterImpl;
 
+import org.apache.hadoop.conf.Configuration;
+
 /**
  * service to get dictionary reader and writer
  */
@@ -47,9 +49,11 @@ public class DictionaryFactory implements DictionaryService {
    */
   @Override public CarbonDictionaryWriter getDictionaryWriter(
       CarbonTableIdentifier carbonTableIdentifier,
-      DictionaryColumnUniqueIdentifier dictionaryColumnUniqueIdentifier, String carbonStorePath) {
+      DictionaryColumnUniqueIdentifier dictionaryColumnUniqueIdentifier,
+      String carbonStorePath,
+      Configuration configuration) {
     return new CarbonDictionaryWriterImpl(carbonStorePath, carbonTableIdentifier,
-        dictionaryColumnUniqueIdentifier);
+        dictionaryColumnUniqueIdentifier, configuration);
   }
 
   /**
@@ -62,9 +66,11 @@ public class DictionaryFactory implements DictionaryService {
    */
   @Override public CarbonDictionarySortIndexWriter getDictionarySortIndexWriter(
       CarbonTableIdentifier carbonTableIdentifier,
-      DictionaryColumnUniqueIdentifier dictionaryColumnUniqueIdentifier, String carbonStorePath) {
+      DictionaryColumnUniqueIdentifier dictionaryColumnUniqueIdentifier,
+      String carbonStorePath,
+      Configuration configuration) {
     return new CarbonDictionarySortIndexWriterImpl(carbonTableIdentifier,
-        dictionaryColumnUniqueIdentifier, carbonStorePath);
+        dictionaryColumnUniqueIdentifier, carbonStorePath, configuration);
   }
 
   /**
@@ -77,9 +83,10 @@ public class DictionaryFactory implements DictionaryService {
    */
   @Override public CarbonDictionaryMetadataReader getDictionaryMetadataReader(
       CarbonTableIdentifier carbonTableIdentifier,
-      DictionaryColumnUniqueIdentifier dictionaryColumnUniqueIdentifier, String carbonStorePath) {
+      DictionaryColumnUniqueIdentifier dictionaryColumnUniqueIdentifier, String carbonStorePath,
+      Configuration configuration) {
     return new CarbonDictionaryMetadataReaderImpl(carbonStorePath, carbonTableIdentifier,
-        dictionaryColumnUniqueIdentifier);
+        dictionaryColumnUniqueIdentifier, configuration);
   }
 
   /**
@@ -92,9 +99,10 @@ public class DictionaryFactory implements DictionaryService {
    */
   @Override public CarbonDictionaryReader getDictionaryReader(
       CarbonTableIdentifier carbonTableIdentifier,
-      DictionaryColumnUniqueIdentifier dictionaryColumnUniqueIdentifier, String carbonStorePath) {
+      DictionaryColumnUniqueIdentifier dictionaryColumnUniqueIdentifier, String carbonStorePath,
+      Configuration configuration) {
     return new CarbonDictionaryReaderImpl(carbonStorePath, carbonTableIdentifier,
-        dictionaryColumnUniqueIdentifier);
+        dictionaryColumnUniqueIdentifier, configuration);
   }
 
   /**
@@ -107,9 +115,10 @@ public class DictionaryFactory implements DictionaryService {
    */
   @Override public CarbonDictionarySortIndexReader getDictionarySortIndexReader(
       CarbonTableIdentifier carbonTableIdentifier,
-      DictionaryColumnUniqueIdentifier dictionaryColumnUniqueIdentifier, String carbonStorePath) {
+      DictionaryColumnUniqueIdentifier dictionaryColumnUniqueIdentifier, String carbonStorePath,
+      Configuration configuration) {
     return new CarbonDictionarySortIndexReaderImpl(carbonTableIdentifier,
-        dictionaryColumnUniqueIdentifier, carbonStorePath);
+        dictionaryColumnUniqueIdentifier, carbonStorePath, configuration);
   }
 
   public static DictionaryService getInstance() {

--- a/core/src/main/java/org/apache/carbondata/core/service/impl/PathFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/service/impl/PathFactory.java
@@ -22,6 +22,8 @@ import org.apache.carbondata.core.service.PathService;
 import org.apache.carbondata.core.util.path.CarbonStorePath;
 import org.apache.carbondata.core.util.path.CarbonTablePath;
 
+import org.apache.hadoop.conf.Configuration;
+
 /**
  * Create helper to get path details
  */
@@ -37,12 +39,13 @@ public class PathFactory implements PathService {
    */
   @Override public CarbonTablePath getCarbonTablePath(String storeLocation,
       CarbonTableIdentifier tableIdentifier,
-      DictionaryColumnUniqueIdentifier dictionaryColumnUniqueIdentifier) {
+      DictionaryColumnUniqueIdentifier dictionaryColumnUniqueIdentifier,
+      Configuration configuration) {
     if (null != dictionaryColumnUniqueIdentifier && null != dictionaryColumnUniqueIdentifier
         .getCarbonTablePath()) {
       return dictionaryColumnUniqueIdentifier.getCarbonTablePath();
     }
-    return CarbonStorePath.getCarbonTablePath(storeLocation, tableIdentifier);
+    return CarbonStorePath.getCarbonTablePath(storeLocation, tableIdentifier, configuration);
   }
 
   public static PathService getInstance() {

--- a/core/src/main/java/org/apache/carbondata/core/util/AbstractDataFileFooterConverter.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/AbstractDataFileFooterConverter.java
@@ -42,11 +42,14 @@ import org.apache.carbondata.core.reader.CarbonIndexFileReader;
 import org.apache.carbondata.core.util.path.CarbonTablePath;
 import org.apache.carbondata.format.BlockIndex;
 
+import org.apache.hadoop.conf.Configuration;
+
 /**
  * Footer reader class
  */
 public abstract class AbstractDataFileFooterConverter {
 
+  protected Configuration configuration;
   /**
    * Below method will be used to convert the thrift presence meta to wrapper
    * presence meta
@@ -73,7 +76,7 @@ public abstract class AbstractDataFileFooterConverter {
     List<DataFileFooter> dataFileFooters = new ArrayList<DataFileFooter>();
     try {
       // open the reader
-      indexReader.openThriftReader(filePath);
+      indexReader.openThriftReader(configuration, filePath);
       // get the index header
       org.apache.carbondata.format.IndexHeader readIndexHeader = indexReader.readIndexHeader();
       List<ColumnSchema> columnSchemaList = new ArrayList<ColumnSchema>();
@@ -131,7 +134,7 @@ public abstract class AbstractDataFileFooterConverter {
     String parentPath = filePath.substring(0, filePath.lastIndexOf("/"));
     try {
       // open the reader
-      indexReader.openThriftReader(filePath);
+      indexReader.openThriftReader(configuration, filePath);
       // get the index header
       org.apache.carbondata.format.IndexHeader readIndexHeader = indexReader.readIndexHeader();
       List<ColumnSchema> columnSchemaList = new ArrayList<ColumnSchema>();
@@ -165,7 +168,7 @@ public abstract class AbstractDataFileFooterConverter {
         dataFileFooter.setVersionId(version);
         if (readBlockIndexInfo.isSetBlocklet_info()) {
           List<BlockletInfo> blockletInfoList = new ArrayList<BlockletInfo>();
-          BlockletInfo blockletInfo = new DataFileFooterConverterV3()
+          BlockletInfo blockletInfo = new DataFileFooterConverterV3(configuration)
               .getBlockletInfo(readBlockIndexInfo.getBlocklet_info(),
                   CarbonUtil.getNumberOfDimensionColumns(columnSchemaList));
           blockletInfo.setBlockletIndex(blockletIndex);

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonMergerUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonMergerUtil.java
@@ -23,6 +23,8 @@ import org.apache.carbondata.common.logging.LogService;
 import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 
+import org.apache.hadoop.conf.Configuration;
+
 /**
  * Util class for merge activities of 2 loads.
  */
@@ -34,10 +36,11 @@ public class CarbonMergerUtil {
   private static final LogService LOGGER =
       LogServiceFactory.getLogService(CarbonMergerUtil.class.getName());
 
-  public static int[] getCardinalityFromLevelMetadata(String path, String tableName) {
+  public static int[] getCardinalityFromLevelMetadata(Configuration configuration,  String path,
+      String tableName) {
     int[] localCardinality = null;
     try {
-      localCardinality = CarbonUtil.getCardinalityFromLevelMetadataFile(
+      localCardinality = CarbonUtil.getCardinalityFromLevelMetadataFile(configuration,
           path + '/' + CarbonCommonConstants.LEVEL_METADATA_FILE + tableName + ".metadata");
     } catch (IOException e) {
       LOGGER.error("Error occurred :: " + e.getMessage());
@@ -52,10 +55,11 @@ public class CarbonMergerUtil {
    * @param tableName table name
    * @return cardinality
    */
-  public static int[] getCardinalityFromLevelMetadata(String[] paths, String tableName) {
+  public static int[] getCardinalityFromLevelMetadata(Configuration configuration, String[] paths,
+      String tableName) {
     int[] localCardinality = null;
     for (String path : paths) {
-      localCardinality = getCardinalityFromLevelMetadata(path, tableName);
+      localCardinality = getCardinalityFromLevelMetadata(configuration, path, tableName);
       if (null != localCardinality) {
         break;
       }

--- a/core/src/main/java/org/apache/carbondata/core/util/DataFileFooterConverter.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/DataFileFooterConverter.java
@@ -33,11 +33,17 @@ import org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema;
 import org.apache.carbondata.core.reader.CarbonFooterReader;
 import org.apache.carbondata.format.FileFooter;
 
+import org.apache.hadoop.conf.Configuration;
+
 /**
  * Below class will be used to convert the thrift object of data file
  * meta data to wrapper object
  */
 public class DataFileFooterConverter extends AbstractDataFileFooterConverter {
+
+  public DataFileFooterConverter(Configuration configuration) {
+    this.configuration = configuration;
+  }
 
   /**
    * Below method will be used to convert thrift file meta to wrapper file meta
@@ -49,10 +55,11 @@ public class DataFileFooterConverter extends AbstractDataFileFooterConverter {
     try {
       long completeBlockLength = tableBlockInfo.getBlockLength();
       long footerPointer = completeBlockLength - 8;
-      fileReader = FileFactory.getFileHolder(FileFactory.getFileType(tableBlockInfo.getFilePath()));
+      fileReader = FileFactory.getFileHolder(configuration,
+          FileFactory.getFileType(tableBlockInfo.getFilePath()));
       long actualFooterOffset = fileReader.readLong(tableBlockInfo.getFilePath(), footerPointer);
       CarbonFooterReader reader =
-          new CarbonFooterReader(tableBlockInfo.getFilePath(), actualFooterOffset);
+          new CarbonFooterReader(configuration, tableBlockInfo.getFilePath(), actualFooterOffset);
       FileFooter footer = reader.readFooter();
       dataFileFooter.setVersionId(ColumnarFormatVersion.valueOf((short) footer.getVersion()));
       dataFileFooter.setNumberOfRows(footer.getNum_rows());

--- a/core/src/main/java/org/apache/carbondata/core/util/DataFileFooterConverter2.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/DataFileFooterConverter2.java
@@ -29,6 +29,8 @@ import org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema;
 import org.apache.carbondata.core.reader.CarbonFooterReader;
 import org.apache.carbondata.format.FileFooter;
 
+import org.apache.hadoop.conf.Configuration;
+
 /**
  * Below class will be used to convert the thrift object of data file
  * meta data to wrapper object for version 2 data file
@@ -36,14 +38,18 @@ import org.apache.carbondata.format.FileFooter;
 
 public class DataFileFooterConverter2 extends AbstractDataFileFooterConverter {
 
+  public DataFileFooterConverter2(Configuration configuration) {
+    this.configuration = configuration;
+  }
+
   /**
    * Below method will be used to convert thrift file meta to wrapper file meta
    */
   @Override public DataFileFooter readDataFileFooter(TableBlockInfo tableBlockInfo)
       throws IOException {
     DataFileFooter dataFileFooter = new DataFileFooter();
-    CarbonFooterReader reader =
-        new CarbonFooterReader(tableBlockInfo.getFilePath(), tableBlockInfo.getBlockOffset());
+    CarbonFooterReader reader = new CarbonFooterReader(
+        configuration, tableBlockInfo.getFilePath(), tableBlockInfo.getBlockOffset());
     FileFooter footer = reader.readFooter();
     dataFileFooter.setVersionId(ColumnarFormatVersion.valueOf((short) footer.getVersion()));
     dataFileFooter.setNumberOfRows(footer.getNum_rows());

--- a/core/src/main/java/org/apache/carbondata/core/util/DataFileFooterConverterFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/DataFileFooterConverterFactory.java
@@ -18,6 +18,8 @@ package org.apache.carbondata.core.util;
 
 import org.apache.carbondata.core.metadata.ColumnarFormatVersion;
 
+import org.apache.hadoop.conf.Configuration;
+
 /**
  * Factory class to get the thrift reader object based on version
  */
@@ -52,15 +54,15 @@ public class DataFileFooterConverterFactory {
    * @return footer reader instance
    */
   public AbstractDataFileFooterConverter getDataFileFooterConverter(
-      final ColumnarFormatVersion version) {
+      final ColumnarFormatVersion version, Configuration configuration) {
     switch (version) {
       case V1:
-        return new DataFileFooterConverter();
+        return new DataFileFooterConverter(configuration);
       case V2:
-        return new DataFileFooterConverter2();
+        return new DataFileFooterConverter2(configuration);
       case V3:
       default:
-        return new DataFileFooterConverterV3();
+        return new DataFileFooterConverterV3(configuration);
     }
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/util/DataFileFooterConverterV3.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/DataFileFooterConverterV3.java
@@ -31,7 +31,13 @@ import org.apache.carbondata.core.reader.CarbonHeaderReader;
 import org.apache.carbondata.format.FileFooter3;
 import org.apache.carbondata.format.FileHeader;
 
+import org.apache.hadoop.conf.Configuration;
+
 public class DataFileFooterConverterV3 extends AbstractDataFileFooterConverter {
+
+  public DataFileFooterConverterV3(Configuration configuration) {
+    this.configuration = configuration;
+  }
 
   /**
    * Below method will be used to convert thrift file meta to wrapper file meta
@@ -49,10 +55,11 @@ public class DataFileFooterConverterV3 extends AbstractDataFileFooterConverter {
   @Override public DataFileFooter readDataFileFooter(TableBlockInfo tableBlockInfo)
       throws IOException {
     DataFileFooter dataFileFooter = new DataFileFooter();
-    CarbonHeaderReader carbonHeaderReader = new CarbonHeaderReader(tableBlockInfo.getFilePath());
+    CarbonHeaderReader carbonHeaderReader =
+        new CarbonHeaderReader(configuration, tableBlockInfo.getFilePath());
     FileHeader fileHeader = carbonHeaderReader.readHeader();
-    CarbonFooterReaderV3 reader =
-        new CarbonFooterReaderV3(tableBlockInfo.getFilePath(), tableBlockInfo.getBlockOffset());
+    CarbonFooterReaderV3 reader = new CarbonFooterReaderV3(configuration,
+        tableBlockInfo.getFilePath(), tableBlockInfo.getBlockOffset());
     FileFooter3 footer = reader.readFooterVersion3();
     dataFileFooter.setVersionId(ColumnarFormatVersion.valueOf((short) fileHeader.getVersion()));
     dataFileFooter.setNumberOfRows(footer.getNum_rows());
@@ -86,7 +93,8 @@ public class DataFileFooterConverterV3 extends AbstractDataFileFooterConverter {
   }
 
   @Override public List<ColumnSchema> getSchema(TableBlockInfo tableBlockInfo) throws IOException {
-    CarbonHeaderReader carbonHeaderReader = new CarbonHeaderReader(tableBlockInfo.getFilePath());
+    CarbonHeaderReader carbonHeaderReader =
+        new CarbonHeaderReader(configuration, tableBlockInfo.getFilePath());
     FileHeader fileHeader = carbonHeaderReader.readHeader();
     List<ColumnSchema> columnSchemaList = new ArrayList<ColumnSchema>();
     List<org.apache.carbondata.format.ColumnSchema> table_columns = fileHeader.getColumn_schema();

--- a/core/src/main/java/org/apache/carbondata/core/util/path/CarbonStorePath.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/path/CarbonStorePath.java
@@ -21,6 +21,7 @@ import java.io.File;
 import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
 import org.apache.carbondata.core.metadata.CarbonTableIdentifier;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 
 /**
@@ -39,27 +40,29 @@ public class CarbonStorePath extends Path {
    * gets CarbonTablePath object to manage table paths
    */
   public static CarbonTablePath getCarbonTablePath(String storePath,
-      CarbonTableIdentifier tableIdentifier) {
+      CarbonTableIdentifier tableIdentifier, Configuration configuration) {
     return new CarbonTablePath(tableIdentifier,
         storePath + File.separator + tableIdentifier.getDatabaseName() + File.separator
-            + tableIdentifier.getTableName());
+            + tableIdentifier.getTableName(), configuration);
   }
 
   public static CarbonTablePath getCarbonTablePath(String storePath,
-      String dbName, String tableName) {
-    return new CarbonTablePath(storePath, dbName, tableName);
+      String dbName, String tableName, Configuration configuration) {
+    return new CarbonTablePath(storePath, dbName, tableName, configuration);
   }
 
-  public static CarbonTablePath getCarbonTablePath(AbsoluteTableIdentifier identifier) {
+  public static CarbonTablePath getCarbonTablePath(AbsoluteTableIdentifier identifier,
+      Configuration configuration) {
     CarbonTableIdentifier id = identifier.getCarbonTableIdentifier();
-    return new CarbonTablePath(id, identifier.getTablePath());
+    return new CarbonTablePath(id, identifier.getTablePath(), configuration);
   }
 
   /**
    * gets CarbonTablePath object to manage table paths
    */
-  public CarbonTablePath getCarbonTablePath(CarbonTableIdentifier tableIdentifier) {
-    return CarbonStorePath.getCarbonTablePath(storePath, tableIdentifier);
+  public CarbonTablePath getCarbonTablePath(CarbonTableIdentifier tableIdentifier,
+      Configuration configuration) {
+    return CarbonStorePath.getCarbonTablePath(storePath, tableIdentifier, configuration);
   }
 
   @Override public boolean equals(Object o) {

--- a/core/src/main/java/org/apache/carbondata/core/util/path/CarbonTablePath.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/path/CarbonTablePath.java
@@ -25,6 +25,7 @@ import org.apache.carbondata.core.datastore.impl.FileFactory;
 import org.apache.carbondata.core.metadata.CarbonTableIdentifier;
 import org.apache.carbondata.core.metadata.ColumnarFormatVersion;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 
 
@@ -53,22 +54,27 @@ public class CarbonTablePath extends Path {
 
   protected String tablePath;
   protected CarbonTableIdentifier carbonTableIdentifier;
+  protected Configuration configuration;
 
   /**
    *
    * @param carbonTableIdentifier
    * @param tablePathString
    */
-  public CarbonTablePath(CarbonTableIdentifier carbonTableIdentifier, String tablePathString) {
+  public CarbonTablePath(CarbonTableIdentifier carbonTableIdentifier, String tablePathString,
+      Configuration configuration) {
     super(tablePathString);
     this.carbonTableIdentifier = carbonTableIdentifier;
     this.tablePath = tablePathString;
+    this.configuration = configuration;
   }
 
-  public CarbonTablePath(String storePath, String dbName, String tableName) {
+  public CarbonTablePath(String storePath, String dbName, String tableName,
+      Configuration configuration) {
     super(storePath + File.separator + dbName + File.separator + tableName);
     this.carbonTableIdentifier = new CarbonTableIdentifier(dbName, tableName, "");
     this.tablePath = storePath + File.separator + dbName + File.separator + tableName;
+    this.configuration = configuration;
   }
 
   /**
@@ -252,11 +258,11 @@ public class CarbonTablePath extends Path {
    * @param segmentId   segment number
    * @return full qualified carbon index path
    */
-  public String getCarbonIndexFilePath(final String taskId, final String partitionId,
-      final String segmentId, final String bucketNumber) {
+  public String getCarbonIndexFilePath(final String taskId,
+      final String partitionId, final String segmentId, final String bucketNumber) {
     String segmentDir = getSegmentDir(partitionId, segmentId);
     CarbonFile carbonFile =
-        FileFactory.getCarbonFile(segmentDir, FileFactory.getFileType(segmentDir));
+        FileFactory.getCarbonFile(configuration, segmentDir, FileFactory.getFileType(segmentDir));
 
     CarbonFile[] files = carbonFile.listFiles(new CarbonFileFilter() {
       @Override public boolean accept(CarbonFile file) {
@@ -334,7 +340,7 @@ public class CarbonTablePath extends Path {
       final String segmentId) {
     String segmentDir = getSegmentDir(partitionId, segmentId);
     CarbonFile carbonFile =
-        FileFactory.getCarbonFile(segmentDir, FileFactory.getFileType(segmentDir));
+        FileFactory.getCarbonFile(configuration, segmentDir, FileFactory.getFileType(segmentDir));
 
     CarbonFile[] files = carbonFile.listFiles(new CarbonFileFilter() {
       @Override public boolean accept(CarbonFile file) {
@@ -363,7 +369,7 @@ public class CarbonTablePath extends Path {
       final String segmentId) {
     String segmentDir = getSegmentDir(partitionId, segmentId);
     CarbonFile carbonFile =
-        FileFactory.getCarbonFile(segmentDir, FileFactory.getFileType(segmentDir));
+        FileFactory.getCarbonFile(configuration, segmentDir, FileFactory.getFileType(segmentDir));
 
     CarbonFile[] files = carbonFile.listFiles(new CarbonFileFilter() {
       @Override public boolean accept(CarbonFile file) {
@@ -737,5 +743,9 @@ public class CarbonTablePath extends Path {
   public static String getCarbonIndexFileName(String actualBlockName) {
     return DataFileUtil.getTaskNo(actualBlockName) + "-" + DataFileUtil.getBucketNo(actualBlockName)
         + "-" + DataFileUtil.getTimeStampFromFileName(actualBlockName) + INDEX_FILE_EXT;
+  }
+
+  public Configuration getConfiguration() {
+    return configuration;
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/writer/CarbonDeleteDeltaWriterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/writer/CarbonDeleteDeltaWriterImpl.java
@@ -30,6 +30,7 @@ import org.apache.carbondata.core.mutate.DeleteDeltaBlockDetails;
 import org.apache.carbondata.core.util.CarbonUtil;
 
 import com.google.gson.Gson;
+import org.apache.hadoop.conf.Configuration;
 
 /**
  * This class is responsible for writing the delete delta file
@@ -48,11 +49,15 @@ public class CarbonDeleteDeltaWriterImpl implements CarbonDeleteDeltaWriter {
 
   private DataOutputStream dataOutStream = null;
 
+  private Configuration configuration;
+
   /**
    * @param filePath
    * @param fileType
    */
-  public CarbonDeleteDeltaWriterImpl(String filePath, FileFactory.FileType fileType) {
+  public CarbonDeleteDeltaWriterImpl(Configuration configuration, String filePath,
+      FileFactory.FileType fileType) {
+    this.configuration = configuration;
     this.filePath = filePath;
     this.fileType = fileType;
 
@@ -67,8 +72,8 @@ public class CarbonDeleteDeltaWriterImpl implements CarbonDeleteDeltaWriter {
   @Override public void write(String value) throws IOException {
     BufferedWriter brWriter = null;
     try {
-      FileFactory.createNewFile(filePath, fileType);
-      dataOutStream = FileFactory.getDataOutputStream(filePath, fileType);
+      FileFactory.createNewFile(configuration, filePath, fileType);
+      dataOutStream = FileFactory.getDataOutputStream(configuration, filePath, fileType);
       brWriter = new BufferedWriter(new OutputStreamWriter(dataOutStream,
           CarbonCommonConstants.CARBON_DEFAULT_STREAM_ENCODEFORMAT));
       brWriter.write(value);
@@ -94,8 +99,8 @@ public class CarbonDeleteDeltaWriterImpl implements CarbonDeleteDeltaWriter {
   @Override public void write(DeleteDeltaBlockDetails deleteDeltaBlockDetails) throws IOException {
     BufferedWriter brWriter = null;
     try {
-      FileFactory.createNewFile(filePath, fileType);
-      dataOutStream = FileFactory.getDataOutputStream(filePath, fileType);
+      FileFactory.createNewFile(configuration, filePath, fileType);
+      dataOutStream = FileFactory.getDataOutputStream(configuration, filePath, fileType);
       Gson gsonObjectToWrite = new Gson();
       brWriter = new BufferedWriter(new OutputStreamWriter(dataOutStream,
           CarbonCommonConstants.CARBON_DEFAULT_STREAM_ENCODEFORMAT));

--- a/core/src/main/java/org/apache/carbondata/core/writer/CarbonIndexFileWriter.java
+++ b/core/src/main/java/org/apache/carbondata/core/writer/CarbonIndexFileWriter.java
@@ -18,6 +18,7 @@ package org.apache.carbondata.core.writer;
 
 import java.io.IOException;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.thrift.TBase;
 
 /**
@@ -42,12 +43,13 @@ public class CarbonIndexFileWriter {
   /**
    * Below method will be used to open the thrift writer
    *
+   * @param configuration
    * @param filePath file path where data need to be written
    * @throws IOException throws io exception in case of any failure
    */
-  public void openThriftWriter(String filePath) throws IOException {
+  public void openThriftWriter(Configuration configuration, String filePath) throws IOException {
     // create thrift writer instance
-    thriftWriter = new ThriftWriter(filePath, true);
+    thriftWriter = new ThriftWriter(configuration, filePath, true);
     // open the file stream
     thriftWriter.open();
   }

--- a/core/src/main/java/org/apache/carbondata/core/writer/ThriftWriter.java
+++ b/core/src/main/java/org/apache/carbondata/core/writer/ThriftWriter.java
@@ -26,6 +26,7 @@ import org.apache.carbondata.core.fileoperations.AtomicFileOperationsImpl;
 import org.apache.carbondata.core.fileoperations.FileWriteOperation;
 import org.apache.carbondata.core.util.CarbonUtil;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.thrift.TBase;
 import org.apache.thrift.TException;
@@ -68,10 +69,13 @@ public class ThriftWriter {
    */
   private boolean append;
 
+  private Configuration configuration;
+
   /**
    * Constructor.
    */
-  public ThriftWriter(String fileName, boolean append) {
+  public ThriftWriter(Configuration configuration, String fileName, boolean append) {
+    this.configuration = configuration;
     this.fileName = fileName;
     this.append = append;
   }
@@ -81,7 +85,8 @@ public class ThriftWriter {
    */
   public void open() throws IOException {
     FileFactory.FileType fileType = FileFactory.getFileType(fileName);
-    dataOutputStream = FileFactory.getDataOutputStream(fileName, fileType, bufferSize, append);
+    dataOutputStream =
+        FileFactory.getDataOutputStream(configuration, fileName, fileType, bufferSize, append);
     binaryOut = new TCompactProtocol(new TIOStreamTransport(dataOutputStream));
   }
 
@@ -93,7 +98,7 @@ public class ThriftWriter {
    */
   public void open(FileWriteOperation fileWriteOperation) throws IOException {
     FileFactory.FileType fileType = FileFactory.getFileType(fileName);
-    atomicFileOperationsWriter = new AtomicFileOperationsImpl(fileName, fileType);
+    atomicFileOperationsWriter = new AtomicFileOperationsImpl(configuration, fileName, fileType);
     dataOutputStream = atomicFileOperationsWriter.openForWrite(fileWriteOperation);
     binaryOut = new TCompactProtocol(new TIOStreamTransport(dataOutputStream));
   }

--- a/core/src/test/java/org/apache/carbondata/core/cache/CacheProviderTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/cache/CacheProviderTest.java
@@ -31,6 +31,7 @@ import org.apache.carbondata.core.datastore.TableSegmentUniqueIdentifier;
 import org.apache.carbondata.core.datastore.block.SegmentTaskIndexWrapper;
 import org.apache.carbondata.core.datastore.block.TableBlockUniqueIdentifier;
 import org.apache.carbondata.core.util.CarbonProperties;
+import org.apache.carbondata.core.util.CarbonTestUtil;
 
 import org.apache.avro.Schema;
 import org.junit.Before;
@@ -65,12 +66,14 @@ public class CacheProviderTest {
     // get cache provider instance
     CacheProvider cacheProvider = CacheProvider.getInstance();
     Cache<DictionaryColumnUniqueIdentifier, Dictionary> dictionaryCache =
-        cacheProvider.createCache(CacheType.FORWARD_DICTIONARY, "carbonStore");
+        cacheProvider.createCache(CacheType.FORWARD_DICTIONARY, "carbonStore",
+            CarbonTestUtil.configuration);
     // assert that dictionary cache is an instance of Forward dictionary cache
     assertTrue(dictionaryCache instanceof ForwardDictionaryCache);
     assertFalse(dictionaryCache instanceof ReverseDictionaryCache);
     Cache<DictionaryColumnUniqueIdentifier, Dictionary> reverseDictionaryCache =
-        cacheProvider.createCache(CacheType.REVERSE_DICTIONARY, "carbonStore");
+        cacheProvider.createCache(CacheType.REVERSE_DICTIONARY, "carbonStore",
+            CarbonTestUtil.configuration);
     // assert that dictionary cache is an instance of Reverse dictionary cache
     assertTrue(reverseDictionaryCache instanceof ReverseDictionaryCache);
     assertFalse(reverseDictionaryCache instanceof ForwardDictionaryCache);
@@ -90,7 +93,8 @@ public class CacheProviderTest {
     CacheProvider cacheProvider = CacheProvider.getInstance();
     CarbonProperties.getInstance().addProperty(CarbonCommonConstants.IS_DRIVER_INSTANCE, "true");
     Cache<TableSegmentUniqueIdentifier, SegmentTaskIndexStore> driverCache =
-        cacheProvider.createCache(CacheType.DRIVER_BTREE, "carbonStore");
+        cacheProvider.createCache(CacheType.DRIVER_BTREE, "carbonStore",
+            CarbonTestUtil.configuration);
     Field carbonLRUCacheField = SegmentTaskIndexStore.class.getDeclaredField("lruCache");
     carbonLRUCacheField.setAccessible(true);
     CarbonLRUCache carbonLRUCache = (CarbonLRUCache) carbonLRUCacheField.get(driverCache);
@@ -105,7 +109,8 @@ public class CacheProviderTest {
     // validation test for the executor memory.
     CarbonProperties.getInstance().addProperty(CarbonCommonConstants.IS_DRIVER_INSTANCE, "false");
     Cache<TableBlockUniqueIdentifier, BlockIndexStore> executorCache =
-        cacheProvider.createCache(CacheType.EXECUTOR_BTREE, "carbonStore");
+        cacheProvider.createCache(CacheType.EXECUTOR_BTREE, "carbonStore",
+            CarbonTestUtil.configuration);
     carbonLRUCacheField = BlockIndexStore.class.getSuperclass().getDeclaredField("lruCache");
     carbonLRUCacheField.setAccessible(true);
     carbonLRUCache = (CarbonLRUCache) carbonLRUCacheField.get(executorCache);

--- a/core/src/test/java/org/apache/carbondata/core/cache/dictionary/AbstractDictionaryCacheTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/cache/dictionary/AbstractDictionaryCacheTest.java
@@ -33,6 +33,7 @@ import org.apache.carbondata.core.cache.Cache;
 import org.apache.carbondata.core.metadata.CarbonTableIdentifier;
 import org.apache.carbondata.core.metadata.ColumnIdentifier;
 import org.apache.carbondata.core.metadata.datatype.DataType;
+import org.apache.carbondata.core.util.CarbonTestUtil;
 import org.apache.carbondata.core.util.path.CarbonStorePath;
 import org.apache.carbondata.core.util.path.CarbonTablePath;
 import org.apache.carbondata.core.datastore.filesystem.CarbonFile;
@@ -40,6 +41,8 @@ import org.apache.carbondata.core.datastore.impl.FileFactory;
 import org.apache.carbondata.core.util.CarbonUtil;
 import org.apache.carbondata.core.writer.CarbonDictionaryWriter;
 import org.apache.carbondata.core.writer.CarbonDictionaryWriterImpl;
+
+import org.apache.hadoop.conf.Configuration;
 
 public class AbstractDictionaryCacheTest {
 
@@ -106,7 +109,7 @@ public class AbstractDictionaryCacheTest {
 	ColumnIdentifier columnIdentifier = new ColumnIdentifier(columnId, null, DataType.STRING);
     return new DictionaryColumnUniqueIdentifier(carbonTableIdentifier, columnIdentifier,
         DataType.STRING,
-        CarbonStorePath.getCarbonTablePath(carbonStorePath, carbonTableIdentifier));
+        CarbonStorePath.getCarbonTablePath(carbonStorePath, carbonTableIdentifier, CarbonTestUtil.configuration));
   }
 
   /**
@@ -114,7 +117,7 @@ public class AbstractDictionaryCacheTest {
    */
   protected void deleteStorePath() {
     FileFactory.FileType fileType = FileFactory.getFileType(this.carbonStorePath);
-    CarbonFile carbonFile = FileFactory.getCarbonFile(this.carbonStorePath, fileType);
+    CarbonFile carbonFile = FileFactory.getCarbonFile(CarbonTestUtil.configuration, this.carbonStorePath, fileType);
     deleteRecursiveSilent(carbonFile);
   }
 
@@ -130,12 +133,12 @@ public class AbstractDictionaryCacheTest {
     DictionaryColumnUniqueIdentifier dictionaryColumnUniqueIdentifier =
         new DictionaryColumnUniqueIdentifier(carbonTableIdentifier, columnIdentifier,
             columnIdentifier.getDataType(),
-            CarbonStorePath.getCarbonTablePath(carbonStorePath, carbonTableIdentifier));
+            CarbonStorePath.getCarbonTablePath(carbonStorePath, carbonTableIdentifier, CarbonTestUtil.configuration));
     CarbonDictionaryWriter carbonDictionaryWriter =
-        new CarbonDictionaryWriterImpl(carbonStorePath, carbonTableIdentifier, dictionaryColumnUniqueIdentifier);
+        new CarbonDictionaryWriterImpl(carbonStorePath, carbonTableIdentifier, dictionaryColumnUniqueIdentifier, CarbonTestUtil.configuration);
     CarbonTablePath carbonTablePath =
-        CarbonStorePath.getCarbonTablePath(carbonStorePath, carbonTableIdentifier);
-    CarbonUtil.checkAndCreateFolder(carbonTablePath.getMetadataDirectoryPath());
+        CarbonStorePath.getCarbonTablePath(carbonStorePath, carbonTableIdentifier, CarbonTestUtil.configuration);
+    CarbonUtil.checkAndCreateFolder(CarbonTestUtil.configuration, carbonTablePath.getMetadataDirectoryPath());
     List<byte[]> valueList = convertStringListToByteArray(data);
     try {
       carbonDictionaryWriter.write(valueList);

--- a/core/src/test/java/org/apache/carbondata/core/cache/dictionary/DictionaryCacheLoaderImplTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/cache/dictionary/DictionaryCacheLoaderImplTest.java
@@ -29,6 +29,7 @@ import org.apache.carbondata.core.metadata.ColumnIdentifier;
 import org.apache.carbondata.core.metadata.datatype.DataType;
 import org.apache.carbondata.core.reader.CarbonDictionaryReaderImpl;
 import org.apache.carbondata.core.reader.sortindex.CarbonDictionarySortIndexReaderImpl;
+import org.apache.carbondata.core.util.CarbonTestUtil;
 import org.apache.carbondata.core.util.path.CarbonStorePath;
 import org.apache.carbondata.format.ColumnDictionaryChunk;
 
@@ -54,9 +55,9 @@ public class DictionaryCacheLoaderImplTest {
     columnIdentifier = new ColumnIdentifier("1", columnProperties, DataType.STRING);
     dictionaryColumnUniqueIdentifier =
         new DictionaryColumnUniqueIdentifier(carbonTableIdentifier, columnIdentifier,
-            columnIdentifier.getDataType(), CarbonStorePath.getCarbonTablePath("/tmp", carbonTableIdentifier));
+            columnIdentifier.getDataType(), CarbonStorePath.getCarbonTablePath("/tmp", carbonTableIdentifier, CarbonTestUtil.configuration));
     dictionaryCacheLoader = new DictionaryCacheLoaderImpl(carbonTableIdentifier, "/tmp/",
-        dictionaryColumnUniqueIdentifier);
+        dictionaryColumnUniqueIdentifier, CarbonTestUtil.configuration);
     dictionaryInfo = new ColumnDictionaryInfo(DataType.STRING);
     new MockUp<CarbonDictionaryReaderImpl>() {
       @Mock @SuppressWarnings("unused") Iterator<byte[]> read(long startOffset, long endOffset)

--- a/core/src/test/java/org/apache/carbondata/core/cache/dictionary/ForwardDictionaryCacheTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/cache/dictionary/ForwardDictionaryCacheTest.java
@@ -32,6 +32,7 @@ import org.apache.carbondata.core.metadata.CarbonTableIdentifier;
 import org.apache.carbondata.core.metadata.ColumnIdentifier;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.util.CarbonProperties;
+import org.apache.carbondata.core.util.CarbonTestUtil;
 import org.apache.carbondata.core.util.path.CarbonStorePath;
 import org.apache.carbondata.core.writer.sortindex.CarbonDictionarySortIndexWriter;
 import org.apache.carbondata.core.writer.sortindex.CarbonDictionarySortIndexWriterImpl;
@@ -72,7 +73,7 @@ public class ForwardDictionaryCacheTest extends AbstractDictionaryCacheTest {
         .addProperty(CarbonCommonConstants.CARBON_MAX_DRIVER_LRU_CACHE_SIZE, "10");
     CacheProvider cacheProvider = CacheProvider.getInstance();
     forwardDictionaryCache =
-        cacheProvider.createCache(CacheType.FORWARD_DICTIONARY, this.carbonStorePath);
+        cacheProvider.createCache(CacheType.FORWARD_DICTIONARY, this.carbonStorePath, CarbonTestUtil.configuration);
   }
 
   @Test public void get() throws Exception {
@@ -213,7 +214,7 @@ public class ForwardDictionaryCacheTest extends AbstractDictionaryCacheTest {
     DictionaryColumnUniqueIdentifier dictionaryColumnUniqueIdentifier =
         new DictionaryColumnUniqueIdentifier(carbonTableIdentifier, columnIdentifier,
             columnIdentifier.getDataType(),
-            CarbonStorePath.getCarbonTablePath(carbonStorePath, carbonTableIdentifier));
+            CarbonStorePath.getCarbonTablePath(carbonStorePath, carbonTableIdentifier, CarbonTestUtil.configuration));
     Map<String, Integer> dataToSurrogateKeyMap = new HashMap<>(data.size());
     int surrogateKey = 0;
     List<Integer> invertedIndexList = new ArrayList<>(data.size());
@@ -234,7 +235,7 @@ public class ForwardDictionaryCacheTest extends AbstractDictionaryCacheTest {
     }
     CarbonDictionarySortIndexWriter dictionarySortIndexWriter =
         new CarbonDictionarySortIndexWriterImpl(carbonTableIdentifier, dictionaryColumnUniqueIdentifier,
-            carbonStorePath);
+            carbonStorePath, CarbonTestUtil.configuration);
     try {
       dictionarySortIndexWriter.writeSortIndex(sortedIndexList);
       dictionarySortIndexWriter.writeInvertedSortIndex(invertedIndexList);

--- a/core/src/test/java/org/apache/carbondata/core/cache/dictionary/ReverseDictionaryCacheTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/cache/dictionary/ReverseDictionaryCacheTest.java
@@ -38,6 +38,7 @@ import org.apache.carbondata.core.metadata.datatype.DataType;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.reader.CarbonDictionaryColumnMetaChunk;
 import org.apache.carbondata.core.util.CarbonProperties;
+import org.apache.carbondata.core.util.CarbonTestUtil;
 
 import org.junit.After;
 import org.junit.Before;
@@ -75,7 +76,7 @@ public class ReverseDictionaryCacheTest extends AbstractDictionaryCacheTest {
     CacheProvider cacheProvider = CacheProvider.getInstance();
     cacheProvider.dropAllCache();
     reverseDictionaryCache =
-        cacheProvider.createCache(CacheType.REVERSE_DICTIONARY, this.carbonStorePath);
+        cacheProvider.createCache(CacheType.REVERSE_DICTIONARY, this.carbonStorePath, CarbonTestUtil.configuration);
   }
 
   @Test public void get() throws Exception {

--- a/core/src/test/java/org/apache/carbondata/core/carbon/datastorage/filesystem/store/impl/DFSFileHolderImplUnitTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/carbon/datastorage/filesystem/store/impl/DFSFileHolderImplUnitTest.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 
 import org.apache.carbondata.core.datastore.impl.DFSFileHolderImpl;
+import org.apache.carbondata.core.util.CarbonTestUtil;
 
 import mockit.Mock;
 import mockit.MockUp;
@@ -46,7 +47,7 @@ public class DFSFileHolderImplUnitTest {
   private static File fileWithEmptyContent;
 
   @BeforeClass public static void setup() {
-    dfsFileHolder = new DFSFileHolderImpl();
+    dfsFileHolder = new DFSFileHolderImpl(CarbonTestUtil.configuration);
     file = new File("Test.carbondata");
     fileWithEmptyContent = new File("TestEXception.carbondata");
 

--- a/core/src/test/java/org/apache/carbondata/core/carbon/datastorage/filesystem/store/impl/FileFactoryImplUnitTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/carbon/datastorage/filesystem/store/impl/FileFactoryImplUnitTest.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.io.IOException;
 
 import org.apache.carbondata.core.datastore.impl.FileFactory;
+import org.apache.carbondata.core.util.CarbonTestUtil;
 
 import mockit.Mock;
 import mockit.MockUp;
@@ -57,50 +58,50 @@ public class FileFactoryImplUnitTest {
   }
 
   @Test public void testFileExistsForVIEWFSType() throws IOException {
-    FileFactory.isFileExist("fakefilePath", FileFactory.FileType.VIEWFS);
+    FileFactory.isFileExist(CarbonTestUtil.configuration, "fakefilePath", FileFactory.FileType.VIEWFS);
   }
 
   @Test public void testFileExistsForDefaultType() throws IOException {
-    FileFactory.isFileExist("fakefilePath", FileFactory.FileType.LOCAL);
+    FileFactory.isFileExist(CarbonTestUtil.configuration, "fakefilePath", FileFactory.FileType.LOCAL);
   }
 
   @Test public void testFileExistsForDefaultTypeWithPerformFileCheck() throws IOException {
-    assertTrue(FileFactory.isFileExist(filePath, FileFactory.FileType.LOCAL, true));
+    assertTrue(FileFactory.isFileExist(CarbonTestUtil.configuration, filePath, FileFactory.FileType.LOCAL, true));
   }
 
   @Test public void testFileExistsForDefaultTypeWithOutPerformFileCheck() throws IOException {
-    assertFalse(FileFactory.isFileExist("fakefilePath", FileFactory.FileType.LOCAL, false));
+    assertFalse(FileFactory.isFileExist(CarbonTestUtil.configuration, "fakefilePath", FileFactory.FileType.LOCAL, false));
   }
 
   @Test public void testFileExistsForVIEWFSTypeWithPerformFileCheck() throws IOException {
-    assertTrue(FileFactory.isFileExist(filePath, FileFactory.FileType.VIEWFS, true));
+    assertTrue(FileFactory.isFileExist(CarbonTestUtil.configuration, filePath, FileFactory.FileType.VIEWFS, true));
   }
 
   @Test public void testFileExistsForVIEWFSTypeWithOutPerformFileCheck() throws IOException {
-    assertFalse(FileFactory.isFileExist("fakefilePath", FileFactory.FileType.VIEWFS, false));
+    assertFalse(FileFactory.isFileExist(CarbonTestUtil.configuration, "fakefilePath", FileFactory.FileType.VIEWFS, false));
   }
 
   @Test public void testCreateNewFileWithDefaultFileType() throws IOException {
     tearDown();
-    assertTrue(FileFactory.createNewFile(filePath, FileFactory.FileType.LOCAL));
+    assertTrue(FileFactory.createNewFile(CarbonTestUtil.configuration, filePath, FileFactory.FileType.LOCAL));
   }
 
   @Test public void testCreateNewLockFileWithDefaultFileType() throws IOException {
     tearDown();
-    assertTrue(FileFactory.createNewLockFile(filePath, FileFactory.FileType.LOCAL));
+    assertTrue(FileFactory.createNewLockFile(CarbonTestUtil.configuration, filePath, FileFactory.FileType.LOCAL));
   }
 
   @Test public void testCreateNewLockFileWithViewFsFileType() throws IOException {
     tearDown();
-    assertTrue(FileFactory.createNewLockFile(filePath, FileFactory.FileType.VIEWFS));
+    assertTrue(FileFactory.createNewLockFile(CarbonTestUtil.configuration, filePath, FileFactory.FileType.VIEWFS));
   }
 
   @Test public void testCreateNewLockFileWithViewFsFileTypeWhenFileExists() throws IOException {
-    assertFalse(FileFactory.createNewLockFile(filePath, FileFactory.FileType.VIEWFS));
+    assertFalse(FileFactory.createNewLockFile(CarbonTestUtil.configuration, filePath, FileFactory.FileType.VIEWFS));
   }
 
   @Test public void testCreateNewFileWithDefaultFileTypeWhenFileExists() throws IOException {
-    assertFalse(FileFactory.createNewFile(filePath, FileFactory.FileType.LOCAL));
+    assertFalse(FileFactory.createNewFile(CarbonTestUtil.configuration, filePath, FileFactory.FileType.LOCAL));
   }
 
   @Test public void testCreateNewFileWithVIEWFSFileType() throws IOException {
@@ -108,11 +109,11 @@ public class FileFactoryImplUnitTest {
     if (file.exists()) {
       file.delete();
     }
-    assertTrue(FileFactory.createNewFile(filePath, FileFactory.FileType.VIEWFS));
+    assertTrue(FileFactory.createNewFile(CarbonTestUtil.configuration, filePath, FileFactory.FileType.VIEWFS));
   }
 
   @Test public void testCreateNewFileWithVIEWFSFileTypeWhenFileExists() throws IOException {
-    assertFalse(FileFactory.createNewFile(filePath, FileFactory.FileType.VIEWFS));
+    assertFalse(FileFactory.createNewFile(CarbonTestUtil.configuration, filePath, FileFactory.FileType.VIEWFS));
   }
 
   @Test public void testMkDirWithVIEWFSFileType() throws IOException {
@@ -124,28 +125,28 @@ public class FileFactoryImplUnitTest {
       }
     };
     tearDown();
-    assertTrue(FileFactory.mkdirs(filePath, FileFactory.FileType.VIEWFS));
+    assertTrue(FileFactory.mkdirs(CarbonTestUtil.configuration, filePath, FileFactory.FileType.VIEWFS));
   }
 
   @Test public void testGetDataOutputStreamUsingAppendeForException() {
     try {
-      FileFactory.getDataOutputStreamUsingAppend(filePath, FileFactory.FileType.VIEWFS);
+      FileFactory.getDataOutputStreamUsingAppend(CarbonTestUtil.configuration, filePath, FileFactory.FileType.VIEWFS);
     } catch (Exception exception) {
       assertEquals("Not supported", exception.getMessage());
     }
   }
 
   @Test public void getDataOutputStreamForVIEWFSType() throws IOException {
-    assertNotNull(FileFactory.getDataOutputStream(filePath, FileFactory.FileType.VIEWFS));
+    assertNotNull(FileFactory.getDataOutputStream(CarbonTestUtil.configuration, filePath, FileFactory.FileType.VIEWFS));
   }
 
   @Test public void getDataOutputStreamForLocalType() throws IOException {
-    assertNotNull(FileFactory.getDataOutputStream(filePath, FileFactory.FileType.LOCAL));
+    assertNotNull(FileFactory.getDataOutputStream(CarbonTestUtil.configuration, filePath, FileFactory.FileType.LOCAL));
   }
 
   @Test public void testGetCarbonFile() throws IOException {
-    FileFactory.getDataOutputStream(filePath, FileFactory.FileType.VIEWFS);
-    assertNotNull(FileFactory.getCarbonFile(filePath, FileFactory.FileType.HDFS));
+    FileFactory.getDataOutputStream(CarbonTestUtil.configuration, filePath, FileFactory.FileType.VIEWFS);
+    assertNotNull(FileFactory.getCarbonFile(CarbonTestUtil.configuration, filePath, FileFactory.FileType.HDFS));
   }
 }
 

--- a/core/src/test/java/org/apache/carbondata/core/datastore/CompressdFileTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/datastore/CompressdFileTest.java
@@ -19,6 +19,7 @@ package org.apache.carbondata.core.datastore;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.datastore.impl.FileFactory;
 import org.apache.carbondata.core.datastore.impl.FileFactory.*;
+import org.apache.carbondata.core.util.CarbonTestUtil;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -97,7 +98,7 @@ public class CompressdFileTest
 
       try {
         fileReader =
-            FileFactory.getDataInputStream(path, FileType.HDFS);
+            FileFactory.getDataInputStream(CarbonTestUtil.configuration, path, FileType.HDFS);
         bufferedReader = new BufferedReader(new InputStreamReader(fileReader,
             Charset.forName(CarbonCommonConstants.DEFAULT_CHARSET)));
         readLine = bufferedReader.readLine();

--- a/core/src/test/java/org/apache/carbondata/core/datastore/SegmentTaskIndexStoreTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/datastore/SegmentTaskIndexStoreTest.java
@@ -36,6 +36,7 @@ import org.apache.carbondata.core.metadata.blocklet.BlockletInfo;
 import org.apache.carbondata.core.metadata.blocklet.DataFileFooter;
 import org.apache.carbondata.core.metadata.blocklet.SegmentInfo;
 import org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema;
+import org.apache.carbondata.core.util.CarbonTestUtil;
 import org.apache.carbondata.core.util.path.CarbonTablePath;
 import org.apache.carbondata.core.util.CarbonUtil;
 
@@ -60,7 +61,7 @@ public class SegmentTaskIndexStoreTest {
     CacheProvider cacheProvider = CacheProvider.getInstance();
     taskIndexStore = (SegmentTaskIndexStore) cacheProvider.
         <TableSegmentUniqueIdentifier, SegmentTaskIndexWrapper>
-            createCache(CacheType.DRIVER_BTREE, "");
+            createCache(CacheType.DRIVER_BTREE, "", CarbonTestUtil.configuration);
     tableBlockInfo = new TableBlockInfo("file", 0L, "SG100", locations, 10L,
         ColumnarFormatVersion.valueOf(version), null);
     absoluteTableIdentifier = new AbsoluteTableIdentifier("/tmp",

--- a/core/src/test/java/org/apache/carbondata/core/datastore/filesystem/AlluxioCarbonFileTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/datastore/filesystem/AlluxioCarbonFileTest.java
@@ -35,6 +35,8 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 
+import org.apache.carbondata.core.util.CarbonTestUtil;
+
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -66,7 +68,7 @@ public class AlluxioCarbonFileTest {
         fileStatus = new FileStatus(12L, true, 60, 120l, 180L, new Path(file.getAbsolutePath()));
         fileStatusWithOutDirectoryPermission = new FileStatus(12L, false, 60, 120l, 180L, new Path(file.getAbsolutePath()));
         fileName = file.getAbsolutePath();
-        alluxioCarbonFile = new AlluxioCarbonFile(fileStatus);
+        alluxioCarbonFile = new AlluxioCarbonFile(CarbonTestUtil.configuration, fileStatus);
     }
 
     @AfterClass
@@ -84,25 +86,25 @@ public class AlluxioCarbonFileTest {
             }
 
         };
-        alluxioCarbonFile = new AlluxioCarbonFile(fileStatus);
+        alluxioCarbonFile = new AlluxioCarbonFile(CarbonTestUtil.configuration, fileStatus);
         alluxioCarbonFile.renameForce(fileName);
     }
 
     @Test
     public void testListFilesWithOutDirectoryPermission() {
-        alluxioCarbonFile = new AlluxioCarbonFile(fileStatusWithOutDirectoryPermission);
+        alluxioCarbonFile = new AlluxioCarbonFile(CarbonTestUtil.configuration, fileStatusWithOutDirectoryPermission);
         assertArrayEquals(alluxioCarbonFile.listFiles(), new CarbonFile[0]);
     }
 
     @Test
     public void testConstructorWithFilePath() {
-        alluxioCarbonFile = new AlluxioCarbonFile(file.getAbsolutePath());
+        alluxioCarbonFile = new AlluxioCarbonFile(CarbonTestUtil.configuration, file.getAbsolutePath());
         assertTrue(alluxioCarbonFile instanceof AlluxioCarbonFile);
     }
 
     @Test
     public void testListFilesForNullListStatus() {
-        alluxioCarbonFile = new AlluxioCarbonFile(fileStatusWithOutDirectoryPermission);
+        alluxioCarbonFile = new AlluxioCarbonFile(CarbonTestUtil.configuration, fileStatusWithOutDirectoryPermission);
         new MockUp<Path>() {
             @Mock
             public FileSystem getFileSystem(Configuration conf) throws IOException {
@@ -118,13 +120,13 @@ public class AlluxioCarbonFileTest {
             }
 
         };
-        alluxioCarbonFile = new AlluxioCarbonFile(fileStatus);
+        alluxioCarbonFile = new AlluxioCarbonFile(CarbonTestUtil.configuration, fileStatus);
         assertTrue(alluxioCarbonFile.listFiles().length == 0);
     }
 
     @Test
     public void testListDirectory() {
-        alluxioCarbonFile = new AlluxioCarbonFile(fileStatus);
+        alluxioCarbonFile = new AlluxioCarbonFile(CarbonTestUtil.configuration, fileStatus);
         new MockUp<Path>() {
             @Mock
             public FileSystem getFileSystem(Configuration conf) throws IOException {
@@ -146,7 +148,7 @@ public class AlluxioCarbonFileTest {
 
     @Test
     public void testListFilesForException() throws IOException {
-        alluxioCarbonFile = new AlluxioCarbonFile(fileStatusWithOutDirectoryPermission);
+        alluxioCarbonFile = new AlluxioCarbonFile(CarbonTestUtil.configuration, fileStatusWithOutDirectoryPermission);
 
         new MockUp<FileStatus>() {
             @Mock
@@ -170,7 +172,7 @@ public class AlluxioCarbonFileTest {
             }
 
         };
-        alluxioCarbonFile = new AlluxioCarbonFile(fileStatus);
+        alluxioCarbonFile = new AlluxioCarbonFile(CarbonTestUtil.configuration, fileStatus);
         alluxioCarbonFile.listFiles();
     }
 
@@ -183,7 +185,7 @@ public class AlluxioCarbonFileTest {
                 return true;
             }
         };
-        alluxioCarbonFile = new AlluxioCarbonFile(fileStatus);
+        alluxioCarbonFile = new AlluxioCarbonFile(CarbonTestUtil.configuration, fileStatus);
         assertTrue(alluxioCarbonFile.listFiles(carbonFileFilter).length == 1);
     }
 
@@ -211,7 +213,7 @@ public class AlluxioCarbonFileTest {
             }
 
         };
-        alluxioCarbonFile = new AlluxioCarbonFile(fileStatus);
+        alluxioCarbonFile = new AlluxioCarbonFile(CarbonTestUtil.configuration, fileStatus);
         assertTrue(alluxioCarbonFile.listFiles(carbonFileFilter).length == 0);
     }
 
@@ -248,13 +250,13 @@ public class AlluxioCarbonFileTest {
 
         };
 
-        alluxioCarbonFile = new AlluxioCarbonFile(fileStatus);
+        alluxioCarbonFile = new AlluxioCarbonFile(CarbonTestUtil.configuration, fileStatus);
         assertFalse(alluxioCarbonFile.getParentFile().equals(null));
     }
 
     @Test
     public void testForNonDisributedSystem() {
-        alluxioCarbonFile = new AlluxioCarbonFile(fileStatus);
+        alluxioCarbonFile = new AlluxioCarbonFile(CarbonTestUtil.configuration, fileStatus);
         new MockUp<Path>() {
             @Mock
             public FileSystem getFileSystem(Configuration conf) throws IOException {
@@ -282,7 +284,7 @@ public class AlluxioCarbonFileTest {
 
         };
 
-        alluxioCarbonFile = new AlluxioCarbonFile(fileStatus);
+        alluxioCarbonFile = new AlluxioCarbonFile(CarbonTestUtil.configuration, fileStatus);
         assertTrue(alluxioCarbonFile.renameForce(fileName));
 
     }

--- a/core/src/test/java/org/apache/carbondata/core/datastore/filesystem/HDFSCarbonFileTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/datastore/filesystem/HDFSCarbonFileTest.java
@@ -21,6 +21,7 @@ import mockit.Mock;
 import mockit.MockUp;
 import org.apache.carbondata.common.logging.LogService;
 import org.apache.carbondata.common.logging.LogServiceFactory;
+import org.apache.carbondata.core.util.CarbonTestUtil;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
@@ -79,7 +80,7 @@ public class HDFSCarbonFileTest {
 
             fileStatus = new FileStatus(12L, true, 60, 120l, 180L, new Path(fileName));
             fileStatusWithOutDirectoryPermission = new FileStatus(12L, false, 60, 120l, 180L, new Path(fileName));
-            hdfsCarbonFile = new HDFSCarbonFile(fileStatus);
+            hdfsCarbonFile = new HDFSCarbonFile(CarbonTestUtil.configuration, fileStatus);
 
         }
     }
@@ -103,13 +104,13 @@ public class HDFSCarbonFileTest {
             }
 
         };
-        hdfsCarbonFile = new HDFSCarbonFile(fileStatus);
+        hdfsCarbonFile = new HDFSCarbonFile(CarbonTestUtil.configuration, fileStatus);
         hdfsCarbonFile.renameForce(fileName);
     }
 
     @Test
     public void testListFilesWithOutDirectoryPermission() {
-        hdfsCarbonFile = new HDFSCarbonFile(fileStatusWithOutDirectoryPermission);
+        hdfsCarbonFile = new HDFSCarbonFile(CarbonTestUtil.configuration, fileStatusWithOutDirectoryPermission);
         new MockUp<FileStatus>() {
             @Mock
             public boolean isDirectory() {
@@ -138,7 +139,7 @@ public class HDFSCarbonFileTest {
 
     @Test
     public void testConstructorWithFilePath() {
-        hdfsCarbonFile = new HDFSCarbonFile(fileName);
+        hdfsCarbonFile = new HDFSCarbonFile(CarbonTestUtil.configuration, fileName);
         assertTrue(hdfsCarbonFile instanceof HDFSCarbonFile);
     }
 
@@ -159,13 +160,13 @@ public class HDFSCarbonFileTest {
             }
 
         };
-        hdfsCarbonFile = new HDFSCarbonFile(fileStatus);
+        hdfsCarbonFile = new HDFSCarbonFile(CarbonTestUtil.configuration, fileStatus);
         assertEquals(hdfsCarbonFile.listFiles().length, 0);
     }
 
     @Test
     public void testListDirectory() {
-        hdfsCarbonFile = new HDFSCarbonFile(fileStatus);
+        hdfsCarbonFile = new HDFSCarbonFile(CarbonTestUtil.configuration, fileStatus);
         new MockUp<Path>() {
             @Mock
             public FileSystem getFileSystem(Configuration conf) throws IOException {
@@ -187,7 +188,7 @@ public class HDFSCarbonFileTest {
 
     @Test
     public void testListFilesForException() throws IOException {
-        new HDFSCarbonFile(fileStatusWithOutDirectoryPermission);
+        new HDFSCarbonFile(CarbonTestUtil.configuration, fileStatusWithOutDirectoryPermission);
 
         new MockUp<FileStatus>() {
             @Mock
@@ -211,7 +212,7 @@ public class HDFSCarbonFileTest {
             }
 
         };
-        hdfsCarbonFile = new HDFSCarbonFile(fileStatus);
+        hdfsCarbonFile = new HDFSCarbonFile(CarbonTestUtil.configuration, fileStatus);
         hdfsCarbonFile.listFiles();
     }
 
@@ -255,7 +256,7 @@ public class HDFSCarbonFileTest {
             }
 
         };
-        hdfsCarbonFile = new HDFSCarbonFile(fileStatus);
+        hdfsCarbonFile = new HDFSCarbonFile(CarbonTestUtil.configuration, fileStatus);
         assertEquals(hdfsCarbonFile.listFiles(carbonFileFilter).length, 1);
     }
 
@@ -283,7 +284,7 @@ public class HDFSCarbonFileTest {
             }
 
         };
-        hdfsCarbonFile = new HDFSCarbonFile(fileStatus);
+        hdfsCarbonFile = new HDFSCarbonFile(CarbonTestUtil.configuration, fileStatus);
         assertEquals(hdfsCarbonFile.listFiles(carbonFileFilter).length, 0);
     }
 
@@ -319,7 +320,7 @@ public class HDFSCarbonFileTest {
             }
 
         };
-        hdfsCarbonFile = new HDFSCarbonFile(fileStatus);
+        hdfsCarbonFile = new HDFSCarbonFile(CarbonTestUtil.configuration, fileStatus);
         assertEquals(hdfsCarbonFile.getParentFile(), null);
     }
 
@@ -355,13 +356,13 @@ public class HDFSCarbonFileTest {
 
         };
 
-        hdfsCarbonFile = new HDFSCarbonFile(fileStatus);
+        hdfsCarbonFile = new HDFSCarbonFile(CarbonTestUtil.configuration, fileStatus);
         assertTrue(hdfsCarbonFile.getParentFile() instanceof CarbonFile);
     }
 
     @Test
     public void testForNonDisributedSystem() {
-        new HDFSCarbonFile(fileStatus);
+        new HDFSCarbonFile(CarbonTestUtil.configuration, fileStatus);
         new MockUp<Path>() {
             @Mock
             public FileSystem getFileSystem(Configuration conf) throws IOException {
@@ -388,7 +389,7 @@ public class HDFSCarbonFileTest {
             }
 
         };
-        hdfsCarbonFile = new HDFSCarbonFile(fileStatus);
+        hdfsCarbonFile = new HDFSCarbonFile(CarbonTestUtil.configuration, fileStatus);
         assertEquals(hdfsCarbonFile.renameForce(fileName), true);
 
     }

--- a/core/src/test/java/org/apache/carbondata/core/datastore/filesystem/LocalCarbonFileTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/datastore/filesystem/LocalCarbonFileTest.java
@@ -21,6 +21,8 @@ import mockit.Mock;
 import mockit.MockUp;
 
 import org.apache.carbondata.core.datastore.impl.FileFactory;
+
+import org.apache.hadoop.conf.Configuration;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -154,7 +156,7 @@ public class LocalCarbonFileTest {
         };
         new MockUp<FileFactory>() {
             @Mock
-            public boolean isFileExist(String filePath, FileFactory.FileType fileType) throws IOException {
+            public boolean isFileExist(Configuration configuration, String filePath, FileFactory.FileType fileType) throws IOException {
                 {
                     return true;
                 }
@@ -168,7 +170,7 @@ public class LocalCarbonFileTest {
         };
         new MockUp<FileFactory>() {
             @Mock
-            public boolean createNewFile(String filePath, FileFactory.FileType fileType) throws IOException {
+            public boolean createNewFile(Configuration configuration, String filePath, FileFactory.FileType fileType) throws IOException {
                 {
                     return true;
                 }
@@ -176,7 +178,7 @@ public class LocalCarbonFileTest {
         };
         new MockUp<FileFactory>() {
             @Mock
-            public CarbonFile getCarbonFile(String path, FileFactory.FileType fileType) {
+            public CarbonFile getCarbonFile(Configuration configuration, String path, FileFactory.FileType fileType) {
                 {
                     return new LocalCarbonFile(path);
                 }
@@ -223,7 +225,7 @@ public class LocalCarbonFileTest {
         };
         new MockUp<FileFactory>() {
             @Mock
-            public boolean isFileExist(String filePath, FileFactory.FileType fileType) throws IOException {
+            public boolean isFileExist(Configuration configuration, String filePath, FileFactory.FileType fileType) throws IOException {
                 {
                     return true;
                 }
@@ -231,7 +233,7 @@ public class LocalCarbonFileTest {
         };
         new MockUp<FileFactory>() {
             @Mock
-            public CarbonFile getCarbonFile(String path, FileFactory.FileType fileType) {
+            public CarbonFile getCarbonFile(Configuration configuration, String path, FileFactory.FileType fileType) {
                 {
                     return new LocalCarbonFile(path);
                 }
@@ -245,7 +247,7 @@ public class LocalCarbonFileTest {
         };
         new MockUp<FileFactory>() {
             @Mock
-            public boolean createNewFile(String filePath, FileFactory.FileType fileType) throws IOException {
+            public boolean createNewFile(Configuration configuration, String filePath, FileFactory.FileType fileType) throws IOException {
                 {
                     throw new IOException();
                 }

--- a/core/src/test/java/org/apache/carbondata/core/datastore/filesystem/ViewFsCarbonFileTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/datastore/filesystem/ViewFsCarbonFileTest.java
@@ -35,6 +35,8 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 
+import org.apache.carbondata.core.util.CarbonTestUtil;
+
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -67,7 +69,7 @@ public class ViewFsCarbonFileTest {
         fileStatus = new FileStatus(12L, true, 60, 120l, 180L, new Path(file.getAbsolutePath()));
         fileStatusWithOutDirectoryPermission = new FileStatus(12L, false, 60, 120l, 180L, new Path(file.getAbsolutePath()));
         fileName = file.getAbsolutePath();
-        viewFSCarbonFile = new ViewFSCarbonFile(fileStatus);
+        viewFSCarbonFile = new ViewFSCarbonFile(CarbonTestUtil.configuration, fileStatus);
     }
 
     @AfterClass
@@ -85,25 +87,25 @@ public class ViewFsCarbonFileTest {
             }
 
         };
-        viewFSCarbonFile = new ViewFSCarbonFile(fileStatus);
+        viewFSCarbonFile = new ViewFSCarbonFile(CarbonTestUtil.configuration, fileStatus);
         viewFSCarbonFile.renameForce(fileName);
     }
 
     @Test
     public void testListFilesWithOutDirectoryPermission() {
-        viewFSCarbonFile = new ViewFSCarbonFile(fileStatusWithOutDirectoryPermission);
+        viewFSCarbonFile = new ViewFSCarbonFile(CarbonTestUtil.configuration, fileStatusWithOutDirectoryPermission);
         assertArrayEquals(viewFSCarbonFile.listFiles(), new CarbonFile[0]);
     }
 
     @Test
     public void testConstructorWithFilePath() {
-        viewFSCarbonFile = new ViewFSCarbonFile(file.getAbsolutePath());
+        viewFSCarbonFile = new ViewFSCarbonFile(CarbonTestUtil.configuration, file.getAbsolutePath());
         assertTrue(viewFSCarbonFile instanceof ViewFSCarbonFile);
     }
 
     @Test
     public void testListFilesForNullListStatus() {
-        viewFSCarbonFile = new ViewFSCarbonFile(fileStatusWithOutDirectoryPermission);
+        viewFSCarbonFile = new ViewFSCarbonFile(CarbonTestUtil.configuration, fileStatusWithOutDirectoryPermission);
         new MockUp<Path>() {
             @Mock
             public FileSystem getFileSystem(Configuration conf) throws IOException {
@@ -128,13 +130,13 @@ public class ViewFsCarbonFileTest {
 
         };
         //public boolean delete(Path var1, boolean var2) throws IOException;
-        viewFSCarbonFile = new ViewFSCarbonFile(fileStatus);
+        viewFSCarbonFile = new ViewFSCarbonFile(CarbonTestUtil.configuration, fileStatus);
         assertTrue(viewFSCarbonFile.listFiles().length == 0);
     }
 
     @Test
     public void testListDirectory() {
-        viewFSCarbonFile = new ViewFSCarbonFile(fileStatus);
+        viewFSCarbonFile = new ViewFSCarbonFile(CarbonTestUtil.configuration, fileStatus);
         new MockUp<Path>() {
             @Mock
             public FileSystem getFileSystem(Configuration conf) throws IOException {
@@ -156,7 +158,7 @@ public class ViewFsCarbonFileTest {
 
     @Test
     public void testListFilesForException() throws IOException {
-        viewFSCarbonFile = new ViewFSCarbonFile(fileStatusWithOutDirectoryPermission);
+        viewFSCarbonFile = new ViewFSCarbonFile(CarbonTestUtil.configuration, fileStatusWithOutDirectoryPermission);
 
         new MockUp<FileStatus>() {
             @Mock
@@ -180,7 +182,7 @@ public class ViewFsCarbonFileTest {
             }
 
         };
-        viewFSCarbonFile = new ViewFSCarbonFile(fileStatus);
+        viewFSCarbonFile = new ViewFSCarbonFile(CarbonTestUtil.configuration, fileStatus);
         viewFSCarbonFile.listFiles();
     }
 
@@ -193,7 +195,7 @@ public class ViewFsCarbonFileTest {
                 return true;
             }
         };
-        viewFSCarbonFile = new ViewFSCarbonFile(fileStatus);
+        viewFSCarbonFile = new ViewFSCarbonFile(CarbonTestUtil.configuration, fileStatus);
         assertTrue(viewFSCarbonFile.listFiles(carbonFileFilter).length == 1);
     }
 
@@ -221,7 +223,7 @@ public class ViewFsCarbonFileTest {
             }
 
         };
-        viewFSCarbonFile = new ViewFSCarbonFile(fileStatus);
+        viewFSCarbonFile = new ViewFSCarbonFile(CarbonTestUtil.configuration, fileStatus);
         assertTrue(viewFSCarbonFile.listFiles(carbonFileFilter).length == 0);
     }
 
@@ -258,13 +260,13 @@ public class ViewFsCarbonFileTest {
 
         };
 
-        viewFSCarbonFile = new ViewFSCarbonFile(fileStatus);
+        viewFSCarbonFile = new ViewFSCarbonFile(CarbonTestUtil.configuration, fileStatus);
         assertFalse(viewFSCarbonFile.getParentFile().equals(null));
     }
 
     @Test
     public void testForNonDisributedSystem() {
-        viewFSCarbonFile = new ViewFSCarbonFile(fileStatus);
+        viewFSCarbonFile = new ViewFSCarbonFile(CarbonTestUtil.configuration, fileStatus);
         new MockUp<Path>() {
             @Mock
             public FileSystem getFileSystem(Configuration conf) throws IOException {

--- a/core/src/test/java/org/apache/carbondata/core/dictionary/client/DictionaryClientTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/dictionary/client/DictionaryClientTest.java
@@ -34,6 +34,7 @@ import org.apache.carbondata.core.metadata.schema.table.TableSchema;
 import org.apache.carbondata.core.metadata.schema.table.column.CarbonDimension;
 import org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema;
 import org.apache.carbondata.core.util.CarbonProperties;
+import org.apache.carbondata.core.util.CarbonTestUtil;
 
 import mockit.Mock;
 import mockit.MockUp;
@@ -96,7 +97,7 @@ public class DictionaryClientTest {
     metadata.addCarbonTable(carbonTable);
 
     // Start the server for testing the client
-    server = DictionaryServer.getInstance(5678, carbonTable);
+    server = DictionaryServer.getInstance(5678, carbonTable, CarbonTestUtil.configuration);
   }
 
   @Test public void testClient() throws Exception {

--- a/core/src/test/java/org/apache/carbondata/core/dictionary/generator/IncrementalColumnDictionaryGeneratorTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/dictionary/generator/IncrementalColumnDictionaryGeneratorTest.java
@@ -28,6 +28,7 @@ import org.apache.carbondata.core.metadata.schema.table.TableSchema;
 import org.apache.carbondata.core.metadata.schema.table.column.CarbonDimension;
 import org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema;
 import org.apache.carbondata.core.util.CarbonProperties;
+import org.apache.carbondata.core.util.CarbonTestUtil;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -66,14 +67,14 @@ public class IncrementalColumnDictionaryGeneratorTest {
   @Test public void generateKeyOnce() throws Exception {
     // Create the generator and add the key to dictionary
     IncrementalColumnDictionaryGenerator generator =
-        new IncrementalColumnDictionaryGenerator(carbonDimension, 10, carbonTable);
+        new IncrementalColumnDictionaryGenerator(carbonDimension, 10, carbonTable, CarbonTestUtil.configuration);
     Integer key = generator.generateKey("First");
     assertEquals(new Integer(11), key);
   }
 
   @Test public void generateKeyTwice() throws Exception {
     IncrementalColumnDictionaryGenerator generator =
-        new IncrementalColumnDictionaryGenerator(carbonDimension, 10, carbonTable);
+        new IncrementalColumnDictionaryGenerator(carbonDimension, 10, carbonTable, CarbonTestUtil.configuration);
     Integer key = generator.generateKey("First");
 
     // Add one more key and check if it works fine.
@@ -84,7 +85,7 @@ public class IncrementalColumnDictionaryGeneratorTest {
   @Test public void generateKeyAgain() throws Exception {
     // Create the generator and add the key to dictionary
     IncrementalColumnDictionaryGenerator generator =
-        new IncrementalColumnDictionaryGenerator(carbonDimension, 10, carbonTable);
+        new IncrementalColumnDictionaryGenerator(carbonDimension, 10, carbonTable, CarbonTestUtil.configuration);
     Integer key = generator.generateKey("First");
 
     // Add the same key again anc check if the value is correct
@@ -95,7 +96,7 @@ public class IncrementalColumnDictionaryGeneratorTest {
   @Test public void getKey() throws Exception {
     // Create the generator and add the key to dictionary
     IncrementalColumnDictionaryGenerator generator =
-        new IncrementalColumnDictionaryGenerator(carbonDimension, 10, carbonTable);
+        new IncrementalColumnDictionaryGenerator(carbonDimension, 10, carbonTable, CarbonTestUtil.configuration);
     Integer generatedKey = generator.generateKey("First");
 
     // Get the value of the key from dictionary and check if it matches with the created value
@@ -105,7 +106,7 @@ public class IncrementalColumnDictionaryGeneratorTest {
 
   @Test public void getKeyInvalid() throws Exception {
     IncrementalColumnDictionaryGenerator generator =
-        new IncrementalColumnDictionaryGenerator(carbonDimension, 10, carbonTable);
+        new IncrementalColumnDictionaryGenerator(carbonDimension, 10, carbonTable, CarbonTestUtil.configuration);
 
     // Try to get value for an invalid key
     Integer obtainedKey = generator.getKey("Second");
@@ -114,7 +115,7 @@ public class IncrementalColumnDictionaryGeneratorTest {
 
   @Test public void getOrGenerateKey() throws Exception {
     IncrementalColumnDictionaryGenerator generator =
-        new IncrementalColumnDictionaryGenerator(carbonDimension, 10, carbonTable);
+        new IncrementalColumnDictionaryGenerator(carbonDimension, 10, carbonTable, CarbonTestUtil.configuration);
 
     // Test first with generating a key and then trying geOrGenerate
     Integer generatedKey = generator.generateKey("First");
@@ -136,7 +137,7 @@ public class IncrementalColumnDictionaryGeneratorTest {
 
     // Create the generator and add the keys to dictionary
     IncrementalColumnDictionaryGenerator generator =
-        new IncrementalColumnDictionaryGenerator(carbonDimension, 10, carbonTable);
+        new IncrementalColumnDictionaryGenerator(carbonDimension, 10, carbonTable, CarbonTestUtil.configuration);
 
     // Create a table schema for saving the dictionary
     TableSchema tableSchema = new TableSchema();

--- a/core/src/test/java/org/apache/carbondata/core/dictionary/generator/ServerDictionaryGeneratorTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/dictionary/generator/ServerDictionaryGeneratorTest.java
@@ -30,6 +30,7 @@ import org.apache.carbondata.core.metadata.schema.table.TableSchema;
 import org.apache.carbondata.core.metadata.schema.table.column.CarbonDimension;
 import org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema;
 import org.apache.carbondata.core.util.CarbonProperties;
+import org.apache.carbondata.core.util.CarbonTestUtil;
 
 import org.junit.After;
 import org.junit.Before;
@@ -98,7 +99,7 @@ public class ServerDictionaryGeneratorTest {
     empKey.setTableUniqueId("1");
     empKey.setColumnName(empColumnSchema.getColumnName());
     empKey.setData("FirstKey");
-    serverDictionaryGenerator.initializeGeneratorForTable(carbonTable);
+    serverDictionaryGenerator.initializeGeneratorForTable(carbonTable, CarbonTestUtil.configuration);
     Integer value = serverDictionaryGenerator.generateKey(empKey);
     assertEquals(new Integer(2), value);
   }
@@ -111,7 +112,7 @@ public class ServerDictionaryGeneratorTest {
     firstKey.setColumnName(empColumnSchema.getColumnName());
     firstKey.setTableUniqueId("1");
     firstKey.setData("FirstKey");
-    serverDictionaryGenerator.initializeGeneratorForTable(carbonTable);
+    serverDictionaryGenerator.initializeGeneratorForTable(carbonTable, CarbonTestUtil.configuration);
     Integer value = serverDictionaryGenerator.generateKey(firstKey);
     assertEquals(new Integer(2), value);
     DictionaryMessage secondKey = new DictionaryMessage();
@@ -129,7 +130,7 @@ public class ServerDictionaryGeneratorTest {
     firstKey.setColumnName(empColumnSchema.getColumnName());
     firstKey.setTableUniqueId("1");
     firstKey.setData("FirstKey");
-    serverDictionaryGenerator.initializeGeneratorForTable(carbonTable);
+    serverDictionaryGenerator.initializeGeneratorForTable(carbonTable, CarbonTestUtil.configuration);
     Integer value = serverDictionaryGenerator.generateKey(firstKey);
     assertEquals(new Integer(2), value);
     DictionaryMessage secondKey = new DictionaryMessage();
@@ -148,7 +149,7 @@ public class ServerDictionaryGeneratorTest {
     empKey.setData("FirstKey");
     empKey.setTableUniqueId("1");
     empKey.setColumnName(ageColumnSchema.getColumnName());
-    serverDictionaryGenerator.initializeGeneratorForTable(carbonTable);
+    serverDictionaryGenerator.initializeGeneratorForTable(carbonTable, CarbonTestUtil.configuration);
     serverDictionaryGenerator.generateKey(empKey);
     assertEquals(new Integer(2), serverDictionaryGenerator.size(empKey));
 
@@ -175,7 +176,7 @@ public class ServerDictionaryGeneratorTest {
     firstKey.setColumnName(empColumnSchema.getColumnName());
     firstKey.setTableUniqueId("1");
     firstKey.setData("FirstKey");
-    serverDictionaryGenerator.initializeGeneratorForTable(carbonTable);
+    serverDictionaryGenerator.initializeGeneratorForTable(carbonTable, CarbonTestUtil.configuration);
 
     //Update generator with a new dimension
 

--- a/core/src/test/java/org/apache/carbondata/core/dictionary/generator/TableDictionaryGeneratorTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/dictionary/generator/TableDictionaryGeneratorTest.java
@@ -31,6 +31,7 @@ import org.apache.carbondata.core.metadata.schema.table.TableSchema;
 import org.apache.carbondata.core.metadata.schema.table.column.CarbonDimension;
 import org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema;
 import org.apache.carbondata.core.util.CarbonProperties;
+import org.apache.carbondata.core.util.CarbonTestUtil;
 
 import org.junit.After;
 import org.junit.Before;
@@ -91,7 +92,7 @@ public class TableDictionaryGeneratorTest {
   }
 
   @Test public void generateKeyOnce() throws Exception {
-    TableDictionaryGenerator tableDictionaryGenerator = new TableDictionaryGenerator(carbonTable);
+    TableDictionaryGenerator tableDictionaryGenerator = new TableDictionaryGenerator(carbonTable, CarbonTestUtil.configuration);
 
     // Generate dictionary for one key
     DictionaryMessage empKey = new DictionaryMessage();
@@ -104,7 +105,7 @@ public class TableDictionaryGeneratorTest {
   }
 
   @Test public void generateKeyTwice() throws Exception {
-    TableDictionaryGenerator tableDictionaryGenerator = new TableDictionaryGenerator(carbonTable);
+    TableDictionaryGenerator tableDictionaryGenerator = new TableDictionaryGenerator(carbonTable, CarbonTestUtil.configuration);
 
     // Generate dictionary for same key twice
     DictionaryMessage firstKey = new DictionaryMessage();
@@ -123,7 +124,7 @@ public class TableDictionaryGeneratorTest {
   }
 
   @Test public void generateKeyAgain() throws Exception {
-    TableDictionaryGenerator tableDictionaryGenerator = new TableDictionaryGenerator(carbonTable);
+    TableDictionaryGenerator tableDictionaryGenerator = new TableDictionaryGenerator(carbonTable, CarbonTestUtil.configuration);
 
     // Generate dictionary for two different keys
     DictionaryMessage firstKey = new DictionaryMessage();
@@ -143,7 +144,7 @@ public class TableDictionaryGeneratorTest {
   }
 
   @Test public void updateGenerator() throws Exception {
-    TableDictionaryGenerator tableDictionaryGenerator = new TableDictionaryGenerator(carbonTable);
+    TableDictionaryGenerator tableDictionaryGenerator = new TableDictionaryGenerator(carbonTable, CarbonTestUtil.configuration);
     DictionaryMessage firstKey = new DictionaryMessage();
     firstKey.setColumnName(empColumnSchema.getColumnName());
     firstKey.setData("FirstKey");
@@ -163,7 +164,7 @@ public class TableDictionaryGeneratorTest {
   }
 
   @Test public void size() throws Exception {
-    TableDictionaryGenerator tableDictionaryGenerator = new TableDictionaryGenerator(carbonTable);
+    TableDictionaryGenerator tableDictionaryGenerator = new TableDictionaryGenerator(carbonTable, CarbonTestUtil.configuration);
     //Add keys for first Column
     DictionaryMessage empKey = new DictionaryMessage();
     //Add key 1
@@ -192,7 +193,7 @@ public class TableDictionaryGeneratorTest {
   }
 
   @Test public void writeDictionaryData() throws Exception {
-    TableDictionaryGenerator tableDictionaryGenerator = new TableDictionaryGenerator(carbonTable);
+    TableDictionaryGenerator tableDictionaryGenerator = new TableDictionaryGenerator(carbonTable, CarbonTestUtil.configuration);
     DictionaryMessage firstKey = new DictionaryMessage();
     firstKey.setColumnName(empColumnSchema.getColumnName());
     firstKey.setData("FirstKey");

--- a/core/src/test/java/org/apache/carbondata/core/reader/CarbonDictionaryReaderImplTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/reader/CarbonDictionaryReaderImplTest.java
@@ -29,6 +29,7 @@ import org.apache.carbondata.core.service.CarbonCommonFactory;
 import org.apache.carbondata.core.metadata.CarbonTableIdentifier;
 import org.apache.carbondata.core.metadata.ColumnIdentifier;
 import org.apache.carbondata.core.service.PathService;
+import org.apache.carbondata.core.util.CarbonTestUtil;
 import org.apache.carbondata.core.util.path.CarbonStorePath;
 
 import mockit.Mock;
@@ -52,9 +53,9 @@ public class CarbonDictionaryReaderImplTest {
     DictionaryColumnUniqueIdentifier dictionaryColumnUniqueIdentifier =
         new DictionaryColumnUniqueIdentifier(carbonTableIdentifier, columnIdentifier,
             columnIdentifier.getDataType(),
-        CarbonStorePath.getCarbonTablePath("storePath", carbonTableIdentifier));
+        CarbonStorePath.getCarbonTablePath("storePath", carbonTableIdentifier, CarbonTestUtil.configuration));
     carbonDictionaryReaderImpl =
-        new CarbonDictionaryReaderImpl("storePath", carbonTableIdentifier, dictionaryColumnUniqueIdentifier);
+        new CarbonDictionaryReaderImpl("storePath", carbonTableIdentifier, dictionaryColumnUniqueIdentifier, CarbonTestUtil.configuration);
   }
 
   @Test public void testRead() throws Exception {

--- a/core/src/test/java/org/apache/carbondata/core/reader/CarbonIndexFileReaderTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/reader/CarbonIndexFileReaderTest.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 
 import org.apache.carbondata.core.reader.CarbonIndexFileReader;
 import org.apache.carbondata.core.reader.ThriftReader;
+import org.apache.carbondata.core.util.CarbonTestUtil;
 import org.apache.carbondata.format.IndexHeader;
 
 import mockit.Mock;
@@ -44,7 +45,7 @@ public class CarbonIndexFileReaderTest {
       }
 
     };
-    carbonIndexFileReader.openThriftReader("TestFile.Carbon");
+    carbonIndexFileReader.openThriftReader(CarbonTestUtil.configuration, "TestFile.Carbon");
   }
 
   @AfterClass public static void cleanUp() {

--- a/core/src/test/java/org/apache/carbondata/core/reader/ThriftReaderTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/reader/ThriftReaderTest.java
@@ -20,6 +20,7 @@ package org.apache.carbondata.core.reader;
 import java.io.IOException;
 
 import org.apache.carbondata.core.reader.ThriftReader;
+import org.apache.carbondata.core.util.CarbonTestUtil;
 import org.apache.carbondata.format.ColumnDictionaryChunkMeta;
 
 import mockit.Mock;
@@ -36,7 +37,7 @@ public class ThriftReaderTest {
   private static ThriftReader thriftReader = null;
 
   @BeforeClass public static void setup() {
-    thriftReader = new ThriftReader("TestFile.carbon");
+    thriftReader = new ThriftReader(CarbonTestUtil.configuration, "TestFile.carbon");
   }
 
   @Test(expected = java.io.IOException.class) public void testReadForException()
@@ -54,7 +55,7 @@ public class ThriftReaderTest {
       }
 
     };
-    thriftReader = new ThriftReader("TestFile.carbon", tBaseCreator);
+    thriftReader = new ThriftReader(CarbonTestUtil.configuration, "TestFile.carbon", tBaseCreator);
     thriftReader.read();
   }
 

--- a/core/src/test/java/org/apache/carbondata/core/reader/sortindex/CarbonDictionarySortIndexReaderImplTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/reader/sortindex/CarbonDictionarySortIndexReaderImplTest.java
@@ -27,6 +27,7 @@ import org.apache.carbondata.core.metadata.CarbonTableIdentifier;
 import org.apache.carbondata.core.metadata.ColumnIdentifier;
 import org.apache.carbondata.core.datastore.filesystem.CarbonFile;
 import org.apache.carbondata.core.datastore.impl.FileFactory;
+import org.apache.carbondata.core.util.CarbonTestUtil;
 import org.apache.carbondata.core.util.CarbonUtil;
 import org.apache.carbondata.core.util.path.CarbonStorePath;
 import org.apache.carbondata.core.writer.CarbonDictionaryWriter;
@@ -65,13 +66,15 @@ public class CarbonDictionarySortIndexReaderImplTest {
     		UUID.randomUUID().toString());
     ColumnIdentifier columnIdentifier = new ColumnIdentifier("Name", null, null);
     DictionaryColumnUniqueIdentifier dictionaryColumnUniqueIdentifier = new DictionaryColumnUniqueIdentifier(carbonTableIdentifier, columnIdentifier, columnIdentifier.getDataType(),
-        CarbonStorePath.getCarbonTablePath(storePath, carbonTableIdentifier));
+        CarbonStorePath.getCarbonTablePath(storePath, carbonTableIdentifier,
+            CarbonTestUtil.configuration));
     CarbonDictionaryWriter dictionaryWriter = new CarbonDictionaryWriterImpl(storePath,
-       carbonTableIdentifier, dictionaryColumnUniqueIdentifier);
+       carbonTableIdentifier, dictionaryColumnUniqueIdentifier, CarbonTestUtil.configuration);
     String metaFolderPath =storePath+File.separator+carbonTableIdentifier.getDatabaseName()+File.separator+carbonTableIdentifier.getTableName()+File.separator+"Metadata";
-    CarbonUtil.checkAndCreateFolder(metaFolderPath);
+    CarbonUtil.checkAndCreateFolder(CarbonTestUtil.configuration, metaFolderPath);
     CarbonDictionarySortIndexWriter dictionarySortIndexWriter =
-        new CarbonDictionarySortIndexWriterImpl(carbonTableIdentifier, dictionaryColumnUniqueIdentifier, storePath);
+        new CarbonDictionarySortIndexWriterImpl(carbonTableIdentifier,
+            dictionaryColumnUniqueIdentifier, storePath, CarbonTestUtil.configuration);
     List<int[]> expectedData = prepareExpectedData();
     int[] data = expectedData.get(0);
     for(int i=0;i<data.length;i++) {
@@ -85,7 +88,7 @@ public class CarbonDictionarySortIndexReaderImplTest {
     dictionarySortIndexWriter.writeInvertedSortIndex(invertedSortIndex);
     dictionarySortIndexWriter.close();
     CarbonDictionarySortIndexReader dictionarySortIndexReader =
-        new CarbonDictionarySortIndexReaderImpl(carbonTableIdentifier, dictionaryColumnUniqueIdentifier, storePath);
+        new CarbonDictionarySortIndexReaderImpl(carbonTableIdentifier, dictionaryColumnUniqueIdentifier, storePath, CarbonTestUtil.configuration);
     List<Integer> actualSortIndex = dictionarySortIndexReader.readSortIndex();
     List<Integer> actualInvertedSortIndex = dictionarySortIndexReader.readInvertedSortIndex();
     for (int i = 0; i < actualSortIndex.size(); i++) {
@@ -114,7 +117,8 @@ public class CarbonDictionarySortIndexReaderImplTest {
    */
   private void deleteStorePath() {
     FileFactory.FileType fileType = FileFactory.getFileType(this.storePath);
-    CarbonFile carbonFile = FileFactory.getCarbonFile(this.storePath, fileType);
+    CarbonFile carbonFile =
+        FileFactory.getCarbonFile(CarbonTestUtil.configuration, this.storePath, fileType);
     deleteRecursiveSilent(carbonFile);
   }
 

--- a/core/src/test/java/org/apache/carbondata/core/util/CarbonMergerUtilTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/util/CarbonMergerUtilTest.java
@@ -21,6 +21,7 @@ import static junit.framework.TestCase.*;
 
 import mockit.Mock;
 import mockit.MockUp;
+import org.apache.hadoop.conf.Configuration;
 import org.junit.Test;
 
 import static org.apache.carbondata.core.util.CarbonMergerUtil.getCardinalityFromLevelMetadata;
@@ -31,11 +32,11 @@ public class CarbonMergerUtilTest {
     final int[] localCardinality = { 1, 2, 3, 4, 5, 6 };
     new MockUp<CarbonUtil>() {
       @SuppressWarnings("unused") @Mock
-      public int[] getCardinalityFromLevelMetadataFile(String levelPath) {
+      public int[] getCardinalityFromLevelMetadataFile(Configuration configuration, String levelPath) {
         return localCardinality;
       }
     };
-    int[] result = getCardinalityFromLevelMetadata("STORE_PATH", "table1");
+    int[] result = getCardinalityFromLevelMetadata(CarbonTestUtil.configuration, "STORE_PATH", "table1");
     assertEquals(result, localCardinality);
   }
 }

--- a/core/src/test/java/org/apache/carbondata/core/util/CarbonTestUtil.java
+++ b/core/src/test/java/org/apache/carbondata/core/util/CarbonTestUtil.java
@@ -21,7 +21,11 @@ import org.apache.carbondata.core.datastore.page.encoding.ColumnPageEncoderMeta;
 import org.apache.carbondata.core.metadata.ColumnarFormatVersion;
 import org.apache.carbondata.core.metadata.ValueEncoderMeta;
 
+import org.apache.hadoop.conf.Configuration;
+
 public class CarbonTestUtil {
+
+  public static Configuration configuration = new Configuration();
 
   public static ValueEncoderMeta createValueEncoderMeta() {
     ColumnarFormatVersion version =

--- a/core/src/test/java/org/apache/carbondata/core/util/CarbonUtilTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/util/CarbonUtilTest.java
@@ -47,6 +47,7 @@ import org.apache.carbondata.core.scan.model.QueryDimension;
 
 import mockit.Mock;
 import mockit.MockUp;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -308,7 +309,7 @@ public class CarbonUtilTest {
 
   @Test public void testToGetCardinalityFromLevelMetadataFileForInvalidPath()
       throws IOException, InterruptedException {
-    int[] cardinality = CarbonUtil.getCardinalityFromLevelMetadataFile("");
+    int[] cardinality = CarbonUtil.getCardinalityFromLevelMetadataFile(CarbonTestUtil.configuration, "");
     assertEquals(cardinality, null);
   }
 
@@ -342,7 +343,7 @@ public class CarbonUtilTest {
         return "BASE_URL";
       }
     };
-    String hdfsURL = CarbonUtil.checkAndAppendHDFSUrl("../core/src/test/resources/testDatabase");
+    String hdfsURL = CarbonUtil.checkAndAppendHDFSUrl(CarbonTestUtil.configuration, "../core/src/test/resources/testDatabase");
     assertEquals(hdfsURL, "file:///BASE_URL/../core/src/test/resources/testDatabase");
   }
 
@@ -357,7 +358,7 @@ public class CarbonUtilTest {
         return "BASE_URL/";
       }
     };
-    String hdfsURL = CarbonUtil.checkAndAppendHDFSUrl("../core/src/test/resources/testDatabase");
+    String hdfsURL = CarbonUtil.checkAndAppendHDFSUrl(CarbonTestUtil.configuration, "../core/src/test/resources/testDatabase");
     assertEquals(hdfsURL, "file:///BASE_URL/../core/src/test/resources/testDatabase");
   }
 
@@ -372,7 +373,7 @@ public class CarbonUtilTest {
         return null;
       }
     };
-    String hdfsURL = CarbonUtil.checkAndAppendHDFSUrl("../core/src/test/resources/testDatabase");
+    String hdfsURL = CarbonUtil.checkAndAppendHDFSUrl(CarbonTestUtil.configuration, "../core/src/test/resources/testDatabase");
     assertEquals(hdfsURL, "file:////../core/src/test/resources/testDatabase");
   }
 
@@ -387,7 +388,7 @@ public class CarbonUtilTest {
         return "hdfs://";
       }
     };
-    String hdfsURL = CarbonUtil.checkAndAppendHDFSUrl("hdfs://ha/core/src/test/resources/testDatabase");
+    String hdfsURL = CarbonUtil.checkAndAppendHDFSUrl(CarbonTestUtil.configuration, "hdfs://ha/core/src/test/resources/testDatabase");
     assertEquals(hdfsURL, "hdfs://ha/core/src/test/resources/testDatabase");
   }
 
@@ -402,7 +403,7 @@ public class CarbonUtilTest {
         return "/opt/";
       }
     };
-    String hdfsURL = CarbonUtil.checkAndAppendHDFSUrl("/core/src/test/resources/testDatabase");
+    String hdfsURL = CarbonUtil.checkAndAppendHDFSUrl(CarbonTestUtil.configuration, "/core/src/test/resources/testDatabase");
     assertEquals(hdfsURL, "file:////opt/core/src/test/resources/testDatabase");
   }
 
@@ -422,7 +423,7 @@ public class CarbonUtilTest {
         return "/opt/";
       }
     };
-    String hdfsURL = CarbonUtil.checkAndAppendHDFSUrl("/core/src/test/resources/testDatabase");
+    String hdfsURL = CarbonUtil.checkAndAppendHDFSUrl(CarbonTestUtil.configuration, "/core/src/test/resources/testDatabase");
     assertEquals(hdfsURL, "hdfs:///opt/core/src/test/resources/testDatabase");
   }
 
@@ -437,7 +438,7 @@ public class CarbonUtilTest {
         return "hdfs://ha/opt/";
       }
     };
-    String hdfsURL = CarbonUtil.checkAndAppendHDFSUrl("/core/src/test/resources/testDatabase");
+    String hdfsURL = CarbonUtil.checkAndAppendHDFSUrl(CarbonTestUtil.configuration, "/core/src/test/resources/testDatabase");
     assertEquals(hdfsURL, "hdfs://ha/opt/core/src/test/resources/testDatabase");
   }
 
@@ -452,17 +453,17 @@ public class CarbonUtilTest {
         return "file:///";
       }
     };
-    String hdfsURL = CarbonUtil.checkAndAppendHDFSUrl("/core/src/test/resources/testDatabase");
+    String hdfsURL = CarbonUtil.checkAndAppendHDFSUrl(CarbonTestUtil.configuration, "/core/src/test/resources/testDatabase");
     assertEquals(hdfsURL, "file:///core/src/test/resources/testDatabase");
   }
 
   @Test public void testToCheckAndAppendHDFSUrlWithFilepathPrefix() {
-    String hdfsURL = CarbonUtil.checkAndAppendHDFSUrl("file:///core/src/test/resources/testDatabase");
+    String hdfsURL = CarbonUtil.checkAndAppendHDFSUrl(CarbonTestUtil.configuration, "file:///core/src/test/resources/testDatabase");
     assertEquals(hdfsURL, "file:///core/src/test/resources/testDatabase");
   }
 
   @Test public void testForisFileExists() {
-    assertTrue(CarbonUtil.isFileExists("../core/src/test/resources/testFile.txt"));
+    assertTrue(CarbonUtil.isFileExists(CarbonTestUtil.configuration, "../core/src/test/resources/testFile.txt"));
   }
 
   @Test public void testForisFileExistsWithException() {
@@ -472,12 +473,12 @@ public class CarbonUtilTest {
         throw new IOException();
       }
     };
-    assertTrue(!CarbonUtil.isFileExists("../core/src/test/resources/testFile.txt"));
+    assertTrue(!CarbonUtil.isFileExists(CarbonTestUtil.configuration, "../core/src/test/resources/testFile.txt"));
   }
 
   @Test public void testToCheckAndCreateFolder() {
-    boolean exists = CarbonUtil.checkAndCreateFolder("../core/src/test/resources/testDatabase");
-    boolean created = CarbonUtil.checkAndCreateFolder("../core/src/test/resources/newDatabase");
+    boolean exists = CarbonUtil.checkAndCreateFolder(CarbonTestUtil.configuration, "../core/src/test/resources/testDatabase");
+    boolean created = CarbonUtil.checkAndCreateFolder(CarbonTestUtil.configuration, "../core/src/test/resources/newDatabase");
     assertTrue(exists);
     assertTrue(created);
   }
@@ -489,12 +490,12 @@ public class CarbonUtilTest {
         throw new IOException();
       }
     };
-    boolean exists = CarbonUtil.checkAndCreateFolder("../core/src/test/resources/testDatabase1");
+    boolean exists = CarbonUtil.checkAndCreateFolder(CarbonTestUtil.configuration, "../core/src/test/resources/testDatabase1");
     assertTrue(!exists);
   }
 
   @Test public void testToGetFileSize() {
-    assertEquals(CarbonUtil.getFileSize("../core/src/test/resources/testFile.txt"), 0);
+    assertEquals(CarbonUtil.getFileSize(CarbonTestUtil.configuration, "../core/src/test/resources/testFile.txt"), 0);
   }
 
   @Test public void testForHasEncoding() {
@@ -603,7 +604,7 @@ public class CarbonUtilTest {
     TableBlockInfo info =
         new TableBlockInfo("file:/", 1, "0", new String[0], 1, ColumnarFormatVersion.V1, null);
 
-    assertEquals(CarbonUtil.readMetadatFile(info).getVersionId().number(), 1);
+    assertEquals(CarbonUtil.readMetadatFile(info, CarbonTestUtil.configuration).getVersionId().number(), 1);
   }
 
   @Test(expected = IOException.class)
@@ -611,7 +612,7 @@ public class CarbonUtilTest {
       throws Exception {
     TableBlockInfo info =
         new TableBlockInfo("file:/", 1, "0", new String[0], 1, ColumnarFormatVersion.V1, null);
-    CarbonUtil.readMetadatFile(info);
+    CarbonUtil.readMetadatFile(info, CarbonTestUtil.configuration);
   }
 
   @Test public void testToFindDimension() {
@@ -671,7 +672,7 @@ public class CarbonUtilTest {
     FileWriter writer = new FileWriter(file);
     writer.write("id,name");
     writer.flush();
-    String headers = CarbonUtil.readHeader("../core/src/test/resources/sampleCSV.csv");
+    String headers = CarbonUtil.readHeader(CarbonTestUtil.configuration, "../core/src/test/resources/sampleCSV.csv");
     assertEquals(headers, "id,name");
     file.deleteOnExit();
   }
@@ -680,12 +681,12 @@ public class CarbonUtilTest {
   public void testToReadHeaderWithFileNotFoundException() throws IOException {
     new MockUp<FileFactory>() {
       @SuppressWarnings("unused") @Mock
-      public DataInputStream getDataInputStream(String path, FileFactory.FileType fileType)
+      public DataInputStream getDataInputStream(Configuration configuration, String path, FileFactory.FileType fileType)
           throws FileNotFoundException {
         throw new FileNotFoundException();
       }
     };
-    String result = CarbonUtil.readHeader("../core/src/test/resources/sampleCSV");
+    String result = CarbonUtil.readHeader(CarbonTestUtil.configuration, "../core/src/test/resources/sampleCSV");
     assertEquals(null, result);
   }
 
@@ -693,12 +694,12 @@ public class CarbonUtilTest {
   public void testToReadHeaderWithIOException() throws IOException {
     new MockUp<FileFactory>() {
       @SuppressWarnings("unused") @Mock
-      public DataInputStream getDataInputStream(String path, FileFactory.FileType fileType)
+      public DataInputStream getDataInputStream(Configuration configuration, String path, FileFactory.FileType fileType)
           throws IOException {
         throw new IOException();
       }
     };
-    String result = CarbonUtil.readHeader("../core/src/test/resources/sampleCSV.csv");
+    String result = CarbonUtil.readHeader(CarbonTestUtil.configuration, "../core/src/test/resources/sampleCSV.csv");
     assertEquals(null, result);
   }
 

--- a/core/src/test/java/org/apache/carbondata/core/util/DataFileFooterConverterTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/util/DataFileFooterConverterTest.java
@@ -33,6 +33,7 @@ import org.apache.carbondata.core.reader.ThriftReader;
 import org.apache.carbondata.format.*;
 import org.apache.carbondata.format.ColumnSchema;
 
+import org.apache.hadoop.conf.Configuration;
 import org.junit.Test;
 
 import java.nio.ByteBuffer;
@@ -47,8 +48,8 @@ import static junit.framework.TestCase.*;
 public class DataFileFooterConverterTest {
 
   @Test public void testGetIndexInfo() throws Exception {
-    DataFileFooterConverter dataFileFooterConverter = new DataFileFooterConverter();
-    final ThriftReader thriftReader = new ThriftReader("file");
+    DataFileFooterConverter dataFileFooterConverter = new DataFileFooterConverter(CarbonTestUtil.configuration);
+    final ThriftReader thriftReader = new ThriftReader(CarbonTestUtil.configuration, "file");
     List<Encoding> encoders = new ArrayList<>();
     encoders.add(Encoding.INVERTED_INDEX);
     encoders.add(Encoding.BIT_PACKED);
@@ -109,7 +110,7 @@ public class DataFileFooterConverterTest {
         return temp;
       }
 
-      @SuppressWarnings("unused") @Mock public void openThriftReader(String filePath)
+      @SuppressWarnings("unused") @Mock public void openThriftReader(Configuration configuration, String filePath)
           throws IOException {
         thriftReader.open();
       }
@@ -136,7 +137,7 @@ public class DataFileFooterConverterTest {
     final DataInputStream dataInputStream = new DataInputStream(byteArrayInputStream);
     new MockUp<FileFactory>() {
       @SuppressWarnings("unused") @Mock
-      public DataInputStream getDataInputStream(String path, FileFactory.FileType fileType,
+      public DataInputStream getDataInputStream(Configuration configuration, String path, FileFactory.FileType fileType,
           int bufferSize) {
         return dataInputStream;
       }
@@ -159,7 +160,7 @@ public class DataFileFooterConverterTest {
   }
 
   @Test public void testReadDataFileFooter() throws Exception {
-    DataFileFooterConverter dataFileFooterConverter = new DataFileFooterConverter();
+    DataFileFooterConverter dataFileFooterConverter = new DataFileFooterConverter(CarbonTestUtil.configuration);
     DataFileFooter dataFileFooter = new DataFileFooter();
     List<Integer> column_cardinalities = new ArrayList<>();
     column_cardinalities.add(new Integer("1"));
@@ -223,7 +224,7 @@ public class DataFileFooterConverterTest {
       }
 
       @SuppressWarnings("unused") @Mock
-      public FileHolder getFileHolder(FileFactory.FileType fileType) {
+      public FileHolder getFileHolder(Configuration configuration, FileFactory.FileType fileType) {
         return new FileHolderImpl();
       }
 

--- a/core/src/test/java/org/apache/carbondata/core/util/path/CarbonFormatDirectoryStructureTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/util/path/CarbonFormatDirectoryStructureTest.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.util.UUID;
 
 import org.apache.carbondata.core.metadata.CarbonTableIdentifier;
+import org.apache.carbondata.core.util.CarbonTestUtil;
 
 import org.junit.Test;
 
@@ -39,7 +40,7 @@ public class CarbonFormatDirectoryStructureTest {
   @Test public void testTablePathStructure() throws IOException {
     CarbonTableIdentifier tableIdentifier = new CarbonTableIdentifier("d1", "t1", UUID.randomUUID().toString());
     CarbonStorePath carbonStorePath = new CarbonStorePath(CARBON_STORE);
-    CarbonTablePath carbonTablePath = carbonStorePath.getCarbonTablePath(tableIdentifier);
+    CarbonTablePath carbonTablePath = carbonStorePath.getCarbonTablePath(tableIdentifier, CarbonTestUtil.configuration);
     assertTrue(carbonTablePath.getPath().replace("\\", "/").equals(CARBON_STORE + "/d1/t1"));
     assertTrue(carbonTablePath.getSchemaFilePath().replace("\\", "/").equals(CARBON_STORE + "/d1/t1/Metadata/schema"));
     assertTrue(carbonTablePath.getTableStatusFilePath().replace("\\", "/")

--- a/core/src/test/java/org/apache/carbondata/core/writer/CarbonDictionaryWriterImplTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/writer/CarbonDictionaryWriterImplTest.java
@@ -35,6 +35,7 @@ import java.util.UUID;
 import org.apache.carbondata.core.cache.dictionary.DictionaryColumnUniqueIdentifier;
 import org.apache.carbondata.core.metadata.CarbonTableIdentifier;
 import org.apache.carbondata.core.metadata.ColumnIdentifier;
+import org.apache.carbondata.core.util.CarbonTestUtil;
 import org.apache.carbondata.core.util.path.CarbonStorePath;
 import org.apache.carbondata.core.util.path.CarbonTablePath;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
@@ -103,7 +104,7 @@ public class CarbonDictionaryWriterImplTest {
     this.dictionaryColumnUniqueIdentifier =
         new DictionaryColumnUniqueIdentifier(carbonTableIdentifier, columnIdentifier,
             columnIdentifier.getDataType(),
-            CarbonStorePath.getCarbonTablePath(carbonStorePath, carbonTableIdentifier));
+            CarbonStorePath.getCarbonTablePath(carbonStorePath, carbonTableIdentifier, CarbonTestUtil.configuration));
     deleteStorePath();
     prepareDataSet();
   }
@@ -153,7 +154,7 @@ public class CarbonDictionaryWriterImplTest {
     CarbonDictionaryWriterImpl writer = prepareWriter();
     writeDictionaryFile(writer, dataSet1);
     // record file size from where data has to be read
-    long end_offset = CarbonUtil.getFileSize(this.dictionaryFilePath);
+    long end_offset = CarbonUtil.getFileSize(CarbonTestUtil.configuration, this.dictionaryFilePath);
     // read metadata chunks from file
     List<CarbonDictionaryColumnMetaChunk> carbonDictionaryColumnMetaChunks =
         readDictionaryMetadataFile();
@@ -184,7 +185,7 @@ public class CarbonDictionaryWriterImplTest {
   private CarbonDictionaryWriterImpl prepareWriter() throws IOException {
     initDictionaryDirPaths();
     return new CarbonDictionaryWriterImpl(this.carbonStorePath, carbonTableIdentifier,
-        dictionaryColumnUniqueIdentifier);
+        dictionaryColumnUniqueIdentifier, CarbonTestUtil.configuration);
   }
 
   /**
@@ -222,7 +223,7 @@ public class CarbonDictionaryWriterImplTest {
     // prepare dictionary writer object
     CarbonDictionaryWriterImpl writer = prepareWriter();
     writeDictionaryFile(writer, dataSet1);
-    long endOffsetAfterFirstDictionaryChunk = CarbonUtil.getFileSize(dictionaryFilePath);
+    long endOffsetAfterFirstDictionaryChunk = CarbonUtil.getFileSize(CarbonTestUtil.configuration, dictionaryFilePath);
     // maintain the offset till end offset of first chunk
     writer = prepareWriter();
     writeDictionaryFile(writer, dataSet2);
@@ -249,7 +250,7 @@ public class CarbonDictionaryWriterImplTest {
    */
   private void overwriteDictionaryMetaFile(ColumnDictionaryChunkMeta firstDictionaryChunkMeta,
       String dictionaryFile) throws IOException {
-    ThriftWriter thriftMetaChunkWriter = new ThriftWriter(dictionaryFile, false);
+    ThriftWriter thriftMetaChunkWriter = new ThriftWriter(CarbonTestUtil.configuration, dictionaryFile, false);
     try {
       thriftMetaChunkWriter.open();
       thriftMetaChunkWriter.write(firstDictionaryChunkMeta);
@@ -276,7 +277,7 @@ public class CarbonDictionaryWriterImplTest {
     // write dataset2
     writeDictionaryFile(writer, dataSet2);
     // record the offset from where data has to be read
-    long dictionaryFileOffsetToRead = CarbonUtil.getFileSize(this.dictionaryFilePath);
+    long dictionaryFileOffsetToRead = CarbonUtil.getFileSize(CarbonTestUtil.configuration, this.dictionaryFilePath);
     // prepare writer to write dataset3
     writer = prepareWriter();
     // write dataset 3
@@ -305,13 +306,13 @@ public class CarbonDictionaryWriterImplTest {
     // write dataset1 data
     writeDictionaryFile(writer, dataSet1);
     // record dictionary file start offset
-    long dictionaryStartOffset = CarbonUtil.getFileSize(this.dictionaryFilePath);
+    long dictionaryStartOffset = CarbonUtil.getFileSize(CarbonTestUtil.configuration, this.dictionaryFilePath);
     // prepare the writer to write dataset2
     writer = prepareWriter();
     // write dataset2
     writeDictionaryFile(writer, dataSet2);
     // record the end offset for dictionary file
-    long dictionaryFileEndOffset = CarbonUtil.getFileSize(this.dictionaryFilePath);
+    long dictionaryFileEndOffset = CarbonUtil.getFileSize(CarbonTestUtil.configuration, this.dictionaryFilePath);
     // prepare writer to write dataset3
     writer = prepareWriter();
     // write dataset 3
@@ -376,7 +377,7 @@ public class CarbonDictionaryWriterImplTest {
     //write metadata
     writer.commit();
     // record end offset of file
-    long end_offset = CarbonUtil.getFileSize(this.dictionaryFilePath);
+    long end_offset = CarbonUtil.getFileSize(CarbonTestUtil.configuration, this.dictionaryFilePath);
     // read dictionary chunk from dictionary file
     List<byte[]> dictionaryData = readDictionaryFile(0L, 0L);
     // prepare the retrieved data
@@ -439,7 +440,7 @@ public class CarbonDictionaryWriterImplTest {
   private List<CarbonDictionaryColumnMetaChunk> readDictionaryMetadataFile() throws IOException {
     CarbonDictionaryMetadataReaderImpl columnMetadataReaderImpl =
         new CarbonDictionaryMetadataReaderImpl(this.carbonStorePath, this.carbonTableIdentifier,
-            this.dictionaryColumnUniqueIdentifier);
+            this.dictionaryColumnUniqueIdentifier, CarbonTestUtil.configuration);
     List<CarbonDictionaryColumnMetaChunk> dictionaryMetaChunkList = null;
     // read metadata file
     try {
@@ -458,7 +459,7 @@ public class CarbonDictionaryWriterImplTest {
       throws IOException {
     CarbonDictionaryReaderImpl dictionaryReader =
         new CarbonDictionaryReaderImpl(this.carbonStorePath, this.carbonTableIdentifier,
-            this.dictionaryColumnUniqueIdentifier);
+            this.dictionaryColumnUniqueIdentifier, CarbonTestUtil.configuration);
     List<byte[]> dictionaryValues = new ArrayList<>(CarbonCommonConstants.DEFAULT_COLLECTION_SIZE);
     try {
       if (0 == dictionaryEndOffset) {
@@ -480,7 +481,7 @@ public class CarbonDictionaryWriterImplTest {
    */
   private void deleteStorePath() {
     FileFactory.FileType fileType = FileFactory.getFileType(this.carbonStorePath);
-    CarbonFile carbonFile = FileFactory.getCarbonFile(this.carbonStorePath, fileType);
+    CarbonFile carbonFile = FileFactory.getCarbonFile(CarbonTestUtil.configuration, this.carbonStorePath, fileType);
     deleteRecursiveSilent(carbonFile);
   }
 
@@ -529,11 +530,11 @@ public class CarbonDictionaryWriterImplTest {
    */
   private void initDictionaryDirPaths() throws IOException {
     CarbonTablePath carbonTablePath =
-        CarbonStorePath.getCarbonTablePath(this.carbonStorePath, carbonTableIdentifier);
+        CarbonStorePath.getCarbonTablePath(this.carbonStorePath, carbonTableIdentifier, CarbonTestUtil.configuration);
     String dictionaryLocation = carbonTablePath.getMetadataDirectoryPath();
     FileFactory.FileType fileType = FileFactory.getFileType(dictionaryLocation);
-    if(!FileFactory.isFileExist(dictionaryLocation, fileType)) {
-      FileFactory.mkdirs(dictionaryLocation, fileType);
+    if(!FileFactory.isFileExist(CarbonTestUtil.configuration, dictionaryLocation, fileType)) {
+      FileFactory.mkdirs(CarbonTestUtil.configuration, dictionaryLocation, fileType);
     }
     this.dictionaryFilePath = carbonTablePath.getDictionaryFilePath(columnIdentifier.getColumnId());
     this.dictionaryMetaFilePath = carbonTablePath.getDictionaryMetaFilePath(columnIdentifier.getColumnId());

--- a/core/src/test/java/org/apache/carbondata/core/writer/sortindex/CarbonDictionarySortIndexWriterImplTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/writer/sortindex/CarbonDictionarySortIndexWriterImplTest.java
@@ -27,6 +27,7 @@ import org.apache.carbondata.core.metadata.CarbonTableIdentifier;
 import org.apache.carbondata.core.metadata.ColumnIdentifier;
 import org.apache.carbondata.core.reader.sortindex.CarbonDictionarySortIndexReader;
 import org.apache.carbondata.core.reader.sortindex.CarbonDictionarySortIndexReaderImpl;
+import org.apache.carbondata.core.util.CarbonTestUtil;
 import org.apache.carbondata.core.util.CarbonUtil;
 import org.apache.carbondata.core.util.path.CarbonStorePath;
 import org.apache.carbondata.core.writer.CarbonDictionaryWriter;
@@ -56,13 +57,13 @@ public class CarbonDictionarySortIndexWriterImplTest {
         new CarbonTableIdentifier("testSchema", "carbon", UUID.randomUUID().toString());
     columnIdentifier = new ColumnIdentifier("Name", null, null);
     DictionaryColumnUniqueIdentifier dictionaryColumnUniqueIdentifier = new DictionaryColumnUniqueIdentifier(carbonTableIdentifier, columnIdentifier, columnIdentifier.getDataType(),
-        CarbonStorePath.getCarbonTablePath(storePath, carbonTableIdentifier));
+        CarbonStorePath.getCarbonTablePath(storePath, carbonTableIdentifier, CarbonTestUtil.configuration));
     dictionaryWriter =
-        new CarbonDictionaryWriterImpl(storePath, carbonTableIdentifier, dictionaryColumnUniqueIdentifier);
+        new CarbonDictionaryWriterImpl(storePath, carbonTableIdentifier, dictionaryColumnUniqueIdentifier, CarbonTestUtil.configuration);
     dictionarySortIndexWriter =
-        new CarbonDictionarySortIndexWriterImpl(carbonTableIdentifier, dictionaryColumnUniqueIdentifier, storePath);
+        new CarbonDictionarySortIndexWriterImpl(carbonTableIdentifier, dictionaryColumnUniqueIdentifier, storePath, CarbonTestUtil.configuration);
     carbonDictionarySortIndexReader =
-        new CarbonDictionarySortIndexReaderImpl(carbonTableIdentifier, dictionaryColumnUniqueIdentifier, storePath);
+        new CarbonDictionarySortIndexReaderImpl(carbonTableIdentifier, dictionaryColumnUniqueIdentifier, storePath, CarbonTestUtil.configuration);
   }
 
   /**
@@ -76,7 +77,7 @@ public class CarbonDictionarySortIndexWriterImplTest {
     String metaFolderPath =
         storePath + File.separator + carbonTableIdentifier.getDatabaseName() + File.separator
             + carbonTableIdentifier.getTableName() + File.separator + "Metadata";
-    CarbonUtil.checkAndCreateFolder(metaFolderPath);
+    CarbonUtil.checkAndCreateFolder(CarbonTestUtil.configuration, metaFolderPath);
 
     List<int[]> indexList = prepareExpectedData();
     int[] data = indexList.get(0);

--- a/examples/spark/pom.xml
+++ b/examples/spark/pom.xml
@@ -35,6 +35,44 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-aws</artifactId>
+      <version>${hadoop.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-annotations</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk</artifactId>
+      <version>1.7.4</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-annotations</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>org.apache.carbondata</groupId>
       <artifactId>carbondata-spark</artifactId>
       <version>${project.version}</version>

--- a/examples/spark/src/main/scala/org/apache/carbondata/examples/AllDictionaryExample.scala
+++ b/examples/spark/src/main/scala/org/apache/carbondata/examples/AllDictionaryExample.scala
@@ -61,7 +61,7 @@ object AllDictionaryExample {
     cc.sql("DROP TABLE IF EXISTS t3")
 
     // clean local dictionary files
-    AllDictionaryUtil.cleanDictionary(allDictFile)
+    AllDictionaryUtil.cleanDictionary(cc.sparkContext.hadoopConfiguration, allDictFile)
   }
 
 }

--- a/examples/spark/src/main/scala/org/apache/carbondata/examples/AlluxioExample.scala
+++ b/examples/spark/src/main/scala/org/apache/carbondata/examples/AlluxioExample.scala
@@ -34,7 +34,6 @@ object AlluxioExample {
   def main(args: Array[String]) {
     val cc = ExampleUtils.createCarbonContext("AlluxioExample")
     cc.sparkContext.hadoopConfiguration.set("fs.alluxio.impl", "alluxio.hadoop.FileSystem")
-    FileFactory.getConfiguration.set("fs.alluxio.impl", "alluxio.hadoop.FileSystem")
 
     // Specify date format based on raw data
     CarbonProperties.getInstance()

--- a/examples/spark/src/main/scala/org/apache/carbondata/examples/CarbonS3Example.scala
+++ b/examples/spark/src/main/scala/org/apache/carbondata/examples/CarbonS3Example.scala
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.examples
+
+import java.io.File
+
+import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.sql.CarbonContext
+
+import org.apache.carbondata.core.constants.CarbonCommonConstants
+import org.apache.carbondata.core.util.CarbonProperties
+/**
+ *
+ */
+object CarbonS3Example {
+
+  def main(args: Array[String]) {
+    if (args.length < 5) {
+      System.err.println("Require 5 parameters")
+      System.err.println("Usage: java CarbonS3Example <fs.s3a.endpoint> <fs.s3a.access.key>" +
+                       " <fs.s3a.secret.key> <fs.s3a.impl> <carbon store location>")
+      return
+    }
+
+    val rootPath = new File(this.getClass.getResource("/").getPath
+                            + "../../../..").getCanonicalPath
+
+    val sc = new SparkContext(new SparkConf()
+      .setAppName("CarbonS3Example")
+      .setMaster("local[2]"))
+
+    sc.hadoopConfiguration.set("fs.s3a.endpoint", args(0))
+    sc.hadoopConfiguration.set("fs.s3a.access.key", args(1))
+    sc.hadoopConfiguration.set("fs.s3a.secret.key", args(2))
+    sc.hadoopConfiguration.set("fs.s3a.impl", args(3))
+
+    val storeLocation = args(4)
+    val metastoredb = s"$rootPath/examples/spark/target"
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, "yyyy/MM/dd HH:mm:ss")
+      .addProperty(CarbonCommonConstants.CARBON_DATE_FORMAT, "yyyy/MM/dd")
+      .addProperty(CarbonCommonConstants.ENABLE_UNSAFE_COLUMN_PAGE_LOADING, "true")
+      .addProperty(CarbonCommonConstants.LOCK_TYPE, "HDFSLOCK")
+      .addProperty("carbon.storelocation", storeLocation)
+
+    val spark = new CarbonContext(sc, storeLocation, metastoredb)
+    spark.sql("drop table if exists t3")
+
+    // Create table
+    spark.sql(
+      s"""
+         | CREATE TABLE IF NOT EXISTS t3
+         | (ID Int, date Date, country String,
+         |  name String, phonetype String, serialname char(10), salary Int)
+         | STORED BY 'carbondata'
+       """.stripMargin)
+
+    val path = s"$rootPath/examples/spark/src/main/resources/data.csv"
+
+    // scalastyle:off
+    spark.sql(
+      s"""
+         | LOAD DATA LOCAL INPATH '$path'
+         | INTO TABLE t3
+         | OPTIONS('HEADER'='true')
+       """.stripMargin)
+
+    spark.sql(
+      s"""
+         | LOAD DATA LOCAL INPATH '$path'
+         | INTO TABLE t3
+         | OPTIONS('HEADER'='true')
+       """.stripMargin)
+    // scalastyle:on
+
+    spark.sql(
+      s"""
+        | SELECT *
+        | FROM t3
+      """.stripMargin).show()
+
+    spark.sql(
+      s"""
+         | SELECT *
+         | FROM t3
+         | where id = 1
+      """.stripMargin).show()
+
+    spark.sql(
+      s"""
+         | SELECT count(*)
+         | FROM t3
+      """.stripMargin).show()
+  }
+
+}

--- a/examples/spark/src/main/scala/org/apache/carbondata/examples/CarbonS3Example.scala
+++ b/examples/spark/src/main/scala/org/apache/carbondata/examples/CarbonS3Example.scala
@@ -31,9 +31,11 @@ object CarbonS3Example {
 
   def main(args: Array[String]) {
     if (args.length < 5) {
+      // scalastyle:off println
       System.err.println("Require 5 parameters")
       System.err.println("Usage: java CarbonS3Example <fs.s3a.endpoint> <fs.s3a.access.key>" +
                        " <fs.s3a.secret.key> <fs.s3a.impl> <carbon store location>")
+      // scalastyle:on println
       return
     }
 

--- a/examples/spark/src/main/scala/org/apache/carbondata/examples/GenerateDictionaryExample.scala
+++ b/examples/spark/src/main/scala/org/apache/carbondata/examples/GenerateDictionaryExample.scala
@@ -38,7 +38,8 @@ object GenerateDictionaryExample {
     val cc = ExampleUtils.createCarbonContext("GenerateDictionaryExample")
     val factFilePath = ExampleUtils.currentPath + "/src/main/resources/factSample.csv"
     val carbonTablePath = CarbonStorePath.getCarbonTablePath(ExampleUtils.storeLocation,
-      new CarbonTableIdentifier(CarbonCommonConstants.DATABASE_DEFAULT_NAME, "dictSample", "1"))
+      new CarbonTableIdentifier(CarbonCommonConstants.DATABASE_DEFAULT_NAME, "dictSample", "1"),
+      cc.sparkContext.hadoopConfiguration)
     val dictFolderPath = carbonTablePath.getMetadataDirectoryPath
 
     // execute sql statement
@@ -78,9 +79,11 @@ object GenerateDictionaryExample {
       println(s"Key\t\t\tValue")
       val columnIdentifier = new DictionaryColumnUniqueIdentifier(carbonTableIdentifier,
         dimension.getColumnIdentifier, dimension.getDataType,
-        CarbonStorePath
-          .getCarbonTablePath(carbonTable.getStorePath, carbonTable.getCarbonTableIdentifier))
-      val dict = CarbonLoaderUtil.getDictionary(columnIdentifier, cc.storePath)
+        CarbonStorePath.getCarbonTablePath(carbonTable.getStorePath,
+          carbonTable.getCarbonTableIdentifier,
+          cc.sparkContext.hadoopConfiguration))
+      val dict = CarbonLoaderUtil.getDictionary(columnIdentifier, cc.storePath,
+        cc.sparkContext.hadoopConfiguration)
       var index: Int = 1
       var distinctValue = dict.getDictionaryValueForKey(index)
       while (distinctValue != null) {

--- a/examples/spark/src/main/scala/org/apache/carbondata/examples/util/AllDictionaryUtil.scala
+++ b/examples/spark/src/main/scala/org/apache/carbondata/examples/util/AllDictionaryUtil.scala
@@ -21,6 +21,7 @@ import java.io.DataOutputStream
 
 import scala.collection.mutable.{ArrayBuffer, HashSet}
 
+import org.apache.hadoop.conf.Configuration
 import org.apache.spark.SparkContext
 
 import org.apache.carbondata.common.logging.LogServiceFactory
@@ -64,13 +65,13 @@ object AllDictionaryUtil {
       distinctValues
     })
     val dictionaryValues = dictionaryRdd.map(x => x._1 + "," + x._2).collect()
-    saveToFile(dictionaryValues, outputPath)
+    saveToFile(sc.hadoopConfiguration, dictionaryValues, outputPath)
   }
 
-  def cleanDictionary(outputPath: String): Unit = {
+  def cleanDictionary(hadoopConf: Configuration, outputPath: String): Unit = {
     try {
       val fileType = FileFactory.getFileType(outputPath)
-      val file = FileFactory.getCarbonFile(outputPath, fileType)
+      val file = FileFactory.getCarbonFile(hadoopConf, outputPath, fileType)
       if (file.exists()) {
         file.delete()
       }
@@ -80,15 +81,15 @@ object AllDictionaryUtil {
     }
   }
 
-  def saveToFile(contents: Array[String], outputPath: String): Unit = {
+  def saveToFile(hadoopConf: Configuration, contents: Array[String], outputPath: String): Unit = {
     var writer: DataOutputStream = null
     try {
       val fileType = FileFactory.getFileType(outputPath)
-      val file = FileFactory.getCarbonFile(outputPath, fileType)
+      val file = FileFactory.getCarbonFile(hadoopConf, outputPath, fileType)
       if (!file.exists()) {
         file.createNewFile()
       }
-      writer = FileFactory.getDataOutputStream(outputPath, fileType)
+      writer = FileFactory.getDataOutputStream(hadoopConf, outputPath, fileType)
       for (content <- contents) {
         writer.writeBytes(content + "\n")
       }

--- a/examples/spark2/pom.xml
+++ b/examples/spark2/pom.xml
@@ -65,6 +65,36 @@
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-repl_${scala.binary.version}</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-aws</artifactId>
+      <version>${hadoop.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-annotations</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk</artifactId>
+      <version>1.7.4</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-annotations</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 
   <build>

--- a/examples/spark2/src/main/resources/data.csv
+++ b/examples/spark2/src/main/resources/data.csv
@@ -1,6 +1,6 @@
 shortField,intField,bigintField,doubleField,stringField,timestampField,decimalField,dateField,charField,floatField,complexData
 1,10,1100,48.4,spark,2015/4/23 12:01:01,1.23,2015/4/23,aaa,2.5,'foo'#'bar'#'world'
-5,17,1140,43.4,spark,2015/7/27 12:01:02,3.45,2015/7/27,bbb,2.5,'foo'#'bar'#'world'
+5,17,1140,43.4,spark2,2015/7/27 12:01:02,3.45,2015/7/27,bbb,2.5,'foo'#'bar'#'world'
 1,11,1100,44.4,flink,2015/5/23 12:01:03,23.23,2015/5/23,ccc,2.5,'foo'#'bar'#'world'
 1,10,1150,43.4,spark,2015/7/24 12:01:04,254.12,2015/7/24,ddd,2.5,'foo'#'bar'#'world'
 1,10,1100,47.4,spark,2015/7/23 12:01:05,876.14,2015/7/23,eeee,3.5,'foo'#'bar'#'world'

--- a/examples/spark2/src/main/scala/org/apache/carbondata/examples/CarbonS3Example.scala
+++ b/examples/spark2/src/main/scala/org/apache/carbondata/examples/CarbonS3Example.scala
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.examples
+
+import java.io.File
+
+import org.apache.spark.sql.SparkSession
+
+import org.apache.carbondata.core.constants.CarbonCommonConstants
+import org.apache.carbondata.core.util.CarbonProperties
+
+/**
+ *
+ */
+object CarbonS3Example {
+
+  def main(args: Array[String]) {
+    if (args.length < 5) {
+      // scalastyle:off println
+      System.err.println("Require 5 parameters")
+      System.err.println("Usage: java CarbonS3Example <fs.s3a.endpoint> <fs.s3a.access.key>" +
+                       " <fs.s3a.secret.key> <fs.s3a.impl> <carbon store location>")
+      // scalastyle:on println
+      return
+    }
+
+    val rootPath = new File(this.getClass.getResource("/").getPath
+                            + "../../../..").getCanonicalPath
+    val storeLocation = args(4)
+    val warehouse = s"$rootPath/examples/spark2/target/warehouse"
+    val metastoredb = s"$rootPath/examples/spark2/target"
+
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, "yyyy/MM/dd HH:mm:ss")
+      .addProperty(CarbonCommonConstants.CARBON_DATE_FORMAT, "yyyy/MM/dd")
+      .addProperty(CarbonCommonConstants.ENABLE_UNSAFE_COLUMN_PAGE_LOADING, "true")
+      .addProperty(CarbonCommonConstants.LOCK_TYPE, "HDFSLOCK")
+
+    import org.apache.spark.sql.CarbonSession._
+    val spark = SparkSession
+      .builder()
+      .master("local")
+      .appName("CarbonSessionExample")
+      .config("spark.sql.warehouse.dir", warehouse)
+      .config("spark.driver.host", "localhost")
+      .config("fs.s3a.endpoint", args(0))
+      .config("fs.s3a.access.key", args(1))
+      .config("fs.s3a.secret.key", args(2))
+      .config("fs.s3a.impl", args(3))
+      .getOrCreateCarbonSession(storeLocation, metastoredb)
+
+    spark.sparkContext.setLogLevel("INFO")
+    // Create table
+    spark.sql(
+      s"""
+         | CREATE TABLE if not exists carbondata_table(
+         | shortField SHORT,
+         | intField INT,
+         | bigintField LONG,
+         | doubleField DOUBLE,
+         | stringField STRING,
+         | timestampField TIMESTAMP,
+         | decimalField DECIMAL(18,2),
+         | dateField DATE,
+         | charField CHAR(5),
+         | floatField FLOAT
+         | )
+         | STORED BY 'carbondata'
+         | TBLPROPERTIES('SORT_COLUMNS'='intField')
+       """.stripMargin)
+
+    val path = s"$rootPath/examples/spark2/src/main/resources/data.csv"
+
+    // scalastyle:off
+    spark.sql(
+      s"""
+         | LOAD DATA LOCAL INPATH '$path'
+         | INTO TABLE carbondata_table
+         | OPTIONS('HEADER'='true')
+       """.stripMargin)
+
+    spark.sql(
+      s"""
+         | LOAD DATA LOCAL INPATH '$path'
+         | INTO TABLE carbondata_table
+         | OPTIONS('HEADER'='true')
+       """.stripMargin)
+    // scalastyle:on
+
+    spark.sql(
+      s"""
+        | SELECT *
+        | FROM carbondata_table
+      """.stripMargin).show()
+
+    spark.sql(
+      s"""
+         | SELECT count(*)
+         | FROM carbondata_table
+      """.stripMargin).show()
+
+    spark.stop()
+  }
+
+}

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/CacheClient.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/CacheClient.java
@@ -22,6 +22,8 @@ import org.apache.carbondata.core.cache.CacheType;
 import org.apache.carbondata.core.datastore.TableSegmentUniqueIdentifier;
 import org.apache.carbondata.core.datastore.block.SegmentTaskIndexWrapper;
 
+import org.apache.hadoop.conf.Configuration;
+
 /**
  * CacheClient : Holds all the Cache access clients for Btree, Dictionary
  */
@@ -31,9 +33,9 @@ public class CacheClient {
   private CacheAccessClient<TableSegmentUniqueIdentifier, SegmentTaskIndexWrapper>
       segmentAccessClient;
 
-  public CacheClient(String storePath) {
+  public CacheClient(Configuration configuration, String storePath) {
     Cache<TableSegmentUniqueIdentifier, SegmentTaskIndexWrapper> segmentCache =
-        CacheProvider.getInstance().createCache(CacheType.DRIVER_BTREE, storePath);
+        CacheProvider.getInstance().createCache(CacheType.DRIVER_BTREE, storePath, configuration);
     segmentAccessClient = new CacheAccessClient<>(segmentCache);
   }
 

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/CarbonRecordReader.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/CarbonRecordReader.java
@@ -79,8 +79,9 @@ public class CarbonRecordReader<T> extends AbstractRecordReader<T> {
     }
     List<TableBlockInfo> tableBlockInfoList = CarbonInputSplit.createBlocks(splitList);
     queryModel.setTableBlockInfos(tableBlockInfoList);
+    queryModel.setConfiguration(context.getConfiguration());
     readSupport.initialize(queryModel.getProjectionColumns(),
-        queryModel.getAbsoluteTableIdentifier());
+        queryModel.getAbsoluteTableIdentifier(), queryModel.getConfiguration());
     try {
       carbonIterator = new ChunkRowIterator(queryExecutor.execute(queryModel));
     } catch (QueryExecutionException e) {

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/DistributableDataMapFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/DistributableDataMapFormat.java
@@ -80,8 +80,8 @@ public class DistributableDataMapFormat extends FileInputFormat<Void, Blocklet> 
 
   @Override
   public List<InputSplit> getSplits(JobContext job) throws IOException {
-    TableDataMap dataMap =
-        DataMapStoreManager.getInstance().getDataMap(identifier, dataMapName, className);
+    TableDataMap dataMap = DataMapStoreManager.getInstance().getDataMap(identifier, dataMapName,
+        className, job.getConfiguration());
     List<DataMapDistributable> distributables = dataMap.toDistributable(validSegments);
     List<InputSplit> inputSplits = new ArrayList<>(distributables.size());
     inputSplits.addAll(distributables);
@@ -103,7 +103,8 @@ public class DistributableDataMapFormat extends FileInputFormat<Void, Blocklet> 
             AbsoluteTableIdentifier.fromTablePath(distributable.getTablePath());
         TableDataMap dataMap = DataMapStoreManager.getInstance()
             .getDataMap(identifier, distributable.getDataMapName(),
-                distributable.getDataMapFactoryClass());
+                distributable.getDataMapFactoryClass(),
+                taskAttemptContext.getConfiguration());
         blockletIterator =
             dataMap.prune(distributable, getFilterExp(taskAttemptContext.getConfiguration()))
                 .iterator();

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/internal/index/impl/InMemoryBTreeIndex.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/internal/index/impl/InMemoryBTreeIndex.java
@@ -53,6 +53,7 @@ import org.apache.carbondata.hadoop.internal.segment.Segment;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.JobContext;
@@ -98,7 +99,8 @@ class InMemoryBTreeIndex implements Index {
   private Map<SegmentTaskIndexStore.TaskBucketHolder, AbstractIndex> getSegmentAbstractIndexs(
       JobContext job, AbsoluteTableIdentifier identifier) throws IOException {
     Map<SegmentTaskIndexStore.TaskBucketHolder, AbstractIndex> segmentIndexMap = null;
-    CacheClient cacheClient = new CacheClient(identifier.getStorePath());
+    Configuration configuration = job.getConfiguration();
+    CacheClient cacheClient = new CacheClient(configuration, identifier.getStorePath());
     TableSegmentUniqueIdentifier segmentUniqueIdentifier =
         new TableSegmentUniqueIdentifier(identifier, segment.getId());
     try {
@@ -175,7 +177,8 @@ class InMemoryBTreeIndex implements Index {
             abstractIndex.getDataRefNode(),
             resolver,
             abstractIndex,
-            identifier
+            identifier,
+            job.getConfiguration()
         );
       }
       resultFilterredBlocks.addAll(filterredBlocks);

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/readsupport/CarbonReadSupport.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/readsupport/CarbonReadSupport.java
@@ -21,6 +21,8 @@ import java.io.IOException;
 import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
 import org.apache.carbondata.core.metadata.schema.table.column.CarbonColumn;
 
+import org.apache.hadoop.conf.Configuration;
+
 /**
  * This is the interface to convert data reading from RecordReader to row representation.
  */
@@ -32,8 +34,8 @@ public interface CarbonReadSupport<T> {
    * @param carbonColumns column list
    * @param absoluteTableIdentifier table identifier
    */
-  void initialize(CarbonColumn[] carbonColumns,
-      AbsoluteTableIdentifier absoluteTableIdentifier) throws IOException;
+  void initialize(CarbonColumn[] carbonColumns, AbsoluteTableIdentifier absoluteTableIdentifier,
+      Configuration configuration) throws IOException;
 
   /**
    * convert column data back to row representation

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/readsupport/impl/DictionaryDecodeReadSupport.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/readsupport/impl/DictionaryDecodeReadSupport.java
@@ -31,6 +31,8 @@ import org.apache.carbondata.core.util.CarbonUtil;
 import org.apache.carbondata.core.util.path.CarbonStorePath;
 import org.apache.carbondata.hadoop.readsupport.CarbonReadSupport;
 
+import org.apache.hadoop.conf.Configuration;
+
 /**
  *  This is the class to decode dictionary encoded column data back to its original value.
  */
@@ -52,7 +54,8 @@ public class DictionaryDecodeReadSupport<T> implements CarbonReadSupport<T> {
    * @param absoluteTableIdentifier table identifier
    */
   @Override public void initialize(CarbonColumn[] carbonColumns,
-      AbsoluteTableIdentifier absoluteTableIdentifier) throws IOException {
+      AbsoluteTableIdentifier absoluteTableIdentifier,
+      Configuration configuration) throws IOException {
     this.carbonColumns = carbonColumns;
     dictionaries = new Dictionary[carbonColumns.length];
     dataTypes = new DataType[carbonColumns.length];
@@ -61,12 +64,13 @@ public class DictionaryDecodeReadSupport<T> implements CarbonReadSupport<T> {
           .hasEncoding(Encoding.DIRECT_DICTIONARY) && !carbonColumns[i].isComplex()) {
         CacheProvider cacheProvider = CacheProvider.getInstance();
         Cache<DictionaryColumnUniqueIdentifier, Dictionary> forwardDictionaryCache = cacheProvider
-            .createCache(CacheType.FORWARD_DICTIONARY, absoluteTableIdentifier.getStorePath());
+            .createCache(CacheType.FORWARD_DICTIONARY, absoluteTableIdentifier.getStorePath(),
+                configuration);
         dataTypes[i] = carbonColumns[i].getDataType();
         dictionaries[i] = forwardDictionaryCache.get(new DictionaryColumnUniqueIdentifier(
             absoluteTableIdentifier.getCarbonTableIdentifier(),
             carbonColumns[i].getColumnIdentifier(), dataTypes[i],
-            CarbonStorePath.getCarbonTablePath(absoluteTableIdentifier)));
+            CarbonStorePath.getCarbonTablePath(absoluteTableIdentifier, configuration)));
       } else {
         dataTypes[i] = carbonColumns[i].getDataType();
       }

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/readsupport/impl/RawDataReadSupport.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/readsupport/impl/RawDataReadSupport.java
@@ -20,6 +20,7 @@ import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
 import org.apache.carbondata.core.metadata.schema.table.column.CarbonColumn;
 import org.apache.carbondata.hadoop.readsupport.CarbonReadSupport;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 
@@ -27,7 +28,7 @@ public class RawDataReadSupport implements CarbonReadSupport<InternalRow> {
 
   @Override
   public void initialize(CarbonColumn[] carbonColumns,
-      AbsoluteTableIdentifier absoluteTableIdentifier) { }
+      AbsoluteTableIdentifier absoluteTableIdentifier, Configuration configuration) { }
 
   /**
    * return column data as InternalRow

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/util/CarbonInputFormatUtil.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/util/CarbonInputFormatUtil.java
@@ -37,6 +37,7 @@ import org.apache.carbondata.core.scan.model.QueryMeasure;
 import org.apache.carbondata.core.scan.model.QueryModel;
 import org.apache.carbondata.hadoop.api.CarbonTableInputFormat;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
@@ -132,12 +133,13 @@ public class CarbonInputFormatUtil {
    * @return
    */
   public static FilterResolverIntf resolveFilter(Expression filterExpression,
-      AbsoluteTableIdentifier absoluteTableIdentifier, TableProvider tableProvider) {
+      AbsoluteTableIdentifier absoluteTableIdentifier, TableProvider tableProvider,
+      Configuration configuration) {
     try {
       FilterExpressionProcessor filterExpressionProcessor = new FilterExpressionProcessor();
       //get resolved filter
-      return filterExpressionProcessor
-          .getFilterResolver(filterExpression, absoluteTableIdentifier, tableProvider);
+      return filterExpressionProcessor.getFilterResolver(filterExpression, absoluteTableIdentifier,
+          tableProvider, configuration);
     } catch (Exception e) {
       throw new RuntimeException("Error while resolving filter expression", e);
     }

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/util/SchemaReader.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/util/SchemaReader.java
@@ -29,6 +29,7 @@ import org.apache.carbondata.core.reader.ThriftReader;
 import org.apache.carbondata.core.util.path.CarbonStorePath;
 import org.apache.carbondata.core.util.path.CarbonTablePath;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.thrift.TBase;
 
 /**
@@ -36,13 +37,15 @@ import org.apache.thrift.TBase;
  */
 public class SchemaReader {
 
-  public static CarbonTable readCarbonTableFromStore(AbsoluteTableIdentifier identifier)
+  public static CarbonTable readCarbonTableFromStore(AbsoluteTableIdentifier identifier,
+      Configuration configuration)
       throws IOException {
-    CarbonTablePath carbonTablePath = CarbonStorePath.getCarbonTablePath(identifier);
+    CarbonTablePath carbonTablePath = CarbonStorePath.getCarbonTablePath(identifier, configuration);
     String schemaFilePath = carbonTablePath.getSchemaFilePath();
-    if (FileFactory.isFileExist(schemaFilePath, FileFactory.FileType.LOCAL) ||
-        FileFactory.isFileExist(schemaFilePath, FileFactory.FileType.HDFS) ||
-        FileFactory.isFileExist(schemaFilePath, FileFactory.FileType.VIEWFS)) {
+    if (FileFactory.isFileExist(configuration, schemaFilePath, FileFactory.FileType.LOCAL) ||
+        FileFactory.isFileExist(configuration, schemaFilePath, FileFactory.FileType.HDFS) ||
+        FileFactory.isFileExist(configuration, schemaFilePath, FileFactory.FileType.VIEWFS) ||
+        FileFactory.isFileExist(configuration, schemaFilePath, FileFactory.FileType.S3)) {
       String tableName = identifier.getCarbonTableIdentifier().getTableName();
 
       ThriftReader.TBaseCreator createTBase = new ThriftReader.TBaseCreator() {
@@ -51,7 +54,7 @@ public class SchemaReader {
         }
       };
       ThriftReader thriftReader =
-          new ThriftReader(carbonTablePath.getSchemaFilePath(), createTBase);
+          new ThriftReader(configuration, carbonTablePath.getSchemaFilePath(), createTBase);
       thriftReader.open();
       org.apache.carbondata.format.TableInfo tableInfo =
           (org.apache.carbondata.format.TableInfo) thriftReader.read();

--- a/hadoop/src/test/java/org/apache/carbondata/hadoop/test/util/StoreCreator.java
+++ b/hadoop/src/test/java/org/apache/carbondata/hadoop/test/util/StoreCreator.java
@@ -98,6 +98,8 @@ import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl;
  */
 public class StoreCreator {
 
+  public final  static Configuration configuration = new Configuration();
+
   private static AbsoluteTableIdentifier absoluteTableIdentifier;
 
   static {
@@ -272,7 +274,7 @@ public class StoreCreator {
     tableInfo.setFactTable(tableSchema);
     CarbonTablePath carbonTablePath = CarbonStorePath
         .getCarbonTablePath(absoluteTableIdentifier.getStorePath(),
-            absoluteTableIdentifier.getCarbonTableIdentifier());
+            absoluteTableIdentifier.getCarbonTableIdentifier(), configuration);
     String schemaFilePath = carbonTablePath.getSchemaFilePath();
     String schemaMetadataPath = CarbonTablePath.getFolderContainingFile(schemaFilePath);
     tableInfo.setMetaDataFilepath(schemaMetadataPath);
@@ -288,11 +290,11 @@ public class StoreCreator {
         .add(schemaEvolutionEntry);
 
     FileFactory.FileType fileType = FileFactory.getFileType(schemaMetadataPath);
-    if (!FileFactory.isFileExist(schemaMetadataPath, fileType)) {
-      FileFactory.mkdirs(schemaMetadataPath, fileType);
+    if (!FileFactory.isFileExist(configuration, schemaMetadataPath, fileType)) {
+      FileFactory.mkdirs(configuration, schemaMetadataPath, fileType);
     }
 
-    ThriftWriter thriftWriter = new ThriftWriter(schemaFilePath, false);
+    ThriftWriter thriftWriter = new ThriftWriter(configuration, schemaFilePath, false);
     thriftWriter.open();
     thriftWriter.write(thriftTableInfo);
     thriftWriter.close();
@@ -322,16 +324,16 @@ public class StoreCreator {
     }
 
     Cache dictCache = CacheProvider.getInstance()
-        .createCache(CacheType.REVERSE_DICTIONARY, absoluteTableIdentifier.getStorePath());
+        .createCache(CacheType.REVERSE_DICTIONARY, absoluteTableIdentifier.getStorePath(), configuration);
     for (int i = 0; i < set.length; i++) {
       ColumnIdentifier columnIdentifier = new ColumnIdentifier(dims.get(i).getColumnId(), null, null);
       DictionaryColumnUniqueIdentifier dictionaryColumnUniqueIdentifier =
           new DictionaryColumnUniqueIdentifier(table.getCarbonTableIdentifier(), columnIdentifier,
               columnIdentifier.getDataType(), CarbonStorePath
-              .getCarbonTablePath(table.getStorePath(), table.getCarbonTableIdentifier()));
+              .getCarbonTablePath(table.getStorePath(), table.getCarbonTableIdentifier(), configuration));
       CarbonDictionaryWriter writer =
           new CarbonDictionaryWriterImpl(absoluteTableIdentifier.getStorePath(),
-              absoluteTableIdentifier.getCarbonTableIdentifier(), dictionaryColumnUniqueIdentifier);
+              absoluteTableIdentifier.getCarbonTableIdentifier(), dictionaryColumnUniqueIdentifier, configuration);
       for (String value : set[i]) {
         writer.write(value);
       }
@@ -340,7 +342,7 @@ public class StoreCreator {
       Dictionary dict = (Dictionary) dictCache.get(
           new DictionaryColumnUniqueIdentifier(absoluteTableIdentifier.getCarbonTableIdentifier(),
         		  columnIdentifier, dims.get(i).getDataType(),CarbonStorePath
-              .getCarbonTablePath(table.getStorePath(), table.getCarbonTableIdentifier())));
+              .getCarbonTablePath(table.getStorePath(), table.getCarbonTableIdentifier(), configuration)));
       CarbonDictionarySortInfoPreparator preparator =
           new CarbonDictionarySortInfoPreparator();
       List<String> newDistinctValues = new ArrayList<String>();
@@ -349,7 +351,7 @@ public class StoreCreator {
       CarbonDictionarySortIndexWriter carbonDictionaryWriter =
           new CarbonDictionarySortIndexWriterImpl(
               absoluteTableIdentifier.getCarbonTableIdentifier(), dictionaryColumnUniqueIdentifier,
-              absoluteTableIdentifier.getStorePath());
+              absoluteTableIdentifier.getStorePath(), configuration);
       try {
         carbonDictionaryWriter.writeSortIndex(dictionarySortInfo.getSortIndex());
         carbonDictionaryWriter.writeInvertedSortIndex(dictionarySortInfo.getSortIndexInverted());
@@ -418,7 +420,8 @@ public class StoreCreator {
     CSVRecordReaderIterator readerIterator = new CSVRecordReaderIterator(recordReader, blockDetails, hadoopAttemptContext);
     new DataLoadExecutor().execute(loadModel,
         new String[] {storeLocation},
-        new CarbonIterator[]{readerIterator});
+        new CarbonIterator[]{readerIterator},
+        configuration);
 
     info.setDatabaseName(databaseName);
     info.setTableName(tableName);
@@ -468,7 +471,7 @@ public class StoreCreator {
     BufferedWriter brWriter = null;
 
     AtomicFileOperations writeOperation =
-        new AtomicFileOperationsImpl(dataLoadLocation, FileFactory.getFileType(dataLoadLocation));
+        new AtomicFileOperationsImpl(configuration, dataLoadLocation, FileFactory.getFileType(dataLoadLocation));
 
     try {
 

--- a/integration/hive/src/main/java/org/apache/carbondata/hive/CarbonDictionaryDecodeReadSupport.java
+++ b/integration/hive/src/main/java/org/apache/carbondata/hive/CarbonDictionaryDecodeReadSupport.java
@@ -37,6 +37,7 @@ import org.apache.carbondata.core.util.CarbonUtil;
 import org.apache.carbondata.core.util.path.CarbonStorePath;
 import org.apache.carbondata.hadoop.readsupport.CarbonReadSupport;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.common.type.HiveDecimal;
 import org.apache.hadoop.hive.serde2.io.DateWritable;
 import org.apache.hadoop.hive.serde2.io.DoubleWritable;
@@ -74,7 +75,8 @@ public class CarbonDictionaryDecodeReadSupport<T> implements CarbonReadSupport<T
    * @param absoluteTableIdentifier table identifier
    */
   @Override public void initialize(CarbonColumn[] carbonColumns,
-      AbsoluteTableIdentifier absoluteTableIdentifier) throws IOException {
+      AbsoluteTableIdentifier absoluteTableIdentifier,
+      Configuration configuration) throws IOException {
     this.carbonColumns = carbonColumns;
     dictionaries = new Dictionary[carbonColumns.length];
     dataTypes = new DataType[carbonColumns.length];
@@ -83,12 +85,13 @@ public class CarbonDictionaryDecodeReadSupport<T> implements CarbonReadSupport<T
           .hasEncoding(Encoding.DIRECT_DICTIONARY) && !carbonColumns[i].isComplex()) {
         CacheProvider cacheProvider = CacheProvider.getInstance();
         Cache<DictionaryColumnUniqueIdentifier, Dictionary> forwardDictionaryCache = cacheProvider
-            .createCache(CacheType.FORWARD_DICTIONARY, absoluteTableIdentifier.getStorePath());
+            .createCache(CacheType.FORWARD_DICTIONARY, absoluteTableIdentifier.getStorePath(),
+                configuration);
         dataTypes[i] = carbonColumns[i].getDataType();
         dictionaries[i] = forwardDictionaryCache.get(
             new DictionaryColumnUniqueIdentifier(absoluteTableIdentifier.getCarbonTableIdentifier(),
                 carbonColumns[i].getColumnIdentifier(), dataTypes[i],
-                CarbonStorePath.getCarbonTablePath(absoluteTableIdentifier)));
+                CarbonStorePath.getCarbonTablePath(absoluteTableIdentifier, configuration)));
       } else {
         dataTypes[i] = carbonColumns[i].getDataType();
       }

--- a/integration/hive/src/main/java/org/apache/carbondata/hive/CarbonHiveRecordReader.java
+++ b/integration/hive/src/main/java/org/apache/carbondata/hive/CarbonHiveRecordReader.java
@@ -79,8 +79,9 @@ class CarbonHiveRecordReader extends CarbonRecordReader<ArrayWritable>
     }
     List<TableBlockInfo> tableBlockInfoList = CarbonHiveInputSplit.createBlocks(splitList);
     queryModel.setTableBlockInfos(tableBlockInfoList);
-    readSupport
-        .initialize(queryModel.getProjectionColumns(), queryModel.getAbsoluteTableIdentifier());
+    queryModel.setConfiguration(conf);
+    readSupport.initialize(queryModel.getProjectionColumns(),
+        queryModel.getAbsoluteTableIdentifier(), conf);
     try {
       carbonIterator = new ChunkRowIterator(queryExecutor.execute(queryModel));
     } catch (QueryExecutionException e) {

--- a/integration/hive/src/main/java/org/apache/carbondata/hive/MapredCarbonInputFormat.java
+++ b/integration/hive/src/main/java/org/apache/carbondata/hive/MapredCarbonInputFormat.java
@@ -81,7 +81,8 @@ public class MapredCarbonInputFormat extends CarbonInputFormat<ArrayWritable>
         AbsoluteTableIdentifier.fromTablePath(validInputPath);
     // read the schema file to get the absoluteTableIdentifier having the correct table id
     // persisted in the schema
-    CarbonTable carbonTable = SchemaReader.readCarbonTableFromStore(absoluteTableIdentifier);
+    CarbonTable carbonTable =
+        SchemaReader.readCarbonTableFromStore(absoluteTableIdentifier, configuration);
     configuration.set(CARBON_TABLE, ObjectSerializationUtil.convertObjectToString(carbonTable));
     setTableInfo(configuration, carbonTable.getTableInfo());
   }
@@ -133,11 +134,13 @@ public class MapredCarbonInputFormat extends CarbonInputFormat<ArrayWritable>
     CarbonQueryPlan queryPlan = CarbonInputFormatUtil.createQueryPlan(carbonTable, projection);
     QueryModel queryModel =
         QueryModel.createModel(identifier, queryPlan, carbonTable, new DataTypeConverterImpl());
+    queryModel.setConfiguration(configuration);
+
     // set the filter to the query model in order to filter blocklet before scan
     Expression filter = getFilterPredicates(configuration);
     CarbonInputFormatUtil.processFilterExpression(filter, carbonTable);
     FilterResolverIntf filterIntf =
-        CarbonInputFormatUtil.resolveFilter(filter, identifier, tableProvider);
+        CarbonInputFormatUtil.resolveFilter(filter, identifier, tableProvider, configuration);
     queryModel.setFilterExpressionResolverTree(filterIntf);
 
     return queryModel;

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/CarbonVectorizedRecordReader.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/CarbonVectorizedRecordReader.java
@@ -108,6 +108,7 @@ class CarbonVectorizedRecordReader extends AbstractRecordReader<Object> {
     List<TableBlockInfo> tableBlockInfoList = CarbonInputSplit.createBlocks(splitList);
     queryModel.setTableBlockInfos(tableBlockInfoList);
     queryModel.setVectorReader(true);
+    queryModel.setConfiguration(taskAttemptContext.getConfiguration());
     try {
       queryExecutor = QueryExecutorFactory.getQueryExecutor(queryModel);
       iterator = (AbstractDetailQueryResultIterator) queryExecutor.execute(queryModel);

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/CarbondataRecordSet.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/CarbondataRecordSet.java
@@ -75,8 +75,8 @@ public class CarbondataRecordSet implements RecordSet {
     queryExecutor = QueryExecutorFactory.getQueryExecutor(queryModel);
     try {
 
-      readSupport
-          .initialize(queryModel.getProjectionColumns(), queryModel.getAbsoluteTableIdentifier());
+      readSupport.initialize(queryModel.getProjectionColumns(),
+          queryModel.getAbsoluteTableIdentifier(), queryModel.getConfiguration());
       CarbonIterator iterator = queryExecutor.execute(queryModel);
       CarbonVectorizedRecordReader vectorReader =
           new CarbonVectorizedRecordReader(queryExecutor, queryModel,

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/CarbondataRecordSetProvider.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/CarbondataRecordSetProvider.java
@@ -92,9 +92,9 @@ public class CarbondataRecordSetProvider implements ConnectorRecordSetProvider {
     try {
       Configuration conf = new Configuration();
       conf.set(CarbonTableInputFormat.INPUT_SEGMENT_NUMBERS, "");
-      String carbonTablePath = PathFactory.getInstance()
-          .getCarbonTablePath(targetTable.getAbsoluteTableIdentifier().getStorePath(),
-              targetTable.getCarbonTableIdentifier(), null).getPath();
+      String carbonTablePath = PathFactory.getInstance().getCarbonTablePath(
+          targetTable.getAbsoluteTableIdentifier().getStorePath(),
+          targetTable.getCarbonTableIdentifier(), null, conf).getPath();
 
       conf.set(CarbonTableInputFormat.INPUT_DIR, carbonTablePath);
       JobConf jobConf = new JobConf(conf);

--- a/integration/presto/src/main/scala/org/apache/carbondata/presto/CarbonDictionaryDecodeReadSupport.scala
+++ b/integration/presto/src/main/scala/org/apache/carbondata/presto/CarbonDictionaryDecodeReadSupport.scala
@@ -19,10 +19,10 @@ package org.apache.carbondata.presto
 import com.facebook.presto.spi.block.SliceArrayBlock
 import io.airlift.slice.{Slice, Slices}
 import io.airlift.slice.Slices._
+import org.apache.hadoop.conf.Configuration
 
 import org.apache.carbondata.core.cache.{Cache, CacheProvider, CacheType}
-import org.apache.carbondata.core.cache.dictionary.{Dictionary, DictionaryChunksWrapper,
-DictionaryColumnUniqueIdentifier}
+import org.apache.carbondata.core.cache.dictionary.{Dictionary, DictionaryChunksWrapper, DictionaryColumnUniqueIdentifier}
 import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier
 import org.apache.carbondata.core.metadata.datatype.DataType
 import org.apache.carbondata.core.metadata.encoder.Encoding
@@ -47,7 +47,7 @@ class CarbonDictionaryDecodeReadSupport[T] extends CarbonReadSupport[T] {
    */
 
   override def initialize(carbonColumns: Array[CarbonColumn],
-      absoluteTableIdentifier: AbsoluteTableIdentifier) {
+      absoluteTableIdentifier: AbsoluteTableIdentifier, configuration: Configuration) {
 
     dictionaries = new Array[Dictionary](carbonColumns.length)
     dataTypes = new Array[DataType](carbonColumns.length)
@@ -59,8 +59,8 @@ class CarbonDictionaryDecodeReadSupport[T] extends CarbonReadSupport[T] {
                                         !carbonColumn.isComplex) {
         val cacheProvider: CacheProvider = CacheProvider.getInstance
         val forwardDictionaryCache: Cache[DictionaryColumnUniqueIdentifier, Dictionary] =
-          cacheProvider
-            .createCache(CacheType.FORWARD_DICTIONARY, absoluteTableIdentifier.getStorePath)
+          cacheProvider.createCache(CacheType.FORWARD_DICTIONARY,
+            absoluteTableIdentifier.getStorePath, configuration)
         dataTypes(index) = carbonColumn.getDataType
         dictionaries(index) = forwardDictionaryCache
           .get(new DictionaryColumnUniqueIdentifier(absoluteTableIdentifier

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/dataload/TestLoadDataGeneral.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/dataload/TestLoadDataGeneral.scala
@@ -46,9 +46,9 @@ class TestLoadDataGeneral extends QueryTest with BeforeAndAfterAll {
       tableName: String): Boolean = {
     val carbonTable = CarbonMetadata.getInstance().getCarbonTable(datbaseName + "_" + tableName)
     val partitionPath = CarbonStorePath.getCarbonTablePath(storeLocation,
-      carbonTable.getCarbonTableIdentifier).getPartitionDir("0")
+      carbonTable.getCarbonTableIdentifier, hadoopConf).getPartitionDir("0")
     val fileType: FileFactory.FileType = FileFactory.getFileType(partitionPath)
-    val carbonFile = FileFactory.getCarbonFile(partitionPath, fileType)
+    val carbonFile = FileFactory.getCarbonFile(hadoopConf, partitionPath, fileType)
     val segments: ArrayBuffer[String] = ArrayBuffer()
     carbonFile.listFiles.foreach { file =>
       segments += CarbonTablePath.DataPathUtil.getSegmentId(file.getAbsolutePath + "/dummy")

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/blockprune/BlockPruneQueryTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/blockprune/BlockPruneQueryTestCase.scala
@@ -37,11 +37,11 @@ class BlockPruneQueryTestCase extends QueryTest with BeforeAndAfterAll {
     var writer: DataOutputStream = null
     try {
       val fileType = FileFactory.getFileType(outputPath)
-      val file = FileFactory.getCarbonFile(outputPath, fileType)
+      val file = FileFactory.getCarbonFile(hadoopConf, outputPath, fileType)
       if (!file.exists()) {
         file.createNewFile()
       }
-      writer = FileFactory.getDataOutputStream(outputPath, fileType)
+      writer = FileFactory.getDataOutputStream(hadoopConf, outputPath, fileType)
       for (i <- 0 to 2) {
         for (j <- 0 to 240000) {
           writer.writeBytes(testData(i) + "," + j + "\n")
@@ -96,7 +96,7 @@ class BlockPruneQueryTestCase extends QueryTest with BeforeAndAfterAll {
     // delete the temp data file
     try {
       val fileType = FileFactory.getFileType(outputPath)
-      val file = FileFactory.getCarbonFile(outputPath, fileType)
+      val file = FileFactory.getCarbonFile(hadoopConf, outputPath, fileType)
       if (file.exists()) {
         file.delete()
       }

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/blockprune/CarbonCustomBlockDistributionTest.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/blockprune/CarbonCustomBlockDistributionTest.scala
@@ -41,11 +41,11 @@ class CarbonCustomBlockDistributionTest extends QueryTest with BeforeAndAfterAll
     var writer: DataOutputStream = null
     try {
       val fileType = FileFactory.getFileType(outputPath)
-      val file = FileFactory.getCarbonFile(outputPath, fileType)
+      val file = FileFactory.getCarbonFile(hadoopConf, outputPath, fileType)
       if (!file.exists()) {
         file.createNewFile()
       }
-      writer = FileFactory.getDataOutputStream(outputPath, fileType)
+      writer = FileFactory.getDataOutputStream(hadoopConf, outputPath, fileType)
       for (i <- 0 to 2) {
         for (j <- 0 to 240000) {
           writer.writeBytes(testData(i) + "," + j + "\n")
@@ -101,7 +101,7 @@ class CarbonCustomBlockDistributionTest extends QueryTest with BeforeAndAfterAll
     CarbonProperties.getInstance().addProperty("carbon.custom.distribution","false")
     try {
       val fileType = FileFactory.getFileType(outputPath)
-      val file = FileFactory.getCarbonFile(outputPath, fileType)
+      val file = FileFactory.getCarbonFile(hadoopConf, outputPath, fileType)
       if (file.exists()) {
         file.delete()
       }

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/DataCompactionCardinalityBoundryTest.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/DataCompactionCardinalityBoundryTest.scala
@@ -77,7 +77,7 @@ class DataCompactionCardinalityBoundryTest extends QueryTest with BeforeAndAfter
           AbsoluteTableIdentifier(
             CarbonProperties.getInstance.getProperty(CarbonCommonConstants.STORE_LOCATION),
             new CarbonTableIdentifier("default", "cardinalityTest", "1")
-          )
+          ), hadoopConf
       )
       val segments = segmentStatusManager.getValidAndInvalidSegments.getValidSegments.asScala.toList
 

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/DataCompactionLockTest.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/DataCompactionLockTest.scala
@@ -43,13 +43,12 @@ class DataCompactionLockTest extends QueryTest with BeforeAndAfterAll {
       )
   val carbonTablePath: CarbonTablePath = CarbonStorePath
     .getCarbonTablePath(absoluteTableIdentifier.getStorePath,
-      absoluteTableIdentifier.getCarbonTableIdentifier
+      absoluteTableIdentifier.getCarbonTableIdentifier, hadoopConf
     )
   val dataPath: String = carbonTablePath.getMetadataDirectoryPath
 
-  val carbonLock: ICarbonLock =
-    CarbonLockFactory
-      .getCarbonLockObj(absoluteTableIdentifier.getCarbonTableIdentifier, LockUsage.COMPACTION_LOCK)
+  val carbonLock: ICarbonLock = CarbonLockFactory.getCarbonLockObj(
+    absoluteTableIdentifier.getCarbonTableIdentifier, LockUsage.COMPACTION_LOCK, hadoopConf)
 
   override def beforeAll {
     CarbonProperties.getInstance()
@@ -101,7 +100,7 @@ class DataCompactionLockTest extends QueryTest with BeforeAndAfterAll {
   test("check if compaction is failed or not.") {
 
     val segmentStatusManager: SegmentStatusManager = new SegmentStatusManager(
-      absoluteTableIdentifier
+      absoluteTableIdentifier, hadoopConf
     )
     val segments = segmentStatusManager.getValidAndInvalidSegments.getValidSegments.asScala.toList
 

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/MajorCompactionIgnoreInMinorTest.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/MajorCompactionIgnoreInMinorTest.scala
@@ -80,7 +80,8 @@ class MajorCompactionIgnoreInMinorTest extends QueryTest with BeforeAndAfterAll 
           new CarbonTableIdentifier(
             CarbonCommonConstants.DATABASE_DEFAULT_NAME, "ignoremajor", "rrr")
         )
-    val segmentStatusManager: SegmentStatusManager = new SegmentStatusManager(identifier)
+    val segmentStatusManager: SegmentStatusManager =
+      new SegmentStatusManager(identifier, hadoopConf)
 
     // merged segment should not be there
     val segments = segmentStatusManager.getValidAndInvalidSegments.getValidSegments.asScala.toList
@@ -88,7 +89,7 @@ class MajorCompactionIgnoreInMinorTest extends QueryTest with BeforeAndAfterAll 
     assert(segments.contains("2.1"))
     assert(!segments.contains("2"))
     assert(!segments.contains("3"))
-    val cacheClient = new CacheClient(CarbonProperties.getInstance.
+    val cacheClient = new CacheClient(hadoopConf, CarbonProperties.getInstance.
       getProperty(CarbonCommonConstants.STORE_LOCATION));
     val segmentIdentifier = new TableSegmentUniqueIdentifier(identifier, "2")
     val wrapper: SegmentTaskIndexWrapper = cacheClient.getSegmentAccessClient.
@@ -112,10 +113,10 @@ class MajorCompactionIgnoreInMinorTest extends QueryTest with BeforeAndAfterAll 
       .getCarbonTablePath(CarbonProperties.getInstance
         .getProperty(CarbonCommonConstants.STORE_LOCATION),
         new CarbonTableIdentifier(
-          CarbonCommonConstants.DATABASE_DEFAULT_NAME, "ignoremajor", "rrr")
+          CarbonCommonConstants.DATABASE_DEFAULT_NAME, "ignoremajor", "rrr"), hadoopConf
       )
       .getMetadataDirectoryPath
-    val segs = SegmentStatusManager.readLoadMetadata(carbontablePath)
+    val segs = SegmentStatusManager.readLoadMetadata(hadoopConf, carbontablePath)
 
     // status should remain as compacted.
     assert(segs(3).getLoadStatus.equalsIgnoreCase(CarbonCommonConstants.COMPACTED))
@@ -134,10 +135,10 @@ class MajorCompactionIgnoreInMinorTest extends QueryTest with BeforeAndAfterAll 
       .getCarbonTablePath(CarbonProperties.getInstance
         .getProperty(CarbonCommonConstants.STORE_LOCATION),
         new CarbonTableIdentifier(
-          CarbonCommonConstants.DATABASE_DEFAULT_NAME, "ignoremajor", "rrr")
+          CarbonCommonConstants.DATABASE_DEFAULT_NAME, "ignoremajor", "rrr"), hadoopConf
       )
       .getMetadataDirectoryPath
-    val segs = SegmentStatusManager.readLoadMetadata(carbontablePath)
+    val segs = SegmentStatusManager.readLoadMetadata(hadoopConf, carbontablePath)
 
     // status should remain as compacted for segment 2.
     assert(segs(3).getLoadStatus.equalsIgnoreCase(CarbonCommonConstants.COMPACTED))
@@ -177,7 +178,8 @@ class MajorCompactionIgnoreInMinorTest extends QueryTest with BeforeAndAfterAll 
       new CarbonTableIdentifier(
         CarbonCommonConstants.DATABASE_DEFAULT_NAME, "testmajor", "ttt")
     )
-    val segmentStatusManager: SegmentStatusManager = new SegmentStatusManager(identifier)
+    val segmentStatusManager: SegmentStatusManager =
+      new SegmentStatusManager(identifier, hadoopConf)
 
     // merged segment should not be there
     val segments = segmentStatusManager.getValidAndInvalidSegments.getValidSegments.asScala.toList

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/MajorCompactionStopsAfterCompaction.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/MajorCompactionStopsAfterCompaction.scala
@@ -84,7 +84,8 @@ class MajorCompactionStopsAfterCompaction extends QueryTest with BeforeAndAfterA
               CarbonCommonConstants.DATABASE_DEFAULT_NAME, "stopmajor", noOfRetries + "")
           )
 
-      val segmentStatusManager: SegmentStatusManager = new SegmentStatusManager(identifier)
+      val segmentStatusManager: SegmentStatusManager =
+        new SegmentStatusManager(identifier, hadoopConf)
 
       val segments = segmentStatusManager.getValidAndInvalidSegments.getValidSegments.asScala.toList
 //      segments.foreach(seg =>
@@ -116,7 +117,8 @@ class MajorCompactionStopsAfterCompaction extends QueryTest with BeforeAndAfterA
           new CarbonTableIdentifier(CarbonCommonConstants.DATABASE_DEFAULT_NAME, "stopmajor", "rrr")
         )
 
-    val segmentStatusManager: SegmentStatusManager = new SegmentStatusManager(identifier)
+    val segmentStatusManager: SegmentStatusManager =
+      new SegmentStatusManager(identifier, hadoopConf)
 
     // merged segment should not be there
     val segments = segmentStatusManager.getValidAndInvalidSegments.getValidSegments.asScala.toList

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestDataLoadWithFileName.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestDataLoadWithFileName.scala
@@ -52,7 +52,7 @@ class TestDataLoadWithFileName extends QueryTest with BeforeAndAfterAll {
         }
       })
     for (carbonIndexPath <- carbonIndexPaths) {
-      indexReader.openThriftReader(carbonIndexPath.getCanonicalPath)
+      indexReader.openThriftReader(hadoopConf, carbonIndexPath.getCanonicalPath)
       assert(indexReader.readIndexHeader().getVersion === 3)
       while (indexReader.hasNext) {
         val readBlockIndexInfo = indexReader.readBlockIndexInfo()

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestLoadDataWithNotProperInputFile.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestLoadDataWithNotProperInputFile.scala
@@ -33,7 +33,7 @@ class TestLoadDataWithNotProperInputFile extends QueryTest {
   test("test loading data with input path exists but has nothing") {
     try {
       val dataPath = s"$resourcesPath/nullSample.csv"
-      FileUtils.getPaths(dataPath)
+      FileUtils.getPaths(hadoopConf, dataPath)
       assert(false)
     } catch {
       case e: Throwable =>
@@ -45,7 +45,7 @@ class TestLoadDataWithNotProperInputFile extends QueryTest {
   test("test loading data with input file not ends with '.csv'") {
     try {
       val dataPath = s"$resourcesPath/noneCsvFormat.cs"
-      FileUtils.getPaths(dataPath)
+      FileUtils.getPaths(hadoopConf, dataPath)
       assert(true)
     } catch {
       case e: Throwable =>
@@ -56,7 +56,7 @@ class TestLoadDataWithNotProperInputFile extends QueryTest {
   test("test loading data with input file does not exist") {
     try {
       val dataPath = s"$resourcesPath/input_file_does_not_exist.csv"
-      FileUtils.getPaths(dataPath)
+      FileUtils.getPaths(hadoopConf, dataPath)
       assert(false)
     } catch {
       case e: Throwable =>

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datamap/DataMapWriterSuite.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datamap/DataMapWriterSuite.scala
@@ -21,6 +21,7 @@ import java.util
 
 import scala.collection.JavaConverters._
 
+import org.apache.hadoop.conf.Configuration
 import org.apache.spark.sql.{DataFrame, SaveMode}
 import org.apache.spark.sql.test.util.QueryTest
 import org.scalatest.BeforeAndAfterAll
@@ -36,7 +37,7 @@ import org.apache.carbondata.core.util.CarbonProperties
 
 class C2DataMapFactory() extends DataMapFactory {
 
-  override def init(identifier: AbsoluteTableIdentifier,
+  override def init(configuration: Configuration, identifier: AbsoluteTableIdentifier,
       dataMapName: String): Unit = {}
 
   override def fireEvent(event: ChangeEvent[_]): Unit = ???
@@ -47,9 +48,11 @@ class C2DataMapFactory() extends DataMapFactory {
 
   override def getDataMap(distributable: DataMapDistributable): DataMap = ???
 
-  override def getDataMaps(segmentId: String): util.List[DataMap] = ???
+  override def getDataMaps(
+      configuration: Configuration, segmentId: String): util.List[DataMap] = ???
 
-  override def createWriter(segmentId: String): DataMapWriter = DataMapWriterSuite.dataMapWriterC2Mock
+  override def createWriter(
+      segmentId: String): DataMapWriter = DataMapWriterSuite.dataMapWriterC2Mock
 
   override def getMeta: DataMapMeta = new DataMapMeta(List("c2").asJava, FilterType.EQUALTO)
 
@@ -58,7 +61,8 @@ class C2DataMapFactory() extends DataMapFactory {
    *
    * @return
    */
-  override def toDistributable(segmentId: String): util.List[DataMapDistributable] = {
+  override def toDistributable(
+      configuration: Configuration, segmentId: String): util.List[DataMapDistributable] = {
     ???
   }
 }
@@ -86,7 +90,8 @@ class DataMapWriterSuite extends QueryTest with BeforeAndAfterAll {
     DataMapStoreManager.getInstance().createAndRegisterDataMap(
       AbsoluteTableIdentifier.from(storeLocation, "default", "carbon1"),
       classOf[C2DataMapFactory].getName,
-      "test")
+      "test",
+      hadoopConf)
 
     val df = buildTestData(33000)
 
@@ -113,7 +118,8 @@ class DataMapWriterSuite extends QueryTest with BeforeAndAfterAll {
     DataMapStoreManager.getInstance().createAndRegisterDataMap(
       AbsoluteTableIdentifier.from(storeLocation, "default", "carbon2"),
       classOf[C2DataMapFactory].getName,
-      "test")
+      "test",
+      hadoopConf)
 
     CarbonProperties.getInstance()
       .addProperty("carbon.blockletgroup.size.in.mb", "1")

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/dataretention/DataRetentionTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/dataretention/DataRetentionTestCase.scala
@@ -36,28 +36,33 @@ import org.apache.spark.sql.test.util.QueryTest
  */
 class DataRetentionTestCase extends QueryTest with BeforeAndAfterAll {
 
-  val absoluteTableIdentifierForLock: AbsoluteTableIdentifier = new
-      AbsoluteTableIdentifier(storeLocation,
-        new CarbonTableIdentifier(CarbonCommonConstants.DATABASE_DEFAULT_NAME, "retentionlock", "200"))
+  val absoluteTableIdentifierForLock: AbsoluteTableIdentifier = new AbsoluteTableIdentifier(
+    storeLocation, new CarbonTableIdentifier(CarbonCommonConstants.DATABASE_DEFAULT_NAME,
+      "retentionlock", "200"))
   val absoluteTableIdentifierForRetention: AbsoluteTableIdentifier = new
       AbsoluteTableIdentifier(storeLocation,
         new CarbonTableIdentifier(
           CarbonCommonConstants.DATABASE_DEFAULT_NAME, "DataRetentionTable".toLowerCase(), "300"))
   val carbonTablePath = CarbonStorePath
     .getCarbonTablePath(absoluteTableIdentifierForRetention.getStorePath,
-      absoluteTableIdentifierForRetention.getCarbonTableIdentifier).getMetadataDirectoryPath
+      absoluteTableIdentifierForRetention.getCarbonTableIdentifier,
+      hadoopConf).getMetadataDirectoryPath
 
   var carbonDateFormat = new SimpleDateFormat(CarbonCommonConstants.CARBON_TIMESTAMP)
   var defaultDateFormat = new SimpleDateFormat(CarbonCommonConstants
     .CARBON_TIMESTAMP_DEFAULT_FORMAT)
-  val carbonTableStatusLock: ICarbonLock = CarbonLockFactory
-    .getCarbonLockObj(absoluteTableIdentifierForLock.getCarbonTableIdentifier, LockUsage.TABLE_STATUS_LOCK)
-  val carbonDeleteSegmentLock: ICarbonLock = CarbonLockFactory
-    .getCarbonLockObj(absoluteTableIdentifierForLock.getCarbonTableIdentifier, LockUsage.DELETE_SEGMENT_LOCK)
-  val carbonCleanFilesLock: ICarbonLock = CarbonLockFactory
-    .getCarbonLockObj(absoluteTableIdentifierForLock.getCarbonTableIdentifier, LockUsage.CLEAN_FILES_LOCK)
-  val carbonMetadataLock: ICarbonLock = CarbonLockFactory
-    .getCarbonLockObj(absoluteTableIdentifierForLock.getCarbonTableIdentifier, LockUsage.METADATA_LOCK)
+  val carbonTableStatusLock: ICarbonLock = CarbonLockFactory.getCarbonLockObj(
+    absoluteTableIdentifierForLock.getCarbonTableIdentifier, LockUsage.TABLE_STATUS_LOCK,
+    hadoopConf)
+  val carbonDeleteSegmentLock: ICarbonLock = CarbonLockFactory.getCarbonLockObj(
+    absoluteTableIdentifierForLock.getCarbonTableIdentifier, LockUsage.DELETE_SEGMENT_LOCK,
+    hadoopConf)
+  val carbonCleanFilesLock: ICarbonLock = CarbonLockFactory.getCarbonLockObj(
+    absoluteTableIdentifierForLock.getCarbonTableIdentifier, LockUsage.CLEAN_FILES_LOCK,
+    hadoopConf)
+  val carbonMetadataLock: ICarbonLock = CarbonLockFactory.getCarbonLockObj(
+    absoluteTableIdentifierForLock.getCarbonTableIdentifier,
+    LockUsage.METADATA_LOCK, hadoopConf)
 
   override def beforeAll {
     sql("drop table if exists DataRetentionTable")
@@ -121,7 +126,7 @@ class DataRetentionTestCase extends QueryTest with BeforeAndAfterAll {
 
   test("RetentionTest_DeleteSegmentsByLoadTime") {
     val segments: Array[LoadMetadataDetails] =
-      SegmentStatusManager.readLoadMetadata(carbonTablePath)
+      SegmentStatusManager.readLoadMetadata(hadoopConf, carbonTablePath)
     // check segment length, it should be 3 (loads)
     if (segments.length != 2) {
       assert(false)

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/detailquery/SubqueryWithFilterAndSortTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/detailquery/SubqueryWithFilterAndSortTestCase.scala
@@ -27,7 +27,7 @@ class SubqueryWithFilterAndSortTestCase extends QueryTest with BeforeAndAfterAll
   val tempFilePath = s"$resourcesPath/temp/subqueryfilterwithsort.csv"
 
   override def beforeAll {
-    FileFactory.mkdirs(tempDirPath,FileType.LOCAL)
+    FileFactory.mkdirs(hadoopConf, tempDirPath,FileType.LOCAL)
     sql("drop table if exists subqueryfilterwithsort")
     sql("drop table if exists subqueryfilterwithsort_hive")
     sql("CREATE TABLE subqueryfilterwithsort (name String, id int) STORED BY 'org.apache.carbondata.format'")
@@ -59,12 +59,13 @@ class SubqueryWithFilterAndSortTestCase extends QueryTest with BeforeAndAfterAll
   }
 
   def writedata(filePath: String, data: String) = {
-    val dis = FileFactory.getDataOutputStream(filePath, FileFactory.getFileType(filePath))
+    val dis =
+      FileFactory.getDataOutputStream(hadoopConf, filePath, FileFactory.getFileType(filePath))
     dis.writeBytes(data.toString())
     dis.close()
   }
   def deleteFile(filePath: String) {
-    val file = FileFactory.getCarbonFile(filePath, FileFactory.getFileType(filePath))
+    val file = FileFactory.getCarbonFile(hadoopConf, filePath, FileFactory.getFileType(filePath))
     file.delete()
   }
 

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/detailquery/ValueCompressionDataTypeTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/detailquery/ValueCompressionDataTypeTestCase.scala
@@ -25,7 +25,7 @@ class ValueCompressionDataTypeTestCase extends QueryTest with BeforeAndAfterAll 
   val tempDirPath = s"$resourcesPath/temp"
 
   override def beforeAll {
-    FileFactory.mkdirs(tempDirPath,FileType.LOCAL)
+    FileFactory.mkdirs(hadoopConf, tempDirPath,FileType.LOCAL)
   }
 
   test("ActualDataType:double,ChangedDatatype:Short,CompressionType:NonDecimalMaxMin") {
@@ -121,12 +121,13 @@ class ValueCompressionDataTypeTestCase extends QueryTest with BeforeAndAfterAll 
   }
 
   def writedata(filePath: String, data: String) = {
-    val dis = FileFactory.getDataOutputStream(filePath, FileFactory.getFileType(filePath))
+    val dis =
+      FileFactory.getDataOutputStream(hadoopConf, filePath, FileFactory.getFileType(filePath))
     dis.writeBytes(data.toString())
     dis.close()
   }
   def deleteFile(filePath: String) {
-    val file = FileFactory.getCarbonFile(filePath, FileFactory.getFileType(filePath))
+    val file = FileFactory.getCarbonFile(hadoopConf, filePath, FileFactory.getFileType(filePath))
     file.delete()
   }
 

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/partition/TestDataLoadingForPartitionTable.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/partition/TestDataLoadingForPartitionTable.scala
@@ -62,9 +62,10 @@ class TestDataLoadingForPartitionTable extends QueryTest with BeforeAndAfterAll 
   def validateDataFiles(tableUniqueName: String, segmentId: String, partitions: Seq[Int]): Unit = {
     val carbonTable = CarbonMetadata.getInstance().getCarbonTable(tableUniqueName)
     val tablePath = new CarbonTablePath(carbonTable.getStorePath, carbonTable.getDatabaseName,
-      carbonTable.getFactTableName)
+      carbonTable.getFactTableName, hadoopConf)
     val segmentDir = tablePath.getCarbonDataDirectoryPath("0", segmentId)
-    val carbonFile = FileFactory.getCarbonFile(segmentDir, FileFactory.getFileType(segmentDir))
+    val carbonFile =
+      FileFactory.getCarbonFile(hadoopConf, segmentDir, FileFactory.getFileType(segmentDir))
     val dataFiles = carbonFile.listFiles(new CarbonFileFilter() {
       override def accept(file: CarbonFile): Boolean = {
         return file.getName.endsWith(".carbondata")

--- a/integration/spark-common/src/main/java/org/apache/carbondata/spark/util/LoadMetadataUtil.java
+++ b/integration/spark-common/src/main/java/org/apache/carbondata/spark/util/LoadMetadataUtil.java
@@ -21,6 +21,8 @@ import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.statusmanager.LoadMetadataDetails;
 import org.apache.carbondata.core.statusmanager.SegmentStatusManager;
 
+import org.apache.hadoop.conf.Configuration;
+
 /**
  * Utility for load data
  */
@@ -29,8 +31,10 @@ public final class LoadMetadataUtil {
 
   }
 
-  public static boolean isLoadDeletionRequired(String metaDataLocation) {
-    LoadMetadataDetails[] details = SegmentStatusManager.readLoadMetadata(metaDataLocation);
+  public static boolean isLoadDeletionRequired(Configuration configuration,
+      String metaDataLocation) {
+    LoadMetadataDetails[] details =
+        SegmentStatusManager.readLoadMetadata(configuration, metaDataLocation);
     if (details != null && details.length != 0) {
       for (LoadMetadataDetails oneRow : details) {
         if ((CarbonCommonConstants.MARKED_FOR_DELETE.equalsIgnoreCase(oneRow.getLoadStatus())

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/CarbonSparkFactory.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/CarbonSparkFactory.scala
@@ -16,6 +16,8 @@
  */
 package org.apache.carbondata.spark
 
+import org.apache.hadoop.conf.Configuration
+
 import org.apache.carbondata.core.metadata.{CarbonTableIdentifier, ColumnIdentifier}
 import org.apache.carbondata.core.metadata.schema.table.column.{CarbonDimension, ColumnSchema}
 
@@ -30,7 +32,8 @@ trait ColumnValidator {
  */
 trait DictionaryDetailService {
   def getDictionaryDetail(dictFolderPath: String, primDimensions: Array[CarbonDimension],
-      table: CarbonTableIdentifier, storePath: String): DictionaryDetail
+      table: CarbonTableIdentifier, storePath: String,
+      configuration: Configuration): DictionaryDetail
 }
 
 /**

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/DictionaryDetailHelper.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/DictionaryDetailHelper.scala
@@ -19,6 +19,8 @@ package org.apache.carbondata.spark
 
 import scala.collection.mutable.HashMap
 
+import org.apache.hadoop.conf.Configuration
+
 import org.apache.carbondata.core.datastore.filesystem.{CarbonFile, CarbonFileFilter}
 import org.apache.carbondata.core.datastore.impl.FileFactory
 import org.apache.carbondata.core.metadata.{CarbonTableIdentifier, ColumnIdentifier}
@@ -27,15 +29,16 @@ import org.apache.carbondata.core.util.path.{CarbonStorePath, CarbonTablePath}
 
 class DictionaryDetailHelper extends DictionaryDetailService {
   def getDictionaryDetail(dictfolderPath: String, primDimensions: Array[CarbonDimension],
-      table: CarbonTableIdentifier, storePath: String): DictionaryDetail = {
-    val carbonTablePath = CarbonStorePath.getCarbonTablePath(storePath, table)
+      table: CarbonTableIdentifier, storePath: String,
+      configuration: Configuration): DictionaryDetail = {
+    val carbonTablePath = CarbonStorePath.getCarbonTablePath(storePath, table, configuration)
     val dictFilePaths = new Array[String](primDimensions.length)
     val dictFileExists = new Array[Boolean](primDimensions.length)
     val columnIdentifier = new Array[ColumnIdentifier](primDimensions.length)
 
     val fileType = FileFactory.getFileType(dictfolderPath)
     // Metadata folder
-    val metadataDirectory = FileFactory.getCarbonFile(dictfolderPath, fileType)
+    val metadataDirectory = FileFactory.getCarbonFile(configuration, dictfolderPath, fileType)
     // need list all dictionary file paths with exists flag
     val carbonFiles = metadataDirectory.listFiles(new CarbonFileFilter {
       @Override def accept(pathname: CarbonFile): Boolean = {

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonIUDMergerRDD.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonIUDMergerRDD.scala
@@ -44,12 +44,14 @@ class CarbonIUDMergerRDD[K, V](
     result: MergeResult[K, V],
     carbonLoadModel: CarbonLoadModel,
     carbonMergerMapping: CarbonMergerMapping,
-    confExecutorsTemp: String)
+    confExecutorsTemp: String,
+    @transient configuration: Configuration)
   extends CarbonMergerRDD[K, V](sc,
     result,
     carbonLoadModel,
     carbonMergerMapping,
-    confExecutorsTemp) {
+    confExecutorsTemp,
+    configuration) {
 
   override def getPartitions: Array[Partition] = {
     val startTime = System.currentTimeMillis()

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/PartitionSplitter.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/PartitionSplitter.scala
@@ -58,7 +58,8 @@ object PartitionSplitter {
          alterPartitionModel,
          carbonTableIdentifier,
          Seq(partitionId),
-         bucketId
+         bucketId,
+         splitPartitionCallableModel.configuration
        ).partitionBy(partitioner).map(_._2)
 
        val splitStatus = new AlterTableLoadPartitionRDD(alterPartitionModel,
@@ -66,7 +67,8 @@ object PartitionSplitter {
          Seq(partitionId),
          bucketId,
          identifier,
-         rdd).collect()
+         rdd,
+         splitPartitionCallableModel.configuration).collect()
 
        if (splitStatus.length == 0) {
          finalSplitStatus = false
@@ -84,7 +86,7 @@ object PartitionSplitter {
        try {
          PartitionUtils.
            deleteOriginalCarbonFile(alterPartitionModel, identifier, Seq(partitionId).toList
-             , databaseName, tableName, partitionInfo)
+             , databaseName, tableName, partitionInfo, splitPartitionCallableModel.configuration)
        } catch {
          case e: IOException => sys.error(s"Exception while delete original carbon files " +
          e.getMessage)

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/UpdateDataLoad.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/UpdateDataLoad.scala
@@ -19,6 +19,7 @@ package org.apache.carbondata.spark.rdd
 
 import scala.collection.mutable
 
+import org.apache.hadoop.conf.Configuration
 import org.apache.spark.TaskContext
 import org.apache.spark.sql.Row
 
@@ -39,7 +40,8 @@ object UpdateDataLoad {
       index: Int,
       iter: Iterator[Row],
       carbonLoadModel: CarbonLoadModel,
-      loadMetadataDetails: LoadMetadataDetails): Unit = {
+      loadMetadataDetails: LoadMetadataDetails,
+      hadoopConf: Configuration): Unit = {
     val LOGGER = LogServiceFactory.getLogService(this.getClass.getCanonicalName)
     try {
       val recordReaders = mutable.Buffer[CarbonIterator[Array[AnyRef]]]()
@@ -57,7 +59,8 @@ object UpdateDataLoad {
       loadMetadataDetails.setLoadStatus(CarbonCommonConstants.STORE_LOADSTATUS_SUCCESS)
       new DataLoadExecutor().execute(carbonLoadModel,
         loader.storeLocation,
-        recordReaders.toArray)
+        recordReaders.toArray,
+        hadoopConf)
 
     } catch {
       case e: Exception =>

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/tasks/DictionaryWriterTask.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/tasks/DictionaryWriterTask.scala
@@ -20,6 +20,8 @@ import java.io.IOException
 
 import scala.collection.mutable
 
+import org.apache.hadoop.conf.Configuration
+
 import org.apache.carbondata.core.cache.dictionary.{Dictionary, DictionaryColumnUniqueIdentifier}
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.metadata.{CarbonTableIdentifier, ColumnIdentifier}
@@ -46,7 +48,8 @@ class DictionaryWriterTask(valuesBuffer: mutable.HashSet[String],
     carbonStoreLocation: String,
     columnSchema: ColumnSchema,
     isDictionaryFileExist: Boolean,
-    var writer: CarbonDictionaryWriter = null) {
+    var writer: CarbonDictionaryWriter = null,
+    configuration: Configuration) {
 
   /**
    * execute the task
@@ -60,7 +63,7 @@ class DictionaryWriterTask(valuesBuffer: mutable.HashSet[String],
     writer = dictService.getDictionaryWriter(
       carbonTableIdentifier,
       dictionaryColumnUniqueIdentifier,
-      carbonStoreLocation)
+      carbonStoreLocation, configuration)
     val distinctValues: java.util.List[String] = new java.util.ArrayList()
 
     try {

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/tasks/SortIndexWriterTask.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/tasks/SortIndexWriterTask.scala
@@ -16,6 +16,8 @@
  */
 package org.apache.carbondata.spark.tasks
 
+import org.apache.hadoop.conf.Configuration
+
 import org.apache.carbondata.core.cache.dictionary.{Dictionary, DictionaryColumnUniqueIdentifier}
 import org.apache.carbondata.core.metadata.{CarbonTableIdentifier, ColumnIdentifier}
 import org.apache.carbondata.core.metadata.datatype.DataType
@@ -40,7 +42,8 @@ class SortIndexWriterTask(
     carbonStoreLocation: String,
     dictionary: Dictionary,
     distinctValues: java.util.List[String],
-    var carbonDictionarySortIndexWriter: CarbonDictionarySortIndexWriter = null) {
+    var carbonDictionarySortIndexWriter: CarbonDictionarySortIndexWriter = null,
+    configuration: Configuration) {
   def execute() {
     try {
       if (distinctValues.size() > 0) {
@@ -49,10 +52,9 @@ class SortIndexWriterTask(
         val dictionarySortInfo: CarbonDictionarySortInfo =
           preparator.getDictionarySortInfo(distinctValues, dictionary,
             dataType)
-        carbonDictionarySortIndexWriter =
-          dictService
-            .getDictionarySortIndexWriter(carbonTableIdentifier, dictionaryColumnUniqueIdentifier,
-            carbonStoreLocation)
+        carbonDictionarySortIndexWriter = dictService.getDictionarySortIndexWriter(
+          carbonTableIdentifier, dictionaryColumnUniqueIdentifier, carbonStoreLocation,
+          configuration)
         carbonDictionarySortIndexWriter.writeSortIndex(dictionarySortInfo.getSortIndex)
         carbonDictionarySortIndexWriter
           .writeInvertedSortIndex(dictionarySortInfo.getSortIndexInverted)

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchemaCommon.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchemaCommon.scala
@@ -23,6 +23,7 @@ import java.util.UUID
 import scala.collection.JavaConverters._
 import scala.collection.mutable.Map
 
+import org.apache.hadoop.conf.Configuration
 import org.apache.spark.SparkContext
 import org.apache.spark.sql.SQLContext
 import org.apache.spark.sql.catalyst.TableIdentifier
@@ -123,7 +124,8 @@ case class CompactionCallableModel(carbonLoadModel: CarbonLoadModel,
     carbonTable: CarbonTable,
     loadsToMerge: util.List[LoadMetadataDetails],
     sqlContext: SQLContext,
-    compactionType: CompactionType)
+    compactionType: CompactionType,
+    configuration: Configuration)
 
 case class AlterPartitionModel(carbonLoadModel: CarbonLoadModel,
     segmentId: String,
@@ -135,7 +137,8 @@ case class SplitPartitionCallableModel(carbonLoadModel: CarbonLoadModel,
     segmentId: String,
     partitionId: String,
     oldPartitionIds: List[Int],
-    sqlContext: SQLContext)
+    sqlContext: SQLContext,
+    configuration: Configuration)
 
 case class DropPartitionCallableModel(carbonLoadModel: CarbonLoadModel,
     segmentId: String,
@@ -143,7 +146,8 @@ case class DropPartitionCallableModel(carbonLoadModel: CarbonLoadModel,
     oldPartitionIds: List[Int],
     dropWithData: Boolean,
     carbonTable: CarbonTable,
-    sqlContext: SQLContext)
+    sqlContext: SQLContext,
+    configuration: Configuration)
 
 case class DataTypeInfo(dataType: String, precision: Int = 0, scale: Int = 0)
 

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/test/TestQueryExecutor.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/test/TestQueryExecutor.scala
@@ -23,6 +23,7 @@ import java.util.ServiceLoader
 import scala.collection.mutable.ArrayBuffer
 import scala.util.Random
 
+import org.apache.hadoop.conf.Configuration
 import org.apache.spark.sql.{DataFrame, SQLContext}
 import org.apache.spark.util.Utils
 
@@ -76,11 +77,13 @@ object TestQueryExecutor {
     s"$integrationPath/spark-common-test/src/test/resources"
   }
 
+  val hadoopConf = new Configuration()
+
   val storeLocation = if (hdfsUrl.startsWith("hdfs://")) {
     CarbonProperties.getInstance().addProperty(CarbonCommonConstants.LOCK_TYPE,
       CarbonCommonConstants.CARBON_LOCK_TYPE_HDFS)
-    val carbonFile = FileFactory.
-      getCarbonFile(s"$hdfsUrl/store", FileFactory.getFileType(s"$hdfsUrl/store"))
+    val carbonFile = FileFactory.getCarbonFile(hadoopConf, s"$hdfsUrl/store",
+      FileFactory.getFileType(s"$hdfsUrl/store"))
     FileFactory.deleteAllCarbonFilesOfDir(carbonFile)
     s"$hdfsUrl/store_" + System.nanoTime()
   } else {
@@ -89,8 +92,8 @@ object TestQueryExecutor {
     s"$integrationPath/spark-common/target/store"
   }
   val warehouse = if (hdfsUrl.startsWith("hdfs://")) {
-    val carbonFile = FileFactory.
-      getCarbonFile(s"$hdfsUrl/warehouse", FileFactory.getFileType(s"$hdfsUrl/warehouse"))
+    val carbonFile = FileFactory.getCarbonFile(hadoopConf, s"$hdfsUrl/warehouse",
+      FileFactory.getFileType(s"$hdfsUrl/warehouse"))
     FileFactory.deleteAllCarbonFilesOfDir(carbonFile)
     s"$hdfsUrl/warehouse_" + System.nanoTime()
   } else {
@@ -99,7 +102,7 @@ object TestQueryExecutor {
 
   val hiveresultpath = if (hdfsUrl.startsWith("hdfs://")) {
     val p = s"$hdfsUrl/hiveresultpath"
-    FileFactory.mkdirs(p, FileFactory.getFileType(p))
+    FileFactory.mkdirs(hadoopConf, p, FileFactory.getFileType(p))
     p
   } else {
     val p = s"$integrationPath/spark-common/target/hiveresultpath"

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/test/util/QueryTest.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/test/util/QueryTest.scala
@@ -87,6 +87,7 @@ class QueryTest extends PlanTest {
   def sql(sqlText: String): DataFrame = TestQueryExecutor.INSTANCE.sql(sqlText)
 
   val sqlContext: SQLContext = TestQueryExecutor.INSTANCE.sqlContext
+  val hadoopConf = TestQueryExecutor.hadoopConf
 
   lazy val storeLocation = CarbonProperties.getInstance().
     getProperty(CarbonCommonConstants.STORE_LOCATION)

--- a/integration/spark-common/src/main/scala/org/apache/spark/util/FileUtils.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/util/FileUtils.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.util
 
+import org.apache.hadoop.conf.Configuration
+
 import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.datastore.filesystem.CarbonFile
@@ -53,7 +55,7 @@ object FileUtils {
    * append all file path to a String, inputPath path separated by comma
    *
    */
-  def getPaths(inputPath: String): String = {
+  def getPaths(hadoopConfiguration: Configuration, inputPath: String): String = {
     if (inputPath == null || inputPath.isEmpty) {
       throw new DataLoadingException("Input file path cannot be empty.")
     } else {
@@ -61,7 +63,7 @@ object FileUtils {
       val filePaths = inputPath.split(",")
       for (i <- 0 until filePaths.size) {
         val fileType = FileFactory.getFileType(filePaths(i))
-        val carbonFile = FileFactory.getCarbonFile(filePaths(i), fileType)
+        val carbonFile = FileFactory.getCarbonFile(hadoopConfiguration, filePaths(i), fileType)
         if (!carbonFile.exists()) {
           throw new DataLoadingException(s"The input file does not exist: ${filePaths(i)}" )
         }
@@ -76,7 +78,7 @@ object FileUtils {
     }
   }
 
-  def getSpaceOccupied(inputPath: String): Long = {
+  def getSpaceOccupied(hadoopConfiguration: Configuration, inputPath: String): Long = {
     var size : Long = 0
     if (inputPath == null || inputPath.isEmpty) {
       size
@@ -84,7 +86,7 @@ object FileUtils {
       val filePaths = inputPath.split(",")
       for (i <- 0 until filePaths.size) {
         val fileType = FileFactory.getFileType(filePaths(i))
-        val carbonFile = FileFactory.getCarbonFile(filePaths(i), fileType)
+        val carbonFile = FileFactory.getCarbonFile(hadoopConfiguration, filePaths(i), fileType)
         size = size + carbonFile.getSize
       }
       size

--- a/integration/spark-common/src/main/scala/org/apache/spark/util/PartitionUtils.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/util/PartitionUtils.scala
@@ -128,10 +128,10 @@ object PartitionUtils {
    */
   def getSegmentProperties(identifier: AbsoluteTableIdentifier, segmentId: String,
       partitionIds: List[String], oldPartitionIdList: List[Int],
-      partitionInfo: PartitionInfo): SegmentProperties = {
+      partitionInfo: PartitionInfo, configuration: Configuration): SegmentProperties = {
     val tableBlockInfoList =
       getPartitionBlockList(identifier, segmentId, partitionIds, oldPartitionIdList, partitionInfo)
-    val footer = CarbonUtil.readMetadatFile(tableBlockInfoList.get(0))
+    val footer = CarbonUtil.readMetadatFile(tableBlockInfoList.get(0), configuration)
     val segmentProperties = new SegmentProperties(footer.getColumnInTable,
       footer.getSegmentInfo.getColumnCardinality)
     segmentProperties
@@ -155,7 +155,7 @@ object PartitionUtils {
   def deleteOriginalCarbonFile(alterPartitionModel: AlterPartitionModel,
       identifier: AbsoluteTableIdentifier,
       partitionIds: List[String], dbName: String, tableName: String,
-      partitionInfo: PartitionInfo): Unit = {
+      partitionInfo: PartitionInfo, configuration: Configuration): Unit = {
     val carbonLoadModel = alterPartitionModel.carbonLoadModel
     val segmentId = alterPartitionModel.segmentId
     val oldPartitionIds = alterPartitionModel.oldPartitionIds
@@ -165,7 +165,7 @@ object PartitionUtils {
       getPartitionBlockList(identifier, segmentId, partitionIds, oldPartitionIds,
         partitionInfo).asScala
     val pathList: util.List[String] = new util.ArrayList[String]()
-    val carbonTablePath = new CarbonTablePath(storePath, dbName, tableName)
+    val carbonTablePath = new CarbonTablePath(storePath, dbName, tableName, configuration)
     tableBlockInfoList.foreach{ tableBlockInfo =>
       val path = tableBlockInfo.getFilePath
       val timestamp = CarbonTablePath.DataFileUtil.getTimeStampFromFileName(path)

--- a/integration/spark/src/main/java/org/apache/carbondata/spark/readsupport/SparkRowReadSupportImpl.java
+++ b/integration/spark/src/main/java/org/apache/carbondata/spark/readsupport/SparkRowReadSupportImpl.java
@@ -28,6 +28,7 @@ import org.apache.carbondata.core.metadata.schema.table.column.CarbonDimension;
 import org.apache.carbondata.core.util.DataTypeUtil;
 import org.apache.carbondata.hadoop.readsupport.impl.DictionaryDecodeReadSupport;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.expressions.GenericRow;
 import org.apache.spark.unsafe.types.UTF8String;
@@ -35,8 +36,9 @@ import org.apache.spark.unsafe.types.UTF8String;
 public class SparkRowReadSupportImpl extends DictionaryDecodeReadSupport<Row> {
 
   @Override public void initialize(CarbonColumn[] carbonColumns,
-      AbsoluteTableIdentifier absoluteTableIdentifier) throws IOException {
-    super.initialize(carbonColumns, absoluteTableIdentifier);
+      AbsoluteTableIdentifier absoluteTableIdentifier,
+      Configuration configuration) throws IOException {
+    super.initialize(carbonColumns, absoluteTableIdentifier, configuration);
     //can initialize and generate schema here.
   }
 

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonDatasourceHadoopRelation.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonDatasourceHadoopRelation.scala
@@ -64,7 +64,8 @@ private[sql] case class CarbonDatasourceHadoopRelation(
   lazy val options = new CarbonOption(parameters)
   lazy val absIdentifier = AbsoluteTableIdentifier.fromTablePath(paths.head)
   lazy val relationRaw: CarbonRelation = {
-    val carbonTable = SchemaReader.readCarbonTableFromStore(absIdentifier)
+    val carbonTable = SchemaReader.readCarbonTableFromStore(absIdentifier,
+      sqlContext.sparkContext.hadoopConfiguration)
     if (carbonTable == null) {
       sys.error(s"CarbonData file path ${paths.head} is not valid")
     }

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonDatasourceRelation.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonDatasourceRelation.scala
@@ -304,16 +304,18 @@ case class CarbonRelation(
   private var sizeInBytesLocalValue = 0L
 
   def sizeInBytes: Long = {
+    val hadoopConf = sqlContext.sparkContext.hadoopConfiguration
     val tableStatusNewLastUpdatedTime = SegmentStatusManager.getTableStatusLastModifiedTime(
-      tableMeta.carbonTable.getAbsoluteTableIdentifier)
+      tableMeta.carbonTable.getAbsoluteTableIdentifier, hadoopConf)
     if (tableStatusLastUpdateTime != tableStatusNewLastUpdatedTime) {
       val tablePath = CarbonStorePath.getCarbonTablePath(
         tableMeta.storePath,
-        tableMeta.carbonTableIdentifier).getPath
+        tableMeta.carbonTableIdentifier,
+        hadoopConf).getPath
       val fileType = FileFactory.getFileType(tablePath)
-      if(FileFactory.isFileExist(tablePath, fileType)) {
+      if(FileFactory.isFileExist(hadoopConf, tablePath, fileType)) {
         tableStatusLastUpdateTime = tableStatusNewLastUpdatedTime
-        sizeInBytesLocalValue = FileFactory.getDirectorySize(tablePath)
+        sizeInBytesLocalValue = FileFactory.getDirectorySize(hadoopConf, tablePath)
       }
     }
     sizeInBytesLocalValue

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonScan.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonScan.scala
@@ -130,7 +130,9 @@ case class CarbonScan(
       buildCarbonPlan.getFilterExpression,
       carbonTable.getAbsoluteTableIdentifier,
       carbonTable.getTableInfo.serialize(),
-      carbonTable.getTableInfo, inputMetricsStats
+      carbonTable.getTableInfo,
+      inputMetricsStats,
+      ocRaw.sparkContext.hadoopConfiguration
     )
   }
 

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/CompactionSystemLockFeatureTest.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/CompactionSystemLockFeatureTest.scala
@@ -84,13 +84,13 @@ class CompactionSystemLockFeatureTest extends QueryTest with BeforeAndAfterAll {
         )
     val carbonTablePath: CarbonTablePath = CarbonStorePath
       .getCarbonTablePath(absoluteTableIdentifier.getStorePath,
-        absoluteTableIdentifier.getCarbonTableIdentifier
+        absoluteTableIdentifier.getCarbonTableIdentifier, hadoopConf
       )
 
     val file = carbonTablePath.getMetadataDirectoryPath + CarbonCommonConstants
       .FILE_SEPARATOR + CarbonCommonConstants.majorCompactionRequiredFile
 
-    FileFactory.createNewFile(file, FileFactory.getFileType(file))
+    FileFactory.createNewFile(hadoopConf, file, FileFactory.getFileType(file))
 
     // compaction will happen here.
     sql("alter table table1 compact 'major'"
@@ -111,7 +111,7 @@ class CompactionSystemLockFeatureTest extends QueryTest with BeforeAndAfterAll {
         AbsoluteTableIdentifier(
           CarbonProperties.getInstance.getProperty(CarbonCommonConstants.STORE_LOCATION),
           new CarbonTableIdentifier("default", "table1", "rrr")
-        )
+        ), hadoopConf
     )
     // merged segment should not be there
     val segments = segmentStatusManager.getValidAndInvalidSegments.getValidSegments.asScala.toList
@@ -123,7 +123,7 @@ class CompactionSystemLockFeatureTest extends QueryTest with BeforeAndAfterAll {
         AbsoluteTableIdentifier(
           CarbonProperties.getInstance.getProperty(CarbonCommonConstants.STORE_LOCATION),
           new CarbonTableIdentifier("default", "table2", "rrr1")
-        )
+        ), hadoopConf
     )
     // merged segment should not be there
     val segments2 = segmentStatusManager2.getValidAndInvalidSegments.getValidSegments.asScala.toList

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/DataCompactionMinorThresholdTest.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/DataCompactionMinorThresholdTest.scala
@@ -80,7 +80,8 @@ class DataCompactionMinorThresholdTest extends QueryTest with BeforeAndAfterAll 
 
     sql("clean files for table minorthreshold")
 
-    val segmentStatusManager: SegmentStatusManager = new SegmentStatusManager(identifier)
+    val segmentStatusManager: SegmentStatusManager =
+      new SegmentStatusManager(identifier, hadoopConf)
     val segments = segmentStatusManager.getValidAndInvalidSegments.getValidSegments.asScala.toList
 
     assert(segments.contains("0.2"))

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/DataCompactionNoDictionaryTest.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/DataCompactionNoDictionaryTest.scala
@@ -38,7 +38,8 @@ class DataCompactionNoDictionaryTest extends QueryTest with BeforeAndAfterAll {
           CarbonProperties.getInstance.getProperty(CarbonCommonConstants.STORE_LOCATION),
           new CarbonTableIdentifier(databaseName, tableName.toLowerCase , tableId))
 
-    val segmentStatusManager: SegmentStatusManager = new SegmentStatusManager(identifier)
+    val segmentStatusManager: SegmentStatusManager =
+      new SegmentStatusManager(identifier, hadoopConf)
     segmentStatusManager.getValidAndInvalidSegments.getValidSegments.asScala.toList
   }
 

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/DataCompactionTest.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/DataCompactionTest.scala
@@ -74,7 +74,8 @@ class DataCompactionTest extends QueryTest with BeforeAndAfterAll {
             new CarbonTableIdentifier(CarbonCommonConstants.DATABASE_DEFAULT_NAME, "normalcompaction", "1")
           )
 
-      val segmentStatusManager: SegmentStatusManager = new SegmentStatusManager(identifier)
+      val segmentStatusManager: SegmentStatusManager =
+        new SegmentStatusManager(identifier, hadoopConf)
 
       val segments = segmentStatusManager.getValidAndInvalidSegments.getValidSegments.asScala.toList
 
@@ -123,7 +124,8 @@ class DataCompactionTest extends QueryTest with BeforeAndAfterAll {
             CarbonCommonConstants.DATABASE_DEFAULT_NAME, "normalcompaction", "uniqueid")
         )
 
-    val segmentStatusManager: SegmentStatusManager = new SegmentStatusManager(identifier)
+    val segmentStatusManager: SegmentStatusManager =
+      new SegmentStatusManager(identifier, hadoopConf)
 
     // merged segment should not be there
     val segments = segmentStatusManager.getValidAndInvalidSegments.getValidSegments.asScala.toList

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/util/AllDictionaryTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/util/AllDictionaryTestCase.scala
@@ -58,7 +58,8 @@ class AllDictionaryTestCase extends QueryTest with BeforeAndAfterAll {
     carbonLoadModel.setDefaultTimestampFormat(CarbonProperties.getInstance().getProperty(
       CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT,
       CarbonCommonConstants.CARBON_TIMESTAMP_DEFAULT_FORMAT))
-    carbonLoadModel.setCsvHeaderColumns(CommonUtil.getCsvHeaderColumns(carbonLoadModel))
+    carbonLoadModel.setCsvHeaderColumns(
+      CommonUtil.getCsvHeaderColumns(hadoopConf, carbonLoadModel))
     carbonLoadModel
   }
 
@@ -114,6 +115,7 @@ class AllDictionaryTestCase extends QueryTest with BeforeAndAfterAll {
     val carbonLoadModel = buildCarbonLoadModel(sampleRelation, null, header, sampleAllDictionaryFile)
     GlobalDictionaryUtil
       .generateGlobalDictionary(sqlContext,
+        hadoopConf,
         carbonLoadModel,
         sampleRelation.tableMeta.storePath)
 
@@ -126,8 +128,9 @@ class AllDictionaryTestCase extends QueryTest with BeforeAndAfterAll {
     val carbonLoadModel = buildCarbonLoadModel(complexRelation, null, header, complexAllDictionaryFile)
     GlobalDictionaryUtil
       .generateGlobalDictionary(sqlContext,
-      carbonLoadModel,
-      complexRelation.tableMeta.storePath)
+        hadoopConf,
+        carbonLoadModel,
+        complexRelation.tableMeta.storePath)
 
     DictionaryTestCaseUtil.
       checkDictionary(complexRelation, "channelsId", "1650")

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/util/DictionaryTestCaseUtil.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/util/DictionaryTestCaseUtil.scala
@@ -17,6 +17,7 @@
 
 package org.apache.carbondata.spark.util
 
+import org.apache.hadoop.conf.Configuration
 import org.apache.spark.sql.CarbonRelation
 import org.apache.spark.sql.test.TestQueryExecutor
 
@@ -43,9 +44,11 @@ object DictionaryTestCaseUtil {
     val tableIdentifier = new CarbonTableIdentifier(table.getDatabaseName, table.getFactTableName, "uniqueid")
     val columnIdentifier = new DictionaryColumnUniqueIdentifier(tableIdentifier,
       dimension.getColumnIdentifier, dimension.getDataType,
-      CarbonStorePath.getCarbonTablePath(table.getStorePath, table.getCarbonTableIdentifier)
+      CarbonStorePath.getCarbonTablePath(table.getStorePath, table.getCarbonTableIdentifier,
+        TestQueryExecutor.hadoopConf)
     )
-    val dict = CarbonLoaderUtil.getDictionary(columnIdentifier, TestQueryExecutor.storeLocation)
+    val dict = CarbonLoaderUtil.getDictionary(columnIdentifier, TestQueryExecutor.storeLocation,
+      TestQueryExecutor.hadoopConf)
     assert(dict.getSurrogateKey(value) != CarbonCommonConstants.INVALID_SURROGATE_KEY)
   }
 }

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/util/ExternalColumnDictionaryTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/util/ExternalColumnDictionaryTestCase.scala
@@ -144,8 +144,9 @@ class ExternalColumnDictionaryTestCase extends QueryTest with BeforeAndAfterAll 
       CarbonCommonConstants.CARBON_TIMESTAMP_DEFAULT_FORMAT))
     carbonLoadModel.setDefaultDateFormat(CarbonProperties.getInstance().getProperty(
       CarbonCommonConstants.CARBON_DATE_FORMAT,
-      CarbonCommonConstants.CARBON_DATE_DEFAULT_FORMAT))  
-    carbonLoadModel.setCsvHeaderColumns(CommonUtil.getCsvHeaderColumns(carbonLoadModel))
+      CarbonCommonConstants.CARBON_DATE_DEFAULT_FORMAT))
+    carbonLoadModel.setCsvHeaderColumns(
+      CommonUtil.getCsvHeaderColumns(hadoopConf, carbonLoadModel))
     carbonLoadModel.setMaxColumns("100")
     carbonLoadModel
   }
@@ -160,7 +161,7 @@ class ExternalColumnDictionaryTestCase extends QueryTest with BeforeAndAfterAll 
     // load the first time
     var carbonLoadModel = buildCarbonLoadModel(extComplexRelation, complexFilePath1,
       header, extColDictFilePath1)
-    GlobalDictionaryUtil.generateGlobalDictionary(sqlContext, carbonLoadModel,
+    GlobalDictionaryUtil.generateGlobalDictionary(sqlContext, hadoopConf, carbonLoadModel,
       extComplexRelation.tableMeta.storePath)
     // check whether the dictionary is generated
     DictionaryTestCaseUtil.checkDictionary(
@@ -169,7 +170,7 @@ class ExternalColumnDictionaryTestCase extends QueryTest with BeforeAndAfterAll 
     // load the second time
     carbonLoadModel = buildCarbonLoadModel(extComplexRelation, complexFilePath1,
       header, extColDictFilePath2)
-    GlobalDictionaryUtil.generateGlobalDictionary(sqlContext, carbonLoadModel,
+    GlobalDictionaryUtil.generateGlobalDictionary(sqlContext, hadoopConf, carbonLoadModel,
       extComplexRelation.tableMeta.storePath)
     // check the old dictionary and whether the new distinct value is generated
     DictionaryTestCaseUtil.checkDictionary(
@@ -182,7 +183,7 @@ class ExternalColumnDictionaryTestCase extends QueryTest with BeforeAndAfterAll 
     //  when csv delimiter is comma
     var carbonLoadModel = buildCarbonLoadModel(extComplexRelation, complexFilePath1,
       header, extColDictFilePath3)
-    GlobalDictionaryUtil.generateGlobalDictionary(sqlContext, carbonLoadModel,
+    GlobalDictionaryUtil.generateGlobalDictionary(sqlContext, hadoopConf, carbonLoadModel,
       extComplexRelation.tableMeta.storePath)
     // check whether the dictionary is generated
     DictionaryTestCaseUtil.checkDictionary(
@@ -191,7 +192,7 @@ class ExternalColumnDictionaryTestCase extends QueryTest with BeforeAndAfterAll 
     //  when csv delimiter is not comma
     carbonLoadModel = buildCarbonLoadModel(verticalDelimiteRelation, complexFilePath2,
       header2, extColDictFilePath3, "|")
-    GlobalDictionaryUtil.generateGlobalDictionary(sqlContext, carbonLoadModel,
+    GlobalDictionaryUtil.generateGlobalDictionary(sqlContext, hadoopConf, carbonLoadModel,
       verticalDelimiteRelation.tableMeta.storePath)
     // check whether the dictionary is generated
     DictionaryTestCaseUtil.checkDictionary(

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/util/GlobalDictionaryUtilTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/util/GlobalDictionaryUtilTestCase.scala
@@ -16,8 +16,6 @@
  */
 package org.apache.carbondata.spark.util
 
-import java.io.File
-
 import org.apache.spark.sql.test.util.QueryTest
 import org.apache.spark.sql.{CarbonEnv, CarbonRelation}
 import org.scalatest.BeforeAndAfterAll
@@ -69,7 +67,8 @@ class GlobalDictionaryUtilTestCase extends QueryTest with BeforeAndAfterAll {
     carbonLoadModel.setDefaultDateFormat(CarbonProperties.getInstance().getProperty(
       CarbonCommonConstants.CARBON_DATE_FORMAT,
       CarbonCommonConstants.CARBON_DATE_DEFAULT_FORMAT))  
-    carbonLoadModel.setCsvHeaderColumns(CommonUtil.getCsvHeaderColumns(carbonLoadModel))
+    carbonLoadModel.setCsvHeaderColumns(
+      CommonUtil.getCsvHeaderColumns(hadoopConf, carbonLoadModel))
     carbonLoadModel.setMaxColumns("2000")
     carbonLoadModel
   }
@@ -157,7 +156,7 @@ class GlobalDictionaryUtilTestCase extends QueryTest with BeforeAndAfterAll {
 
     val carbonLoadModel = buildCarbonLoadModel(sampleRelation, filePath, null)
     GlobalDictionaryUtil
-      .generateGlobalDictionary(sqlContext, carbonLoadModel,
+      .generateGlobalDictionary(sqlContext, hadoopConf, carbonLoadModel,
         sampleRelation.tableMeta.storePath
       )
 
@@ -174,7 +173,7 @@ class GlobalDictionaryUtilTestCase extends QueryTest with BeforeAndAfterAll {
       "proddate,gamePointId,contractNumber"
     val carbonLoadModel = buildCarbonLoadModel(complexRelation, complexfilePath, header)
     GlobalDictionaryUtil
-      .generateGlobalDictionary(sqlContext, carbonLoadModel,
+      .generateGlobalDictionary(sqlContext, hadoopConf, carbonLoadModel,
         complexRelation.tableMeta.storePath
       )
   }
@@ -188,7 +187,7 @@ class GlobalDictionaryUtilTestCase extends QueryTest with BeforeAndAfterAll {
       header
     )
     GlobalDictionaryUtil
-      .generateGlobalDictionary(sqlContext, carbonLoadModel,
+      .generateGlobalDictionary(sqlContext, hadoopConf, carbonLoadModel,
         sampleRelation.tableMeta.storePath
       )
     DictionaryTestCaseUtil.
@@ -200,7 +199,7 @@ class GlobalDictionaryUtilTestCase extends QueryTest with BeforeAndAfterAll {
       header
     )
     GlobalDictionaryUtil
-      .generateGlobalDictionary(sqlContext, carbonLoadModel,
+      .generateGlobalDictionary(sqlContext, hadoopConf, carbonLoadModel,
         sampleRelation.tableMeta.storePath
       )
     DictionaryTestCaseUtil.

--- a/integration/spark2/src/main/java/org/apache/carbondata/spark/readsupport/SparkRowReadSupportImpl.java
+++ b/integration/spark2/src/main/java/org/apache/carbondata/spark/readsupport/SparkRowReadSupportImpl.java
@@ -22,13 +22,15 @@ import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
 import org.apache.carbondata.core.metadata.schema.table.column.CarbonColumn;
 import org.apache.carbondata.hadoop.readsupport.impl.DictionaryDecodeReadSupport;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 
 public class SparkRowReadSupportImpl extends DictionaryDecodeReadSupport<InternalRow> {
 
   @Override public void initialize(CarbonColumn[] carbonColumns,
-      AbsoluteTableIdentifier absoluteTableIdentifier) throws IOException {
+      AbsoluteTableIdentifier absoluteTableIdentifier,
+      Configuration configuration) throws IOException {
   }
 
   @Override public InternalRow readRow(Object[] data) {

--- a/integration/spark2/src/main/java/org/apache/carbondata/spark/vectorreader/VectorizedCarbonRecordReader.java
+++ b/integration/spark2/src/main/java/org/apache/carbondata/spark/vectorreader/VectorizedCarbonRecordReader.java
@@ -111,6 +111,7 @@ class VectorizedCarbonRecordReader extends AbstractRecordReader<Object> {
     List<TableBlockInfo> tableBlockInfoList = CarbonInputSplit.createBlocks(splitList);
     queryModel.setTableBlockInfos(tableBlockInfoList);
     queryModel.setVectorReader(true);
+    queryModel.setConfiguration(taskAttemptContext.getConfiguration());
     try {
       queryExecutor = QueryExecutorFactory.getQueryExecutor(queryModel);
       iterator = (AbstractDetailQueryResultIterator) queryExecutor.execute(queryModel);

--- a/integration/spark2/src/main/scala/org/apache/carbondata/spark/util/CarbonSparkUtil.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/spark/util/CarbonSparkUtil.scala
@@ -19,6 +19,7 @@ package org.apache.carbondata.spark.util
 
 import scala.collection.JavaConverters._
 
+import org.apache.hadoop.conf.Configuration
 import org.apache.spark.sql.hive.{CarbonMetaData, CarbonRelation, DictionaryMap}
 
 import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier
@@ -45,13 +46,14 @@ object CarbonSparkUtil {
     CarbonMetaData(dimensionsAttr, measureAttr, carbonTable, DictionaryMap(dictionary.toMap))
   }
 
-  def createCarbonRelation(tableInfo: TableInfo, tablePath: String): CarbonRelation = {
+  def createCarbonRelation(tableInfo: TableInfo, tablePath: String,
+      configuration: Configuration): CarbonRelation = {
     val identifier = AbsoluteTableIdentifier.fromTablePath(tablePath)
     val table = CarbonTable.buildFromTableInfo(tableInfo)
     val meta = new TableMeta(identifier.getCarbonTableIdentifier,
       identifier.getStorePath, tablePath, table)
     CarbonRelation(tableInfo.getDatabaseName, tableInfo.getFactTable.getTableName,
-      CarbonSparkUtil.createSparkMeta(table), meta)
+      CarbonSparkUtil.createSparkMeta(table), meta, configuration)
   }
 
 }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSession.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSession.scala
@@ -158,7 +158,9 @@ object CarbonSession {
         options.foreach { case (k, v) => session.sessionState.conf.setConfString(k, v) }
         SparkSession.setDefaultSession(session)
         CommonUtil.cleanInProgressSegments(
-          carbonProperties.getProperty(CarbonCommonConstants.STORE_LOCATION), sparkContext)
+          carbonProperties.getProperty(CarbonCommonConstants.STORE_LOCATION),
+          sparkContext,
+          session.sessionState.newHadoopConf())
         // Register a successfully instantiated context to the singleton. This should be at the
         // end of the class definition so that the singleton is updated only if there is no
         // exception in the construction of the instance.

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/SparkSQLUtil.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/SparkSQLUtil.scala
@@ -14,26 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.carbondata.core.service;
 
-import org.apache.carbondata.core.cache.dictionary.DictionaryColumnUniqueIdentifier;
-import org.apache.carbondata.core.metadata.CarbonTableIdentifier;
-import org.apache.carbondata.core.util.path.CarbonTablePath;
+package org.apache.spark.sql
 
-import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.conf.Configuration
 
-/**
- * Create helper to get path details
- */
-public interface PathService {
-
-  /**
-   * @param storeLocation
-   * @param tableIdentifier
-   * @param dictionaryColumnUniqueIdentifier
-   * @return store path related to tables
-   */
-  CarbonTablePath getCarbonTablePath(String storeLocation, CarbonTableIdentifier tableIdentifier,
-      DictionaryColumnUniqueIdentifier dictionaryColumnUniqueIdentifier,
-      Configuration configuration);
+object SparkSQLUtil {
+  def newHadoopConf(sparkSession: SparkSession): Configuration =
+    sparkSession.sessionState.newHadoopConf()
 }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonMetaStore.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonMetaStore.scala
@@ -16,6 +16,7 @@
  */
 package org.apache.spark.sql.hive
 
+import org.apache.hadoop.conf.Configuration
 import org.apache.spark.sql.{RuntimeConfig, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
@@ -48,7 +49,8 @@ trait CarbonMetaStore {
    */
   def createCarbonRelation(parameters: Map[String, String],
       absIdentifier: AbsoluteTableIdentifier,
-      sparkSession: SparkSession): CarbonRelation
+      sparkSession: SparkSession,
+      configuration: Configuration): CarbonRelation
 
 
   def tableExists(
@@ -70,7 +72,8 @@ trait CarbonMetaStore {
       oldTableIdentifier: CarbonTableIdentifier,
       thriftTableInfo: org.apache.carbondata.format.TableInfo,
       schemaEvolutionEntry: SchemaEvolutionEntry,
-      carbonStorePath: String)(sparkSession: SparkSession): String
+      carbonStorePath: String,
+      configuration: Configuration)(sparkSession: SparkSession): String
 
   /**
    * This method will is used to remove the evolution entry in case of failure.
@@ -82,13 +85,13 @@ trait CarbonMetaStore {
    */
   def revertTableSchema(carbonTableIdentifier: CarbonTableIdentifier,
       thriftTableInfo: org.apache.carbondata.format.TableInfo,
-      tablePath: String)
+      tablePath: String, configuration: Configuration)
     (sparkSession: SparkSession): String
 
   /**
    * Prepare Thrift Schema from wrapper TableInfo and write to disk
    */
-  def saveToDisk(tableInfo: schema.table.TableInfo, tablePath: String)
+  def saveToDisk(tableInfo: schema.table.TableInfo, tablePath: String, configuration: Configuration)
 
   /**
    * Generates schema string to save it in hive metastore
@@ -96,7 +99,7 @@ trait CarbonMetaStore {
    * @return
    */
   def generateTableSchemaString(tableInfo: schema.table.TableInfo,
-      tablePath: String): String
+      tablePath: String, configuration: Configuration): String
 
   /**
    * This method will remove the table meta from catalog metadata array
@@ -109,14 +112,15 @@ trait CarbonMetaStore {
   def updateMetadataByThriftTable(schemaFilePath: String,
       tableInfo: TableInfo, dbName: String, tableName: String, tablePath: String): Unit
 
-  def isTablePathExists(tableIdentifier: TableIdentifier)(sparkSession: SparkSession): Boolean
+  def isTablePathExists(tableIdentifier: TableIdentifier,
+      configuration: Configuration)(sparkSession: SparkSession): Boolean
 
-  def dropTable(tablePath: String, tableIdentifier: TableIdentifier)
+  def dropTable(tablePath: String, tableIdentifier: TableIdentifier, configuration: Configuration)
     (sparkSession: SparkSession)
 
-  def updateAndTouchSchemasUpdatedTime(basePath: String)
+  def updateAndTouchSchemasUpdatedTime(configuration: Configuration, basePath: String)
 
-  def checkSchemasModifiedTimeAndReloadTables(storePath: String)
+  def checkSchemasModifiedTimeAndReloadTables(configuration: Configuration, storePath: String)
 
   def isReadFromHiveMetaStore : Boolean
 

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonSessionState.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonSessionState.scala
@@ -103,8 +103,8 @@ class CarbonSessionCatalog(
       alias: Option[String],
       carbonDatasourceHadoopRelation: CarbonDatasourceHadoopRelation): Boolean = {
     var isRefreshed = false
-    carbonEnv.carbonMetastore.
-      checkSchemasModifiedTimeAndReloadTables(CarbonEnv.getInstance(sparkSession).storePath)
+    carbonEnv.carbonMetastore.checkSchemasModifiedTimeAndReloadTables(hadoopConf,
+      CarbonEnv.getInstance(sparkSession).storePath)
 
     val tableMeta = carbonEnv.carbonMetastore
       .getTableFromMetadataCache(carbonDatasourceHadoopRelation.carbonTable.getDatabaseName,
@@ -129,7 +129,7 @@ class CarbonSessionState(sparkSession: SparkSession) extends HiveSessionState(sp
   override lazy val sqlParser: ParserInterface = new CarbonSparkSqlParser(conf, sparkSession)
 
   experimentalMethods.extraStrategies =
-    Seq(new CarbonLateDecodeStrategy, new DDLStrategy(sparkSession))
+    Seq(new CarbonLateDecodeStrategy(sparkSession), new DDLStrategy(sparkSession))
   experimentalMethods.extraOptimizations = Seq(new CarbonLateDecodeRule)
 
   override lazy val optimizer: Optimizer = new CarbonOptimizer(catalog, conf, experimentalMethods)

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/hive/execution/command/CarbonHiveCommands.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/hive/execution/command/CarbonHiveCommands.scala
@@ -41,7 +41,7 @@ case class CarbonDropDatabaseCommand(command: DropDatabaseCommand)
         CarbonDropTableCommand(true, tableName.database, tableName.table).run(sparkSession)
       }
     }
-    CarbonUtil.dropDatabaseDirectory(dbName.toLowerCase,
+    CarbonUtil.dropDatabaseDirectory(sparkSession.sessionState.newHadoopConf(), dbName.toLowerCase,
       CarbonEnv.getInstance(sparkSession).storePath)
     rows
   }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/test/Spark2TestQueryExecutor.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/test/Spark2TestQueryExecutor.scala
@@ -58,7 +58,7 @@ object Spark2TestQueryExecutor {
       set("spark.executor.cores", "2").
       set("spark.executor.instances", "2").
       set("spark.cores.max", "4")
-    FileFactory.getConfiguration.
+    TestQueryExecutor.hadoopConf.
       set("dfs.client.block.write.replace-datanode-on-failure.policy", "NEVER")
   }
   val metastoredb = s"$integrationPath/spark-common-cluster-test/target"
@@ -76,9 +76,10 @@ object Spark2TestQueryExecutor {
       CarbonCommonConstants.CARBON_LOCK_TYPE_HDFS)
     ResourceRegisterAndCopier.
       copyResourcesifNotExists(hdfsUrl, s"$integrationPath/spark-common-test/src/test/resources",
-        s"$integrationPath//spark-common-cluster-test/src/test/resources/testdatafileslist.txt")
+        s"$integrationPath//spark-common-cluster-test/src/test/resources/testdatafileslist.txt",
+        TestQueryExecutor.hadoopConf)
   }
-  FileFactory.getConfiguration.
+  TestQueryExecutor.hadoopConf.
     set("dfs.client.block.write.replace-datanode-on-failure.policy", "NEVER")
   spark.sparkContext.setLogLevel("ERROR")
 }

--- a/integration/spark2/src/main/scala/org/apache/spark/util/CleanFiles.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/util/CleanFiles.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.util
 
-import org.apache.spark.sql.{CarbonEnv, SparkSession}
+import org.apache.spark.sql.{CarbonEnv, SparkSession, SparkSQLUtil}
 import org.apache.spark.sql.hive.CarbonRelation
 
 import org.apache.carbondata.api.CarbonStore
@@ -43,7 +43,8 @@ object CleanFiles {
     val carbonTable = CarbonEnv.getInstance(spark).carbonMetastore.
       lookupRelation(Some(dbName), tableName)(spark).asInstanceOf[CarbonRelation].
       tableMeta.carbonTable
-    CarbonStore.cleanFiles(dbName, tableName, storePath, carbonTable, forceTableClean)
+    CarbonStore.cleanFiles(dbName, tableName, storePath, carbonTable, forceTableClean,
+      SparkSQLUtil.newHadoopConf(spark))
   }
 
   def main(args: Array[String]): Unit = {
@@ -60,8 +61,8 @@ object CleanFiles {
       forceTableClean = args(2).toBoolean
     }
     val spark = TableAPIUtil.spark(storePath, s"CleanFiles: $dbName.$tableName")
-    CarbonEnv.getInstance(spark).carbonMetastore.
-      checkSchemasModifiedTimeAndReloadTables(CarbonEnv.getInstance(spark).storePath)
+    CarbonEnv.getInstance(spark).carbonMetastore.checkSchemasModifiedTimeAndReloadTables(
+      SparkSQLUtil.newHadoopConf(spark), CarbonEnv.getInstance(spark).storePath)
     cleanFiles(spark, dbName, tableName, storePath, forceTableClean)
   }
 }

--- a/integration/spark2/src/main/scala/org/apache/spark/util/Compaction.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/util/Compaction.scala
@@ -16,11 +16,10 @@
  */
 package org.apache.spark.util
 
-import org.apache.spark.sql.{CarbonEnv, SparkSession}
+import org.apache.spark.sql.{CarbonEnv, SparkSession, SparkSQLUtil}
 import org.apache.spark.sql.execution.command.{AlterTableCompaction, AlterTableModel}
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants
-import org.apache.carbondata.processing.merger.CompactionType
 
 /**
  * table compaction api
@@ -56,8 +55,8 @@ object Compaction {
     val (dbName, tableName) = TableAPIUtil.parseSchemaName(TableAPIUtil.escape(args(1)))
     val compactionType = TableAPIUtil.escape(args(2))
     val spark = TableAPIUtil.spark(storePath, s"Compaction: $dbName.$tableName")
-    CarbonEnv.getInstance(spark).carbonMetastore.
-      checkSchemasModifiedTimeAndReloadTables(CarbonEnv.getInstance(spark).storePath)
+    CarbonEnv.getInstance(spark).carbonMetastore.checkSchemasModifiedTimeAndReloadTables(
+      SparkSQLUtil.newHadoopConf(spark), CarbonEnv.getInstance(spark).storePath)
     compaction(spark, dbName, tableName, compactionType)
   }
 }

--- a/integration/spark2/src/main/scala/org/apache/spark/util/DeleteSegmentByDate.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/util/DeleteSegmentByDate.scala
@@ -16,10 +16,10 @@
  */
  package org.apache.spark.util
 
- import org.apache.spark.sql.{CarbonEnv, SparkSession}
+ import org.apache.spark.sql.{CarbonEnv, SparkSession, SparkSQLUtil}
  import org.apache.spark.sql.hive.CarbonRelation
 
-import org.apache.carbondata.api.CarbonStore
+ import org.apache.carbondata.api.CarbonStore
 
 /**
  * delete segments before some date
@@ -33,7 +33,8 @@ object DeleteSegmentByDate {
     val carbonTable = CarbonEnv.getInstance(spark).carbonMetastore.
       lookupRelation(Some(dbName), tableName)(spark).asInstanceOf[CarbonRelation].
       tableMeta.carbonTable
-    CarbonStore.deleteLoadByDate(dateValue, dbName, tableName, carbonTable)
+    CarbonStore.deleteLoadByDate(dateValue, dbName, tableName, carbonTable,
+      SparkSQLUtil.newHadoopConf(spark))
   }
 
   def main(args: Array[String]): Unit = {
@@ -47,8 +48,8 @@ object DeleteSegmentByDate {
     val (dbName, tableName) = TableAPIUtil.parseSchemaName(TableAPIUtil.escape(args(1)))
     val dateValue = TableAPIUtil.escape(args(2))
     val spark = TableAPIUtil.spark(storePath, s"DeleteSegmentByDate: $dbName.$tableName")
-    CarbonEnv.getInstance(spark).carbonMetastore.
-      checkSchemasModifiedTimeAndReloadTables(CarbonEnv.getInstance(spark).storePath)
+    CarbonEnv.getInstance(spark).carbonMetastore.checkSchemasModifiedTimeAndReloadTables(
+      SparkSQLUtil.newHadoopConf(spark), CarbonEnv.getInstance(spark).storePath)
     deleteSegmentByDate(spark, dbName, tableName, dateValue)
   }
 }

--- a/integration/spark2/src/main/scala/org/apache/spark/util/DeleteSegmentById.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/util/DeleteSegmentById.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.spark.util
 
-import org.apache.spark.sql.{CarbonEnv, SparkSession}
+import org.apache.spark.sql.{CarbonEnv, SparkSession, SparkSQLUtil}
 import org.apache.spark.sql.hive.CarbonRelation
 
 import org.apache.carbondata.api.CarbonStore
@@ -37,7 +37,8 @@ object DeleteSegmentById {
     val carbonTable = CarbonEnv.getInstance(spark).carbonMetastore.
       lookupRelation(Some(dbName), tableName)(spark).asInstanceOf[CarbonRelation].
       tableMeta.carbonTable
-    CarbonStore.deleteLoadById(segmentIds, dbName, tableName, carbonTable)
+    CarbonStore.deleteLoadById(segmentIds, dbName, tableName, carbonTable,
+      SparkSQLUtil.newHadoopConf(spark))
   }
 
   def main(args: Array[String]): Unit = {
@@ -52,8 +53,8 @@ object DeleteSegmentById {
     val (dbName, tableName) = TableAPIUtil.parseSchemaName(TableAPIUtil.escape(args(1)))
     val segmentIds = extractSegmentIds(TableAPIUtil.escape(args(2)))
     val spark = TableAPIUtil.spark(storePath, s"DeleteSegmentById: $dbName.$tableName")
-    CarbonEnv.getInstance(spark).carbonMetastore.
-      checkSchemasModifiedTimeAndReloadTables(CarbonEnv.getInstance(spark).storePath)
+    CarbonEnv.getInstance(spark).carbonMetastore.checkSchemasModifiedTimeAndReloadTables(
+      SparkSQLUtil.newHadoopConf(spark), CarbonEnv.getInstance(spark).storePath)
     deleteSegmentById(spark, dbName, tableName, segmentIds)
   }
 }

--- a/integration/spark2/src/main/scala/org/apache/spark/util/ShowSegments.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/util/ShowSegments.scala
@@ -20,7 +20,7 @@ package org.apache.spark.util
 import java.text.SimpleDateFormat
 
 import org.apache.commons.lang3.StringUtils
-import org.apache.spark.sql.{CarbonEnv, Row, SparkSession}
+import org.apache.spark.sql.{CarbonEnv, Row, SparkSession, SparkSQLUtil}
 import org.apache.spark.sql.hive.CarbonRelation
 
 import org.apache.carbondata.api.CarbonStore
@@ -34,7 +34,8 @@ object ShowSegments {
     val carbonTable = CarbonEnv.getInstance(spark).carbonMetastore.
       lookupRelation(Some(dbName), tableName)(spark).asInstanceOf[CarbonRelation].
       tableMeta.carbonTable
-    CarbonStore.showSegments(dbName, tableName, limit, carbonTable.getMetaDataFilepath)
+    CarbonStore.showSegments(dbName, tableName, limit, carbonTable.getMetaDataFilepath,
+      SparkSQLUtil.newHadoopConf(spark))
   }
 
   def showString(rows: Seq[Row]): String = {
@@ -78,8 +79,8 @@ object ShowSegments {
       None
     }
     val spark = TableAPIUtil.spark(storePath, s"ShowSegments: $dbName.$tableName")
-    CarbonEnv.getInstance(spark).carbonMetastore.
-      checkSchemasModifiedTimeAndReloadTables(CarbonEnv.getInstance(spark).storePath)
+    CarbonEnv.getInstance(spark).carbonMetastore.checkSchemasModifiedTimeAndReloadTables(
+      SparkSQLUtil.newHadoopConf(spark), CarbonEnv.getInstance(spark).storePath)
     val rows = showSegments(spark, dbName, tableName, limit)
     System.out.println(showString(rows))
   }

--- a/integration/spark2/src/main/scala/org/apache/spark/util/TableLoader.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/util/TableLoader.scala
@@ -27,7 +27,6 @@ import org.apache.spark.sql._
 import org.apache.spark.sql.execution.command.LoadTable
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants
-import org.apache.carbondata.core.util.CarbonProperties
 
 /**
  * load data api
@@ -80,8 +79,8 @@ object TableLoader {
 
     val spark = TableAPIUtil.spark(storePath, s"TableLoader: $dbName.$tableName")
 
-    CarbonEnv.getInstance(spark).carbonMetastore.
-      checkSchemasModifiedTimeAndReloadTables(CarbonEnv.getInstance(spark).storePath)
+    CarbonEnv.getInstance(spark).carbonMetastore.checkSchemasModifiedTimeAndReloadTables(
+      SparkSQLUtil.newHadoopConf(spark), CarbonEnv.getInstance(spark).storePath)
     loadTable(spark, Option(dbName), tableName, inputPaths, map)
   }
 

--- a/integration/spark2/src/test/scala/org/apache/carbondata/spark/testsuite/partition/TestAlterPartitionTable.scala
+++ b/integration/spark2/src/test/scala/org/apache/carbondata/spark/testsuite/partition/TestAlterPartitionTable.scala
@@ -786,9 +786,9 @@ class TestAlterPartitionTable extends QueryTest with BeforeAndAfterAll {
 
   def getDataFiles(carbonTable: CarbonTable, segmentId: String): Array[CarbonFile] = {
     val tablePath = new CarbonTablePath(carbonTable.getStorePath, carbonTable.getDatabaseName,
-      carbonTable.getFactTableName)
+      carbonTable.getFactTableName, hadoopConf)
     val segmentDir = tablePath.getCarbonDataDirectoryPath("0", segmentId)
-    val carbonFile = FileFactory.getCarbonFile(segmentDir, FileFactory.getFileType(segmentDir))
+    val carbonFile = FileFactory.getCarbonFile(hadoopConf, segmentDir, FileFactory.getFileType(segmentDir))
     val dataFiles = carbonFile.listFiles(new CarbonFileFilter() {
       override def accept(file: CarbonFile): Boolean = {
         return file.getName.endsWith(".carbondata")

--- a/integration/spark2/src/test/scala/org/apache/carbondata/spark/util/AllDictionaryTestCase.scala
+++ b/integration/spark2/src/test/scala/org/apache/carbondata/spark/util/AllDictionaryTestCase.scala
@@ -61,14 +61,14 @@ class AllDictionaryTestCase extends Spark2QueryTest with BeforeAndAfterAll {
     carbonLoadModel.setDefaultTimestampFormat(CarbonProperties.getInstance().getProperty(
       CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT,
       CarbonCommonConstants.CARBON_TIMESTAMP_DEFAULT_FORMAT))
-    carbonLoadModel.setCsvHeaderColumns(CommonUtil.getCsvHeaderColumns(carbonLoadModel))
+    carbonLoadModel.setCsvHeaderColumns(CommonUtil.getCsvHeaderColumns(hadoopConf, carbonLoadModel))
     // Create table and metadata folders if not exist
     val carbonTablePath = CarbonStorePath
-      .getCarbonTablePath(table.getStorePath, table.getCarbonTableIdentifier)
+      .getCarbonTablePath(table.getStorePath, table.getCarbonTableIdentifier, hadoopConf)
     val metadataDirectoryPath = carbonTablePath.getMetadataDirectoryPath
     val fileType = FileFactory.getFileType(metadataDirectoryPath)
-    if (!FileFactory.isFileExist(metadataDirectoryPath, fileType)) {
-      FileFactory.mkdirs(metadataDirectoryPath, fileType)
+    if (!FileFactory.isFileExist(hadoopConf, metadataDirectoryPath, fileType)) {
+      FileFactory.mkdirs(hadoopConf, metadataDirectoryPath, fileType)
     }
     carbonLoadModel
   }
@@ -143,6 +143,7 @@ class AllDictionaryTestCase extends Spark2QueryTest with BeforeAndAfterAll {
     val carbonLoadModel = buildCarbonLoadModel(sampleRelation, null, header, sampleAllDictionaryFile)
     GlobalDictionaryUtil
       .generateGlobalDictionary(sqlContext,
+        hadoopConf,
         carbonLoadModel,
         sampleRelation.tableMeta.storePath)
 
@@ -153,8 +154,8 @@ class AllDictionaryTestCase extends Spark2QueryTest with BeforeAndAfterAll {
   test("Support generate global dictionary from all dictionary files for complex type") {
     val header = "deviceInformationId,channelsId,ROMSize,purchasedate,mobile,MAC,locationinfo,proddate,gamePointId,contractNumber"
     val carbonLoadModel = buildCarbonLoadModel(complexRelation, null, header, complexAllDictionaryFile)
-    GlobalDictionaryUtil
-      .generateGlobalDictionary(sqlContext,
+    GlobalDictionaryUtil.generateGlobalDictionary(sqlContext,
+      hadoopConf,
       carbonLoadModel,
       complexRelation.tableMeta.storePath)
 

--- a/integration/spark2/src/test/scala/org/apache/carbondata/spark/util/DictionaryTestCaseUtil.scala
+++ b/integration/spark2/src/test/scala/org/apache/carbondata/spark/util/DictionaryTestCaseUtil.scala
@@ -43,9 +43,9 @@ object DictionaryTestCaseUtil {
     val tableIdentifier = new CarbonTableIdentifier(table.getDatabaseName, table.getFactTableName, "uniqueid")
     val columnIdentifier = new DictionaryColumnUniqueIdentifier(tableIdentifier,
       dimension.getColumnIdentifier, dimension.getDataType,
-      CarbonStorePath.getCarbonTablePath(table.getAbsoluteTableIdentifier)
+      CarbonStorePath.getCarbonTablePath(table.getAbsoluteTableIdentifier, TestQueryExecutor.hadoopConf)
     )
-    val dict = CarbonLoaderUtil.getDictionary(columnIdentifier, TestQueryExecutor.storeLocation)
+    val dict = CarbonLoaderUtil.getDictionary(columnIdentifier, TestQueryExecutor.storeLocation, TestQueryExecutor.hadoopConf)
     assert(dict.getSurrogateKey(value) != CarbonCommonConstants.INVALID_SURROGATE_KEY)
   }
 }

--- a/integration/spark2/src/test/scala/org/apache/carbondata/spark/util/ExternalColumnDictionaryTestCase.scala
+++ b/integration/spark2/src/test/scala/org/apache/carbondata/spark/util/ExternalColumnDictionaryTestCase.scala
@@ -173,15 +173,15 @@ class ExternalColumnDictionaryTestCase extends Spark2QueryTest with BeforeAndAft
     carbonLoadModel.setDefaultDateFormat(CarbonProperties.getInstance().getProperty(
       CarbonCommonConstants.CARBON_DATE_FORMAT,
       CarbonCommonConstants.CARBON_DATE_DEFAULT_FORMAT))
-    carbonLoadModel.setCsvHeaderColumns(CommonUtil.getCsvHeaderColumns(carbonLoadModel))
+    carbonLoadModel.setCsvHeaderColumns(CommonUtil.getCsvHeaderColumns(hadoopConf, carbonLoadModel))
     carbonLoadModel.setMaxColumns("100")
     // Create table and metadata folders if not exist
     val carbonTablePath = CarbonStorePath
-      .getCarbonTablePath(table.getStorePath, table.getCarbonTableIdentifier)
+      .getCarbonTablePath(table.getStorePath, table.getCarbonTableIdentifier, hadoopConf)
     val metadataDirectoryPath = carbonTablePath.getMetadataDirectoryPath
     val fileType = FileFactory.getFileType(metadataDirectoryPath)
-    if (!FileFactory.isFileExist(metadataDirectoryPath, fileType)) {
-      FileFactory.mkdirs(metadataDirectoryPath, fileType)
+    if (!FileFactory.isFileExist(hadoopConf, metadataDirectoryPath, fileType)) {
+      FileFactory.mkdirs(hadoopConf, metadataDirectoryPath, fileType)
     }
     carbonLoadModel
   }
@@ -197,7 +197,7 @@ class ExternalColumnDictionaryTestCase extends Spark2QueryTest with BeforeAndAft
     // load the first time
     var carbonLoadModel = buildCarbonLoadModel(extComplexRelation, complexFilePath1,
       header, extColDictFilePath1)
-    GlobalDictionaryUtil.generateGlobalDictionary(sqlContext, carbonLoadModel,
+    GlobalDictionaryUtil.generateGlobalDictionary(sqlContext, hadoopConf, carbonLoadModel,
       extComplexRelation.tableMeta.storePath)
     // check whether the dictionary is generated
     DictionaryTestCaseUtil.checkDictionary(
@@ -206,7 +206,7 @@ class ExternalColumnDictionaryTestCase extends Spark2QueryTest with BeforeAndAft
     // load the second time
     carbonLoadModel = buildCarbonLoadModel(extComplexRelation, complexFilePath1,
       header, extColDictFilePath2)
-    GlobalDictionaryUtil.generateGlobalDictionary(sqlContext, carbonLoadModel,
+    GlobalDictionaryUtil.generateGlobalDictionary(sqlContext, hadoopConf, carbonLoadModel,
       extComplexRelation.tableMeta.storePath)
     // check the old dictionary and whether the new distinct value is generated
     DictionaryTestCaseUtil.checkDictionary(
@@ -219,7 +219,7 @@ class ExternalColumnDictionaryTestCase extends Spark2QueryTest with BeforeAndAft
     //  when csv delimiter is comma
     var carbonLoadModel = buildCarbonLoadModel(extComplexRelation, complexFilePath1,
       header, extColDictFilePath3)
-    GlobalDictionaryUtil.generateGlobalDictionary(sqlContext, carbonLoadModel,
+    GlobalDictionaryUtil.generateGlobalDictionary(sqlContext, hadoopConf, carbonLoadModel,
       extComplexRelation.tableMeta.storePath)
     // check whether the dictionary is generated
     DictionaryTestCaseUtil.checkDictionary(
@@ -228,7 +228,7 @@ class ExternalColumnDictionaryTestCase extends Spark2QueryTest with BeforeAndAft
     //  when csv delimiter is not comma
     carbonLoadModel = buildCarbonLoadModel(verticalDelimiteRelation, complexFilePath2,
       header2, extColDictFilePath3, "|")
-    GlobalDictionaryUtil.generateGlobalDictionary(sqlContext, carbonLoadModel,
+    GlobalDictionaryUtil.generateGlobalDictionary(sqlContext, hadoopConf, carbonLoadModel,
       verticalDelimiteRelation.tableMeta.storePath)
     // check whether the dictionary is generated
     DictionaryTestCaseUtil.checkDictionary(

--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/BadRecordPathLoadOptionTest.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/BadRecordPathLoadOptionTest.scala
@@ -68,7 +68,7 @@ class BadRecordPathLoadOptionTest extends Spark2QueryTest with BeforeAndAfterAll
   def isFilesWrittenAtBadStoreLocation: Boolean = {
     val badStorePath = badRecordPath + "/default/salestest/0/0"
     val carbonFile: CarbonFile = FileFactory
-      .getCarbonFile(badStorePath, FileFactory.getFileType(badStorePath))
+      .getCarbonFile(hadoopConf, badStorePath, FileFactory.getFileType(badStorePath))
     var exists: Boolean = carbonFile.exists()
     if (exists) {
       val listFiles: Array[CarbonFile] = carbonFile.listFiles(new CarbonFileFilter {

--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/restructure/AlterTableRevertTestCase.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/restructure/AlterTableRevertTestCase.scala
@@ -97,7 +97,7 @@ class AlterTableRevertTestCase extends Spark2QueryTest with BeforeAndAfterAll {
 
   test("test to check if exception during rename table does not throws table not found exception") {
     val locks = AlterTableUtil
-      .validateTableAndAcquireLock("default", "reverttest", List("meta.lock"))(sqlContext
+      .validateTableAndAcquireLock("default", "reverttest", List("meta.lock"), hadoopConf)(sqlContext
         .sparkSession)
     val exception = intercept[RuntimeException] {
       sql("alter table reverttest rename to revert")

--- a/integration/spark2/src/test/scala/org/apache/spark/util/CarbonCommandSuite.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/util/CarbonCommandSuite.scala
@@ -102,14 +102,14 @@ class CarbonCommandSuite extends Spark2QueryTest with BeforeAndAfterAll {
 
   test("delete segment by id") {
     DeleteSegmentById.main(Array(s"${location}", "carbon_table", "0"))
-    assert(!CarbonStore.isSegmentValid("default", "carbon_table",location,  "0"))
+    assert(!CarbonStore.isSegmentValid("default", "carbon_table",location,  "0", hadoopConf))
   }
 
   test("delete segment by date") {
     createAndLoadTestTable("carbon_table2", "csv_table")
     val time = new Timestamp(new Date().getTime)
     DeleteSegmentByDate.main(Array(s"${location}", "carbon_table2", time.toString))
-    assert(!CarbonStore.isSegmentValid("default", "carbon_table2", location, "0"))
+    assert(!CarbonStore.isSegmentValid("default", "carbon_table2", location, "0", hadoopConf))
     dropTable("carbon_table2")
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <snappy.version>1.1.2.6</snappy.version>
-    <hadoop.version>2.2.0</hadoop.version>
+    <hadoop.version>2.7.2</hadoop.version>
     <hadoop.deps.scope>compile</hadoop.deps.scope>
     <spark.deps.scope>compile</spark.deps.scope>
     <scala.deps.scope>compile</scala.deps.scope>

--- a/processing/src/main/java/org/apache/carbondata/processing/datatypes/PrimitiveDataType.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/datatypes/PrimitiveDataType.java
@@ -48,6 +48,8 @@ import org.apache.carbondata.processing.newflow.dictionary.DictionaryServerClien
 import org.apache.carbondata.processing.newflow.dictionary.DirectDictionary;
 import org.apache.carbondata.processing.newflow.dictionary.PreCreatedDictionary;
 
+import org.apache.hadoop.conf.Configuration;
+
 /**
  * Primitive DataType stateless object used in data loading
  */
@@ -123,7 +125,7 @@ public class PrimitiveDataType implements GenericDataType<Object> {
   public PrimitiveDataType(String name, String parentname, String columnId,
       CarbonDimension carbonDimension, Cache<DictionaryColumnUniqueIdentifier, Dictionary> cache,
       CarbonTableIdentifier carbonTableIdentifier, DictionaryClient client, Boolean useOnePass,
-      String storePath, Map<Object, Integer> localCache) {
+      String storePath, Map<Object, Integer> localCache, Configuration configuration) {
     this.name = name;
     this.parentname = parentname;
     this.columnId = columnId;
@@ -131,7 +133,7 @@ public class PrimitiveDataType implements GenericDataType<Object> {
     DictionaryColumnUniqueIdentifier identifier =
         new DictionaryColumnUniqueIdentifier(carbonTableIdentifier,
             carbonDimension.getColumnIdentifier(), carbonDimension.getDataType(),
-            CarbonStorePath.getCarbonTablePath(storePath, carbonTableIdentifier));
+            CarbonStorePath.getCarbonTablePath(storePath, carbonTableIdentifier, configuration));
     try {
       if (carbonDimension.hasEncoding(Encoding.DIRECT_DICTIONARY)) {
         dictionaryGenerator = new DirectDictionary(DirectDictionaryKeyGeneratorFactory
@@ -139,7 +141,7 @@ public class PrimitiveDataType implements GenericDataType<Object> {
       } else {
         Dictionary dictionary = null;
         if (useOnePass) {
-          if (CarbonUtil.isFileExistsForGivenColumn(storePath, identifier)) {
+          if (CarbonUtil.isFileExistsForGivenColumn(configuration, storePath, identifier)) {
             dictionary = cache.get(identifier);
           }
           DictionaryMessage dictionaryMessage = new DictionaryMessage();

--- a/processing/src/main/java/org/apache/carbondata/processing/merger/AbstractResultProcessor.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/merger/AbstractResultProcessor.java
@@ -48,7 +48,8 @@ public abstract class AbstractResultProcessor {
     if (compactionType == CompactionType.IUD_UPDDEL_DELTA_COMPACTION) {
       int taskNo = CarbonUpdateUtil.getLatestTaskIdForSegment(loadModel.getSegmentId(),
           CarbonStorePath.getCarbonTablePath(loadModel.getStorePath(),
-              carbonTable.getCarbonTableIdentifier()));
+              carbonTable.getCarbonTableIdentifier(), carbonFactDataHandlerModel.getHadoopConf()),
+          carbonFactDataHandlerModel.getHadoopConf());
       // Increase the Task Index as in IUD_UPDDEL_DELTA_COMPACTION the new file will
       // be written in same segment. So the TaskNo should be incremented by 1 from max val.
       int index = taskNo + 1;

--- a/processing/src/main/java/org/apache/carbondata/processing/merger/CompactionResultSortProcessor.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/merger/CompactionResultSortProcessor.java
@@ -44,6 +44,7 @@ import org.apache.carbondata.processing.store.CarbonFactHandlerFactory;
 import org.apache.carbondata.processing.store.SingleThreadFinalSortFilesMerger;
 import org.apache.carbondata.processing.util.CarbonDataProcessorUtil;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.spark.sql.types.Decimal;
 
 /**
@@ -126,6 +127,8 @@ public class CompactionResultSortProcessor extends AbstractResultProcessor {
    */
   private SortIntermediateFileMerger intermediateFileMerger;
 
+  private Configuration configuration;
+
   /**
    * @param carbonLoadModel
    * @param carbonTable
@@ -134,13 +137,15 @@ public class CompactionResultSortProcessor extends AbstractResultProcessor {
    * @param tableName
    */
   public CompactionResultSortProcessor(CarbonLoadModel carbonLoadModel, CarbonTable carbonTable,
-      SegmentProperties segmentProperties, CompactionType compactionType, String tableName) {
+      SegmentProperties segmentProperties, CompactionType compactionType, String tableName,
+      Configuration configuration) {
     this.carbonLoadModel = carbonLoadModel;
     this.carbonTable = carbonTable;
     this.segmentProperties = segmentProperties;
     this.segmentId = carbonLoadModel.getSegmentId();
     this.compactionType = compactionType;
     this.tableName = tableName;
+    this.configuration = configuration;
   }
 
   /**
@@ -383,7 +388,7 @@ public class CompactionResultSortProcessor extends AbstractResultProcessor {
   private void initDataHandler() throws Exception {
     CarbonFactDataHandlerModel carbonFactDataHandlerModel = CarbonFactDataHandlerModel
         .getCarbonFactDataHandlerModel(carbonLoadModel, carbonTable, segmentProperties, tableName,
-            tempStoreLocation);
+            tempStoreLocation, configuration);
     setDataFileAttributesInModel(carbonLoadModel, compactionType, carbonTable,
         carbonFactDataHandlerModel);
     dataHandler = CarbonFactHandlerFactory.createCarbonFactHandler(carbonFactDataHandlerModel,

--- a/processing/src/main/java/org/apache/carbondata/processing/merger/RowResultMergerProcessor.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/merger/RowResultMergerProcessor.java
@@ -41,6 +41,8 @@ import org.apache.carbondata.processing.store.CarbonFactDataHandlerModel;
 import org.apache.carbondata.processing.store.CarbonFactHandler;
 import org.apache.carbondata.processing.util.CarbonDataProcessorUtil;
 
+import org.apache.hadoop.conf.Configuration;
+
 /**
  * This is the Merger class responsible for the merging of the segments.
  */
@@ -58,7 +60,7 @@ public class RowResultMergerProcessor extends AbstractResultProcessor {
 
   public RowResultMergerProcessor(String databaseName,
       String tableName, SegmentProperties segProp, String[] tempStoreLocation,
-      CarbonLoadModel loadModel, CompactionType compactionType) {
+      CarbonLoadModel loadModel, CompactionType compactionType, Configuration configuration) {
     this.segprop = segProp;
     CarbonDataProcessorUtil.createLocations(tempStoreLocation);
 
@@ -66,7 +68,7 @@ public class RowResultMergerProcessor extends AbstractResultProcessor {
             .getCarbonTable(databaseName + CarbonCommonConstants.UNDERSCORE + tableName);
     CarbonFactDataHandlerModel carbonFactDataHandlerModel = CarbonFactDataHandlerModel
         .getCarbonFactDataHandlerModel(loadModel, carbonTable, segProp, tableName,
-            tempStoreLocation);
+            tempStoreLocation, configuration);
     setDataFileAttributesInModel(loadModel, compactionType, carbonTable,
         carbonFactDataHandlerModel);
     carbonFactDataHandlerModel.setCompactionFlow(true);

--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/CarbonDataLoadConfiguration.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/CarbonDataLoadConfiguration.java
@@ -31,11 +31,15 @@ import org.apache.carbondata.core.metadata.schema.BucketingInfo;
 import org.apache.carbondata.core.metadata.schema.table.column.CarbonColumn;
 import org.apache.carbondata.processing.newflow.converter.DictionaryCardinalityFinder;
 
+import org.apache.hadoop.conf.Configuration;
+
 public class CarbonDataLoadConfiguration {
 
   private DataField[] dataFields;
 
   private AbsoluteTableIdentifier tableIdentifier;
+
+  private Configuration hadoopConf;
 
   private String[] header;
 
@@ -309,5 +313,13 @@ public class CarbonDataLoadConfiguration {
 
   public void setTableSpec(TableSpec tableSpec) {
     this.tableSpec = tableSpec;
+  }
+
+  public Configuration getHadoopConf() {
+    return hadoopConf;
+  }
+
+  public void setHadoopConf(Configuration hadoopConf) {
+    this.hadoopConf = hadoopConf;
   }
 }

--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/DataLoadExecutor.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/DataLoadExecutor.java
@@ -27,6 +27,8 @@ import org.apache.carbondata.processing.newflow.exception.CarbonDataLoadingExcep
 import org.apache.carbondata.processing.newflow.exception.NoRetryException;
 import org.apache.carbondata.processing.surrogatekeysgenerator.csvbased.BadRecordsLogger;
 
+import org.apache.hadoop.conf.Configuration;
+
 /**
  * It executes the data load.
  */
@@ -40,10 +42,10 @@ public class DataLoadExecutor {
   private boolean isClosed;
 
   public void execute(CarbonLoadModel loadModel, String[] storeLocation,
-      CarbonIterator<Object[]>[] inputIterators) throws Exception {
+      CarbonIterator<Object[]>[] inputIterators, Configuration hadoopConf) throws Exception {
     try {
-      loadProcessorStep =
-          new DataLoadProcessBuilder().build(loadModel, storeLocation, inputIterators);
+      loadProcessorStep = new DataLoadProcessBuilder().build(loadModel, storeLocation,
+          inputIterators, hadoopConf);
       // 1. initialize
       loadProcessorStep.initialize();
       LOGGER.info("Data Loading is started for table " + loadModel.getTableName());

--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/converter/impl/DictionaryFieldConverterImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/converter/impl/DictionaryFieldConverterImpl.java
@@ -45,6 +45,8 @@ import org.apache.carbondata.processing.newflow.dictionary.PreCreatedDictionary;
 import org.apache.carbondata.processing.newflow.exception.CarbonDataLoadingException;
 import org.apache.carbondata.processing.util.CarbonDataProcessorUtil;
 
+import org.apache.hadoop.conf.Configuration;
+
 public class DictionaryFieldConverterImpl extends AbstractDictionaryFieldConverterImpl {
 
   private static final LogService LOGGER =
@@ -68,7 +70,8 @@ public class DictionaryFieldConverterImpl extends AbstractDictionaryFieldConvert
       Cache<DictionaryColumnUniqueIdentifier, Dictionary> cache,
       CarbonTableIdentifier carbonTableIdentifier, String nullFormat, int index,
       DictionaryClient client, boolean useOnePass, String storePath,
-      Map<Object, Integer> localCache, boolean isEmptyBadRecord) throws IOException {
+      Map<Object, Integer> localCache, boolean isEmptyBadRecord,
+      Configuration configuration) throws IOException {
     this.index = index;
     this.carbonDimension = (CarbonDimension) dataField.getColumn();
     this.nullFormat = nullFormat;
@@ -76,11 +79,11 @@ public class DictionaryFieldConverterImpl extends AbstractDictionaryFieldConvert
     DictionaryColumnUniqueIdentifier identifier =
         new DictionaryColumnUniqueIdentifier(carbonTableIdentifier,
             dataField.getColumn().getColumnIdentifier(), dataField.getColumn().getDataType(),
-            CarbonStorePath.getCarbonTablePath(storePath, carbonTableIdentifier));
+            CarbonStorePath.getCarbonTablePath(storePath, carbonTableIdentifier, configuration));
 
     // if use one pass, use DictionaryServerClientDictionary
     if (useOnePass) {
-      if (CarbonUtil.isFileExistsForGivenColumn(storePath, identifier)) {
+      if (CarbonUtil.isFileExistsForGivenColumn(configuration, storePath, identifier)) {
         dictionary = cache.get(identifier);
       }
       dictionaryMessage = new DictionaryMessage();

--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/converter/impl/RowConverterImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/converter/impl/RowConverterImpl.java
@@ -85,7 +85,7 @@ public class RowConverterImpl implements RowConverter {
   public void initialize() throws IOException {
     CacheProvider cacheProvider = CacheProvider.getInstance();
     cache = cacheProvider.createCache(CacheType.REVERSE_DICTIONARY,
-        configuration.getTableIdentifier().getStorePath());
+        configuration.getTableIdentifier().getStorePath(), configuration.getHadoopConf());
     String nullFormat =
         configuration.getDataLoadProperty(DataLoadProcessorConstants.SERIALIZATION_NULL_FORMAT)
             .toString();
@@ -104,7 +104,7 @@ public class RowConverterImpl implements RowConverter {
           .createFieldEncoder(fields[i], cache,
               configuration.getTableIdentifier().getCarbonTableIdentifier(), i, nullFormat, client,
               configuration.getUseOnePass(), configuration.getTableIdentifier().getStorePath(),
-              localCaches[i], isEmptyBadRecord);
+              localCaches[i], isEmptyBadRecord, configuration.getHadoopConf());
       fieldConverterList.add(fieldConverter);
     }
     CarbonTimeStatisticsFactory.getLoadStatisticsInstance()
@@ -210,7 +210,7 @@ public class RowConverterImpl implements RowConverter {
         fieldConverter = FieldEncoderFactory.getInstance().createFieldEncoder(fields[i], cache,
             configuration.getTableIdentifier().getCarbonTableIdentifier(), i, nullFormat, client,
             configuration.getUseOnePass(), configuration.getTableIdentifier().getStorePath(),
-            localCaches[i], isEmptyBadRecord);
+            localCaches[i], isEmptyBadRecord, configuration.getHadoopConf());
       } catch (IOException e) {
         throw new RuntimeException(e);
       }

--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/steps/DataConverterProcessorStepImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/steps/DataConverterProcessorStepImpl.java
@@ -159,7 +159,8 @@ public class DataConverterProcessorStepImpl extends AbstractDataLoadProcessorSte
             identifier.getDatabaseName() + CarbonCommonConstants.FILE_SEPARATOR + identifier
                 .getTableName() + CarbonCommonConstants.FILE_SEPARATOR + configuration
                 .getSegmentId() + CarbonCommonConstants.FILE_SEPARATOR + configuration.getTaskNo()),
-        badRecordsLogRedirect, badRecordsLoggerEnable, badRecordConvertNullDisable, isDataLoadFail);
+        badRecordsLogRedirect, badRecordsLoggerEnable, badRecordConvertNullDisable, isDataLoadFail,
+        configuration.getHadoopConf());
   }
 
   public static String getBadLogStoreLocation(CarbonDataLoadConfiguration configuration,

--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/steps/DataConverterProcessorWithBucketingStepImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/steps/DataConverterProcessorWithBucketingStepImpl.java
@@ -186,7 +186,8 @@ public class DataConverterProcessorWithBucketingStepImpl extends AbstractDataLoa
         identifier.getDatabaseName() + CarbonCommonConstants.FILE_SEPARATOR + identifier
             .getTableName() + CarbonCommonConstants.FILE_SEPARATOR + configuration.getSegmentId()
             + CarbonCommonConstants.FILE_SEPARATOR + configuration.getTaskNo()),
-        badRecordsLogRedirect, badRecordsLoggerEnable, badRecordConvertNullDisable, isDataLoadFail);
+        badRecordsLogRedirect, badRecordsLoggerEnable, badRecordConvertNullDisable, isDataLoadFail,
+        configuration.getHadoopConf());
   }
 
   private String getBadLogStoreLocation(String storeLocation) {

--- a/processing/src/main/java/org/apache/carbondata/processing/spliter/RowResultProcessor.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/spliter/RowResultProcessor.java
@@ -33,6 +33,8 @@ import org.apache.carbondata.processing.store.CarbonFactDataHandlerModel;
 import org.apache.carbondata.processing.store.CarbonFactHandler;
 import org.apache.carbondata.processing.util.CarbonDataProcessorUtil;
 
+import org.apache.hadoop.conf.Configuration;
+
 public class RowResultProcessor {
 
   private CarbonFactHandler dataHandler;
@@ -43,13 +45,14 @@ public class RowResultProcessor {
 
 
   public RowResultProcessor(CarbonTable carbonTable, CarbonLoadModel loadModel,
-      SegmentProperties segProp, String[] tempStoreLocation, Integer bucketId) {
+      SegmentProperties segProp, String[] tempStoreLocation, Integer bucketId,
+      Configuration configuration) {
     CarbonDataProcessorUtil.createLocations(tempStoreLocation);
     this.segmentProperties = segProp;
     String tableName = carbonTable.getFactTableName();
     CarbonFactDataHandlerModel carbonFactDataHandlerModel =
         CarbonFactDataHandlerModel.getCarbonFactDataHandlerModel(loadModel, carbonTable,
-            segProp, tableName, tempStoreLocation);
+            segProp, tableName, tempStoreLocation, configuration);
     CarbonDataFileAttributes carbonDataFileAttributes =
         new CarbonDataFileAttributes(Integer.parseInt(loadModel.getTaskNo()),
             loadModel.getFactTimeStamp());

--- a/processing/src/main/java/org/apache/carbondata/processing/store/CarbonDataWriterFactory.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/CarbonDataWriterFactory.java
@@ -22,6 +22,8 @@ import org.apache.carbondata.processing.store.writer.CarbonDataWriterVo;
 import org.apache.carbondata.processing.store.writer.CarbonFactDataWriter;
 import org.apache.carbondata.processing.store.writer.v3.CarbonFactDataWriterImplV3;
 
+import org.apache.hadoop.conf.Configuration;
+
 /**
  * Factory class to get the writer instance
  */
@@ -57,15 +59,15 @@ public class CarbonDataWriterFactory {
    * @return writer instance
    */
   public CarbonFactDataWriter<?> getFactDataWriter(final ColumnarFormatVersion version,
-      final CarbonDataWriterVo carbonDataWriterVo) {
+      final CarbonDataWriterVo carbonDataWriterVo, Configuration configuration) {
     switch (version) {
       case V1:
       case V2:
         throw new UnsupportedOperationException("V1 and V2 CarbonData Writer is not supported");
       case V3:
-        return new CarbonFactDataWriterImplV3(carbonDataWriterVo);
+        return new CarbonFactDataWriterImplV3(carbonDataWriterVo, configuration);
       default:
-        return new CarbonFactDataWriterImplV3(carbonDataWriterVo);
+        return new CarbonFactDataWriterImplV3(carbonDataWriterVo, configuration);
     }
   }
 

--- a/processing/src/main/java/org/apache/carbondata/processing/store/CarbonFactDataHandlerColumnar.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/CarbonFactDataHandlerColumnar.java
@@ -569,7 +569,7 @@ public class CarbonFactDataHandlerColumnar implements CarbonFactHandler {
    */
   private CarbonFactDataWriter<?> getFactDataWriter() {
     return CarbonDataWriterFactory.getInstance()
-        .getFactDataWriter(version, getDataWriterVo());
+        .getFactDataWriter(version, getDataWriterVo(), model.getHadoopConf());
   }
 
   /**
@@ -681,7 +681,7 @@ public class CarbonFactDataHandlerColumnar implements CarbonFactHandler {
     }
 
     /**
-     * @param encodedTablePage
+     * @param tablePage
      * @param index
      */
     public synchronized void put(TablePage tablePage, int index) {

--- a/processing/src/main/java/org/apache/carbondata/processing/store/writer/v3/CarbonFactDataWriterImplV3.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/writer/v3/CarbonFactDataWriterImplV3.java
@@ -43,6 +43,8 @@ import org.apache.carbondata.processing.store.TablePage;
 import org.apache.carbondata.processing.store.writer.AbstractFactDataWriter;
 import org.apache.carbondata.processing.store.writer.CarbonDataWriterVo;
 
+import org.apache.hadoop.conf.Configuration;
+
 /**
  * Below class will be used to write the data in V3 format
  * <Column1 Data ChunkV3><Column1<Page1><Page2><Page3><Page4>>
@@ -65,8 +67,8 @@ public class CarbonFactDataWriterImplV3 extends AbstractFactDataWriter<short[]> 
    */
   private long blockletSizeThreshold;
 
-  public CarbonFactDataWriterImplV3(CarbonDataWriterVo dataWriterVo) {
-    super(dataWriterVo);
+  public CarbonFactDataWriterImplV3(CarbonDataWriterVo dataWriterVo, Configuration configuration) {
+    super(dataWriterVo, configuration);
     blockletSizeThreshold = Long.parseLong(CarbonProperties.getInstance()
         .getProperty(CarbonV3DataFormatConstants.BLOCKLET_SIZE_IN_MB,
             CarbonV3DataFormatConstants.BLOCKLET_SIZE_IN_MB_DEFAULT_VALUE))
@@ -307,7 +309,7 @@ public class CarbonFactDataWriterImplV3 extends AbstractFactDataWriter<short[]> 
   protected void fillBlockIndexInfoDetails(long numberOfRows, String carbonDataFileName,
       long currentPosition) {
     int i = 0;
-    DataFileFooterConverterV3 converterV3 = new DataFileFooterConverterV3();
+    DataFileFooterConverterV3 converterV3 = new DataFileFooterConverterV3(configuration);
     for (org.apache.carbondata.format.BlockletIndex index : blockletIndex) {
       BlockletInfo3 blockletInfo3 = blockletMetadata.get(i);
       BlockletInfo blockletInfo = converterV3.getBlockletInfo(blockletInfo3,

--- a/processing/src/main/java/org/apache/carbondata/processing/surrogatekeysgenerator/csvbased/BadRecordsLogger.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/surrogatekeysgenerator/csvbased/BadRecordsLogger.java
@@ -35,6 +35,8 @@ import org.apache.carbondata.core.datastore.impl.FileFactory.FileType;
 import org.apache.carbondata.core.util.CarbonUtil;
 import org.apache.carbondata.processing.newflow.exception.CarbonDataLoadingException;
 
+import org.apache.hadoop.conf.Configuration;
+
 public class BadRecordsLogger {
 
   /**
@@ -88,11 +90,13 @@ public class BadRecordsLogger {
 
   private boolean isDataLoadFail;
 
+  private Configuration configuration;
+
   // private final Object syncObject =new Object();
 
   public BadRecordsLogger(String key, String fileName, String storePath,
       boolean badRecordsLogRedirect, boolean badRecordLoggerEnable,
-      boolean badRecordConvertNullDisable, boolean isDataLoadFail) {
+      boolean badRecordConvertNullDisable, boolean isDataLoadFail, Configuration configuration) {
     // Initially no bad rec
     taskKey = key;
     this.fileName = fileName;
@@ -101,6 +105,7 @@ public class BadRecordsLogger {
     this.badRecordLoggerEnable = badRecordLoggerEnable;
     this.badRecordConvertNullDisable = badRecordConvertNullDisable;
     this.isDataLoadFail = isDataLoadFail;
+    this.configuration = configuration;
   }
 
   /**
@@ -178,15 +183,15 @@ public class BadRecordsLogger {
     try {
       if (null == bufferedWriter) {
         FileType fileType = FileFactory.getFileType(storePath);
-        if (!FileFactory.isFileExist(this.storePath, fileType)) {
+        if (!FileFactory.isFileExist(configuration, this.storePath, fileType)) {
           // create the folders if not exist
-          FileFactory.mkdirs(this.storePath, fileType);
+          FileFactory.mkdirs(configuration, this.storePath, fileType);
 
           // create the files
-          FileFactory.createNewFile(logFilePath, fileType);
+          FileFactory.createNewFile(configuration, logFilePath, fileType);
         }
 
-        outStream = FileFactory.getDataOutputStream(logFilePath, fileType);
+        outStream = FileFactory.getDataOutputStream(configuration, logFilePath, fileType);
 
         bufferedWriter = new BufferedWriter(new OutputStreamWriter(outStream,
             Charset.forName(CarbonCommonConstants.DEFAULT_CHARSET)));
@@ -223,15 +228,15 @@ public class BadRecordsLogger {
     try {
       if (null == bufferedCSVWriter) {
         FileType fileType = FileFactory.getFileType(storePath);
-        if (!FileFactory.isFileExist(this.storePath, fileType)) {
+        if (!FileFactory.isFileExist(configuration, this.storePath, fileType)) {
           // create the folders if not exist
-          FileFactory.mkdirs(this.storePath, fileType);
+          FileFactory.mkdirs(configuration, this.storePath, fileType);
 
           // create the files
-          FileFactory.createNewFile(csvFilePath, fileType);
+          FileFactory.createNewFile(configuration, csvFilePath, fileType);
         }
 
-        outCSVStream = FileFactory.getDataOutputStream(csvFilePath, fileType);
+        outCSVStream = FileFactory.getDataOutputStream(configuration, csvFilePath, fileType);
 
         bufferedCSVWriter = new BufferedWriter(new OutputStreamWriter(outCSVStream,
             Charset.forName(CarbonCommonConstants.DEFAULT_CHARSET)));

--- a/processing/src/main/java/org/apache/carbondata/processing/util/CarbonDataProcessorUtil.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/util/CarbonDataProcessorUtil.java
@@ -59,6 +59,7 @@ import org.apache.carbondata.processing.newflow.sort.SortScopeOptions;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.conf.Configuration;
 
 public final class CarbonDataProcessorUtil {
   private static final LogService LOGGER =
@@ -108,13 +109,14 @@ public final class CarbonDataProcessorUtil {
 
     FileType fileType = FileFactory.getFileType(badLogStoreLocation);
     try {
-      if (!FileFactory.isFileExist(badLogStoreLocation, fileType)) {
+      if (!FileFactory.isFileExist(configuration.getHadoopConf(), badLogStoreLocation, fileType)) {
         return;
       }
     } catch (IOException e1) {
       LOGGER.info("bad record folder does not exist");
     }
-    CarbonFile carbonFile = FileFactory.getCarbonFile(badLogStoreLocation, fileType);
+    CarbonFile carbonFile = FileFactory.getCarbonFile(configuration.getHadoopConf(),
+        badLogStoreLocation, fileType);
 
     CarbonFile[] listFiles = carbonFile.listFiles(new CarbonFileFilter() {
       @Override public boolean accept(CarbonFile pathname) {
@@ -202,8 +204,8 @@ public final class CarbonDataProcessorUtil {
         .getCarbonTable(databaseName + CarbonCommonConstants.UNDERSCORE + tableName);
     for (int i = 0 ; i < baseTmpStorePathArray.length; i++) {
       String tmpStore = baseTmpStorePathArray[i];
-      CarbonTablePath carbonTablePath =
-          CarbonStorePath.getCarbonTablePath(tmpStore, carbonTable.getCarbonTableIdentifier());
+      CarbonTablePath carbonTablePath = CarbonStorePath.getCarbonTablePath(tmpStore,
+          carbonTable.getCarbonTableIdentifier(), null);
       String carbonDataDirectoryPath =
           carbonTablePath.getCarbonDataDirectoryPath(partitionId, segmentId + "");
 
@@ -439,15 +441,16 @@ public final class CarbonDataProcessorUtil {
    * @return data directory path
    */
   public static String checkAndCreateCarbonStoreLocation(String factStoreLocation,
-      String databaseName, String tableName, String partitionId, String segmentId) {
+      String databaseName, String tableName, String partitionId, String segmentId,
+      Configuration configuration) {
     CarbonTable carbonTable = CarbonMetadata.getInstance()
         .getCarbonTable(databaseName + CarbonCommonConstants.UNDERSCORE + tableName);
     CarbonTableIdentifier carbonTableIdentifier = carbonTable.getCarbonTableIdentifier();
     CarbonTablePath carbonTablePath =
-        CarbonStorePath.getCarbonTablePath(factStoreLocation, carbonTableIdentifier);
+        CarbonStorePath.getCarbonTablePath(factStoreLocation, carbonTableIdentifier, configuration);
     String carbonDataDirectoryPath =
         carbonTablePath.getCarbonDataDirectoryPath(partitionId, segmentId);
-    CarbonUtil.checkAndCreateFolder(carbonDataDirectoryPath);
+    CarbonUtil.checkAndCreateFolder(configuration, carbonDataDirectoryPath);
     return carbonDataDirectoryPath;
   }
 

--- a/processing/src/test/java/org/apache/carbondata/carbon/datastore/BlockIndexStoreTest.java
+++ b/processing/src/test/java/org/apache/carbondata/carbon/datastore/BlockIndexStoreTest.java
@@ -63,7 +63,7 @@ public class BlockIndexStoreTest extends TestCase {
     CarbonProperties.getInstance().
         addProperty(CarbonCommonConstants.CARBON_MAX_DRIVER_LRU_CACHE_SIZE, "10");
     CacheProvider cacheProvider = CacheProvider.getInstance();
-    cache = (BlockIndexStore) cacheProvider.createCache(CacheType.EXECUTOR_BTREE, "");
+    cache = (BlockIndexStore) cacheProvider.createCache(CacheType.EXECUTOR_BTREE, "", StoreCreator.configuration);
   }
 
   @AfterClass public void tearDown() {


### PR DESCRIPTION
1. support to store CarbonData file in object storage by S3 interface (spark 1.6 and 2.1)
we can set carbon.storelocation to a object storage path

2.  support multiple sessions
pass Hadoop configuration to executor side from driver side
different users can use different Hadoop configuration in the same cluster
