### PR TITLE
[CARBONDATA-1247] Block pruning not working for date type column

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -19,6 +19,7 @@ package org.apache.carbondata.spark.rdd
 
 import java.text.SimpleDateFormat
 import java.util
+import java.util.TimeZone
 import java.util.concurrent._
 
 import scala.collection.JavaConverters._
@@ -842,6 +843,7 @@ object CarbonDataRDDFactory {
         .CARBON_DATE_FORMAT, CarbonCommonConstants.CARBON_DATE_DEFAULT_FORMAT)
       new SimpleDateFormat(dateFormatString)
     }
+    dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"))
 
     // generate RDD[(K, V)] to use the partitionBy method of PairRDDFunctions
     val inputRDD: RDD[(String, Row)] = if (dataFrame.isDefined) {


### PR DESCRIPTION
Block pruning not working for date type column.
Root Cause : Type casting of String for DateType is not handled

Solution: CastExpressionOptimization should handle the casting of String for DateType

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [X] Any interfaces changed?
 None
 - [X] Any backward compatibility impacted?
 None
 - [X] Document update required?
NA
 - [X] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       Done manual testing
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA

