### PR TITLE
[CARBONDATA-1837] Reusing origin row to reduce memory consumption

### DIFF
--- a/processing/src/main/java/org/apache/carbondata/processing/loading/row/CarbonRowBatch.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/row/CarbonRowBatch.java
@@ -61,4 +61,23 @@ public class CarbonRowBatch extends CarbonIterator<CarbonRow> {
   @Override public void remove() {
 
   }
+
+  /**
+   * set previous row, this can be used to set value for the RowBatch after iterating it. The
+   * `index` here is `index-1` because after we iterate this value, the `index` has increased by 1.
+   * @param row row
+   */
+  public void setPreviousRow(CarbonRow row) {
+    if (index == 0) {
+      throw new RuntimeException("Unable to set a row in RowBatch before index 0");
+    }
+    rowBatch[index - 1] = row;
+  }
+
+  /**
+   * rewind to the head, this can be used for reuse the origin batch instead of generating a new one
+   */
+  public void rewind() {
+    index = 0;
+  }
 }

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/steps/DataConverterProcessorStepImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/steps/DataConverterProcessorStepImpl.java
@@ -106,12 +106,14 @@ public class DataConverterProcessorStepImpl extends AbstractDataLoadProcessorSte
    * @return processed row.
    */
   protected CarbonRowBatch processRowBatch(CarbonRowBatch rowBatch, RowConverter localConverter) {
-    CarbonRowBatch newBatch = new CarbonRowBatch(rowBatch.getSize());
     while (rowBatch.hasNext()) {
-      newBatch.addRow(localConverter.convert(rowBatch.next()));
+      CarbonRow convertRow = localConverter.convert(rowBatch.next());
+      rowBatch.setPreviousRow(convertRow);
     }
-    rowCounter.getAndAdd(newBatch.getSize());
-    return newBatch;
+    rowCounter.getAndAdd(rowBatch.getSize());
+    // reuse the origin batch
+    rowBatch.rewind();
+    return rowBatch;
   }
 
   @Override

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/steps/DataConverterProcessorWithBucketingStepImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/steps/DataConverterProcessorWithBucketingStepImpl.java
@@ -128,16 +128,17 @@ public class DataConverterProcessorWithBucketingStepImpl extends AbstractDataLoa
    * @return processed row.
    */
   protected CarbonRowBatch processRowBatch(CarbonRowBatch rowBatch, RowConverter localConverter) {
-    CarbonRowBatch newBatch = new CarbonRowBatch(rowBatch.getSize());
     while (rowBatch.hasNext()) {
-      CarbonRow next = rowBatch.next();
-      short bucketNumber = (short) partitioner.getPartition(next.getData());
-      CarbonRow convertRow = localConverter.convert(next);
+      CarbonRow row = rowBatch.next();
+      short bucketNumber = (short) partitioner.getPartition(row.getData());
+      CarbonRow convertRow = localConverter.convert(row);
       convertRow.bucketNumber = bucketNumber;
-      newBatch.addRow(convertRow);
+      rowBatch.setPreviousRow(convertRow);
     }
-    rowCounter.getAndAdd(newBatch.getSize());
-    return newBatch;
+    rowCounter.getAndAdd(rowBatch.getSize());
+    // reuse the origin batch
+    rowBatch.rewind();
+    return rowBatch;
   }
 
   @Override


### PR DESCRIPTION
Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [X] Any interfaces changed?
  `ADDED TWO INTERFACE FOR CARBON_ROW_BATCH`
 - [X] Any backward compatibility impacted?
  `NO`
 - [X] Document update required?
  `NO`
 - [X] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        `NO. ONLY FOR OPTIMIZATION`
        - How it is tested? Please attach test report.
        `TESTED IN CLUSTER OF 3 NODES`
        - Is it a performance related change? Please attach the performance test report.
        `PERFORMANCE SHOULD BE ENHANCED A BIT, SINCE MEMORY CONSUMPTION IS REDUCED`
        - Any additional information to help reviewers in testing this change.
        `NO`
 - [X] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
        `NOT RELATED`

NOTES:
===
In data converting process of data loading, Carbondata will convert each row to another by batch.

Currently, it will create a new batch to store the converted rows, which I think can be optimized to reuse the old row batch's space, thus will reduce memory consumption and GC related overhead.

Tests have been done in my local cluster, enhancement gained is not obvious (maybe the tests didn't reach the memory shortage of the cluster), but the performance didn't become worse than that of before.