### PR TITLE
[CARBONDATA-1737] [CARBONDATA-1760] [PreAgg] Fixed partial load issue if user has set segments to access on parent table

### DIFF
--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
@@ -359,14 +359,20 @@ class CarbonScanRDD(
     }
     val carbonSessionInfo = ThreadLocalSessionInfo.getCarbonSessionInfo
     if (carbonSessionInfo != null) {
-      CarbonTableInputFormat.setAggeragateTableSegments(conf, carbonSessionInfo.getSessionParams
-        .getProperty(CarbonCommonConstants.CARBON_INPUT_SEGMENTS +
-                     identifier.getCarbonTableIdentifier.getDatabaseName + "." +
-                     identifier.getCarbonTableIdentifier.getTableName, ""))
-      CarbonTableInputFormat.setValidateSegmentsToAccess(conf, carbonSessionInfo.getSessionParams
-          .getProperty(CarbonCommonConstants.VALIDATE_CARBON_INPUT_SEGMENTS +
-                       identifier.getCarbonTableIdentifier.getDatabaseName + "." +
-                       identifier.getCarbonTableIdentifier.getTableName, "true").toBoolean)
+      val segmentsToScan = carbonSessionInfo.getSessionParams.getProperty(
+        CarbonCommonConstants.CARBON_INPUT_SEGMENTS +
+        identifier.getCarbonTableIdentifier.getDatabaseName + "." +
+        identifier.getCarbonTableIdentifier.getTableName)
+      if (segmentsToScan != null) {
+        CarbonTableInputFormat.setAggeragateTableSegments(conf, segmentsToScan)
+      }
+      val validateSegments = carbonSessionInfo.getSessionParams.getProperty(
+        CarbonCommonConstants.VALIDATE_CARBON_INPUT_SEGMENTS +
+        identifier.getCarbonTableIdentifier.getDatabaseName + "." +
+        identifier.getCarbonTableIdentifier.getTableName)
+      if (validateSegments != null) {
+        CarbonTableInputFormat.setValidateSegmentsToAccess(conf, validateSegments.toBoolean)
+      }
     }
     format
   }


### PR DESCRIPTION
Analysis: Partial load was happening on pre-aggregate table when the user has set segments to access for the parent table.

Solution: Set segments to access to * before firing load for child table.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 No
 - [x] Any backward compatibility impacted?
 No
 - [x] Document update required?
No
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

