### PR TITLE
[CARBONDATA-1714] Fixed Issue for Selection of null values after having multiple alter commands

### DIFF
--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableInputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableInputFormat.java
@@ -826,8 +826,9 @@ public class CarbonTableInputFormat<T> extends FileInputFormat<Void, T> {
     // set the filter to the query model in order to filter blocklet before scan
     Expression filter = getFilterPredicates(configuration);
     boolean[] isFilterDimensions = new boolean[carbonTable.getDimensionOrdinalMax()];
+    // getAllMeasures returns list of visible and invisible columns
     boolean[] isFilterMeasures =
-        new boolean[carbonTable.getNumberOfMeasures(carbonTable.getTableName())];
+        new boolean[carbonTable.getAllMeasures().size()];
     CarbonInputFormatUtil.processFilterExpression(filter, carbonTable, isFilterDimensions,
         isFilterMeasures);
     queryModel.setIsFilterDimensions(isFilterDimensions);

--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/restructure/AlterTableValidationTestCase.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/restructure/AlterTableValidationTestCase.scala
@@ -527,6 +527,26 @@ class AlterTableValidationTestCase extends Spark2QueryTest with BeforeAndAfterAl
     sql("drop table if exists preaggmain_new")
     sql("drop table if exists preaggMain_preagg1")
   }
+  test("test to check select columns after alter commands with null values"){
+    sql("drop table if exists restructure")
+    sql("drop table if exists restructure1")
+    sql(
+      "CREATE TABLE restructure (empno int, empname String, designation String, doj Timestamp, " +
+      "workgroupcategory int, workgroupcategoryname String, deptno int, deptname String, " +
+      "projectcode int, projectjoindate Timestamp, projectenddate Timestamp,attendance int," +
+      "utilization int,salary int) STORED BY 'org.apache.carbondata.format'")
+    sql(
+      s"""LOAD DATA LOCAL INPATH '$resourcesPath/data.csv' INTO TABLE restructure OPTIONS
+         |('DELIMITER'= ',', 'QUOTECHAR'= '\"')""".stripMargin)
+    sql("ALTER TABLE restructure rename to restructure1")
+    sql("ALTER TABLE restructure1 ADD COLUMNS (projId int)")
+    sql("ALTER TABLE restructure1 DROP COLUMNS (projId)")
+    sql("ALTER TABLE restructure1 CHANGE empno empno BIGINT")
+    sql("ALTER TABLE restructure1 ADD COLUMNS (a1 INT, b1 STRING) TBLPROPERTIES('DICTIONARY_EXCLUDE'='b1')")
+    checkAnswer(sql("select a1,b1,empname from restructure1 where a1 is null and b1 is null and empname='arvind'"),Row(null,null,"arvind"))
+    sql("drop table if exists restructure1")
+    sql("drop table if exists restructure")
+  }
 
   override def afterAll {
     sql("DROP TABLE IF EXISTS restructure")


### PR DESCRIPTION
In CarbonTableInputFormat, isFilterMesure is populated with measurelist size as this includes the count of previous drop column having invisible true.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed? No
 
 - [x] Any backward compatibility impacted? No
 
 - [x] Document update required? No

 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required? No
        - How it is tested? Please attach test report. NA
        - Is it a performance related change? Please attach the performance test report. NA
        - Any additional information to help reviewers in testing this change. NA
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

