### PR TITLE
[CARBONDATA-1505] Get the detailed blocklet information using default BlockletDataMap for other datamaps

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datamap/TableDataMap.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/TableDataMap.java
@@ -26,7 +26,7 @@ import org.apache.carbondata.core.events.ChangeEvent;
 import org.apache.carbondata.core.events.EventListener;
 import org.apache.carbondata.core.indexstore.Blocklet;
 import org.apache.carbondata.core.indexstore.BlockletDetailsFetcher;
-import org.apache.carbondata.core.indexstore.DetailedBlocklet;
+import org.apache.carbondata.core.indexstore.ExtendedBlocklet;
 import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
 import org.apache.carbondata.core.scan.filter.resolver.FilterResolverIntf;
 
@@ -62,9 +62,9 @@ public final class TableDataMap implements EventListener {
    * @param filterExp
    * @return
    */
-  public List<DetailedBlocklet> prune(List<String> segmentIds, FilterResolverIntf filterExp)
+  public List<ExtendedBlocklet> prune(List<String> segmentIds, FilterResolverIntf filterExp)
       throws IOException {
-    List<DetailedBlocklet> blocklets = new ArrayList<>();
+    List<ExtendedBlocklet> blocklets = new ArrayList<>();
     for (String segmentId : segmentIds) {
       List<Blocklet> pruneBlocklets = new ArrayList<>();
       List<DataMap> dataMaps = dataMapFactory.getDataMaps(segmentId);
@@ -72,14 +72,14 @@ public final class TableDataMap implements EventListener {
         pruneBlocklets.addAll(dataMap.prune(filterExp));
       }
       blocklets.addAll(addSegmentId(blockletDetailsFetcher
-          .getDetailedBlocklets(pruneBlocklets, segmentId), segmentId));
+          .getExtendedBlocklets(pruneBlocklets, segmentId), segmentId));
     }
     return blocklets;
   }
 
