### PR TITLE
[CARBONDATA-1729]Fix the compatibility issue with hadoop <= 2.6 and 2.7

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/AbstractDFSCarbonFile.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/AbstractDFSCarbonFile.java
@@ -160,11 +160,13 @@ public abstract  class AbstractDFSCarbonFile implements CarbonFile {
       // if hadoop version >= 2.7, it can call method 'truncate' to truncate file,
       // this method was new in hadoop 2.7
       FileSystem fs = fileStatus.getPath().getFileSystem(FileFactory.getConfiguration());
-      Method truncateMethod = fs.getClass().getDeclaredMethod("truncate", new Class[]{Path.class, long.class});
-      fileTruncatedSuccessfully = (boolean)truncateMethod.invoke(fs, new Object[]{fileStatus.getPath(), validDataEndOffset});
+      Method truncateMethod = fs.getClass().getDeclaredMethod("truncate",
+          new Class[]{Path.class, long.class});
+      fileTruncatedSuccessfully = (boolean)truncateMethod.invoke(fs,
+          new Object[]{fileStatus.getPath(), validDataEndOffset});
     } catch (NoSuchMethodException e) {
-      LOGGER.error("there is no 'truncate' method in FileSystem, the version of hadoop is below 2.7 ."
-          + "It needs to implement truncate file by other way.");
+      LOGGER.error("there is no 'truncate' method in FileSystem, the version of hadoop is"
+          + " below 2.7, It needs to implement truncate file by other way.");
       DataOutputStream dataOutputStream = null;
       DataInputStream dataInputStream = null;
       // if bytes to read less than 1024 then buffer size should be equal to the given offset

--- a/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/AbstractDFSCarbonFile.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/AbstractDFSCarbonFile.java
@@ -20,6 +20,7 @@ package org.apache.carbondata.core.datastore.filesystem;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.lang.reflect.Method;
 
 import org.apache.carbondata.common.logging.LogService;
 import org.apache.carbondata.common.logging.LogServiceFactory;
@@ -154,52 +155,66 @@ public abstract  class AbstractDFSCarbonFile implements CarbonFile {
    * This method will delete the data in file data from a given offset
    */
   @Override public boolean truncate(String fileName, long validDataEndOffset) {
-    DataOutputStream dataOutputStream = null;
-    DataInputStream dataInputStream = null;
     boolean fileTruncatedSuccessfully = false;
-    // if bytes to read less than 1024 then buffer size should be equal to the given offset
-    int bufferSize = validDataEndOffset > CarbonCommonConstants.BYTE_TO_KB_CONVERSION_FACTOR ?
-        CarbonCommonConstants.BYTE_TO_KB_CONVERSION_FACTOR :
-        (int) validDataEndOffset;
-    // temporary file name
-    String tempWriteFilePath = fileName + CarbonCommonConstants.TEMPWRITEFILEEXTENSION;
-    FileFactory.FileType fileType = FileFactory.getFileType(fileName);
     try {
-      CarbonFile tempFile;
-      // delete temporary file if it already exists at a given path
-      if (FileFactory.isFileExist(tempWriteFilePath, fileType)) {
-        tempFile = FileFactory.getCarbonFile(tempWriteFilePath, fileType);
-        tempFile.delete();
-      }
-      // create new temporary file
-      FileFactory.createNewFile(tempWriteFilePath, fileType);
-      tempFile = FileFactory.getCarbonFile(tempWriteFilePath, fileType);
-      byte[] buff = new byte[bufferSize];
-      dataInputStream = FileFactory.getDataInputStream(fileName, fileType);
-      // read the data
-      int read = dataInputStream.read(buff, 0, buff.length);
-      dataOutputStream = FileFactory.getDataOutputStream(tempWriteFilePath, fileType);
-      dataOutputStream.write(buff, 0, read);
-      long remaining = validDataEndOffset - read;
-      // anytime we should not cross the offset to be read
-      while (remaining > 0) {
-        if (remaining > bufferSize) {
-          buff = new byte[bufferSize];
-        } else {
-          buff = new byte[(int) remaining];
+      // if hadoop version >= 2.7, it can call method 'truncate' to truncate file,
+      // this method was new in hadoop 2.7
+      FileSystem fs = fileStatus.getPath().getFileSystem(FileFactory.getConfiguration());
+      Method truncateMethod = fs.getClass().getDeclaredMethod("truncate", new Class[]{Path.class, long.class});
+      fileTruncatedSuccessfully = (boolean)truncateMethod.invoke(fs, new Object[]{fileStatus.getPath(), validDataEndOffset});
+    } catch (NoSuchMethodException e) {
+      LOGGER.error("there is no 'truncate' method in FileSystem, the version of hadoop is below 2.7 ."
+          + "It needs to implement truncate file by other way.");
+      DataOutputStream dataOutputStream = null;
+      DataInputStream dataInputStream = null;
+      // if bytes to read less than 1024 then buffer size should be equal to the given offset
+      int bufferSize = validDataEndOffset > CarbonCommonConstants.BYTE_TO_KB_CONVERSION_FACTOR ?
+          CarbonCommonConstants.BYTE_TO_KB_CONVERSION_FACTOR :
+          (int) validDataEndOffset;
+      // temporary file name
+      String tempWriteFilePath = fileName + CarbonCommonConstants.TEMPWRITEFILEEXTENSION;
+      FileFactory.FileType fileType = FileFactory.getFileType(fileName);
+      try {
+        CarbonFile tempFile;
+        // delete temporary file if it already exists at a given path
+        if (FileFactory.isFileExist(tempWriteFilePath, fileType)) {
+          tempFile = FileFactory.getCarbonFile(tempWriteFilePath, fileType);
+          tempFile.delete();
         }
-        read = dataInputStream.read(buff, 0, buff.length);
+        // create new temporary file
+        FileFactory.createNewFile(tempWriteFilePath, fileType);
+        tempFile = FileFactory.getCarbonFile(tempWriteFilePath, fileType);
+        byte[] buff = new byte[bufferSize];
+        dataInputStream = FileFactory.getDataInputStream(fileName, fileType);
+        // read the data
+        int read = dataInputStream.read(buff, 0, buff.length);
+        dataOutputStream = FileFactory.getDataOutputStream(tempWriteFilePath, fileType);
         dataOutputStream.write(buff, 0, read);
-        remaining = remaining - read;
+        long remaining = validDataEndOffset - read;
+        // anytime we should not cross the offset to be read
+        while (remaining > 0) {
+          if (remaining > bufferSize) {
+            buff = new byte[bufferSize];
+          } else {
+            buff = new byte[(int) remaining];
+          }
+          read = dataInputStream.read(buff, 0, buff.length);
+          dataOutputStream.write(buff, 0, read);
+          remaining = remaining - read;
+        }
+        CarbonUtil.closeStreams(dataInputStream, dataOutputStream);
+        // rename the temp file to original file
+        tempFile.renameForce(fileName);
+        fileTruncatedSuccessfully = true;
+      } catch (IOException ioe) {
+        LOGGER.error("IOException occurred while truncating the file " + ioe.getMessage());
+      } finally {
+        CarbonUtil.closeStreams(dataOutputStream, dataInputStream);
       }
-      CarbonUtil.closeStreams(dataInputStream, dataOutputStream);
-      // rename the temp file to original file
-      tempFile.renameForce(fileName);
-      fileTruncatedSuccessfully = true;
     } catch (IOException e) {
-      LOGGER.error("Exception occurred while truncating the file " + e.getMessage());
-    } finally {
-      CarbonUtil.closeStreams(dataOutputStream, dataInputStream);
+      LOGGER.error("IOException occurred while truncating the file " + e.getMessage());
+    } catch (Exception e) {
+      LOGGER.error("Other exception occurred while truncating the file " + e.getMessage());
     }
     return fileTruncatedSuccessfully;
   }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/impl/FileFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/impl/FileFactory.java
@@ -40,6 +40,7 @@ import org.apache.carbondata.core.datastore.filesystem.HDFSCarbonFile;
 import org.apache.carbondata.core.datastore.filesystem.LocalCarbonFile;
 import org.apache.carbondata.core.datastore.filesystem.ViewFSCarbonFile;
 import org.apache.carbondata.core.util.CarbonUtil;
+
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;

--- a/core/src/main/java/org/apache/carbondata/core/datastore/impl/FileFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/impl/FileFactory.java
@@ -26,7 +26,6 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.channels.FileChannel;
 import java.util.zip.GZIPInputStream;
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants;

--- a/core/src/main/java/org/apache/carbondata/core/datastore/impl/FileFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/impl/FileFactory.java
@@ -462,39 +462,8 @@ public final class FileFactory {
    * @throws IOException
    */
   public static void truncateFile(String path, FileType fileType, long newSize) throws IOException {
-    path = path.replace("\\", "/");
-    FileChannel fileChannel = null;
-    switch (fileType) {
-      case LOCAL:
-        path = getUpdatedFilePath(path, fileType);
-        fileChannel = new FileOutputStream(path, true).getChannel();
-        try {
-          fileChannel.truncate(newSize);
-        } finally {
-          if (fileChannel != null) {
-            fileChannel.close();
-          }
-        }
-        return;
-      case HDFS:
-      case ALLUXIO:
-      case VIEWFS:
-      case S3:
-        Path pt = new Path(path);
-        FileSystem fs = pt.getFileSystem(configuration);
-        fs.truncate(pt, newSize);
-        return;
-      default:
-        fileChannel = new FileOutputStream(path, true).getChannel();
-        try {
-          fileChannel.truncate(newSize);
-        } finally {
-          if (fileChannel != null) {
-            fileChannel.close();
-          }
-        }
-        return;
-    }
+    CarbonFile carbonFile = FileFactory.getCarbonFile(path, fileType);
+    carbonFile.truncate(path, newSize);
   }
 
   /**

--- a/core/src/main/java/org/apache/carbondata/core/datastore/impl/FileFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/impl/FileFactory.java
@@ -494,7 +494,7 @@ public final class FileFactory {
           Path pt = new Path(path);
           FileSystem fs = pt.getFileSystem(configuration);
           Method truncateMethod = fs.getClass().getDeclaredMethod("truncate",
-            new Class[]{Path.class, long.class});
+              new Class[]{Path.class, long.class});
           truncateMethod.invoke(fs, new Object[]{pt, newSize});
         } catch (NoSuchMethodException e) {
           LOGGER.error("the version of hadoop is below 2.7, there is no 'truncate'"

--- a/pom.xml
+++ b/pom.xml
@@ -453,9 +453,9 @@
       </build>
     </profile>
     <profile>
-      <id>hadoop-2.7.2</id>
+      <id>hadoop-2.2.0</id>
       <properties>
-        <hadoop.version>2.7.2</hadoop.version>
+        <hadoop.version>2.2.0</hadoop.version>
       </properties>
     </profile>
     <profile>


### PR DESCRIPTION
1. Recover profile of 'hadoop-2.2.0' to pom.xml
2. Use reflection mechanism to implement 'truncate' method

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

