### PR TITLE
[CARBONDATA-1612][CARBONDATA-1615][Streaming] Support delete segment for streaming table

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonCatalystOperators.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonCatalystOperators.scala
@@ -82,10 +82,10 @@ case class ShowLoadsCommand(
   extends Command {
 
   override def output: Seq[Attribute] = {
-    Seq(AttributeReference("SegmentSequenceId", StringType, nullable = false)(),
+    Seq(AttributeReference("Segment Id", StringType, nullable = false)(),
       AttributeReference("Status", StringType, nullable = false)(),
       AttributeReference("Load Start Time", TimestampType, nullable = false)(),
-      AttributeReference("Load End Time", TimestampType, nullable = false)(),
+      AttributeReference("Load End Time", TimestampType, nullable = true)(),
       AttributeReference("Merged To", StringType, nullable = false)())
   }
 }


### PR DESCRIPTION
Support delete segment by ID and by Date for streaming table

 - [X] Any interfaces changed?
 No

 - [X] Any backward compatibility impacted?
 No

 - [X] Document update required?
Yes. Need to explain delete segment operation is valid for streaming table

 - [X] Testing done
  Two new testcase added

 - [X] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA
