### PR TITLE
[CARBONDATA-1908][PARTITION] Support UPDATE/DELETE on partition tables.

### DIFF
--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableInputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableInputFormat.java
@@ -128,6 +128,8 @@ public class CarbonTableInputFormat<T> extends FileInputFormat<Void, T> {
   public static final String TABLE_NAME = "mapreduce.input.carboninputformat.tableName";
   public static final String PARTITIONS_TO_PRUNE =
       "mapreduce.input.carboninputformat.partitions.to.prune";
+  public static final String UPADTE_T =
+      "mapreduce.input.carboninputformat.partitions.to.prune";
 
   // a cache for carbon table, it will be used in task side
   private CarbonTable carbonTable;
@@ -915,7 +917,6 @@ public class CarbonTableInputFormat<T> extends FileInputFormat<Void, T> {
    * @param identifier
    * @return
    * @throws IOException
-   * @throws KeyGenException
    */
   public BlockMappingVO getBlockRowCount(Job job, AbsoluteTableIdentifier identifier,
       List<String> partitions) throws IOException {

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/iud/DeleteCarbonTableTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/iud/DeleteCarbonTableTestCase.scala
@@ -104,6 +104,27 @@ class DeleteCarbonTableTestCase extends QueryTest with BeforeAndAfterAll {
     )
   }
 
+  test("partition delete data from carbon table with alias [where clause ]") {
+    sql("drop table if exists iud_db.dest")
+    sql("""create table iud_db.dest (c1 string,c2 int,c5 string) PARTITIONED BY(c3 string) STORED BY 'org.apache.carbondata.format'""")
+    sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/IUD/dest.csv' INTO table iud_db.dest""")
+    sql("""delete from iud_db.dest d where d.c1 = 'a'""").show
+    checkAnswer(
+      sql("""select c2 from iud_db.dest"""),
+      Seq(Row(2), Row(3),Row(4), Row(5))
+    )
+  }
+  test("partition delete data from  carbon table[where clause ]") {
+    sql("""drop table if exists iud_db.dest""")
+    sql("""create table iud_db.dest (c1 string,c2 int,c5 string) PARTITIONED BY(c3 string) STORED BY 'org.apache.carbondata.format'""")
+    sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/IUD/dest.csv' INTO table iud_db.dest""")
+    sql("""delete from iud_db.dest where c2 = 2""").show
+    checkAnswer(
+      sql("""select c1 from iud_db.dest"""),
+      Seq(Row("a"), Row("c"), Row("d"), Row("e"))
+    )
+  }
+
   test("Records more than one pagesize after delete operation ") {
     sql("DROP TABLE IF EXISTS carbon2")
     import sqlContext.implicits._

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/CommonUtil.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/CommonUtil.scala
@@ -520,7 +520,7 @@ object CommonUtil {
   def readLoadMetadataDetails(model: CarbonLoadModel): Unit = {
     val metadataPath = model.getCarbonDataLoadSchema.getCarbonTable.getMetaDataFilepath
     val details = SegmentStatusManager.readLoadMetadata(metadataPath)
-    model.setLoadMetadataDetails(details.toList.asJava)
+    model.setLoadMetadataDetails(new util.ArrayList[LoadMetadataDetails](details.toList.asJava))
   }
 
   def configureCSVInputFormat(configuration: Configuration,

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/partition/CarbonAlterTableDropHivePartitionCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/partition/CarbonAlterTableDropHivePartitionCommand.scala
@@ -48,7 +48,7 @@ import org.apache.carbondata.spark.rdd.{CarbonDropPartitionCommitRDD, CarbonDrop
  * @param purge
  * @param retainData
  */
-case class CarbonStandardAlterTableDropPartition(
+case class CarbonAlterTableDropHivePartitionCommand(
     tableName: TableIdentifier,
     specs: Seq[TablePartitionSpec],
     ifExists: Boolean,

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/datasources/CarbonFileFormat.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/datasources/CarbonFileFormat.scala
@@ -104,8 +104,15 @@ with Serializable {
     model.setUseOnePass(options.getOrElse("onepass", "false").toBoolean)
     model.setDictionaryServerHost(options.getOrElse("dicthost", null))
     model.setDictionaryServerPort(options.getOrElse("dictport", "-1").toInt)
-    CarbonTableOutputFormat.setLoadModel(conf, model)
     CarbonTableOutputFormat.setOverwrite(conf, options("overwrite").toBoolean)
+    // Set the update timestamp if user sets in case of update query. It needs to be updated
+    // in load status update time
+    val updateTimeStamp = options.getOrElse("updatetimestamp", null)
+    if (updateTimeStamp != null) {
+      conf.set(CarbonTableOutputFormat.UPADTE_TIMESTAMP, updateTimeStamp)
+      model.setFactTimeStamp(updateTimeStamp.toLong)
+    }
+    CarbonTableOutputFormat.setLoadModel(conf, model)
 
     new OutputWriterFactory {
 

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/strategy/DDLStrategy.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/strategy/DDLStrategy.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.{SparkPlan, SparkStrategy}
 import org.apache.spark.sql.execution.command._
 import org.apache.spark.sql.execution.command.management.{CarbonAlterTableCompactionCommand, CarbonInsertIntoCommand, CarbonLoadDataCommand, RefreshCarbonTableCommand}
-import org.apache.spark.sql.execution.command.partition.{CarbonShowCarbonPartitionsCommand, CarbonStandardAlterTableDropPartition}
+import org.apache.spark.sql.execution.command.partition.{CarbonAlterTableDropHivePartitionCommand, CarbonShowCarbonPartitionsCommand}
 import org.apache.spark.sql.execution.command.schema._
 import org.apache.spark.sql.execution.command.table.{CarbonDescribeFormattedCommand, CarbonDropTableCommand}
 import org.apache.spark.sql.hive.execution.command.{CarbonDropDatabaseCommand, CarbonResetCommand, CarbonSetCommand}
@@ -174,7 +174,7 @@ class DDLStrategy(sparkSession: SparkSession) extends SparkStrategy {
           .tableExists(tableName)(sparkSession)
         if (isCarbonTable) {
           ExecutedCommandExec(
-            CarbonStandardAlterTableDropPartition(
+            CarbonAlterTableDropHivePartitionCommand(
               tableName,
               specs,
               ifExists,

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/CarbonDataLoadConfiguration.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/CarbonDataLoadConfiguration.java
@@ -104,6 +104,11 @@ public class CarbonDataLoadConfiguration {
   // contains metadata used in write step of loading process
   private TableSpec tableSpec;
 
+  /**
+   * Number of thread cores to use while writing data files
+   */
+  private short writingCoresCount;
+
   public CarbonDataLoadConfiguration() {
   }
 
@@ -351,5 +356,11 @@ public class CarbonDataLoadConfiguration {
     this.tableSpec = tableSpec;
   }
 
+  public short getWritingCoresCount() {
+    return writingCoresCount;
+  }
 
+  public void setWritingCoresCount(short writingCoresCount) {
+    this.writingCoresCount = writingCoresCount;
+  }
 }

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/DataLoadProcessBuilder.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/DataLoadProcessBuilder.java
@@ -224,7 +224,11 @@ public final class DataLoadProcessBuilder {
     configuration.setPreFetch(loadModel.isPreFetch());
     configuration.setNumberOfSortColumns(carbonTable.getNumberOfSortColumns());
     configuration.setNumberOfNoDictSortColumns(carbonTable.getNumberOfNoDictSortColumns());
-
+    // For partition loading always use single core as it already runs in multiple
+    // threads per partition
+    if (carbonTable.isHivePartitionTable()) {
+      configuration.setWritingCoresCount((short) 1);
+    }
     TableSpec tableSpec = new TableSpec(dimensions, measures);
     configuration.setTableSpec(tableSpec);
     return configuration;

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/sort/impl/UnsafeParallelReadMergeSorterImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/sort/impl/UnsafeParallelReadMergeSorterImpl.java
@@ -90,16 +90,10 @@ public class UnsafeParallelReadMergeSorterImpl extends AbstractMergeSorter {
     this.threadStatusObserver = new ThreadStatusObserver(executorService);
 
     try {
-      // If it is a single iterator better run in main thread
-      if (iterators.length == 1) {
-        new SortIteratorThread(iterators[0], sortDataRow, batchSize, rowCounter,
-            this.threadStatusObserver).run();
-      } else {
-        for (int i = 0; i < iterators.length; i++) {
-          executorService.execute(
-              new SortIteratorThread(iterators[i], sortDataRow, batchSize, rowCounter,
-                  this.threadStatusObserver));
-        }
+      for (int i = 0; i < iterators.length; i++) {
+        executorService.execute(
+            new SortIteratorThread(iterators[i], sortDataRow, batchSize, rowCounter,
+                this.threadStatusObserver));
       }
       executorService.shutdown();
       executorService.awaitTermination(2, TimeUnit.DAYS);
@@ -192,8 +186,9 @@ public class UnsafeParallelReadMergeSorterImpl extends AbstractMergeSorter {
 
     private ThreadStatusObserver threadStatusObserver;
 
-    public SortIteratorThread(Iterator<CarbonRowBatch> iterator, UnsafeSortDataRows sortDataRows,
-        int batchSize, AtomicLong rowCounter, ThreadStatusObserver threadStatusObserver) {
+    public SortIteratorThread(Iterator<CarbonRowBatch> iterator,
+        UnsafeSortDataRows sortDataRows, int batchSize, AtomicLong rowCounter,
+        ThreadStatusObserver threadStatusObserver) {
       this.iterator = iterator;
       this.sortDataRows = sortDataRows;
       this.buffer = new Object[batchSize][];
@@ -201,7 +196,8 @@ public class UnsafeParallelReadMergeSorterImpl extends AbstractMergeSorter {
       this.threadStatusObserver = threadStatusObserver;
     }
 
-    @Override public void run() {
+    @Override
+    public void run() {
       try {
         while (iterator.hasNext()) {
           CarbonRowBatch batch = iterator.next();

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/sort/impl/UnsafeParallelReadMergeSorterImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/sort/impl/UnsafeParallelReadMergeSorterImpl.java
@@ -90,10 +90,16 @@ public class UnsafeParallelReadMergeSorterImpl extends AbstractMergeSorter {
     this.threadStatusObserver = new ThreadStatusObserver(executorService);
 
     try {
-      for (int i = 0; i < iterators.length; i++) {
-        executorService.execute(
-            new SortIteratorThread(iterators[i], sortDataRow, batchSize, rowCounter,
-                this.threadStatusObserver));
+      // If it is a single iterator better run in main thread
+      if (iterators.length == 1) {
+        new SortIteratorThread(iterators[0], sortDataRow, batchSize, rowCounter,
+            this.threadStatusObserver).run();
+      } else {
+        for (int i = 0; i < iterators.length; i++) {
+          executorService.execute(
+              new SortIteratorThread(iterators[i], sortDataRow, batchSize, rowCounter,
+                  this.threadStatusObserver));
+        }
       }
       executorService.shutdown();
       executorService.awaitTermination(2, TimeUnit.DAYS);
@@ -186,9 +192,8 @@ public class UnsafeParallelReadMergeSorterImpl extends AbstractMergeSorter {
 
     private ThreadStatusObserver threadStatusObserver;
 
-    public SortIteratorThread(Iterator<CarbonRowBatch> iterator,
-        UnsafeSortDataRows sortDataRows, int batchSize, AtomicLong rowCounter,
-        ThreadStatusObserver threadStatusObserver) {
+    public SortIteratorThread(Iterator<CarbonRowBatch> iterator, UnsafeSortDataRows sortDataRows,
+        int batchSize, AtomicLong rowCounter, ThreadStatusObserver threadStatusObserver) {
       this.iterator = iterator;
       this.sortDataRows = sortDataRows;
       this.buffer = new Object[batchSize][];
@@ -196,8 +201,7 @@ public class UnsafeParallelReadMergeSorterImpl extends AbstractMergeSorter {
       this.threadStatusObserver = threadStatusObserver;
     }
 
-    @Override
-    public void run() {
+    @Override public void run() {
       try {
         while (iterator.hasNext()) {
           CarbonRowBatch batch = iterator.next();

--- a/processing/src/main/java/org/apache/carbondata/processing/store/CarbonFactDataHandlerColumnar.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/CarbonFactDataHandlerColumnar.java
@@ -161,6 +161,10 @@ public class CarbonFactDataHandlerColumnar implements CarbonFactHandler {
     if (sortScope != null && sortScope.equals(SortScopeOptions.SortScope.GLOBAL_SORT)) {
       numberOfCores = 1;
     }
+    // Overriding it to the task specified cores.
+    if (model.getWritingCoresCount() > 0) {
+      numberOfCores = model.getWritingCoresCount();
+    }
 
     blockletProcessingCount = new AtomicInteger(0);
     producerExecutorService = Executors.newFixedThreadPool(numberOfCores,

--- a/processing/src/main/java/org/apache/carbondata/processing/store/CarbonFactDataHandlerModel.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/CarbonFactDataHandlerModel.java
@@ -161,6 +161,8 @@ public class CarbonFactDataHandlerModel {
 
   private DataMapWriterListener dataMapWriterlistener;
 
+  private short writingCoresCount;
+
   /**
    * Create the model using @{@link CarbonDataLoadConfiguration}
    */
@@ -260,6 +262,7 @@ public class CarbonFactDataHandlerModel {
     DataMapWriterListener listener = new DataMapWriterListener();
     listener.registerAllWriter(configuration.getTableIdentifier(), configuration.getSegmentId());
     carbonFactDataHandlerModel.dataMapWriterlistener = listener;
+    carbonFactDataHandlerModel.writingCoresCount = configuration.getWritingCoresCount();
 
     return carbonFactDataHandlerModel;
   }
@@ -321,6 +324,7 @@ public class CarbonFactDataHandlerModel {
     carbonFactDataHandlerModel.tableSpec = new TableSpec(
         segmentProperties.getDimensions(),
         segmentProperties.getMeasures());
+
     return carbonFactDataHandlerModel;
   }
 
@@ -561,6 +565,10 @@ public class CarbonFactDataHandlerModel {
 
   public SortScopeOptions.SortScope getSortScope() {
     return sortScope;
+  }
+
+  public short getWritingCoresCount() {
+    return writingCoresCount;
   }
 
   public DataMapWriterListener getDataMapWriterlistener() {

--- a/processing/src/main/java/org/apache/carbondata/processing/util/CarbonLoaderUtil.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/util/CarbonLoaderUtil.java
@@ -858,17 +858,19 @@ public final class CarbonLoaderUtil {
   }
 
   /*
-   * This method will add data size and index size into tablestatus for each segment
+   * This method will add data size and index size into tablestatus for each segment. And also
+   * returns the size of the segment.
    */
-  public static void addDataIndexSizeIntoMetaEntry(LoadMetadataDetails loadMetadataDetails,
+  public static Long addDataIndexSizeIntoMetaEntry(LoadMetadataDetails loadMetadataDetails,
       String segmentId, CarbonTable carbonTable) throws IOException {
     CarbonTablePath carbonTablePath =
         CarbonStorePath.getCarbonTablePath((carbonTable.getAbsoluteTableIdentifier()));
     Map<String, Long> dataIndexSize =
         CarbonUtil.getDataSizeAndIndexSize(carbonTablePath, segmentId);
-    loadMetadataDetails
-        .setDataSize(dataIndexSize.get(CarbonCommonConstants.CARBON_TOTAL_DATA_SIZE).toString());
-    loadMetadataDetails
-        .setIndexSize(dataIndexSize.get(CarbonCommonConstants.CARBON_TOTAL_INDEX_SIZE).toString());
+    Long dataSize = dataIndexSize.get(CarbonCommonConstants.CARBON_TOTAL_DATA_SIZE);
+    loadMetadataDetails.setDataSize(String.valueOf(dataSize));
+    Long indexSize = dataIndexSize.get(CarbonCommonConstants.CARBON_TOTAL_INDEX_SIZE);
+    loadMetadataDetails.setIndexSize(String.valueOf(indexSize));
+    return dataSize + indexSize;
   }
 }


### PR DESCRIPTION
This PR depends on https://github.com/apache/carbondata/pull/1672 and https://github.com/apache/carbondata/pull/1674 and https://github.com/apache/carbondata/pull/1677

This PR supports update/delete for the partition table. It allows writing of update dataframe through CarbonFileFormat to allow partitioning. And handled the update status updation in committer class

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

