### PR TITLE
[CARBONDATA-1485] timestamp no dictionary bug

### DIFF
--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanPartitionRDD.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanPartitionRDD.scala
@@ -202,6 +202,9 @@ class CarbonScanPartitionRDD(alterPartitionModel: AlterPartitionModel,
         if (partitionValue.isInstanceOf[UTF8String]) {
           partitionValue = partitionValue.toString
         }
+        if (partitionDataType == DataType.TIMESTAMP) {
+          partitionValue = (partitionValue.asInstanceOf[Long] / 1000L).asInstanceOf[AnyRef]
+        }
       } else {  // normal dictionary
         val dict = CarbonLoaderUtil.getDictionary(carbonTableIdentifier,
           dimension.getColumnIdentifier, storePath, partitionDataType)


### PR DESCRIPTION
when partition column is timestamp type and dictionary exclude, data file is not operated correctly in add/split partition function. This pr is to fix this bug