### PR TITLE
[CARBONDATA-1854] Add support for implicit column filter

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/DataRefNode.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/DataRefNode.java
@@ -128,4 +128,12 @@ public interface DataRefNode {
    * @return
    */
   int numberOfPages();
+
+  /**
+   * Return the number of rows for a give page
+   *
+   * @param pageNumber
+   * @return
+   */
+  int getPageRowCount(int pageNumber);
 }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/impl/btree/AbstractBTreeLeafNode.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/impl/btree/AbstractBTreeLeafNode.java
@@ -239,4 +239,9 @@ public abstract class AbstractBTreeLeafNode implements BTreeNode {
   public BlockletLevelDeleteDeltaDataCache getDeleteDeltaDataCache() {
     return deleteDeltaDataCache;
   }
+
+  @Override
+  public int getPageRowCount(int pageNumber) {
+    throw new UnsupportedOperationException("Unsupported operation");
+  }
 }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/impl/btree/BTreeNonLeafNode.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/impl/btree/BTreeNonLeafNode.java
@@ -254,4 +254,9 @@ public class BTreeNonLeafNode implements BTreeNode {
     // TODO Auto-generated method stub
     throw new UnsupportedOperationException("Unsupported operation");
   }
+
+  @Override
+  public int getPageRowCount(int pageNumber) {
+    throw new UnsupportedOperationException("Unsupported operation");
+  }
 }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/impl/btree/BlockletBTreeLeafNode.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/impl/btree/BlockletBTreeLeafNode.java
@@ -18,6 +18,7 @@ package org.apache.carbondata.core.datastore.impl.btree;
 
 import java.io.IOException;
 
+import org.apache.carbondata.core.constants.CarbonV3DataFormatConstants;
 import org.apache.carbondata.core.datastore.BTreeBuilderInfo;
 import org.apache.carbondata.core.datastore.FileHolder;
 import org.apache.carbondata.core.datastore.chunk.impl.DimensionRawColumnChunk;
@@ -46,6 +47,8 @@ public class BlockletBTreeLeafNode extends AbstractBTreeLeafNode {
    * number of pages in blocklet
    */
   private int numberOfPages;
+
+  private int[] pageRowCount;
 
   /**
    * Create a leaf node
@@ -82,6 +85,17 @@ public class BlockletBTreeLeafNode extends AbstractBTreeLeafNode {
     this.nodeNumber = nodeNumber;
     this.numberOfPages =
         builderInfos.getFooterList().get(0).getBlockletList().get(leafIndex).getNumberOfPages();
+    this.pageRowCount = new int[numberOfPages];
+    int numberOfPagesCompletelyFilled =
+        numberOfKeys / CarbonV3DataFormatConstants.NUMBER_OF_ROWS_PER_BLOCKLET_COLUMN_PAGE_DEFAULT;
+    int lastPageRowCount =
+        numberOfKeys % CarbonV3DataFormatConstants.NUMBER_OF_ROWS_PER_BLOCKLET_COLUMN_PAGE_DEFAULT;
+    for (int i = 0; i < numberOfPagesCompletelyFilled; i++) {
+      pageRowCount[i] = CarbonV3DataFormatConstants.NUMBER_OF_ROWS_PER_BLOCKLET_COLUMN_PAGE_DEFAULT;
+    }
+    if (lastPageRowCount > 0) {
+      pageRowCount[pageRowCount.length - 1] = lastPageRowCount;
+    }
   }
 
   /**
@@ -137,5 +151,9 @@ public class BlockletBTreeLeafNode extends AbstractBTreeLeafNode {
    */
   @Override public int numberOfPages() {
     return numberOfPages;
+  }
+
+  @Override public int getPageRowCount(int pageNumber) {
+    return this.pageRowCount[pageNumber];
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/metadata/blocklet/BlockletInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/blocklet/BlockletInfo.java
@@ -87,6 +87,8 @@ public class BlockletInfo implements Serializable, Writable {
    */
   private int numberOfPages = 1;
 
+  private int[] numberOfRowsPerPage;
+
   /**
    * @return the numberOfRows
    */
@@ -306,5 +308,13 @@ public class BlockletInfo implements Serializable, Writable {
       input.readFully(bytes);
       measureColumnChunk.add(deserializeDataChunk(bytes));
     }
+  }
+
+  public int[] getNumberOfRowsPerPage() {
+    return numberOfRowsPerPage;
+  }
+
+  public void setNumberOfRowsPerPage(int[] numberOfRowsPerPage) {
+    this.numberOfRowsPerPage = numberOfRowsPerPage;
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/ColumnFilterInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/ColumnFilterInfo.java
@@ -18,7 +18,11 @@
 package org.apache.carbondata.core.scan.filter;
 
 import java.io.Serializable;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+
+import org.apache.carbondata.core.constants.CarbonCommonConstants;
 
 public class ColumnFilterInfo implements Serializable {
 
@@ -33,6 +37,7 @@ public class ColumnFilterInfo implements Serializable {
    */
   private List<String> implicitColumnFilterList;
   private List<Integer> excludeFilterList;
+  private transient Set<String> implicitDriverColumnFilterList;
   /**
    * maintain the no dictionary filter values list.
    */
@@ -86,6 +91,7 @@ public class ColumnFilterInfo implements Serializable {
 
   public void setImplicitColumnFilterList(List<String> implicitColumnFilterList) {
     this.implicitColumnFilterList = implicitColumnFilterList;
+    populateBlockIdListForDriverBlockPruning();
   }
 
   public List<Object> getMeasuresFilterValuesList() {
@@ -94,5 +100,19 @@ public class ColumnFilterInfo implements Serializable {
 
   public void setMeasuresFilterValuesList(List<Object> measuresFilterValuesList) {
     this.measuresFilterValuesList = measuresFilterValuesList;
+  }
+
+  public Set<String> getImplicitDriverColumnFilterList() {
+    return implicitDriverColumnFilterList;
+  }
+
+  private void populateBlockIdListForDriverBlockPruning() {
+    implicitDriverColumnFilterList = new HashSet<>(implicitColumnFilterList.size());
+    String blockId = null;
+    for (String blockletId : implicitColumnFilterList) {
+      blockId =
+          blockletId.substring(0, blockletId.lastIndexOf(CarbonCommonConstants.FILE_SEPARATOR));
+      implicitDriverColumnFilterList.add(blockId);
+    }
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/AndFilterExecuterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/AndFilterExecuterImpl.java
@@ -24,7 +24,7 @@ import org.apache.carbondata.core.scan.filter.intf.RowIntf;
 import org.apache.carbondata.core.scan.processor.BlocksChunkHolder;
 import org.apache.carbondata.core.util.BitSetGroup;
 
-public class AndFilterExecuterImpl implements FilterExecuter {
+public class AndFilterExecuterImpl implements FilterExecuter, ImplicitColumnFilterExecutor {
 
   private FilterExecuter leftExecuter;
   private FilterExecuter rightExecuter;
@@ -72,5 +72,64 @@ public class AndFilterExecuterImpl implements FilterExecuter {
   @Override public void readBlocks(BlocksChunkHolder blocksChunkHolder) throws IOException {
     leftExecuter.readBlocks(blocksChunkHolder);
     rightExecuter.readBlocks(blocksChunkHolder);
+  }
+
+  @Override
+  public BitSet isFilterValuesPresentInBlockOrBlocklet(byte[][] maxValue, byte[][] minValue,
+      String uniqueBlockPath) {
+    BitSet leftFilters = null;
+    if (leftExecuter instanceof ImplicitColumnFilterExecutor) {
+      leftFilters = ((ImplicitColumnFilterExecutor) leftExecuter)
+          .isFilterValuesPresentInBlockOrBlocklet(maxValue, minValue,uniqueBlockPath);
+    } else {
+      leftFilters = leftExecuter
+          .isScanRequired(maxValue, minValue);
+    }
+    if (leftFilters.isEmpty()) {
+      return leftFilters;
+    }
+    BitSet rightFilter = null;
+    if (rightExecuter instanceof ImplicitColumnFilterExecutor) {
+      rightFilter = ((ImplicitColumnFilterExecutor) rightExecuter)
+          .isFilterValuesPresentInBlockOrBlocklet(maxValue, minValue, uniqueBlockPath);
+    } else {
+      rightFilter = rightExecuter
+          .isScanRequired(maxValue, minValue);
+    }
+    if (rightFilter.isEmpty()) {
+      return rightFilter;
+    }
+    leftFilters.and(rightFilter);
+    return leftFilters;
+  }
+
+  @Override
+  public Boolean isFilterValuesPresentInAbstractIndex(byte[][] maxValue, byte[][] minValue) {
+    Boolean leftRes;
+    BitSet tempFilter;
+    if (leftExecuter instanceof ImplicitColumnFilterExecutor) {
+      leftRes = ((ImplicitColumnFilterExecutor) leftExecuter)
+          .isFilterValuesPresentInAbstractIndex(maxValue, minValue);
+    } else {
+      tempFilter = leftExecuter
+          .isScanRequired(maxValue, minValue);
+      leftRes = !tempFilter.isEmpty();
+    }
+    if (!leftRes) {
+      return leftRes;
+    }
+
+    Boolean rightRes = null;
+    if (rightExecuter instanceof ImplicitColumnFilterExecutor) {
+      rightRes = ((ImplicitColumnFilterExecutor) rightExecuter)
+          .isFilterValuesPresentInAbstractIndex(maxValue, minValue);
+    } else {
+      tempFilter = rightExecuter
+          .isScanRequired(maxValue, minValue);
+      rightRes = !tempFilter.isEmpty();
+    }
+
+    // Equivalent to leftRes && rightRes.
+    return rightRes;
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/ImplicitColumnFilterExecutor.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/ImplicitColumnFilterExecutor.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.core.scan.filter.executer;
+
+import java.util.BitSet;
+
+/**
+ * Implementation of this interface will involve block
+ * and blocklet pruning based on block/blocklet id where
+ * the filter values are present.
+ */
+public interface ImplicitColumnFilterExecutor {
+
+  /**
+   * This method will validate the block or blocklet id with the implicit
+   * column filter value list and decide whether the required block or
+   * blocklet has to be scanned for the data or not
+   *
+   * @param uniqueBlockPath
+   * @return
+   */
+  BitSet isFilterValuesPresentInBlockOrBlocklet(byte[][] maxValue, byte[][] minValue,
+      String uniqueBlockPath);
+
+  /**
+   * This method will validate the abstract index
+   * and decide whether the index is valid for scanning or not.
+   * Implicit index is always considered valid as it can be decided at block level.
+   *
+   * @return
+   */
+  Boolean isFilterValuesPresentInAbstractIndex(byte[][] maxValue, byte[][] minValue);
+}

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/ImplicitIncludeFilterExecutorImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/ImplicitIncludeFilterExecutorImpl.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.core.scan.filter.executer;
+
+import java.io.IOException;
+import java.util.BitSet;
+
+import org.apache.carbondata.core.scan.expression.exception.FilterUnsupportedException;
+import org.apache.carbondata.core.scan.filter.intf.RowIntf;
+import org.apache.carbondata.core.scan.filter.resolver.resolverinfo.DimColumnResolvedFilterInfo;
+import org.apache.carbondata.core.scan.processor.BlocksChunkHolder;
+import org.apache.carbondata.core.util.BitSetGroup;
+import org.apache.carbondata.core.util.path.CarbonTablePath;
+
+/**
+ * This class will implement the blocklet and block pruning logic based
+ * on the implicit column filter values
+ */
+public class ImplicitIncludeFilterExecutorImpl
+    implements FilterExecuter, ImplicitColumnFilterExecutor {
+
+  private final DimColumnResolvedFilterInfo dimColumnEvaluatorInfo;
+
+  public ImplicitIncludeFilterExecutorImpl(DimColumnResolvedFilterInfo dimColumnEvaluatorInfo) {
+    this.dimColumnEvaluatorInfo = dimColumnEvaluatorInfo;
+  }
+
+  @Override
+  public BitSetGroup applyFilter(BlocksChunkHolder blockChunkHolder, boolean useBitsetPipeline)
+      throws FilterUnsupportedException {
+    BitSetGroup bitSetGroup = new BitSetGroup(blockChunkHolder.getDataBlock().numberOfPages());
+    for (int i = 0; i < blockChunkHolder.getDataBlock().numberOfPages(); i++) {
+      bitSetGroup.setBitSet(
+          setBitSetForCompleteDimensionData(blockChunkHolder.getDataBlock().getPageRowCount(i)), i);
+    }
+    return bitSetGroup;
+  }
+
+  @Override public boolean applyFilter(RowIntf value, int dimOrdinalMax)
+      throws FilterUnsupportedException, IOException {
+    return false;
+  }
+
+  @Override public BitSet isScanRequired(byte[][] blockMaxValue, byte[][] blockMinValue) {
+    return null;
+  }
+
+  @Override public void readBlocks(BlocksChunkHolder blockChunkHolder) throws IOException {
+
+  }
+
+  @Override
+  public BitSet isFilterValuesPresentInBlockOrBlocklet(byte[][] maxValue, byte[][] minValue,
+      String uniqueBlockPath) {
+    BitSet bitSet = new BitSet(1);
+    boolean isScanRequired = false;
+    String shortBlockId = CarbonTablePath.getShortBlockId(uniqueBlockPath);
+    if (uniqueBlockPath.endsWith(".carbondata")) {
+      if (dimColumnEvaluatorInfo.getFilterValues().getImplicitDriverColumnFilterList()
+          .contains(shortBlockId)) {
+        isScanRequired = true;
+      }
+    } else if (dimColumnEvaluatorInfo.getFilterValues().getImplicitColumnFilterList()
+        .contains(shortBlockId)) {
+      isScanRequired = true;
+    }
+    if (isScanRequired) {
+      bitSet.set(0);
+    }
+    return bitSet;
+  }
+
+  /**
+   * For implicit column filtering, complete data need to be selected. As it is a special case
+   * no data need to be discarded, implicit filtering is only for slecting block and blocklets
+   *
+   * @param numberOfRows
+   * @return
+   */
+  private BitSet setBitSetForCompleteDimensionData(int numberOfRows) {
+    BitSet bitSet = new BitSet();
+    bitSet.set(0, numberOfRows, true);
+    return bitSet;
+  }
+
+  @Override
+  public Boolean isFilterValuesPresentInAbstractIndex(byte[][] maxValue, byte[][] minValue) {
+    return true;
+  }
+}

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/resolver/resolverinfo/visitor/FilterInfoTypeVisitorFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/resolver/resolverinfo/visitor/FilterInfoTypeVisitorFactory.java
@@ -35,6 +35,8 @@ public class FilterInfoTypeVisitorFactory {
     if (exp instanceof RangeExpression) {
       if (columnExpression.getDimension().hasEncoding(Encoding.DIRECT_DICTIONARY)) {
         return new RangeDirectDictionaryVisitor();
+      } else if (columnExpression.getDimension().hasEncoding(Encoding.IMPLICIT)) {
+        return new ImplicitColumnVisitor();
       } else if (!columnExpression.getDimension().hasEncoding(Encoding.DICTIONARY)) {
         return new RangeNoDictionaryTypeVisitor();
       } else if (columnExpression.getDimension().hasEncoding(Encoding.DICTIONARY)) {
@@ -45,6 +47,8 @@ public class FilterInfoTypeVisitorFactory {
       if (null != columnExpression.getDimension()) {
         if (columnExpression.getDimension().hasEncoding(Encoding.DIRECT_DICTIONARY)) {
           return new CustomTypeDictionaryVisitor();
+        } else if (columnExpression.getDimension().hasEncoding(Encoding.IMPLICIT)) {
+          return new ImplicitColumnVisitor();
         } else if (!columnExpression.getDimension().hasEncoding(Encoding.DICTIONARY)) {
           return new NoDictionaryTypeVisitor();
         } else if (columnExpression.getDimension().hasEncoding(Encoding.DICTIONARY)) {

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/resolver/resolverinfo/visitor/ImplicitColumnVisitor.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/resolver/resolverinfo/visitor/ImplicitColumnVisitor.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.core.scan.filter.resolver.resolverinfo.visitor;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.apache.carbondata.core.scan.expression.exception.FilterIllegalMemberException;
+import org.apache.carbondata.core.scan.expression.exception.FilterUnsupportedException;
+import org.apache.carbondata.core.scan.filter.ColumnFilterInfo;
+import org.apache.carbondata.core.scan.filter.FilterUtil;
+import org.apache.carbondata.core.scan.filter.resolver.metadata.FilterResolverMetadata;
+import org.apache.carbondata.core.scan.filter.resolver.resolverinfo.ColumnResolvedFilterInfo;
+import org.apache.carbondata.core.scan.filter.resolver.resolverinfo.DimColumnResolvedFilterInfo;
+
+public class ImplicitColumnVisitor implements ResolvedFilterInfoVisitorIntf {
+
+  /**
+   * Visitor Method will update the filter related details in visitableObj, For implicit
+   * type columns the filter members will resolved directly, no need to look up in dictionary
+   * since it will not be part of dictionary, directly the actual data can be taken
+   * and can be set. This type of encoding is effective when the particular column
+   * is having very high cardinality.
+   *
+   * @param visitableObj
+   * @param metadata
+   * @throws FilterUnsupportedException,if exception occurs while evaluating
+   *                                       filter models.
+   */
+
+  @Override public void populateFilterResolvedInfo(ColumnResolvedFilterInfo visitableObj,
+      FilterResolverMetadata metadata) throws FilterUnsupportedException, IOException {
+    if (visitableObj instanceof DimColumnResolvedFilterInfo) {
+      ColumnFilterInfo resolvedFilterObject = null;
+      List<String> evaluateResultListFinal;
+      try {
+        evaluateResultListFinal = metadata.getExpression().evaluate(null).getListAsString();
+      } catch (FilterIllegalMemberException e) {
+        throw new FilterUnsupportedException(e);
+      }
+      resolvedFilterObject = FilterUtil
+          .getImplicitColumnFilterList(evaluateResultListFinal, metadata.isIncludeFilter());
+      ((DimColumnResolvedFilterInfo)visitableObj).setFilterValues(resolvedFilterObject);
+    }
+  }
+}


### PR DESCRIPTION
Added code to support implicit column filtering. Whenever a filter is applied on implicit column, filter is applied at blocklet level to scan/read only the valid blocklets. This will ensure that only blocklets that contain the required data are read.

 - [ ] Any interfaces changed?
 No
 - [ ] Any backward compatibility impacted?
 No
 - [ ] Document update required?
 No
 - [ ] Testing done
 Not yet integrated into the main flow. This will be used for segment pruning. Testing will be done as while merging segment pruning #1624 .      
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
 NA
