### PR TITLE
[Docs] Fix partition-guide.md docs NUM_PARTITIONS wrong keyword

### DIFF
--- a/docs/partition-guide.md
+++ b/docs/partition-guide.md
@@ -39,7 +39,7 @@ This tutorial is designed to provide a quick introduction to create and use part
    PARTITIONED BY (partition_col_name data_type)
    STORED BY 'carbondata'
    [TBLPROPERTIES ('PARTITION_TYPE'='HASH',
-                   'NUM_PARTITION'='N' ...)]
+                   'NUM_PARTITIONS'='N' ...)]
    //N is the number of hash partitions
 ```
 

--- a/docs/partition-guide.md
+++ b/docs/partition-guide.md
@@ -39,7 +39,7 @@ This tutorial is designed to provide a quick introduction to create and use part
    PARTITIONED BY (partition_col_name data_type)
    STORED BY 'carbondata'
    [TBLPROPERTIES ('PARTITION_TYPE'='HASH',
-                   'PARTITION_NUM'='N' ...)]
+                   'NUM_PARTITION'='N' ...)]
    //N is the number of hash partitions
 ```
 
@@ -54,7 +54,7 @@ Example:
       col_F Timestamp
    ) partitioned by (col_E Long)
    stored by 'carbondata'
-   tblproperties('partition_type'='Hash','partition_num'='9')
+   tblproperties('partition_type'='Hash','num_partition'='9')
 ```
 
 ### Create Range Partition Table

--- a/docs/partition-guide.md
+++ b/docs/partition-guide.md
@@ -54,7 +54,7 @@ Example:
       col_F Timestamp
    ) partitioned by (col_E Long)
    stored by 'carbondata'
-   tblproperties('partition_type'='Hash','num_partition'='9')
+   tblproperties('partition_type'='Hash','num_partitions'='9')
 ```
 
 ### Create Range Partition Table


### PR DESCRIPTION
It's an obvious keyword spelling mistake,  `PARTITION_NUM` should be `NUM_PARTITION `.

No Tests.