### PR TITLE
[CARBONDATA-1917] While loading, check for stale dictionary files

### DIFF
--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonGlobalDictionaryRDD.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonGlobalDictionaryRDD.scala
@@ -402,6 +402,16 @@ class CarbonGlobalDictionaryGenerateRDD(
             model.primDimensions(split.index).getDataType
           )
         } else {
+          // check if any stale dictionary data available for given column
+          CarbonLoaderUtil.validateForStaleDictionaryData(model.table,
+            model.columnIdentifier(split.index),
+            model.primDimensions(split.index).getDataType
+          )
+          // clearing stale dictionary cache
+          CarbonLoaderUtil.clearDictionaryCache(model.table,
+            model.columnIdentifier(split.index),
+            model.primDimensions(split.index).getDataType
+          )
           null
         }
         val dictCacheTime = System.currentTimeMillis - t2


### PR DESCRIPTION
If any stale dictionary files is left in a load, the next load should check for the stale dict files existence and alert the user.
 
 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [x] Testing done
        Manual Testing
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

