### PR TITLE
[CARBONDATA-1947]fix select * issue after compaction, delete and clean files operation

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/iud/DeleteCarbonTableTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/iud/DeleteCarbonTableTestCase.scala
@@ -165,6 +165,21 @@ class DeleteCarbonTableTestCase extends QueryTest with BeforeAndAfterAll {
     sql("drop table if exists preaggmain_preagg1")
   }
 
+  test("test select query after compaction, delete and clean files") {
+    sql("drop table if exists select_after_clean")
+    sql("create table select_after_clean(id int, name string) stored by 'carbondata'")
+    sql("insert into select_after_clean select 1,'abc'")
+    sql("insert into select_after_clean select 2,'def'")
+    sql("insert into select_after_clean select 3,'uhj'")
+    sql("insert into select_after_clean select 4,'frg'")
+    sql("alter table select_after_clean compact 'minor'")
+    sql("clean files for table select_after_clean")
+    sql("delete from select_after_clean where name='def'")
+    sql("clean files for table select_after_clean")
+    checkAnswer(sql("""select * from select_after_clean"""),
+      Seq(Row(1, "abc"), Row(3, "uhj"), Row(4, "frg")))
+  }
+
 
   override def afterAll {
     sql("use default")

--- a/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonTableCompactor.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonTableCompactor.scala
@@ -135,7 +135,6 @@ class CarbonTableCompactor(carbonLoadModel: CarbonLoadModel,
     val factTableName = carbonLoadModel.getTableName
     val validSegments: Array[String] = CarbonDataMergerUtil
       .getValidSegments(loadsToMerge).split(',')
-    val mergeLoadStartTime = CarbonUpdateUtil.readCurrentTime()
     val partitionMapper = if (carbonTable.isHivePartitionTable) {
       var partitionMap: util.Map[String, util.List[String]] = null
       validSegments.foreach { segmentId =>
@@ -245,7 +244,7 @@ class CarbonTableCompactor(carbonLoadModel: CarbonLoadModel,
              carbonLoadModel)) ||
         CarbonDataMergerUtil
           .updateLoadMetadataWithMergeStatus(loadsToMerge, carbonTable.getMetaDataFilepath,
-            mergedLoadNumber, carbonLoadModel, mergeLoadStartTime, compactionType)
+            mergedLoadNumber, carbonLoadModel, compactionType)
 
       if (!statusFileUpdation) {
         LOGGER.audit(s"Compaction request failed for table ${ carbonLoadModel.getDatabaseName }." +

--- a/processing/src/main/java/org/apache/carbondata/processing/merger/CarbonDataMergerUtil.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/merger/CarbonDataMergerUtil.java
@@ -280,7 +280,7 @@ public final class CarbonDataMergerUtil {
    */
   public static boolean updateLoadMetadataWithMergeStatus(List<LoadMetadataDetails> loadsToMerge,
       String metaDataFilepath, String mergedLoadNumber, CarbonLoadModel carbonLoadModel,
-      long mergeLoadStartTime, CompactionType compactionType) throws IOException {
+      CompactionType compactionType) throws IOException {
     boolean tableStatusUpdationStatus = false;
     AbsoluteTableIdentifier absoluteTableIdentifier =
         carbonLoadModel.getCarbonDataLoadSchema().getCarbonTable().getAbsoluteTableIdentifier();
@@ -327,7 +327,7 @@ public final class CarbonDataMergerUtil {
         loadMetadataDetails.setLoadName(mergedLoadNumber);
         CarbonLoaderUtil
             .addDataIndexSizeIntoMetaEntry(loadMetadataDetails, mergedLoadNumber, carbonTable);
-        loadMetadataDetails.setLoadStartTime(mergeLoadStartTime);
+        loadMetadataDetails.setLoadStartTime(carbonLoadModel.getFactTimeStamp());
         loadMetadataDetails.setPartitionCount("0");
         // if this is a major compaction then set the segment as major compaction.
         if (CompactionType.MAJOR == compactionType) {


### PR DESCRIPTION
**Problem**: fix select * issue after compaction, delete and clean files operation

**Analysis**: during compaction the timestamp of fact file and the load starttime present in metadata details are different for the same segments, so when the delete operation is executed and after that clean files is called,  since there is a timestamp difference, it will delete the carbondata file which inturn gives empty result for select query.

**solution**: when updating the metadata details for merged segment, get the load starttime from carbonloadModel facttime stamp

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [X] Any interfaces changed?
 NA
 - [X] Any backward compatibility impacted?
 NA
 - [X] Document update required?
NA
 - [X] Testing done
        Please provide details on 
        - Units test cases are added to test the scenario
       
 - [X] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA
