### PR TITLE
[CARBONDATA-1803] Changing format of Show segments

### DIFF
--- a/integration/spark-common/src/main/scala/org/apache/carbondata/api/CarbonStore.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/api/CarbonStore.scala
@@ -92,8 +92,8 @@ object CarbonStore {
             load.getSegmentStatus.getMessage,
             startTime,
             endTime,
-            load.getFileFormat.toString,
-            mergedTo)
+            mergedTo,
+            load.getFileFormat.toString)
         }.toSeq
     } else {
       Seq.empty

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/GlobalDictionaryUtil.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/GlobalDictionaryUtil.scala
@@ -375,7 +375,7 @@ object GlobalDictionaryUtil {
       classOf[CSVInputFormat],
       classOf[NullWritable],
       classOf[StringArrayWritable],
-      hadoopConf).setName("global dictionary").map[Row] { currentRow =>
+      jobConf).setName("global dictionary").map[Row] { currentRow =>
       row.setValues(currentRow._2.get())
     }
     sqlContext.createDataFrame(rdd, schema)

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonCatalystOperators.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonCatalystOperators.scala
@@ -122,12 +122,12 @@ case class ShowLoadsCommand(
   extends Command {
 
   override def output: Seq[Attribute] = {
-    Seq(AttributeReference("Segment Id", StringType, nullable = false)(),
+    Seq(AttributeReference("SegmentSequenceId", StringType, nullable = false)(),
       AttributeReference("Status", StringType, nullable = false)(),
       AttributeReference("Load Start Time", TimestampType, nullable = false)(),
       AttributeReference("Load End Time", TimestampType, nullable = true)(),
-      AttributeReference("File Format", StringType, nullable = false)(),
-      AttributeReference("Merged To", StringType, nullable = false)())
+      AttributeReference("Merged To", StringType, nullable = false)(),
+      AttributeReference("File Format", StringType, nullable = false)())
   }
 }
 

--- a/integration/spark2/src/test/scala/org/apache/carbondata/spark/testsuite/segmentreading/TestSegmentReading.scala
+++ b/integration/spark2/src/test/scala/org/apache/carbondata/spark/testsuite/segmentreading/TestSegmentReading.scala
@@ -248,7 +248,7 @@ class TestSegmentReading extends QueryTest with BeforeAndAfterAll {
             |('DELIMITER'= ',', 'QUOTECHAR'= '\"')""".stripMargin)
       val df = sql("SHOW SEGMENTS for table carbon_table_show_seg")
       val col = df.collect().map{
-        row => Row(row.getString(0),row.getString(1),row.getString(5))
+        row => Row(row.getString(0),row.getString(1),row.getString(4))
       }.toSeq
       assert(col.equals(Seq(Row("2","Success","NA"),
         Row("1","Compacted","0.1"),

--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/TestStreamingTableOperation.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/TestStreamingTableOperation.scala
@@ -566,7 +566,7 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
     result.foreach { row =>
       if (row.getString(0).equals("1")) {
         assertResult(SegmentStatus.STREAMING.getMessage)(row.getString(1))
-        assertResult(FileFormat.ROW_V1.toString)(row.getString(4))
+        assertResult(FileFormat.ROW_V1.toString)(row.getString(5))
       }
     }
   }


### PR DESCRIPTION
Changing the show segments format for backward compatibility.
(1) File Format is a new option previously added in between, so moved the same to last
(2) Segment Id is again changed back to SegmentSequenceId

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [x] Testing done
       Manual Testing
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

