### PR TITLE
[CARBONDATA-1909] Load is failing during insert into operation when load is concurrently done to source table

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -865,6 +865,24 @@ public final class CarbonCommonConstants {
   public static final String CARBON_MERGE_SORT_PREFETCH_DEFAULT = "true";
 
   /**
+   * If we are executing insert into query from source table using select statement
+   * & loading the same source table concurrently, when select happens on source table
+   * during the data load , it gets new record for which dictionary is not generated,
+   * So there will be inconsistency. To avoid this condition we can persist the dataframe
+   * into MEMORY_AND_DISK and perform insert into operation. By default this value
+   * will be false because no need to persist the dataframe in all cases. If user want
+   * to run load and insert queries on source table concurrently then user can enable this flag
+   */
+  @CarbonProperty
+  public static final String CARBON_INSERT_PERSIST_ENABLED = "carbon.insert.persist.enable";
+
+  /**
+   * by default rdd will not be persisted in the insert case.
+
+   */
+  public static final String CARBON_INSERT_PERSIST_ENABLED_DEFAULT = "false";
+
+  /**
    * default name of data base
    */
   public static final String DATABASE_DEFAULT_NAME = "default";


### PR DESCRIPTION
Load is failing during insert into operation when load is concurrently done to source table

Scenario:
Client1:
1. Create source table
2. load big data

Client2:
1. create table t1
2. insert into t1 select * from  source table   - load fails

Data Load:
Step1 : Dictionary Generarion
Step2: Loading data

Assume 100 records is read from source table using select statement, but when execution reaches step2, 50 more records has been added to source table. So when select happens on source table during data loading , it gets new record for which dictionary is not generated. So there is inconsistency.

Solution : 
To solve this issue we persisted dataframe, so that select will not get fired for second time. But this has some performance impact. So we are providing configuration to enable persist, if user wants to perform this kind of scenario he can enable this configuration at cost of performance.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

