### PR TITLE
[CARBONDATA-1719][Pre-Aggregate][Bug] Fixed bug to handle data inconsistency on concurrent data load and pre-aggregate table creation

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/preaaggregate/PreAggregateListeners.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/preaaggregate/PreAggregateListeners.scala
@@ -20,9 +20,10 @@ package org.apache.spark.sql.execution.command.preaaggregate
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 
+import org.apache.spark.sql.CarbonEnv
 import org.apache.spark.sql.catalyst.TableIdentifier
-import org.apache.spark.sql.execution.command.management.CarbonAlterTableCompactionCommand
 import org.apache.spark.sql.execution.command.AlterTableModel
+import org.apache.spark.sql.execution.command.management.CarbonAlterTableCompactionCommand
 
 import org.apache.carbondata.core.metadata.schema.table.AggregationDataMapSchema
 import org.apache.carbondata.core.util.CarbonUtil
@@ -38,7 +39,8 @@ object LoadPostAggregateListener extends OperationEventListener {
     val loadEvent = event.asInstanceOf[LoadTablePreStatusUpdateEvent]
     val sparkSession = loadEvent.sparkSession
     val carbonLoadModel = loadEvent.carbonLoadModel
-    val table = carbonLoadModel.getCarbonDataLoadSchema.getCarbonTable
+    val table = CarbonEnv.getCarbonTable(Option(carbonLoadModel.getDatabaseName),
+      carbonLoadModel.getTableName)(sparkSession)
     if (CarbonUtil.hasAggregationDataMap(table)) {
       // getting all the aggergate datamap schema
       val aggregationDataMapList = table.getTableInfo.getDataMapSchemaList.asScala


### PR DESCRIPTION
Problem: On concurrent data load and pre-aggregate table creation, datamap was not getting populated with the load data even after data load completes.

This PR fix this issue. 

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed? No
 
 - [x] Any backward compatibility impacted? No
 
 - [x] Document update required? No

 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
    Tested the functionality on Two node cluster      
 
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. (N/A) 

