### PR TITLE
[CARBONDATA-1678] Fixed incorrect partitionCount on Alter Partition Table

### DIFF
--- a/integration/spark-common/src/main/scala/org/apache/spark/util/PartitionUtils.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/util/PartitionUtils.scala
@@ -113,7 +113,8 @@ object PartitionUtils {
     }
 
     if (partitionId == 0) {
-      partitionInfo.addPartition(splitInfo.size)
+      val addedPartitionList = PartitionUtils.getListInfo(splitInfo.mkString(","))
+      partitionInfo.addPartition(addedPartitionList.size)
     } else {
       partitionInfo.splitPartition(index, splitInfo.size)
     }


### PR DESCRIPTION
Fixed the issue of "Show partition throws an index out of bounds exception as the partitionCount gets incorrect after altering partition table to add partitions"

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed? No
 
 - [x] Any backward compatibility impacted? No
 
 - [x] Document update required? No

 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. (N/A) 

