### PR TITLE
[CARBONDATA-1846] Incorrect output on presto CLI while executing IN operator with multiple load

### DIFF
--- a/integration/presto/src/main/java/org/apache/carbondata/presto/PrestoFilterUtil.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/PrestoFilterUtil.java
@@ -175,7 +175,7 @@ public class PrestoFilterUtil {
       } else if (singleValues.size() > 1) {
         ListExpression candidates = null;
         List<Expression> exs = singleValues.stream()
-            .map((a) -> new LiteralExpression(ConvertDataByType(a, type), coltype))
+            .map((a) -> new LiteralExpression(a, coltype))
             .collect(Collectors.toList());
         candidates = new ListExpression(exs);
         filters.add(new InExpression(colExpression, candidates));

--- a/integration/presto/src/test/scala/org/apache/carbondata/presto/integrationtest/PrestoAllDataTypeTest.scala
+++ b/integration/presto/src/test/scala/org/apache/carbondata/presto/integrationtest/PrestoAllDataTypeTest.scala
@@ -427,4 +427,12 @@ class PrestoAllDataTypeTest extends FunSuiteLike with BeforeAndAfterAll {
     val expectedResult: List[Map[String, Any]] = List(Map("RESULT" -> "jatin"))
     assert(actualResult.equals(expectedResult))
   }
+
+  test("test timestamp datatype using cast and in operator") {
+    val actualResult: List[Map[String, Any]] = PrestoServer
+      .executeQuery("SELECT ID AS RESULT FROM TESTDB.TESTTABLE WHERE DOB in (cast('2016-04-14 " +
+                    "15:00:09' as timestamp),cast('2015-10-07' as timestamp),cast('2015-10-07 01:00:03' as timestamp))")
+    val expectedResult: List[Map[String, Any]] = List(Map("RESULT" -> "2"))
+    assert(actualResult.toString() equals expectedResult.toString())
+  }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CARBONDATA-1846

Problem: problem is that in operator on timestamp is not working correctly because timestamp was getting multiplied by 1000 twice when we are creating inexpression