### PR TITLE
[CARBONDATA-1906] Update registerTempTable method because it was marked deprecated

### DIFF
--- a/examples/spark2/src/main/scala/org/apache/carbondata/examples/CompareTest.scala
+++ b/examples/spark2/src/main/scala/org/apache/carbondata/examples/CompareTest.scala
@@ -21,8 +21,6 @@ import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Date
 
-import scala.util.Random
-
 import org.apache.spark.sql.{DataFrame, Row, SaveMode, SparkSession}
 import org.apache.spark.sql.types._
 
@@ -52,7 +50,7 @@ object CompareTest {
   // +-------------+-----------+-------------+-------------+------------+
   // | country     | string    | 1103        | dimension   | yes        |
   // +-------------+-----------+-------------+-------------+------------+
-  // | planet      | string    | 100,007     | dimension   | yes        |
+  // | planet      | string    | 10,007      | dimension   | yes        |
   // +-------------+-----------+-------------+-------------+------------+
   // | id          | string    | 10,000,000  | dimension   | no         |
   // +-------------+-----------+-------------+-------------+------------+
@@ -67,7 +65,6 @@ object CompareTest {
   // | m5          | decimal   | NA          | measure     | no         |
   // +-------------+-----------+-------------+-------------+------------+
   private def generateDataFrame(spark: SparkSession): DataFrame = {
-    val r = new Random()
     val rdd = spark.sparkContext
         .parallelize(1 to 10 * 1000 * 1000, 4)
         .map { x =>
@@ -257,7 +254,7 @@ object CompareTest {
         .partitionBy("partitionCol")
         .mode(SaveMode.Overwrite)
         .parquet(table)
-    spark.read.parquet(table).registerTempTable(table)
+    spark.read.parquet(table).createOrReplaceTempView(table)
   }
 
   private def loadOrcTable(spark: SparkSession, input: DataFrame, table: String): Double = time {
@@ -265,7 +262,7 @@ object CompareTest {
     input.write
         .mode(SaveMode.Overwrite)
         .orc(table)
-    spark.read.orc(table).registerTempTable(table)
+    spark.read.orc(table).createOrReplaceTempView(table)
   }
 
   private def loadCarbonTable(spark: SparkSession, input: DataFrame, tableName: String): Double = {
@@ -337,7 +334,6 @@ object CompareTest {
   private def runTest(spark: SparkSession, table1: String, table2: String): Unit = {
     val formatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
     val date = new Date
-    val timestamp = date.getTime
     // run queries on parquet and carbon
     val table1Result: Array[(Double, Array[Row])] = runQueries(spark, table1)
     // do GC and sleep for some time before running next table

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/allqueries/AllDataTypesTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/allqueries/AllDataTypesTestCase.scala
@@ -1085,7 +1085,7 @@ class AllDataTypesTestCase extends QueryTest with BeforeAndAfterAll {
     sql("drop table if exists carbonunion")
     import sqlContext.implicits._
     val df = sqlContext.sparkContext.parallelize(1 to 1000).map(x => (x+"", (x+100)+"")).toDF("c1", "c2")
-    df.registerTempTable("sparkunion")
+    df.createOrReplaceTempView("sparkunion")
     df.write
       .format("carbondata")
       .mode(SaveMode.Overwrite)

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/allqueries/MeasureOnlyTableTestCases.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/allqueries/MeasureOnlyTableTestCases.scala
@@ -375,7 +375,7 @@ class MeasureOnlyTableTestCases extends QueryTest with BeforeAndAfterAll {
     sql("drop table if exists carbonunion")
     import sqlContext.implicits._
     val df = sqlContext.sparkContext.parallelize(1 to 1000).map(x => (x, (x+100))).toDF("c1", "c2")
-    df.registerTempTable("sparkunion")
+    df.createOrReplaceTempView("sparkunion")
     df.write
       .format("carbondata")
       .mode(SaveMode.Overwrite)

--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/CarbonDataSourceSuite.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/CarbonDataSourceSuite.scala
@@ -147,7 +147,7 @@ class CarbonDataSourceSuite extends Spark2QueryTest with BeforeAndAfterAll {
     sql("drop table if exists sparkunion")
     import sqlContext.implicits._
     val df = sqlContext.sparkContext.parallelize(1 to 1000).map(x => (x+"", (x+100)+"")).toDF("c1", "c2")
-    df.registerTempTable("sparkunion")
+    df.createOrReplaceTempView("sparkunion")
     df.write
       .format("carbondata")
       .mode(SaveMode.Overwrite)


### PR DESCRIPTION

Update registerTempTable method to createOrReplaceTempView, because registerTempTable was marked deprecated

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 No
 - [x] Any backward compatibility impacted?
 No
 - [x] Document update required?
No
 - [x] Testing done
     No new test cases
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

No