### PR TITLE
[CARBONDATA-1704] [FILTER] Filter Optimization

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -23,6 +23,10 @@ import org.apache.carbondata.core.util.CarbonProperty;
 
 public final class CarbonCommonConstants {
   /**
+   * surrogate value of null
+   */
+  public static final int DICT_VALUE_NULL = 1;
+  /**
    * integer size in bytes
    */
   public static final int INT_SIZE_IN_BYTE = 4;

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/ColumnFilterInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/ColumnFilterInfo.java
@@ -38,6 +38,16 @@ public class ColumnFilterInfo implements Serializable {
    */
   private List<byte[]> noDictionaryFilterValuesList;
 
+  public boolean isOptimized() {
+    return isOptimized;
+  }
+
+  public void setOptimized(boolean optimized) {
+    isOptimized = optimized;
+  }
+
+  private boolean isOptimized;
+
   private List<Object> measuresFilterValuesList;
 
   public List<byte[]> getNoDictionaryFilterValuesList() {

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/DimColumnExecuterFilterInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/DimColumnExecuterFilterInfo.java
@@ -20,6 +20,16 @@ public class DimColumnExecuterFilterInfo {
 
   byte[][] filterKeys;
 
+  public byte[][] getExcludeFilterKeys() {
+    return filterKeysForExclude;
+  }
+
+  public void setExcludeFilterKeys(byte[][] filterKeysForExclude) {
+    this.filterKeysForExclude = filterKeysForExclude;
+  }
+
+  byte[][] filterKeysForExclude;
+
   public void setFilterKeys(byte[][] filterKeys) {
     this.filterKeys = filterKeys;
   }

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/ExcludeColGroupFilterExecuterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/ExcludeColGroupFilterExecuterImpl.java
@@ -61,7 +61,7 @@ public class ExcludeColGroupFilterExecuterImpl extends ExcludeFilterExecuterImpl
     bitSet.flip(0, numerOfRows);
     try {
       KeyStructureInfo keyStructureInfo = getKeyStructureInfo();
-      byte[][] filterValues = dimColumnExecuterInfo.getFilterKeys();
+      byte[][] filterValues = dimColumnExecuterInfo.getExcludeFilterKeys();
       for (int i = 0; i < filterValues.length; i++) {
         byte[] filterVal = filterValues[i];
         for (int rowId = 0; rowId < numerOfRows; rowId++) {

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/ExcludeFilterExecuterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/ExcludeFilterExecuterImpl.java
@@ -286,7 +286,7 @@ public class ExcludeFilterExecuterImpl implements FilterExecuter {
       int numberOfRows, boolean useBitsetPipeLine, BitSetGroup prvBitSetGroup, int pageNumber) {
     // check whether applying filtered based on previous bitset will be optimal
     if (CarbonUtil.usePreviousFilterBitsetGroup(useBitsetPipeLine, prvBitSetGroup, pageNumber,
-        dimColumnExecuterInfo.getFilterKeys().length)) {
+        dimColumnExecuterInfo.getExcludeFilterKeys().length)) {
       return getFilteredIndexesUisngPrvBitset(dimensionColumnDataChunk, prvBitSetGroup, pageNumber,
           numberOfRows);
     } else {
@@ -313,8 +313,9 @@ public class ExcludeFilterExecuterImpl implements FilterExecuter {
   private BitSet getFilteredIndexesUisngPrvBitset(DimensionColumnDataChunk dimensionColumnDataChunk,
       BitSetGroup prvBitSetGroup, int pageNumber, int numberOfRows) {
     BitSet prvPageBitSet = prvBitSetGroup.getBitSet(pageNumber);
-    BitSet bitSet = new BitSet(numberOfRows);
-    byte[][] filterKeys = dimColumnExecuterInfo.getFilterKeys();
+    BitSet bitSet = new BitSet();
+    bitSet.or(prvPageBitSet);
+    byte[][] filterKeys = dimColumnExecuterInfo.getExcludeFilterKeys();
     int compareResult = 0;
     // if dimension data was natural sorted then get the index from previous bitset
     // and use the same in next column data, otherwise use the inverted index reverse
@@ -354,7 +355,7 @@ public class ExcludeFilterExecuterImpl implements FilterExecuter {
     BitSet bitSet = new BitSet(numerOfRows);
     bitSet.flip(0, numerOfRows);
     int startIndex = 0;
-    byte[][] filterValues = dimColumnExecuterInfo.getFilterKeys();
+    byte[][] filterValues = dimColumnExecuterInfo.getExcludeFilterKeys();
     for (int i = 0; i < filterValues.length; i++) {
       if (startIndex >= numerOfRows) {
         break;
@@ -376,7 +377,7 @@ public class ExcludeFilterExecuterImpl implements FilterExecuter {
       int numerOfRows) {
     BitSet bitSet = new BitSet(numerOfRows);
     bitSet.flip(0, numerOfRows);
-    byte[][] filterValues = dimColumnExecuterInfo.getFilterKeys();
+    byte[][] filterValues = dimColumnExecuterInfo.getExcludeFilterKeys();
     // binary search can only be applied if column is sorted
     if (isNaturalSorted) {
       int startIndex = 0;

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RestructureEvaluatorImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RestructureEvaluatorImpl.java
@@ -76,7 +76,12 @@ public abstract class RestructureEvaluatorImpl implements FilterExecuter {
       if (null != defaultValue) {
         defaultSurrogateValueToCompare++;
       }
-      List<Integer> filterList = filterValues.getFilterList();
+      List<Integer> filterList = null;
+      if (filterValues.isIncludeFilter() && !filterValues.isOptimized()) {
+        filterList = filterValues.getFilterList();
+      } else {
+        filterList = filterValues.getExcludeFilterList();
+      }
       for (Integer filterValue : filterList) {
         if (defaultSurrogateValueToCompare == filterValue) {
           isDefaultValuePresentInFilterValues = true;

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/resolver/ConditionalFilterResolverImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/resolver/ConditionalFilterResolverImpl.java
@@ -171,7 +171,7 @@ public class ConditionalFilterResolverImpl implements FilterResolverIntf {
               ! columnList.get(0).getDimension().getDataType().isComplexType())) {
         dimColResolvedFilterInfo.setFilterValues(FilterUtil
             .getFilterListForAllValues(absoluteTableIdentifier, exp, columnList.get(0),
-                isIncludeFilter, tableProvider));
+                isIncludeFilter, tableProvider, isExpressionResolve));
 
         dimColResolvedFilterInfo.setColumnIndex(columnList.get(0).getDimension().getOrdinal());
         dimColResolvedFilterInfo.setDimension(columnList.get(0).getDimension());
@@ -319,7 +319,7 @@ public class ConditionalFilterResolverImpl implements FilterResolverIntf {
     } else if (null != dimColResolvedFilterInfo.getFilterValues() && dimColResolvedFilterInfo
         .getDimension().hasEncoding(Encoding.DIRECT_DICTIONARY)) {
       return FilterUtil.getKeyArray(this.dimColResolvedFilterInfo.getFilterValues(),
-          this.dimColResolvedFilterInfo.getDimension(), segmentProperties);
+          this.dimColResolvedFilterInfo.getDimension(), segmentProperties, false);
     }
     return null;
 

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/resolver/RowLevelRangeFilterResolverImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/resolver/RowLevelRangeFilterResolverImpl.java
@@ -90,7 +90,7 @@ public class RowLevelRangeFilterResolverImpl extends ConditionalFilterResolverIm
           .getDimensionFromCurrentBlock(this.dimColEvaluatorInfoList.get(0).getDimension());
       if (null != dimensionFromCurrentBlock) {
         return FilterUtil.getKeyArray(this.dimColEvaluatorInfoList.get(0).getFilterValues(),
-            dimensionFromCurrentBlock, segmentProperties);
+            dimensionFromCurrentBlock, segmentProperties, false);
       }
     }
     return null;
@@ -243,7 +243,11 @@ public class RowLevelRangeFilterResolverImpl extends ConditionalFilterResolverIm
           dimColumnEvaluatorInfo.setDimension(columnExpression.getDimension());
           dimColumnEvaluatorInfo.setDimensionExistsInCurrentSilce(false);
           if (columnExpression.getDimension().hasEncoding(Encoding.DIRECT_DICTIONARY)) {
-            filterInfo.setFilterList(getDirectSurrogateValues(columnExpression));
+            if (!isIncludeFilter) {
+              filterInfo.setExcludeFilterList(getDirectSurrogateValues(columnExpression));
+            } else {
+              filterInfo.setFilterList(getDirectSurrogateValues(columnExpression));
+            }
           } else {
             filterInfo.setFilterListForNoDictionaryCols(getNoDictionaryRangeValues());
           }

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/resolver/resolverinfo/visitor/CustomTypeDictionaryVisitor.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/resolver/resolverinfo/visitor/CustomTypeDictionaryVisitor.java
@@ -62,12 +62,13 @@ public class CustomTypeDictionaryVisitor implements ResolvedFilterInfoVisitorInt
               evaluateResultListFinal, metadata.isIncludeFilter(),
               metadata.getColumnExpression().getDimension().getDataType());
       if (!metadata.isIncludeFilter() && null != resolvedFilterObject && !resolvedFilterObject
-          .getFilterList().contains(CarbonCommonConstants.MEMBER_DEFAULT_VAL_SURROGATE_KEY)) {
+          .getExcludeFilterList()
+          .contains(CarbonCommonConstants.MEMBER_DEFAULT_VAL_SURROGATE_KEY)) {
         // Adding default surrogate key of null member inorder to not display the same while
         // displaying the report as per hive compatibility.
-        resolvedFilterObject.getFilterList()
+        resolvedFilterObject.getExcludeFilterList()
             .add(CarbonCommonConstants.MEMBER_DEFAULT_VAL_SURROGATE_KEY);
-        Collections.sort(resolvedFilterObject.getFilterList());
+        Collections.sort(resolvedFilterObject.getExcludeFilterList());
       }
       resolveDimension.setFilterValues(resolvedFilterObject);
     }
@@ -88,7 +89,11 @@ public class CustomTypeDictionaryVisitor implements ResolvedFilterInfoVisitorInt
     if (surrogates.size() > 0) {
       columnFilterInfo = new ColumnFilterInfo();
       columnFilterInfo.setIncludeFilter(isIncludeFilter);
-      columnFilterInfo.setFilterList(surrogates);
+      if (!isIncludeFilter) {
+        columnFilterInfo.setExcludeFilterList(surrogates);
+      } else {
+        columnFilterInfo.setFilterList(surrogates);
+      }
     }
     return columnFilterInfo;
   }

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/resolver/resolverinfo/visitor/DictionaryColumnVisitor.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/resolver/resolverinfo/visitor/DictionaryColumnVisitor.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
+import org.apache.carbondata.core.scan.executor.exception.QueryExecutionException;
 import org.apache.carbondata.core.scan.expression.exception.FilterIllegalMemberException;
 import org.apache.carbondata.core.scan.expression.exception.FilterUnsupportedException;
 import org.apache.carbondata.core.scan.filter.ColumnFilterInfo;
@@ -53,21 +54,26 @@ public class DictionaryColumnVisitor implements ResolvedFilterInfoVisitorIntf {
       } catch (FilterIllegalMemberException e) {
         throw new FilterUnsupportedException(e);
       }
-      resolvedFilterObject = FilterUtil
-          .getFilterValues(metadata.getTableIdentifier(), metadata.getColumnExpression(),
-              evaluateResultListFinal, metadata.isIncludeFilter(), metadata.getTableProvider());
-      if (!metadata.isIncludeFilter() && null != resolvedFilterObject) {
-        // Adding default surrogate key of null member inorder to not display the same while
-        // displaying the report as per hive compatibility.
-        // first check of surrogate key for null value is already added then
-        // no need to add again otherwise result will be wrong in case of exclude filter
-        // this is because two times it will flip the same bit
-        if (!resolvedFilterObject.getFilterList()
-            .contains(CarbonCommonConstants.MEMBER_DEFAULT_VAL_SURROGATE_KEY)) {
-          resolvedFilterObject.getFilterList()
-              .add(CarbonCommonConstants.MEMBER_DEFAULT_VAL_SURROGATE_KEY);
+      try {
+
+        resolvedFilterObject = FilterUtil
+            .getFilterValues(metadata.getTableIdentifier(), metadata.getColumnExpression(),
+                evaluateResultListFinal, metadata.isIncludeFilter(), metadata.getTableProvider());
+        if (!metadata.isIncludeFilter() && null != resolvedFilterObject) {
+          // Adding default surrogate key of null member inorder to not display the same while
+          // displaying the report as per hive compatibility.
+          // first check of surrogate key for null value is already added then
+          // no need to add again otherwise result will be wrong in case of exclude filter
+          // this is because two times it will flip the same bit
+          if (!resolvedFilterObject.getExcludeFilterList()
+              .contains(CarbonCommonConstants.MEMBER_DEFAULT_VAL_SURROGATE_KEY)) {
+            resolvedFilterObject.getExcludeFilterList()
+                .add(CarbonCommonConstants.MEMBER_DEFAULT_VAL_SURROGATE_KEY);
+          }
+          Collections.sort(resolvedFilterObject.getExcludeFilterList());
         }
-        Collections.sort(resolvedFilterObject.getFilterList());
+      } catch (QueryExecutionException e) {
+        throw new FilterUnsupportedException(e);
       }
       resolveDimension.setFilterValues(resolvedFilterObject);
     }

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/resolver/resolverinfo/visitor/RangeDictionaryColumnVisitor.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/resolver/resolverinfo/visitor/RangeDictionaryColumnVisitor.java
@@ -51,14 +51,17 @@ public class RangeDictionaryColumnVisitor extends DictionaryColumnVisitor
       resolvedFilterObject = FilterUtil
           .getFilterListForAllValues(metadata.getTableIdentifier(), metadata.getExpression(),
               metadata.getColumnExpression(), metadata.isIncludeFilter(),
-              metadata.getTableProvider());
+              metadata.getTableProvider(), true);
 
       if (!metadata.isIncludeFilter() && null != resolvedFilterObject) {
         // Adding default surrogate key of null member inorder to not display the same while
         // displaying the report as per hive compatibility.
-        resolvedFilterObject.getFilterList()
-            .add(CarbonCommonConstants.MEMBER_DEFAULT_VAL_SURROGATE_KEY);
-        Collections.sort(resolvedFilterObject.getFilterList());
+        if (!resolvedFilterObject.getExcludeFilterList()
+            .contains(CarbonCommonConstants.MEMBER_DEFAULT_VAL_SURROGATE_KEY)) {
+          resolvedFilterObject.getExcludeFilterList()
+              .add(CarbonCommonConstants.MEMBER_DEFAULT_VAL_SURROGATE_KEY);
+          Collections.sort(resolvedFilterObject.getFilterList());
+        }
       }
       resolveDimension.setFilterValues(resolvedFilterObject);
     }

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/resolver/resolverinfo/visitor/RangeDirectDictionaryVisitor.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/resolver/resolverinfo/visitor/RangeDirectDictionaryVisitor.java
@@ -71,12 +71,13 @@ public class RangeDirectDictionaryVisitor extends CustomTypeDictionaryVisitor
               metadata.getColumnExpression().getDimension().getDataType());
 
       if (!metadata.isIncludeFilter() && null != resolvedFilterObject && !resolvedFilterObject
-          .getFilterList().contains(CarbonCommonConstants.MEMBER_DEFAULT_VAL_SURROGATE_KEY)) {
+          .getExcludeFilterList()
+          .contains(CarbonCommonConstants.MEMBER_DEFAULT_VAL_SURROGATE_KEY)) {
         // Adding default surrogate key of null member inorder to not display the same while
         // displaying the report as per hive compatibility.
-        resolvedFilterObject.getFilterList()
+        resolvedFilterObject.getExcludeFilterList()
             .add(CarbonCommonConstants.MEMBER_DEFAULT_VAL_SURROGATE_KEY);
-        Collections.sort(resolvedFilterObject.getFilterList());
+        Collections.sort(resolvedFilterObject.getExcludeFilterList());
       }
       resolveDimension.setFilterValues(resolvedFilterObject);
     }


### PR DESCRIPTION
If the include filter (on a dictionary column)gives more than 60% of data from a block, then Include Filter will be converted to Exclude Filter

Scenario: 
**column1**
a
b
c
d

Query --> **Select * from table_name where column1 in (a,b,c);**
This will consume more than 60% of the data. In this case internally query will be optimized to exclude filter as below,
**Select * from table_name where column1 not in (d);**

 - [X] Any interfaces changed?
        Added variables and methods 
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [X] Testing done
         Manual Testing. Logs added        
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 



