### PR TITLE
[CARBONDATA-1912] Handling lock issues

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonAlterTableCompactionCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonAlterTableCompactionCommand.scala
@@ -223,7 +223,7 @@ case class CarbonAlterTableCompactionCommand(
                 "")
             OperationListenerBus.getInstance
               .fireEvent(alterTableCompactionPreStatusUpdateEvent, operationContext)
-
+          lock.unlock()
           } else {
             CarbonDataRDDFactory.startCompactionThreads(
               sqlContext,
@@ -237,9 +237,8 @@ case class CarbonAlterTableCompactionCommand(
         } catch {
           case e: Exception =>
             LOGGER.error(s"Exception in start compaction thread. ${ e.getMessage }")
+            lock.unlock()
             throw e
-        } finally {
-          lock.unlock()
         }
       } else {
         LOGGER.audit("Not able to acquire the compaction lock for table " +

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/schema/CarbonAlterTableRenameCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/schema/CarbonAlterTableRenameCommand.scala
@@ -166,10 +166,10 @@ private[sql] case class CarbonAlterTableRenameCommand(
               sparkSession)
           renameBadRecords(newTableName, oldTableName, oldDatabaseName)
         }
+        // release lock from old location in case of any rename failure
+        AlterTableUtil.releaseLocks(locks)
         sys.error(s"Alter table rename table operation failed: ${e.getMessage}")
     } finally {
-      // release lock after command execution completion
-      AlterTableUtil.releaseLocks(locks)
       // case specific to rename table as after table rename old table path will not be found
       if (carbonTable != null) {
         val newTablePath = CarbonUtil


### PR DESCRIPTION
Description : 
Getting error trace in spark-sql console while executing compaction and alter table rename commands.

Scenario:
execute compaction and alter table rename queries in spark - sql
Even though operation is success , getting error trace on the console

Solution: In compaction we are already handling unlock after operation , so we can handle unlock in catch block instead of finally block.
In alter table rename operation: no need to unlock file on old location which will result error due to table name change.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