-  private List<DetailedBlocklet> addSegmentId(List<DetailedBlocklet> pruneBlocklets,
+  private List<ExtendedBlocklet> addSegmentId(List<ExtendedBlocklet> pruneBlocklets,
       String segmentId) {
-    for (DetailedBlocklet blocklet : pruneBlocklets) {
+    for (ExtendedBlocklet blocklet : pruneBlocklets) {
       blocklet.setSegmentId(segmentId);
     }
     return pruneBlocklets;
@@ -115,13 +115,13 @@ public final class TableDataMap implements EventListener {
    * @param filterExp
    * @return
    */
-  public List<DetailedBlocklet> prune(DataMapDistributable distributable,
+  public List<ExtendedBlocklet> prune(DataMapDistributable distributable,
       FilterResolverIntf filterExp) throws IOException {
-    List<DetailedBlocklet> detailedBlocklets = new ArrayList<>();
+    List<ExtendedBlocklet> detailedBlocklets = new ArrayList<>();
     List<Blocklet> blocklets = dataMapFactory.getDataMap(distributable).prune(filterExp);
     for (Blocklet blocklet: blocklets) {
-      DetailedBlocklet detailedBlocklet =
-          blockletDetailsFetcher.getDetailedBlocklet(blocklet, distributable.getSegmentId());
+      ExtendedBlocklet detailedBlocklet =
+          blockletDetailsFetcher.getExtendedBlocklet(blocklet, distributable.getSegmentId());
       detailedBlocklet.setSegmentId(distributable.getSegmentId());
       detailedBlocklets.add(detailedBlocklet);
     }

--- a/core/src/main/java/org/apache/carbondata/core/datamap/TableDataMap.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/TableDataMap.java
@@ -25,6 +25,8 @@ import org.apache.carbondata.core.datamap.dev.DataMapFactory;
 import org.apache.carbondata.core.events.ChangeEvent;
 import org.apache.carbondata.core.events.EventListener;
 import org.apache.carbondata.core.indexstore.Blocklet;
+import org.apache.carbondata.core.indexstore.BlockletDetailsFetcher;
+import org.apache.carbondata.core.indexstore.DetailedBlocklet;
 import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
 import org.apache.carbondata.core.scan.filter.resolver.FilterResolverIntf;
 
@@ -40,14 +42,17 @@ public final class TableDataMap implements EventListener {
 
   private DataMapFactory dataMapFactory;
 
+  private BlockletDetailsFetcher blockletDetailsFetcher;
+
   /**
    * It is called to initialize and load the required table datamap metadata.
    */
-  public TableDataMap(AbsoluteTableIdentifier identifier,
-      String dataMapName, DataMapFactory dataMapFactory) {
+  public TableDataMap(AbsoluteTableIdentifier identifier, String dataMapName,
+      DataMapFactory dataMapFactory, BlockletDetailsFetcher blockletDetailsFetcher) {
     this.identifier = identifier;
     this.dataMapName = dataMapName;
     this.dataMapFactory = dataMapFactory;
+    this.blockletDetailsFetcher = blockletDetailsFetcher;
   }
 
   /**
@@ -57,21 +62,24 @@ public final class TableDataMap implements EventListener {
    * @param filterExp
    * @return
    */
-  public List<Blocklet> prune(List<String> segmentIds, FilterResolverIntf filterExp)
+  public List<DetailedBlocklet> prune(List<String> segmentIds, FilterResolverIntf filterExp)
       throws IOException {
-    List<Blocklet> blocklets = new ArrayList<>();
+    List<DetailedBlocklet> blocklets = new ArrayList<>();
     for (String segmentId : segmentIds) {
+      List<Blocklet> pruneBlocklets = new ArrayList<>();
       List<DataMap> dataMaps = dataMapFactory.getDataMaps(segmentId);
       for (DataMap dataMap : dataMaps) {
-        List<Blocklet> pruneBlocklets = dataMap.prune(filterExp);
-        blocklets.addAll(addSegmentId(pruneBlocklets, segmentId));
+        pruneBlocklets.addAll(dataMap.prune(filterExp));
       }
+      blocklets.addAll(addSegmentId(blockletDetailsFetcher
+          .getDetailedBlocklets(pruneBlocklets, segmentId), segmentId));
     }
     return blocklets;
   }
 
-  private List<Blocklet> addSegmentId(List<Blocklet> pruneBlocklets, String segmentId) {
-    for (Blocklet blocklet : pruneBlocklets) {
+  private List<DetailedBlocklet> addSegmentId(List<DetailedBlocklet> pruneBlocklets,
+      String segmentId) {
+    for (DetailedBlocklet blocklet : pruneBlocklets) {
       blocklet.setSegmentId(segmentId);
     }
     return pruneBlocklets;
@@ -107,12 +115,17 @@ public final class TableDataMap implements EventListener {
    * @param filterExp
    * @return
    */
-  public List<Blocklet> prune(DataMapDistributable distributable, FilterResolverIntf filterExp) {
+  public List<DetailedBlocklet> prune(DataMapDistributable distributable,
+      FilterResolverIntf filterExp) throws IOException {
+    List<DetailedBlocklet> detailedBlocklets = new ArrayList<>();
     List<Blocklet> blocklets = dataMapFactory.getDataMap(distributable).prune(filterExp);
     for (Blocklet blocklet: blocklets) {
-      blocklet.setSegmentId(distributable.getSegmentId());
+      DetailedBlocklet detailedBlocklet =
+          blockletDetailsFetcher.getDetailedBlocklet(blocklet, distributable.getSegmentId());
+      detailedBlocklet.setSegmentId(distributable.getSegmentId());
+      detailedBlocklets.add(detailedBlocklet);
     }
-    return blocklets;
+    return detailedBlocklets;
   }
 
   @Override public void fireEvent(ChangeEvent event) {

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/Blocklet.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/Blocklet.java
@@ -16,15 +16,7 @@
  */
 package org.apache.carbondata.core.indexstore;
 
-import java.io.IOException;
 import java.io.Serializable;
-
-import org.apache.carbondata.core.datastore.impl.FileFactory;
-
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.LocatedFileStatus;
-import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.RemoteIterator;
 
 /**
  * Blocklet
@@ -33,15 +25,7 @@ public class Blocklet implements Serializable {
 
   private String path;
 
-  private String segmentId;
-
   private String blockletId;
-
-  private BlockletDetailInfo detailInfo;
-
-  private long length;
-
-  private String[] location;
 
   public Blocklet(String path, String blockletId) {
     this.path = path;
@@ -54,39 +38,6 @@ public class Blocklet implements Serializable {
 
   public String getBlockletId() {
     return blockletId;
-  }
-
-  public BlockletDetailInfo getDetailInfo() {
-    return detailInfo;
-  }
-
-  public void setDetailInfo(BlockletDetailInfo detailInfo) {
-    this.detailInfo = detailInfo;
-  }
-
-  public void updateLocations() throws IOException {
-    Path path = new Path(this.path);
-    FileSystem fs = path.getFileSystem(FileFactory.getConfiguration());
-    RemoteIterator<LocatedFileStatus> iter = fs.listLocatedStatus(path);
-    LocatedFileStatus fileStatus = iter.next();
-    location = fileStatus.getBlockLocations()[0].getHosts();
-    length = fileStatus.getLen();
-  }
-
-  public String[] getLocations() throws IOException {
-    return location;
-  }
-
-  public long getLength() throws IOException {
-    return length;
-  }
-
-  public String getSegmentId() {
-    return segmentId;
-  }
-
-  public void setSegmentId(String segmentId) {
-    this.segmentId = segmentId;
   }
 
 }

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/BlockletDetailsFetcher.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/BlockletDetailsFetcher.java
@@ -32,7 +32,7 @@ public interface BlockletDetailsFetcher {
    * @return
    * @throws IOException
    */
-  List<DetailedBlocklet> getDetailedBlocklets(List<Blocklet> blocklets, String segmentId)
+  List<ExtendedBlocklet> getExtendedBlocklets(List<Blocklet> blocklets, String segmentId)
       throws IOException;
 
   /**
@@ -43,5 +43,5 @@ public interface BlockletDetailsFetcher {
    * @return
    * @throws IOException
    */
-  DetailedBlocklet getDetailedBlocklet(Blocklet blocklet, String segmentId) throws IOException;
+  ExtendedBlocklet getExtendedBlocklet(Blocklet blocklet, String segmentId) throws IOException;
 }

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/BlockletDetailsFetcher.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/BlockletDetailsFetcher.java
@@ -14,21 +14,34 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.carbondata.hadoop.api;
+package org.apache.carbondata.core.indexstore;
 
-import java.io.Serializable;
+import java.io.IOException;
 import java.util.List;
 
-import org.apache.carbondata.core.indexstore.DetailedBlocklet;
-import org.apache.carbondata.core.scan.filter.resolver.FilterResolverIntf;
-
 /**
- * Distributable datamap job to execute the #DistributableDataMapFormat in cluster. it prunes the
- * datamaps distributably and returns the final blocklet list
+ * Fetches the detailed blocklet which has more information to execute the query
  */
-public interface DataMapJob extends Serializable {
+public interface BlockletDetailsFetcher {
 
-  List<DetailedBlocklet> execute(DistributableDataMapFormat dataMapFormat,
-      FilterResolverIntf resolverIntf);
+  /**
+   * Get the blocklet detail information based on blockletid, blockid and segmentid.
+   *
+   * @param blocklets
+   * @param segmentId
+   * @return
+   * @throws IOException
+   */
+  List<DetailedBlocklet> getDetailedBlocklets(List<Blocklet> blocklets, String segmentId)
+      throws IOException;
 
+  /**
+   * Get the blocklet detail information based on blockletid, blockid and segmentid.
+   *
+   * @param blocklet
+   * @param segmentId
+   * @return
+   * @throws IOException
+   */
+  DetailedBlocklet getDetailedBlocklet(Blocklet blocklet, String segmentId) throws IOException;
 }

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/DetailedBlocklet.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/DetailedBlocklet.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.core.indexstore;
+
+import java.io.IOException;
+
+import org.apache.carbondata.core.datastore.impl.FileFactory;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.LocatedFileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.RemoteIterator;
+
+/**
+ * Detailed blocklet information
+ */
+public class DetailedBlocklet extends Blocklet {
+
+  private String segmentId;
+
+  private BlockletDetailInfo detailInfo;
+
+  private long length;
+
+  private String[] location;
+
+  public DetailedBlocklet(String path, String blockletId) {
+    super(path, blockletId);
+  }
+
+  public BlockletDetailInfo getDetailInfo() {
+    return detailInfo;
+  }
+
+  public void setDetailInfo(BlockletDetailInfo detailInfo) {
+    this.detailInfo = detailInfo;
+  }
+
+  public void updateLocations() throws IOException {
+    Path path = new Path(getPath());
+    FileSystem fs = path.getFileSystem(FileFactory.getConfiguration());
+    RemoteIterator<LocatedFileStatus> iter = fs.listLocatedStatus(path);
+    LocatedFileStatus fileStatus = iter.next();
+    location = fileStatus.getBlockLocations()[0].getHosts();
+    length = fileStatus.getLen();
+  }
+
+  public String[] getLocations() throws IOException {
+    return location;
+  }
+
+  public long getLength() throws IOException {
+    return length;
+  }
+
+  public String getSegmentId() {
+    return segmentId;
+  }
+
+  public void setSegmentId(String segmentId) {
+    this.segmentId = segmentId;
+  }
+}

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/ExtendedBlocklet.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/ExtendedBlocklet.java
@@ -28,7 +28,7 @@ import org.apache.hadoop.fs.RemoteIterator;
 /**
  * Detailed blocklet information
  */
-public class DetailedBlocklet extends Blocklet {
+public class ExtendedBlocklet extends Blocklet {
 
   private String segmentId;
 
@@ -38,7 +38,7 @@ public class DetailedBlocklet extends Blocklet {
 
   private String[] location;
 
-  public DetailedBlocklet(String path, String blockletId) {
+  public ExtendedBlocklet(String path, String blockletId) {
     super(path, blockletId);
   }
 
@@ -50,6 +50,11 @@ public class DetailedBlocklet extends Blocklet {
     this.detailInfo = detailInfo;
   }
 
+  /**
+   * It gets the hdfs block locations and length for this blocklet. It is used internally to get the
+   * locations for allocating tasks.
+   * @throws IOException
+   */
   public void updateLocations() throws IOException {
     Path path = new Path(getPath());
     FileSystem fs = path.getFileSystem(FileFactory.getConfiguration());

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/TableBlockIndexUniqueIdentifier.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/TableBlockIndexUniqueIdentifier.java
@@ -100,4 +100,8 @@ public class TableBlockIndexUniqueIdentifier {
     result = 31 * result + carbonIndexFileName.hashCode();
     return result;
   }
+
+  public String getCarbonIndexFileName() {
+    return carbonIndexFileName;
+  }
 }

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMap.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMap.java
@@ -39,6 +39,7 @@ import org.apache.carbondata.core.datastore.block.SegmentProperties;
 import org.apache.carbondata.core.datastore.block.TableBlockInfo;
 import org.apache.carbondata.core.indexstore.Blocklet;
 import org.apache.carbondata.core.indexstore.BlockletDetailInfo;
+import org.apache.carbondata.core.indexstore.DetailedBlocklet;
 import org.apache.carbondata.core.indexstore.UnsafeMemoryDMStore;
 import org.apache.carbondata.core.indexstore.row.DataMapRow;
 import org.apache.carbondata.core.indexstore.row.DataMapRowImpl;
@@ -286,6 +287,12 @@ public class BlockletDataMap implements DataMap, Cacheable {
     return blocklets;
   }
 
+  public DetailedBlocklet getDetailedBlocklet(String blockletId) {
+    int index = Integer.parseInt(blockletId);
+    DataMapRow unsafeRow = unsafeMemoryDMStore.getUnsafeRow(index);
+    return createBlocklet(unsafeRow, index);
+  }
+
   private byte[][] getMinMaxValue(DataMapRow row, int index) {
     DataMapRow minMaxRow = row.getRow(index);
     byte[][] minMax = new byte[minMaxRow.getColumnCount()][];
@@ -295,8 +302,8 @@ public class BlockletDataMap implements DataMap, Cacheable {
     return minMax;
   }
 
-  private Blocklet createBlocklet(DataMapRow row, int blockletId) {
-    Blocklet blocklet = new Blocklet(
+  private DetailedBlocklet createBlocklet(DataMapRow row, int blockletId) {
+    DetailedBlocklet blocklet = new DetailedBlocklet(
         new String(row.getByteArray(FILE_PATH_INDEX), CarbonCommonConstants.DEFAULT_CHARSET_CLASS),
         blockletId + "");
     BlockletDetailInfo detailInfo = new BlockletDetailInfo();

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMap.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMap.java
@@ -39,7 +39,7 @@ import org.apache.carbondata.core.datastore.block.SegmentProperties;
 import org.apache.carbondata.core.datastore.block.TableBlockInfo;
 import org.apache.carbondata.core.indexstore.Blocklet;
 import org.apache.carbondata.core.indexstore.BlockletDetailInfo;
-import org.apache.carbondata.core.indexstore.DetailedBlocklet;
+import org.apache.carbondata.core.indexstore.ExtendedBlocklet;
 import org.apache.carbondata.core.indexstore.UnsafeMemoryDMStore;
 import org.apache.carbondata.core.indexstore.row.DataMapRow;
 import org.apache.carbondata.core.indexstore.row.DataMapRowImpl;
@@ -287,7 +287,7 @@ public class BlockletDataMap implements DataMap, Cacheable {
     return blocklets;
   }
 
-  public DetailedBlocklet getDetailedBlocklet(String blockletId) {
+  public ExtendedBlocklet getDetailedBlocklet(String blockletId) {
     int index = Integer.parseInt(blockletId);
     DataMapRow unsafeRow = unsafeMemoryDMStore.getUnsafeRow(index);
     return createBlocklet(unsafeRow, index);
@@ -302,8 +302,8 @@ public class BlockletDataMap implements DataMap, Cacheable {
     return minMax;
   }
 
-  private DetailedBlocklet createBlocklet(DataMapRow row, int blockletId) {
-    DetailedBlocklet blocklet = new DetailedBlocklet(
+  private ExtendedBlocklet createBlocklet(DataMapRow row, int blockletId) {
+    ExtendedBlocklet blocklet = new ExtendedBlocklet(
         new String(row.getByteArray(FILE_PATH_INDEX), CarbonCommonConstants.DEFAULT_CHARSET_CLASS),
         blockletId + "");
     BlockletDetailInfo detailInfo = new BlockletDetailInfo();

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMapFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMapFactory.java
@@ -36,7 +36,7 @@ import org.apache.carbondata.core.datastore.impl.FileFactory;
 import org.apache.carbondata.core.events.ChangeEvent;
 import org.apache.carbondata.core.indexstore.Blocklet;
 import org.apache.carbondata.core.indexstore.BlockletDetailsFetcher;
-import org.apache.carbondata.core.indexstore.DetailedBlocklet;
+import org.apache.carbondata.core.indexstore.ExtendedBlocklet;
 import org.apache.carbondata.core.indexstore.TableBlockIndexUniqueIdentifier;
 import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
 import org.apache.carbondata.core.util.path.CarbonTablePath;
@@ -74,7 +74,6 @@ public class BlockletDataMapFactory implements DataMapFactory, BlockletDetailsFe
   public List<DataMap> getDataMaps(String segmentId) throws IOException {
     List<TableBlockIndexUniqueIdentifier> tableBlockIndexUniqueIdentifiers =
         getTableBlockIndexUniqueIdentifiers(segmentId);
-
     return cache.getAll(tableBlockIndexUniqueIdentifiers);
   }
 
@@ -98,19 +97,15 @@ public class BlockletDataMapFactory implements DataMapFactory, BlockletDetailsFe
    * Get the blocklet detail information based on blockletid, blockid and segmentid. This method is
    * exclusively for BlockletDataMapFactory as detail information is only available in this default
    * datamap.
-   * @param blocklets
-   * @param segmentId
-   * @return
-   * @throws IOException
    */
   @Override
-  public List<DetailedBlocklet> getDetailedBlocklets(List<Blocklet> blocklets, String segmentId)
+  public List<ExtendedBlocklet> getExtendedBlocklets(List<Blocklet> blocklets, String segmentId)
       throws IOException {
-    List<DetailedBlocklet> detailedBlocklets = new ArrayList<>();
+    List<ExtendedBlocklet> detailedBlocklets = new ArrayList<>();
     // If it is already detailed blocklet then type cast and return same
-    if (blocklets.size() > 0 && blocklets.get(0) instanceof DetailedBlocklet) {
+    if (blocklets.size() > 0 && blocklets.get(0) instanceof ExtendedBlocklet) {
       for (Blocklet blocklet : blocklets) {
-        detailedBlocklets.add((DetailedBlocklet) blocklet);
+        detailedBlocklets.add((ExtendedBlocklet) blocklet);
       }
       return detailedBlocklets;
     }
@@ -118,23 +113,23 @@ public class BlockletDataMapFactory implements DataMapFactory, BlockletDetailsFe
         getTableBlockIndexUniqueIdentifiers(segmentId);
     // Retrieve each blocklets detail information from blocklet datamap
     for (Blocklet blocklet : blocklets) {
-      detailedBlocklets.add(getDetailedBlocklet(identifiers, blocklet));
+      detailedBlocklets.add(getExtendedBlocklet(identifiers, blocklet));
     }
     return detailedBlocklets;
   }
 
   @Override
-  public DetailedBlocklet getDetailedBlocklet(Blocklet blocklet, String segmentId)
+  public ExtendedBlocklet getExtendedBlocklet(Blocklet blocklet, String segmentId)
       throws IOException {
-    if (blocklet instanceof DetailedBlocklet) {
-      return (DetailedBlocklet) blocklet;
+    if (blocklet instanceof ExtendedBlocklet) {
+      return (ExtendedBlocklet) blocklet;
     }
     List<TableBlockIndexUniqueIdentifier> identifiers =
         getTableBlockIndexUniqueIdentifiers(segmentId);
-    return getDetailedBlocklet(identifiers, blocklet);
+    return getExtendedBlocklet(identifiers, blocklet);
   }
 
-  private DetailedBlocklet getDetailedBlocklet(List<TableBlockIndexUniqueIdentifier> identifiers,
+  private ExtendedBlocklet getExtendedBlocklet(List<TableBlockIndexUniqueIdentifier> identifiers,
       Blocklet blocklet) throws IOException {
     String carbonIndexFileName = CarbonTablePath.getCarbonIndexFileName(blocklet.getPath());
     for (TableBlockIndexUniqueIdentifier identifier : identifiers) {

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableInputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableInputFormat.java
@@ -32,7 +32,7 @@ import java.util.Map;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.datamap.DataMapStoreManager;
 import org.apache.carbondata.core.datamap.TableDataMap;
-import org.apache.carbondata.core.indexstore.DetailedBlocklet;
+import org.apache.carbondata.core.indexstore.ExtendedBlocklet;
 import org.apache.carbondata.core.indexstore.blockletindex.BlockletDataMap;
 import org.apache.carbondata.core.indexstore.blockletindex.BlockletDataMapFactory;
 import org.apache.carbondata.core.keygenerator.KeyGenException;
@@ -539,7 +539,7 @@ public class CarbonTableInputFormat<T> extends FileInputFormat<Void, T> {
         .getDataMap(absoluteTableIdentifier, BlockletDataMap.NAME,
             BlockletDataMapFactory.class.getName());
     DataMapJob dataMapJob = getDataMapJob(job.getConfiguration());
-    List<DetailedBlocklet> prunedBlocklets;
+    List<ExtendedBlocklet> prunedBlocklets;
     if (dataMapJob != null) {
       DistributableDataMapFormat datamapDstr =
           new DistributableDataMapFormat(absoluteTableIdentifier, BlockletDataMap.NAME,
@@ -555,7 +555,7 @@ public class CarbonTableInputFormat<T> extends FileInputFormat<Void, T> {
     if (partitionInfo != null) {
       partitionIdList = partitionInfo.getPartitionIds();
     }
-    for (DetailedBlocklet blocklet : prunedBlocklets) {
+    for (ExtendedBlocklet blocklet : prunedBlocklets) {
       int partitionId = CarbonTablePath.DataFileUtil.getTaskIdFromTaskNo(
           CarbonTablePath.DataFileUtil.getTaskNo(blocklet.getPath().toString()));
 
@@ -586,7 +586,7 @@ public class CarbonTableInputFormat<T> extends FileInputFormat<Void, T> {
     return resultFilterredBlocks;
   }
 
-  private CarbonInputSplit convertToCarbonInputSplit(DetailedBlocklet blocklet)
+  private CarbonInputSplit convertToCarbonInputSplit(ExtendedBlocklet blocklet)
       throws IOException {
     blocklet.updateLocations();
     org.apache.carbondata.hadoop.CarbonInputSplit split =
@@ -721,9 +721,9 @@ public class CarbonTableInputFormat<T> extends FileInputFormat<Void, T> {
         new HashMap<>(CarbonCommonConstants.DEFAULT_COLLECTION_SIZE);
     Map<String, Long> segmentAndBlockCountMapping =
         new HashMap<>(CarbonCommonConstants.DEFAULT_COLLECTION_SIZE);
-    List<DetailedBlocklet> blocklets =
+    List<ExtendedBlocklet> blocklets =
         blockletMap.prune(validAndInvalidSegments.getValidSegments(), null);
-    for (DetailedBlocklet blocklet : blocklets) {
+    for (ExtendedBlocklet blocklet : blocklets) {
       String blockName = blocklet.getPath();
       blockName = CarbonTablePath.getCarbonDataFileName(blockName);
       blockName = blockName + CarbonTablePath.getCarbonDataExtension();

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableInputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableInputFormat.java
@@ -21,12 +21,18 @@ import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.BitSet;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.datamap.DataMapStoreManager;
 import org.apache.carbondata.core.datamap.TableDataMap;
-import org.apache.carbondata.core.indexstore.Blocklet;
+import org.apache.carbondata.core.indexstore.DetailedBlocklet;
 import org.apache.carbondata.core.indexstore.blockletindex.BlockletDataMap;
 import org.apache.carbondata.core.indexstore.blockletindex.BlockletDataMapFactory;
 import org.apache.carbondata.core.keygenerator.KeyGenException;
@@ -533,7 +539,7 @@ public class CarbonTableInputFormat<T> extends FileInputFormat<Void, T> {
         .getDataMap(absoluteTableIdentifier, BlockletDataMap.NAME,
             BlockletDataMapFactory.class.getName());
     DataMapJob dataMapJob = getDataMapJob(job.getConfiguration());
-    List<Blocklet> prunedBlocklets;
+    List<DetailedBlocklet> prunedBlocklets;
     if (dataMapJob != null) {
       DistributableDataMapFormat datamapDstr =
           new DistributableDataMapFormat(absoluteTableIdentifier, BlockletDataMap.NAME,
@@ -549,7 +555,7 @@ public class CarbonTableInputFormat<T> extends FileInputFormat<Void, T> {
     if (partitionInfo != null) {
       partitionIdList = partitionInfo.getPartitionIds();
     }
-    for (Blocklet blocklet : prunedBlocklets) {
+    for (DetailedBlocklet blocklet : prunedBlocklets) {
       int partitionId = CarbonTablePath.DataFileUtil.getTaskIdFromTaskNo(
           CarbonTablePath.DataFileUtil.getTaskNo(blocklet.getPath().toString()));
 
@@ -580,7 +586,7 @@ public class CarbonTableInputFormat<T> extends FileInputFormat<Void, T> {
     return resultFilterredBlocks;
   }
 
-  private org.apache.carbondata.hadoop.CarbonInputSplit convertToCarbonInputSplit(Blocklet blocklet)
+  private CarbonInputSplit convertToCarbonInputSplit(DetailedBlocklet blocklet)
       throws IOException {
     blocklet.updateLocations();
     org.apache.carbondata.hadoop.CarbonInputSplit split =
@@ -715,9 +721,10 @@ public class CarbonTableInputFormat<T> extends FileInputFormat<Void, T> {
         new HashMap<>(CarbonCommonConstants.DEFAULT_COLLECTION_SIZE);
     Map<String, Long> segmentAndBlockCountMapping =
         new HashMap<>(CarbonCommonConstants.DEFAULT_COLLECTION_SIZE);
-    List<Blocklet> blocklets = blockletMap.prune(validAndInvalidSegments.getValidSegments(), null);
-    for (Blocklet blocklet : blocklets) {
-      String blockName = blocklet.getPath().toString();
+    List<DetailedBlocklet> blocklets =
+        blockletMap.prune(validAndInvalidSegments.getValidSegments(), null);
+    for (DetailedBlocklet blocklet : blocklets) {
+      String blockName = blocklet.getPath();
       blockName = CarbonTablePath.getCarbonDataFileName(blockName);
       blockName = blockName + CarbonTablePath.getCarbonDataExtension();
 

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/DataMapJob.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/DataMapJob.java
@@ -19,7 +19,7 @@ package org.apache.carbondata.hadoop.api;
 import java.io.Serializable;
 import java.util.List;
 
-import org.apache.carbondata.core.indexstore.DetailedBlocklet;
+import org.apache.carbondata.core.indexstore.ExtendedBlocklet;
 import org.apache.carbondata.core.scan.filter.resolver.FilterResolverIntf;
 
 /**
@@ -28,7 +28,7 @@ import org.apache.carbondata.core.scan.filter.resolver.FilterResolverIntf;
  */
 public interface DataMapJob extends Serializable {
 
-  List<DetailedBlocklet> execute(DistributableDataMapFormat dataMapFormat,
+  List<ExtendedBlocklet> execute(DistributableDataMapFormat dataMapFormat,
       FilterResolverIntf resolverIntf);
 
 }

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/DistributableDataMapFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/DistributableDataMapFormat.java
@@ -25,7 +25,7 @@ import java.util.List;
 import org.apache.carbondata.core.datamap.DataMapDistributable;
 import org.apache.carbondata.core.datamap.DataMapStoreManager;
 import org.apache.carbondata.core.datamap.TableDataMap;
-import org.apache.carbondata.core.indexstore.DetailedBlocklet;
+import org.apache.carbondata.core.indexstore.ExtendedBlocklet;
 import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
 import org.apache.carbondata.core.scan.filter.resolver.FilterResolverIntf;
 import org.apache.carbondata.hadoop.util.ObjectSerializationUtil;
@@ -40,7 +40,7 @@ import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 /**
  * Input format for datamaps, it makes the datamap pruning distributable.
  */
-public class DistributableDataMapFormat extends FileInputFormat<Void, DetailedBlocklet> implements
+public class DistributableDataMapFormat extends FileInputFormat<Void, ExtendedBlocklet> implements
     Serializable {
 
   private static final String FILTER_EXP = "mapreduce.input.distributed.datamap.filter";
@@ -89,11 +89,11 @@ public class DistributableDataMapFormat extends FileInputFormat<Void, DetailedBl
   }
 
   @Override
-  public RecordReader<Void, DetailedBlocklet> createRecordReader(InputSplit inputSplit,
+  public RecordReader<Void, ExtendedBlocklet> createRecordReader(InputSplit inputSplit,
       TaskAttemptContext taskAttemptContext) throws IOException, InterruptedException {
-    return new RecordReader<Void, DetailedBlocklet>() {
-      private Iterator<DetailedBlocklet> blockletIterator;
-      private DetailedBlocklet currBlocklet;
+    return new RecordReader<Void, ExtendedBlocklet>() {
+      private Iterator<ExtendedBlocklet> blockletIterator;
+      private ExtendedBlocklet currBlocklet;
 
       @Override
       public void initialize(InputSplit inputSplit, TaskAttemptContext taskAttemptContext)
@@ -124,7 +124,7 @@ public class DistributableDataMapFormat extends FileInputFormat<Void, DetailedBl
       }
 
       @Override
-      public DetailedBlocklet getCurrentValue() throws IOException, InterruptedException {
+      public ExtendedBlocklet getCurrentValue() throws IOException, InterruptedException {
         return currBlocklet;
       }
 

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/DistributableDataMapFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/DistributableDataMapFormat.java
@@ -25,7 +25,7 @@ import java.util.List;
 import org.apache.carbondata.core.datamap.DataMapDistributable;
 import org.apache.carbondata.core.datamap.DataMapStoreManager;
 import org.apache.carbondata.core.datamap.TableDataMap;
-import org.apache.carbondata.core.indexstore.Blocklet;
+import org.apache.carbondata.core.indexstore.DetailedBlocklet;
 import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
 import org.apache.carbondata.core.scan.filter.resolver.FilterResolverIntf;
 import org.apache.carbondata.hadoop.util.ObjectSerializationUtil;
@@ -40,7 +40,7 @@ import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 /**
  * Input format for datamaps, it makes the datamap pruning distributable.
  */
-public class DistributableDataMapFormat extends FileInputFormat<Void, Blocklet> implements
+public class DistributableDataMapFormat extends FileInputFormat<Void, DetailedBlocklet> implements
     Serializable {
 
   private static final String FILTER_EXP = "mapreduce.input.distributed.datamap.filter";
@@ -89,11 +89,11 @@ public class DistributableDataMapFormat extends FileInputFormat<Void, Blocklet> 
   }
 
   @Override
-  public RecordReader<Void, Blocklet> createRecordReader(InputSplit inputSplit,
+  public RecordReader<Void, DetailedBlocklet> createRecordReader(InputSplit inputSplit,
       TaskAttemptContext taskAttemptContext) throws IOException, InterruptedException {
-    return new RecordReader<Void, Blocklet>() {
-      private Iterator<Blocklet> blockletIterator;
-      private Blocklet currBlocklet;
+    return new RecordReader<Void, DetailedBlocklet>() {
+      private Iterator<DetailedBlocklet> blockletIterator;
+      private DetailedBlocklet currBlocklet;
 
       @Override
       public void initialize(InputSplit inputSplit, TaskAttemptContext taskAttemptContext)
@@ -124,7 +124,7 @@ public class DistributableDataMapFormat extends FileInputFormat<Void, Blocklet> 
       }
 
       @Override
-      public Blocklet getCurrentValue() throws IOException, InterruptedException {
+      public DetailedBlocklet getCurrentValue() throws IOException, InterruptedException {
         return currBlocklet;
       }
 

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/SparkDataMapJob.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/SparkDataMapJob.scala
@@ -29,7 +29,7 @@ import org.apache.spark.{Partition, SparkContext, TaskContext, TaskKilledExcepti
 
 import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.core.constants.CarbonCommonConstants
-import org.apache.carbondata.core.indexstore.DetailedBlocklet
+import org.apache.carbondata.core.indexstore.ExtendedBlocklet
 import org.apache.carbondata.core.scan.filter.resolver.FilterResolverIntf
 import org.apache.carbondata.hadoop.api.{DataMapJob, DistributableDataMapFormat}
 
@@ -39,7 +39,7 @@ import org.apache.carbondata.hadoop.api.{DataMapJob, DistributableDataMapFormat}
 class SparkDataMapJob extends DataMapJob {
 
   override def execute(dataMapFormat: DistributableDataMapFormat,
-      resolverIntf: FilterResolverIntf): util.List[DetailedBlocklet] = {
+      resolverIntf: FilterResolverIntf): util.List[ExtendedBlocklet] = {
     new DataMapPruneRDD(SparkContext.getOrCreate(), dataMapFormat, resolverIntf).collect().toList
       .asJava
   }
@@ -60,7 +60,7 @@ class DataMapRDDPartition(rddId: Int, idx: Int, val inputSplit: InputSplit) exte
 class DataMapPruneRDD(sc: SparkContext,
     dataMapFormat: DistributableDataMapFormat,
     resolverIntf: FilterResolverIntf)
-  extends CarbonRDD[(DetailedBlocklet)](sc, Nil) {
+  extends CarbonRDD[(ExtendedBlocklet)](sc, Nil) {
 
   private val jobTrackerId: String = {
     val formatter = new SimpleDateFormat("yyyyMMddHHmm")
@@ -68,7 +68,7 @@ class DataMapPruneRDD(sc: SparkContext,
   }
 
   override def internalCompute(split: Partition,
-      context: TaskContext): Iterator[DetailedBlocklet] = {
+      context: TaskContext): Iterator[ExtendedBlocklet] = {
     val LOGGER = LogServiceFactory.getLogService(this.getClass.getName)
     val status = CarbonCommonConstants.STORE_LOADSTATUS_SUCCESS
     val attemptId = new TaskAttemptID(jobTrackerId, id, TaskType.MAP, split.index, 0)
@@ -77,7 +77,7 @@ class DataMapPruneRDD(sc: SparkContext,
     DistributableDataMapFormat.setFilterExp(attemptContext.getConfiguration, resolverIntf)
     val reader = dataMapFormat.createRecordReader(inputSplit, attemptContext)
     reader.initialize(inputSplit, attemptContext)
-    val iter = new Iterator[DetailedBlocklet] {
+    val iter = new Iterator[ExtendedBlocklet] {
 
       private var havePair = false
       private var finished = false
@@ -93,7 +93,7 @@ class DataMapPruneRDD(sc: SparkContext,
         !finished
       }
 
-      override def next(): DetailedBlocklet = {
+      override def next(): ExtendedBlocklet = {
         if (!hasNext) {
           throw new java.util.NoSuchElementException("End of stream")
         }

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/SparkDataMapJob.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/SparkDataMapJob.scala
@@ -29,7 +29,7 @@ import org.apache.spark.{Partition, SparkContext, TaskContext, TaskKilledExcepti
 
 import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.core.constants.CarbonCommonConstants
-import org.apache.carbondata.core.indexstore.Blocklet
+import org.apache.carbondata.core.indexstore.DetailedBlocklet
 import org.apache.carbondata.core.scan.filter.resolver.FilterResolverIntf
 import org.apache.carbondata.hadoop.api.{DataMapJob, DistributableDataMapFormat}
 
@@ -39,7 +39,7 @@ import org.apache.carbondata.hadoop.api.{DataMapJob, DistributableDataMapFormat}
 class SparkDataMapJob extends DataMapJob {
 
   override def execute(dataMapFormat: DistributableDataMapFormat,
-      resolverIntf: FilterResolverIntf): util.List[Blocklet] = {
+      resolverIntf: FilterResolverIntf): util.List[DetailedBlocklet] = {
     new DataMapPruneRDD(SparkContext.getOrCreate(), dataMapFormat, resolverIntf).collect().toList
       .asJava
   }
@@ -60,7 +60,7 @@ class DataMapRDDPartition(rddId: Int, idx: Int, val inputSplit: InputSplit) exte
 class DataMapPruneRDD(sc: SparkContext,
     dataMapFormat: DistributableDataMapFormat,
     resolverIntf: FilterResolverIntf)
-  extends CarbonRDD[(Blocklet)](sc, Nil) {
+  extends CarbonRDD[(DetailedBlocklet)](sc, Nil) {
 
   private val jobTrackerId: String = {
     val formatter = new SimpleDateFormat("yyyyMMddHHmm")
@@ -68,7 +68,7 @@ class DataMapPruneRDD(sc: SparkContext,
   }
 
   override def internalCompute(split: Partition,
-      context: TaskContext): Iterator[Blocklet] = {
+      context: TaskContext): Iterator[DetailedBlocklet] = {
     val LOGGER = LogServiceFactory.getLogService(this.getClass.getName)
     val status = CarbonCommonConstants.STORE_LOADSTATUS_SUCCESS
     val attemptId = new TaskAttemptID(jobTrackerId, id, TaskType.MAP, split.index, 0)
@@ -77,7 +77,7 @@ class DataMapPruneRDD(sc: SparkContext,
     DistributableDataMapFormat.setFilterExp(attemptContext.getConfiguration, resolverIntf)
     val reader = dataMapFormat.createRecordReader(inputSplit, attemptContext)
     reader.initialize(inputSplit, attemptContext)
-    val iter = new Iterator[Blocklet] {
+    val iter = new Iterator[DetailedBlocklet] {
 
       private var havePair = false
       private var finished = false
@@ -93,7 +93,7 @@ class DataMapPruneRDD(sc: SparkContext,
         !finished
       }
 
-      override def next(): Blocklet = {
+      override def next(): DetailedBlocklet = {
         if (!hasNext) {
           throw new java.util.NoSuchElementException("End of stream")
         }


### PR DESCRIPTION
All the detail information of blocklet which is need for exceuting query is present only BlockletDataMap. It is actually default datamap.
So if new datamap is added then it gives only information of blocklet and blockid, it is insuffucient information to exceute query.
Now this PR adds the functionality of retrieving detailed blocklet information from the BlockletDataMap based on block and blocklet id.  So now new datamaps can only concentrate on business logic and return only block and blockletid. 