### PR TITLE
[CARBONDATA-1771] While segment_index compaction, .carbonindex files of invalid segments are also getting merged

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/AlterTableCompactionCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/AlterTableCompactionCommand.scala
@@ -129,7 +129,7 @@ case class AlterTableCompactionCommand(
     if (compactionType == CompactionType.SEGMENT_INDEX_COMPACTION) {
       // Just launch job to merge index and return
       CommonUtil.mergeIndexFiles(sqlContext.sparkContext,
-        carbonLoadModel.getLoadMetadataDetails.asScala.map(_.getLoadName),
+        CarbonDataMergerUtil.getValidSegmentList(carbonTable.getAbsoluteTableIdentifier).asScala,
         carbonLoadModel.getTablePath,
         carbonTable, true)
       return


### PR DESCRIPTION
**Scenario:**
Disable feature, do loads, execute MINOR compaction
Execute SEGMENT_INDEX compaction
SEGMENT_INDEX  compaction merges .carbonindex files of compacted invalid segments also

**Solution:**
Merge index files of valid segments only

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [X] Testing done
        UT Added
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

