### PR TITLE
[CARBONDATA-1942] Documentation for Concurrent Lock Retries

### DIFF
--- a/docs/configuration-parameters.md
+++ b/docs/configuration-parameters.md
@@ -103,6 +103,8 @@ This section provides the details of all the configurations required for CarbonD
 | carbon.merge.sort.reader.thread | 3 | Maximum no of threads used for reading intermediate files for final merging. |
 | carbon.load.metadata.lock.retries | 3 | Maximum number of retries to get the metadata lock for loading data to table. |
 | carbon.load.metadata.lock.retry.timeout.sec | 5 | Interval between the retries to get the lock. |
+| carbon.concurrent.lock.retries | 100 | Specifies the maximum number of retries to obtain the lock for concurrent operations. This is used for concurrent loading. |
+| carbon.concurrent.lock.retry.timeout.sec | 1 | Specifies the interval between the retries to obtain the lock for concurrent operations. |
 | carbon.tempstore.location | /opt/Carbon/TempStoreLoc | Temporary store location. By default it takes System.getProperty("java.io.tmpdir"). |
 | carbon.load.log.counter | 500000 | Data loading records count logger. |   
 


### PR DESCRIPTION
Add documentation for concurrent lock retires. Add the parameter name, Default value, and description
