### PR TITLE
[CARBONDATA-1862][PARTITION] Support compaction for partition table

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/metadata/PartitionMapFileStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/PartitionMapFileStore.java
@@ -276,6 +276,10 @@ public class PartitionMapFileStore {
     return partitionMap.get(indexFileName);
   }
 
+  public Map<String, List<String>> getPartitionMap() {
+    return partitionMap;
+  }
+
   public static class PartitionMapper implements Serializable {
 
     private static final long serialVersionUID = 3582245668420401089L;

--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/CarbonTable.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/CarbonTable.java
@@ -571,7 +571,8 @@ public class CarbonTable implements Serializable {
   }
 
   public boolean isPartitionTable() {
-    return null != tablePartitionMap.get(getTableName());
+    return null != tablePartitionMap.get(getTableName())
+        && tablePartitionMap.get(getTableName()).getPartitionType() != PartitionType.NATIVE_HIVE;
   }
 
   public boolean isHivePartitionTable() {

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/standardpartition/StandardPartitionTableCompactionTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/standardpartition/StandardPartitionTableCompactionTestCase.scala
@@ -106,8 +106,6 @@ class StandardPartitionTableCompactionTestCase extends QueryTest with BeforeAndA
 
     validateDataFiles("default_partitionthree", "0.1", 1)
 
-    checkExistence(sql("show partitions partitionthree"), true, "workgroupcategory=1")
-
     checkAnswer(sql("select empno, empname, designation, doj, workgroupcategory, workgroupcategoryname, deptno, deptname, projectcode, projectjoindate, projectenddate, attendance, utilization, salary from partitionthree where workgroupcategory=1 and empname='arvind' and designation='SE' order by empno"),
       sql("select empno, empname, designation, doj, workgroupcategory, workgroupcategoryname, deptno, deptname, projectcode, projectjoindate, projectenddate, attendance, utilization, salary from originTable where workgroupcategory=1 and empname='arvind' and designation='SE' order by empno"))
   }
@@ -135,7 +133,6 @@ class StandardPartitionTableCompactionTestCase extends QueryTest with BeforeAndA
     val rows = sql("select empno, empname, designation, doj, workgroupcategory, workgroupcategoryname, deptno, deptname, projectcode, projectjoindate, projectenddate, attendance, utilization, salary from partitionmajor where workgroupcategory=1 and empname='arvind' and designation='SE' order by empno").collect()
     sql("ALTER TABLE partitionmajor COMPACT 'MAJOR'").collect()
     validateDataFiles("default_partitionmajor", "0.2", 1)
-    checkExistence(sql("show partitions partitionmajor"), true, "workgroupcategory=1")
     checkAnswer(sql("select empno, empname, designation, doj, workgroupcategory, workgroupcategoryname, deptno, deptname, projectcode, projectjoindate, projectenddate, attendance, utilization, salary from partitionmajor where workgroupcategory=1 and empname='arvind' and designation='SE' order by empno"),
       rows)
   }
@@ -159,8 +156,6 @@ class StandardPartitionTableCompactionTestCase extends QueryTest with BeforeAndA
     sql("ALTER TABLE staticpartition COMPACT 'MINOR'").collect()
 
     validateDataFiles("default_staticpartition", "0.1", 1)
