### PR TITLE
[CARBONDATA-1509] Fixed bug for maintaining compatibility of decimal type with older releases of Carbondata

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/TableSpec.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/TableSpec.java
@@ -130,7 +130,9 @@ public class TableSpec {
     }
 
     public ColumnSpec(String fieldName, DataType schemaDataType, ColumnType columnType) {
-      this(fieldName, schemaDataType, columnType, 0, 0);
+      // for backward compatibility as the precision and scale is not stored, the values should be
+      // initialized with -1 for both precision and scale
+      this(fieldName, schemaDataType, columnType, -1, -1);
     }
 
     public ColumnSpec(String fieldName, DataType schemaDataType, ColumnType columnType,


### PR DESCRIPTION
In old Carbondata releases, precision and scale is not stored for decimal data type and both values are initialized to -1. In TableSpec.ColumnSpec  default values for precision and scale are initialized to 0 because of which exception is thrown while reading the old store with decimal column. Both precision and scale should be initialized to -1.