### PR TITLE
[CARBONDATA-1943][PARTITION] Fix Load static partition with LOAD COMMAND creates multiple partitions

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/standardpartition/StandardPartitionTableLoadingTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/standardpartition/StandardPartitionTableLoadingTestCase.scala
@@ -254,6 +254,23 @@ class StandardPartitionTableLoadingTestCase extends QueryTest with BeforeAndAfte
     }
   }
 
+  test("load static partition table for one static partition column with load syntax issue") {
+    sql(
+      """
+        | CREATE TABLE loadstaticpartitiononeissue (empname String, designation String, doj Timestamp,
+        |  workgroupcategory int, workgroupcategoryname String, deptno int, deptname String,
+        |  projectcode int, projectjoindate Timestamp, projectenddate Timestamp,attendance int,
+        |  utilization int,salary int)
+        | PARTITIONED BY (empno int)
+        | STORED BY 'org.apache.carbondata.format'
+      """.stripMargin)
+
+    sql(s"""LOAD DATA local inpath '$resourcesPath/data.csv' INTO TABLE loadstaticpartitiononeissue PARTITION(empno='1')""")
+    val df = sql("show partitions loadstaticpartitiononeissue")
+    assert(df.collect().length == 1)
+    checkExistence(df, true,  "empno=1")
+  }
+
 
   override def afterAll = {
     dropTable
@@ -272,6 +289,7 @@ class StandardPartitionTableLoadingTestCase extends QueryTest with BeforeAndAfte
     sql("drop table if exists loadstaticpartitionone")
     sql("drop table if exists loadstaticpartitiononeoverwrite")
     sql("drop table if exists streamingpartitionedtable")
+    sql("drop table if exists loadstaticpartitiononeissue")
   }
 
 }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/strategy/DDLStrategy.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/strategy/DDLStrategy.scala
@@ -51,12 +51,19 @@ class DDLStrategy(sparkSession: SparkSession) extends SparkStrategy {
           .tableExists(identifier)(sparkSession) =>
         ExecutedCommandExec(
           CarbonLoadDataCommand(
-            identifier.database,
-            identifier.table.toLowerCase,
-            path,
-            Seq(),
-            Map(),
-            isOverwrite)) :: Nil
+            databaseNameOp = identifier.database,
+            tableName = identifier.table.toLowerCase,
+            factPathFromUser = path,
+            dimFilesPath = Seq(),
+            options = Map(),
+            isOverwriteTable = isOverwrite,
+            inputSqlString = null,
+            dataFrame = None,
+            updateModel = None,
+            tableInfoOp = None,
+            internalOptions = Map.empty,
+            partition = partition.getOrElse(Map.empty).map { case (col, value) =>
+              (col, Some(value))})) :: Nil
       case alter@AlterTableRenameCommand(oldTableIdentifier, newTableIdentifier, _) =>
         val dbOption = oldTableIdentifier.database.map(_.toLowerCase)
         val tableIdentifier = TableIdentifier(oldTableIdentifier.table.toLowerCase(), dbOption)


### PR DESCRIPTION
When using the LOAD syntax without options then spark creates `LoadDataCommand` so passing of partitions information to `CarbonLoadDataCommand` is missing in that case. This PR fixes it.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [X] Any interfaces changed?
 
 - [X] Any backward compatibility impacted?
 
 - [X] Document update required?

 - [X] Testing done
       tests added
       
 - [X] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

