### PR TITLE
[CARBONDATA-1869] Null pointer exception thrown when concurrent load and select queries executed for table with dictionary exclude or NO_INVERTED_INDEX

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/AbstractDFSCarbonFile.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/AbstractDFSCarbonFile.java
@@ -138,23 +138,29 @@ public abstract  class AbstractDFSCarbonFile implements CarbonFile {
   public boolean renameTo(String changetoName) {
     FileSystem fs;
     try {
-      fs = fileStatus.getPath().getFileSystem(hadoopConf);
-      return fs.rename(fileStatus.getPath(), new Path(changetoName));
+      if (null != fileStatus) {
+        fs = fileStatus.getPath().getFileSystem(hadoopConf);
+        return fs.rename(fileStatus.getPath(), new Path(changetoName));
+      }
     } catch (IOException e) {
       LOGGER.error("Exception occurred:" + e.getMessage());
       return false;
     }
+    return false;
   }
 
   public boolean delete() {
     FileSystem fs;
     try {
-      fs = fileStatus.getPath().getFileSystem(hadoopConf);
-      return fs.delete(fileStatus.getPath(), true);
+      if (null != fileStatus) {
+        fs = fileStatus.getPath().getFileSystem(hadoopConf);
+        return fs.delete(fileStatus.getPath(), true);
+      }
     } catch (IOException e) {
       LOGGER.error("Exception occurred:" + e.getMessage());
       return false;
     }
+    return false;
   }
 
   @Override public long getLastModifiedTime() {
@@ -164,8 +170,10 @@ public abstract  class AbstractDFSCarbonFile implements CarbonFile {
   @Override public boolean setLastModifiedTime(long timestamp) {
     FileSystem fs;
     try {
-      fs = fileStatus.getPath().getFileSystem(hadoopConf);
-      fs.setTimes(fileStatus.getPath(), timestamp, timestamp);
+      if (null != fileStatus) {
+        fs = fileStatus.getPath().getFileSystem(hadoopConf);
+        fs.setTimes(fileStatus.getPath(), timestamp, timestamp);
+      }
     } catch (IOException e) {
       return false;
     }


### PR DESCRIPTION
While updating the file, we need FileStatus, this FileStatus can be null. So before accessing FileStatus, a null check is needed.


 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [x] Testing done
        Manual Testing
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

