### PR TITLE
[CARBONDATA-1896] Clean files operation improvement

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSession.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSession.scala
@@ -181,18 +181,6 @@ object CarbonSession {
         }
         options.foreach { case (k, v) => session.sessionState.conf.setConfString(k, v) }
         SparkSession.setDefaultSession(session)
-        try {
-          val databases = session.sessionState.catalog.listDatabases()
-          databases.foreach(dbName => {
-            val databaseLocation = CarbonEnv.getDatabaseLocation(dbName, session)
-            CommonUtil.cleanInProgressSegments(databaseLocation, dbName)
-          })
-        } catch {
-          case e: Throwable =>
-            // catch all exceptions to avoid CarbonSession initialization failure
-          LogServiceFactory.getLogService(this.getClass.getCanonicalName)
-            .error(e, "Failed to clean in progress segments")
-        }
         // Register a successfully instantiated context to the singleton. This should be at the
         // end of the class definition so that the singleton is updated only if there is no
         // exception in the construction of the instance.


### PR DESCRIPTION
**Problem:**
(1) When bringing up the session, clean operation is handled in a way to mark all the INSERT_OVERWRITE_IN_PROGRESS or INSERT_IN_PROGRESS segments to MARKED_FOR_DELETE in tablestatus file. This clean operation is not considering the other parallel sessions. If any other session's data load is IN_PROGRESS at the time of bringing up one session, then the executing load also will be changed to MARKED_FOR_DELETE irrespective of the actual load status. 
(2) Handling stale segments cleaning while session bring up also increases the time of bringing up a session.

**Solution:**
(1) SEGMENT_LOCK should be taken on the new segment while loading to filter out stale IN_PROGRESS segments.
(2) While cleaning segments both tablestatus file and SEGMENT_LOCK should be considered.
Cleaning stale files while bringing up the session should be removed and this can be either manually done on the needed tables through already existing CLEAN FILES DDL or the next load on the table will clean the same.



 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [x] Testing done
        Manual Testing
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

