### PR TITLE
[Tests] Fix BTreeBlockFinderTest variable mistake

### DIFF
--- a/core/src/test/java/org/apache/carbondata/core/datastore/impl/btree/BTreeBlockFinderTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/datastore/impl/btree/BTreeBlockFinderTest.java
@@ -197,7 +197,7 @@ public class BTreeBlockFinderTest extends TestCase {
         buffer1.put((byte) 1);
         buffer1.putInt(i + 10);
         buffer1.array();
-        byte[] noDictionaryEndKey = buffer.array();
+        byte[] noDictionaryEndKey = buffer1.array();
         DataFileFooter footer =
             getFileFooter(startKey, endKey, noDictionaryStartKey, noDictionaryEndKey);
         list.add(footer);
@@ -232,7 +232,7 @@ public class BTreeBlockFinderTest extends TestCase {
         buffer1.putShort((short) 2);
         buffer1.putInt(i + 10);
         buffer1.array();
-        byte[] noDictionaryEndKey = buffer.array();
+        byte[] noDictionaryEndKey = buffer1.array();
         DataFileFooter footer =
             getFileMatadataWithOnlyNoDictionaryKey(startKey, endKey, noDictionaryStartKey,
                 noDictionaryEndKey);
@@ -268,7 +268,7 @@ public class BTreeBlockFinderTest extends TestCase {
         buffer1.put((byte) 1);
         buffer1.putInt(i + 10);
         buffer1.array();
-        byte[] noDictionaryEndKey = buffer.array();
+        byte[] noDictionaryEndKey = buffer1.array();
         DataFileFooter footer =
             getFileFooterWithOnlyDictionaryKey(startKey, endKey, noDictionaryStartKey,
                 noDictionaryEndKey);


### PR DESCRIPTION
### Changes
> There are some obvious spelling mistake leading to some variable unused, and it may change the unit test's meaning.

### Test
> Run BTreeBlockFinderTest unitTest.