### PR TITLE
[CARBONDATA-1805][Dictionary] Optimize pruning for dictionary loading

### DIFF
--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/GlobalDictionaryUtil.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/GlobalDictionaryUtil.scala
@@ -356,8 +356,10 @@ object GlobalDictionaryUtil {
    * @param hadoopConf hadoop configuration
    * @return rdd that contains only dictionary columns
    */
-  private def loadInputDataAsDictRdd(sqlContext: SQLContext, carbonLoadModel: CarbonLoadModel,
-      inputDF: Option[DataFrame], requiredCols: Array[String],
+  private def loadInputDataAsDictRdd(sqlContext: SQLContext,
+      carbonLoadModel: CarbonLoadModel,
+      inputDF: Option[DataFrame],
+      requiredCols: Array[String],
       hadoopConf: Configuration): RDD[Row] = {
     if (inputDF.isDefined) {
       inputDF.get.select(requiredCols.head, requiredCols.tail : _*).rdd
@@ -379,7 +381,9 @@ object GlobalDictionaryUtil {
         classOf[CSVInputFormat],
         classOf[NullWritable],
         classOf[StringArrayWritable],
-        jobConf).setName("global dictionary").map[Row] { currentRow =>
+        jobConf)
+        .setName("global dictionary")
+        .map[Row] { currentRow =>
         val rawRow = currentRow._2.get()
         val destRow = new Array[String](dictColIdx.length)
         for (i <- dictColIdx.indices) {

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/GlobalDictionaryUtil.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/GlobalDictionaryUtil.scala
@@ -37,7 +37,6 @@ import org.apache.spark.{Accumulator, SparkException}
 import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.rdd.{NewHadoopRDD, RDD}
 import org.apache.spark.sql._
-import org.apache.spark.sql.types.{StringType, StructField, StructType}
 import org.apache.spark.util.FileUtils
 
 import org.apache.carbondata.common.logging.LogServiceFactory
@@ -348,36 +347,53 @@ object GlobalDictionaryUtil {
   }
 
   /**
-   * load CSV files to DataFrame by using datasource "com.databricks.spark.csv"
+   * load and prune dictionary Rdd from csv file or input dataframe
    *
-   * @param sqlContext      SQLContext
-   * @param carbonLoadModel carbon data load model
+   * @param sqlContext sqlContext
+   * @param carbonLoadModel carbonLoadModel
+   * @param inputDF input dataframe
+   * @param requiredCols names of dictionary column
+   * @param hadoopConf hadoop configuration
+   * @return rdd that contains only dictionary columns
    */
-  def loadDataFrame(sqlContext: SQLContext,
-      carbonLoadModel: CarbonLoadModel,
-      hadoopConf: Configuration): DataFrame = {
-    CommonUtil.configureCSVInputFormat(hadoopConf, carbonLoadModel)
-    hadoopConf.set(FileInputFormat.INPUT_DIR, carbonLoadModel.getFactFilePath)
-    val columnNames = carbonLoadModel.getCsvHeaderColumns
-    val schema = StructType(columnNames.map[StructField, Array[StructField]] { column =>
-      StructField(column, StringType)
-    })
-    val values = new Array[String](columnNames.length)
-    val row = new StringArrayRow(values)
-    val jobConf = new JobConf(hadoopConf)
-    SparkHadoopUtil.get.addCredentials(jobConf)
-    TokenCache.obtainTokensForNamenodes(jobConf.getCredentials,
-      Array[Path](new Path(carbonLoadModel.getFactFilePath)),
-      jobConf)
-    val rdd = new NewHadoopRDD[NullWritable, StringArrayWritable](
-      sqlContext.sparkContext,
-      classOf[CSVInputFormat],
-      classOf[NullWritable],
-      classOf[StringArrayWritable],
-      jobConf).setName("global dictionary").map[Row] { currentRow =>
-      row.setValues(currentRow._2.get())
+  private def loadInputDataAsDictRdd(sqlContext: SQLContext, carbonLoadModel: CarbonLoadModel,
+      inputDF: Option[DataFrame], requiredCols: Array[String],
+      hadoopConf: Configuration): RDD[Row] = {
+    if (inputDF.isDefined) {
+      inputDF.get.select(requiredCols.head, requiredCols.tail : _*).rdd
+    } else {
+      CommonUtil.configureCSVInputFormat(hadoopConf, carbonLoadModel)
+      hadoopConf.set(FileInputFormat.INPUT_DIR, carbonLoadModel.getFactFilePath)
+      val headerCols = carbonLoadModel.getCsvHeaderColumns.map(_.toLowerCase)
+      val header2Idx = headerCols.zipWithIndex.toMap
+      // index of dictionary columns in header
+      val dictColIdx = requiredCols.map(c => header2Idx(c.toLowerCase))
+
+      val jobConf = new JobConf(hadoopConf)
+      SparkHadoopUtil.get.addCredentials(jobConf)
+      TokenCache.obtainTokensForNamenodes(jobConf.getCredentials,
+        Array[Path](new Path(carbonLoadModel.getFactFilePath)),
+        jobConf)
+      val dictRdd = new NewHadoopRDD[NullWritable, StringArrayWritable](
+        sqlContext.sparkContext,
+        classOf[CSVInputFormat],
+        classOf[NullWritable],
+        classOf[StringArrayWritable],
+        jobConf).setName("global dictionary").map[Row] { currentRow =>
+        val rawRow = currentRow._2.get()
+        val destRow = new Array[String](dictColIdx.length)
+        for (i <- dictColIdx.indices) {
+          // dictionary index in this row
+          val idx = dictColIdx(i)
+          // copy specific dictionary value from source to dest
+          if (idx < rawRow.length) {
+            System.arraycopy(rawRow, idx, destRow, i, 1)
+          }
+        }
+        Row.fromSeq(destRow)
+      }
+      dictRdd
     }
-    sqlContext.createDataFrame(rdd, schema)
   }
 
   // Hack for spark2 integration
@@ -697,21 +713,25 @@ object GlobalDictionaryUtil {
         carbonTable.getTableName).asScala.toArray
       // generate global dict from pre defined column dict file
       carbonLoadModel.initPredefDictMap()
-
       val allDictionaryPath = carbonLoadModel.getAllDictPath
       if (StringUtils.isEmpty(allDictionaryPath)) {
         LOGGER.info("Generate global dictionary from source data files!")
         // load data by using dataSource com.databricks.spark.csv
-        var df = dataFrame.getOrElse(loadDataFrame(sqlContext, carbonLoadModel, hadoopConf))
-        var headers = carbonLoadModel.getCsvHeaderColumns
-        headers = headers.map(headerName => headerName.trim)
+        val headers = carbonLoadModel.getCsvHeaderColumns.map(_.trim)
         val colDictFilePath = carbonLoadModel.getColDictFilePath
         if (colDictFilePath != null) {
           // generate predefined dictionary
           generatePredefinedColDictionary(colDictFilePath, carbonTableIdentifier,
             dimensions, carbonLoadModel, sqlContext, tablePath, dictfolderPath)
         }
-        if (headers.length > df.columns.length) {
+
+        val headerOfInputData: Array[String] = if (dataFrame.isDefined) {
+          dataFrame.get.columns
+        } else {
+          headers
+        }
+
+        if (headers.length > headerOfInputData.length) {
           val msg = "The number of columns in the file header do not match the " +
                     "number of columns in the data file; Either delimiter " +
                     "or fileheader provided is not correct"
@@ -720,14 +740,15 @@ object GlobalDictionaryUtil {
         }
         // use fact file to generate global dict
         val (requireDimension, requireColumnNames) = pruneDimensions(dimensions,
-          headers, df.columns)
+          headers, headerOfInputData)
         if (requireDimension.nonEmpty) {
           // select column to push down pruning
-          df = df.select(requireColumnNames.head, requireColumnNames.tail: _*)
+          val dictRdd = loadInputDataAsDictRdd(sqlContext, carbonLoadModel, dataFrame,
+            requireColumnNames, hadoopConf)
           val model = createDictionaryLoadModel(carbonLoadModel, carbonTableIdentifier,
             requireDimension, tablePath, dictfolderPath, false)
           // combine distinct value in a block and partition by column
-          val inputRDD = new CarbonBlockDistinctValuesCombineRDD(df.rdd, model)
+          val inputRDD = new CarbonBlockDistinctValuesCombineRDD(dictRdd, model)
             .partitionBy(new ColumnPartitioner(model.primDimensions.length))
           // generate global dictionary files
           val statusList = new CarbonGlobalDictionaryGenerateRDD(inputRDD, model).collect()


### PR DESCRIPTION
Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [X] Any interfaces changed?
      `NO`
 - [X] Any backward compatibility impacted?
      `NO`
 - [X] Document update required?
      `NO`
 - [X] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        `NO TESTS ADDED, PERFORMANCE ENHANCEMENT DIDN'T AFFECT THE FUNCTIONALITY`
        - How it is tested? Please attach test report.
        `TESTED IN CLUSTER WITH REAL DATA. THE QUERY RESULT IS OK AND THE DICTIONARY FILE SIZE IS EXACTLY THE SAME AS THAT BEFORE OPTIMIZATION`
        - Is it a performance related change? Please attach the performance test report.
        `PERFORMANCE ENHANCED, DICTIONARY TIME REDUCED FROM 2.9MIN TO 29SEC`
        - Any additional information to help reviewers in testing this change.
        `NO`
 - [X] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
        `NOT RELATED`

COPY FROM JIRA
===

# SCENARIO

Recently I have tried dictionary feature in Carbondata and found its dictionary generating phase in data loading is quite slow. My scenario is as below:

+ Input Data: 35.8GB CSV file with 199 columns and 126 Million lines

+ Dictionary columns: 3 columns each containing 19213,4,9 distinct values

The whole data loading consumes about 2.9min for dictionary generating and 4.6min for fact data loading -- about 39% of the time are spent on dictionary.

Having observed the nmon result, Ifound the CPU usage were quite high during the dictionary generating phase and the Disk, Network were quite normal.

# ANALYZE

After I went through the dictionary generating related code, I found Carbondata aleady prune non-dictionary columns before generating dictionary. But the problem is that `the pruning comes after data file reading`, this will cause some overhead, we can optimize it by `prune while reading data file`.

# RESOLVE

Refactor the `loadDataFrame` method in `GlobalDictionaryUtil`, only pruning the non-dictionary columns while reading the data file.

After implementing the above optimization, the dictionary generating costs only `29s` -- **`about 6 times better than before`**(2.9min), and the fact data loading costs the same as before(4.6min), about 10% of the time are spent on dictionary.

I also tested the scenario that making the first, middle and last fields in the csv file be the dictionary column, the dictionary generating costs about 29s too.

# NOTE

+ Currently only `load data file` will benefit from this optimization, while `load data frame` will not.

+ Before implementing this solution, I tried another solution -- cache dataframe of the data file, the performance was even worse -- the dictionary generating time was 5.6min.
