### PR TITLE
[CARBONDATA-1876]clean all the InProgress segments for all databases during session initialization

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -1302,7 +1302,7 @@ public final class CarbonCommonConstants {
    */
   public static final String DATA_MANAGEMENT_DRIVER = "spark.carbon.datamanagement.driver";
 
-  public static final String DATA_MANAGEMENT_DRIVER_DEFAULT = "false";
+  public static final String DATA_MANAGEMENT_DRIVER_DEFAULT = "true";
 
   public static final String CARBON_SESSIONSTATE_CLASSNAME = "spark.carbon.sessionstate.classname";
 

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSession.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSession.scala
@@ -182,8 +182,11 @@ object CarbonSession {
         options.foreach { case (k, v) => session.sessionState.conf.setConfString(k, v) }
         SparkSession.setDefaultSession(session)
         try {
-          CommonUtil.cleanInProgressSegments(
-            carbonProperties.getProperty(CarbonCommonConstants.STORE_LOCATION), sparkContext)
+          val databases = session.sessionState.catalog.listDatabases()
+          databases.foreach(dbName => {
+            val databaseLocation = CarbonEnv.getDatabaseLocation(dbName, session)
+            CommonUtil.cleanInProgressSegments(databaseLocation, dbName)
+          })
         } catch {
           case e: Throwable =>
             // catch all exceptions to avoid CarbonSession initialization failure


### PR DESCRIPTION
clean all the InProgress segments for all databases during session initialization

clean all the InProgress segments for all databases during session initialization. when carbon session initialize , clean all the in progress segments for all the databases created by user.


Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [X] Any interfaces changed?
 NA
 - [X] Any backward compatibility impacted?
 NA
 - [X] Document update required?
NA
 - [X] Testing done
local testing is done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [X] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA
