### PR TITLE
[CARBONDATA-1946] Exception thrown after alter data type change operation on dictionary exclude integer type column

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/safe/SafeVariableLengthDimensionDataChunkStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/safe/SafeVariableLengthDimensionDataChunkStore.java
@@ -24,7 +24,7 @@ import org.apache.carbondata.core.metadata.datatype.DataType;
 import org.apache.carbondata.core.metadata.datatype.DataTypes;
 import org.apache.carbondata.core.scan.result.vector.CarbonColumnVector;
 import org.apache.carbondata.core.util.ByteUtil;
-
+import org.apache.carbondata.core.util.DataTypeUtil;
 
 /**
  * Below class is responsible to store variable length dimension data chunk in
@@ -153,7 +153,9 @@ public class SafeVariableLengthDimensionDataChunkStore extends SafeAbsractDimens
       } else if (dt == DataTypes.INT) {
         vector.putInt(vectorRow, ByteUtil.toInt(data, currentDataOffset, length));
       } else if (dt == DataTypes.LONG) {
-        vector.putLong(vectorRow, ByteUtil.toLong(data, currentDataOffset, length));
+        vector.putLong(vectorRow, DataTypeUtil
+            .getDataBasedOnRestructuredDataType(data, vector.getBlockDataType(),
+                currentDataOffset, length));
       } else if (dt  == DataTypes.TIMESTAMP) {
         vector.putLong(vectorRow, ByteUtil.toLong(data, currentDataOffset, length) * 1000L);
       }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/unsafe/UnsafeVariableLengthDimesionDataChunkStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/unsafe/UnsafeVariableLengthDimesionDataChunkStore.java
@@ -25,7 +25,7 @@ import org.apache.carbondata.core.metadata.datatype.DataType;
 import org.apache.carbondata.core.metadata.datatype.DataTypes;
 import org.apache.carbondata.core.scan.result.vector.CarbonColumnVector;
 import org.apache.carbondata.core.util.ByteUtil;
-
+import org.apache.carbondata.core.util.DataTypeUtil;
 
 /**
  * Below class is responsible to store variable length dimension data chunk in
@@ -177,7 +177,9 @@ public class UnsafeVariableLengthDimesionDataChunkStore
       } else if (dt == DataTypes.INT) {
         vector.putInt(vectorRow, ByteUtil.toInt(value, 0, value.length));
       } else if (dt == DataTypes.LONG) {
-        vector.putLong(vectorRow, ByteUtil.toLong(value, 0, value.length));
+        vector.putLong(vectorRow, DataTypeUtil
+            .getDataBasedOnRestructuredDataType(value, vector.getBlockDataType(), 0,
+                value.length));
       } else if (dt == DataTypes.TIMESTAMP) {
         vector.putLong(vectorRow, ByteUtil.toLong(value, 0, value.length) * 1000L);
       }

--- a/core/src/main/java/org/apache/carbondata/core/scan/collector/impl/DictionaryBasedVectorResultCollector.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/collector/impl/DictionaryBasedVectorResultCollector.java
@@ -181,6 +181,10 @@ public class DictionaryBasedVectorResultCollector extends AbstractScannedResultC
       allColumnInfo[i].offset = rowCounter;
       allColumnInfo[i].vectorOffset = columnarBatch.getRowCounter();
       allColumnInfo[i].vector = columnarBatch.columnVectors[i];
+      if (null != allColumnInfo[i].dimension) {
+        allColumnInfo[i].vector
+            .setBlockDataType(allColumnInfo[i].dimension.getDimension().getDataType());
+      }
     }
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/scan/executor/util/RestructureUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/executor/util/RestructureUtil.java
@@ -83,8 +83,6 @@ public class RestructureUtil {
           if (tableDimension.getColumnId().equals(queryDimension.getDimension().getColumnId())) {
             QueryDimension currentBlockDimension = new QueryDimension(tableDimension.getColName());
             tableDimension.getColumnSchema()
-                .setDataType(queryDimension.getDimension().getDataType());
-            tableDimension.getColumnSchema()
                 .setPrecision(queryDimension.getDimension().getColumnSchema().getPrecision());
             tableDimension.getColumnSchema()
                 .setScale(queryDimension.getDimension().getColumnSchema().getScale());

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/vector/CarbonColumnVector.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/vector/CarbonColumnVector.java
@@ -67,6 +67,20 @@ public interface CarbonColumnVector {
 
   DataType getType();
 
+  /**
+   * Method to be used for getting the restructured data type. This method will used for
+   * retrieving the data after change in data type restructure operation
+   *
+   * @return
+   */
+  DataType getBlockDataType();
+
+  /**
+   * Method to be used for setting the restructured data type. This method will used for
+   * retrieving the data after change in data type restructure operation
+   */
+  void setBlockDataType(DataType blockDataType);
+
   void setFilteredRowsExist(boolean filteredRowsExist);
 
 }

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/vector/impl/CarbonColumnVectorImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/vector/impl/CarbonColumnVectorImpl.java
@@ -51,6 +51,8 @@ public class CarbonColumnVectorImpl implements CarbonColumnVector {
 
   private DataType dataType;
 
+  private DataType blockDataType;
+
   /**
    * True if there is at least one NULL byte set. This is an optimization for the writer, to skip
    * having to clear NULL bits.
@@ -233,6 +235,16 @@ public class CarbonColumnVectorImpl implements CarbonColumnVector {
 
   @Override public DataType getType() {
     return dataType;
+  }
+
+  @Override
+  public DataType getBlockDataType() {
+    return blockDataType;
+  }
+
+  @Override
+  public void setBlockDataType(DataType blockDataType) {
+    this.blockDataType = blockDataType;
   }
 
   @Override public void setFilteredRowsExist(boolean filteredRowsExist) {

--- a/core/src/main/java/org/apache/carbondata/core/util/DataTypeUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/DataTypeUtil.java
@@ -775,4 +775,25 @@ public final class DataTypeUtil {
     }
   }
 
+  /**
+   * Method to type case the data based on modified data type. This method will used for
+   * retrieving the data after change in data type restructure operation
+   *
+   * @param data
+   * @param restructuredDataType
+   * @param currentDataOffset
+   * @param length
+   * @return
+   */
+  public static long getDataBasedOnRestructuredDataType(byte[] data, DataType restructuredDataType,
+      int currentDataOffset, int length) {
+    long value = 0L;
+    if (restructuredDataType == DataTypes.INT) {
+      value = ByteUtil.toInt(data, currentDataOffset, length);
+    } else if (restructuredDataType == DataTypes.LONG) {
+      value = ByteUtil.toLong(data, currentDataOffset, length);
+    }
+    return value;
+  }
+
 }

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/CarbonColumnVectorWrapper.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/CarbonColumnVectorWrapper.java
@@ -33,6 +33,8 @@ public class CarbonColumnVectorWrapper implements CarbonColumnVector {
 
   private boolean filteredRowsExist;
 
+  private DataType blockDataType;
+
   public CarbonColumnVectorWrapper(CarbonColumnVectorImpl columnVector, boolean[] filteredRows) {
     this.columnVector = columnVector;
     this.filteredRows = filteredRows;
@@ -201,6 +203,16 @@ public class CarbonColumnVectorWrapper implements CarbonColumnVector {
 
   @Override public DataType getType() {
     return columnVector.getType();
+  }
+
+  @Override
+  public DataType getBlockDataType() {
+    return blockDataType;
+  }
+
+  @Override
+  public void setBlockDataType(DataType blockDataType) {
+    this.blockDataType = blockDataType;
   }
 
   @Override public void setFilteredRowsExist(boolean filteredRowsExist) {

--- a/integration/spark2/src/main/java/org/apache/carbondata/spark/vectorreader/ColumnarVectorWrapper.java
+++ b/integration/spark2/src/main/java/org/apache/carbondata/spark/vectorreader/ColumnarVectorWrapper.java
@@ -38,6 +38,8 @@ class ColumnarVectorWrapper implements CarbonColumnVector {
 
   private DataType dataType;
 
+  private DataType blockDataType;
+
   public ColumnarVectorWrapper(ColumnVector columnVector, boolean[] filteredRows) {
     this.columnVector = columnVector;
     this.filteredRows = filteredRows;
@@ -209,6 +211,16 @@ class ColumnarVectorWrapper implements CarbonColumnVector {
 
   @Override public DataType getType() {
     return dataType;
+  }
+
+  @Override
+  public DataType getBlockDataType() {
+    return blockDataType;
+  }
+
+  @Override
+  public void setBlockDataType(DataType blockDataType) {
+    this.blockDataType = blockDataType;
   }
 
   @Override public void setFilteredRowsExist(boolean filteredRowsExist) {


### PR DESCRIPTION
Problem: After restructure change data type operation (INT to BIGINT) on dictionary exclude INT type column if select query is triggered then exception is thrown.

Analysis: This is happening because while retrieving the data the vector is created for BIGINT type (size 8 bytes) which but the actual length of each data is 4 bytes and there is length check while reading the data which is failing.

Solution: Added a new restructuredType variable in vector and assigned the block dimension data type to it.

 - [ ] Any interfaces changed?
 No
 - [ ] Any backward compatibility impacted?
 No
 - [ ] Document update required?
No
 - [ ] Testing done
 Added a test case
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA

