### PR TITLE
[CARBONDATA-1901]Fixed Pre aggregate data map creation and query parsing 

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggCreateCommand.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggCreateCommand.scala
@@ -1,7 +1,15 @@
 package org.apache.carbondata.integration.spark.testsuite.preaggregate
 
+import org.apache.spark.sql.CarbonDatasourceHadoopRelation
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.execution.datasources.LogicalRelation
+import org.apache.spark.sql.hive.CarbonRelation
 import org.apache.spark.sql.test.util.QueryTest
 import org.scalatest.BeforeAndAfterAll
+import scala.collection.JavaConverters._
+
+import org.apache.carbondata.core.metadata.encoder.Encoding
+import org.apache.carbondata.core.metadata.schema.table.CarbonTable
 
 class TestPreAggCreateCommand extends QueryTest with BeforeAndAfterAll {
 
@@ -9,34 +17,37 @@ class TestPreAggCreateCommand extends QueryTest with BeforeAndAfterAll {
     sql("drop table if exists PreAggMain")
     sql("drop table if exists PreAggMain1")
     sql("drop table if exists PreAggMain2")
+    sql("drop table if exists maintable")
     sql("create table preaggMain (a string, b string, c string) stored by 'carbondata'")
     sql("create table preaggMain1 (a string, b string, c string) stored by 'carbondata' tblProperties('DICTIONARY_INCLUDE' = 'a')")
     sql("create table preaggMain2 (a string, b string, c string) stored by 'carbondata'")
+    sql("create table maintable (column1 int, column6 string, column5 string, column2 string, column3 int, column4 int) stored by 'carbondata' tblproperties('dictionary_include'='column1,column6', 'dictionary_exclude'='column3,column5')")
+
   }
 
 
-  test("test pre agg create table One") {
+  test("test pre agg create table 1") {
     sql("create datamap preagg1 on table PreAggMain using 'preaggregate' as select a,sum(b) from PreAggMain group by a")
     checkExistence(sql("DESCRIBE FORMATTED PreAggMain_preagg1"), true, "preaggmain_a")
     checkExistence(sql("DESCRIBE FORMATTED PreAggMain_preagg1"), true, "preaggmain_b_sum")
     sql("drop datamap preagg1 on table PreAggMain")
   }
 
-  test("test pre agg create table Two") {
+  test("test pre agg create table 2") {
     sql("create datamap preagg2 on table PreAggMain using 'preaggregate' as select a as a1,sum(b) from PreAggMain group by a")
     checkExistence(sql("DESCRIBE FORMATTED PreAggMain_preagg2"), true, "preaggmain_a")
     checkExistence(sql("DESCRIBE FORMATTED PreAggMain_preagg2"), true, "preaggmain_b_sum")
     sql("drop datamap preagg2 on table PreAggMain")
   }
 
-  test("test pre agg create table Three") {
+  test("test pre agg create table 3") {
     sql("create datamap preagg3 on table PreAggMain using 'preaggregate' as select a,sum(b) as sum from PreAggMain group by a")
     checkExistence(sql("DESCRIBE FORMATTED PreAggMain_preagg3"), true, "preaggmain_a")
     checkExistence(sql("DESCRIBE FORMATTED PreAggMain_preagg3"), true, "preaggmain_b_sum")
     sql("drop datamap preagg3 on table PreAggMain")
   }
 
-  test("test pre agg create table four") {
+  test("test pre agg create table 4") {
     sql("create datamap preagg4 on table PreAggMain using 'preaggregate' as select a as a1,sum(b) as sum from PreAggMain group by a")
     checkExistence(sql("DESCRIBE FORMATTED PreAggMain_preagg4"), true, "preaggmain_a")
     checkExistence(sql("DESCRIBE FORMATTED PreAggMain_preagg4"), true, "preaggmain_b_sum")
@@ -44,7 +55,7 @@ class TestPreAggCreateCommand extends QueryTest with BeforeAndAfterAll {
   }
 
 
-  test("test pre agg create table five") {
+  test("test pre agg create table 5") {
     sql("create datamap preagg11 on table PreAggMain1 using 'preaggregate'as select a,sum(b) from PreAggMain1 group by a")
     checkExistence(sql("DESCRIBE FORMATTED PreAggMain1_preagg11"), true, "preaggmain1_a")
     checkExistence(sql("DESCRIBE FORMATTED PreAggMain1_preagg11"), true, "preaggmain1_b_sum")
@@ -52,7 +63,7 @@ class TestPreAggCreateCommand extends QueryTest with BeforeAndAfterAll {
     sql("drop datamap preagg11 on table PreAggMain1")
   }
 
-  test("test pre agg create table six") {
+  test("test pre agg create table 6") {
     sql("create datamap preagg12 on table PreAggMain1 using 'preaggregate' as select a as a1,sum(b) from PreAggMain1 group by a")
     checkExistence(sql("DESCRIBE FORMATTED PreAggMain1_preagg12"), true, "preaggmain1_a")
     checkExistence(sql("DESCRIBE FORMATTED PreAggMain1_preagg12"), true, "preaggmain1_b_sum")
@@ -60,7 +71,7 @@ class TestPreAggCreateCommand extends QueryTest with BeforeAndAfterAll {
     sql("drop datamap preagg12 on table PreAggMain1")
   }
 
-  test("test pre agg create table seven") {
+  test("test pre agg create table 7") {
     sql("create datamap preagg13 on table PreAggMain1 using 'preaggregate' as select a,sum(b) as sum from PreAggMain1 group by a")
     checkExistence(sql("DESCRIBE FORMATTED PreAggMain1_preagg13"), true, "preaggmain1_a")
     checkExistence(sql("DESCRIBE FORMATTED PreAggMain1_preagg13"), true, "preaggmain1_b_sum")
@@ -68,7 +79,7 @@ class TestPreAggCreateCommand extends QueryTest with BeforeAndAfterAll {
     sql("drop datamap preagg13 on table PreAggMain1")
   }
 
-  test("test pre agg create table eight") {
+  test("test pre agg create table 8") {
     sql("create datamap preagg14 on table PreAggMain1 using 'preaggregate' as select a as a1,sum(b) as sum from PreAggMain1 group by a")
     checkExistence(sql("DESCRIBE FORMATTED PreAggMain1_preagg14"), true, "preaggmain1_a")
     checkExistence(sql("DESCRIBE FORMATTED PreAggMain1_preagg14"), true, "preaggmain1_b_sum")
@@ -77,7 +88,7 @@ class TestPreAggCreateCommand extends QueryTest with BeforeAndAfterAll {
   }
 
 
-  test("test pre agg create table nine") {
+  test("test pre agg create table 9") {
     sql("create datamap preagg15 on table PreAggMain2 using 'preaggregate' as select a,avg(b) from PreAggMain2 group by a")
     checkExistence(sql("DESCRIBE FORMATTED PreAggMain2_preagg15"), true, "preaggmain2_a")
     checkExistence(sql("DESCRIBE FORMATTED PreAggMain2_preagg15"), true, "preaggmain2_b_sum")
@@ -85,28 +96,28 @@ class TestPreAggCreateCommand extends QueryTest with BeforeAndAfterAll {
     sql("drop datamap preagg15 on table PreAggMain2")
   }
 
-  test("test pre agg create table ten") {
+  test("test pre agg create table 10") {
     sql("create datamap preagg16 on table PreAggMain2 using 'preaggregate' as select a as a1,max(b) from PreAggMain2 group by a")
     checkExistence(sql("DESCRIBE FORMATTED PreAggMain2_preagg16"), true, "preaggmain2_a")
     checkExistence(sql("DESCRIBE FORMATTED PreAggMain2_preagg16"), true, "preaggmain2_b_max")
     sql("drop datamap preagg16 on table PreAggMain2")
   }
 
-  test("test pre agg create table eleven") {
+  test("test pre agg create table 11") {
     sql("create datamap preagg17 on table PreAggMain2 using 'preaggregate' as select a,min(b) from PreAggMain2 group by a")
     checkExistence(sql("DESCRIBE FORMATTED PreAggMain2_preagg17"), true, "preaggmain2_a")
     checkExistence(sql("DESCRIBE FORMATTED PreAggMain2_preagg17"), true, "preaggmain2_b_min")
     sql("drop datamap preagg17 on table PreAggMain2")
   }
 
-  test("test pre agg create table twelve") {
+  test("test pre agg create table 12") {
     sql("create datamap preagg18 on table PreAggMain2 using 'preaggregate' as select a as a1,count(b) from PreAggMain2 group by a")
     checkExistence(sql("DESCRIBE FORMATTED PreAggMain2_preagg18"), true, "preaggmain2_a")
     checkExistence(sql("DESCRIBE FORMATTED PreAggMain2_preagg18"), true, "preaggmain2_b_count")
     sql("drop datamap preagg18 on table PreAggMain2")
   }
 
-  test("test pre agg create table thirteen") {
+  test("test pre agg create table 13") {
     try {
       sql(
         "create datamap preagg19 on table PreAggMain2 using 'preaggregate' as select a as a1,count(distinct b) from PreAggMain2 group by a")
@@ -117,7 +128,7 @@ class TestPreAggCreateCommand extends QueryTest with BeforeAndAfterAll {
     }
   }
 
-  test("test pre agg create table fourteen") {
+  test("test pre agg create table 14") {
     try {
       sql(
         "create datamap preagg20 on table PreAggMain2 using 'preaggregate' as select a as a1,sum(distinct b) from PreAggMain2 group by a")
@@ -128,7 +139,7 @@ class TestPreAggCreateCommand extends QueryTest with BeforeAndAfterAll {
     }
   }
 
-  test("test pre agg create table fifteen") {
+  test("test pre agg create table 15") {
     try {
       sql(
         "create datamap preagg21 on table PreAggMain2 using 'preaggregate' as select a as a1,sum(b) from PreAggMain2 where a='vishal' group by a")
@@ -139,8 +150,75 @@ class TestPreAggCreateCommand extends QueryTest with BeforeAndAfterAll {
     }
   }
 
+  test("test pre agg create table 16") {
+    sql("create datamap agg0 on table mainTable using 'preaggregate' as select column4, sum(column4) from maintable group by column4")
+    val df = sql("select * from maintable_agg0")
+    val carbontable = getCarbontable(df.queryExecution.analyzed)
+    assert(carbontable.getAllMeasures.size()==2)
+    assert(carbontable.getAllDimensions.size()==0)
+    sql("drop datamap agg0 on table maintable")
+  }
+
+  test("test pre agg create table 17") {
+    sql("create datamap agg0 on table mainTable using 'preaggregate' as select column1, sum(column1),column6, sum(column6) from maintable group by column6,column1")
+    val df = sql("select * from maintable_agg0")
+    val carbontable = getCarbontable(df.queryExecution.analyzed)
+    assert(carbontable.getAllMeasures.size()==2)
+    assert(carbontable.getAllDimensions.size()==2)
+    carbontable.getAllDimensions.asScala.foreach{ f =>
+      assert(f.getEncoder.contains(Encoding.DICTIONARY))
+    }
+    sql("drop datamap agg0 on table maintable")
+  }
+
+  test("test pre agg create table 18") {
+    sql("create datamap agg0 on table mainTable using 'preaggregate' as select column1, count(column1),column6, count(column6) from maintable group by column6,column1")
+    val df = sql("select * from maintable_agg0")
+    val carbontable = getCarbontable(df.queryExecution.analyzed)
+    assert(carbontable.getAllMeasures.size()==1)
+    assert(carbontable.getAllDimensions.size()==4)
+    carbontable.getAllDimensions.asScala.foreach{ f =>
+      assert(f.getEncoder.contains(Encoding.DICTIONARY))
+    }
+    sql("drop datamap agg0 on table maintable")
+  }
+
+  test("test pre agg create table 19") {
+    sql("create datamap agg0 on table mainTable using 'preaggregate' as select column3, sum(column3),column5, sum(column5) from maintable group by column3,column5")
+    val df = sql("select * from maintable_agg0")
+    val carbontable = getCarbontable(df.queryExecution.analyzed)
+    assert(carbontable.getAllMeasures.size()==2)
+    assert(carbontable.getAllDimensions.size()==2)
+    carbontable.getAllDimensions.asScala.foreach{ f =>
+      assert(!f.getEncoder.contains(Encoding.DICTIONARY))
+    }
+    sql("drop datamap agg0 on table maintable")
+  }
+
+
+  def getCarbontable(plan: LogicalPlan) : CarbonTable ={
+    var carbonTable : CarbonTable = null
+    plan.transform {
+      // first check if any preaTable1 scala function is applied it is present is in plan
+      // then call is from create preaTable1regate table class so no need to transform the query plan
+      case ca:CarbonRelation =>
+        if (ca.isInstanceOf[CarbonDatasourceHadoopRelation]) {
+          val relation = ca.asInstanceOf[CarbonDatasourceHadoopRelation]
+          carbonTable = relation.carbonTable
+        }
+        ca
+      case logicalRelation:LogicalRelation =>
+        if(logicalRelation.relation.isInstanceOf[CarbonDatasourceHadoopRelation]) {
+          val relation = logicalRelation.relation.asInstanceOf[CarbonDatasourceHadoopRelation]
+          carbonTable = relation.carbonTable
+        }
+        logicalRelation
+    }
+    carbonTable
+  }
 
   override def afterAll {
+    sql("drop table if exists maintable")
     sql("drop table if exists PreAggMain")
     sql("drop table if exists PreAggMain1")
     sql("drop table if exists PreAggMain2")

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggregateTableSelection.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggregateTableSelection.scala
@@ -27,14 +27,6 @@ class TestPreAggregateTableSelection extends QueryTest with BeforeAndAfterAll {
 
   override def beforeAll: Unit = {
     sql("drop table if exists mainTable")
-    sql("drop table if exists agg0")
-    sql("drop table if exists agg1")
-    sql("drop table if exists agg2")
-    sql("drop table if exists agg3")
-    sql("drop table if exists agg4")
-    sql("drop table if exists agg5")
-    sql("drop table if exists agg6")
-    sql("drop table if exists agg7")
     sql("drop table if exists lineitem")
     sql("CREATE TABLE mainTable(id int, name string, city string, age string) STORED BY 'org.apache.carbondata.format'")
     sql("create datamap agg0 on table mainTable using 'preaggregate' as select name from mainTable group by name")
@@ -191,6 +183,11 @@ class TestPreAggregateTableSelection extends QueryTest with BeforeAndAfterAll {
     preAggTableValidator(df.queryExecution.analyzed, "maintable_agg0")
   }
 
+  test("test PreAggregate table selection 28") {
+    val df = sql("select name as NewName, sum(case when age=2016 then 1 else 0 end) as sum from mainTable group by name")
+    preAggTableValidator(df.queryExecution.analyzed, "maintable")
+  }
+
 
   def preAggTableValidator(plan: LogicalPlan, actualTableName: String) : Unit ={
     var isValidPlan = false
@@ -223,14 +220,7 @@ class TestPreAggregateTableSelection extends QueryTest with BeforeAndAfterAll {
 
   override def afterAll: Unit = {
     sql("drop table if exists mainTable")
-    sql("drop table if exists agg0")
-    sql("drop table if exists agg1")
-    sql("drop table if exists agg2")
-    sql("drop table if exists agg3")
-    sql("drop table if exists agg4")
-    sql("drop table if exists agg5")
-    sql("drop table if exists agg6")
-    sql("drop table if exists agg7")
+    sql("drop table if exists lineitem")
   }
 
 }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/preaaggregate/PreAggregateUtil.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/preaaggregate/PreAggregateUtil.scala
@@ -116,17 +116,6 @@ object PreAggregateUtil {
       throw new MalformedCarbonCommandException(
         "Pre Aggregation is not supported on Pre-Aggregated Table")
     }
-    groupByExp.map {
-      case attr: AttributeReference =>
-        fieldToDataMapFieldMap += getField(attr.name,
-          attr.dataType,
-          parentColumnId = carbonTable.getColumnByName(parentTableName, attr.name).getColumnId,
-          parentTableName = parentTableName,
-          parentDatabaseName = parentDatabaseName, parentTableId = parentTableId)
-      case _ =>
-        throw new MalformedCarbonCommandException(s"Unsupported Function in select Statement:${
-          selectStmt } ")
-    }
     aggExp.map {
       case Alias(attr: AggregateExpression, _) =>
         if (attr.isDistinct) {

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonPreAggregateRules.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonPreAggregateRules.scala
@@ -148,7 +148,9 @@ case class CarbonPreAggregateQueryRules(sparkSession: SparkSession) extends Rule
             carbonTable,
             tableName,
             list)
-          isValidPlan = !CarbonReflectionUtils.hasPredicateSubquery(filterExp)
+          if(isValidPlan) {
+            isValidPlan = !CarbonReflectionUtils.hasPredicateSubquery(filterExp)
+          }
           // getting the columns from filter expression
           if(isValidPlan) {
             isValidPlan = extractQueryColumnFromFilterExp(filterExp, list, carbonTable, tableName)
@@ -208,7 +210,9 @@ case class CarbonPreAggregateQueryRules(sparkSession: SparkSession) extends Rule
             carbonTable,
             tableName,
             list)
-          isValidPlan = !CarbonReflectionUtils.hasPredicateSubquery(filterExp)
+          if(isValidPlan) {
+            isValidPlan = !CarbonReflectionUtils.hasPredicateSubquery(filterExp)
+          }
           if (isValidPlan) {
             list ++
             extractQueryColumnForOrderBy(Some(projectList), sortOrders, carbonTable, tableName)
@@ -251,7 +255,9 @@ case class CarbonPreAggregateQueryRules(sparkSession: SparkSession) extends Rule
             carbonTable,
             tableName,
             list)
-          isValidPlan = !CarbonReflectionUtils.hasPredicateSubquery(filterExp)
+          if(isValidPlan) {
+            isValidPlan = !CarbonReflectionUtils.hasPredicateSubquery(filterExp)
+          }
           if(isValidPlan) {
             list ++ extractQueryColumnForOrderBy(sortOrders = sortOrders,
               carbonTable = carbonTable,


### PR DESCRIPTION
*Problem:*Fixed below issues in case of pre aggregate
1. Pre aggregate data map table column order is not as per query given by user because of which while data is loaded to wrong column
2. when aggregate function contains any expression query is failing with match error
3. pre aggregate data map columns and parent tables columns encoder is not matching
Solution:
1. Do not consider group columns in pre aggregate
2. when aggregate function contains any expression hit the maintable
3. Get encoder from main table and add in pre aggregate table column
When aggregation type is sum or avg create measure column

 - [ ] Any interfaces changed?
No
 - [ ] Any backward compatibility impacted?
No
  - [ ] Document update required?
No
 - [ ] Testing done
     Added UT for all the scenario 
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

