### PR TITLE
[CARBONDATA-1740][Pre-Aggregate] Fixed order by issue in case of preAggregate

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/AggregationDataMapSchema.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/AggregationDataMapSchema.java
@@ -93,7 +93,8 @@ public class AggregationDataMapSchema extends DataMapSchema {
     for (ColumnSchema columnSchema : listOfColumns) {
       List<ParentColumnTableRelation> parentColumnTableRelations =
           columnSchema.getParentColumnTableRelations();
-      if (parentColumnTableRelations.get(0).getColumnName().equals(columName)) {
+      if (null != parentColumnTableRelations && parentColumnTableRelations.size() == 1
+          && parentColumnTableRelations.get(0).getColumnName().equals(columName)) {
         return columnSchema;
       }
     }

--- a/core/src/main/java/org/apache/carbondata/core/preagg/QueryColumn.java
+++ b/core/src/main/java/org/apache/carbondata/core/preagg/QueryColumn.java
@@ -67,4 +67,28 @@ public class QueryColumn {
   public boolean isFilterColumn() {
     return isFilterColumn;
   }
+
+  @Override public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    QueryColumn that = (QueryColumn) o;
+    if (isFilterColumn != that.isFilterColumn) {
+      return false;
+    }
+    if (!columnSchema.equals(that.columnSchema)) {
+      return false;
+    }
+    return aggFunction != null ? aggFunction.equals(that.aggFunction) : that.aggFunction == null;
+  }
+
+  @Override public int hashCode() {
+    int result = columnSchema.hashCode();
+    result = 31 * result + (aggFunction != null ? aggFunction.hashCode() : 0);
+    result = 31 * result + (isFilterColumn ? 1 : 0);
+    return result;
+  }
 }

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggregateTableSelection.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggregateTableSelection.scala
@@ -150,6 +150,46 @@ class TestPreAggregateTableSelection extends QueryTest with BeforeAndAfterAll {
     val df = sql("select L_RETURNFLAG,L_LINESTATUS,sum(L_QUANTITY),sum(L_EXTENDEDPRICE) from lineitem group by L_RETURNFLAG, L_LINESTATUS")
     preAggTableValidator(df.queryExecution.analyzed, "lineitem_agr_lineitem")
   }
+  test("test PreAggregate table selection 20") {
+    val df = sql("select name from mainTable group by name order by name")
+    preAggTableValidator(df.queryExecution.analyzed, "maintable_agg0")
+  }
+
+  test("test PreAggregate table selection 21") {
+    val df = sql("select name as NewName from mainTable group by name order by name")
+    preAggTableValidator(df.queryExecution.analyzed, "maintable_agg0")
+  }
+
+  test("test PreAggregate table selection 22") {
+    val df = sql("select name, sum(age) from mainTable group by name order by name")
+    preAggTableValidator(df.queryExecution.analyzed, "maintable_agg1")
+  }
+
+  test("test PreAggregate table selection 23") {
+    val df = sql("select name as NewName, sum(age) as sum from mainTable group by name order by name")
+    preAggTableValidator(df.queryExecution.analyzed, "maintable_agg1")
+  }
+
+  test("test PreAggregate table selection 24") {
+    val df = sql("select name as NewName, sum(age) as sum from mainTable where name='vishal' group by name order by name")
+    preAggTableValidator(df.queryExecution.analyzed, "maintable_agg1")
+  }
+
+  test("test PreAggregate table selection 25") {
+    val df = sql("select name as NewName, sum(age) as sum from mainTable where city = 'Bangalore' group by name order by name")
+    preAggTableValidator(df.queryExecution.analyzed, "maintable")
+  }
+
+  test("test PreAggregate table selection 26") {
+    val df = sql("select name from mainTable where name='vishal' group by name order by name")
+    preAggTableValidator(df.queryExecution.analyzed, "maintable_agg0")
+  }
+
+  test("test PreAggregate table selection 27") {
+    val df = sql("select name as NewName from mainTable where name='vishal' group by name order by name")
+    preAggTableValidator(df.queryExecution.analyzed, "maintable_agg0")
+  }
+
 
   def preAggTableValidator(plan: LogicalPlan, actualTableName: String) : Unit ={
     var isValidPlan = false


### PR DESCRIPTION
**Problem:** Order by query is failing in case of pre aggregate table.
**Solution:** In pre aggregate rules order by scenario is not handled. Handling the same in this pr

 - [x] Any interfaces changed- 
No
 
 - [x] Any backward compatibility impacted-
 No
 
 - [x] Document update required-
 No

 - [x] Testing done
        Added UT test cases as part of TestPreAggregateTableSelection.scala to verify all the scenario in case of order by query
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

