### PR TITLE
[HOTFIX] rename CarbonStandardAlterTableDropPartition

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/partition/CarbonAlterTableDropHivePartitionCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/partition/CarbonAlterTableDropHivePartitionCommand.scala
@@ -48,7 +48,7 @@ import org.apache.carbondata.spark.rdd.{CarbonDropPartitionCommitRDD, CarbonDrop
  * @param purge
  * @param retainData
  */
-case class CarbonStandardAlterTableDropPartition(
+case class CarbonAlterTableDropHivePartitionCommand(
     tableName: TableIdentifier,
     specs: Seq[TablePartitionSpec],
     ifExists: Boolean,

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/strategy/DDLStrategy.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/strategy/DDLStrategy.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.{SparkPlan, SparkStrategy}
 import org.apache.spark.sql.execution.command._
 import org.apache.spark.sql.execution.command.management.{CarbonAlterTableCompactionCommand, CarbonInsertIntoCommand, CarbonLoadDataCommand, RefreshCarbonTableCommand}
-import org.apache.spark.sql.execution.command.partition.{CarbonShowCarbonPartitionsCommand, CarbonStandardAlterTableDropPartition}
+import org.apache.spark.sql.execution.command.partition.{CarbonAlterTableDropHivePartitionCommand, CarbonShowCarbonPartitionsCommand}
 import org.apache.spark.sql.execution.command.schema._
 import org.apache.spark.sql.execution.command.table.{CarbonDescribeFormattedCommand, CarbonDropTableCommand}
 import org.apache.spark.sql.hive.execution.command.{CarbonDropDatabaseCommand, CarbonResetCommand, CarbonSetCommand}
@@ -174,7 +174,7 @@ class DDLStrategy(sparkSession: SparkSession) extends SparkStrategy {
           .tableExists(tableName)(sparkSession)
         if (isCarbonTable) {
           ExecutedCommandExec(
-            CarbonStandardAlterTableDropPartition(
+            CarbonAlterTableDropHivePartitionCommand(
               tableName,
               specs,
               ifExists,


### PR DESCRIPTION
Rename CarbonStandardAlterTableDropPartition to CarbonAlterTableDropHivePartitionCommand, make it consistent with other commands

 - [X] Any interfaces changed?
 No
 - [X] Any backward compatibility impacted?
 No
 - [X] Document update required?
No
 - [X] Testing done
No logic is modified, retest all testcase
 - [X] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA