### PR TITLE
[CARBONDATA-1831] BAD_RECORDS: Data Loading with Action as Redirect & logger enable is not logging the logs in the defined path.

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/LocalCarbonFile.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/LocalCarbonFile.java
@@ -123,6 +123,7 @@ public class LocalCarbonFile implements CarbonFile {
   }
 
   public boolean renameTo(String changetoName) {
+    changetoName = getUpdatedFilePath(changetoName);
     return file.renameTo(new File(changetoName));
   }
 
@@ -318,6 +319,7 @@ public class LocalCarbonFile implements CarbonFile {
   @Override public DataOutputStream getDataOutputStream(String path, FileFactory.FileType fileType)
       throws IOException {
     path = path.replace("\\", "/");
+    path = getUpdatedFilePath(path);
     return new DataOutputStream(new BufferedOutputStream(new FileOutputStream(path)));
   }
 

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/DataLoadingUtil.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/DataLoadingUtil.scala
@@ -209,7 +209,7 @@ object DataLoadingUtil {
     val single_pass = optionsFinal("single_pass")
     val bad_records_logger_enable = optionsFinal("bad_records_logger_enable")
     val bad_records_action = optionsFinal("bad_records_action")
-    val bad_record_path = optionsFinal("bad_record_path")
+    var bad_record_path = optionsFinal("bad_record_path")
     val global_sort_partitions = optionsFinal("global_sort_partitions")
     val timestampformat = optionsFinal("timestampformat")
     val dateFormat = optionsFinal("dateformat")
@@ -224,6 +224,7 @@ object DataLoadingUtil {
 
     if (bad_records_logger_enable.toBoolean ||
         LoggerAction.REDIRECT.name().equalsIgnoreCase(bad_records_action)) {
+      bad_record_path = CarbonUtil.checkAndAppendHDFSUrl(bad_record_path)
       if (!CarbonUtil.isValidBadStorePath(bad_record_path)) {
         CarbonException.analysisException("Invalid bad records location.")
       }


### PR DESCRIPTION
Current system expects the carbon.badRecords.location to be absolute path with filescheme.
But, it should support absolute path without file scheme(eg.: hdfs://, viewfs://)

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [x] Testing done
        Manual Testing
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

