### PR TITLE
[CARBONDATA-1797] Segment_Index compaction should take compaction lock to support concurrent scenarios better

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -93,6 +93,16 @@ object CarbonDataRDDFactory {
       LOGGER.info(s"Acquired the compaction lock for table ${ carbonLoadModel.getDatabaseName }" +
           s".${ carbonLoadModel.getTableName }")
       try {
+        if (compactionType == CompactionType.SEGMENT_INDEX_COMPACTION) {
+          // Just launch job to merge index and return
+          CommonUtil.mergeIndexFiles(sqlContext.sparkContext,
+            CarbonDataMergerUtil.getValidSegmentList(
+              carbonTable.getAbsoluteTableIdentifier).asScala,
+            carbonLoadModel.getTablePath,
+            carbonTable, true)
+          lock.unlock()
+          return
+        }
         startCompactionThreads(sqlContext,
           carbonLoadModel,
           storeLocation,


### PR DESCRIPTION
SEGMENT_INDEX compaction is not taking compaction lock. While concurrent operation, compaction may be successful but the output may not be as expected.

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [x] Testing done
        Manual testing
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

