### PR TITLE
[CARBONDATA-1878] [DataMap] Fix bugs in unsafe datamap store

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/indexstore/UnsafeMemoryDMStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/UnsafeMemoryDMStore.java
@@ -147,7 +147,8 @@ public class UnsafeMemoryDMStore {
         break;
       case VARIABLE:
         byte[] data = row.getByteArray(index);
-        getUnsafe().putShort(memoryBlock.getBaseOffset() + runningLength, (short) data.length);
+        getUnsafe().putShort(memoryBlock.getBaseObject(),
+            memoryBlock.getBaseOffset() + runningLength, (short) data.length);
         runningLength += 2;
         getUnsafe().copyMemory(data, BYTE_ARRAY_OFFSET, memoryBlock.getBaseObject(),
             memoryBlock.getBaseOffset() + runningLength, data.length);

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/directdictionary/DateDataTypeDirectDictionaryWithOffHeapSortDisabledTest.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/directdictionary/DateDataTypeDirectDictionaryWithOffHeapSortDisabledTest.scala
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.spark.testsuite.directdictionary
+
+import java.sql.Date
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.test.util.QueryTest
+import org.scalatest.BeforeAndAfterAll
+
+import org.apache.carbondata.common.constants.LoggerAction
+import org.apache.carbondata.core.constants.CarbonCommonConstants
+import org.apache.carbondata.core.util.CarbonProperties
+
+/**
+ * test case copied from `DateDataTypeDirectDictionaryTest` to verify CARBONDATA-1878
+ */
+class DateDataTypeDirectDictionaryWithOffHeapSortDisabledTest
+  extends QueryTest with BeforeAndAfterAll {
+  private val originBadRecordsAction: String = CarbonProperties.getInstance()
+    .getProperty(CarbonCommonConstants.CARBON_BAD_RECORDS_ACTION,
+      CarbonCommonConstants.CARBON_BAD_RECORDS_ACTION_DEFAULT)
+  private val originOffHeapSortStatus: String = CarbonProperties.getInstance()
+    .getProperty(CarbonCommonConstants.ENABLE_OFFHEAP_SORT,
+      CarbonCommonConstants.ENABLE_OFFHEAP_SORT_DEFAULT)
+
+  override def beforeAll {
+    try {
+      CarbonProperties.getInstance().addProperty("carbon.direct.dictionary", "true")
+      CarbonProperties.getInstance().addProperty(
+        CarbonCommonConstants.CARBON_BAD_RECORDS_ACTION, LoggerAction.FORCE.name())
+      CarbonProperties.getInstance().addProperty(CarbonCommonConstants.ENABLE_OFFHEAP_SORT, "false")
+
+      sql("drop table if exists directDictionaryTable ")
+      sql("CREATE TABLE if not exists directDictionaryTable (empno int,doj date, salary int) " +
+        "STORED BY 'org.apache.carbondata.format'")
+
+      CarbonProperties.getInstance()
+        .addProperty(CarbonCommonConstants.CARBON_DATE_FORMAT, "yyyy-MM-dd")
+      val csvFilePath = s"$resourcesPath/datasamplefordate.csv"
+      sql("LOAD DATA local inpath '" + csvFilePath + "' INTO TABLE directDictionaryTable OPTIONS" +
+          "('DELIMITER'= ',', 'QUOTECHAR'= '\"')" )
+    } catch {
+      case x: Throwable =>
+        x.printStackTrace()
+        CarbonProperties.getInstance().addProperty(CarbonCommonConstants.CARBON_DATE_FORMAT,
+            CarbonCommonConstants.CARBON_TIMESTAMP_DEFAULT_FORMAT)
+    }
+  }
+
+  test("test direct dictionary for not null condition") {
+    checkAnswer(sql("select doj from directDictionaryTable where doj is not null"),
+      Seq(Row(Date.valueOf("2016-03-14")), Row(Date.valueOf("2016-04-14"))))
+  }
+
+  override def afterAll {
+    sql("drop table directDictionaryTable")
+    CarbonProperties.getInstance().addProperty(CarbonCommonConstants.CARBON_DATE_FORMAT,
+        CarbonCommonConstants.CARBON_TIMESTAMP_DEFAULT_FORMAT)
+    CarbonProperties.getInstance().addProperty(CarbonCommonConstants.CARBON_BAD_RECORDS_ACTION,
+      originBadRecordsAction)
+    CarbonProperties.getInstance().addProperty("carbon.direct.dictionary", "false")
+    CarbonProperties.getInstance().addProperty(CarbonCommonConstants.ENABLE_OFFHEAP_SORT,
+      originOffHeapSortStatus)
+  }
+}


### PR DESCRIPTION
Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [X] Any interfaces changed?
  `NO`
 - [X] Any backward compatibility impacted?
  `NO`
 - [X] Document update required?
  `NO`
 - [X] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        `ADDED TESTS`
        - How it is tested? Please attach test report.
        `TEST IN LOCAL MACHINE`
        - Is it a performance related change? Please attach the performance test report.
        `NO, ONLY BUG FIXED`
        - Any additional information to help reviewers in testing this change.
        `NO`
       
 - [X] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
        `NOT RELATED`

COPY FROM JIRA:
===

# SCENARIO

Recently I have fixed some issues in Carbondata. To perform a full test to cover all the code that has been modified by me, I performed some iteration of the whole test case. Each iteration is started with different  key configurations that will affect the flow in the code.

After I set `enable.offheap.sort=false` (default value is true) in the configuration, running tests will always end up with JVM crash error. The error messages are shown as below:

```
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  SIGSEGV (0xb) at pc=0x00007f346b207ff1, pid=144619, tid=0x00007f346c2fc700
#
# JRE version: Java(TM) SE Runtime Environment (8.0_111-b14) (build 1.8.0_111-b14)
# Java VM: Java HotSpot(TM) 64-Bit Server VM (25.111-b14 mixed mode linux-amd64 compressed oops)
# Problematic frame:
# V  [libjvm.so+0xa90ff1]  Unsafe_SetNativeShort+0x51
#
# Failed to write core dump. Core dumps have been disabled. To enable core dumping, try "ulimit -c unlimited" before starting Java again
#
# An error report file with more information is saved as:
# /home/xu/ws/carbondata/hs_err_pid144619.log
#
# If you would like to submit a bug report, please visit:
#   http://bugreport.java.com/bugreport/crash.jsp
#

Process finished with exit code 134 (interrupted by signal 6: SIGABRT)
```

# STEPS TO REPRODUCE

The error can be easily reproduced in different ways. Here I will provide a simple way to reproduce it:

1. Find the test case `DateDataTypeDirectDictionaryTest`.

2. Add the following code in the method `beforeAll`.
```
CarbonProperties.getInstance()
    .addProperty(CarbonCommonConstants.ENABLE_OFFHEAP_SORT, "false")
```

3. Run this test case.

4. You will find the test failed with the above error.

5. Replace the code in Step2 with the following code:
```
CarbonProperties.getInstance()
    .addProperty(CarbonCommonConstants.ENABLE_OFFHEAP_SORT, "true")
```

6. Run this test case.

7. The test is success without error.

# ANALYZE & RESOLVE

I have reproduced this error and analyzed the core dump file. The final stack message in core dump looks like below:

```
Thread 73303: (state = IN_VM)
 - sun.misc.Unsafe.putShort(long, short) @bci=0 (Interpreted frame)
 - org.apache.carbondata.core.indexstore.UnsafeMemoryDMStore.addToUnsafe(org.apache.carbondata.core.indexstore.schema.CarbonRowSchema, org.apache.carbondata.core.indexstore.row.DataMapRow, int) @bci=781, line=150 (Interpreted frame)
 - org.apache.carbondata.core.indexstore.UnsafeMemoryDMStore.addIndexRowToUnsafe(org.apache.carbondata.core.indexstore.row.DataMapRow) @bci=59, line=99 (Interpreted frame)
 ...
```

After inspecting the code, I found there lies bug in `UnsafeMemoryDMStore line=150` while writing length to unsafe memory -- It writes with wrong base object.