### PR TITLE
[CARBONDATA-1929][Validation]carbon property configuration validation

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -297,6 +297,10 @@ public final class CarbonCommonConstants {
    * SORT_INTERMEDIATE_FILES_LIMIT_DEFAULT_VALUE
    */
   public static final String SORT_INTERMEDIATE_FILES_LIMIT_DEFAULT_VALUE = "20";
+
+  public static final int SORT_INTERMEDIATE_FILES_LIMIT_MIN = 2;
+
+  public static final int SORT_INTERMEDIATE_FILES_LIMIT_MAX = 50;
   /**
    * BAD_RECORD_KEY_VALUE
    */
@@ -325,6 +329,8 @@ public final class CarbonCommonConstants {
   @CarbonProperty
   public static final String CARBON_SORT_FILE_WRITE_BUFFER_SIZE =
       "carbon.sort.file.write.buffer.size";
+  public static final int CARBON_SORT_FILE_WRITE_BUFFER_SIZE_MIN = 10240;
+  public static final int CARBON_SORT_FILE_WRITE_BUFFER_SIZE_MAX = 10485760;
   /**
    * SORT_FILE_WRITE_BUFFER_SIZE_DEFAULT_VALUE
    */

--- a/core/src/test/java/org/apache/carbondata/core/CarbonPropertiesValidationTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/CarbonPropertiesValidationTest.java
@@ -60,7 +60,7 @@ public class CarbonPropertiesValidationTest extends TestCase {
     validateMethodType.invoke(carbonProperties);
     String valueAfterValidation =
         carbonProperties.getProperty(CarbonCommonConstants.ENABLE_UNSAFE_SORT);
-    assertTrue(!valueBeforeValidation.equals(valueAfterValidation));
+    assertTrue(valueBeforeValidation.equals(valueAfterValidation));
     assertTrue(
         CarbonCommonConstants.ENABLE_UNSAFE_SORT_DEFAULT.equalsIgnoreCase(valueAfterValidation));
   }
@@ -76,7 +76,7 @@ public class CarbonPropertiesValidationTest extends TestCase {
     validateMethodType.invoke(carbonProperties);
     String valueAfterValidation =
         carbonProperties.getProperty(CarbonCommonConstants.CARBON_CUSTOM_BLOCK_DISTRIBUTION);
-    assertTrue(!valueBeforeValidation.equals(valueAfterValidation));
+    assertTrue(valueBeforeValidation.equals(valueAfterValidation));
     assertTrue(CarbonCommonConstants.CARBON_CUSTOM_BLOCK_DISTRIBUTION_DEFAULT
         .equalsIgnoreCase(valueAfterValidation));
   }
@@ -92,7 +92,7 @@ public class CarbonPropertiesValidationTest extends TestCase {
     validateMethodType.invoke(carbonProperties);
     String valueAfterValidation =
         carbonProperties.getProperty(CarbonCommonConstants.ENABLE_VECTOR_READER);
-    assertTrue(!valueBeforeValidation.equals(valueAfterValidation));
+    assertTrue(valueBeforeValidation.equals(valueAfterValidation));
     assertTrue(
         CarbonCommonConstants.ENABLE_VECTOR_READER_DEFAULT.equalsIgnoreCase(valueAfterValidation));
   }
@@ -108,7 +108,7 @@ public class CarbonPropertiesValidationTest extends TestCase {
     validateMethodType.invoke(carbonProperties);
     String valueAfterValidation =
         carbonProperties.getProperty(CarbonCommonConstants.CSV_READ_BUFFER_SIZE);
-    assertTrue(!valueBeforeValidation.equals(valueAfterValidation));
+    assertTrue(valueBeforeValidation.equals(valueAfterValidation));
     assertTrue(
         CarbonCommonConstants.CSV_READ_BUFFER_SIZE_DEFAULT.equalsIgnoreCase(valueAfterValidation));
   }
@@ -124,7 +124,7 @@ public class CarbonPropertiesValidationTest extends TestCase {
     validateMethodType.invoke(carbonProperties);
     String valueAfterValidation =
         carbonProperties.getProperty(CarbonCommonConstants.CSV_READ_BUFFER_SIZE);
-    assertTrue(!valueBeforeValidation.equals(valueAfterValidation));
+    assertTrue(valueBeforeValidation.equals(valueAfterValidation));
     assertTrue(
         CarbonCommonConstants.CSV_READ_BUFFER_SIZE_DEFAULT.equalsIgnoreCase(valueAfterValidation));
     carbonProperties.addProperty(CarbonCommonConstants.CSV_READ_BUFFER_SIZE, "10240");
@@ -140,7 +140,7 @@ public class CarbonPropertiesValidationTest extends TestCase {
     validateMethodType.invoke(carbonProperties);
     valueAfterValidation =
         carbonProperties.getProperty(CarbonCommonConstants.CSV_READ_BUFFER_SIZE);
-    assertTrue(!valueBeforeValidation.equals(valueAfterValidation));
+    assertTrue(valueBeforeValidation.equals(valueAfterValidation));
     assertTrue(
         CarbonCommonConstants.CSV_READ_BUFFER_SIZE_DEFAULT.equalsIgnoreCase(valueAfterValidation));
   }
@@ -150,5 +150,59 @@ public class CarbonPropertiesValidationTest extends TestCase {
     long newSize = 1024L * 1024 * 100;
     carbonProperties.addProperty(CarbonCommonConstants.HANDOFF_SIZE, "" + newSize);
     assertEquals(newSize, carbonProperties.getHandoffSize());
+  }
+
+  @Test public void testValidateTimeStampFormat()
+      throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+    Method validateMethodType = carbonProperties.getClass()
+        .getDeclaredMethod("validateTimeFormatKey", new Class[] { String.class, String.class });
+    validateMethodType.setAccessible(true);
+    carbonProperties.addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, "agdgaJIASDG667");
+    String valueBeforeValidation =
+        carbonProperties.getProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT);
+    validateMethodType.invoke(carbonProperties, CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT,
+        CarbonCommonConstants.CARBON_TIMESTAMP_DEFAULT_FORMAT);
+    String valueAfterValidation =
+        carbonProperties.getProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT);
+    assertTrue(valueBeforeValidation.equals(valueAfterValidation));
+    assertTrue(CarbonCommonConstants.CARBON_TIMESTAMP_DEFAULT_FORMAT
+        .equalsIgnoreCase(valueAfterValidation));
+    carbonProperties.addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT,
+        "yyyy-MM-dd hh:mm:ss");
+    validateMethodType.invoke(carbonProperties, CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT,
+        CarbonCommonConstants.CARBON_TIMESTAMP_DEFAULT_FORMAT);
+    assertEquals("yyyy-MM-dd hh:mm:ss",
+        carbonProperties.getProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT));
+  }
+
+  @Test public void testValidateSortFileWriteBufferSize()
+      throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+    Method validateMethodType =
+        carbonProperties.getClass().getDeclaredMethod("validateSortFileWriteBufferSize");
+    validateMethodType.setAccessible(true);
+    carbonProperties.addProperty(CarbonCommonConstants.CARBON_SORT_FILE_WRITE_BUFFER_SIZE, "test");
+    String valueBeforeValidation =
+        carbonProperties.getProperty(CarbonCommonConstants.CARBON_SORT_FILE_WRITE_BUFFER_SIZE);
+    validateMethodType.invoke(carbonProperties);
+    String valueAfterValidation =
+        carbonProperties.getProperty(CarbonCommonConstants.CARBON_SORT_FILE_WRITE_BUFFER_SIZE);
+    assertTrue(valueBeforeValidation.equals(valueAfterValidation));
+    assertTrue(CarbonCommonConstants.CARBON_SORT_FILE_WRITE_BUFFER_SIZE_DEFAULT_VALUE
+        .equalsIgnoreCase(valueAfterValidation));
+  }
+  @Test public void testValidateSortIntermediateFilesLimit()
+      throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+    Method validateMethodType =
+        carbonProperties.getClass().getDeclaredMethod("validateSortIntermediateFilesLimit");
+    validateMethodType.setAccessible(true);
+    carbonProperties.addProperty(CarbonCommonConstants.SORT_INTERMEDIATE_FILES_LIMIT, "test");
+    String valueBeforeValidation =
+        carbonProperties.getProperty(CarbonCommonConstants.SORT_INTERMEDIATE_FILES_LIMIT);
+    validateMethodType.invoke(carbonProperties);
+    String valueAfterValidation =
+        carbonProperties.getProperty(CarbonCommonConstants.SORT_INTERMEDIATE_FILES_LIMIT);
+    assertTrue(valueBeforeValidation.equals(valueAfterValidation));
+    assertTrue(CarbonCommonConstants.SORT_INTERMEDIATE_FILES_LIMIT_DEFAULT_VALUE
+        .equalsIgnoreCase(valueAfterValidation));
   }
 }

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datamap/DataMapWriterSuite.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datamap/DataMapWriterSuite.scala
@@ -138,6 +138,8 @@ class DataMapWriterSuite extends QueryTest with BeforeAndAfterAll {
 
     assert(DataMapWriterSuite.callbackSeq.head.contains("block start"))
     assert(DataMapWriterSuite.callbackSeq.last.contains("block end"))
+    // corrected test case the min "carbon.blockletgroup.size.in.mb" size could not be less than
+    // 64 MB
     assert(
       DataMapWriterSuite.callbackSeq.slice(1, DataMapWriterSuite.callbackSeq.length - 1) == Seq(
         "blocklet start 0",
@@ -145,17 +147,13 @@ class DataMapWriterSuite extends QueryTest with BeforeAndAfterAll {
         "add page data: blocklet 0, page 1",
         "add page data: blocklet 0, page 2",
         "add page data: blocklet 0, page 3",
-        "blocklet end: 0",
-        "blocklet start 1",
-        "add page data: blocklet 1, page 0",
-        "add page data: blocklet 1, page 1",
-        "add page data: blocklet 1, page 2",
-        "add page data: blocklet 1, page 3",
-        "blocklet end: 1",
-        "blocklet start 2",
-        "add page data: blocklet 2, page 0",
-        "add page data: blocklet 2, page 1",
-        "blocklet end: 2"
+        "add page data: blocklet 0, page 4",
+        "add page data: blocklet 0, page 5",
+        "add page data: blocklet 0, page 6",
+        "add page data: blocklet 0, page 7",
+        "add page data: blocklet 0, page 8",
+        "add page data: blocklet 0, page 9",
+        "blocklet end: 0"
       ))
     DataMapWriterSuite.callbackSeq = Seq()
   }


### PR DESCRIPTION
Added validation for below parameter:
carbon.timestamp.format
carbon.date.format
carbon.sort.file.write.buffer.size (minValue = 10 KB,  maxValue=10MB, defaultValue =16 KB )
carbon.sort.intermediate.files.limit (minValue = 2,  maxValue=50, defaultValue =20 )

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [X] Any interfaces changed?
 NA
 - [X] Any backward compatibility impacted?
 NA
 - [X] Document update required?
NA
 - [X] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       Added test case for property validation. 
 - [X] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA
