### PR TITLE
[CARBONDATA-1759]make visibility of segments as false eventhough file is not present To take care show segments after clean files operation

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/allqueries/InsertIntoCarbonTableTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/allqueries/InsertIntoCarbonTableTestCase.scala
@@ -278,6 +278,18 @@ class InsertIntoCarbonTableTestCase extends QueryTest with BeforeAndAfterAll {
     assert(rowCount == sql("select imei from TCarbonSourceOverwrite").count())
   }
 
+  test("test show segments after clean files for insert overwrite") {
+    sql("drop table if exists show_insert")
+    sql("create table show_insert (name String, age int) stored by 'carbondata'")
+    sql("insert into show_insert select 'abc',1")
+    sql("insert into show_insert select 'abc',1")
+    sql("insert into show_insert select 'abc',1")
+    sql("insert overwrite table show_insert select * from show_insert")
+    assert(sql("show segments for table show_insert").collect().length == 4)
+    sql("clean files for table show_insert")
+    assert(sql("show segments for table show_insert").collect().length == 1)
+  }
+
   override def afterAll {
     sql("drop table if exists load")
     sql("drop table if exists inser")
@@ -296,6 +308,7 @@ class InsertIntoCarbonTableTestCase extends QueryTest with BeforeAndAfterAll {
     sql("drop table if exists carbon_table")
     sql("DROP TABLE IF EXISTS student")
     sql("DROP TABLE IF EXISTS uniqdata")
+    sql("DROP TABLE IF EXISTS show_insert")
 
     if (timeStampPropOrig != null) {
       CarbonProperties.getInstance()

--- a/processing/src/main/java/org/apache/carbondata/processing/util/DeleteLoadFolders.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/util/DeleteLoadFolders.java
@@ -95,7 +95,9 @@ public final class DeleteLoadFolders {
         }
 
       } else {
-        status = false;
+        LOGGER.warn("Files are not found in segment " + path
+            + " it seems, files are already being deleted");
+        status = true;
       }
     } catch (IOException e) {
       LOGGER.warn("Unable to delete the file as per delete command " + path);


### PR DESCRIPTION
make visibility of segments as false eventhough file is not present To take care show segments after clean files operation

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 NA
 - [X] Any backward compatibility impacted?
 NA
 - [X] Document update required?
NA
 - [X] Testing done
       test case is added in UT
       
 - [X] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

