### PR TITLE
[CARBONDATA-1817] Reject creating datamap on streaming table

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonAlterTableCompactionCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonAlterTableCompactionCommand.scala
@@ -21,7 +21,7 @@ import scala.collection.JavaConverters._
 
 import org.apache.spark.sql.{CarbonEnv, Row, SparkSession, SQLContext}
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException
-import org.apache.spark.sql.execution.command.{AlterTableModel, CompactionModel, DataCommand, DataProcessOperation, RunnableCommand}
+import org.apache.spark.sql.execution.command.{AlterTableModel, CompactionModel, DataCommand}
 import org.apache.spark.sql.hive.CarbonRelation
 import org.apache.spark.sql.util.CarbonException
 

--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/TestStreamingTableOperation.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/TestStreamingTableOperation.scala
@@ -707,6 +707,15 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
     )
   }
 
+  test("do not support creating datamap on streaming table") {
+    assert(
+      intercept[MalformedCarbonCommandException](
+        sql("CREATE DATAMAP datamap ON TABLE source " +
+            "USING 'preaggregate'" +
+            " AS SELECT c1, sum(c2) FROM source GROUP BY c1")
+      ).getMessage.contains("Streaming table does not support creating datamap"))
+  }
+
   def createWriteSocketThread(
       serverSocket: ServerSocket,
       writeNums: Int,


### PR DESCRIPTION
Since streaming segment does not support building index and pre-aggregate yet, so streaming table should not support create datamap operation

 - [X] Any interfaces changed?
 No
 - [X] Any backward compatibility impacted?
 No
 - [X] Document update required?
No
 - [X] Testing done
One testcase added
 - [X] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA