### PR TITLE
[CARBONDATA-1898]Fixed Like, Contains, Ends with query optimization With OR condition

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonBoundReference.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonBoundReference.scala
@@ -48,12 +48,3 @@ case class CarbonBoundReference(colExp: ColumnExpression, dataType: DataType, nu
 
   override def newInstance(): NamedExpression = throw new UnsupportedOperationException
 }
-
-case class CarbonEndsWith(expr: Expression) extends Filter {
-  override def references: Array[String] = null
-}
-
-case class CarbonContainsWith(expr: Expression) extends Filter {
-  override def references: Array[String] = null
-}
-

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/strategy/CarbonLateDecodeStrategy.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/strategy/CarbonLateDecodeStrategy.scala
@@ -471,7 +471,6 @@ private[sql] class CarbonLateDecodeStrategy extends SparkStrategy {
     (unrecognizedPredicates ++ unhandledPredicates, translatedFilters)
   }
 
-
   /**
    * Tries to translate a Catalyst [[Expression]] into data source [[Filter]].
    *
@@ -568,10 +567,6 @@ private[sql] class CarbonLateDecodeStrategy extends SparkStrategy {
         CastExpressionOptimization.checkIfCastCanBeRemove(c)
       case StartsWith(a: Attribute, Literal(v, t)) =>
         Some(sources.StringStartsWith(a.name, v.toString))
-      case c@EndsWith(a: Attribute, Literal(v, t)) =>
-        Some(CarbonEndsWith(c))
-      case c@Contains(a: Attribute, Literal(v, t)) =>
-        Some(CarbonContainsWith(c))
       case others => None
     }
   }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/optimizer/CarbonFilters.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/optimizer/CarbonFilters.scala
@@ -24,8 +24,6 @@ import org.apache.spark.sql.CastExpr
 import org.apache.spark.sql.SparkUnknownExpression
 import org.apache.spark.sql.sources
 import org.apache.spark.sql.types._
-import org.apache.spark.sql.CarbonContainsWith
-import org.apache.spark.sql.CarbonEndsWith
 import org.apache.spark.sql.CarbonExpressions.{MatchCast => Cast}
 
 import org.apache.carbondata.core.metadata.datatype.{DataTypes => CarbonDataTypes}
@@ -108,18 +106,6 @@ object CarbonFilters {
           val r = new LessThanExpression(
             getCarbonExpression(name), getCarbonLiteralExpression(name, maxValueLimit))
           Some(new AndExpression(l, r))
-        case CarbonEndsWith(expr: Expression) =>
-          Some(new SparkUnknownExpression(expr.transform {
-            case AttributeReference(name, dataType, _, _) =>
-              CarbonBoundReference(new CarbonColumnExpression(name.toString,
-                CarbonScalaUtil.convertSparkToCarbonDataType(dataType)), dataType, expr.nullable)
-          }))
-        case CarbonContainsWith(expr: Expression) =>
-          Some(new SparkUnknownExpression(expr.transform {
-            case AttributeReference(name, dataType, _, _) =>
-              CarbonBoundReference(new CarbonColumnExpression(name.toString,
-                CarbonScalaUtil.convertSparkToCarbonDataType(dataType)), dataType, expr.nullable)
-          }))
         case CastExpr(expr: Expression) =>
           Some(transformExpression(expr))
         case _ => None
@@ -250,10 +236,6 @@ object CarbonFilters {
           CastExpressionOptimization.checkIfCastCanBeRemove(c)
         case StartsWith(a: Attribute, Literal(v, t)) =>
           Some(sources.StringStartsWith(a.name, v.toString))
-        case c@EndsWith(a: Attribute, Literal(v, t)) =>
-          Some(CarbonEndsWith(c))
-        case c@Contains(a: Attribute, Literal(v, t)) =>
-          Some(CarbonContainsWith(c))
         case c@Cast(a: Attribute, _) =>
           Some(CastExpr(c))
         case others =>


### PR DESCRIPTION
**Problem:** In case of like, contains, ends with filter With all or condition query is taking more time in carbon
**Solution:** This type of query avoid filter push down and let spark handle those filters

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

