### PR TITLE
[CARBONDATA-1571] DataMap Example for RTree

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datamap/DataMapStoreManager.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/DataMapStoreManager.java
@@ -16,6 +16,7 @@
  */
 package org.apache.carbondata.core.datamap;
 
+import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -123,8 +124,15 @@ public final class DataMapStoreManager {
       LOGGER.error(e);
       throw new RuntimeException(e);
     }
-    tableDataMaps.add(dataMap);
-    allDataMaps.put(table, tableDataMaps);
+    //tableDataMaps.add(dataMap);
+    //allDataMaps.put(table, tableDataMaps);
+    if (allDataMaps.get(table) != null)
+      allDataMaps.get(table).add(dataMap);
+    else {
+      ArrayList<TableDataMap> list = new ArrayList<>();
+      list.add(dataMap);
+      allDataMaps.put(table, list);
+    }
     return dataMap;
   }
 

--- a/examples/spark2/pom.xml
+++ b/examples/spark2/pom.xml
@@ -54,6 +54,11 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>com.vividsolutions</groupId>
+      <artifactId>jts-core</artifactId>
+      <version>1.14.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-sql_${scala.binary.version}</artifactId>
     </dependency>
@@ -105,6 +110,14 @@
           <target>1.7</target>
         </configuration>
       </plugin>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+                <source>1.8</source>
+                <target>1.8</target>
+            </configuration>
+        </plugin>
     </plugins>
   </build>
 

--- a/examples/spark2/src/main/java/org/apache/carbondata/examples/rtree/BlockletBoundingBox.java
+++ b/examples/spark2/src/main/java/org/apache/carbondata/examples/rtree/BlockletBoundingBox.java
@@ -11,7 +11,7 @@ public class BlockletBoundingBox {
         this.blockletId = blockletId;
         this.lowx = low[0];
         this.lowy = low[1];
-        this.highx = high[1];
+        this.highx = high[0];
         this.highy = high[1];
     }
 

--- a/examples/spark2/src/main/java/org/apache/carbondata/examples/rtree/BlockletBoundingBox.java
+++ b/examples/spark2/src/main/java/org/apache/carbondata/examples/rtree/BlockletBoundingBox.java
@@ -1,0 +1,21 @@
+package org.apache.carbondata.examples.rtree;
+
+public class BlockletBoundingBox {
+    String directoryPath;
+    Integer blockletId;
+    double lowx, lowy, highx, highy;
+
+    public BlockletBoundingBox(double[] low, double[] high, int blockletId, String directoryPath) {
+        assert(low.length == 2 && low.length == high.length);
+        this.directoryPath = directoryPath;
+        this.blockletId = blockletId;
+        this.lowx = low[0];
+        this.lowy = low[1];
+        this.highx = high[1];
+        this.highy = high[1];
+    }
+
+    public Integer getBlockletId() {
+        return blockletId;
+    }
+}

--- a/examples/spark2/src/main/java/org/apache/carbondata/examples/rtree/RTreeDataMap.java
+++ b/examples/spark2/src/main/java/org/apache/carbondata/examples/rtree/RTreeDataMap.java
@@ -1,0 +1,104 @@
+package org.apache.carbondata.examples.rtree;
+
+import com.google.gson.Gson;
+import com.vividsolutions.jts.geom.Envelope;
+import com.vividsolutions.jts.index.strtree.STRtree;
+import org.apache.carbondata.common.logging.LogService;
+import org.apache.carbondata.common.logging.LogServiceFactory;
+import org.apache.carbondata.core.cache.Cacheable;
+import org.apache.carbondata.core.constants.CarbonCommonConstants;
+import org.apache.carbondata.core.datamap.dev.DataMap;
+import org.apache.carbondata.core.datastore.block.SegmentProperties;
+import org.apache.carbondata.core.datastore.filesystem.CarbonFile;
+import org.apache.carbondata.core.datastore.filesystem.CarbonFileFilter;
+import org.apache.carbondata.core.datastore.impl.FileFactory;
+import org.apache.carbondata.core.fileoperations.AtomicFileOperations;
+import org.apache.carbondata.core.fileoperations.AtomicFileOperationsImpl;
+import org.apache.carbondata.core.indexstore.Blocklet;
+import org.apache.carbondata.core.memory.MemoryException;
+import org.apache.carbondata.core.scan.filter.resolver.FilterResolverIntf;
+import org.apache.carbondata.core.util.CarbonUtil;
+
+import java.io.BufferedReader;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.List;
+
+public class RTreeDataMap implements DataMap, Cacheable {
+    private static final LogService LOGGER = LogServiceFactory.getLogService(RTreeDataMap.class.getName());
+
+    public static final String NAME = "unclustered.rtree.blocklet";
+
+    private SegmentProperties segmentProperties;
+
+    private String filePath;
+
+    private STRtree rtree;
+
+    @Override
+    public void init(String filePath) throws MemoryException, IOException {
+        this.filePath = filePath;
+        CarbonFile carbonFile = FileFactory.getCarbonFile(filePath.substring(0, filePath.lastIndexOf("/") + 1));
+        CarbonFile[] listFiles = carbonFile.listFiles(new CarbonFileFilter() {
+            @Override
+            public boolean accept(CarbonFile file) {
+                return file.getName().endsWith(".rtreeindex");
+            }
+        });
+        this.rtree = new STRtree(25);
+        for (int i = 0; i < listFiles.length; ++i) {
+            String index_path = listFiles[i].getPath();
+            Gson gsonObjectToRead = new Gson();
+            DataInputStream dataInputStream = null;
+            BufferedReader buffReader = null;
+            InputStreamReader inStream = null;
+            AtomicFileOperations fileOperation =
+                    new AtomicFileOperationsImpl(index_path, FileFactory.getFileType(index_path));
+            try {
+                if (!FileFactory.isFileExist(index_path, FileFactory.getFileType(index_path))) {
+                    throw new IOException("cannot find index file");
+                }
+                dataInputStream = fileOperation.openForRead();
+                inStream = new InputStreamReader(dataInputStream,
+                        CarbonCommonConstants.CARBON_DEFAULT_STREAM_ENCODEFORMAT);
+                buffReader = new BufferedReader(inStream);
+                BlockletBoundingBox[] boxes = gsonObjectToRead.fromJson(buffReader, BlockletBoundingBox[].class);
+                for (BlockletBoundingBox box : boxes) {
+                    BlockletBoundingBox now = boxes[i];
+                    rtree.insert(new Envelope(now.lowx, now.highx, now.lowy, now.highy), now);
+                }
+            } catch (IOException e) {
+                LOGGER.info(e.getMessage());
+            } finally {
+                CarbonUtil.closeStreams(buffReader, inStream, dataInputStream);
+            }
+        }
+    }
+
+    @Override
+    public List<Blocklet> prune(FilterResolverIntf filterExp) {
+        return null;
+    }
+
+    @Override
+    public void clear() {
+        rtree = null;
+    }
+
+    @Override
+    public long getFileTimeStamp() {
+        return 0;
+    }
+
+    @Override
+    public int getAccessCount() {
+        return 0;
+    }
+
+    @Override
+    public long getMemorySize() {
+        return 0;
+    }
+}

--- a/examples/spark2/src/main/java/org/apache/carbondata/examples/rtree/RTreeDataMap.java
+++ b/examples/spark2/src/main/java/org/apache/carbondata/examples/rtree/RTreeDataMap.java
@@ -31,8 +31,6 @@ public class RTreeDataMap implements DataMap, Cacheable {
 
     public static final String NAME = "unclustered.rtree.blocklet";
 
-    private SegmentProperties segmentProperties;
-
     private String filePath;
 
     private STRtree rtree;

--- a/examples/spark2/src/main/java/org/apache/carbondata/examples/rtree/RTreeDataMapFactory.java
+++ b/examples/spark2/src/main/java/org/apache/carbondata/examples/rtree/RTreeDataMapFactory.java
@@ -1,0 +1,77 @@
+package org.apache.carbondata.examples.rtree;
+
+import org.apache.carbondata.core.datamap.DataMapDistributable;
+import org.apache.carbondata.core.datamap.DataMapMeta;
+import org.apache.carbondata.core.datamap.dev.DataMap;
+import org.apache.carbondata.core.datamap.dev.DataMapFactory;
+import org.apache.carbondata.core.datamap.dev.DataMapWriter;
+import org.apache.carbondata.core.events.ChangeEvent;
+import org.apache.carbondata.core.indexstore.schema.FilterType;
+import org.apache.carbondata.core.memory.MemoryException;
+import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class RTreeDataMapFactory implements DataMapFactory {
+    private String x, y;
+    private DataMapMeta meta;
+
+    private AbsoluteTableIdentifier identifier;
+    private String dataMapName;
+
+    @Override
+    public void init(AbsoluteTableIdentifier identifier, String dataMapName) {
+        this.identifier = identifier;
+        this.dataMapName = dataMapName;
+        this.meta = new DataMapMeta(Arrays.asList("c1", "c2"), FilterType.EQUALTO);
+    }
+
+    @Override
+    public DataMapWriter createWriter(String segmentId) {
+        return new RTreeDataMapWriter(identifier.getTablePath() + "/Fact/Part0/Segment_" + segmentId + File.separator);
+    }
+
+    @Override
+    public List<DataMap> getDataMaps(String segmentId) throws IOException {
+        List<DataMap> dataMapList = new ArrayList<>();
+        // Form a dataMap of Type MinMaxDataMap.
+        RTreeDataMap dataMap = new RTreeDataMap();
+        try {
+            dataMap.init(identifier.getTablePath() + "/Fact/Part0/Segment_" + segmentId + File.separator);
+        } catch (MemoryException ex) {
+        }
+        dataMapList.add(dataMap);
+        return dataMapList;
+    }
+
+    @Override
+    public DataMap getDataMap(DataMapDistributable distributable) {
+        return null;
+    }
+
+    @Override
+    public List<DataMapDistributable> toDistributable(String segmentId) {
+        return null;
+    }
+
+    @Override
+    public void fireEvent(ChangeEvent event) {
+    }
+
+    @Override
+    public void clear(String segmentId) {
+    }
+
+    @Override
+    public void clear() {
+    }
+
+    @Override
+    public DataMapMeta getMeta() {
+        return meta;
+    }
+}

--- a/examples/spark2/src/main/java/org/apache/carbondata/examples/rtree/RTreeDataMapWriter.java
+++ b/examples/spark2/src/main/java/org/apache/carbondata/examples/rtree/RTreeDataMapWriter.java
@@ -1,0 +1,107 @@
+package org.apache.carbondata.examples.rtree;
+
+import com.google.gson.Gson;
+import org.apache.carbondata.common.logging.LogService;
+import org.apache.carbondata.common.logging.LogServiceFactory;
+import org.apache.carbondata.core.constants.CarbonCommonConstants;
+import org.apache.carbondata.core.datamap.dev.DataMapWriter;
+import org.apache.carbondata.core.datastore.impl.FileFactory;
+import org.apache.carbondata.core.datastore.page.ColumnPage;
+
+import org.apache.carbondata.core.metadata.schema.table.TableInfo;
+
+import java.io.*;
+import java.util.ArrayList;
+import java.util.Comparator;
+
+public class RTreeDataMapWriter implements DataMapWriter {
+    private static final LogService LOGGER =
+            LogServiceFactory.getLogService(TableInfo.class.getName());
+
+    private double[] pageLevelMin, pageLevelMax;
+
+    private double[] blockletLevelMin, blockletLevelMax;
+
+    private ArrayList<BlockletBoundingBox> boundingBoxes;
+
+    private String directoryPath;
+
+    public RTreeDataMapWriter(String directoryPath) {
+        this.directoryPath = directoryPath;
+    }
+
+    @Override
+    public void onBlockStart(String blockId) {
+        boundingBoxes = new ArrayList<>();
+    }
+
+    @Override
+    public void onBlockEnd(String blockId) {
+        boundingBoxes.sort(Comparator.comparing(BlockletBoundingBox::getBlockletId));
+        String filePath =directoryPath.substring(0, directoryPath.lastIndexOf(File.separator) + 1)
+                + blockId + ".rtreeindex";
+        BufferedWriter brWriter;
+        DataOutputStream dataOutStream;
+        try {
+            FileFactory.createNewFile(filePath, FileFactory.getFileType(filePath));
+            dataOutStream = FileFactory.getDataOutputStream(filePath, FileFactory.getFileType(filePath));
+            Gson gsonObjectToWrite = new Gson();
+            brWriter = new BufferedWriter(new OutputStreamWriter(dataOutStream,
+                    CarbonCommonConstants.CARBON_DEFAULT_STREAM_ENCODEFORMAT));
+            brWriter.write(gsonObjectToWrite.toJson(boundingBoxes));
+        } catch (IOException e) {
+            LOGGER.info("Error in writing index file");
+        }
+    }
+
+    @Override
+    public void onBlockletStart(int blockletId) {
+        pageLevelMax = null;
+        pageLevelMin = null;
+        blockletLevelMax = null;
+        blockletLevelMin = null;
+    }
+
+    @Override
+    public void onBlockletEnd(int blockletId) {
+        if (blockletLevelMin == null || blockletLevelMax == null) {
+            blockletLevelMin = new double[2];
+            blockletLevelMax = new double[2];
+            blockletLevelMin[0] = pageLevelMin[0];
+            blockletLevelMin[1] = pageLevelMin[1];
+            blockletLevelMax[0] = pageLevelMax[0];
+            blockletLevelMax[1] = pageLevelMax[1];
+        } else {
+            blockletLevelMin[0] = Math.min(blockletLevelMin[0], pageLevelMin[0]);
+            blockletLevelMin[1] = Math.min(blockletLevelMin[1], pageLevelMin[1]);
+            blockletLevelMax[0] = Math.min(blockletLevelMax[0], pageLevelMax[0]);
+            blockletLevelMax[1] = Math.min(blockletLevelMax[1], pageLevelMax[1]);
+        }
+        boundingBoxes.add(new BlockletBoundingBox(blockletLevelMin, blockletLevelMax, blockletId, directoryPath));
+    }
+
+    @Override
+    public void onPageAdded(int blockletId, int pageId, ColumnPage[] pages) {
+        assert(pages.length == 2);
+        if (pageLevelMin == null || pageLevelMax == null) {
+            pageLevelMin = new double[2];
+            pageLevelMax = new double[2];
+
+            double x = pages[0].getDouble(0);
+            double y = pages[1].getDouble(0);
+            pageLevelMin[0] = x;
+            pageLevelMin[1] = y;
+            pageLevelMax[0] = x;
+            pageLevelMax[1] = y;
+        } else {
+            for (int rowIndex = 0; rowIndex < pages[0].getPageSize(); rowIndex++) {
+                double x = pages[0].getDouble(rowIndex);
+                double y = pages[0].getDouble(rowIndex);
+                pageLevelMin[0] = Math.min(pageLevelMin[0], x);
+                pageLevelMin[1] = Math.min(pageLevelMin[1], y);
+                pageLevelMax[0] = Math.max(pageLevelMax[0], x);
+                pageLevelMax[1] = Math.max(pageLevelMax[1], y);
+            }
+        }
+    }
+}

--- a/examples/spark2/src/main/java/org/apache/carbondata/examples/rtree/RTreeDataMapWriter.java
+++ b/examples/spark2/src/main/java/org/apache/carbondata/examples/rtree/RTreeDataMapWriter.java
@@ -49,6 +49,9 @@ public class RTreeDataMapWriter implements DataMapWriter {
             brWriter = new BufferedWriter(new OutputStreamWriter(dataOutStream,
                     CarbonCommonConstants.CARBON_DEFAULT_STREAM_ENCODEFORMAT));
             brWriter.write(gsonObjectToWrite.toJson(boundingBoxes));
+            brWriter.flush();
+            brWriter.close();
+            dataOutStream.close();
         } catch (IOException e) {
             LOGGER.info("Error in writing index file");
         }
@@ -93,15 +96,15 @@ public class RTreeDataMapWriter implements DataMapWriter {
             pageLevelMin[1] = y;
             pageLevelMax[0] = x;
             pageLevelMax[1] = y;
-        } else {
-            for (int rowIndex = 0; rowIndex < pages[0].getPageSize(); rowIndex++) {
-                double x = pages[0].getDouble(rowIndex);
-                double y = pages[0].getDouble(rowIndex);
-                pageLevelMin[0] = Math.min(pageLevelMin[0], x);
-                pageLevelMin[1] = Math.min(pageLevelMin[1], y);
-                pageLevelMax[0] = Math.max(pageLevelMax[0], x);
-                pageLevelMax[1] = Math.max(pageLevelMax[1], y);
-            }
+        }
+
+        for (int rowIndex = 0; rowIndex < pages[0].getPageSize(); rowIndex++) {
+            double x = pages[0].getDouble(rowIndex);
+            double y = pages[1].getDouble(rowIndex);
+            pageLevelMin[0] = Math.min(pageLevelMin[0], x);
+            pageLevelMin[1] = Math.min(pageLevelMin[1], y);
+            pageLevelMax[0] = Math.max(pageLevelMax[0], x);
+            pageLevelMax[1] = Math.max(pageLevelMax[1], y);
         }
     }
 }

--- a/examples/spark2/src/main/java/org/apache/carbondata/examples/rtree/RTreeIndexDetails.java
+++ b/examples/spark2/src/main/java/org/apache/carbondata/examples/rtree/RTreeIndexDetails.java
@@ -1,0 +1,15 @@
+package org.apache.carbondata.examples.rtree;
+
+import com.vividsolutions.jts.index.strtree.STRtree;
+
+import java.io.Serializable;
+
+public class RTreeIndexDetails implements Serializable {
+    private static final long serialVersionUID = -4022024835627190048L;
+
+    private STRtree rtree;
+
+    private String filePath;
+    private Integer BlockletId;
+
+}

--- a/examples/spark2/src/main/scala/org/apache/carbondata/examples/rtree/RTreeDataMapTest.scala
+++ b/examples/spark2/src/main/scala/org/apache/carbondata/examples/rtree/RTreeDataMapTest.scala
@@ -26,19 +26,22 @@ class RTreeDataMapTest extends QueryTest with BeforeAndAfterAll {
   }
 
   test("Test Min Max DataMap") {
-    // register datamap writer
     DataMapStoreManager.getInstance().createAndRegisterDataMap(
       AbsoluteTableIdentifier.from(storeLocation, "default", "carbonminmax"),
       classOf[RTreeDataMapFactory].getName,
       RTreeDataMap.NAME)
 
+
+    // register datamap writer
     val df = buildTestData(33000)
 
+    // XX: Cannot use Overwrite since it will eliminate the DataMap Meta in DataMapStoreManager.
+    // Need to delete the table manually every time.
     // save dataframe to carbon file
     df.write
       .format("carbondata")
+      .option("dbName", "default")
       .option("tableName", "carbonminmax")
-      .mode(SaveMode.Overwrite)
       .save()
 
     // Query the table.

--- a/examples/spark2/src/main/scala/org/apache/carbondata/examples/rtree/RTreeDataMapTest.scala
+++ b/examples/spark2/src/main/scala/org/apache/carbondata/examples/rtree/RTreeDataMapTest.scala
@@ -1,0 +1,53 @@
+package org.apache.carbondata.examples.rtree
+
+import org.apache.spark.sql.test.util.QueryTest
+import org.apache.spark.sql.{DataFrame, SaveMode}
+import org.scalatest.BeforeAndAfterAll
+
+import org.apache.carbondata.core.datamap.DataMapStoreManager
+import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier
+
+
+class RTreeDataMapTest extends QueryTest with BeforeAndAfterAll {
+
+  def buildTestData(numRows: Int): DataFrame = {
+    import sqlContext.implicits._
+    sqlContext.sparkContext.parallelize(1 to numRows)
+      .map(x => (x.toDouble, (x + 10).toDouble, x))
+      .toDF("c1", "c2", "c3")
+  }
+
+  def dropTable(): Unit = {
+    sql("DROP TABLE IF EXISTS carbonrtree")
+  }
+
+  override def beforeAll {
+    dropTable()
+  }
+
+  test("Test Min Max DataMap") {
+    // register datamap writer
+    DataMapStoreManager.getInstance().createAndRegisterDataMap(
+      AbsoluteTableIdentifier.from(storeLocation, "default", "carbonminmax"),
+      classOf[RTreeDataMapFactory].getName,
+      RTreeDataMap.NAME)
+
+    val df = buildTestData(33000)
+
+    // save dataframe to carbon file
+    df.write
+      .format("carbondata")
+      .option("tableName", "carbonminmax")
+      .mode(SaveMode.Overwrite)
+      .save()
+
+    // Query the table.
+    sql("select c1, c2 from carbonminmax").show(20,false)
+    sql("select c1, c2 from carbonminmax where c1 = 20.0 and c2 = 10.0").show(20,false)
+
+  }
+
+  override def afterAll {
+    dropTable()
+  }
+}


### PR DESCRIPTION
Example for DataMap Use Case. Creating an R-Tree index through DataMap API to index blocklet bounding boxes.
Also, try to fix bugs encountered in DataMap life cycle.