### PR TITLE
[CARBONDATA-1802] Alter query fails if a column is dropped and there is no key column

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/schema/CarbonAlterTableDropColumnCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/schema/CarbonAlterTableDropColumnCommand.scala
@@ -70,7 +70,6 @@ private[sql] case class CarbonAlterTableDropColumnCommand(
       val tableColumns = carbonTable.getCreateOrderColumn(tableName).asScala
       var dictionaryColumns = Seq[org.apache.carbondata.core.metadata.schema.table.column
       .ColumnSchema]()
-      var keyColumnCountToBeDeleted = 0
       // TODO: if deleted column list includes bucketted column throw an error
       alterTableDropColumnModel.columns.foreach { column =>
         var columnExist = false
@@ -78,7 +77,6 @@ private[sql] case class CarbonAlterTableDropColumnCommand(
           // column should not be already deleted and should exist in the table
           if (!tableColumn.isInvisible && column.equalsIgnoreCase(tableColumn.getColName)) {
             if (tableColumn.isDimension) {
-              keyColumnCountToBeDeleted += 1
               if (tableColumn.hasEncoding(Encoding.DICTIONARY)) {
                 dictionaryColumns ++= Seq(tableColumn.getColumnSchema)
               }
@@ -89,14 +87,6 @@ private[sql] case class CarbonAlterTableDropColumnCommand(
         if (!columnExist) {
           sys.error(s"Column $column does not exists in the table $dbName.$tableName")
         }
-      }
-      // take the total key column count. key column to be deleted should not
-      // be >= key columns in schema
-      val totalKeyColumnInSchema = tableColumns.count {
-        tableColumn => !tableColumn.isInvisible && tableColumn.isDimension
-      }
-      if (keyColumnCountToBeDeleted >= totalKeyColumnInSchema) {
-        sys.error(s"Alter drop operation failed. AtLeast one key column should exist after drop.")
       }
 
       val operationContext = new OperationContext

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonCreateTableCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonCreateTableCommand.scala
@@ -71,7 +71,7 @@ case class CarbonCreateTableCommand(
         LOGGER.audit(
           s"Table creation with Database name [$dbName] and Table name [$tbName] failed. " +
           s"Table [$tbName] already exists under database [$dbName]")
-        throw new TableAlreadyExistsException(dbName, dbName)
+        throw new TableAlreadyExistsException(dbName, tbName)
       }
     } else {
       val tableIdentifier = AbsoluteTableIdentifier.from(tablePath, dbName, tbName)

--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/restructure/AlterTableValidationTestCase.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/restructure/AlterTableValidationTestCase.scala
@@ -44,6 +44,7 @@ class AlterTableValidationTestCase extends Spark2QueryTest with BeforeAndAfterAl
     sql("drop table if exists restructure_new")
     sql("drop table if exists restructure_bad")
     sql("drop table if exists restructure_badnew")
+    sql("drop table if exists allKeyCol")
     // clean data folder
     CarbonProperties.getInstance()
     sql(
@@ -149,6 +150,19 @@ class AlterTableValidationTestCase extends Spark2QueryTest with BeforeAndAfterAl
     checkExistence(sql("desc restructure"), true, "longfldbigint")
     checkExistence(sql("desc restructure"), true, "dblflddouble")
     checkExistence(sql("desc restructure"), true, "dcmldecimal(5,4)")
+  }
+
+  test("test drop all keycolumns in a table") {
+    sql(
+      "create table allKeyCol (name string, age int, address string) stored by 'org.apache" +
+      ".carbondata.format'")
+    try {
+      sql("alter table allKeyCol drop columns(name,address)")
+      assert(true)
+    } catch {
+      case _: Exception =>
+        assert(false)
+    }
   }
 
   ignore(
@@ -526,5 +540,6 @@ class AlterTableValidationTestCase extends Spark2QueryTest with BeforeAndAfterAl
     sql("drop table if exists uniqdata1")
     sql("drop table if exists defaultSortColumnsWithAlter")
     sql("drop table if exists specifiedSortColumnsWithAlter")
+    sql("drop table if exists allKeyCol")
   }
 }


### PR DESCRIPTION
(1) Alter query fails if a column is dropped and there is no key column
All key columns in a carbon table can be dropped, as we are supporting table creation with no keycolumn, alter also should be consistent with this.

(2) Table already exists exception is wrong. Corrected error message

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [X] Testing done
        UT Added
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

