### PR TITLE
[CARBONDATA-1879][Streaming] Support alter table to change the status of the streaming segment

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/metadata/converter/ThriftWrapperSchemaConverterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/converter/ThriftWrapperSchemaConverterImpl.java
@@ -635,13 +635,13 @@ public class ThriftWrapperSchemaConverterImpl implements SchemaConverter {
         schemaEvolutionList.get(schemaEvolutionList.size() - 1).getTime_stamp());
     wrapperTableInfo.setDatabaseName(dbName);
     wrapperTableInfo.setTableUniqueName(CarbonTable.buildUniqueName(dbName, tableName));
-    wrapperTableInfo.setTablePath(tablePath);
     wrapperTableInfo.setFactTable(
         fromExternalToWrapperTableSchema(externalTableInfo.getFact_table(), tableName));
     if (null != externalTableInfo.getDataMapSchemas()) {
       wrapperTableInfo.setDataMapSchemaList(
           fromExternalToWrapperChildSchemaList(externalTableInfo.getDataMapSchemas()));
     }
+    wrapperTableInfo.setTablePath(tablePath);
     return wrapperTableInfo;
   }
 

--- a/hadoop/src/test/java/org/apache/carbondata/hadoop/test/util/StoreCreator.java
+++ b/hadoop/src/test/java/org/apache/carbondata/hadoop/test/util/StoreCreator.java
@@ -186,7 +186,6 @@ public class StoreCreator {
   public static CarbonTable createTable(
       AbsoluteTableIdentifier absoluteTableIdentifier) throws IOException {
     TableInfo tableInfo = new TableInfo();
-    tableInfo.setTablePath(absoluteTableIdentifier.getTablePath());
     tableInfo.setDatabaseName(absoluteTableIdentifier.getCarbonTableIdentifier().getDatabaseName());
     TableSchema tableSchema = new TableSchema();
     tableSchema.setTableName(absoluteTableIdentifier.getCarbonTableIdentifier().getTableName());
@@ -278,6 +277,7 @@ public class StoreCreator {
     );
     tableInfo.setLastUpdatedTime(System.currentTimeMillis());
     tableInfo.setFactTable(tableSchema);
+    tableInfo.setTablePath(absoluteTableIdentifier.getTablePath());
     CarbonTablePath carbonTablePath = CarbonStorePath.getCarbonTablePath(absoluteTableIdentifier);
     String schemaFilePath = carbonTablePath.getSchemaFilePath();
     String schemaMetadataPath = CarbonTablePath.getFolderContainingFile(schemaFilePath);

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
@@ -66,6 +66,8 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
   protected val COLS = carbonKeyWord("COLS")
   protected val COLUMNS = carbonKeyWord("COLUMNS")
   protected val COMPACT = carbonKeyWord("COMPACT")
+  protected val FINISH = carbonKeyWord("FINISH")
+  protected val STREAMING = carbonKeyWord("STREAMING")
   protected val CREATE = carbonKeyWord("CREATE")
   protected val CUBE = carbonKeyWord("CUBE")
   protected val CUBES = carbonKeyWord("CUBES")

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonAlterTableFinishStreaming.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonAlterTableFinishStreaming.scala
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.command.management
+
+import org.apache.spark.sql.{CarbonEnv, Row, SparkSession}
+import org.apache.spark.sql.execution.command.DataCommand
+
+import org.apache.carbondata.streaming.segment.StreamSegment
+
+/**
+ * This command will try to change the status of the segment from "streaming" to "streaming finish"
+ */
+case class CarbonAlterTableFinishStreaming(
+    dbName: Option[String],
+    tableName: String)
+  extends DataCommand {
+  override def processData(sparkSession: SparkSession): Seq[Row] = {
+    val carbonTable = CarbonEnv.getCarbonTable(dbName, tableName)(sparkSession)
+    StreamSegment.finishStreaming(carbonTable)
+    Seq.empty
+  }
+}

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonAlterTableFinishStreaming.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonAlterTableFinishStreaming.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.sql.execution.command.management
 
 import org.apache.spark.sql.{CarbonEnv, Row, SparkSession}
-import org.apache.spark.sql.execution.command.DataCommand
+import org.apache.spark.sql.execution.command.MetadataCommand
 
 import org.apache.carbondata.streaming.segment.StreamSegment
 
@@ -28,8 +28,8 @@ import org.apache.carbondata.streaming.segment.StreamSegment
 case class CarbonAlterTableFinishStreaming(
     dbName: Option[String],
     tableName: String)
-  extends DataCommand {
-  override def processData(sparkSession: SparkSession): Seq[Row] = {
+  extends MetadataCommand {
+  override def processMetadata(sparkSession: SparkSession): Seq[Row] = {
     val carbonTable = CarbonEnv.getCarbonTable(dbName, tableName)(sparkSession)
     StreamSegment.finishStreaming(carbonTable)
     Seq.empty

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSpark2SqlParser.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSpark2SqlParser.scala
@@ -129,6 +129,11 @@ class CarbonSpark2SqlParser extends CarbonDDLSqlParser {
         CarbonAlterTableCompactionCommand(altertablemodel)
     }
 
+  /**
+   * The below syntax is used to change the status of the segment
+   * from "streaming" to "streaming finish".
+   * ALTER TABLE tableName FINISH STREAMING
+   */
   protected lazy val alterTableFinishStreaming: Parser[LogicalPlan] =
     ALTER ~> TABLE ~> (ident <~ ".").? ~ ident <~ FINISH <~ STREAMING <~ opt(";") ^^ {
       case dbName ~ table =>

--- a/processing/src/test/java/org/apache/carbondata/processing/StoreCreator.java
+++ b/processing/src/test/java/org/apache/carbondata/processing/StoreCreator.java
@@ -176,7 +176,6 @@ public class StoreCreator {
 
   private static CarbonTable createTable() throws IOException {
     TableInfo tableInfo = new TableInfo();
-    tableInfo.setTablePath(absoluteTableIdentifier.getTablePath());
     tableInfo.setDatabaseName(absoluteTableIdentifier.getCarbonTableIdentifier().getDatabaseName());
     TableSchema tableSchema = new TableSchema();
     tableSchema.setTableName(absoluteTableIdentifier.getCarbonTableIdentifier().getTableName());
@@ -263,6 +262,7 @@ public class StoreCreator {
     );
     tableInfo.setLastUpdatedTime(System.currentTimeMillis());
     tableInfo.setFactTable(tableSchema);
+    tableInfo.setTablePath(absoluteTableIdentifier.getTablePath());
 
     CarbonTablePath carbonTablePath = CarbonStorePath
         .getCarbonTablePath(absoluteTableIdentifier.getTablePath(),

--- a/streaming/src/main/java/org/apache/carbondata/streaming/segment/StreamSegment.java
+++ b/streaming/src/main/java/org/apache/carbondata/streaming/segment/StreamSegment.java
@@ -29,7 +29,9 @@ import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.datastore.filesystem.CarbonFile;
 import org.apache.carbondata.core.datastore.filesystem.CarbonFileFilter;
 import org.apache.carbondata.core.datastore.impl.FileFactory;
+import org.apache.carbondata.core.locks.CarbonLockFactory;
 import org.apache.carbondata.core.locks.ICarbonLock;
+import org.apache.carbondata.core.locks.LockUsage;
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
 import org.apache.carbondata.core.reader.CarbonIndexFileReader;
 import org.apache.carbondata.core.statusmanager.FileFormat;
@@ -176,6 +178,70 @@ public class StreamSegment {
       } else {
         LOGGER.error("Unable to unlock Table lock for table" + table.getDatabaseName() + "." + table
             .getTableName() + " during table status updation");
+      }
+    }
+  }
+
+  /**
+   * change the status of the segment from "streaming" to "streaming finish"
+   */
+  public static void finishStreaming(CarbonTable carbonTable) throws Exception {
+    ICarbonLock lock = CarbonLockFactory.getCarbonLockObj(
+        carbonTable.getTableInfo().getOrCreateAbsoluteTableIdentifier(),
+        LockUsage.TABLE_STATUS_LOCK);
+    try {
+      if (lock.lockWithRetries()) {
+        ICarbonLock streamingLock = CarbonLockFactory.getCarbonLockObj(
+            carbonTable.getTableInfo().getOrCreateAbsoluteTableIdentifier(),
+            LockUsage.STREAMING_LOCK);
+        try {
+          if (streamingLock.lockWithRetries()) {
+            LoadMetadataDetails[] details =
+                SegmentStatusManager.readLoadMetadata(carbonTable.getMetaDataFilepath());
+            boolean updated = false;
+            for (LoadMetadataDetails detail : details) {
+              if (SegmentStatus.STREAMING == detail.getSegmentStatus()) {
+                detail.setLoadEndTime(System.currentTimeMillis());
+                detail.setSegmentStatus(SegmentStatus.STREAMING_FINISH);
+                updated = true;
+              }
+            }
+            if (updated) {
+              CarbonTablePath tablePath =
+                  CarbonStorePath.getCarbonTablePath(carbonTable.getAbsoluteTableIdentifier());
+              SegmentStatusManager.writeLoadDetailsIntoFile(
+                  tablePath.getTableStatusFilePath(), details);
+            }
+          } else {
+            String msg = "Failed to finish streaming, because streaming is locked for table " +
+                carbonTable.getDatabaseName() + "." + carbonTable.getTableName();
+            LOGGER.error(msg);
+            throw new Exception(msg);
+          }
+        } finally {
+          if (streamingLock.unlock()) {
+            LOGGER.info("Table unlocked successfully after streaming finished" + carbonTable
+                .getDatabaseName() + "." + carbonTable.getTableName());
+          } else {
+            LOGGER.error("Unable to unlock Table lock for table " +
+                carbonTable.getDatabaseName() + "." + carbonTable.getTableName() +
+                " during streaming finished");
+          }
+        }
+      } else {
+        String msg = "Failed to acquire table status lock of " +
+            carbonTable.getDatabaseName() + "." + carbonTable.getTableName();
+        LOGGER.error(msg);
+        throw new Exception(msg);
+      }
+    } finally {
+      if (lock.unlock()) {
+        LOGGER.info("Table unlocked successfully after table status updation" +
+            carbonTable.getDatabaseName() + "." + carbonTable.getTableName());
+      } else {
+        LOGGER.error("Unable to unlock Table lock for table " +
+            carbonTable.getDatabaseName() + "." + carbonTable.getTableName() +
+            " during table status updation");
       }
     }
   }


### PR DESCRIPTION
Support new SQL command to change the status of the segment from "streaming" to "streaming finish":
Alter table <dbname.tablename> finish streaming

1. If streaming is running, the command will throw an exception.
2. If there isn't streaming segment, do nothing.

 - [x] Any interfaces changed?
 add new sql command:
  Alter table <dbname.tablename> finish streaming
 - [x] Any backward compatibility impacted?
  no
 - [x] Document update required?
  required
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
           added
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
  NA
