### PR TITLE
[CARBONDATA-1780] Create configuration from SparkSession for data loading

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/AbstractDFSCarbonFile.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/AbstractDFSCarbonFile.java
@@ -27,6 +27,7 @@ import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.datastore.impl.FileFactory;
 import org.apache.carbondata.core.util.CarbonUtil;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -38,13 +39,19 @@ public abstract  class AbstractDFSCarbonFile implements CarbonFile {
   private static final LogService LOGGER =
       LogServiceFactory.getLogService(AbstractDFSCarbonFile.class.getName());
   protected FileStatus fileStatus;
+  protected Configuration hadoopConf;
 
   public AbstractDFSCarbonFile(String filePath) {
+    this(filePath, FileFactory.getConfiguration());
+  }
+
+  public AbstractDFSCarbonFile(String filePath, Configuration hadoopConf) {
+    this.hadoopConf = hadoopConf;
     filePath = filePath.replace("\\", "/");
     Path path = new Path(filePath);
     FileSystem fs;
     try {
-      fs = path.getFileSystem(FileFactory.getConfiguration());
+      fs = path.getFileSystem(this.hadoopConf);
       fileStatus = fs.getFileStatus(path);
     } catch (IOException e) {
       LOGGER.error("Exception occurred:" + e.getMessage());
@@ -52,9 +59,14 @@ public abstract  class AbstractDFSCarbonFile implements CarbonFile {
   }
 
   public AbstractDFSCarbonFile(Path path) {
+    this(path, FileFactory.getConfiguration());
+  }
+
+  public AbstractDFSCarbonFile(Path path, Configuration hadoopConf) {
+    this.hadoopConf = hadoopConf;
     FileSystem fs;
     try {
-      fs = path.getFileSystem(FileFactory.getConfiguration());
+      fs = path.getFileSystem(this.hadoopConf);
       fileStatus = fs.getFileStatus(path);
     } catch (IOException e) {
       LOGGER.error("Exception occurred:" + e.getMessage());
@@ -69,7 +81,7 @@ public abstract  class AbstractDFSCarbonFile implements CarbonFile {
     Path path = fileStatus.getPath();
     FileSystem fs;
     try {
-      fs = fileStatus.getPath().getFileSystem(FileFactory.getConfiguration());
+      fs = fileStatus.getPath().getFileSystem(hadoopConf);
       return fs.createNewFile(path);
     } catch (IOException e) {
       return false;
@@ -92,7 +104,7 @@ public abstract  class AbstractDFSCarbonFile implements CarbonFile {
     FileSystem fs;
     try {
       if (null != fileStatus) {
-        fs = fileStatus.getPath().getFileSystem(FileFactory.getConfiguration());
+        fs = fileStatus.getPath().getFileSystem(hadoopConf);
         return fs.exists(fileStatus.getPath());
       }
     } catch (IOException e) {
@@ -116,7 +128,7 @@ public abstract  class AbstractDFSCarbonFile implements CarbonFile {
   public boolean renameTo(String changetoName) {
     FileSystem fs;
     try {
-      fs = fileStatus.getPath().getFileSystem(FileFactory.getConfiguration());
+      fs = fileStatus.getPath().getFileSystem(hadoopConf);
       return fs.rename(fileStatus.getPath(), new Path(changetoName));
     } catch (IOException e) {
       LOGGER.error("Exception occurred:" + e.getMessage());
@@ -127,7 +139,7 @@ public abstract  class AbstractDFSCarbonFile implements CarbonFile {
   public boolean delete() {
     FileSystem fs;
     try {
-      fs = fileStatus.getPath().getFileSystem(FileFactory.getConfiguration());
+      fs = fileStatus.getPath().getFileSystem(hadoopConf);
       return fs.delete(fileStatus.getPath(), true);
     } catch (IOException e) {
       LOGGER.error("Exception occurred:" + e.getMessage());
@@ -142,7 +154,7 @@ public abstract  class AbstractDFSCarbonFile implements CarbonFile {
   @Override public boolean setLastModifiedTime(long timestamp) {
     FileSystem fs;
     try {
-      fs = fileStatus.getPath().getFileSystem(FileFactory.getConfiguration());
+      fs = fileStatus.getPath().getFileSystem(hadoopConf);
       fs.setTimes(fileStatus.getPath(), timestamp, timestamp);
     } catch (IOException e) {
       return false;

--- a/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/HDFSCarbonFile.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/HDFSCarbonFile.java
@@ -25,6 +25,7 @@ import org.apache.carbondata.common.logging.LogService;
 import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.datastore.impl.FileFactory;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -41,8 +42,16 @@ public class HDFSCarbonFile extends AbstractDFSCarbonFile {
     super(filePath);
   }
 
+  public HDFSCarbonFile(String filePath, Configuration hadoopConf) {
+    super(filePath, hadoopConf);
+  }
+
   public HDFSCarbonFile(Path path) {
     super(path);
+  }
+
+  public HDFSCarbonFile(Path path, Configuration hadoopConf) {
+    super(path, hadoopConf);
   }
 
   public HDFSCarbonFile(FileStatus fileStatus) {
@@ -103,14 +112,14 @@ public class HDFSCarbonFile extends AbstractDFSCarbonFile {
   @Override
   public CarbonFile getParentFile() {
     Path parent = fileStatus.getPath().getParent();
-    return null == parent ? null : new HDFSCarbonFile(parent);
+    return null == parent ? null : new HDFSCarbonFile(parent, hadoopConf);
   }
 
   @Override
   public boolean renameForce(String changetoName) {
     FileSystem fs;
     try {
-      fs = fileStatus.getPath().getFileSystem(FileFactory.getConfiguration());
+      fs = fileStatus.getPath().getFileSystem(hadoopConf);
       if (fs instanceof DistributedFileSystem) {
         ((DistributedFileSystem) fs).rename(fileStatus.getPath(), new Path(changetoName),
             org.apache.hadoop.fs.Options.Rename.OVERWRITE);

--- a/core/src/main/java/org/apache/carbondata/core/datastore/impl/FileFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/impl/FileFactory.java
@@ -116,12 +116,35 @@ public final class FileFactory {
     }
   }
 
+  public static CarbonFile getCarbonFile(String path, FileType fileType,
+      Configuration hadoopConf) {
+    switch (fileType) {
+      case LOCAL:
+        return new LocalCarbonFile(getUpdatedFilePath(path, fileType));
+      case HDFS:
+      case S3:
+        return new HDFSCarbonFile(path, hadoopConf);
+      case ALLUXIO:
+        return new AlluxioCarbonFile(path);
+      case VIEWFS:
+        return new ViewFSCarbonFile(path);
+      default:
+        return new LocalCarbonFile(getUpdatedFilePath(path, fileType));
+    }
+  }
+
   public static DataInputStream getDataInputStream(String path, FileType fileType)
       throws IOException {
     return getDataInputStream(path, fileType, -1);
   }
 
   public static DataInputStream getDataInputStream(String path, FileType fileType, int bufferSize)
+      throws IOException {
+    return getDataInputStream(path, fileType, bufferSize, configuration);
+  }
+
+  public static DataInputStream getDataInputStream(String path, FileType fileType, int bufferSize,
+      Configuration hadoopConf)
       throws IOException {
     path = path.replace("\\", "/");
     boolean gzip = path.endsWith(".gz");
@@ -143,7 +166,7 @@ public final class FileFactory {
       case VIEWFS:
       case S3:
         Path pt = new Path(path);
-        FileSystem fs = pt.getFileSystem(configuration);
+        FileSystem fs = pt.getFileSystem(hadoopConf);
         if (bufferSize == -1) {
           stream = fs.open(pt);
         } else {
@@ -156,7 +179,7 @@ public final class FileFactory {
           codecName = BZip2Codec.class.getName();
         }
         if (null != codecName) {
-          CompressionCodecFactory ccf = new CompressionCodecFactory(configuration);
+          CompressionCodecFactory ccf = new CompressionCodecFactory(hadoopConf);
           CompressionCodec codec = ccf.getCodecByClassName(codecName);
           stream = codec.createInputStream(stream);
         }

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
@@ -1358,6 +1358,25 @@ public final class CarbonUtil {
     return readLine;
   }
 
+  public static String readHeader(String csvFilePath,
+      Configuration hadoopConf) throws IOException {
+
+    DataInputStream fileReader = null;
+    BufferedReader bufferedReader = null;
+    String readLine = null;
+
+    try {
+      fileReader = FileFactory.getDataInputStream(
+          csvFilePath, FileFactory.getFileType(csvFilePath), -1, hadoopConf);
+      bufferedReader = new BufferedReader(new InputStreamReader(fileReader,
+          Charset.forName(CarbonCommonConstants.DEFAULT_CHARSET)));
+      readLine = bufferedReader.readLine();
+    } finally {
+      CarbonUtil.closeStreams(fileReader, bufferedReader);
+    }
+    return readLine;
+  }
+
   /**
    * Below method will create string like "***********"
    *

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/load/DataLoadProcessBuilderOnSpark.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/load/DataLoadProcessBuilderOnSpark.scala
@@ -49,21 +49,21 @@ object DataLoadProcessBuilderOnSpark {
   def loadDataUsingGlobalSort(
       sc: SparkContext,
       dataFrame: Option[DataFrame],
-      model: CarbonLoadModel): Array[(String, (LoadMetadataDetails, ExecutionErrors))] = {
+      model: CarbonLoadModel,
+      hadoopConf: Configuration): Array[(String, (LoadMetadataDetails, ExecutionErrors))] = {
     val originRDD = if (dataFrame.isDefined) {
       dataFrame.get.rdd
     } else {
       // input data from files
-      val hadoopConfiguration = new Configuration()
-      CommonUtil.configureCSVInputFormat(hadoopConfiguration, model)
-      hadoopConfiguration.set(FileInputFormat.INPUT_DIR, model.getFactFilePath)
+      CommonUtil.configureCSVInputFormat(hadoopConf, model)
+      hadoopConf.set(FileInputFormat.INPUT_DIR, model.getFactFilePath)
       val columnCount = model.getCsvHeaderColumns.length
       new NewHadoopRDD[NullWritable, StringArrayWritable](
         sc,
         classOf[CSVInputFormat],
         classOf[NullWritable],
         classOf[StringArrayWritable],
-        hadoopConfiguration)
+        hadoopConf)
         .map(x => DataLoadProcessorStepOnSpark.toStringArrayRow(x._2, columnCount))
     }
 

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/NewCarbonDataLoadRDD.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/NewCarbonDataLoadRDD.scala
@@ -179,7 +179,8 @@ class NewCarbonDataLoadRDD[K, V](
     sc: SparkContext,
     result: DataLoadResult[K, V],
     carbonLoadModel: CarbonLoadModel,
-    blocksGroupBy: Array[(String, Array[BlockDetails])])
+    blocksGroupBy: Array[(String, Array[BlockDetails])],
+    @transient hadoopConf: Configuration)
   extends CarbonRDD[(K, V)](sc, Nil) {
 
   sc.setLocalProperty("spark.scheduler.pool", "DDL")
@@ -192,7 +193,7 @@ class NewCarbonDataLoadRDD[K, V](
   private val confBytes = {
     val bao = new ByteArrayOutputStream()
     val oos = new ObjectOutputStream(bao)
-    sc.hadoopConfiguration.write(oos)
+    hadoopConf.write(oos)
     oos.close()
     CompressorFactory.getInstance().getCompressor.compressByte(bao.toByteArray)
   }

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/CommonUtil.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/CommonUtil.scala
@@ -607,7 +607,9 @@ object CommonUtil {
     }
   }
 
-  def getCsvHeaderColumns(carbonLoadModel: CarbonLoadModel): Array[String] = {
+  def getCsvHeaderColumns(
+      carbonLoadModel: CarbonLoadModel,
+      hadoopConf: Configuration): Array[String] = {
     val delimiter = if (StringUtils.isEmpty(carbonLoadModel.getCsvDelimiter)) {
       CarbonCommonConstants.COMMA
     } else {
@@ -618,7 +620,7 @@ object CommonUtil {
     val csvColumns = if (StringUtils.isBlank(csvHeader)) {
       // read header from csv file
       csvFile = carbonLoadModel.getFactFilePath.split(",")(0)
-      csvHeader = CarbonUtil.readHeader(csvFile)
+      csvHeader = CarbonUtil.readHeader(csvFile, hadoopConf)
       if (StringUtils.isBlank(csvHeader)) {
         throw new CarbonDataLoadingException("First line of the csv is not valid.")
       }
@@ -638,10 +640,10 @@ object CommonUtil {
       } else {
         LOGGER.error(
           "CSV header in input file is not proper. Column names in schema and csv header are not "
-          + "the same. Input file : " + csvFile)
+          + "the same. Input file : " + CarbonUtil.removeAKSK(csvFile))
         throw new CarbonDataLoadingException(
           "CSV header in input file is not proper. Column names in schema and csv header are not "
-          + "the same. Input file : " + csvFile)
+          + "the same. Input file : " + CarbonUtil.removeAKSK(csvFile))
       }
     }
     csvColumns

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/DataLoadingUtil.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/DataLoadingUtil.scala
@@ -22,6 +22,7 @@ import scala.collection.JavaConverters._
 import scala.collection.mutable
 
 import org.apache.commons.lang3.StringUtils
+import org.apache.hadoop.conf.Configuration
 import org.apache.spark.sql.util.CarbonException
 
 import org.apache.carbondata.common.constants.LoggerAction
@@ -195,7 +196,8 @@ object DataLoadingUtil {
       carbonProperty: CarbonProperties,
       options: immutable.Map[String, String],
       optionsFinal: mutable.Map[String, String],
-      carbonLoadModel: CarbonLoadModel): Unit = {
+      carbonLoadModel: CarbonLoadModel,
+      hadoopConf: Configuration): Unit = {
     carbonLoadModel.setTableName(table.getTableName)
     carbonLoadModel.setDatabaseName(table.getDatabaseName)
     carbonLoadModel.setTablePath(table.getTablePath)
@@ -306,7 +308,8 @@ object DataLoadingUtil {
     carbonLoadModel.setCsvDelimiter(CarbonUtil.unescapeChar(delimeter))
     carbonLoadModel.setCsvHeader(fileHeader)
     carbonLoadModel.setColDictFilePath(column_dict)
-    carbonLoadModel.setCsvHeaderColumns(CommonUtil.getCsvHeaderColumns(carbonLoadModel))
+    carbonLoadModel.setCsvHeaderColumns(
+      CommonUtil.getCsvHeaderColumns(carbonLoadModel, hadoopConf))
 
     val validatedMaxColumns = CommonUtil.validateMaxColumns(
       carbonLoadModel.getCsvHeaderColumns,

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSource.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSource.scala
@@ -246,6 +246,7 @@ class CarbonSource extends CreatableRelationProvider with RelationProvider
       // create sink
       StreamSinkFactory.createStreamTableSink(
         sqlContext.sparkSession,
+        sqlContext.sparkSession.sessionState.newHadoopConf(),
         carbonTable,
         parameters)
     } else {

--- a/integration/spark2/src/test/scala/org/apache/carbondata/spark/util/AllDictionaryTestCase.scala
+++ b/integration/spark2/src/test/scala/org/apache/carbondata/spark/util/AllDictionaryTestCase.scala
@@ -61,7 +61,8 @@ class AllDictionaryTestCase extends Spark2QueryTest with BeforeAndAfterAll {
     carbonLoadModel.setDefaultTimestampFormat(CarbonProperties.getInstance().getProperty(
       CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT,
       CarbonCommonConstants.CARBON_TIMESTAMP_DEFAULT_FORMAT))
-    carbonLoadModel.setCsvHeaderColumns(CommonUtil.getCsvHeaderColumns(carbonLoadModel))
+    carbonLoadModel.setCsvHeaderColumns(
+      CommonUtil.getCsvHeaderColumns(carbonLoadModel, FileFactory.getConfiguration))
     // Create table and metadata folders if not exist
     val carbonTablePath = CarbonStorePath
       .getCarbonTablePath(table.getTablePath, table.getCarbonTableIdentifier)
@@ -142,7 +143,10 @@ class AllDictionaryTestCase extends Spark2QueryTest with BeforeAndAfterAll {
     val header = "id,name,city,age"
     val carbonLoadModel = buildCarbonLoadModel(sampleRelation, null, header, sampleAllDictionaryFile)
     GlobalDictionaryUtil.generateGlobalDictionary(
-      sqlContext, carbonLoadModel, sampleRelation.carbonTable.getTablePath)
+      sqlContext,
+      carbonLoadModel,
+      sampleRelation.carbonTable.getTablePath,
+      FileFactory.getConfiguration)
 
     DictionaryTestCaseUtil.
       checkDictionary(sampleRelation, "city", "shenzhen")
@@ -151,10 +155,11 @@ class AllDictionaryTestCase extends Spark2QueryTest with BeforeAndAfterAll {
   test("Support generate global dictionary from all dictionary files for complex type") {
     val header = "deviceInformationId,channelsId,ROMSize,purchasedate,mobile,MAC,locationinfo,proddate,gamePointId,contractNumber"
     val carbonLoadModel = buildCarbonLoadModel(complexRelation, null, header, complexAllDictionaryFile)
-    GlobalDictionaryUtil
-      .generateGlobalDictionary(sqlContext,
+    GlobalDictionaryUtil.generateGlobalDictionary(
+      sqlContext,
       carbonLoadModel,
-      complexRelation.carbonTable.getTablePath)
+      complexRelation.carbonTable.getTablePath,
+      FileFactory.getConfiguration)
 
     DictionaryTestCaseUtil.
       checkDictionary(complexRelation, "channelsId", "1650")

--- a/integration/spark2/src/test/scala/org/apache/carbondata/spark/util/ExternalColumnDictionaryTestCase.scala
+++ b/integration/spark2/src/test/scala/org/apache/carbondata/spark/util/ExternalColumnDictionaryTestCase.scala
@@ -173,7 +173,8 @@ class ExternalColumnDictionaryTestCase extends Spark2QueryTest with BeforeAndAft
     carbonLoadModel.setDefaultDateFormat(CarbonProperties.getInstance().getProperty(
       CarbonCommonConstants.CARBON_DATE_FORMAT,
       CarbonCommonConstants.CARBON_DATE_DEFAULT_FORMAT))
-    carbonLoadModel.setCsvHeaderColumns(CommonUtil.getCsvHeaderColumns(carbonLoadModel))
+    carbonLoadModel.setCsvHeaderColumns(
+      CommonUtil.getCsvHeaderColumns(carbonLoadModel, FileFactory.getConfiguration))
     carbonLoadModel.setMaxColumns("100")
     // Create table and metadata folders if not exist
     val carbonTablePath = CarbonStorePath
@@ -197,8 +198,11 @@ class ExternalColumnDictionaryTestCase extends Spark2QueryTest with BeforeAndAft
     // load the first time
     var carbonLoadModel = buildCarbonLoadModel(extComplexRelation, complexFilePath1,
       header, extColDictFilePath1)
-    GlobalDictionaryUtil.generateGlobalDictionary(sqlContext, carbonLoadModel,
-      extComplexRelation.carbonTable.getTablePath)
+    GlobalDictionaryUtil.generateGlobalDictionary(
+      sqlContext,
+      carbonLoadModel,
+      extComplexRelation.carbonTable.getTablePath,
+      FileFactory.getConfiguration)
     // check whether the dictionary is generated
     DictionaryTestCaseUtil.checkDictionary(
       extComplexRelation, "deviceInformationId", "10086")
@@ -206,8 +210,11 @@ class ExternalColumnDictionaryTestCase extends Spark2QueryTest with BeforeAndAft
     // load the second time
     carbonLoadModel = buildCarbonLoadModel(extComplexRelation, complexFilePath1,
       header, extColDictFilePath2)
-    GlobalDictionaryUtil.generateGlobalDictionary(sqlContext, carbonLoadModel,
-      extComplexRelation.carbonTable.getTablePath)
+    GlobalDictionaryUtil.generateGlobalDictionary(
+      sqlContext,
+      carbonLoadModel,
+      extComplexRelation.carbonTable.getTablePath,
+      FileFactory.getConfiguration)
     // check the old dictionary and whether the new distinct value is generated
     DictionaryTestCaseUtil.checkDictionary(
       extComplexRelation, "deviceInformationId", "10086")
@@ -219,8 +226,11 @@ class ExternalColumnDictionaryTestCase extends Spark2QueryTest with BeforeAndAft
     //  when csv delimiter is comma
     var carbonLoadModel = buildCarbonLoadModel(extComplexRelation, complexFilePath1,
       header, extColDictFilePath3)
-    GlobalDictionaryUtil.generateGlobalDictionary(sqlContext, carbonLoadModel,
-      extComplexRelation.carbonTable.getTablePath)
+    GlobalDictionaryUtil.generateGlobalDictionary(
+      sqlContext,
+      carbonLoadModel,
+      extComplexRelation.carbonTable.getTablePath,
+      FileFactory.getConfiguration)
     // check whether the dictionary is generated
     DictionaryTestCaseUtil.checkDictionary(
       extComplexRelation, "channelsId", "1421|")
@@ -228,8 +238,11 @@ class ExternalColumnDictionaryTestCase extends Spark2QueryTest with BeforeAndAft
     //  when csv delimiter is not comma
     carbonLoadModel = buildCarbonLoadModel(verticalDelimiteRelation, complexFilePath2,
       header2, extColDictFilePath3, "|")
-    GlobalDictionaryUtil.generateGlobalDictionary(sqlContext, carbonLoadModel,
-      verticalDelimiteRelation.carbonTable.getTablePath)
+    GlobalDictionaryUtil.generateGlobalDictionary(
+      sqlContext,
+      carbonLoadModel,
+      verticalDelimiteRelation.carbonTable.getTablePath,
+      FileFactory.getConfiguration)
     // check whether the dictionary is generated
     DictionaryTestCaseUtil.checkDictionary(
       verticalDelimiteRelation, "channelsId", "1431,")

--- a/streaming/src/main/scala/org/apache/carbondata/streaming/StreamSinkFactory.scala
+++ b/streaming/src/main/scala/org/apache/carbondata/streaming/StreamSinkFactory.scala
@@ -19,6 +19,7 @@ package org.apache.carbondata.streaming
 
 import scala.collection.JavaConverters._
 
+import org.apache.hadoop.conf.Configuration
 import org.apache.spark.scheduler.{SparkListener, SparkListenerApplicationEnd}
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.execution.streaming.{CarbonAppendableStreamSink, Sink}
@@ -42,6 +43,7 @@ object StreamSinkFactory {
 
   def createStreamTableSink(
       sparkSession: SparkSession,
+      hadoopConf: Configuration,
       carbonTable: CarbonTable,
       parameters: Map[String, String]): Sink = {
     validateParameters(parameters)
@@ -51,6 +53,7 @@ object StreamSinkFactory {
     // build load model
     val carbonLoadModel = buildCarbonLoadModelForStream(
       sparkSession,
+      hadoopConf,
       carbonTable,
       parameters,
       segmentId)
@@ -139,6 +142,7 @@ object StreamSinkFactory {
 
   private def buildCarbonLoadModelForStream(
       sparkSession: SparkSession,
+      hadoopConf: Configuration,
       carbonTable: CarbonTable,
       parameters: Map[String, String],
       segmentId: String): CarbonLoadModel = {
@@ -156,8 +160,8 @@ object StreamSinkFactory {
       carbonProperty,
       parameters,
       optionsFinal,
-      carbonLoadModel
-    )
+      carbonLoadModel,
+      hadoopConf)
     carbonLoadModel.setSegmentId(segmentId)
     // stream should use one pass
     val dictionaryServerPort = parameters.getOrElse(


### PR DESCRIPTION
Create configuration from SparkSession for data loading, so that we can set configuration into SparkSession during dataloading.

 - [x] Any interfaces changed?
 
 - [x] Any backward compatibility impacted?
 
 - [x] Document update required?

 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

