### PR TITLE
[CARBONDATA-1576] Added create datamap parser and saved to schema file

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/metadata/converter/ThriftWrapperSchemaConverterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/converter/ThriftWrapperSchemaConverterImpl.java
@@ -325,8 +325,8 @@ public class ThriftWrapperSchemaConverterImpl implements SchemaConverter {
       if (wrapperChildSchema.getRelationIdentifier() != null) {
         org.apache.carbondata.format.RelationIdentifier relationIdentifier =
             new org.apache.carbondata.format.RelationIdentifier();
-        relationIdentifier
-            .setDatabaseName(wrapperChildSchema.getRelationIdentifier().getDatabaseName());
+        relationIdentifier.setDatabaseName(
+            wrapperChildSchema.getRelationIdentifier().getDatabaseName());
         relationIdentifier.setTableName(wrapperChildSchema.getRelationIdentifier().getTableName());
         relationIdentifier.setTableId(wrapperChildSchema.getRelationIdentifier().getTableId());
         thriftChildSchema.setRelationIdentifire(relationIdentifier);

--- a/core/src/main/java/org/apache/carbondata/core/metadata/converter/ThriftWrapperSchemaConverterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/converter/ThriftWrapperSchemaConverterImpl.java
@@ -322,17 +322,22 @@ public class ThriftWrapperSchemaConverterImpl implements SchemaConverter {
     for (DataMapSchema wrapperChildSchema : wrapperChildSchemaList) {
       org.apache.carbondata.format.DataMapSchema thriftChildSchema =
           new org.apache.carbondata.format.DataMapSchema();
-      org.apache.carbondata.format.RelationIdentifier relationIdentifier =
-          new org.apache.carbondata.format.RelationIdentifier();
-      relationIdentifier
-          .setDatabaseName(wrapperChildSchema.getRelationIdentifier().getDatabaseName());
-      relationIdentifier.setTableName(wrapperChildSchema.getRelationIdentifier().getTableName());
-      relationIdentifier.setTableId(wrapperChildSchema.getRelationIdentifier().getTableId());
-      thriftChildSchema.setRelationIdentifire(relationIdentifier);
+      if (wrapperChildSchema.getRelationIdentifier() != null) {
+        org.apache.carbondata.format.RelationIdentifier relationIdentifier =
+            new org.apache.carbondata.format.RelationIdentifier();
+        relationIdentifier
+            .setDatabaseName(wrapperChildSchema.getRelationIdentifier().getDatabaseName());
+        relationIdentifier.setTableName(wrapperChildSchema.getRelationIdentifier().getTableName());
+        relationIdentifier.setTableId(wrapperChildSchema.getRelationIdentifier().getTableId());
+        thriftChildSchema.setRelationIdentifire(relationIdentifier);
+      }
       thriftChildSchema.setProperties(wrapperChildSchema.getProperties());
       thriftChildSchema.setClassName(wrapperChildSchema.getClassName());
-      thriftChildSchema.setChildTableSchema(
-          fromWrapperToExternalTableSchema(wrapperChildSchema.getChildSchema()));
+      thriftChildSchema.setDataMapName(wrapperChildSchema.getDataMapName());
+      if (wrapperChildSchema.getChildSchema() != null) {
+        thriftChildSchema.setChildTableSchema(
+            fromWrapperToExternalTableSchema(wrapperChildSchema.getChildSchema()));
+      }
       thriftChildSchemas.add(thriftChildSchema);
     }
     return thriftChildSchemas;
@@ -623,16 +628,19 @@ public class ThriftWrapperSchemaConverterImpl implements SchemaConverter {
 
   @Override public DataMapSchema fromExternalToWrapperDataMapSchema(
       org.apache.carbondata.format.DataMapSchema thriftDataMapSchema) {
-    RelationIdentifier relationIdentifier =
-        new RelationIdentifier(thriftDataMapSchema.getRelationIdentifire().getDatabaseName(),
-            thriftDataMapSchema.getRelationIdentifire().getTableName(),
-            thriftDataMapSchema.getRelationIdentifire().getTableId());
-    DataMapSchema childSchema = new DataMapSchema(thriftDataMapSchema.getClassName());
+    DataMapSchema childSchema =
+        new DataMapSchema(thriftDataMapSchema.getDataMapName(), thriftDataMapSchema.getClassName());
     childSchema.setProperties(thriftDataMapSchema.getProperties());
-    childSchema.setChildSchema(
-        fromExternalToWrapperTableSchema(thriftDataMapSchema.getChildTableSchema(),
-            relationIdentifier.getTableName()));
-    childSchema.setRelationIdentifier(relationIdentifier);
+    if (thriftDataMapSchema.getRelationIdentifire() != null) {
+      RelationIdentifier relationIdentifier =
+          new RelationIdentifier(thriftDataMapSchema.getRelationIdentifire().getDatabaseName(),
+              thriftDataMapSchema.getRelationIdentifire().getTableName(),
+              thriftDataMapSchema.getRelationIdentifire().getTableId());
+      childSchema.setRelationIdentifier(relationIdentifier);
+      childSchema.setChildSchema(
+          fromExternalToWrapperTableSchema(thriftDataMapSchema.getChildTableSchema(),
+              relationIdentifier.getTableName()));
+    }
     return childSchema;
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/DataMapSchema.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/DataMapSchema.java
@@ -30,6 +30,8 @@ public class DataMapSchema implements Serializable, Writable {
 
   private static final long serialVersionUID = 6577149126264181553L;
 
+  private String dataMapName;
+
   private String className;
 
   private RelationIdentifier relationIdentifier;
@@ -43,7 +45,11 @@ public class DataMapSchema implements Serializable, Writable {
    */
   private Map<String, String> properties;
 
-  public DataMapSchema(String className) {
+  public DataMapSchema() {
+  }
+
+  public DataMapSchema(String dataMapName, String className) {
+    this.dataMapName = dataMapName;
     this.className = className;
   }
 
@@ -75,7 +81,12 @@ public class DataMapSchema implements Serializable, Writable {
     this.properties = properties;
   }
 
+  public String getDataMapName() {
+    return dataMapName;
+  }
+
   @Override public void write(DataOutput out) throws IOException {
+    out.writeUTF(dataMapName);
     out.writeUTF(className);
     boolean isRelationIdentifierExists = null != relationIdentifier;
     out.writeBoolean(isRelationIdentifierExists);
@@ -99,6 +110,7 @@ public class DataMapSchema implements Serializable, Writable {
   }
 
   @Override public void readFields(DataInput in) throws IOException {
+    this.dataMapName = in.readUTF();
     this.className = in.readUTF();
     boolean isRelationIdnentifierExists = in.readBoolean();
     if (isRelationIdnentifierExists) {

--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/TableInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/TableInfo.java
@@ -293,7 +293,7 @@ public class TableInfo implements Serializable, Writable {
     if (isChildSchemaExists) {
       short numberOfChildTable = in.readShort();
       for (int i = 0; i < numberOfChildTable; i++) {
-        DataMapSchema childSchema = new DataMapSchema(null);
+        DataMapSchema childSchema = new DataMapSchema();
         childSchema.readFields(in);
         dataMapSchemaList.add(childSchema);
       }

--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/TableSchema.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/TableSchema.java
@@ -255,21 +255,15 @@ public class TableSchema implements Serializable, Writable {
    * Below method will be used to build child schema object which will be stored in
    * parent table
    *
-   * @param className
-   * @param databaseName
-   * @param queryString
-   * @param queryType
-   *
-   * @return datamap schema
    */
-  public DataMapSchema buildChildSchema(String className, String databaseName, String queryString,
-      String queryType) {
+  public DataMapSchema buildChildSchema(String dataMapName, String className, String databaseName,
+      String queryString, String queryType) {
     RelationIdentifier relationIdentifier =
         new RelationIdentifier(databaseName, tableName, tableId);
     Map<String, String> properties = new HashMap<>();
     properties.put("CHILD_SELECT QUERY", queryString);
     properties.put("QUERYTYPE", queryType);
-    DataMapSchema dataMapSchema = new DataMapSchema(className);
+    DataMapSchema dataMapSchema = new DataMapSchema(dataMapName, className);
     dataMapSchema.setChildSchema(this);
     dataMapSchema.setProperties(properties);
     dataMapSchema.setRelationIdentifier(relationIdentifier);

--- a/format/src/main/thrift/schema.thrift
+++ b/format/src/main/thrift/schema.thrift
@@ -187,15 +187,17 @@ struct ParentColumnTableRelation {
 }
 
 struct DataMapSchema  {
+    // DataMap name
+    1: required string dataMapName;
     // class name
-    1: required string className;
+    2: required string className;
     // relation indentifier
-    2: optional RelationIdentifier relationIdentifire;
+    3: optional RelationIdentifier relationIdentifire;
     // in case of preaggregate it will be used to maintain the child schema
     // which will be usefull in case of query and data load
-    3: optional TableSchema childTableSchema;
+    4: optional TableSchema childTableSchema;
     // to maintain properties like select query, query type like groupby, join
-    4: optional map<string, string> properties;
+    5: optional map<string, string> properties;
 }
 
 struct TableInfo{

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggCreateCommand.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggCreateCommand.scala
@@ -16,28 +16,28 @@ class TestPreAggCreateCommand extends QueryTest with BeforeAndAfterAll {
 
 
   test("test pre agg create table One") {
-    sql("create table preagg1 stored BY 'carbondata' tblproperties('parent'='PreAggMain') as select a,sum(b) from PreAggMain group by a")
+    sql("create datamap preagg1 on table PreAggMain using 'preaggregate' as select a,sum(b) from PreAggMain group by a")
     checkExistence(sql("DESCRIBE FORMATTED preagg1"), true, "preaggmain_a")
     checkExistence(sql("DESCRIBE FORMATTED preagg1"), true, "preaggmain_b_sum")
     sql("drop table preagg1")
   }
 
   test("test pre agg create table Two") {
-    sql("create table preagg2 stored BY 'carbondata' tblproperties('parent'='PreAggMain') as select a as a1,sum(b) from PreAggMain group by a")
+    sql("create datamap preagg2 on table PreAggMain using 'preaggregate' as select a as a1,sum(b) from PreAggMain group by a")
     checkExistence(sql("DESCRIBE FORMATTED preagg2"), true, "preaggmain_a")
     checkExistence(sql("DESCRIBE FORMATTED preagg2"), true, "preaggmain_b_sum")
     sql("drop table preagg2")
   }
 
   test("test pre agg create table Three") {
-    sql("create table preagg3 stored BY 'carbondata' tblproperties('parent'='PreAggMain') as select a,sum(b) as sum from PreAggMain group by a")
+    sql("create datamap preagg3 on table PreAggMain using 'preaggregate' as select a,sum(b) as sum from PreAggMain group by a")
     checkExistence(sql("DESCRIBE FORMATTED preagg3"), true, "preaggmain_a")
     checkExistence(sql("DESCRIBE FORMATTED preagg3"), true, "preaggmain_b_sum")
     sql("drop table preagg3")
   }
 
   test("test pre agg create table four") {
-    sql("create table preagg4 stored BY 'carbondata' tblproperties('parent'='PreAggMain') as select a as a1,sum(b) as sum from PreAggMain group by a")
+    sql("create datamap preagg4 on table PreAggMain using 'preaggregate' as select a as a1,sum(b) as sum from PreAggMain group by a")
     checkExistence(sql("DESCRIBE FORMATTED preagg4"), true, "preaggmain_a")
     checkExistence(sql("DESCRIBE FORMATTED preagg4"), true, "preaggmain_b_sum")
     sql("drop table preagg4")
@@ -45,7 +45,7 @@ class TestPreAggCreateCommand extends QueryTest with BeforeAndAfterAll {
 
 
   test("test pre agg create table five") {
-    sql("create table preagg11 stored BY 'carbondata' tblproperties('parent'='PreAggMain1') as select a,sum(b) from PreAggMain1 group by a")
+    sql("create datamap preagg11 on table PreAggMain1 using 'preaggregate'as select a,sum(b) from PreAggMain1 group by a")
     checkExistence(sql("DESCRIBE FORMATTED preagg11"), true, "preaggmain1_a")
     checkExistence(sql("DESCRIBE FORMATTED preagg11"), true, "preaggmain1_b_sum")
     checkExistence(sql("DESCRIBE FORMATTED preagg11"), true, "DICTIONARY")
@@ -53,7 +53,7 @@ class TestPreAggCreateCommand extends QueryTest with BeforeAndAfterAll {
   }
 
   test("test pre agg create table six") {
-    sql("create table preagg12 stored BY 'carbondata' tblproperties('parent'='PreAggMain1') as select a as a1,sum(b) from PreAggMain1 group by a")
+    sql("create datamap preagg12 on table PreAggMain1 using 'preaggregate' as select a as a1,sum(b) from PreAggMain1 group by a")
     checkExistence(sql("DESCRIBE FORMATTED preagg12"), true, "preaggmain1_a")
     checkExistence(sql("DESCRIBE FORMATTED preagg12"), true, "preaggmain1_b_sum")
     checkExistence(sql("DESCRIBE FORMATTED preagg12"), true, "DICTIONARY")
@@ -61,7 +61,7 @@ class TestPreAggCreateCommand extends QueryTest with BeforeAndAfterAll {
   }
 
   test("test pre agg create table seven") {
-    sql("create table preagg13 stored BY 'carbondata' tblproperties('parent'='PreAggMain1') as select a,sum(b) as sum from PreAggMain1 group by a")
+    sql("create datamap preagg13 on table PreAggMain1 using 'preaggregate' as select a,sum(b) as sum from PreAggMain1 group by a")
     checkExistence(sql("DESCRIBE FORMATTED preagg13"), true, "preaggmain1_a")
     checkExistence(sql("DESCRIBE FORMATTED preagg13"), true, "preaggmain1_b_sum")
     checkExistence(sql("DESCRIBE FORMATTED preagg13"), true, "DICTIONARY")
@@ -69,7 +69,7 @@ class TestPreAggCreateCommand extends QueryTest with BeforeAndAfterAll {
   }
 
   test("test pre agg create table eight") {
-    sql("create table preagg14 stored BY 'carbondata' tblproperties('parent'='PreAggMain1') as select a as a1,sum(b) as sum from PreAggMain1 group by a")
+    sql("create datamap preagg14 on table PreAggMain1 using 'preaggregate' as select a as a1,sum(b) as sum from PreAggMain1 group by a")
     checkExistence(sql("DESCRIBE FORMATTED preagg14"), true, "preaggmain1_a")
     checkExistence(sql("DESCRIBE FORMATTED preagg14"), true, "preaggmain1_b_sum")
     checkExistence(sql("DESCRIBE FORMATTED preagg14"), true, "DICTIONARY")
@@ -78,7 +78,7 @@ class TestPreAggCreateCommand extends QueryTest with BeforeAndAfterAll {
 
 
   test("test pre agg create table nine") {
-    sql("create table preagg15 stored BY 'carbondata' tblproperties('parent'='PreAggMain2') as select a,avg(b) from PreAggMain2 group by a")
+    sql("create datamap preagg15 on table PreAggMain2 using 'preaggregate' as select a,avg(b) from PreAggMain2 group by a")
     checkExistence(sql("DESCRIBE FORMATTED preagg15"), true, "preaggmain2_a")
     checkExistence(sql("DESCRIBE FORMATTED preagg15"), true, "preaggmain2_b_sum")
     checkExistence(sql("DESCRIBE FORMATTED preagg15"), true, "preaggmain2_b_count")
@@ -86,21 +86,21 @@ class TestPreAggCreateCommand extends QueryTest with BeforeAndAfterAll {
   }
 
   test("test pre agg create table ten") {
-    sql("create table preagg16 stored BY 'carbondata' tblproperties('parent'='PreAggMain2') as select a as a1,max(b) from PreAggMain2 group by a")
+    sql("create datamap preagg16 on table PreAggMain2 using 'preaggregate' as select a as a1,max(b) from PreAggMain2 group by a")
     checkExistence(sql("DESCRIBE FORMATTED preagg16"), true, "preaggmain2_a")
     checkExistence(sql("DESCRIBE FORMATTED preagg16"), true, "preaggmain2_b_max")
     sql("drop table preagg16")
   }
 
   test("test pre agg create table eleven") {
-    sql("create table preagg17 stored BY 'carbondata' tblproperties('parent'='PreAggMain2') as select a,min(b) from PreAggMain2 group by a")
+    sql("create datamap preagg17 on table PreAggMain2 using 'preaggregate' as select a,min(b) from PreAggMain2 group by a")
     checkExistence(sql("DESCRIBE FORMATTED preagg17"), true, "preaggmain2_a")
     checkExistence(sql("DESCRIBE FORMATTED preagg17"), true, "preaggmain2_b_min")
     sql("drop table preagg17")
   }
 
   test("test pre agg create table twelve") {
-    sql("create table preagg18 stored BY 'carbondata' tblproperties('parent'='PreAggMain2') as select a as a1,count(b) from PreAggMain2 group by a")
+    sql("create datamap preagg18 on table PreAggMain2 using 'preaggregate' as select a as a1,count(b) from PreAggMain2 group by a")
     checkExistence(sql("DESCRIBE FORMATTED preagg18"), true, "preaggmain2_a")
     checkExistence(sql("DESCRIBE FORMATTED preagg18"), true, "preaggmain2_b_count")
     sql("drop table preagg18")
@@ -109,7 +109,7 @@ class TestPreAggCreateCommand extends QueryTest with BeforeAndAfterAll {
   test("test pre agg create table thirteen") {
     try {
       sql(
-        "create table preagg19 stored BY 'carbondata' tblproperties('parent'='PreAggMain2') as select a as a1,count(distinct b) from PreAggMain2 group by a")
+        "create datamap preagg19 on table PreAggMain2 using 'preaggregate' as select a as a1,count(distinct b) from PreAggMain2 group by a")
       assert(false)
     } catch {
       case _: Exception =>
@@ -120,7 +120,7 @@ class TestPreAggCreateCommand extends QueryTest with BeforeAndAfterAll {
   test("test pre agg create table fourteen") {
     try {
       sql(
-        "create table preagg20 stored BY 'carbondata' tblproperties('parent'='PreAggMain2') as select a as a1,sum(distinct b) from PreAggMain2 group by a")
+        "create datamap preagg20 on table PreAggMain2 using 'preaggregate' as select a as a1,sum(distinct b) from PreAggMain2 group by a")
       assert(false)
     } catch {
       case _: Exception =>
@@ -131,7 +131,7 @@ class TestPreAggCreateCommand extends QueryTest with BeforeAndAfterAll {
   test("test pre agg create table fifteen") {
     try {
       sql(
-        "create table preagg21 stored BY 'carbondata' tblproperties('parent'='PreAggMain2') as select a as a1,sum(b) from PreAggMain2 where a='vishal' group by a")
+        "create datamap preagg21 on table PreAggMain2 using 'preaggregate' as select a as a1,sum(b) from PreAggMain2 where a='vishal' group by a")
       assert(false)
     } catch {
       case _: Exception =>

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggCreateCommand.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggCreateCommand.scala
@@ -17,93 +17,93 @@ class TestPreAggCreateCommand extends QueryTest with BeforeAndAfterAll {
 
   test("test pre agg create table One") {
     sql("create datamap preagg1 on table PreAggMain using 'preaggregate' as select a,sum(b) from PreAggMain group by a")
-    checkExistence(sql("DESCRIBE FORMATTED preagg1"), true, "preaggmain_a")
-    checkExistence(sql("DESCRIBE FORMATTED preagg1"), true, "preaggmain_b_sum")
-    sql("drop table preagg1")
+    checkExistence(sql("DESCRIBE FORMATTED PreAggMain_preagg1"), true, "preaggmain_a")
+    checkExistence(sql("DESCRIBE FORMATTED PreAggMain_preagg1"), true, "preaggmain_b_sum")
+    sql("drop table PreAggMain_preagg1")
   }
 
   test("test pre agg create table Two") {
     sql("create datamap preagg2 on table PreAggMain using 'preaggregate' as select a as a1,sum(b) from PreAggMain group by a")
-    checkExistence(sql("DESCRIBE FORMATTED preagg2"), true, "preaggmain_a")
-    checkExistence(sql("DESCRIBE FORMATTED preagg2"), true, "preaggmain_b_sum")
-    sql("drop table preagg2")
+    checkExistence(sql("DESCRIBE FORMATTED PreAggMain_preagg2"), true, "preaggmain_a")
+    checkExistence(sql("DESCRIBE FORMATTED PreAggMain_preagg2"), true, "preaggmain_b_sum")
+    sql("drop table PreAggMain_preagg2")
   }
 
   test("test pre agg create table Three") {
     sql("create datamap preagg3 on table PreAggMain using 'preaggregate' as select a,sum(b) as sum from PreAggMain group by a")
-    checkExistence(sql("DESCRIBE FORMATTED preagg3"), true, "preaggmain_a")
-    checkExistence(sql("DESCRIBE FORMATTED preagg3"), true, "preaggmain_b_sum")
-    sql("drop table preagg3")
+    checkExistence(sql("DESCRIBE FORMATTED PreAggMain_preagg3"), true, "preaggmain_a")
+    checkExistence(sql("DESCRIBE FORMATTED PreAggMain_preagg3"), true, "preaggmain_b_sum")
+    sql("drop table PreAggMain_preagg3")
   }
 
   test("test pre agg create table four") {
     sql("create datamap preagg4 on table PreAggMain using 'preaggregate' as select a as a1,sum(b) as sum from PreAggMain group by a")
-    checkExistence(sql("DESCRIBE FORMATTED preagg4"), true, "preaggmain_a")
-    checkExistence(sql("DESCRIBE FORMATTED preagg4"), true, "preaggmain_b_sum")
-    sql("drop table preagg4")
+    checkExistence(sql("DESCRIBE FORMATTED PreAggMain_preagg4"), true, "preaggmain_a")
+    checkExistence(sql("DESCRIBE FORMATTED PreAggMain_preagg4"), true, "preaggmain_b_sum")
+    sql("drop table PreAggMain_preagg4")
   }
 
 
   test("test pre agg create table five") {
     sql("create datamap preagg11 on table PreAggMain1 using 'preaggregate'as select a,sum(b) from PreAggMain1 group by a")
-    checkExistence(sql("DESCRIBE FORMATTED preagg11"), true, "preaggmain1_a")
-    checkExistence(sql("DESCRIBE FORMATTED preagg11"), true, "preaggmain1_b_sum")
-    checkExistence(sql("DESCRIBE FORMATTED preagg11"), true, "DICTIONARY")
-    sql("drop table preagg11")
+    checkExistence(sql("DESCRIBE FORMATTED PreAggMain1_preagg11"), true, "preaggmain1_a")
+    checkExistence(sql("DESCRIBE FORMATTED PreAggMain1_preagg11"), true, "preaggmain1_b_sum")
+    checkExistence(sql("DESCRIBE FORMATTED PreAggMain1_preagg11"), true, "DICTIONARY")
+    sql("drop table PreAggMain1_preagg11")
   }
 
   test("test pre agg create table six") {
     sql("create datamap preagg12 on table PreAggMain1 using 'preaggregate' as select a as a1,sum(b) from PreAggMain1 group by a")
-    checkExistence(sql("DESCRIBE FORMATTED preagg12"), true, "preaggmain1_a")
-    checkExistence(sql("DESCRIBE FORMATTED preagg12"), true, "preaggmain1_b_sum")
-    checkExistence(sql("DESCRIBE FORMATTED preagg12"), true, "DICTIONARY")
-    sql("drop table preagg12")
+    checkExistence(sql("DESCRIBE FORMATTED PreAggMain1_preagg12"), true, "preaggmain1_a")
+    checkExistence(sql("DESCRIBE FORMATTED PreAggMain1_preagg12"), true, "preaggmain1_b_sum")
+    checkExistence(sql("DESCRIBE FORMATTED PreAggMain1_preagg12"), true, "DICTIONARY")
+    sql("drop table PreAggMain1_preagg12")
   }
 
   test("test pre agg create table seven") {
     sql("create datamap preagg13 on table PreAggMain1 using 'preaggregate' as select a,sum(b) as sum from PreAggMain1 group by a")
-    checkExistence(sql("DESCRIBE FORMATTED preagg13"), true, "preaggmain1_a")
-    checkExistence(sql("DESCRIBE FORMATTED preagg13"), true, "preaggmain1_b_sum")
-    checkExistence(sql("DESCRIBE FORMATTED preagg13"), true, "DICTIONARY")
-    sql("drop table preagg13")
+    checkExistence(sql("DESCRIBE FORMATTED PreAggMain1_preagg13"), true, "preaggmain1_a")
+    checkExistence(sql("DESCRIBE FORMATTED PreAggMain1_preagg13"), true, "preaggmain1_b_sum")
+    checkExistence(sql("DESCRIBE FORMATTED PreAggMain1_preagg13"), true, "DICTIONARY")
+    sql("drop table PreAggMain1_preagg13")
   }
 
   test("test pre agg create table eight") {
     sql("create datamap preagg14 on table PreAggMain1 using 'preaggregate' as select a as a1,sum(b) as sum from PreAggMain1 group by a")
-    checkExistence(sql("DESCRIBE FORMATTED preagg14"), true, "preaggmain1_a")
-    checkExistence(sql("DESCRIBE FORMATTED preagg14"), true, "preaggmain1_b_sum")
-    checkExistence(sql("DESCRIBE FORMATTED preagg14"), true, "DICTIONARY")
-    sql("drop table preagg14")
+    checkExistence(sql("DESCRIBE FORMATTED PreAggMain1_preagg14"), true, "preaggmain1_a")
+    checkExistence(sql("DESCRIBE FORMATTED PreAggMain1_preagg14"), true, "preaggmain1_b_sum")
+    checkExistence(sql("DESCRIBE FORMATTED PreAggMain1_preagg14"), true, "DICTIONARY")
+    sql("drop table PreAggMain1_preagg14")
   }
 
 
   test("test pre agg create table nine") {
     sql("create datamap preagg15 on table PreAggMain2 using 'preaggregate' as select a,avg(b) from PreAggMain2 group by a")
-    checkExistence(sql("DESCRIBE FORMATTED preagg15"), true, "preaggmain2_a")
-    checkExistence(sql("DESCRIBE FORMATTED preagg15"), true, "preaggmain2_b_sum")
-    checkExistence(sql("DESCRIBE FORMATTED preagg15"), true, "preaggmain2_b_count")
-    sql("drop table preagg15")
+    checkExistence(sql("DESCRIBE FORMATTED PreAggMain2_preagg15"), true, "preaggmain2_a")
+    checkExistence(sql("DESCRIBE FORMATTED PreAggMain2_preagg15"), true, "preaggmain2_b_sum")
+    checkExistence(sql("DESCRIBE FORMATTED PreAggMain2_preagg15"), true, "preaggmain2_b_count")
+    sql("drop table PreAggMain2_preagg15")
   }
 
   test("test pre agg create table ten") {
     sql("create datamap preagg16 on table PreAggMain2 using 'preaggregate' as select a as a1,max(b) from PreAggMain2 group by a")
-    checkExistence(sql("DESCRIBE FORMATTED preagg16"), true, "preaggmain2_a")
-    checkExistence(sql("DESCRIBE FORMATTED preagg16"), true, "preaggmain2_b_max")
-    sql("drop table preagg16")
+    checkExistence(sql("DESCRIBE FORMATTED PreAggMain2_preagg16"), true, "preaggmain2_a")
+    checkExistence(sql("DESCRIBE FORMATTED PreAggMain2_preagg16"), true, "preaggmain2_b_max")
+    sql("drop table PreAggMain2_preagg16")
   }
 
   test("test pre agg create table eleven") {
     sql("create datamap preagg17 on table PreAggMain2 using 'preaggregate' as select a,min(b) from PreAggMain2 group by a")
-    checkExistence(sql("DESCRIBE FORMATTED preagg17"), true, "preaggmain2_a")
-    checkExistence(sql("DESCRIBE FORMATTED preagg17"), true, "preaggmain2_b_min")
-    sql("drop table preagg17")
+    checkExistence(sql("DESCRIBE FORMATTED PreAggMain2_preagg17"), true, "preaggmain2_a")
+    checkExistence(sql("DESCRIBE FORMATTED PreAggMain2_preagg17"), true, "preaggmain2_b_min")
+    sql("drop table PreAggMain2_preagg17")
   }
 
   test("test pre agg create table twelve") {
     sql("create datamap preagg18 on table PreAggMain2 using 'preaggregate' as select a as a1,count(b) from PreAggMain2 group by a")
-    checkExistence(sql("DESCRIBE FORMATTED preagg18"), true, "preaggmain2_a")
-    checkExistence(sql("DESCRIBE FORMATTED preagg18"), true, "preaggmain2_b_count")
-    sql("drop table preagg18")
+    checkExistence(sql("DESCRIBE FORMATTED PreAggMain2_preagg18"), true, "preaggmain2_a")
+    checkExistence(sql("DESCRIBE FORMATTED PreAggMain2_preagg18"), true, "preaggmain2_b_count")
+    sql("drop table PreAggMain2_preagg18")
   }
 
   test("test pre agg create table thirteen") {

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggregateDrop.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggregateDrop.scala
@@ -31,7 +31,7 @@ class TestPreAggregateDrop extends QueryTest with BeforeAndAfterAll {
 
   test("create and drop preaggregate table") {
     sql(
-      "create table preagg1 stored BY 'carbondata' tblproperties('parent'='maintable') as select" +
+      "create datamap preagg1 on table maintable using 'preaggregate' as select" +
       " a,sum(b) from maintable group by a")
     sql("drop table if exists preagg1")
     checkExistence(sql("show tables"), false, "preagg1")
@@ -39,10 +39,10 @@ class TestPreAggregateDrop extends QueryTest with BeforeAndAfterAll {
 
   test("dropping 1 aggregate table should not drop others") {
     sql(
-      "create table preagg1 stored BY 'carbondata' tblproperties('parent'='maintable') as select" +
+      "create datamap preagg1 on table maintable using 'preaggregate' as select" +
       " a,sum(b) from maintable group by a")
     sql(
-      "create table preagg2 stored BY 'carbondata' tblproperties('parent'='maintable') as select" +
+      "create datamap preagg2 on table maintable using 'preaggregate'  as select" +
       " a,sum(c) from maintable group by a")
     sql("drop table if exists preagg2")
     val showTables = sql("show tables")
@@ -52,7 +52,7 @@ class TestPreAggregateDrop extends QueryTest with BeforeAndAfterAll {
   
   test("drop main table and check if preaggreagte is deleted") {
     sql(
-      "create table preagg2 stored BY 'carbondata' tblproperties('parent'='maintable') as select" +
+      "create datamap preagg2 on table maintable using 'preaggregate' as select" +
       " a,sum(c) from maintable group by a")
     sql("drop table if exists maintable")
     checkExistence(sql("show tables"), false, "preagg1", "maintable", "preagg2")

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggregateDrop.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggregateDrop.scala
@@ -24,8 +24,8 @@ class TestPreAggregateDrop extends QueryTest with BeforeAndAfterAll {
 
   override def beforeAll {
     sql("drop table if exists maintable")
-    sql("drop table if exists preagg1")
-    sql("drop table if exists preagg2")
+    sql("drop table if exists maintable_preagg1")
+    sql("drop table if exists maintable_preagg2")
     sql("create table maintable (a string, b string, c string) stored by 'carbondata'")
   }
 
@@ -33,8 +33,8 @@ class TestPreAggregateDrop extends QueryTest with BeforeAndAfterAll {
     sql(
       "create datamap preagg1 on table maintable using 'preaggregate' as select" +
       " a,sum(b) from maintable group by a")
-    sql("drop table if exists preagg1")
-    checkExistence(sql("show tables"), false, "preagg1")
+    sql("drop table if exists maintable_preagg1")
+    checkExistence(sql("show tables"), false, "maintable_preagg1")
   }
 
   test("dropping 1 aggregate table should not drop others") {
@@ -44,10 +44,10 @@ class TestPreAggregateDrop extends QueryTest with BeforeAndAfterAll {
     sql(
       "create datamap preagg2 on table maintable using 'preaggregate'  as select" +
       " a,sum(c) from maintable group by a")
-    sql("drop table if exists preagg2")
+    sql("drop table if exists maintable_preagg2")
     val showTables = sql("show tables")
-    checkExistence(showTables, false, "preagg2")
-    checkExistence(showTables, true, "preagg1")
+    checkExistence(showTables, false, "maintable_preagg2")
+    checkExistence(showTables, true, "maintable_preagg1")
   }
   
   test("drop main table and check if preaggreagte is deleted") {
@@ -55,13 +55,13 @@ class TestPreAggregateDrop extends QueryTest with BeforeAndAfterAll {
       "create datamap preagg2 on table maintable using 'preaggregate' as select" +
       " a,sum(c) from maintable group by a")
     sql("drop table if exists maintable")
-    checkExistence(sql("show tables"), false, "preagg1", "maintable", "preagg2")
+    checkExistence(sql("show tables"), false, "maintable_preagg1", "maintable", "maintable_preagg2")
   }
 
   override def afterAll() {
     sql("drop table if exists maintable")
-    sql("drop table if exists preagg1")
-    sql("drop table if exists preagg2")
+    sql("drop table if exists maintable_preagg1")
+    sql("drop table if exists maintable_preagg2")
   }
   
 }

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggregateLoad.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggregateLoad.scala
@@ -23,33 +23,28 @@ import org.scalatest.{BeforeAndAfterAll, Ignore}
 
 @Ignore
 class TestPreAggregateLoad extends QueryTest with BeforeAndAfterAll {
-  
+
   val testData = s"$resourcesPath/sample.csv"
-  
+
   override def beforeAll(): Unit = {
     sql("DROP TABLE IF EXISTS maintable")
   }
 
   private def createAllAggregateTables(parentTableName: String): Unit = {
     sql(
-      s"""create table ${ parentTableName }_preagg_sum stored BY 'carbondata' tblproperties
-         |('parent'='$parentTableName') as select id,sum(age) from $parentTableName group by id"""
+      s"""create datamap ${ parentTableName }_preagg_sum on table $parentTableName using 'preaggregate' as select id,sum(age) from $parentTableName group by id"""
         .stripMargin)
     sql(
-      s"""create table ${ parentTableName }_preagg_avg stored BY 'carbondata' tblproperties
-         |('parent'='$parentTableName') as select id,avg(age) from $parentTableName group by id"""
+      s"""create datamap ${ parentTableName }_preagg_avg on table $parentTableName using 'preaggregate' as select id,avg(age) from $parentTableName group by id"""
         .stripMargin)
     sql(
-      s"""create table ${ parentTableName }_preagg_count stored BY 'carbondata' tblproperties
-         |('parent'='$parentTableName') as select id,count(age) from $parentTableName group by id"""
+      s"""create datamap ${ parentTableName }_preagg_count on table $parentTableName using 'preaggregate' as select id,count(age) from $parentTableName group by id"""
         .stripMargin)
     sql(
-      s"""create table ${ parentTableName }_preagg_min stored BY 'carbondata' tblproperties
-         |('parent'='$parentTableName') as select id,min(age) from $parentTableName group by id"""
+      s"""create datamap ${ parentTableName }_preagg_min on table $parentTableName using 'preaggregate' as select id,min(age) from $parentTableName group by id"""
         .stripMargin)
     sql(
-      s"""create table ${ parentTableName }_preagg_max stored BY 'carbondata' tblproperties
-         |('parent'='$parentTableName') as select id,max(age) from $parentTableName group by id"""
+      s"""create datamap ${ parentTableName }_preagg_max on table $parentTableName using 'preaggregate' as select id,max(age) from $parentTableName group by id"""
         .stripMargin)
   }
 

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggregateLoad.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggregateLoad.scala
@@ -32,19 +32,19 @@ class TestPreAggregateLoad extends QueryTest with BeforeAndAfterAll {
 
   private def createAllAggregateTables(parentTableName: String): Unit = {
     sql(
-      s"""create datamap ${ parentTableName }_preagg_sum on table $parentTableName using 'preaggregate' as select id,sum(age) from $parentTableName group by id"""
+      s"""create datamap preagg_sum on table $parentTableName using 'preaggregate' as select id,sum(age) from $parentTableName group by id"""
         .stripMargin)
     sql(
-      s"""create datamap ${ parentTableName }_preagg_avg on table $parentTableName using 'preaggregate' as select id,avg(age) from $parentTableName group by id"""
+      s"""create datamap preagg_avg on table $parentTableName using 'preaggregate' as select id,avg(age) from $parentTableName group by id"""
         .stripMargin)
     sql(
-      s"""create datamap ${ parentTableName }_preagg_count on table $parentTableName using 'preaggregate' as select id,count(age) from $parentTableName group by id"""
+      s"""create datamap preagg_count on table $parentTableName using 'preaggregate' as select id,count(age) from $parentTableName group by id"""
         .stripMargin)
     sql(
-      s"""create datamap ${ parentTableName }_preagg_min on table $parentTableName using 'preaggregate' as select id,min(age) from $parentTableName group by id"""
+      s"""create datamap preagg_min on table $parentTableName using 'preaggregate' as select id,min(age) from $parentTableName group by id"""
         .stripMargin)
     sql(
-      s"""create datamap ${ parentTableName }_preagg_max on table $parentTableName using 'preaggregate' as select id,max(age) from $parentTableName group by id"""
+      s"""create datamap preagg_max on table $parentTableName using 'preaggregate' as select id,max(age) from $parentTableName group by id"""
         .stripMargin)
   }
 

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datamap/TestDataMapCommand.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datamap/TestDataMapCommand.scala
@@ -1,0 +1,78 @@
+package org.apache.carbondata.spark.testsuite.datamap
+
+import org.apache.spark.sql.test.util.QueryTest
+import org.scalatest.BeforeAndAfterAll
+
+import org.apache.carbondata.core.metadata.CarbonMetadata
+
+class TestDataMapCommand extends QueryTest with BeforeAndAfterAll {
+
+  override def beforeAll {
+    sql("drop table if exists datamaptest")
+    sql("create table datamaptest (a string, b string, c string) stored by 'carbondata'")
+  }
+
+
+  test("test datamap create") {
+    sql("create datamap datamap1 on table datamaptest using 'new.class'")
+    val table = CarbonMetadata.getInstance().getCarbonTable("default_datamaptest")
+    assert(table != null)
+    val dataMapSchemaList = table.getTableInfo.getDataMapSchemaList
+    assert(dataMapSchemaList.size() == 1)
+    assert(dataMapSchemaList.get(0).getDataMapName.equals("datamap1"))
+    assert(dataMapSchemaList.get(0).getClassName.equals("new.class"))
+  }
+
+  test("test datamap create with dmproperties") {
+    sql("create datamap datamap2 on table datamaptest using 'new.class' dmproperties('key'='value')")
+    val table = CarbonMetadata.getInstance().getCarbonTable("default_datamaptest")
+    assert(table != null)
+    val dataMapSchemaList = table.getTableInfo.getDataMapSchemaList
+    assert(dataMapSchemaList.size() == 2)
+    assert(dataMapSchemaList.get(1).getDataMapName.equals("datamap2"))
+    assert(dataMapSchemaList.get(1).getClassName.equals("new.class"))
+    assert(dataMapSchemaList.get(1).getProperties.get("key").equals("value"))
+  }
+
+  test("test datamap create with existing name") {
+    intercept[Exception] {
+      sql(
+        "create datamap datamap2 on table datamaptest using 'new.class' dmproperties('key'='value')")
+    }
+    val table = CarbonMetadata.getInstance().getCarbonTable("default_datamaptest")
+    assert(table != null)
+    val dataMapSchemaList = table.getTableInfo.getDataMapSchemaList
+    assert(dataMapSchemaList.size() == 2)
+  }
+
+  test("test datamap create with preagg") {
+    sql("drop table if exists datamap3")
+    sql(
+      "create datamap datamap3 on table datamaptest using 'preaggregate' dmproperties('key'='value') as select count(a) from datamaptest")
+    val table = CarbonMetadata.getInstance().getCarbonTable("default_datamaptest")
+    assert(table != null)
+    val dataMapSchemaList = table.getTableInfo.getDataMapSchemaList
+    assert(dataMapSchemaList.size() == 3)
+    assert(dataMapSchemaList.get(2).getDataMapName.equals("datamap3"))
+    assert(dataMapSchemaList.get(2).getProperties.get("key").equals("value"))
+    assert(dataMapSchemaList.get(2).getChildSchema.getTableName.equals("datamap3"))
+  }
+
+  test("test datamap create with preagg with duplicate name") {
+    intercept[Exception] {
+      sql("drop table if exists datamap2")
+      sql(
+        "create datamap datamap2 on table datamaptest using 'preaggregate' dmproperties('key'='value') as select count(a) from datamaptest")
+
+    }
+    val table = CarbonMetadata.getInstance().getCarbonTable("default_datamaptest")
+    assert(table != null)
+    val dataMapSchemaList = table.getTableInfo.getDataMapSchemaList
+    assert(dataMapSchemaList.size() == 3)
+  }
+
+
+  override def afterAll {
+    sql("drop table if exists datamaptest")
+  }
+}

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datamap/TestDataMapCommand.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datamap/TestDataMapCommand.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.carbondata.spark.testsuite.datamap
 
 import org.apache.spark.sql.test.util.QueryTest
@@ -55,7 +72,7 @@ class TestDataMapCommand extends QueryTest with BeforeAndAfterAll {
     assert(dataMapSchemaList.size() == 3)
     assert(dataMapSchemaList.get(2).getDataMapName.equals("datamap3"))
     assert(dataMapSchemaList.get(2).getProperties.get("key").equals("value"))
-    assert(dataMapSchemaList.get(2).getChildSchema.getTableName.equals("datamap3"))
+    assert(dataMapSchemaList.get(2).getChildSchema.getTableName.equals("datamaptest_datamap3"))
   }
 
   test("test datamap create with preagg with duplicate name") {

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/iud/DeleteCarbonTableTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/iud/DeleteCarbonTableTestCase.scala
@@ -131,17 +131,17 @@ class DeleteCarbonTableTestCase extends QueryTest with BeforeAndAfterAll {
 
   test("test if delete is unsupported for pre-aggregate tables") {
     sql("drop table if exists preaggMain")
-    sql("drop table if exists preagg1")
+    sql("drop table if exists preaggmain_preagg1")
     sql("create table preaggMain (a string, b string, c string) stored by 'carbondata'")
-    sql("create table preagg1 stored BY 'carbondata' tblproperties('parent'='PreAggMain') as select a,sum(b) from PreAggMain group by a")
+    sql("create datamap preagg1 on table PreAggMain USING 'preaggregate' as select a,sum(b) from PreAggMain group by a")
     intercept[RuntimeException] {
       sql("delete from preaggmain where a = 'abc'").show()
     }.getMessage.contains("Delete operation is not supported for tables")
     intercept[RuntimeException] {
-      sql("delete from preagg1 where preaggmain_a = 'abc'").show()
+      sql("delete from preaggmain_preagg1 where preaggmain_a = 'abc'").show()
     }.getMessage.contains("Delete operation is not supported for pre-aggregate table")
     sql("drop table if exists preaggMain")
-    sql("drop table if exists preagg1")
+    sql("drop table if exists preaggmain_preagg1")
   }
 
 

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/iud/UpdateCarbonTableTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/iud/UpdateCarbonTableTestCase.scala
@@ -515,17 +515,17 @@ class UpdateCarbonTableTestCase extends QueryTest with BeforeAndAfterAll {
 
   test("test if update is unsupported for pre-aggregate tables") {
     sql("drop table if exists preaggMain")
-    sql("drop table if exists preagg1")
+    sql("drop table if exists preaggMain_preagg1")
     sql("create table preaggMain (a string, b string, c string) stored by 'carbondata'")
-    sql("create table preagg1 stored BY 'carbondata' tblproperties('parent'='PreAggMain') as select a,sum(b) from PreAggMain group by a")
+    sql("create datamap preagg1 on table PreAggMain using 'preaggregate' as select a,sum(b) from PreAggMain group by a")
     intercept[RuntimeException] {
       sql("update preaggmain set (a)=('a')").show
     }.getMessage.contains("Update operation is not supported for tables")
     intercept[RuntimeException] {
-      sql("update preagg1 set (a)=('a')").show
+      sql("update preaggMain_preagg1 set (a)=('a')").show
     }.getMessage.contains("Update operation is not supported for pre-aggregate table")
     sql("drop table if exists preaggMain")
-    sql("drop table if exists preagg1")
+    sql("drop table if exists preaggMain_preagg1")
   }
 
   override def afterAll {

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
@@ -170,6 +170,9 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
   protected val CHANGE = carbonKeyWord("CHANGE")
   protected val TBLPROPERTIES = carbonKeyWord("TBLPROPERTIES")
   protected val ID = carbonKeyWord("ID")
+  protected val DATAMAP = carbonKeyWord("DATAMAP")
+  protected val ON = carbonKeyWord("ON")
+  protected val DMPROPERTIES = carbonKeyWord("DMPROPERTIES")
 
   protected val doubleQuotedString = "\"([^\"]+)\"".r
   protected val singleQuotedString = "'([^']+)'".r
@@ -750,7 +753,7 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
    * @param dbName
    * @return Option of String
    */
-  protected def convertDbNameToLowerCase(dbName: Option[String]): Option[String] = {
+  def convertDbNameToLowerCase(dbName: Option[String]): Option[String] = {
     dbName match {
       case Some(databaseName) => Some(convertDbNameToLowerCase(databaseName))
       case None => dbName

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/datamap/CarbonCreateDataMapCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/datamap/CarbonCreateDataMapCommand.scala
@@ -32,7 +32,7 @@ import org.apache.carbondata.core.metadata.schema.table.DataMapSchema
  *
  * @param queryString
  */
-case class CreateDataMapCommand(
+case class CarbonCreateDataMapCommand(
     dataMapName: String,
     tableIdentifier: TableIdentifier,
     dmClassName: String,
@@ -54,7 +54,6 @@ case class CreateDataMapCommand(
         dmproperties,
         queryString.get).run(sparkSession)
     } else {
-
       val dataMapSchema = new DataMapSchema(dataMapName, dmClassName)
       dataMapSchema.setProperties(new java.util.HashMap[String, String](dmproperties.asJava))
       val dbName = GetDB.getDatabaseName(tableIdentifier.database, sparkSession)

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/datamap/CreateDataMapCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/datamap/CreateDataMapCommand.scala
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.command.datamap
+
+import scala.collection.JavaConverters._
+
+import org.apache.spark.sql._
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.execution.command._
+import org.apache.spark.sql.execution.command.preaaggregate.{CreatePreAggregateTableCommand, PreAggregateUtil}
+
+import org.apache.carbondata.common.logging.LogServiceFactory
+import org.apache.carbondata.core.metadata.schema.table.DataMapSchema
+
+/**
+ * Below command class will be used to create datamap on table
+ * and updating the parent table about the datamap information
+ *
+ * @param queryString
+ */
+case class CreateDataMapCommand(
+    dataMapName: String,
+    tableIdentifier: TableIdentifier,
+    dmClassName: String,
+    dmproperties: Map[String, String],
+    queryString: Option[String])
+  extends RunnableCommand with SchemaProcessCommand {
+
+  override def run(sparkSession: SparkSession): Seq[Row] = {
+    processSchema(sparkSession)
+  }
+
+  override def processSchema(sparkSession: SparkSession): Seq[Row] = {
+    val LOGGER = LogServiceFactory.getLogService(this.getClass.getCanonicalName)
+    if (dmClassName.equals("org.apache.carbondata.datamap.AggregateDataMapHandler") ||
+        dmClassName.equalsIgnoreCase("preaggregate")) {
+      CreatePreAggregateTableCommand(dataMapName,
+        tableIdentifier,
+        dmClassName,
+        dmproperties,
+        queryString.get).run(sparkSession)
+    } else {
+
+      val dataMapSchema = new DataMapSchema(dataMapName, dmClassName)
+      dataMapSchema.setProperties(new java.util.HashMap[String, String](dmproperties.asJava))
+      val dbName = GetDB.getDatabaseName(tableIdentifier.database, sparkSession)
+      // upadting the parent table about dataschema
+      PreAggregateUtil.updateMainTable(dbName, tableIdentifier.table, dataMapSchema, sparkSession)
+    }
+    LOGGER.audit(s"DataMap ${dataMapName} successfully added to Table ${tableIdentifier.table}")
+    Seq.empty
+  }
+}
+
+

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/preaaggregate/PreAggregateListeners.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/preaaggregate/PreAggregateListeners.scala
@@ -41,9 +41,11 @@ object DropPreAggregateTablePostListener extends OperationEventListener {
         !carbonTable.get.getTableInfo.getDataMapSchemaList.isEmpty) {
       val childSchemas = carbonTable.get.getTableInfo.getDataMapSchemaList
       for (childSchema: DataMapSchema <- childSchemas.asScala) {
-        CarbonDropTableCommand(ifExistsSet = true,
-          Some(childSchema.getRelationIdentifier.getDatabaseName),
-          childSchema.getRelationIdentifier.getTableName).run(sparkSession)
+        if (childSchema.getRelationIdentifier != null) {
+          CarbonDropTableCommand(ifExistsSet = true,
+            Some(childSchema.getRelationIdentifier.getDatabaseName),
+            childSchema.getRelationIdentifier.getTableName).run(sparkSession)
+        }
       }
     }
 

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/preaaggregate/PreAggregateUtil.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/preaaggregate/PreAggregateUtil.scala
@@ -260,7 +260,7 @@ object PreAggregateUtil {
         precision = precision,
         scale = scale,
         rawSchema = rawSchema), dataMapField)
-} else {
+    } else {
       (Field(column = actualColumnName,
         dataType = Some(dataType.typeName),
         name = Some(actualColumnName),

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonFileMetastore.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonFileMetastore.scala
@@ -465,8 +465,9 @@ class CarbonFileMetastore extends CarbonMetaStore {
         }
         val childSchemaIterator = childSchemas.iterator()
         while (childSchemaIterator.hasNext) {
-          val childSchema = childSchemaIterator.next()
-          if (childSchema.getChildSchema.equals(childCarbonTable.getTableInfo.getFactTable)) {
+          val childSchema = childSchemaIterator.next().getChildSchema
+          if (childSchema != null &&
+              childSchema.equals(childCarbonTable.getTableInfo.getFactTable)) {
             childSchemaIterator.remove()
           }
         }

--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/restructure/AlterTableValidationTestCase.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/restructure/AlterTableValidationTestCase.scala
@@ -493,13 +493,13 @@ class AlterTableValidationTestCase extends Spark2QueryTest with BeforeAndAfterAl
   test("test to check if new parent table name is reflected in pre-aggregate tables") {
     sql("drop table if exists preaggMain")
     sql("drop table if exists preaggmain_new")
-    sql("drop table if exists preagg1")
+    sql("drop table if exists preaggMain_preagg1")
     sql("create table preaggMain (a string, b string, c string) stored by 'carbondata'")
     sql(
-      "create table preagg1 stored BY 'carbondata' tblproperties('parent'='PreAggMain') as select" +
+      "create datamap preagg1 on table PreAggMain using 'preaggregate' as select" +
       " a,sum(b) from PreAggMain group by a")
     intercept[RuntimeException] {
-      sql("alter table preagg1 rename to preagg2")
+      sql("alter table PreAggMain_preagg1 rename to preagg2")
     }.getMessage.contains("Rename operation for pre-aggregate table is not supported.")
     intercept[RuntimeException] {
       sql("alter table preaggmain rename to preaggmain_new")

--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/restructure/vectorreader/ChangeDataTypeTestCases.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/restructure/vectorreader/ChangeDataTypeTestCases.scala
@@ -149,19 +149,19 @@ class ChangeDataTypeTestCases extends Spark2QueryTest with BeforeAndAfterAll {
 
   test("test data type change for with pre-aggregate table should throw exception") {
     sql("drop table if exists preaggMain")
-    sql("drop table if exists preagg1")
+    sql("drop table if exists PreAggMain_preagg1")
     sql("create table preaggMain (a string, b string, c string) stored by 'carbondata'")
     sql(
-      "create table preagg1 stored BY 'carbondata' tblproperties('parent'='PreAggMain') as select" +
+      "create datamap preagg1 on table PreAggMain using 'preaggregate' as select" +
       " a,sum(b) from PreAggMain group by a")
     intercept[RuntimeException] {
       sql("alter table preaggmain drop columns(a)").show
     }.getMessage.contains("exists in pre-aggregate table")
     intercept[RuntimeException] {
-      sql("alter table preagg1 drop columns(a)").show
+      sql("alter table PreAggMain_preagg1 drop columns(a)").show
     }.getMessage.contains("cannot be dropped")
     sql("drop table if exists preaggMain")
-    sql("drop table if exists preagg1")
+    sql("drop table if exists PreAggMain_preagg1")
   }
 
   override def afterAll {

--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/restructure/vectorreader/DropColumnTestCases.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/restructure/vectorreader/DropColumnTestCases.scala
@@ -100,10 +100,10 @@ class DropColumnTestCases extends Spark2QueryTest with BeforeAndAfterAll {
 
   test("test dropping of column in pre-aggregate should throw exception") {
     sql("drop table if exists preaggMain")
-    sql("drop table if exists preagg1")
+    sql("drop table if exists preaggMain_preagg1")
     sql("create table preaggMain (a string, b string, c string) stored by 'carbondata'")
     sql(
-      "create table preagg1 stored BY 'carbondata' tblproperties('parent'='PreAggMain') as select" +
+      "create datamap preagg1 on table PreAggMain using 'preaggregate' as select" +
       " a,sum(b) from PreAggMain group by a")
     sql("alter table preaggmain drop columns(c)").show
     checkExistence(sql("desc table preaggmain"), false, "c")
@@ -111,7 +111,7 @@ class DropColumnTestCases extends Spark2QueryTest with BeforeAndAfterAll {
       sql("alter table preaggmain drop columns(a)").show
     }.getMessage.contains("cannot be dropped")
     sql("drop table if exists preaggMain")
-    sql("drop table if exists preagg1")
+    sql("drop table if exists preaggMain_preagg1")
   }
 
   override def afterAll {

--- a/integration/spark2/src/test/scala/org/apache/spark/util/CarbonCommandSuite.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/util/CarbonCommandSuite.scala
@@ -143,14 +143,14 @@ class CarbonCommandSuite extends Spark2QueryTest with BeforeAndAfterAll {
 
   test("test if delete segments by id is unsupported for pre-aggregate tables") {
     dropTable("preaggMain")
-    dropTable("preagg1")
+    dropTable("preaggMain_preagg1")
     sql("create table preaggMain (a string, b string, c string) stored by 'carbondata'")
-    sql("create table preagg1 stored BY 'carbondata' tblproperties('parent'='PreAggMain') as select a,sum(b) from PreAggMain group by a")
+    sql("create datamap preagg1 on table PreAggMain using 'preaggregate' as select a,sum(b) from PreAggMain group by a")
     intercept[UnsupportedOperationException] {
       sql("delete from table preaggMain where segment.id in (1,2)")
     }.getMessage.contains("Delete segment operation is not supported on tables")
     intercept[UnsupportedOperationException] {
-      sql("delete from table preagg1 where segment.id in (1,2)")
+      sql("delete from table preaggMain_preagg1 where segment.id in (1,2)")
     }.getMessage.contains("Delete segment operation is not supported on pre-aggregate tables")
     dropTable("preaggMain")
     dropTable("preagg1")


### PR DESCRIPTION
Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:
   User can create datamap using the following syntax.
   ```
    CREATE DATAMAP agg_sales
     ON TABLE sales
   USING "org.apache.carbondata.datamap.AggregateDataMapHandler"
  DMPROPERTIES (
    'KEY’=’VALUE’
   ) AS
   SELECT order_time, count(user_id) FROM sales GROUP BY order_time
   ```  

In the above syntax `DMPROPERTIES` and `AS QUERY` are optional.

 - [X] Any interfaces changed?
   NO
 - [X] Any backward compatibility impacted?
   NO
 - [X] Document update required?
    Yes, need to add new syntax to document
 - [X] Testing done
        Testcases are added
 - [X] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

