### PR TITLE
[CARBONDATA-1649]insert overwrite fix during job interruption

### DIFF
--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/CommonUtil.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/CommonUtil.scala
@@ -540,6 +540,23 @@ object CommonUtil {
   }
 
   /**
+   * this method will clean segment if interrupted
+   * @param carbonLoadModel
+   */
+  def cleanSegmentForInterrupt(carbonLoadModel: CarbonLoadModel): Unit = {
+    LOGGER.info("using new thread to clean segment for interrupt")
+    val thread = new Thread() {
+      override def run(): Unit = {
+        LOGGER.info("start to clean segment for interrupt")
+        updateTableStatusForFailure(carbonLoadModel)
+        CarbonLoaderUtil.deleteSegment(carbonLoadModel, carbonLoadModel.getSegmentId.toInt)
+        LOGGER.info("clean segments for interrupt is finished")
+      }
+    }
+    thread.start()
+  }
+
+  /**
    * This method will update the load failure entry in the table status file
    *
    * @param model

--- a/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -58,8 +58,7 @@ import org.apache.carbondata.processing.loading.FailureCauses
 import org.apache.carbondata.processing.loading.csvinput.BlockDetails
 import org.apache.carbondata.processing.loading.csvinput.CSVInputFormat
 import org.apache.carbondata.processing.loading.csvinput.StringArrayWritable
-import org.apache.carbondata.processing.loading.exception.CarbonDataLoadingException
-import org.apache.carbondata.processing.loading.exception.NoRetryException
+import org.apache.carbondata.processing.loading.exception.{CarbonDataLoadingException, NoRetryException, UpdateTablestatusException}
 import org.apache.carbondata.processing.loading.model.{CarbonDataLoadSchema, CarbonLoadModel}
 import org.apache.carbondata.processing.loading.sort.SortScopeOptions
 import org.apache.carbondata.processing.merger.{CarbonCompactionUtil, CarbonDataMergerUtil, CompactionType}
@@ -448,7 +447,7 @@ object CarbonDataRDDFactory {
           case ex =>
             // catch exceptions and throw InterruptedException
             LOGGER.error(ex)
-            throw new InterruptedException("update fail status failed")
+            throw new UpdateTablestatusException("update fail status failed")
         }
       }
       LOGGER.audit(s"Data load is failed for " +

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/LoadTableCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/LoadTableCommand.scala
@@ -39,7 +39,7 @@ import org.apache.carbondata.core.util.{CarbonProperties, CarbonUtil}
 import org.apache.carbondata.core.util.path.CarbonStorePath
 import org.apache.carbondata.format
 import org.apache.carbondata.processing.exception.DataLoadingException
-import org.apache.carbondata.processing.loading.exception.NoRetryException
+import org.apache.carbondata.processing.loading.exception.{NoRetryException, UpdateTablestatusException}
 import org.apache.carbondata.processing.loading.model.{CarbonDataLoadSchema, CarbonLoadModel}
 import org.apache.carbondata.spark.exception.MalformedCarbonCommandException
 import org.apache.carbondata.spark.rdd.{CarbonDataRDDFactory, DictionaryLoadModel}
@@ -186,8 +186,7 @@ case class LoadTableCommand(
           LOGGER.error(ex, s"Dataload failure for $dbName.$tableName")
           throw new RuntimeException(s"Dataload failure for $dbName.$tableName, ${ex.getMessage}")
         case ex: Exception =>
-          if (ex.isInstanceOf[InterruptedException] &&
-              ex.getMessage.contains("update fail status")) {
+          if (ex.isInstanceOf[UpdateTablestatusException]) {
             if (Thread.currentThread().isInterrupted) {
               CommonUtil.cleanSegmentForInterrupt(carbonLoadModel)
             }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/LoadTableCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/LoadTableCommand.scala
@@ -186,6 +186,12 @@ case class LoadTableCommand(
           LOGGER.error(ex, s"Dataload failure for $dbName.$tableName")
           throw new RuntimeException(s"Dataload failure for $dbName.$tableName, ${ex.getMessage}")
         case ex: Exception =>
+          if (ex.isInstanceOf[InterruptedException] &&
+              ex.getMessage.contains("update fail status")) {
+            if (Thread.currentThread().isInterrupted) {
+              CommonUtil.cleanSegmentForInterrupt(carbonLoadModel)
+            }
+          }
           LOGGER.error(ex)
           LOGGER.audit(s"Dataload failure for $dbName.$tableName. Please check the logs")
           throw ex

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/exception/UpdateTablestatusException.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/exception/UpdateTablestatusException.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.processing.loading.exception;
+
+public class UpdateTablestatusException extends Exception {
+
+  public UpdateTablestatusException() {
+  }
+
+  public UpdateTablestatusException(String message) {
+    super(message);
+  }
+
+  public UpdateTablestatusException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [*] Make sure the PR title is formatted like:
   `[CARBONDATA-1649>] 
    when insert overwrite job is in progress and if that job is cancelled, then table status should be 
    changed and segment should be deleted during the interruption
   
 - [*] Make sure to add PR description including
       Root cause - when insert overwrite job is in progress and if that job is cancelled, then table status 
       was not getting updated and after that insert or any load was not possible 
       Implemented Solution- when the insert overwrite is interrupted, then update the table status to 
      failure
 - [*] Any interfaces changed?
       NONE

 - [*] Any backward compatibility impacted?
      NONE

 - [*] Document update required?
     NONE

 - [*] Testing done
     Tested and there is no performance hit for this
      
         
 - [*] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
             NONE    
---
