### PR TITLE
[CARBONDATA-1764] Fix issue of when create table with short data type

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/aggquery/IntegerDataTypeTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/aggquery/IntegerDataTypeTestCase.scala
@@ -32,6 +32,7 @@ class IntegerDataTypeTestCase extends QueryTest with BeforeAndAfterAll {
 
   override def beforeAll {
     sql("DROP TABLE IF EXISTS integertypetableAgg")
+    sql("DROP TABLE IF EXISTS short_table")
     sql("CREATE TABLE integertypetableAgg (empno int, workgroupcategory string, deptno int, projectcode int, attendance int) STORED BY 'org.apache.carbondata.format'")
     sql(s"""LOAD DATA local inpath '$resourcesPath/data.csv' INTO TABLE integertypetableAgg OPTIONS ('DELIMITER'= ',', 'QUOTECHAR'= '\"', 'FILEHEADER'='')""")
   }
@@ -141,7 +142,25 @@ class IntegerDataTypeTestCase extends QueryTest with BeforeAndAfterAll {
         | DROP TABLE short_int_target_table
       """.stripMargin)
   }
-  
+
+  test("Create a table that contains short data type") {
+    sql("CREATE TABLE if not exists short_table(col1 short, col2 BOOLEAN) STORED BY 'carbondata'")
+
+    sql("insert into short_table values(1,true)")
+    sql("insert into short_table values(11,false)")
+    sql("insert into short_table values(211,false)")
+    sql("insert into short_table values(3111,true)")
+    sql("insert into short_table values(31111,false)")
+    sql("insert into short_table values(411111,false)")
+    sql("insert into short_table values(5111111,true)")
+
+    checkAnswer(
+      sql("select count(*) from short_table"),
+      Row(7)
+    )
+    sql("DROP TABLE IF EXISTS short_table")
+  }
+
   override def afterAll {
     sql("drop table if exists integertypetableAgg")
     CarbonProperties.getInstance().addProperty(

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/util/DataTypeConverterUtilSuite.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/util/DataTypeConverterUtilSuite.scala
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.spark.util
+
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
+
+import org.apache.spark.sql.test.util.QueryTest
+
+import org.apache.carbondata.core.metadata.datatype.DataTypes
+
+/**
+  * test [[DataTypeConverterUtil]]
+  */
+class DataTypeConverterUtilSuite extends QueryTest with BeforeAndAfterEach with BeforeAndAfterAll {
+  test("test short convert") {
+    assert(DataTypeConverterUtil.convertToCarbonType("short") == DataTypes.SHORT)
+  }
+}

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/DataTypeConverterUtil.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/DataTypeConverterUtil.scala
@@ -32,6 +32,7 @@ object DataTypeConverterUtil {
       case "integer" => DataTypes.INT
       case "tinyint" => DataTypes.SHORT
       case "smallint" => DataTypes.SHORT
+      case "short" => DataTypes.SHORT
       case "long" => DataTypes.LONG
       case "bigint" => DataTypes.LONG
       case "numeric" => DataTypes.DOUBLE


### PR DESCRIPTION
Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 No
 - [ ] Any backward compatibility impacted?
 No
 - [ ] Document update required?
No
 - [ ] Testing done
       add DataTypeConverterUtilSuite.scala test case for DataTypeConverterUtil
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
   MR37
