### PR TITLE
[CARBONDATA-1818] Make carbon.streaming.segment.max.size as configurable

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -1412,6 +1412,22 @@ public final class CarbonCommonConstants {
 
   public static final String CARBON_SKIP_EMPTY_LINE_DEFAULT = "false";
 
+  /**
+   * if the byte size of streaming segment reach this value,
+   * the system will create a new stream segment
+   */
+  public static final String HANDOFF_SIZE = "carbon.streaming.segment.max.size";
+
+  /**
+   * the min handoff size of streaming segment, the unit is byte
+   */
+  public static final long HANDOFF_SIZE_MIN = 1024L * 1024 * 64;
+
+  /**
+   * the default handoff size of streaming segment, the unit is byte
+   */
+  public static final long HANDOFF_SIZE_DEFAULT = 1024L * 1024 * 1024;
+
   private CarbonCommonConstants() {
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
@@ -105,6 +105,7 @@ public final class CarbonProperties {
     validateEnableVectorReader();
     validateLockType();
     validateCarbonCSVReadBufferSizeByte();
+    validateHandoffSize();
   }
 
   private void validateCarbonCSVReadBufferSizeByte() {
@@ -253,6 +254,31 @@ public final class CarbonProperties {
             + CarbonCommonConstants.CARBON_PREFETCH_BUFFERSIZE_DEFAULT + "\"");
         carbonProperties.setProperty(CarbonCommonConstants.CARBON_PREFETCH_BUFFERSIZE,
             CarbonCommonConstants.CARBON_PREFETCH_BUFFERSIZE_DEFAULT);
+      }
+    }
+  }
+
+  private void validateHandoffSize() {
+    String handoffSizeStr = carbonProperties.getProperty(CarbonCommonConstants.HANDOFF_SIZE);
+    if (null == handoffSizeStr || handoffSizeStr.length() == 0) {
+      carbonProperties.setProperty(CarbonCommonConstants.HANDOFF_SIZE,
+          "" + CarbonCommonConstants.HANDOFF_SIZE_DEFAULT);
+    } else {
+      try {
+        long handoffSize = Long.parseLong(handoffSizeStr);
+        if (handoffSize < CarbonCommonConstants.HANDOFF_SIZE_MIN) {
+          LOGGER.info("The streaming segment max size configured value " + handoffSizeStr +
+              " is invalid. Using the default value "
+              + CarbonCommonConstants.HANDOFF_SIZE_DEFAULT);
+          carbonProperties.setProperty(CarbonCommonConstants.HANDOFF_SIZE,
+              "" + CarbonCommonConstants.HANDOFF_SIZE_DEFAULT);
+        }
+      } catch (NumberFormatException e) {
+        LOGGER.info("The streaming segment max size value \"" + handoffSizeStr
+            + "\" is invalid. Using the default value \""
+            + CarbonCommonConstants.HANDOFF_SIZE_DEFAULT + "\"");
+        carbonProperties.setProperty(CarbonCommonConstants.HANDOFF_SIZE,
+            "" + CarbonCommonConstants.HANDOFF_SIZE_DEFAULT);
       }
     }
   }
@@ -733,6 +759,21 @@ public final class CarbonProperties {
       batchSize = Integer.parseInt(CarbonCommonConstants.DATA_LOAD_BATCH_SIZE_DEFAULT);
     }
     return batchSize;
+  }
+
+  public long getHandoffSize() {
+    Long handoffSize;
+    try {
+      handoffSize = Long.parseLong(
+          CarbonProperties.getInstance().getProperty(
+              CarbonCommonConstants.HANDOFF_SIZE,
+              "" + CarbonCommonConstants.HANDOFF_SIZE_DEFAULT
+          )
+      );
+    } catch (NumberFormatException exc) {
+      handoffSize = CarbonCommonConstants.HANDOFF_SIZE_DEFAULT;
+    }
+    return handoffSize;
   }
 
   /**

--- a/core/src/test/java/org/apache/carbondata/core/CarbonPropertiesValidationTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/CarbonPropertiesValidationTest.java
@@ -145,4 +145,11 @@ public class CarbonPropertiesValidationTest extends TestCase {
     assertTrue(
         CarbonCommonConstants.CSV_READ_BUFFER_SIZE_DEFAULT.equalsIgnoreCase(valueAfterValidation));
   }
+
+  @Test public void testValidateHandoffSize() {
+    assertEquals(CarbonCommonConstants.HANDOFF_SIZE_DEFAULT, carbonProperties.getHandoffSize());
+    long newSize = 1024L * 1024 * 100;
+    carbonProperties.addProperty(CarbonCommonConstants.HANDOFF_SIZE, "" + newSize);
+    assertEquals(newSize, carbonProperties.getHandoffSize());
+  }
 }

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/streaming/CarbonStreamOutputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/streaming/CarbonStreamOutputFormat.java
@@ -53,22 +53,6 @@ public class CarbonStreamOutputFormat extends FileOutputFormat<Void, Object> {
 
   private static final String SEGMENT_ID = "carbon.segment.id";
 
-  /**
-   * if the byte size of streaming segment reach this value,
-   * the system will create a new stream segment
-   */
-  public static final String HANDOFF_SIZE = "carbon.streaming.segment.max.size";
-
-  /**
-   * the min handoff size of streaming segment, the unit is byte
-   */
-  public static final long HANDOFF_SIZE_MIN = 1024L * 1024 * 64;
-
-  /**
-   * the default handoff size of streaming segment, the unit is byte
-   */
-  public static final long HANDOFF_SIZE_DEFAULT = 1024L * 1024 * 1024;
-
   @Override public RecordWriter<Void, Object> getRecordWriter(TaskAttemptContext job)
       throws IOException, InterruptedException {
     return new CarbonStreamRecordWriter(job);

--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/TestStreamingTableOperation.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/TestStreamingTableOperation.scala
@@ -32,6 +32,7 @@ import org.apache.spark.sql.test.util.QueryTest
 import org.apache.spark.sql.types.StructType
 import org.scalatest.BeforeAndAfterAll
 
+import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.statusmanager.{FileFormat, SegmentStatus}
 import org.apache.carbondata.core.util.path.{CarbonStorePath, CarbonTablePath}
 import org.apache.carbondata.hadoop.streaming.CarbonStreamOutputFormat
@@ -759,7 +760,7 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
       tableIdentifier: TableIdentifier,
       badRecordAction: String = "force",
       intervalSecond: Int = 2,
-      handoffSize: Long = CarbonStreamOutputFormat.HANDOFF_SIZE_DEFAULT): Thread = {
+      handoffSize: Long = CarbonCommonConstants.HANDOFF_SIZE_DEFAULT): Thread = {
     new Thread() {
       override def run(): Unit = {
         var qry: StreamingQuery = null
@@ -779,7 +780,7 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
             .option("bad_records_action", badRecordAction)
             .option("dbName", tableIdentifier.database.get)
             .option("tableName", tableIdentifier.table)
-            .option(CarbonStreamOutputFormat.HANDOFF_SIZE, handoffSize)
+            .option(CarbonCommonConstants.HANDOFF_SIZE, handoffSize)
             .start()
           qry.awaitTermination()
         } catch {
@@ -806,7 +807,7 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
       continueSeconds: Int,
       generateBadRecords: Boolean,
       badRecordAction: String,
-      handoffSize: Long = CarbonStreamOutputFormat.HANDOFF_SIZE_DEFAULT
+      handoffSize: Long = CarbonCommonConstants.HANDOFF_SIZE_DEFAULT
   ): Unit = {
     val identifier = new TableIdentifier(tableName, Option("streaming"))
     val carbonTable = CarbonEnv.getInstance(spark).carbonMetastore.lookupRelation(identifier)(spark)

--- a/streaming/src/main/scala/org/apache/carbondata/streaming/StreamSinkFactory.scala
+++ b/streaming/src/main/scala/org/apache/carbondata/streaming/StreamSinkFactory.scala
@@ -79,18 +79,18 @@ object StreamSinkFactory {
   }
 
   private def validateParameters(parameters: Map[String, String]): Unit = {
-    val segmentSize = parameters.get(CarbonStreamOutputFormat.HANDOFF_SIZE)
+    val segmentSize = parameters.get(CarbonCommonConstants.HANDOFF_SIZE)
     if (segmentSize.isDefined) {
       try {
         val value = java.lang.Long.parseLong(segmentSize.get)
-        if (value < CarbonStreamOutputFormat.HANDOFF_SIZE_MIN) {
-          new CarbonStreamException(CarbonStreamOutputFormat.HANDOFF_SIZE +
+        if (value < CarbonCommonConstants.HANDOFF_SIZE_MIN) {
+          new CarbonStreamException(CarbonCommonConstants.HANDOFF_SIZE +
                                     "should be bigger than or equal " +
-                                    CarbonStreamOutputFormat.HANDOFF_SIZE_MIN)
+                                    CarbonCommonConstants.HANDOFF_SIZE_MIN)
         }
       } catch {
         case ex: NumberFormatException =>
-          new CarbonStreamException(CarbonStreamOutputFormat.HANDOFF_SIZE +
+          new CarbonStreamException(CarbonCommonConstants.HANDOFF_SIZE +
                                     s" $segmentSize is an illegal number")
       }
     }

--- a/streaming/src/main/scala/org/apache/spark/sql/execution/streaming/CarbonAppendableStreamSink.scala
+++ b/streaming/src/main/scala/org/apache/spark/sql/execution/streaming/CarbonAppendableStreamSink.scala
@@ -35,10 +35,12 @@ import org.apache.spark.util.{SerializableConfiguration, Utils}
 
 import org.apache.carbondata.common.CarbonIterator
 import org.apache.carbondata.common.logging.LogServiceFactory
+import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.datastore.impl.FileFactory
 import org.apache.carbondata.core.dictionary.server.DictionaryServer
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable
 import org.apache.carbondata.core.stats.QueryStatistic
+import org.apache.carbondata.core.util.CarbonProperties
 import org.apache.carbondata.core.util.path.CarbonStorePath
 import org.apache.carbondata.hadoop.streaming.CarbonStreamOutputFormat
 import org.apache.carbondata.hadoop.util.CarbonInputFormatUtil
@@ -74,8 +76,9 @@ class CarbonAppendableStreamSink(
   }
   // segment max size(byte)
   private val segmentMaxSize = hadoopConf.getLong(
-    CarbonStreamOutputFormat.HANDOFF_SIZE,
-    CarbonStreamOutputFormat.HANDOFF_SIZE_DEFAULT)
+    CarbonCommonConstants.HANDOFF_SIZE,
+    CarbonProperties.getInstance().getHandoffSize
+  )
 
   override def addBatch(batchId: Long, data: DataFrame): Unit = {
     if (batchId <= fileLog.getLatest().map(_._1).getOrElse(-1L)) {


### PR DESCRIPTION
 Make carbon.streaming.segment.max.size as configurable

 - [x] Any interfaces changed?
 no
 - [x] Any backward compatibility impacted?
 no
 - [x] Document update required?
 yes, should add carbon.streaming.segment.max.size property
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
         yes
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
 ok
