### PR TITLE
[CARBONDATA-1490] Fixed memory allocation for carbon row

### DIFF
--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/steps/CarbonRowDataWriterProcessorStepImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/steps/CarbonRowDataWriterProcessorStepImpl.java
@@ -254,7 +254,7 @@ public class CarbonRowDataWriterProcessorStepImpl extends AbstractDataLoadProces
       nonDicArray[nonDicIndex++] = (byte[]) row.getObject(dimCount);
     }
 
-    Object[] measures = new Object[outputLength];
+    Object[] measures = new Object[measureCount];
     for (int i = 0; i < this.measureCount; i++) {
       measures[i] = row.getObject(i + this.dimensionWithComplexCount);
     }


### PR DESCRIPTION
Analysis: While creating carbon row the space for measures is assigned based on outputLength and not on measureCount which will tend to allocate more space than is actually needed.
**outputLength = measureCount + ((noDictCount + complexCount) > 0 ? 1 : 0) + 1**
When the table has 1 complex column then measureCount=0, noDictCount=0, complexCount=1
therefore, outputLength = 2
Even if there are no measure columns the measure object is created with 2 null values.

Solution: Create measure object based on the measureCount.