### PR TITLE
[CARBONDATA-1592] Added Event Listeners & Removed Unnecessary parameters in the events

### DIFF
--- a/integration/spark-common/src/main/scala/org/apache/carbondata/events/AlterTableEvents.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/events/AlterTableEvents.scala
@@ -16,12 +16,16 @@
  */
 package org.apache.carbondata.events
 
+import java.util
+
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.SQLContext
 import org.apache.spark.sql.execution.command.{AlterTableAddColumnsModel, AlterTableDataTypeChangeModel, AlterTableDropColumnModel, AlterTableRenameModel, CarbonMergerMapping}
 
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable
+import org.apache.carbondata.core.statusmanager.LoadMetadataDetails
 import org.apache.carbondata.processing.loading.model.CarbonLoadModel
+import org.apache.carbondata.processing.merger.CompactionType
 
 /**
  *
@@ -144,37 +148,53 @@ case class AlterTableRenameAbortEvent(
     sparkSession: SparkSession) extends Event with AlterTableRenameEventInfo
 
 
-case class AlterTableCompactionPreEvent(
+/**
+ * Event for handling pre compaction operations, lister has to implement this event on pre execution
+ *
+ * @param sparkSession
+ * @param carbonTable
+ */
+case class AlterTableCompactionPreEvent(sparkSession: SparkSession,
     carbonTable: CarbonTable,
     carbonMergerMapping: CarbonMergerMapping,
-    mergedLoadName: String,
-    sqlContext: SQLContext) extends Event with AlterTableCompactionEventInfo
-
+    mergedLoadName: String) extends Event with AlterTableCompactionEventInfo
 
 /**
+ * Compaction Event for handling pre update status file opeartions, lister has to implement this
+ * event before updating the table status file
+ * @param sparkSession
+ * @param carbonTable
+ * @param carbonMergerMapping
+ * @param mergedLoadName
+ */
+case class AlterTableCompactionPostEvent(sparkSession: SparkSession,
+    carbonTable: CarbonTable,
+    carbonMergerMapping: CarbonMergerMapping,
+    mergedLoadName: String) extends Event with AlterTableCompactionEventInfo
+/**
+ * Compaction Event for handling pre update status file opeartions, lister has to implement this
+ * event before updating the table status file
+ * @param sparkSession
+ * @param carbonTable
+ * @param carbonMergerMapping
+ * @param carbonLoadModel
+ * @param mergedLoadName
+ */
+case class AlterTableCompactionPreStatusUpdateEvent(sparkSession: SparkSession,
+    carbonTable: CarbonTable,
+    carbonMergerMapping: CarbonMergerMapping,
+    carbonLoadModel: CarbonLoadModel,
+    mergedLoadName: String) extends Event with AlterTableCompactionStatusUpdateEventInfo
+
+/**
+ * Compaction Event for handling clean up in case of any compaction failure and abort the
+ * operation, lister has to implement this event to handle failure scenarios
  *
  * @param carbonTable
  * @param carbonMergerMapping
  * @param mergedLoadName
- * @param sQLContext
  */
-case class AlterTableCompactionPostEvent(
+case class AlterTableCompactionAbortEvent(sparkSession: SparkSession,
     carbonTable: CarbonTable,
     carbonMergerMapping: CarbonMergerMapping,
-    mergedLoadName: String,
-    sQLContext: SQLContext) extends Event with AlterTableCompactionEventInfo
-
-
-/**
- * Class for handling clean up in case of any failure and abort the operation
- *
- * @param carbonTable
- * @param carbonMergerMapping
- * @param mergedLoadName
- * @param sQLContext
- */
-case class AlterTableCompactionAbortEvent(
-    carbonTable: CarbonTable,
-    carbonMergerMapping: CarbonMergerMapping,
-    mergedLoadName: String,
-    sQLContext: SQLContext) extends Event with AlterTableCompactionEventInfo
+    mergedLoadName: String) extends Event with AlterTableCompactionEventInfo

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/events/Events.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/events/Events.scala
@@ -93,10 +93,18 @@ trait AlterTableAddColumnEventInfo {
 /**
  * event for alter_table_rename
  */
-trait AlterTableCompactionEventInfo {
+trait AlterTableCompactionStatusUpdateEventInfo {
   val carbonTable: CarbonTable
   val carbonMergerMapping: CarbonMergerMapping
   val mergedLoadName: String
+}
+
+/**
+ * event for alter_table_compaction
+ */
+trait AlterTableCompactionEventInfo {
+  val sparkSession: SparkSession
+  val carbonTable: CarbonTable
 }
 
 /**

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/events/LoadEvents.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/events/LoadEvents.scala
@@ -45,8 +45,8 @@ case class LoadTablePostExecutionEvent(sparkSession: SparkSession,
     carbonLoadModel: CarbonLoadModel) extends Event with LoadEventInfo
 
 /**
- * Class for handling operations after data load completion and before final commit of load
- * operation. Example usage: For loading pre-aggregate tables
+ * Event for handling operations after data load completion and before final
+ * commit of load operation. Example usage: For loading pre-aggregate tables
  */
 case class LoadTablePreStatusUpdateEvent(sparkSession: SparkSession,
     carbonTableIdentifier: CarbonTableIdentifier,

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSession.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSession.scala
@@ -271,7 +271,7 @@ object CarbonSession {
       .addListener(classOf[AlterTableAddColumnPreEvent], PreAggregateAddColumnsPreListener)
       .addListener(classOf[DropDataMapPostEvent], DropDataMapPostListener)
       .addListener(classOf[LoadTablePreExecutionEvent], LoadPreAggregateTablePreListener)
-      .addListener(classOf[AlterTableCompactionPostEvent],
+      .addListener(classOf[AlterTableCompactionPreStatusUpdateEvent],
         AlterPreAggregateTableCompactionPostListener)
   }
 }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/preaaggregate/PreAggregateListeners.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/preaaggregate/PreAggregateListeners.scala
@@ -70,10 +70,10 @@ object AlterPreAggregateTableCompactionPostListener extends OperationEventListen
    * @param operationContext
    */
   override def onEvent(event: Event, operationContext: OperationContext): Unit = {
-    val compactionEvent = event.asInstanceOf[AlterTableCompactionPostEvent]
+    val compactionEvent = event.asInstanceOf[AlterTableCompactionPreStatusUpdateEvent]
     val carbonTable = compactionEvent.carbonTable
     val compactionType = compactionEvent.carbonMergerMapping.campactionType
-    val sparkSession = compactionEvent.sQLContext.sparkSession
+    val sparkSession = compactionEvent.sparkSession
     if (carbonTable.hasDataMapSchema) {
       carbonTable.getTableInfo.getDataMapSchemaList.asScala.foreach { dataMapSchema =>
         val childRelationIdentifier = dataMapSchema.getRelationIdentifier

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/schema/CarbonAlterTableRenameCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/schema/CarbonAlterTableRenameCommand.scala
@@ -17,7 +17,9 @@
 
 package org.apache.spark.sql.execution.command.schema
 
+import org.apache.hadoop.fs.Path
 import org.apache.spark.sql._
+import org.apache.spark.sql.{CarbonEnv, CarbonSession, Row, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.execution.command.{AlterTableRenameModel, MetadataCommand}
 import org.apache.spark.sql.hive.{CarbonRelation, CarbonSessionCatalog, HiveExternalCatalog}
@@ -170,12 +172,14 @@ private[sql] case class CarbonAlterTableRenameCommand(
       AlterTableUtil.releaseLocks(locks)
       // case specific to rename table as after table rename old table path will not be found
       if (carbonTable != null) {
+        val newTablePath = CarbonUtil
+          .getNewTablePath(new Path(carbonTable.getTablePath), newTableName)
         AlterTableUtil
           .releaseLocksManually(locks,
             locksToBeAcquired,
             oldDatabaseName,
             newTableName,
-            carbonTable.getTablePath)
+            newTablePath)
       }
     }
     Seq.empty


### PR DESCRIPTION
Description : 
1. Added AlterTableCompactionPreStatusUpdateEvent :
 This event will be used if we want to perform some operations before updating the table status file

Example : alter table test compact 'major';

After executing above query if we want to handle any operation before updating the table status file we can use AlterTableCompactionPreStatusUpdateEvent 


2. Changed compaction Event params
Removed all unnecessary params in the compaction pre & post Events
Example : alter table test compact 'major';

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

