### PR TITLE
[CARBONDATA-1579][PREAGG][DATAMAP] Support DataMap show

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/datamap/CarbonDataMapShowCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/datamap/CarbonDataMapShowCommand.scala
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.command.datamap
+
+import scala.collection.JavaConverters._
+
+import org.apache.spark.sql.{CarbonEnv, Row, SparkSession}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
+import org.apache.spark.sql.execution.command.{Checker, DataProcessCommand, RunnableCommand}
+import org.apache.spark.sql.hive.CarbonRelation
+import org.apache.spark.sql.types.StringType
+
+/**
+ * Show the datamaps on the table
+ * @param databaseNameOp
+ * @param tableName
+ */
+case class CarbonDataMapShowCommand(
+    databaseNameOp: Option[String],
+    tableName: String)
+  extends RunnableCommand with DataProcessCommand {
+
+  override def output: Seq[Attribute] = {
+    Seq(AttributeReference("DataMapName", StringType, nullable = false)(),
+      AttributeReference("ClassName", StringType, nullable = false)(),
+      AttributeReference("Associated Table", StringType, nullable = false)())
+  }
+
+  override def run(sparkSession: SparkSession): Seq[Row] = {
+    processData(sparkSession)
+  }
+
+  override def processData(sparkSession: SparkSession): Seq[Row] = {
+    Checker.validateTableExists(databaseNameOp, tableName, sparkSession)
+    val carbonTable = CarbonEnv.getInstance(sparkSession).carbonMetastore.
+      lookupRelation(databaseNameOp, tableName)(sparkSession).asInstanceOf[CarbonRelation].
+      tableMeta.carbonTable
+    val schemaList = carbonTable.getTableInfo.getDataMapSchemaList
+    if (schemaList != null && schemaList.size() > 0) {
+      schemaList.asScala.map { s =>
+        var table = "(NA)"
+        val relationIdentifier = s.getRelationIdentifier
+        if (relationIdentifier != null) {
+          table = relationIdentifier.getDatabaseName + "." + relationIdentifier.getTableName
+        }
+        Row(s.getDataMapName, s.getClassName, table)
+      }
+    } else {
+      Seq.empty
+    }
+  }
+}


### PR DESCRIPTION
Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:
  Added support for show datamap on table.
  ```
   SHOW DATAMAP ON TABLE test
  ```
  The above command shows all datamaps on the table name test.
 Output of it shows the following attributes
  ```
  +-----------+---------+----------------+
|DataMapName|ClassName|Associated Table|
+-----------+---------+----------------+
  ```

This PR is dependent on the PRs https://github.com/apache/carbondata/pull/1481  and https://github.com/apache/carbondata/pull/1489 . First those PR need to be merged
 - [X] Any interfaces changed?
   NO
 - [X] Any backward compatibility impacted?
   NO
 - [X] Document update required?
   Yes, sql command needs to be added to document
 - [X] Testing done
       Tests are added        
 - [X] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

