### PR TITLE
[CARBONDATA-1836][Spark-2.2] Carbon Spark2.2 Integration Resolve CatalogRelation

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonFileMetastore.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonFileMetastore.scala
@@ -146,7 +146,9 @@ class CarbonFileMetastore extends CarbonMetaStore {
       case LogicalRelation(
       carbonDatasourceHadoopRelation: CarbonDatasourceHadoopRelation, _, _) =>
         carbonDatasourceHadoopRelation.carbonRelation
-      case SubqueryAlias(_, c: CatalogRelation) if SPARK_VERSION.startsWith("2.2") =>
+      case SubqueryAlias(_, c) if SPARK_VERSION.startsWith("2.2") &&
+      (c.getClass.getName.equals("org.apache.spark.sql.catalyst.catalog.CatalogRelation") ||
+       c.getClass.getName.equals("org.apache.spark.sql.catalyst.catalog.HiveTableRelation")) =>
         val catalogTable = CarbonReflectionUtils.getFieldOfCatalogTable(
           "tableMeta",
           c).asInstanceOf[CatalogTable]

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonFileMetastore.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonFileMetastore.scala
@@ -149,8 +149,8 @@ class CarbonFileMetastore extends CarbonMetaStore {
       case SubqueryAlias(_, c) if SPARK_VERSION.startsWith("2.2") &&
       (c.getClass.getName.equals("org.apache.spark.sql.catalyst.catalog.CatalogRelation") ||
        c.getClass.getName.equals("org.apache.spark.sql.catalyst.catalog.HiveTableRelation") ||
-       c.getClass.getName
-         .equals("org.apache.spark.sql.catalyst.catalog.UnresolvedCatalogRelation")) =>
+       c.getClass.getName.equals(
+         "org.apache.spark.sql.catalyst.catalog.UnresolvedCatalogRelation")) =>
         val catalogTable = CarbonReflectionUtils.getFieldOfCatalogTable(
           "tableMeta",
           c).asInstanceOf[CatalogTable]

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonFileMetastore.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonFileMetastore.scala
@@ -148,7 +148,9 @@ class CarbonFileMetastore extends CarbonMetaStore {
         carbonDatasourceHadoopRelation.carbonRelation
       case SubqueryAlias(_, c) if SPARK_VERSION.startsWith("2.2") &&
       (c.getClass.getName.equals("org.apache.spark.sql.catalyst.catalog.CatalogRelation") ||
-       c.getClass.getName.equals("org.apache.spark.sql.catalyst.catalog.HiveTableRelation")) =>
+       c.getClass.getName.equals("org.apache.spark.sql.catalyst.catalog.HiveTableRelation") ||
+       c.getClass.getName
+         .equals("org.apache.spark.sql.catalyst.catalog.UnresolvedCatalogRelation")) =>
         val catalogTable = CarbonReflectionUtils.getFieldOfCatalogTable(
           "tableMeta",
           c).asInstanceOf[CatalogTable]

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonFileMetastore.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonFileMetastore.scala
@@ -146,14 +146,14 @@ class CarbonFileMetastore extends CarbonMetaStore {
       case LogicalRelation(
       carbonDatasourceHadoopRelation: CarbonDatasourceHadoopRelation, _, _) =>
         carbonDatasourceHadoopRelation.carbonRelation
-      case SubqueryAlias(_, c) if SPARK_VERSION.startsWith("2.2") &&
-      (c.getClass.getName.equals("org.apache.spark.sql.catalyst.catalog.CatalogRelation") ||
-       c.getClass.getName.equals("org.apache.spark.sql.catalyst.catalog.HiveTableRelation") ||
-       c.getClass.getName.equals(
-         "org.apache.spark.sql.catalyst.catalog.UnresolvedCatalogRelation")) =>
-        val catalogTable = CarbonReflectionUtils.getFieldOfCatalogTable(
-          "tableMeta",
-          c).asInstanceOf[CatalogTable]
+      case SubqueryAlias(_, c)
+        if SPARK_VERSION.startsWith("2.2") &&
+           (c.getClass.getName.equals("org.apache.spark.sql.catalyst.catalog.CatalogRelation") ||
+            c.getClass.getName.equals("org.apache.spark.sql.catalyst.catalog.HiveTableRelation") ||
+            c.getClass.getName.equals(
+              "org.apache.spark.sql.catalyst.catalog.UnresolvedCatalogRelation")) =>
+        val catalogTable =
+          CarbonReflectionUtils.getFieldOfCatalogTable("tableMeta", c).asInstanceOf[CatalogTable]
         catalogTable.provider match {
           case Some(name) if name.equals("org.apache.spark.sql.CarbonSource") => name
           case _ => throw new NoSuchTableException(database, tableIdentifier.table)


### PR DESCRIPTION
Code change in order to support change in CatalogRelation case class name change to HiveTableRelation. 

 - [ ] Any interfaces changed?
      No
 
 - [ ] Any backward compatibility impacted?
      No
 
 - [ ] Document update required?
      No

 - [ ] Testing done
      Yes
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
   NA
