### PR TITLE
[CARBONDATA-1608]Support Column Comment for Create Table

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestCreateTableWithColumnComment.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestCreateTableWithColumnComment.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.spark.testsuite.createTable
+
+import org.apache.spark.sql.test.util.QueryTest
+import org.scalatest.BeforeAndAfterAll
+
+/**
+ * Test functionality of create table with column comment
+ */
+class TestCreateTableWithColumnComment extends QueryTest with BeforeAndAfterAll {
+
+  override def beforeAll {
+    sql("use default")
+    sql("drop table if exists columnComment")
+    sql("drop table if exists defaultComment")
+  }
+
+  test("test create table with column comment") {
+    sql(
+      "create table columnComment(id int, name string comment \"This column is called name\") " +
+      "stored by 'carbondata'")
+    checkExistence(sql("describe formatted columnComment"), true, "This column is called name")
+  }
+
+  test("test create table with default column comment value") {
+    sql(
+      "create table defaultComment(id int, name string) " +
+      "stored by 'carbondata'")
+    checkExistence(sql("describe formatted defaultComment"), true, "null")
+  }
+
+  override def afterAll {
+    sql("use default")
+    sql("drop table if exists columnComment")
+    sql("drop table if exists defaultComment")
+  }
+
+}

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSpark2SqlParser.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSpark2SqlParser.scala
@@ -465,12 +465,16 @@ class CarbonSpark2SqlParser extends CarbonDDLSqlParser {
 
   def getFields(schema: Seq[StructField]): Seq[Field] = {
     schema.map { col =>
-      val x = if (col.dataType.catalogString == "float") {
-        '`' + col.name + '`' + " double"
+      var columnComment: String = ""
+      if (col.getComment().isDefined) {
+        columnComment = " comment \"" + col.getComment().get + "\""
       }
-      else {
-        '`' + col.name + '`' + ' ' + col.dataType.catalogString
-      }
+      val x =
+        if (col.dataType.catalogString == "float") {
+          '`' + col.name + '`' + " double" + columnComment
+        } else {
+          '`' + col.name + '`' + ' ' + col.dataType.catalogString + columnComment
+        }
       val f: Field = anyFieldDef(new lexical.Scanner(x.toLowerCase))
       match {
         case Success(field, _) => field.asInstanceOf[Field]


### PR DESCRIPTION
add column comment during carbon create table and when table is described if comment is not mentioned, default comment will be null

Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [*] Make sure the PR title is formatted like:
   `[CARBONDATA-<Jira issue #>] Description of pull request`
   
 - [*] Make sure to add PR description including
      -create carbon table with column comment is added in this PR, previously there was no option for column comment, now it has been added
-for implementing this, the parser has been edited to get column comment and instead of checking its encoding technique to display in desc sql, we can just show the comment for that specific column if any, if there are no comment for the columns, the default value is null  
        - the root cause/problem statement
        - What is the implemented solution

 - [*] Any interfaces changed?
 NONE
 - [*] Any backward compatibility impacted?
 NONE
 - [*] Document update required?
NONE
 - [*] Testing done
 
test cases are added for this 
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
         
 - [*] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
                 
---
