### PR TITLE
[CARBONDATA-1915]In the insert into and update flow when static values are inserted then preferred locations are coming empty

### DIFF
--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/hive/DistributionUtil.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/hive/DistributionUtil.scala
@@ -115,7 +115,9 @@ object DistributionUtil {
       sparkContext: SparkContext): Seq[String] = {
     val confExecutors: Int = getConfiguredExecutors(sparkContext)
     LOGGER.info(s"Executors configured : $confExecutors")
-    val requiredExecutors = if (nodesOfData < 1 || nodesOfData > confExecutors) {
+    val requiredExecutors = if (nodesOfData < 1) {
+      1
+    } else if (nodesOfData > confExecutors) {
       confExecutors
     } else {
       nodesOfData


### PR DESCRIPTION
In the insert into and update flow when static values are inserted then preferred locations are coming empty

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

update the table,then query table was not working (if the dynamic executors are enabled and in insert and update flow when static content is used then nodedata is coming as 0)

so, if the number of nodes are coming less than 1, assign 1 executor
 - [X] Any interfaces changed?
 NA
 - [X] Any backward compatibility impacted?
 NA
 - [X] Document update required?
NA
 - [X] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
Yes
       
 - [X] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

