### PR TITLE
[CARBONDATA-1686]  Presto Version Upgrade to  0.186

### DIFF
--- a/integration/presto/pom.xml
+++ b/integration/presto/pom.xml
@@ -31,7 +31,7 @@
   <packaging>presto-plugin</packaging>
 
   <properties>
-    <presto.version>0.166</presto.version>
+    <presto.version>0.186</presto.version>
     <dev.path>${basedir}/../../dev</dev.path>
   </properties>
 
@@ -143,7 +143,6 @@
           <groupId>io.dropwizard.metrics</groupId>
           <artifactId>metrics-graphite</artifactId>
         </exclusion>
-
         <exclusion>
           <groupId>com.google.code.findbugs</groupId>
           <artifactId>jsr305</artifactId>
@@ -413,7 +412,7 @@
     <dependency>
       <groupId>io.airlift</groupId>
       <artifactId>slice</artifactId>
-      <version>0.27</version>
+      <version>0.31</version>
       <scope>provided</scope>
       <exclusions>
         <exclusion>
@@ -441,6 +440,34 @@
       <scope>test</scope>
       <version>2.1.0</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <version>3.0.2</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <version>3.0.2</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.hk2</groupId>
+      <artifactId>hk2-api</artifactId>
+      <version>2.5.0-b42</version>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.hk2</groupId>
+      <artifactId>hk2-locator</artifactId>
+      <version>2.5.0-b42</version>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.hk2</groupId>
+      <artifactId>hk2-utils</artifactId>
+      <version>2.5.0-b42</version>
+    </dependency>
+
   </dependencies>
 
   <build>
@@ -516,14 +543,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-        </configuration>
-      </plugin>
-
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/CarbondataColumnConstraint.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/CarbondataColumnConstraint.java
@@ -25,8 +25,7 @@ import com.fasterxml.jackson.annotation.JsonSetter;
 import java.util.Objects;
 import java.util.Optional;
 
-//import static com.google.common.base.MoreObjects.toStringHelper;
-import static com.google.common.base.Objects.toStringHelper;
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
 /**

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/CarbondataColumnHandle.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/CarbondataColumnHandle.java
@@ -25,8 +25,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Objects;
 
-//import static com.google.common.base.MoreObjects.toStringHelper;
-import static com.google.common.base.Objects.toStringHelper;
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
 public class CarbondataColumnHandle implements ColumnHandle {

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/CarbondataConnector.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/CarbondataConnector.java
@@ -51,7 +51,7 @@ public class CarbondataConnector implements Connector {
   @Override public ConnectorTransactionHandle beginTransaction(IsolationLevel isolationLevel,
       boolean readOnly) {
     checkConnectorSupports(READ_COMMITTED, isolationLevel);
-    return CarbondataTransactionHandle.INSTANCE;
+    return new CarbondataTransactionHandle();
   }
 
   @Override public ConnectorMetadata getMetadata(ConnectorTransactionHandle transactionHandle) {

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/CarbondataPageSource.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/CarbondataPageSource.java
@@ -78,10 +78,6 @@ class CarbondataPageSource implements ConnectorPageSource {
     this.readers = createStreamReaders();
   }
 
-  @Override public long getTotalBytes() {
-    return sizeOfData;
-  }
-
   @Override public long getCompletedBytes() {
     return sizeOfData;
   }

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/CarbondataRecordCursor.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/CarbondataRecordCursor.java
@@ -22,7 +22,6 @@ import java.math.BigInteger;
 import java.sql.Timestamp;
 import java.util.List;
 
-import org.apache.carbondata.common.CarbonIterator;
 import org.apache.carbondata.core.cache.dictionary.Dictionary;
 import org.apache.carbondata.core.metadata.datatype.DataType;
 
@@ -71,10 +70,6 @@ public class CarbondataRecordCursor implements RecordCursor {
     this.columnHandles = columnHandles;
     this.readSupport = readSupport;
     this.totalBytes = 0;
-  }
-
-  @Override public long getTotalBytes() {
-    return totalBytes;
   }
 
   @Override public long getCompletedBytes() {

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/CarbondataTableLayoutHandle.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/CarbondataTableLayoutHandle.java
@@ -25,8 +25,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Objects;
 
-//import static com.google.common.base.MoreObjects.toStringHelper;
-import static com.google.common.base.Objects.toStringHelper;
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
 public class CarbondataTableLayoutHandle implements ConnectorTableLayoutHandle {

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/CarbondataTransactionHandle.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/CarbondataTransactionHandle.java
@@ -17,8 +17,48 @@
 
 package org.apache.carbondata.presto;
 
-import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import java.util.Objects;
+import java.util.UUID;
 
-public enum CarbondataTransactionHandle implements ConnectorTransactionHandle {
-  INSTANCE
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public class CarbondataTransactionHandle implements ConnectorTransactionHandle {
+  private final UUID uuid;
+
+  public CarbondataTransactionHandle() {
+    this(UUID.randomUUID());
+  }
+
+  @JsonCreator public CarbondataTransactionHandle(@JsonProperty("uuid") UUID uuid) {
+    this.uuid = requireNonNull(uuid, "uuid is null");
+  }
+
+  @JsonProperty public UUID getUuid() {
+    return uuid;
+  }
+
+  @Override public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if ((obj == null) || (getClass() != obj.getClass())) {
+      return false;
+    }
+
+    return Objects.equals(uuid, ((CarbondataTransactionHandle) obj).uuid);
+  }
+
+  @Override public int hashCode() {
+    return Objects.hash(uuid);
+  }
+
+  @Override public String toString() {
+    return toStringHelper(this).add("uuid", uuid).toString();
+  }
+
 }

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/readers/DecimalSliceStreamReader.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/readers/DecimalSliceStreamReader.java
@@ -187,9 +187,9 @@ public class DecimalSliceStreamReader  extends AbstractStreamReader {
         builder.appendNull();
       } else {
         if (isShortDecimal(type)) {
-          long rescaledDecimal = Decimals
-              .rescale(columnVector.getDecimal(i, precision, scale).toLong(),
-                  columnVector.getDecimal(i, precision, scale).scale(), scale);
+          BigDecimal decimalValue = columnVector.getDecimal(i, precision, scale).toJavaBigDecimal();
+          long rescaledDecimal = Decimals.rescale(decimalValue.unscaledValue().longValue(),
+              decimalValue.scale(), scale);
           type.writeLong(builder, rescaledDecimal);
         } else {
           Slice slice =

--- a/integration/presto/src/test/scala/org/apache/carbondata/presto/server/PrestoServer.scala
+++ b/integration/presto/src/test/scala/org/apache/carbondata/presto/server/PrestoServer.scala
@@ -18,7 +18,7 @@ package org.apache.carbondata.presto.server
 
 import java.sql.{Connection, DriverManager, ResultSet}
 import java.util
-import java.util.{Locale, Optional}
+import java.util.{Locale, Optional, Properties}
 
 import scala.collection.JavaConverters._
 import scala.util.{Failure, Success, Try}
@@ -119,14 +119,14 @@ object PrestoServer {
     val JDBC_DRIVER = "com.facebook.presto.jdbc.PrestoDriver"
     val DB_URL = "jdbc:presto://localhost:8086/carbondata/testdb"
 
+    val properties = new Properties
     // The database Credentials
-    val USER = "username"
-    val PASS = "password"
-
+    properties.setProperty("user", "test");
+  
     // STEP 2: Register JDBC driver
     Class.forName(JDBC_DRIVER)
     // STEP 3: Open a connection
-    DriverManager.getConnection(DB_URL, USER, PASS)
+    DriverManager.getConnection(DB_URL, properties)
   }
 
   /**


### PR DESCRIPTION

 - [No] Any interfaces changed?
 
 - [Yes ] Any backward compatibility impacted?  Carbondata will now work with Presto Server 0.186 onward
 
 - [ No] Document update required?

 - [ Yes] Testing done
       Since it is a version upgrade  all the integration test cases are executed successfuly.
       Performance testing done manually and there is improvement in query execution times.