-
-    checkExistence(sql("show partitions staticpartition"), true, "deptname=software","deptname=finance")
 
     checkAnswer(sql(s"""select count(*) from staticpartition where deptname='software'"""), p1)
     checkAnswer(sql(s"""select count(*) from staticpartition where deptname='finance'"""), p2)

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/standardpartition/StandardPartitionTableCompactionTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/standardpartition/StandardPartitionTableCompactionTestCase.scala
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.spark.testsuite.standardpartition
+
+import org.apache.spark.sql.test.util.QueryTest
+import org.scalatest.BeforeAndAfterAll
+
+import org.apache.carbondata.core.constants.CarbonCommonConstants
+import org.apache.carbondata.core.datastore.filesystem.{CarbonFile, CarbonFileFilter}
+import org.apache.carbondata.core.datastore.impl.FileFactory
+import org.apache.carbondata.core.metadata.CarbonMetadata
+import org.apache.carbondata.core.util.CarbonProperties
+import org.apache.carbondata.core.util.path.CarbonTablePath
+
+class StandardPartitionTableCompactionTestCase extends QueryTest with BeforeAndAfterAll {
+
+  override def beforeAll {
+    dropTable
+
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, "dd-MM-yyyy")
+    sql(
+      """
+        | CREATE TABLE originTable (empno int, empname String, designation String, doj Timestamp,
+        |  workgroupcategory int, workgroupcategoryname String, deptno int, deptname String,
+        |  projectcode int, projectjoindate Timestamp, projectenddate Timestamp,attendance int,
+        |  utilization int,salary int)
+        | STORED BY 'org.apache.carbondata.format'
+      """.stripMargin)
+
+    sql(s"""LOAD DATA local inpath '$resourcesPath/data.csv' INTO TABLE originTable OPTIONS('DELIMITER'= ',', 'QUOTECHAR'= '"')""")
+    sql(s"""LOAD DATA local inpath '$resourcesPath/data.csv' INTO TABLE originTable OPTIONS('DELIMITER'= ',', 'QUOTECHAR'= '"')""")
+    sql(s"""LOAD DATA local inpath '$resourcesPath/data.csv' INTO TABLE originTable OPTIONS('DELIMITER'= ',', 'QUOTECHAR'= '"')""")
+    sql(s"""LOAD DATA local inpath '$resourcesPath/data.csv' INTO TABLE originTable OPTIONS('DELIMITER'= ',', 'QUOTECHAR'= '"')""")
+
+  }
+
+  def validateDataFiles(tableUniqueName: String, segmentId: String, partitions: Int): Unit = {
+    val carbonTable = CarbonMetadata.getInstance().getCarbonTable(tableUniqueName)
+    val tablePath = new CarbonTablePath(carbonTable.getCarbonTableIdentifier,
+      carbonTable.getTablePath)
+    val segmentDir = tablePath.getCarbonDataDirectoryPath("0", segmentId)
+    val carbonFile = FileFactory.getCarbonFile(segmentDir, FileFactory.getFileType(segmentDir))
+    val dataFiles = carbonFile.listFiles(new CarbonFileFilter() {
+      override def accept(file: CarbonFile): Boolean = {
+        return file.getName.endsWith(".partitionmap")
+      }
+    })
+    assert(dataFiles.length == partitions)
+  }
+
+  test("data compaction for partition table for one partition column") {
+    sql(
+      """
+        | CREATE TABLE partitionone (empname String, designation String, doj Timestamp,
+        |  workgroupcategory int, workgroupcategoryname String, deptno int, deptname String,
+        |  projectcode int, projectjoindate Timestamp, projectenddate Timestamp,attendance int,
+        |  utilization int,salary int)
+        | PARTITIONED BY (empno int)
+        | STORED BY 'org.apache.carbondata.format'
+      """.stripMargin)
+    sql(s"""LOAD DATA local inpath '$resourcesPath/data.csv' INTO TABLE partitionone OPTIONS('DELIMITER'= ',', 'QUOTECHAR'= '"')""")
+    sql(s"""LOAD DATA local inpath '$resourcesPath/data.csv' INTO TABLE partitionone OPTIONS('DELIMITER'= ',', 'QUOTECHAR'= '"')""")
+    sql(s"""LOAD DATA local inpath '$resourcesPath/data.csv' INTO TABLE partitionone OPTIONS('DELIMITER'= ',', 'QUOTECHAR'= '"')""")
+    sql(s"""LOAD DATA local inpath '$resourcesPath/data.csv' INTO TABLE partitionone OPTIONS('DELIMITER'= ',', 'QUOTECHAR'= '"')""")
+
+    sql("ALTER TABLE partitionone COMPACT 'MINOR'").collect()
+
+    validateDataFiles("default_partitionone", "0.1", 1)
+
+    checkAnswer(sql("select empno, empname, designation, doj, workgroupcategory, workgroupcategoryname, deptno, deptname, projectcode, projectjoindate, projectenddate, attendance, utilization, salary from partitionone where empno=11 order by empno"),
+      sql("select  empno, empname, designation, doj, workgroupcategory, workgroupcategoryname, deptno, deptname, projectcode, projectjoindate, projectenddate, attendance, utilization, salary from originTable where empno=11 order by empno"))
+
+  }
+
+
+  test("data compaction for partition table for three partition column") {
+    sql(
+      """
+        | CREATE TABLE partitionthree (empno int, doj Timestamp,
+        |  workgroupcategoryname String, deptno int, deptname String,
+        |  projectcode int, projectjoindate Timestamp, projectenddate Timestamp,attendance int,
+        |  utilization int,salary int)
+        | PARTITIONED BY (workgroupcategory int, empname String, designation String)
+        | STORED BY 'org.apache.carbondata.format'
+      """.stripMargin)
+    sql(s"""LOAD DATA local inpath '$resourcesPath/data.csv' INTO TABLE partitionthree OPTIONS('DELIMITER'= ',', 'QUOTECHAR'= '"')""")
+    sql(s"""LOAD DATA local inpath '$resourcesPath/data.csv' INTO TABLE partitionthree OPTIONS('DELIMITER'= ',', 'QUOTECHAR'= '"')""")
+    sql(s"""LOAD DATA local inpath '$resourcesPath/data.csv' INTO TABLE partitionthree OPTIONS('DELIMITER'= ',', 'QUOTECHAR'= '"')""")
+    sql(s"""LOAD DATA local inpath '$resourcesPath/data.csv' INTO TABLE partitionthree OPTIONS('DELIMITER'= ',', 'QUOTECHAR'= '"')""")
+    sql("ALTER TABLE partitionthree COMPACT 'MINOR'").collect()
+
+    validateDataFiles("default_partitionthree", "0.1", 1)
+
+    checkExistence(sql("show partitions partitionthree"), true, "workgroupcategory=1")
+
+    checkAnswer(sql("select empno, empname, designation, doj, workgroupcategory, workgroupcategoryname, deptno, deptname, projectcode, projectjoindate, projectenddate, attendance, utilization, salary from partitionthree where workgroupcategory=1 and empname='arvind' and designation='SE' order by empno"),
+      sql("select empno, empname, designation, doj, workgroupcategory, workgroupcategoryname, deptno, deptname, projectcode, projectjoindate, projectenddate, attendance, utilization, salary from originTable where workgroupcategory=1 and empname='arvind' and designation='SE' order by empno"))
+  }
+
+  test("data major compaction for partition table") {
+    sql(
+      """
+        | CREATE TABLE partitionmajor (empno int, doj Timestamp,
+        |  workgroupcategoryname String, deptno int, deptname String,
+        |  projectcode int, projectjoindate Timestamp, projectenddate Timestamp,attendance int,
+        |  utilization int,salary int)
+        | PARTITIONED BY (workgroupcategory int, empname String, designation String)
+        | STORED BY 'org.apache.carbondata.format'
+      """.stripMargin)
+    sql(s"""LOAD DATA local inpath '$resourcesPath/data.csv' INTO TABLE partitionmajor OPTIONS('DELIMITER'= ',', 'QUOTECHAR'= '"')""")
+    sql(s"""LOAD DATA local inpath '$resourcesPath/data.csv' INTO TABLE partitionmajor OPTIONS('DELIMITER'= ',', 'QUOTECHAR'= '"')""")
+    sql(s"""LOAD DATA local inpath '$resourcesPath/data.csv' INTO TABLE partitionmajor OPTIONS('DELIMITER'= ',', 'QUOTECHAR'= '"')""")
+    sql(s"""LOAD DATA local inpath '$resourcesPath/data.csv' INTO TABLE partitionmajor OPTIONS('DELIMITER'= ',', 'QUOTECHAR'= '"')""")
+    sql("ALTER TABLE partitionmajor COMPACT 'MINOR'").collect()
+    sql(s"""ALTER TABLE partitionmajor DROP PARTITION(workgroupcategory='1')""")
+    sql(s"""LOAD DATA local inpath '$resourcesPath/data.csv' INTO TABLE partitionmajor OPTIONS('DELIMITER'= ',', 'QUOTECHAR'= '"')""")
+    sql(s"""LOAD DATA local inpath '$resourcesPath/data.csv' INTO TABLE partitionmajor OPTIONS('DELIMITER'= ',', 'QUOTECHAR'= '"')""")
+    sql(s"""LOAD DATA local inpath '$resourcesPath/data.csv' INTO TABLE partitionmajor OPTIONS('DELIMITER'= ',', 'QUOTECHAR'= '"')""")
+    sql(s"""LOAD DATA local inpath '$resourcesPath/data.csv' INTO TABLE partitionmajor OPTIONS('DELIMITER'= ',', 'QUOTECHAR'= '"')""")
+    val rows = sql("select empno, empname, designation, doj, workgroupcategory, workgroupcategoryname, deptno, deptname, projectcode, projectjoindate, projectenddate, attendance, utilization, salary from partitionmajor where workgroupcategory=1 and empname='arvind' and designation='SE' order by empno").collect()
+    sql("ALTER TABLE partitionmajor COMPACT 'MAJOR'").collect()
+    validateDataFiles("default_partitionmajor", "0.2", 1)
+    checkExistence(sql("show partitions partitionmajor"), true, "workgroupcategory=1")
+    checkAnswer(sql("select empno, empname, designation, doj, workgroupcategory, workgroupcategoryname, deptno, deptname, projectcode, projectjoindate, projectenddate, attendance, utilization, salary from partitionmajor where workgroupcategory=1 and empname='arvind' and designation='SE' order by empno"),
+      rows)
+  }
+
+  test("data compaction for static partition table") {
+    sql(
+      """
+        | CREATE TABLE staticpartition (empno int, doj Timestamp,
+        |  workgroupcategoryname String, deptno int,
+        |  projectcode int, projectjoindate Timestamp, projectenddate Timestamp,attendance int,
+        |  utilization int,salary int,workgroupcategory int, empname String, designation String)
+        | PARTITIONED BY (deptname String)
+        | STORED BY 'org.apache.carbondata.format'
+      """.stripMargin)
+    sql(s"""insert into staticpartition PARTITION(deptname='software') select empno,doj,workgroupcategoryname,deptno,projectcode,projectjoindate,projectenddate,attendance,utilization,salary,workgroupcategory,empname,designation from originTable""")
+    sql(s"""insert into staticpartition PARTITION(deptname='software') select empno,doj,workgroupcategoryname,deptno,projectcode,projectjoindate,projectenddate,attendance,utilization,salary,workgroupcategory,empname,designation from originTable""")
+    sql(s"""insert into staticpartition PARTITION(deptname='finance') select empno,doj,workgroupcategoryname,deptno,projectcode,projectjoindate,projectenddate,attendance,utilization,salary,workgroupcategory,empname,designation from originTable""")
+    sql(s"""insert into staticpartition PARTITION(deptname='finance') select empno,doj,workgroupcategoryname,deptno,projectcode,projectjoindate,projectenddate,attendance,utilization,salary,workgroupcategory,empname,designation from originTable""")
+    val p1 = sql(s"""select count(*) from staticpartition where deptname='software'""").collect()
+    val p2 = sql(s"""select count(*) from staticpartition where deptname='finance'""").collect()
+    sql("ALTER TABLE staticpartition COMPACT 'MINOR'").collect()
+
+    validateDataFiles("default_staticpartition", "0.1", 1)
+
+    checkExistence(sql("show partitions staticpartition"), true, "deptname=software","deptname=finance")
+
+    checkAnswer(sql(s"""select count(*) from staticpartition where deptname='software'"""), p1)
+    checkAnswer(sql(s"""select count(*) from staticpartition where deptname='finance'"""), p2)
+  }
+
+  override def afterAll = {
+    dropTable
+  }
+
+  def dropTable = {
+    sql("drop table if exists originTable")
+    sql("drop table if exists originMultiLoads")
+    sql("drop table if exists partitionone")
+    sql("drop table if exists partitiontwo")
+    sql("drop table if exists partitionthree")
+    sql("drop table if exists partitionmajor")
+    sql("drop table if exists staticpartition")
+  }
+
+}

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/standardpartition/StandardPartitionTableQueryTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/standardpartition/StandardPartitionTableQueryTestCase.scala
@@ -182,7 +182,7 @@ class StandardPartitionTableQueryTestCase extends QueryTest with BeforeAndAfterA
            "doj=2014-08-15 00:00:00",
            "projectenddate=2016-12-30"))
     checkAnswer(frame1,
-      sql("select  empno, empname, designation, doj, workgroupcategory, workgroupcategoryname, deptno, deptname, projectcode, projectjoindate, projectenddate, attendance, utilization, salary from originTable where doj>'2006-01-17 00:00:00'"))
+      sql("select  empno, empname, designation, doj, workgroupcategory, workgroupcategoryname, deptno, deptname, projectcode, projectjoindate, projectenddate, attendance, utilization, salary from originTable where doj>cast('2006-01-17 00:00:00' as Timestamp)"))
 
   }
 
