### PR TITLE
[CARBONDATA-1907] Avoid unnecessary logging to improve query performance for no dictionary non string columns

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/scan/executor/impl/AbstractQueryExecutor.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/executor/impl/AbstractQueryExecutor.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.carbondata.common.CarbonIterator;
 import org.apache.carbondata.common.logging.LogService;
@@ -544,12 +543,10 @@ public abstract class AbstractQueryExecutor<E> implements QueryExecutor<E> {
     }
     UnsafeMemoryManager.INSTANCE.freeMemoryAll(ThreadLocalTaskInfo.getCarbonTaskInfo().getTaskId());
     if (null != queryProperties.executorService) {
-      queryProperties.executorService.shutdown();
-      try {
-        queryProperties.executorService.awaitTermination(1, TimeUnit.HOURS);
-      } catch (InterruptedException e) {
-        throw new QueryExecutionException(e);
-      }
+      // In case of limit query when number of limit records is already found so executors
+      // must stop all the running execution otherwise it will keep running and will hit
+      // the query performance.
+      queryProperties.executorService.shutdownNow();
     }
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/util/DataTypeUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/DataTypeUtil.java
@@ -353,12 +353,26 @@ public final class DataTypeUtil {
       } else if (actualDataType == DataTypes.STRING) {
         return getDataTypeConverter().convertFromByteToUTF8String(dataInBytes);
       } else if (actualDataType == DataTypes.SHORT) {
+        // for non string type no dictionary column empty byte array is empty value
+        // so no need to parse
+        if (isEmptyByteArray(dataInBytes)) {
+          return null;
+        }
         return ByteUtil.toShort(dataInBytes, 0, dataInBytes.length);
       } else if (actualDataType == DataTypes.INT) {
+        if (isEmptyByteArray(dataInBytes)) {
+          return null;
+        }
         return ByteUtil.toInt(dataInBytes, 0, dataInBytes.length);
       } else if (actualDataType == DataTypes.LONG) {
+        if (isEmptyByteArray(dataInBytes)) {
+          return null;
+        }
         return ByteUtil.toLong(dataInBytes, 0, dataInBytes.length);
       } else if (actualDataType == DataTypes.TIMESTAMP) {
+        if (isEmptyByteArray(dataInBytes)) {
+          return null;
+        }
         return ByteUtil.toLong(dataInBytes, 0, dataInBytes.length) * 1000L;
       } else {
         return ByteUtil.toString(dataInBytes, 0, dataInBytes.length);
@@ -370,6 +384,16 @@ public final class DataTypeUtil {
       LOGGER.error("Problem while converting data type" + data);
       return null;
     }
+  }
+
+  /**
+   * Method to check if byte array is empty
+   *
+   * @param dataInBytes
+   * @return
+   */
+  private static boolean isEmptyByteArray(byte[] dataInBytes) {
+    return dataInBytes.length == 0;
   }
 
 

--- a/core/src/test/java/org/apache/carbondata/core/util/DataTypeUtilTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/util/DataTypeUtilTest.java
@@ -98,6 +98,24 @@ public class DataTypeUtilTest {
 
   }
 
+  @Test public void testGetDataBasedOnDataTypeForNoDictionaryColumn() {
+    Object result = DataTypeUtil.getDataBasedOnDataTypeForNoDictionaryColumn(new byte[0],
+        DataTypes.INT);
+    assert (result == null);
+    result = DataTypeUtil.getDataBasedOnDataTypeForNoDictionaryColumn(new byte[0],
+        DataTypes.SHORT);
+    assert (result == null);
+    result = DataTypeUtil.getDataBasedOnDataTypeForNoDictionaryColumn(new byte[0],
+        DataTypes.LONG);
+    assert (result == null);
+    result = DataTypeUtil.getDataBasedOnDataTypeForNoDictionaryColumn(new byte[0],
+        DataTypes.TIMESTAMP);
+    assert (result == null);
+    result = DataTypeUtil.getDataBasedOnDataTypeForNoDictionaryColumn(new byte[0],
+        DataTypes.STRING);
+    assert (result != null);
+  }
+
 }
 
 


### PR DESCRIPTION
Changes done to return null in case of no dictionary column for non string data types when data is empty. This is done to avoid excessive logging which is impacting the query performance.

 - [ ] Any interfaces changed?
 No
 - [ ] Any backward compatibility impacted?
 No
 - [ ] Document update required?
No
 - [ ] Testing done
Added UT
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA
