### PR TITLE
[CARBONDATA-1913][global_sort] Global Sort data dataload fails for big data with RPC timeout exception

### DIFF
--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/load/DataLoadProcessBuilderOnSpark.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/load/DataLoadProcessBuilderOnSpark.scala
@@ -134,8 +134,12 @@ object DataLoadProcessBuilderOnSpark {
       DataLoadProcessorStepOnSpark.writeFunc(rows, context.partitionId, modelBroadcast,
         writeStepRowCounter))
 
-    // clean cache
-    convertRDD.unpersist()
+    // clean cache only if persisted and keeping unpersist non-blocking as non-blocking call will
+    // not have any functional impact as spark automatically monitors the cache usage on each node
+    // and drops out old data partiotions in a least-recently used (LRU) fashion.
+    if (numPartitions > 1) {
+      convertRDD.unpersist(false)
+    }
 
     // Log the number of rows in each step
     LOGGER.info("Total rows processed in step Input Processor: " + inputStepRowCounter.value)


### PR DESCRIPTION
**Problem**
When gloabl sort option is used for big data then for some times it fails with
RPC timeout after 120s.
This is happening because the driver is not able to unpersist rdd cache with in 120s.
The issue is happening due to rdd unpersist blocking call. Sometimes spark is not able 
to unppersist the rdd in default "spark.rpc.askTimeout" or "spark.network.timeout" time.
**Solution**
 Clean cache only if persisted and keeping unpersist non-blocking. Non blocking will not wait for cache
clean up task to finish and non-blocking call will not have any functional impact as spark automatically monitors the cache usage on each node and drops out old data partitions in a least-recently used (LRU) fashion.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [X] Any interfaces changed?
 NA
 - [X] Any backward compatibility impacted?
 NA
 - [X] Document update required?
NA
 - [X] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       Not possible to add testcase, fails only with bigdata and failure is random.
 - [X] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA

