### PR TITLE
[CARBONDATA-1914] [Dictionary Cache] Cache Access Rectification

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/cache/dictionary/Dictionary.java
+++ b/core/src/main/java/org/apache/carbondata/core/cache/dictionary/Dictionary.java
@@ -108,4 +108,10 @@ public interface Dictionary {
    * This method will release the objects and set default value for primitive types
    */
   void clear();
+
+  /**
+   * This method return the access count associated with the dictionary.
+   * @return
+   */
+  int getAccessCount();
 }

--- a/core/src/main/java/org/apache/carbondata/core/cache/dictionary/ForwardDictionary.java
+++ b/core/src/main/java/org/apache/carbondata/core/cache/dictionary/ForwardDictionary.java
@@ -161,4 +161,15 @@ public class ForwardDictionary implements Dictionary {
     columnDictionaryInfo
         .getIncrementalSurrogateKeyFromDictionary(byteValuesOfFilterMembers, surrogates);
   }
+
+  /**
+   * This method return the access count associated with the dictionary.
+   * @return
+   */
+  @Override public int getAccessCount() {
+    if (null != columnDictionaryInfo) {
+      return columnDictionaryInfo.getAccessCount();
+    }
+    return 0;
+  }
 }

--- a/core/src/main/java/org/apache/carbondata/core/cache/dictionary/ReverseDictionary.java
+++ b/core/src/main/java/org/apache/carbondata/core/cache/dictionary/ReverseDictionary.java
@@ -137,4 +137,14 @@ public class ReverseDictionary implements Dictionary {
     }
   }
 
+  /**
+   * This method return the access count associated with the dictionary.
+   * @return
+   */
+  @Override public int getAccessCount() {
+    if (null != columnReverseDictionaryInfo) {
+      return columnReverseDictionaryInfo.getAccessCount();
+    }
+    return 0;
+  }
 }

--- a/core/src/main/java/org/apache/carbondata/core/dictionary/generator/IncrementalColumnDictionaryGenerator.java
+++ b/core/src/main/java/org/apache/carbondata/core/dictionary/generator/IncrementalColumnDictionaryGenerator.java
@@ -151,6 +151,10 @@ public class IncrementalColumnDictionaryGenerator implements BiDictionary<Intege
             "\n create dictionary cache: " + dictCacheTime +
             "\n sort list, distinct and write: " + dictWriteTime +
             "\n write sort info: " + sortIndexWriteTime);
+
+    if (isDictExists) {
+      CarbonUtil.clearDictionaryCache(dictionary);
+    }
   }
 
   /**

--- a/integration/spark2/src/test/scala/org/apache/carbondata/spark/util/DictionaryLRUCacheTestCase.scala
+++ b/integration/spark2/src/test/scala/org/apache/carbondata/spark/util/DictionaryLRUCacheTestCase.scala
@@ -1,0 +1,376 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.spark.util
+
+import java.io.File
+
+import scala.collection.JavaConverters._
+
+import org.apache.spark.sql.common.util.Spark2QueryTest
+import org.apache.spark.sql.hive.CarbonRelation
+import org.apache.spark.sql.test.Spark2TestQueryExecutor
+import org.apache.spark.sql.{CarbonEnv, SparkSession}
+import org.scalatest.BeforeAndAfterAll
+
+import org.apache.carbondata.core.cache.{Cache, CacheProvider, CacheType}
+import org.apache.carbondata.core.cache.dictionary.{Dictionary, DictionaryColumnUniqueIdentifier}
+import org.apache.carbondata.core.constants.CarbonCommonConstants
+import org.apache.carbondata.core.util.{CarbonProperties, CarbonUtil}
+
+/**
+  * Test Case for Dictionary LRU Cache.
+  */
+class DictionaryLRUCacheTestCase extends Spark2QueryTest with BeforeAndAfterAll {
+  var spark : SparkSession = null
+  var path : String = null
+
+  def checkDictionaryAccessCount(databaseName: String, tableName: String): Unit = {
+    val carbonTable = CarbonEnv.getInstance(Spark2TestQueryExecutor.spark).carbonMetastore
+      .lookupRelation(Option(databaseName), tableName)(Spark2TestQueryExecutor.spark)
+      .asInstanceOf[CarbonRelation].carbonTable
+    val absoluteTableIdentifier = carbonTable.getAbsoluteTableIdentifier
+
+    val dimensions = carbonTable.getAllDimensions.asScala.toList
+    dimensions.foreach { dim =>
+      val columnIdentifier = dim.getColumnIdentifier
+      // Check the dictionary cache access.
+      val identifier: DictionaryColumnUniqueIdentifier = new DictionaryColumnUniqueIdentifier(
+        absoluteTableIdentifier,
+        columnIdentifier,
+        columnIdentifier.getDataType)
+
+      val isDictExists: Boolean = CarbonUtil.isFileExistsForGivenColumn(identifier)
+      var dictionary: Dictionary = null
+      if (isDictExists) {
+        val dictCacheReverse: Cache[DictionaryColumnUniqueIdentifier, Dictionary]
+        = CacheProvider.getInstance().createCache(CacheType.REVERSE_DICTIONARY)
+        dictionary = dictCacheReverse.get(identifier)
+        assert(dictionary.getAccessCount == 1)
+        CarbonUtil.clearDictionaryCache(dictionary)
+
+        val dictCacheForward: Cache[DictionaryColumnUniqueIdentifier, Dictionary]
+        = CacheProvider.getInstance().createCache(CacheType.FORWARD_DICTIONARY)
+        dictionary = dictCacheForward.get(identifier)
+        assert(dictionary.getAccessCount == 1)
+        CarbonUtil.clearDictionaryCache(dictionary)
+      }
+    }
+  }
+
+
+  override def beforeAll {
+
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.CARBON_MAX_DRIVER_LRU_CACHE_SIZE, "1")
+      .addProperty(CarbonCommonConstants.CARBON_MAX_EXECUTOR_LRU_CACHE_SIZE, "1")
+
+    path = s"$resourcesPath/restructure/data_2000.csv"
+
+    sql("drop table if exists carbon_new1")
+    sql("drop table if exists carbon_new2")
+    sql("drop table if exists carbon_new3")
+    sql("drop table if exists carbon_new4")
+    sql("drop table if exists carbon_new5")
+    sql("drop table if exists carbon_new6")
+    sql("drop table if exists carbon_new7")
+    sql("drop table if exists carbon_new8")
+    sql("drop table if exists carbon_new9")
+    sql("drop table if exists carbon_new10")
+  }
+
+  test("test for dictionary LRU Cache for Load Single Pass") {
+
+    sql(
+        "CREATE TABLE carbon_new1 (CUST_ID INT,CUST_NAME STRING,ACTIVE_EMUI_VERSION STRING, DOB " +
+        "TIMESTAMP, DOJ TIMESTAMP, BIGINT_COLUMN1 BIGINT,BIGINT_COLUMN2 BIGINT,DECIMAL_COLUMN1 " +
+        "decimal(30,10), DECIMAL_COLUMN2 DECIMAL(36,10),Double_COLUMN1 double, Double_COLUMN2 " +
+        "double,INTEGER_COLUMN1 INT) STORED BY 'org.apache.carbondata.format' TBLPROPERTIES " +
+        "('dictionary_include'='CUST_NAME, ACTIVE_EMUI_VERSION,BIGINT_COLUMN1,Double_COLUMN1, " +
+        "Double_COLUMN2')")
+
+    sql(
+        s"LOAD DATA INPATH '$path' INTO TABLE carbon_new1 OPTIONS" +
+        "('DELIMITER'=',' , 'QUOTECHAR'='\"','BAD_RECORDS_ACTION'='FORCE','SINGLE_PASS'='TRUE'," +
+        "'FILEHEADER'='CUST_ID,CUST_NAME,ACTIVE_EMUI_VERSION,DOB,DOJ,BIGINT_COLUMN1," +
+        "BIGINT_COLUMN2,DECIMAL_COLUMN1,DECIMAL_COLUMN2,Double_COLUMN1,Double_COLUMN2, " +
+        "INTEGER_COLUMN1')")
+
+    sql(
+        s"LOAD DATA INPATH '$path' INTO TABLE carbon_new1 OPTIONS" +
+        "('DELIMITER'=',' , 'QUOTECHAR'='\"','BAD_RECORDS_ACTION'='FORCE','SINGLE_PASS'='TRUE'," +
+        "'FILEHEADER'='CUST_ID,CUST_NAME,ACTIVE_EMUI_VERSION,DOB,DOJ,BIGINT_COLUMN1," +
+        "BIGINT_COLUMN2,DECIMAL_COLUMN1,DECIMAL_COLUMN2,Double_COLUMN1,Double_COLUMN2, " +
+        "INTEGER_COLUMN1')")
+
+    sql(
+        "CREATE TABLE carbon_new2 (CUST_ID INT,CUST_NAME STRING,ACTIVE_EMUI_VERSION STRING, DOB " +
+        "TIMESTAMP, DOJ TIMESTAMP, BIGINT_COLUMN1 BIGINT,BIGINT_COLUMN2 BIGINT,DECIMAL_COLUMN1 " +
+        "decimal(30,10), DECIMAL_COLUMN2 DECIMAL(36,10),Double_COLUMN1 double, Double_COLUMN2 " +
+        "double,INTEGER_COLUMN1 INT) STORED BY 'org.apache.carbondata.format' TBLPROPERTIES " +
+        "('dictionary_include'='CUST_NAME, ACTIVE_EMUI_VERSION,BIGINT_COLUMN1,Double_COLUMN1, " +
+        "Double_COLUMN2')")
+
+    sql(
+        s"LOAD DATA INPATH '$path' INTO TABLE carbon_new2 OPTIONS" +
+        "('DELIMITER'=',' , 'QUOTECHAR'='\"','BAD_RECORDS_ACTION'='FORCE','SINGLE_PASS'='TRUE'," +
+        "'FILEHEADER'='CUST_ID,CUST_NAME,ACTIVE_EMUI_VERSION,DOB,DOJ,BIGINT_COLUMN1," +
+        "BIGINT_COLUMN2,DECIMAL_COLUMN1,DECIMAL_COLUMN2,Double_COLUMN1,Double_COLUMN2, " +
+        "INTEGER_COLUMN1')")
+
+    sql(
+        s"LOAD DATA INPATH '$path' INTO TABLE carbon_new2 OPTIONS" +
+        "('DELIMITER'=',' , 'QUOTECHAR'='\"','BAD_RECORDS_ACTION'='FORCE','SINGLE_PASS'='TRUE'," +
+        "'FILEHEADER'='CUST_ID,CUST_NAME,ACTIVE_EMUI_VERSION,DOB,DOJ,BIGINT_COLUMN1," +
+        "BIGINT_COLUMN2,DECIMAL_COLUMN1,DECIMAL_COLUMN2,Double_COLUMN1,Double_COLUMN2, " +
+        "INTEGER_COLUMN1')")
+
+    checkDictionaryAccessCount("default", "carbon_new2")
+  }
+
+  test("test for dictionary LRU Cache for Load Non Single Pass") {
+
+    sql(
+        "CREATE TABLE carbon_new3 (CUST_ID INT,CUST_NAME STRING,ACTIVE_EMUI_VERSION STRING, DOB " +
+        "TIMESTAMP, DOJ TIMESTAMP, BIGINT_COLUMN1 BIGINT,BIGINT_COLUMN2 BIGINT,DECIMAL_COLUMN1 " +
+        "decimal(30,10), DECIMAL_COLUMN2 DECIMAL(36,10),Double_COLUMN1 double, Double_COLUMN2 " +
+        "double,INTEGER_COLUMN1 INT) STORED BY 'org.apache.carbondata.format' TBLPROPERTIES " +
+        "('dictionary_include'='CUST_NAME, ACTIVE_EMUI_VERSION,BIGINT_COLUMN1,Double_COLUMN1, " +
+        "Double_COLUMN2')")
+
+    sql(
+        s"LOAD DATA INPATH '$path' INTO TABLE carbon_new3 OPTIONS" +
+        "('DELIMITER'=',' , 'QUOTECHAR'='\"','BAD_RECORDS_ACTION'='FORCE','SINGLE_PASS'='FALSE'," +
+        "'FILEHEADER'='CUST_ID,CUST_NAME,ACTIVE_EMUI_VERSION,DOB,DOJ,BIGINT_COLUMN1," +
+        "BIGINT_COLUMN2,DECIMAL_COLUMN1,DECIMAL_COLUMN2,Double_COLUMN1,Double_COLUMN2, " +
+        "INTEGER_COLUMN1')")
+
+    sql(
+        s"LOAD DATA INPATH '$path' INTO TABLE carbon_new3 OPTIONS" +
+        "('DELIMITER'=',' , 'QUOTECHAR'='\"','BAD_RECORDS_ACTION'='FORCE','SINGLE_PASS'='FALSE'," +
+        "'FILEHEADER'='CUST_ID,CUST_NAME,ACTIVE_EMUI_VERSION,DOB,DOJ,BIGINT_COLUMN1," +
+        "BIGINT_COLUMN2,DECIMAL_COLUMN1,DECIMAL_COLUMN2,Double_COLUMN1,Double_COLUMN2, " +
+        "INTEGER_COLUMN1')")
+
+    sql(
+        "CREATE TABLE carbon_new4 (CUST_ID INT,CUST_NAME STRING,ACTIVE_EMUI_VERSION STRING, DOB " +
+        "TIMESTAMP, DOJ TIMESTAMP, BIGINT_COLUMN1 BIGINT,BIGINT_COLUMN2 BIGINT,DECIMAL_COLUMN1 " +
+        "decimal(30,10), DECIMAL_COLUMN2 DECIMAL(36,10),Double_COLUMN1 double, Double_COLUMN2 " +
+        "double,INTEGER_COLUMN1 INT) STORED BY 'org.apache.carbondata.format' TBLPROPERTIES " +
+        "('dictionary_include'='CUST_NAME, ACTIVE_EMUI_VERSION,BIGINT_COLUMN1,Double_COLUMN1, " +
+        "Double_COLUMN2')")
+
+    sql(
+        s"LOAD DATA INPATH '$path' INTO TABLE carbon_new4 OPTIONS" +
+        "('DELIMITER'=',' , 'QUOTECHAR'='\"','BAD_RECORDS_ACTION'='FORCE','SINGLE_PASS'='FALSE'," +
+        "'FILEHEADER'='CUST_ID,CUST_NAME,ACTIVE_EMUI_VERSION,DOB,DOJ,BIGINT_COLUMN1," +
+        "BIGINT_COLUMN2,DECIMAL_COLUMN1,DECIMAL_COLUMN2,Double_COLUMN1,Double_COLUMN2, " +
+        "INTEGER_COLUMN1')")
+
+    sql(
+        s"LOAD DATA INPATH '$path' INTO TABLE carbon_new4 OPTIONS" +
+        "('DELIMITER'=',' , 'QUOTECHAR'='\"','BAD_RECORDS_ACTION'='FORCE','SINGLE_PASS'='FALSE'," +
+        "'FILEHEADER'='CUST_ID,CUST_NAME,ACTIVE_EMUI_VERSION,DOB,DOJ,BIGINT_COLUMN1," +
+        "BIGINT_COLUMN2,DECIMAL_COLUMN1,DECIMAL_COLUMN2,Double_COLUMN1,Double_COLUMN2, " +
+        "INTEGER_COLUMN1')")
+
+    checkDictionaryAccessCount("default", "carbon_new4")
+  }
+
+  test("test for dictionary LRU Cache for Select On Table") {
+
+    sql(
+        "CREATE TABLE carbon_new5 (CUST_ID INT,CUST_NAME STRING,ACTIVE_EMUI_VERSION STRING, DOB " +
+        "TIMESTAMP, DOJ TIMESTAMP, BIGINT_COLUMN1 BIGINT,BIGINT_COLUMN2 BIGINT,DECIMAL_COLUMN1 " +
+        "decimal(30,10), DECIMAL_COLUMN2 DECIMAL(36,10),Double_COLUMN1 double, Double_COLUMN2 " +
+        "double,INTEGER_COLUMN1 INT) STORED BY 'org.apache.carbondata.format' TBLPROPERTIES " +
+        "('dictionary_include'='CUST_NAME, ACTIVE_EMUI_VERSION,BIGINT_COLUMN1,Double_COLUMN1, " +
+        "Double_COLUMN2')")
+
+    sql(
+        s"LOAD DATA INPATH '$path' INTO TABLE carbon_new5 OPTIONS" +
+        "('DELIMITER'=',' , 'QUOTECHAR'='\"','BAD_RECORDS_ACTION'='FORCE','SINGLE_PASS'='FALSE'," +
+        "'FILEHEADER'='CUST_ID,CUST_NAME,ACTIVE_EMUI_VERSION,DOB,DOJ,BIGINT_COLUMN1," +
+        "BIGINT_COLUMN2,DECIMAL_COLUMN1,DECIMAL_COLUMN2,Double_COLUMN1,Double_COLUMN2, " +
+        "INTEGER_COLUMN1')")
+
+    sql(
+        s"LOAD DATA INPATH '$path' INTO TABLE carbon_new5 OPTIONS" +
+        "('DELIMITER'=',' , 'QUOTECHAR'='\"','BAD_RECORDS_ACTION'='FORCE','SINGLE_PASS'='FALSE'," +
+        "'FILEHEADER'='CUST_ID,CUST_NAME,ACTIVE_EMUI_VERSION,DOB,DOJ,BIGINT_COLUMN1," +
+        "BIGINT_COLUMN2,DECIMAL_COLUMN1,DECIMAL_COLUMN2,Double_COLUMN1,Double_COLUMN2, " +
+        "INTEGER_COLUMN1')")
+
+    sql("select * from carbon_new5")
+
+    checkDictionaryAccessCount("default", "carbon_new5")
+
+
+    sql(
+        "CREATE TABLE carbon_new6 (CUST_ID INT,CUST_NAME STRING,ACTIVE_EMUI_VERSION STRING, DOB " +
+        "TIMESTAMP, DOJ TIMESTAMP, BIGINT_COLUMN1 BIGINT,BIGINT_COLUMN2 BIGINT,DECIMAL_COLUMN1 " +
+        "decimal(30,10), DECIMAL_COLUMN2 DECIMAL(36,10),Double_COLUMN1 double, Double_COLUMN2 " +
+        "double,INTEGER_COLUMN1 INT) STORED BY 'org.apache.carbondata.format' TBLPROPERTIES " +
+        "('dictionary_include'='CUST_NAME, ACTIVE_EMUI_VERSION,BIGINT_COLUMN1,Double_COLUMN1, " +
+        "Double_COLUMN2')")
+
+    sql(
+        s"LOAD DATA INPATH '$path' INTO TABLE carbon_new6 OPTIONS" +
+        "('DELIMITER'=',' , 'QUOTECHAR'='\"','BAD_RECORDS_ACTION'='FORCE','SINGLE_PASS'='FALSE'," +
+        "'FILEHEADER'='CUST_ID,CUST_NAME,ACTIVE_EMUI_VERSION,DOB,DOJ,BIGINT_COLUMN1," +
+        "BIGINT_COLUMN2,DECIMAL_COLUMN1,DECIMAL_COLUMN2,Double_COLUMN1,Double_COLUMN2, " +
+        "INTEGER_COLUMN1')")
+
+    sql(
+        s"LOAD DATA INPATH '$path' INTO TABLE carbon_new6 OPTIONS" +
+        "('DELIMITER'=',' , 'QUOTECHAR'='\"','BAD_RECORDS_ACTION'='FORCE','SINGLE_PASS'='FALSE'," +
+        "'FILEHEADER'='CUST_ID,CUST_NAME,ACTIVE_EMUI_VERSION,DOB,DOJ,BIGINT_COLUMN1," +
+        "BIGINT_COLUMN2,DECIMAL_COLUMN1,DECIMAL_COLUMN2,Double_COLUMN1,Double_COLUMN2, " +
+        "INTEGER_COLUMN1')")
+
+    sql("select * from carbon_new6")
+
+    checkDictionaryAccessCount("default", "carbon_new6")
+  }
+
+  test("test for dictionary LRU Cache for Select With Filter On Table") {
+
+    sql(
+        "CREATE TABLE carbon_new7 (CUST_ID INT,CUST_NAME STRING,ACTIVE_EMUI_VERSION STRING, DOB " +
+        "TIMESTAMP, DOJ TIMESTAMP, BIGINT_COLUMN1 BIGINT,BIGINT_COLUMN2 BIGINT,DECIMAL_COLUMN1 " +
+        "decimal(30,10), DECIMAL_COLUMN2 DECIMAL(36,10),Double_COLUMN1 double, Double_COLUMN2 " +
+        "double,INTEGER_COLUMN1 INT) STORED BY 'org.apache.carbondata.format' TBLPROPERTIES " +
+        "('dictionary_include'='CUST_NAME, ACTIVE_EMUI_VERSION,BIGINT_COLUMN1,Double_COLUMN1, " +
+        "Double_COLUMN2')")
+
+    sql(
+        s"LOAD DATA INPATH '$path' INTO TABLE carbon_new7 OPTIONS" +
+        "('DELIMITER'=',' , 'QUOTECHAR'='\"','BAD_RECORDS_ACTION'='FORCE','SINGLE_PASS'='FALSE'," +
+        "'FILEHEADER'='CUST_ID,CUST_NAME,ACTIVE_EMUI_VERSION,DOB,DOJ,BIGINT_COLUMN1," +
+        "BIGINT_COLUMN2,DECIMAL_COLUMN1,DECIMAL_COLUMN2,Double_COLUMN1,Double_COLUMN2, " +
+        "INTEGER_COLUMN1')")
+
+    sql(
+        s"LOAD DATA INPATH '$path' INTO TABLE carbon_new7 OPTIONS" +
+        "('DELIMITER'=',' , 'QUOTECHAR'='\"','BAD_RECORDS_ACTION'='FORCE','SINGLE_PASS'='FALSE'," +
+        "'FILEHEADER'='CUST_ID,CUST_NAME,ACTIVE_EMUI_VERSION,DOB,DOJ,BIGINT_COLUMN1," +
+        "BIGINT_COLUMN2,DECIMAL_COLUMN1,DECIMAL_COLUMN2,Double_COLUMN1,Double_COLUMN2, " +
+        "INTEGER_COLUMN1')")
+
+    sql("select * from carbon_new7 where CUST_ID > 10")
+
+    checkDictionaryAccessCount("default", "carbon_new7")
+
+
+    sql(
+        "CREATE TABLE carbon_new8 (CUST_ID INT,CUST_NAME STRING,ACTIVE_EMUI_VERSION STRING, DOB " +
+        "TIMESTAMP, DOJ TIMESTAMP, BIGINT_COLUMN1 BIGINT,BIGINT_COLUMN2 BIGINT,DECIMAL_COLUMN1 " +
+        "decimal(30,10), DECIMAL_COLUMN2 DECIMAL(36,10),Double_COLUMN1 double, Double_COLUMN2 " +
+        "double,INTEGER_COLUMN1 INT) STORED BY 'org.apache.carbondata.format' TBLPROPERTIES " +
+        "('dictionary_include'='CUST_NAME, ACTIVE_EMUI_VERSION,BIGINT_COLUMN1,Double_COLUMN1, " +
+        "Double_COLUMN2')")
+
+    sql(
+        s"LOAD DATA INPATH '$path' INTO TABLE carbon_new8 OPTIONS" +
+        "('DELIMITER'=',' , 'QUOTECHAR'='\"','BAD_RECORDS_ACTION'='FORCE','SINGLE_PASS'='FALSE'," +
+        "'FILEHEADER'='CUST_ID,CUST_NAME,ACTIVE_EMUI_VERSION,DOB,DOJ,BIGINT_COLUMN1," +
+        "BIGINT_COLUMN2,DECIMAL_COLUMN1,DECIMAL_COLUMN2,Double_COLUMN1,Double_COLUMN2, " +
+        "INTEGER_COLUMN1')")
+
+    sql(
+        s"LOAD DATA INPATH '$path' INTO TABLE carbon_new8 OPTIONS" +
+        "('DELIMITER'=',' , 'QUOTECHAR'='\"','BAD_RECORDS_ACTION'='FORCE','SINGLE_PASS'='FALSE'," +
+        "'FILEHEADER'='CUST_ID,CUST_NAME,ACTIVE_EMUI_VERSION,DOB,DOJ,BIGINT_COLUMN1," +
+        "BIGINT_COLUMN2,DECIMAL_COLUMN1,DECIMAL_COLUMN2,Double_COLUMN1,Double_COLUMN2, " +
+        "INTEGER_COLUMN1')")
+
+    sql("select * from carbon_new8 where CUST_ID > 100")
+
+    checkDictionaryAccessCount("default", "carbon_new8")
+  }
+
+  test("test for dictionary LRU Cache for Insert Into") {
+
+    sql(
+        "CREATE TABLE carbon_new9 (CUST_ID INT,CUST_NAME STRING,ACTIVE_EMUI_VERSION STRING, DOB " +
+        "TIMESTAMP, DOJ TIMESTAMP, BIGINT_COLUMN1 BIGINT,BIGINT_COLUMN2 BIGINT,DECIMAL_COLUMN1 " +
+        "decimal(30,10), DECIMAL_COLUMN2 DECIMAL(36,10),Double_COLUMN1 double, Double_COLUMN2 " +
+        "double,INTEGER_COLUMN1 INT) STORED BY 'org.apache.carbondata.format' TBLPROPERTIES " +
+        "('dictionary_include'='CUST_NAME, ACTIVE_EMUI_VERSION,BIGINT_COLUMN1,Double_COLUMN1, " +
+        "Double_COLUMN2')")
+
+    sql(
+        s"LOAD DATA INPATH '$path' INTO TABLE carbon_new9 OPTIONS" +
+        "('DELIMITER'=',' , 'QUOTECHAR'='\"','BAD_RECORDS_ACTION'='FORCE','SINGLE_PASS'='FALSE'," +
+        "'FILEHEADER'='CUST_ID,CUST_NAME,ACTIVE_EMUI_VERSION,DOB,DOJ,BIGINT_COLUMN1," +
+        "BIGINT_COLUMN2,DECIMAL_COLUMN1,DECIMAL_COLUMN2,Double_COLUMN1,Double_COLUMN2, " +
+        "INTEGER_COLUMN1')")
+
+    sql(
+        s"LOAD DATA INPATH '$path' INTO TABLE carbon_new9 OPTIONS" +
+        "('DELIMITER'=',' , 'QUOTECHAR'='\"','BAD_RECORDS_ACTION'='FORCE','SINGLE_PASS'='FALSE'," +
+        "'FILEHEADER'='CUST_ID,CUST_NAME,ACTIVE_EMUI_VERSION,DOB,DOJ,BIGINT_COLUMN1," +
+        "BIGINT_COLUMN2,DECIMAL_COLUMN1,DECIMAL_COLUMN2,Double_COLUMN1,Double_COLUMN2, " +
+        "INTEGER_COLUMN1')")
+
+    sql("select * from carbon_new9 where CUST_ID > 10")
+
+    checkDictionaryAccessCount("default", "carbon_new9")
+
+
+    sql(
+        "CREATE TABLE carbon_new10 (CUST_ID INT,CUST_NAME STRING,ACTIVE_EMUI_VERSION STRING, DOB " +
+        "TIMESTAMP, DOJ TIMESTAMP, BIGINT_COLUMN1 BIGINT,BIGINT_COLUMN2 BIGINT,DECIMAL_COLUMN1 " +
+        "decimal(30,10), DECIMAL_COLUMN2 DECIMAL(36,10),Double_COLUMN1 double, Double_COLUMN2 " +
+        "double,INTEGER_COLUMN1 INT) STORED BY 'org.apache.carbondata.format' TBLPROPERTIES " +
+        "('dictionary_include'='CUST_NAME')")
+
+    sql("insert into carbon_new10 select * from carbon_new9")
+
+    checkDictionaryAccessCount("default", "carbon_new10")
+
+    sql(
+        s"LOAD DATA INPATH '$path' INTO TABLE carbon_new10 OPTIONS" +
+        "('DELIMITER'=',' , 'QUOTECHAR'='\"','BAD_RECORDS_ACTION'='FORCE','SINGLE_PASS'='FALSE'," +
+        "'FILEHEADER'='CUST_ID,CUST_NAME,ACTIVE_EMUI_VERSION,DOB,DOJ,BIGINT_COLUMN1," +
+        "BIGINT_COLUMN2,DECIMAL_COLUMN1,DECIMAL_COLUMN2,Double_COLUMN1,Double_COLUMN2, " +
+        "INTEGER_COLUMN1')")
+
+    checkDictionaryAccessCount("default", "carbon_new10")
+
+  }
+
+
+
+  override def afterAll {
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.CARBON_MAX_DRIVER_LRU_CACHE_SIZE,
+        CarbonCommonConstants.CARBON_MAX_LRU_CACHE_SIZE_DEFAULT)
+      .addProperty(CarbonCommonConstants.CARBON_MAX_EXECUTOR_LRU_CACHE_SIZE,
+        CarbonCommonConstants.CARBON_MAX_LRU_CACHE_SIZE_DEFAULT)
+
+    sql("drop table if exists carbon_new1")
+    sql("drop table if exists carbon_new2")
+    sql("drop table if exists carbon_new3")
+    sql("drop table if exists carbon_new4")
+    sql("drop table if exists carbon_new5")
+    sql("drop table if exists carbon_new6")
+    sql("drop table if exists carbon_new7")
+    sql("drop table if exists carbon_new8")
+    sql("drop table if exists carbon_new9")
+    sql("drop table if exists carbon_new10")
+  }
+}

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/converter/FieldConverter.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/converter/FieldConverter.java
@@ -33,4 +33,9 @@ public interface FieldConverter {
    * @throws CarbonDataLoadingException
    */
   void convert(CarbonRow row, BadRecordLogHolder logHolder) throws CarbonDataLoadingException;
+
+  /**
+   * This method clears all the dictionary caches being acquired.
+   */
+  void clear();
 }

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/converter/impl/ComplexFieldConverterImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/converter/impl/ComplexFieldConverterImpl.java
@@ -52,6 +52,12 @@ public class ComplexFieldConverterImpl extends AbstractDictionaryFieldConverterI
     }
   }
 
+  /**
+   * Method to clear out the dictionary caches. In this instance nothing to clear.
+   */
+  @Override public void clear() {
+  }
+
   @Override public void fillColumnCardinality(List<Integer> cardinality) {
     genericDataType.fillCardinality(cardinality);
   }

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/converter/impl/DictionaryFieldConverterImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/converter/impl/DictionaryFieldConverterImpl.java
@@ -123,6 +123,13 @@ public class DictionaryFieldConverterImpl extends AbstractDictionaryFieldConvert
     }
   }
 
+  /**
+   * Method to clear out the dictionary cache.
+   */
+  @Override public void clear() {
+    CarbonUtil.clearDictionaryCache(dictionary);
+  }
+
   @Override
   public void fillColumnCardinality(List<Integer> cardinality) {
     cardinality.add(dictionaryGenerator.size());

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/converter/impl/DirectDictionaryFieldConverterImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/converter/impl/DirectDictionaryFieldConverterImpl.java
@@ -89,6 +89,12 @@ public class DirectDictionaryFieldConverterImpl extends AbstractDictionaryFieldC
     }
   }
 
+  /**
+   * Method to clean the dictionary cache. In this instance nothing to clear.
+   */
+  @Override public void clear() {
+  }
+
   @Override
   public void fillColumnCardinality(List<Integer> cardinality) {
     cardinality.add(Integer.MAX_VALUE);

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/converter/impl/MeasureFieldConverterImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/converter/impl/MeasureFieldConverterImpl.java
@@ -98,4 +98,11 @@ public class MeasureFieldConverterImpl implements FieldConverter {
     }
 
   }
+
+  /**
+   * Method to clean the dictionary cache. As in this MeasureFieldConverterImpl convert no
+   * dictionary caches are acquired so nothing to clear. s
+   */
+  @Override public void clear() {
+  }
 }

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/converter/impl/NonDictionaryFieldConverterImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/converter/impl/NonDictionaryFieldConverterImpl.java
@@ -87,6 +87,9 @@ public class NonDictionaryFieldConverterImpl implements FieldConverter {
     }
   }
 
+  @Override public void clear() {
+  }
+
   private void updateWithNullValue(CarbonRow row) {
     if (dataType == DataTypes.STRING) {
       row.update(CarbonCommonConstants.MEMBER_DEFAULT_VAL_ARRAY, index);

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/converter/impl/RowConverterImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/converter/impl/RowConverterImpl.java
@@ -183,6 +183,10 @@ public class RowConverterImpl implements RowConverter {
 
   @Override
   public void finish() {
+    // Clear up dictionary cache access count.
+    for (int i = 0; i < fieldConverters.length; i ++) {
+      fieldConverters[i].clear();
+    }
     // close dictionary client when finish write
     if (configuration.getUseOnePass()) {
       for (DictionaryClient client : dictClients) {


### PR DESCRIPTION
Rectifying Cache Access. In order to mark Dictionary Caches are in-use, there is a Atomic access Count variable which is incremented and post  usage it is being decremented. In some of the places Cache access is not being cleared, therefore is was difficult to evict it from cache as AccessCount will be non zero.

 - [x] Any interfaces changed?
   No
 
 - [x] Any backward compatibility impacted?
  No
 
 - [x] Document update required?
  No

 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
   NA
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
   NA

