### PR TITLE
[CARBONDATA-1610][Streaming] Reject alter table to disable streaming property

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/strategy/DDLStrategy.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/strategy/DDLStrategy.scala
@@ -156,11 +156,12 @@ class DDLStrategy(sparkSession: SparkSession) extends SparkStrategy {
       case AlterTableSetPropertiesCommand(tableName, properties, isView)
         if CarbonEnv.getInstance(sparkSession).carbonMetastore
           .tableExists(tableName)(sparkSession) => {
+        // TODO remove this limitation later
         val property = properties.find(_._1.equalsIgnoreCase("streaming"))
         if (property.isDefined) {
           if (!property.get._2.trim.equalsIgnoreCase("true")) {
             throw new MalformedCarbonCommandException(
-              "Unsupported alter table to disable streaming property")
+              "Streaming property can not be changed to 'false' once it is 'true'")
           }
         }
         ExecutedCommandExec(AlterTableSetCommand(tableName, properties, isView)) :: Nil
@@ -168,9 +169,10 @@ class DDLStrategy(sparkSession: SparkSession) extends SparkStrategy {
       case AlterTableUnsetPropertiesCommand(tableName, propKeys, ifExists, isView)
         if CarbonEnv.getInstance(sparkSession).carbonMetastore
           .tableExists(tableName)(sparkSession) => {
+        // TODO remove this limitation later
         if (propKeys.find(_.equalsIgnoreCase("streaming")).isDefined) {
           throw new MalformedCarbonCommandException(
-            "Unsupported alter table to unset streaming properties")
+            "Streaming property can not be removed")
         }
         ExecutedCommandExec(AlterTableUnsetCommand(tableName, propKeys, ifExists, isView)) :: Nil
       }


### PR DESCRIPTION
1. unsupported
ALTER TABLE stream_table_alter UNSET TBLPROPERTIES IF EXISTS ('streaming')
ALTER TABLE stream_table_alter SET TBLPROPERTIES('streaming'='false')

2. supported
ALTER TABLE stream_table_alter SET TBLPROPERTIES('streaming'='true')

 - [x] Any interfaces changed?
 no
 - [x] Any backward compatibility impacted?
 no
 - [x] Document update required?
no
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
          yes
        - How it is tested? Please attach test report.
         tested
        - Is it a performance related change? Please attach the performance test report.
          no
        - Any additional information to help reviewers in testing this change.
          yes
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA
