### PR TITLE
[CARBONDATA-1515]Fixed NPE in data loading in long run

### DIFF
--- a/processing/src/main/java/org/apache/carbondata/processing/newflow/steps/DataConverterProcessorStepImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/newflow/steps/DataConverterProcessorStepImpl.java
@@ -87,7 +87,9 @@ public class DataConverterProcessorStepImpl extends AbstractDataLoadProcessorSte
         if (first) {
           first = false;
           localConverter = converters.get(0).createCopyForNewThread();
-          converters.add(localConverter);
+          synchronized (converters) {
+            converters.add(localConverter);
+          }
         }
         return childIter.hasNext();
       }
@@ -185,7 +187,9 @@ public class DataConverterProcessorStepImpl extends AbstractDataLoadProcessorSte
       super.close();
       if (converters != null) {
         for (RowConverter converter : converters) {
-          converter.finish();
+          if (null != converter) {
+            converter.finish();
+          }
         }
       }
     }


### PR DESCRIPTION
**Scenario:** 
Data size: 3.5 billion rows(4.1 tb data)
3 node cluster
Number of core while data loading 12.
No. of loads 100 times
**Problem:** In DataConverterProcessorStepImpl it is using array list for adding all the local converter, in case of multiple thread scenario it is creating a hole (null value)(as array list if not synchronized). while closing the converter it is it is throwing NPE
**Solution:** Add local converter in synchronized block