@@ -209,8 +209,6 @@ class StandardPartitionTableQueryTestCase extends QueryTest with BeforeAndAfterA
     sql("drop table if exists partitionmany")
     sql("drop table if exists partitiondate")
     sql("drop table if exists partitiondateinsert")
-    sql("drop table if exists staticpartitionone")
-    sql("drop table if exists singlepasspartitionone")
   }
 
 }

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonMergerRDD.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonMergerRDD.scala
@@ -86,7 +86,7 @@ class CarbonMergerRDD[K, V](
       } else {
         carbonLoadModel.setTaskNo(String.valueOf(theSplit.index))
       }
-      val partitionNames = if (carbonTable.isStandardPartitionTable) {
+      val partitionNames = if (carbonTable.isHivePartitionTable) {
         carbonSparkPartition.partitionNames.get.asJava
       } else {
         null
@@ -438,7 +438,8 @@ class CarbonMergerRDD[K, V](
             carbonPartitionId = Integer.parseInt(taskInfo.getTaskId)
           }
           result.add(
-            new CarbonSparkPartition(id,
+            new CarbonSparkPartition(
+              id,
               taskPartitionNo,
               multiBlockSplit,
               carbonPartitionId,
@@ -473,7 +474,7 @@ class CarbonMergerRDD[K, V](
   private def getTaskNo(
       split: CarbonInputSplit,
       partitionTaskMap: util.Map[List[String], String]): String = {
-    if (carbonLoadModel.getCarbonDataLoadSchema.getCarbonTable.isStandardPartitionTable) {
+    if (carbonLoadModel.getCarbonDataLoadSchema.getCarbonTable.isHivePartitionTable) {
       val partitions =
         carbonMergerMapping.partitionMapper.getPartitionMap.get(
           CarbonTablePath.getCarbonIndexFileName(split.getBlockPath))
@@ -490,7 +491,7 @@ class CarbonMergerRDD[K, V](
 
   private def getPartitionNamesFromTask(taskId: String,
       partitionTaskMap: util.Map[List[String], String]): Option[Seq[String]] = {
-    if (carbonLoadModel.getCarbonDataLoadSchema.getCarbonTable.isStandardPartitionTable) {
+    if (carbonLoadModel.getCarbonDataLoadSchema.getCarbonTable.isHivePartitionTable) {
       Some(partitionTaskMap.asScala.find(f => f._2.equals(taskId)).get._1.asScala)
     } else {
       None

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonSparkPartition.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonSparkPartition.scala
@@ -25,7 +25,8 @@ class CarbonSparkPartition(
     val rddId: Int,
     val idx: Int,
     @transient val multiBlockSplit: CarbonMultiBlockSplit,
-    val partitionId: Int = 0)
+    val partitionId: Int = 0,
+    val partitionNames: Option[Seq[String]] = None)
     extends Partition {
 
   val split = new SerializableWritable[CarbonMultiBlockSplit](multiBlockSplit)

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchemaCommon.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchemaCommon.scala
@@ -29,7 +29,8 @@ import org.apache.spark.sql.util.CarbonException
 
 import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.core.constants.CarbonCommonConstants
-import org.apache.carbondata.core.metadata.{AbsoluteTableIdentifier, CarbonTableIdentifier}
+import org.apache.carbondata.core.metadata.CarbonTableIdentifier
+import org.apache.carbondata.core.metadata.PartitionFileStore.PartitionMapper
 import org.apache.carbondata.core.metadata.datatype.{DataType, DataTypes, DecimalType}
 import org.apache.carbondata.core.metadata.encoder.Encoding
 import org.apache.carbondata.core.metadata.schema._
@@ -114,7 +115,9 @@ case class CarbonMergerMapping(
     // maxSegmentColCardinality is Cardinality of last segment of compaction
     var maxSegmentColCardinality: Array[Int],
     // maxSegmentColumnSchemaList is list of column schema of last segment of compaction
-    var maxSegmentColumnSchemaList: List[ColumnSchema])
+    var maxSegmentColumnSchemaList: List[ColumnSchema],
+    currentPartitions: Seq[String],
+    @transient partitionMapper: PartitionMapper)
 
 case class NodeInfo(TaskId: String, noOfBlocks: Int)
 
@@ -134,13 +137,15 @@ case class UpdateTableModel(
 case class CompactionModel(compactionSize: Long,
     compactionType: CompactionType,
     carbonTable: CarbonTable,
-    isDDLTrigger: Boolean)
+    isDDLTrigger: Boolean,
+    currentPartitions: Seq[String])
 
 case class CompactionCallableModel(carbonLoadModel: CarbonLoadModel,
     carbonTable: CarbonTable,
     loadsToMerge: util.List[LoadMetadataDetails],
     sqlContext: SQLContext,
-    compactionType: CompactionType)
+    compactionType: CompactionType,
+    currentPartitions: Seq[String])
 
 case class AlterPartitionModel(carbonLoadModel: CarbonLoadModel,
     segmentId: String,

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchemaCommon.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchemaCommon.scala
@@ -30,7 +30,7 @@ import org.apache.spark.sql.util.CarbonException
 import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.metadata.CarbonTableIdentifier
-import org.apache.carbondata.core.metadata.PartitionFileStore.PartitionMapper
+import org.apache.carbondata.core.metadata.PartitionMapFileStore.PartitionMapper
 import org.apache.carbondata.core.metadata.datatype.{DataType, DataTypes, DecimalType}
 import org.apache.carbondata.core.metadata.encoder.Encoding
 import org.apache.carbondata.core.metadata.schema._

--- a/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -210,7 +210,8 @@ object CarbonDataRDDFactory {
 
               val compactionSize = CarbonDataMergerUtil.getCompactionSize(CompactionType.MAJOR)
 
-              val newcompactionModel = CompactionModel(compactionSize,
+              val newcompactionModel = CompactionModel(
+                compactionSize,
                 compactionType,
                 table,
                 compactionModel.isDDLTrigger,
@@ -725,7 +726,8 @@ object CarbonDataRDDFactory {
                    s"${ carbonLoadModel.getDatabaseName }.${ carbonLoadModel.getTableName }")
       val compactionSize = 0
       val isCompactionTriggerByDDl = false
-      val compactionModel = CompactionModel(compactionSize,
+      val compactionModel = CompactionModel(
+        compactionSize,
         CompactionType.MINOR,
         carbonTable,
         isCompactionTriggerByDDl,

--- a/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -40,6 +40,7 @@ import org.apache.spark.rdd.{DataLoadCoalescedRDD, DataLoadPartitionCoalescer, N
 import org.apache.spark.sql.{CarbonEnv, DataFrame, Row, SQLContext}
 import org.apache.spark.sql.execution.command.{CompactionModel, ExecutionErrors, UpdateTableModel}
 import org.apache.spark.sql.hive.DistributionUtil
+import org.apache.spark.sql.optimizer.CarbonFilters
 import org.apache.spark.sql.util.CarbonException
 
 import org.apache.carbondata.common.constants.LoggerAction
@@ -212,8 +213,8 @@ object CarbonDataRDDFactory {
               val newcompactionModel = CompactionModel(compactionSize,
                 compactionType,
                 table,
-                compactionModel.isDDLTrigger
-              )
+                compactionModel.isDDLTrigger,
+                CarbonFilters.getCurrentPartitions(sqlContext.sparkSession, table))
               // proceed for compaction
               try {
                 CompactionFactory.getCompactor(
@@ -727,8 +728,8 @@ object CarbonDataRDDFactory {
       val compactionModel = CompactionModel(compactionSize,
         CompactionType.MINOR,
         carbonTable,
-        isCompactionTriggerByDDl
-      )
+        isCompactionTriggerByDDl,
+        CarbonFilters.getCurrentPartitions(sqlContext.sparkSession, carbonTable))
       var storeLocation = ""
       val configuredStore = Util.getConfiguredLocalDirs(SparkEnv.get.conf)
       if (null != configuredStore && configuredStore.nonEmpty) {

--- a/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonTableCompactor.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonTableCompactor.scala
@@ -18,6 +18,7 @@
 package org.apache.carbondata.spark.rdd
 
 import java.util
+import java.util.{List, Map}
 import java.util.concurrent.ExecutorService
 
 import scala.collection.JavaConverters._
@@ -26,8 +27,11 @@ import scala.concurrent.{Await, ExecutionContext, ExecutionContextExecutor, Futu
 import org.apache.spark.sql.SQLContext
 import org.apache.spark.sql.execution.command.{CarbonMergerMapping, CompactionCallableModel, CompactionModel}
 
+import org.apache.carbondata.core.metadata.PartitionFileStore
+import org.apache.carbondata.core.metadata.PartitionFileStore.PartitionMapper
 import org.apache.carbondata.core.mutate.CarbonUpdateUtil
 import org.apache.carbondata.core.statusmanager.{LoadMetadataDetails, SegmentStatusManager}
+import org.apache.carbondata.core.util.path.CarbonTablePath
 import org.apache.carbondata.events.{AlterTableCompactionPostEvent, AlterTableCompactionPreEvent, AlterTableCompactionPreStatusUpdateEvent, OperationContext, OperationListenerBus}
 import org.apache.carbondata.processing.loading.model.CarbonLoadModel
 import org.apache.carbondata.processing.merger.{CarbonDataMergerUtil, CompactionType}
@@ -111,7 +115,8 @@ class CarbonTableCompactor(carbonLoadModel: CarbonLoadModel,
       compactionModel.carbonTable,
       loadsToMerge,
       sqlContext,
-      compactionModel.compactionType)
+      compactionModel.compactionType,
+      compactionModel.currentPartitions)
     triggerCompaction(compactionCallableModel)
   }
 
@@ -121,6 +126,7 @@ class CarbonTableCompactor(carbonLoadModel: CarbonLoadModel,
     val sc = compactionCallableModel.sqlContext
     val carbonLoadModel = compactionCallableModel.carbonLoadModel
     val compactionType = compactionCallableModel.compactionType
+    val partitions = compactionCallableModel.currentPartitions
     val tablePath = carbonLoadModel.getTablePath
     val startTime = System.nanoTime()
     val mergedLoadName = CarbonDataMergerUtil.getMergedLoadName(loadsToMerge)
@@ -130,6 +136,24 @@ class CarbonTableCompactor(carbonLoadModel: CarbonLoadModel,
     val validSegments: Array[String] = CarbonDataMergerUtil
       .getValidSegments(loadsToMerge).split(',')
     val mergeLoadStartTime = CarbonUpdateUtil.readCurrentTime()
+    val partitionMapper = if (carbonTable.isStandardPartitionTable) {
+      var partitionMap: util.Map[String, util.List[String]] = null
+      validSegments.foreach { segmentId =>
+        val localMapper = new PartitionFileStore()
+        localMapper.readAllPartitionsOfSegment(
+          CarbonTablePath.getSegmentPath(carbonLoadModel.getTablePath, segmentId))
+        if (partitionMap == null) {
+          partitionMap = localMapper.getPartitionMap
+        } else {
+          partitionMap.putAll(localMapper.getPartitionMap)
+        }
+      }
+      val mapper = new PartitionMapper()
+      mapper.setPartitionMap(partitionMap)
+      mapper
+    } else {
+      null
+    }
     val carbonMergerMapping = CarbonMergerMapping(tablePath,
       carbonTable.getMetaDataFilepath,
       mergedLoadName,
@@ -139,8 +163,9 @@ class CarbonTableCompactor(carbonLoadModel: CarbonLoadModel,
       carbonTable.getAbsoluteTableIdentifier.getCarbonTableIdentifier.getTableId,
       compactionType,
       maxSegmentColCardinality = null,
-      maxSegmentColumnSchemaList = null
-    )
+      maxSegmentColumnSchemaList = null,
+      currentPartitions = partitions,
+      partitionMapper)
     carbonLoadModel.setTablePath(carbonMergerMapping.hdfsStoreLocation)
     carbonLoadModel.setLoadMetadataDetails(
       SegmentStatusManager.readLoadMetadata(carbonTable.getMetaDataFilepath).toList.asJava)
@@ -196,7 +221,8 @@ class CarbonTableCompactor(carbonLoadModel: CarbonLoadModel,
       val mergedLoadNumber = CarbonDataMergerUtil.getLoadNumberFromLoadName(mergedLoadName)
       CommonUtil.mergeIndexFiles(
         sc.sparkContext, Seq(mergedLoadNumber), tablePath, carbonTable, false)
-
+      new PartitionFileStore().mergePartitionMapFiles(
+        CarbonTablePath.getSegmentPath(tablePath, mergedLoadNumber))
       // trigger event for compaction
       val alterTableCompactionPreStatusUpdateEvent: AlterTableCompactionPreStatusUpdateEvent =
       AlterTableCompactionPreStatusUpdateEvent(sc.sparkSession,

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/optimizer/CarbonFilters.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/optimizer/CarbonFilters.scala
@@ -395,7 +395,7 @@ object CarbonFilters {
 
   def getCurrentPartitions(sparkSession: SparkSession,
       carbonTable: CarbonTable): Seq[String] = {
-    if (carbonTable.isStandardPartitionTable) {
+    if (carbonTable.isHivePartitionTable) {
       CarbonFilters.getPartitions(
         Seq.empty,
         sparkSession,

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/optimizer/CarbonFilters.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/optimizer/CarbonFilters.scala
@@ -25,6 +25,7 @@ import org.apache.spark.sql.CarbonExpressions.{MatchCast => Cast}
 import org.apache.spark.sql.catalyst.TableIdentifier
 
 import org.apache.carbondata.core.metadata.datatype.{DataTypes => CarbonDataTypes}
+import org.apache.carbondata.core.metadata.schema.table.CarbonTable
 import org.apache.carbondata.core.scan.expression.{ColumnExpression => CarbonColumnExpression, Expression => CarbonExpression, LiteralExpression => CarbonLiteralExpression}
 import org.apache.carbondata.core.scan.expression.conditional._
 import org.apache.carbondata.core.scan.expression.logical.{AndExpression, FalseExpression, OrExpression}
@@ -389,6 +390,18 @@ object CarbonFilters {
       case List(left, right) => List(And(left, right))
 
       case _ => expressions
+    }
+  }
+
+  def getCurrentPartitions(sparkSession: SparkSession,
+      carbonTable: CarbonTable): Seq[String] = {
+    if (carbonTable.isStandardPartitionTable) {
+      CarbonFilters.getPartitions(
+        Seq.empty,
+        sparkSession,
+        TableIdentifier(carbonTable.getTableName, Some(carbonTable.getDatabaseName)))
+    } else {
+      Seq.empty
     }
   }
 

--- a/processing/src/main/java/org/apache/carbondata/processing/merger/CompactionResultSortProcessor.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/merger/CompactionResultSortProcessor.java
@@ -26,6 +26,7 @@ import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.datastore.block.SegmentProperties;
 import org.apache.carbondata.core.datastore.exception.CarbonDataWriterException;
 import org.apache.carbondata.core.datastore.row.CarbonRow;
+import org.apache.carbondata.core.metadata.PartitionFileStore;
 import org.apache.carbondata.core.metadata.datatype.DataType;
 import org.apache.carbondata.core.metadata.datatype.DataTypes;
 import org.apache.carbondata.core.metadata.encoder.Encoding;
@@ -34,6 +35,7 @@ import org.apache.carbondata.core.metadata.schema.table.column.CarbonDimension;
 import org.apache.carbondata.core.scan.result.iterator.RawResultIterator;
 import org.apache.carbondata.core.scan.wrappers.ByteArrayWrapper;
 import org.apache.carbondata.core.util.CarbonUtil;
+import org.apache.carbondata.core.util.path.CarbonTablePath;
 import org.apache.carbondata.processing.loading.model.CarbonLoadModel;
 import org.apache.carbondata.processing.sort.exception.CarbonSortKeyAndGroupByException;
 import org.apache.carbondata.processing.sort.sortdata.SingleThreadFinalSortFilesMerger;
@@ -127,6 +129,8 @@ public class CompactionResultSortProcessor extends AbstractResultProcessor {
    */
   private SortIntermediateFileMerger intermediateFileMerger;
 
+  private List<String> partitionNames;
+
   /**
    * @param carbonLoadModel
    * @param carbonTable
@@ -135,13 +139,15 @@ public class CompactionResultSortProcessor extends AbstractResultProcessor {
    * @param tableName
    */
   public CompactionResultSortProcessor(CarbonLoadModel carbonLoadModel, CarbonTable carbonTable,
-      SegmentProperties segmentProperties, CompactionType compactionType, String tableName) {
+      SegmentProperties segmentProperties, CompactionType compactionType, String tableName,
+      List<String> partitionNames) {
     this.carbonLoadModel = carbonLoadModel;
     this.carbonTable = carbonTable;
     this.segmentProperties = segmentProperties;
     this.segmentId = carbonLoadModel.getSegmentId();
     this.compactionType = compactionType;
     this.tableName = tableName;
+    this.partitionNames = partitionNames;
   }
 
   /**
@@ -168,6 +174,18 @@ public class CompactionResultSortProcessor extends AbstractResultProcessor {
     } catch (Exception e) {
       LOGGER.error(e, "Compaction failed: " + e.getMessage());
     } finally {
+      if (partitionNames != null) {
+        try {
+          new PartitionFileStore().writePartitionMapFile(
+              CarbonTablePath.getSegmentPath(
+                  carbonLoadModel.getTablePath(),
+                  carbonLoadModel.getSegmentId()),
+              carbonLoadModel.getTaskNo(), partitionNames);
+        } catch (IOException e) {
+          LOGGER.error(e, "Compaction failed: " + e.getMessage());
+          isCompactionSuccess = false;
+        }
+      }
       // clear temp files and folders created during compaction
       deleteTempStoreLocation();
     }

--- a/processing/src/main/java/org/apache/carbondata/processing/merger/CompactionResultSortProcessor.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/merger/CompactionResultSortProcessor.java
@@ -26,7 +26,7 @@ import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.datastore.block.SegmentProperties;
 import org.apache.carbondata.core.datastore.exception.CarbonDataWriterException;
 import org.apache.carbondata.core.datastore.row.CarbonRow;
-import org.apache.carbondata.core.metadata.PartitionFileStore;
+import org.apache.carbondata.core.metadata.PartitionMapFileStore;
 import org.apache.carbondata.core.metadata.datatype.DataType;
 import org.apache.carbondata.core.metadata.datatype.DataTypes;
 import org.apache.carbondata.core.metadata.encoder.Encoding;
@@ -131,13 +131,7 @@ public class CompactionResultSortProcessor extends AbstractResultProcessor {
 
   private List<String> partitionNames;
 
-  /**
-   * @param carbonLoadModel
-   * @param carbonTable
-   * @param segmentProperties
-   * @param compactionType
-   * @param tableName
-   */
+
   public CompactionResultSortProcessor(CarbonLoadModel carbonLoadModel, CarbonTable carbonTable,
       SegmentProperties segmentProperties, CompactionType compactionType, String tableName,
       List<String> partitionNames) {
@@ -176,11 +170,12 @@ public class CompactionResultSortProcessor extends AbstractResultProcessor {
     } finally {
       if (partitionNames != null) {
         try {
-          new PartitionFileStore().writePartitionMapFile(
+          new PartitionMapFileStore().writePartitionMapFile(
               CarbonTablePath.getSegmentPath(
                   carbonLoadModel.getTablePath(),
                   carbonLoadModel.getSegmentId()),
-              carbonLoadModel.getTaskNo(), partitionNames);
+              carbonLoadModel.getTaskNo(),
+              partitionNames);
         } catch (IOException e) {
           LOGGER.error(e, "Compaction failed: " + e.getMessage());
           isCompactionSuccess = false;

--- a/processing/src/main/java/org/apache/carbondata/processing/merger/RowResultMergerProcessor.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/merger/RowResultMergerProcessor.java
@@ -30,7 +30,7 @@ import org.apache.carbondata.core.datastore.row.CarbonRow;
 import org.apache.carbondata.core.datastore.row.WriteStepRowUtil;
 import org.apache.carbondata.core.keygenerator.KeyGenException;
 import org.apache.carbondata.core.metadata.CarbonMetadata;
-import org.apache.carbondata.core.metadata.PartitionFileStore;
+import org.apache.carbondata.core.metadata.PartitionMapFileStore;
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
 import org.apache.carbondata.core.scan.result.iterator.RawResultIterator;
 import org.apache.carbondata.core.scan.wrappers.ByteArrayWrapper;
@@ -158,12 +158,13 @@ public class RowResultMergerProcessor extends AbstractResultProcessor {
           this.dataHandler.closeHandler();
         }
         if (partitionNames != null) {
-          new PartitionFileStore().writePartitionMapFile(
+          new PartitionMapFileStore().writePartitionMapFile(
               CarbonTablePath.getSegmentPath(loadModel.getTablePath(), loadModel.getSegmentId()),
-              loadModel.getTaskNo(), partitionNames);
+              loadModel.getTaskNo(),
+              partitionNames);
         }
       } catch (CarbonDataWriterException | IOException e) {
-        LOGGER.error("Exception while closing the handler in compaction merger " + e.getMessage());
+        LOGGER.error(e,"Exception in compaction merger");
         mergeStatus = false;
       }
     }

--- a/processing/src/main/java/org/apache/carbondata/processing/merger/RowResultMergerProcessor.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/merger/RowResultMergerProcessor.java
@@ -16,6 +16,7 @@
  */
 package org.apache.carbondata.processing.merger;
 
+import java.io.IOException;
 import java.util.AbstractQueue;
 import java.util.Comparator;
 import java.util.List;
@@ -29,10 +30,12 @@ import org.apache.carbondata.core.datastore.row.CarbonRow;
 import org.apache.carbondata.core.datastore.row.WriteStepRowUtil;
 import org.apache.carbondata.core.keygenerator.KeyGenException;
 import org.apache.carbondata.core.metadata.CarbonMetadata;
+import org.apache.carbondata.core.metadata.PartitionFileStore;
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
 import org.apache.carbondata.core.scan.result.iterator.RawResultIterator;
 import org.apache.carbondata.core.scan.wrappers.ByteArrayWrapper;
 import org.apache.carbondata.core.util.ByteUtil;
+import org.apache.carbondata.core.util.path.CarbonTablePath;
 import org.apache.carbondata.processing.exception.SliceMergerException;
 import org.apache.carbondata.processing.loading.model.CarbonLoadModel;
 import org.apache.carbondata.processing.store.CarbonFactDataHandlerColumnar;
@@ -47,6 +50,8 @@ public class RowResultMergerProcessor extends AbstractResultProcessor {
 
   private CarbonFactHandler dataHandler;
   private SegmentProperties segprop;
+  private CarbonLoadModel loadModel;
+  private List<String> partitionNames;
   /**
    * record holder heap
    */
@@ -57,8 +62,10 @@ public class RowResultMergerProcessor extends AbstractResultProcessor {
 
   public RowResultMergerProcessor(String databaseName,
       String tableName, SegmentProperties segProp, String[] tempStoreLocation,
-      CarbonLoadModel loadModel, CompactionType compactionType) {
+      CarbonLoadModel loadModel, CompactionType compactionType, List<String> partitionNames) {
     this.segprop = segProp;
+    this.partitionNames = partitionNames;
+    this.loadModel = loadModel;
     CarbonDataProcessorUtil.createLocations(tempStoreLocation);
 
     CarbonTable carbonTable = CarbonMetadata.getInstance().getCarbonTable(databaseName, tableName);
@@ -150,7 +157,12 @@ public class RowResultMergerProcessor extends AbstractResultProcessor {
         if (isDataPresent) {
           this.dataHandler.closeHandler();
         }
-      } catch (CarbonDataWriterException e) {
+        if (partitionNames != null) {
+          new PartitionFileStore().writePartitionMapFile(
+              CarbonTablePath.getSegmentPath(loadModel.getTablePath(), loadModel.getSegmentId()),
+              loadModel.getTaskNo(), partitionNames);
+        }
+      } catch (CarbonDataWriterException | IOException e) {
         LOGGER.error("Exception while closing the handler in compaction merger " + e.getMessage());
         mergeStatus = false;
       }

--- a/streaming/src/main/scala/org/apache/carbondata/streaming/StreamHandoffRDD.scala
+++ b/streaming/src/main/scala/org/apache/carbondata/streaming/StreamHandoffRDD.scala
@@ -177,7 +177,8 @@ class StreamHandoffRDD[K, V](
       carbonTable,
       segmentProperties,
       CompactionType.STREAMING,
-      carbonTable.getTableName
+      carbonTable.getTableName,
+      null
     )
   }
 


### PR DESCRIPTION
This PR depends on https://github.com/apache/carbondata/pull/1654 and https://github.com/apache/carbondata/pull/1672 and https://github.com/apache/carbondata/pull/1674

It supports compaction on partition table.
There is a change in compaction during the block identification and grouping. As all blocks which are related same partition always needs to group to same set for compaction.So compactor needs to get the partition information from partition map file during compaction of partition table

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [X] Any interfaces changed?
 - [X] Any backward compatibility impacted?
   NO
 - [X] Document update required?
   Yes
 - [X] Testing done
        Tests added
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

