### PR TITLE
[CARBONDATA-1892]updated documentation for disability of single_pass on first load

### DIFF
--- a/docs/data-management-on-carbondata.md
+++ b/docs/data-management-on-carbondata.md
@@ -314,7 +314,6 @@ This tutorial is going to introduce all commands and data operations on CarbonDa
    * If this option is set to TRUE then data loading will take less time.
    * If this option is set to some invalid value other than TRUE or FALSE then it uses the default value.
    * If this option is set to TRUE, then high.cardinality.identify.enable property will be disabled during data load.
-   * For first Load SINGLE_PASS loading option is disabled.
 
    Example:
 


### PR DESCRIPTION
Correction In the documentation of single_pass is required as now single_pass is not disabled for the first load, with reference to https://github.com/apache/carbondata/pull/1622