### PR TITLE
[CARBONDATA-1843]  Add configuration to enable dictionary and complex type

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -1434,6 +1434,14 @@ public final class CarbonCommonConstants {
    */
   public static final long HANDOFF_SIZE_DEFAULT = 1024L * 1024 * 1024;
 
+  public static final String ENABLE_DICTIONARY_SUPPORT = "carbon.enable.dictionary";
+
+  public static final String ENABLE_DICTIONARY_SUPPORT_DEFAULT = "true";
+
+  public static final String ENABLE_COMPLEX_TYPE_SUPPORT = "carbon.enable.complexType";
+
+  public static final String ENABLE_COMPLEX_TYPE_SUPPORT_DEFAULT = "true";
+
   private CarbonCommonConstants() {
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
@@ -989,4 +989,24 @@ public final class CarbonProperties {
   public Map<String, String> getAddedProperty() {
     return addedProperty;
   }
+
+  /**
+   * Return true if global dictionary support is enabled
+   */
+  public static boolean isDictionaryEnabled() {
+    String support = getInstance().getProperty(
+        CarbonCommonConstants.ENABLE_DICTIONARY_SUPPORT,
+        CarbonCommonConstants.ENABLE_DICTIONARY_SUPPORT_DEFAULT);
+    return support.equalsIgnoreCase("true");
+  }
+
+  /**
+   * Return true if complex type support is enabled
+   */
+  public static boolean isComplexTypeEnabled() {
+    String support = getInstance().getProperty(
+        CarbonCommonConstants.ENABLE_COMPLEX_TYPE_SUPPORT,
+        CarbonCommonConstants.ENABLE_COMPLEX_TYPE_SUPPORT_DEFAULT);
+    return support.equalsIgnoreCase("true");
+  }
 }

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestDataWithDicExcludeAndInclude.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestDataWithDicExcludeAndInclude.scala
@@ -17,7 +17,9 @@
 
 package org.apache.carbondata.spark.testsuite.dataload
 
+import org.apache.spark.sql.AnalysisException
 import org.scalatest.BeforeAndAfterAll
+
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.util.CarbonProperties
 import org.apache.spark.sql.test.util.QueryTest
@@ -86,6 +88,56 @@ class TestLoadDataWithDictionaryExcludeAndInclude extends QueryTest with BeforeA
     checkAnswer(
       sql("select ID from exclude_include_t3"), sql("select ID from exclude_include_hive_t3")
     )
+  }
+
+  test("test create table with dictionary property when dictionary is disabled") {
+    CarbonProperties.getInstance().addProperty(
+      CarbonCommonConstants.ENABLE_DICTIONARY_SUPPORT,
+      "false")
+    intercept[AnalysisException](
+      sql(
+        """
+          | CREATE TABLE t1 (id string, value int)
+          | STORED BY 'carbondata'
+          | TBLPROPERTIES ('dictionary_include'='id')
+        """.stripMargin)
+    )
+    CarbonProperties.getInstance().addProperty(
+      CarbonCommonConstants.ENABLE_DICTIONARY_SUPPORT,
+      CarbonCommonConstants.ENABLE_DICTIONARY_SUPPORT_DEFAULT)
+  }
+
+  test("test create external table should fail") {
+    intercept[AnalysisException](
+      sql(
+        """
+          | CREATE EXTERNAL TABLE t1 (id string, value int)
+          | STORED BY 'carbondata'
+        """.stripMargin)
+    )
+  }
+
+  test("test create table with complex type when complex type is disabled") {
+    CarbonProperties.getInstance().addProperty(
+      CarbonCommonConstants.ENABLE_COMPLEX_TYPE_SUPPORT,
+      "false")
+    intercept[AnalysisException](
+      sql(
+        """
+          | CREATE TABLE t1 (id string, complex array<string>, value int)
+          | STORED BY 'carbondata'
+        """.stripMargin)
+    )
+    intercept[AnalysisException](
+      sql(
+        """
+          | CREATE TABLE t1 (id string, complex struct<a1:string>, value int)
+          | STORED BY 'carbondata'
+        """.stripMargin)
+    )
+    CarbonProperties.getInstance().addProperty(
+      CarbonCommonConstants.ENABLE_COMPLEX_TYPE_SUPPORT,
+      CarbonCommonConstants.ENABLE_COMPLEX_TYPE_SUPPORT_DEFAULT)
   }
 
   override def afterAll {

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
@@ -60,7 +60,8 @@ class CarbonScanRDD(
     var filterExpression: Expression,
     identifier: AbsoluteTableIdentifier,
     @transient serializedTableInfo: Array[Byte],
-    @transient tableInfo: TableInfo, inputMetricsStats: InitInputMetrics)
+    @transient tableInfo: TableInfo,
+    inputMetricsStats: InitInputMetrics)
   extends CarbonRDDWithTableInfo[InternalRow](sc, Nil, serializedTableInfo) {
 
   private val queryId = sparkContext.getConf.get("queryId", System.nanoTime() + "")

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonDatasourceHadoopRelation.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonDatasourceHadoopRelation.scala
@@ -73,7 +73,7 @@ case class CarbonDatasourceHadoopRelation(
     requiredColumns.foreach(projection.addColumn)
     val inputMetricsStats: CarbonInputMetrics = new CarbonInputMetrics
     new CarbonScanRDD(
-      sqlContext.sparkContext,
+      sparkSession.sparkContext,
       projection,
       filterExpression.orNull,
       identifier,

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonShowLoadsCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonShowLoadsCommand.scala
@@ -33,8 +33,8 @@ case class CarbonShowLoadsCommand(
   override def output: Seq[Attribute] = {
     Seq(AttributeReference("SegmentSequenceId", StringType, nullable = false)(),
       AttributeReference("Status", StringType, nullable = false)(),
-      AttributeReference("Load Start Time", TimestampType, nullable = false)(),
-      AttributeReference("Load End Time", TimestampType, nullable = true)(),
+      AttributeReference("Load Start Time (GMT+0)", TimestampType, nullable = false)(),
+      AttributeReference("Load End Time (GMT+0)", TimestampType, nullable = true)(),
       AttributeReference("Merged To", StringType, nullable = false)(),
       AttributeReference("File Format", StringType, nullable = false)())
   }

--- a/integration/spark2/src/main/spark2.1/CarbonSessionState.scala
+++ b/integration/spark2/src/main/spark2.1/CarbonSessionState.scala
@@ -251,7 +251,8 @@ class CarbonSqlAstBuilder(conf: SQLConf, parser: CarbonSpark2SqlParser) extends
           ctx.partitionColumns,
           ctx.columns,
           ctx.tablePropertyList,
-          Option(ctx.STRING()).map(string))
+          Option(ctx.STRING()).map(string),
+          ctx.AS)
     } else {
       super.visitCreateTable(ctx)
     }

--- a/integration/spark2/src/main/spark2.2/CarbonSessionState.scala
+++ b/integration/spark2/src/main/spark2.2/CarbonSessionState.scala
@@ -248,7 +248,8 @@ class CarbonSqlAstBuilder(conf: SQLConf, parser: CarbonSpark2SqlParser) extends
           ctx.partitionColumns,
           ctx.columns,
           ctx.tablePropertyList,
-          Option(ctx.STRING()).map(string))
+          Option(ctx.STRING()).map(string),
+          ctx.AS)
     } else {
       super.visitCreateHiveTable(ctx)
     }


### PR DESCRIPTION
Improvement:
1. To improve usability, new carbon property is added to support dictionary and complex type, user can disable these features if not required
2. Block 'external', 'CTAS' syntax
3. Some other minor fix to catch exceptions

 - [X] Any interfaces changed?
 No
 - [X] Any backward compatibility impacted?
 No
 - [X] Document update required?
No
 - [X] Testing done
Yes
 - [X] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA