### PR TITLE
[CARBONDATA-1593] Add partition to table cause NoSuchTableException

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/partition/AlterTableSplitCarbonPartitionCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/partition/AlterTableSplitCarbonPartitionCommand.scala
@@ -23,6 +23,7 @@ import java.util
 import scala.collection.JavaConverters._
 
 import org.apache.spark.sql.{CarbonEnv, Row, SparkSession}
+import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.execution.command.{AlterTableSplitPartitionModel, DataProcessCommand, RunnableCommand, SchemaProcessCommand}
 import org.apache.spark.sql.hive.{CarbonMetaStore, CarbonRelation}
 import org.apache.spark.util.{AlterTableUtil, PartitionUtils}
@@ -41,7 +42,6 @@ import org.apache.carbondata.core.util.{CarbonProperties, CarbonUtil}
 import org.apache.carbondata.core.util.path.CarbonStorePath
 import org.apache.carbondata.processing.loading.model.{CarbonDataLoadSchema, CarbonLoadModel}
 import org.apache.carbondata.spark.rdd.CarbonDataRDDFactory
-import org.apache.spark.sql.catalyst.TableIdentifier
 
 /**
  * Command for Alter Table Add & Split partition

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/partition/AlterTableSplitCarbonPartitionCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/partition/AlterTableSplitCarbonPartitionCommand.scala
@@ -41,6 +41,7 @@ import org.apache.carbondata.core.util.{CarbonProperties, CarbonUtil}
 import org.apache.carbondata.core.util.path.CarbonStorePath
 import org.apache.carbondata.processing.loading.model.{CarbonDataLoadSchema, CarbonLoadModel}
 import org.apache.carbondata.spark.rdd.CarbonDataRDDFactory
+import org.apache.spark.sql.catalyst.TableIdentifier
 
 /**
  * Command for Alter Table Add & Split partition
@@ -109,7 +110,7 @@ case class AlterTableSplitCarbonPartitionCommand(
     CarbonUtil.writeThriftTableToSchemaFile(schemaFilePath, thriftTable)
     // update the schema modified time
     carbonMetaStore.updateAndTouchSchemasUpdatedTime(storePath)
-    sparkSession.catalog.refreshTable(tableName)
+    sparkSession.sessionState.catalog.refreshTable(TableIdentifier(tableName, Option(dbName)))
     Seq.empty
   }
 

--- a/integration/spark2/src/test/scala/org/apache/carbondata/spark/testsuite/partition/TestAlterPartitionTable.scala
+++ b/integration/spark2/src/test/scala/org/apache/carbondata/spark/testsuite/partition/TestAlterPartitionTable.scala
@@ -779,6 +779,23 @@ class TestAlterPartitionTable extends QueryTest with BeforeAndAfterAll {
          .contains("Data in range info must be the same type with the partition field's type"))
   }
 
+  test("Alter table in or not in default database") {
+    sql("DROP TABLE IF EXISTS carbonTable_default_db")
+    sql("""
+          | create table carbonTable_default_db(id int, name string) partitioned by (city string)
+          | row format delimited fields terminated by ','
+        """.stripMargin)
+    sql("alter table carbonTable_default_db add partition (city = 'Beijing')")
+
+    sql(s"CREATE DATABASE if not exists carbonDB")
+    sql("DROP TABLE IF EXISTS carbonDB.carbonTable")
+    sql("""
+          | create table carbonDB.carbonTable(id int, name string) partitioned by (city string)
+          | row format delimited fields terminated by ','
+        """.stripMargin)
+    sql("alter table carbonDB.carbonTable add partition (city = 'Beijing')")
+  }
+
   def validateDataFiles(tableUniqueName: String, segmentId: String, partitions: Seq[Int]): Unit = {
     val carbonTable = CarbonMetadata.getInstance().getCarbonTable(tableUniqueName)
     val dataFiles = getDataFiles(carbonTable, segmentId)

--- a/integration/spark2/src/test/scala/org/apache/carbondata/spark/testsuite/partition/TestAlterPartitionTable.scala
+++ b/integration/spark2/src/test/scala/org/apache/carbondata/spark/testsuite/partition/TestAlterPartitionTable.scala
@@ -779,21 +779,23 @@ class TestAlterPartitionTable extends QueryTest with BeforeAndAfterAll {
          .contains("Data in range info must be the same type with the partition field's type"))
   }
 
-  test("Alter table in or not in default database") {
-    sql("DROP TABLE IF EXISTS carbonTable_default_db")
-    sql("""
-          | create table carbonTable_default_db(id int, name string) partitioned by (city string)
-          | row format delimited fields terminated by ','
-        """.stripMargin)
-    sql("alter table carbonTable_default_db add partition (city = 'Beijing')")
+  test("Add partition to table in or not in default database") {
+    sql("DROP TABLE IF EXISTS carbon_table_default_db")
+    sql(
+      """
+        | CREATE TABLE carbon_table_default_db(id INT, name STRING) PARTITIONED BY (dt STRING)
+        | STORED BY 'carbondata' TBLPROPERTIES('PARTITION_TYPE'='RANGE', 'RANGE_INFO'='2015,2016')
+      """.stripMargin)
+    sql("ALTER TABLE carbon_table_default_db ADD PARTITION ('2017')")
 
-    sql(s"CREATE DATABASE if not exists carbonDB")
-    sql("DROP TABLE IF EXISTS carbonDB.carbonTable")
-    sql("""
-          | create table carbonDB.carbonTable(id int, name string) partitioned by (city string)
-          | row format delimited fields terminated by ','
-        """.stripMargin)
-    sql("alter table carbonDB.carbonTable add partition (city = 'Beijing')")
+    sql("CREATE DATABASE IF NOT EXISTS carbondb")
+    sql("DROP TABLE IF EXISTS carbondb.carbontable")
+    sql(
+      """
+        | CREATE TABLE carbondb.carbontable(id INT, name STRING) PARTITIONED BY (dt STRING)
+        | STORED BY 'carbondata' TBLPROPERTIES('PARTITION_TYPE'='RANGE', 'RANGE_INFO'='2015,2016')
+      """.stripMargin)
+    sql("ALTER TABLE carbondb.carbontable ADD PARTITION ('2017')")
   }
 
   def validateDataFiles(tableUniqueName: String, segmentId: String, partitions: Seq[Int]): Unit = {


### PR DESCRIPTION
`AlterTableSplitCarbonPartition`'s `processSchema` method doesn't  provide db info to `sparkSession.catalog.refreshTable`, this will cause `NoSuchTableException` when we add partitions to carbondata table.  See [CARBONDATA-1593](https://issues.apache.org/jira/browse/CARBONDATA-1593)

Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[CARBONDATA-<Jira issue #>] Description of pull request`
   
 - [x] Make sure to add PR description including
        
        - the root cause/problem statement
        - What is the implemented solution

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
 
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
         
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
                 
---
