### PR TITLE
[CARBONDATA-1953]Pre-aggregate Should inherit sort column,sort_scope,dictionary encoding

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggregateMisc.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggregateMisc.scala
@@ -16,9 +16,11 @@
  */
 package org.apache.carbondata.integration.spark.testsuite.preaggregate
 
-import org.apache.spark.sql.Row
+import org.apache.spark.sql.{CarbonEnv, Row}
 import org.apache.spark.sql.test.util.QueryTest
 import org.scalatest.{BeforeAndAfterAll, Ignore}
+
+import org.apache.carbondata.core.constants.CarbonCommonConstants
 
 @Ignore
 class TestPreAggregateMisc extends QueryTest with BeforeAndAfterAll {
@@ -38,6 +40,37 @@ class TestPreAggregateMisc extends QueryTest with BeforeAndAfterAll {
     sql("drop datamap agg1 on table mainTable")
 
   }
+  test("check preagg tbl properties sort columns inherit from main tbl") {
+    sql("drop table if exists y ")
+    sql(
+      "create table y(year int,month int,name string,salary int) stored by 'carbondata' " +
+      "tblproperties('NO_INVERTED_INDEX'='name','sort_scope'='Global_sort'," +
+      "'table_blocksize'='23','Dictionary_include'='month','Dictionary_exclude'='year,name'," +
+      "'sort_columns'='month,year,name')")
+    sql("insert into y select 10,11,'babu',12")
+    sql(
+      "create datamap y1_sum1 on table y using 'preaggregate' as select year,month,name,sum" +
+      "(salary) from y group by year,month,name")
+
+    val carbonTable = CarbonEnv.getCarbonTable(Some("default"), "y")(sqlContext.sparkSession)
+    val datamaptable = CarbonEnv
+      .getCarbonTable(Some("default"), "y_y1_sum1")(sqlContext.sparkSession)
+
+    val sortcolumns = datamaptable.getTableInfo.getFactTable.getTableProperties
+      .get(CarbonCommonConstants.SORT_COLUMNS)
+    val sortcolummatch = sortcolumns != null && sortcolumns.equals("y_month,y_year,y_name")
+
+    val sortscope = datamaptable.getTableInfo.getFactTable.getTableProperties.get("sort_scope")
+    val sortscopematch = sortscope != null && sortscope.equals(
+      carbonTable.getTableInfo.getFactTable.getTableProperties.get("sort_scope"))
+    val blockSize = datamaptable.getTableInfo.getFactTable.getTableProperties
+      .get(CarbonCommonConstants.TABLE_BLOCKSIZE)
+    val blocksizematch = blockSize != null &&
+                         blockSize.equals(carbonTable.getTableInfo.getFactTable.getTableProperties.
+                           get(CarbonCommonConstants.TABLE_BLOCKSIZE))
+    assert(sortcolummatch && sortscopematch && blocksizematch)
+  }
+
 
   override def afterAll: Unit = {
     sql("drop table if exists mainTable")

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchemaCommon.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchemaCommon.scala
@@ -581,20 +581,22 @@ class TableNewProcessor(cm: TableModel) {
 
     updateColumnGroupsInFields(cm.columnGroups, allColumns)
 
-    // Setting the boolean value of useInvertedIndex in column schema
-    val noInvertedIndexCols = cm.noInvertedIdxCols.getOrElse(Seq())
-    LOGGER.info("NoINVERTEDINDEX columns are : " + noInvertedIndexCols.mkString(","))
-    for (column <- allColumns) {
-      // When the column is measure or the specified no inverted index column in DDL,
-      // set useInvertedIndex to false, otherwise true.
-      if (noInvertedIndexCols.contains(column.getColumnName) ||
-          cm.msrCols.exists(_.column.equalsIgnoreCase(column.getColumnName))) {
-        column.setUseInvertedIndex(false)
-      } else {
-        column.setUseInvertedIndex(true)
+    // Setting the boolean value of useInvertedIndex in column schema, if Paranet table is defined
+    // Encoding is already decided above
+    if (!cm.parentTable.isDefined) {
+      val noInvertedIndexCols = cm.noInvertedIdxCols.getOrElse(Seq())
+      LOGGER.info("NoINVERTEDINDEX columns are : " + noInvertedIndexCols.mkString(","))
+      for (column <- allColumns) {
+        // When the column is measure or the specified no inverted index column in DDL,
+        // set useInvertedIndex to false, otherwise true.
+        if (noInvertedIndexCols.contains(column.getColumnName) ||
+            cm.msrCols.exists(_.column.equalsIgnoreCase(column.getColumnName))) {
+          column.setUseInvertedIndex(false)
+        } else {
+          column.setUseInvertedIndex(true)
+        }
       }
     }
-
     // Adding dummy measure if no measure is provided
     if (measureCount == 0) {
       val encoders = new java.util.ArrayList[Encoding]()


### PR DESCRIPTION
Pre-aggregate should inherit the main table properties , sort column order , sort scope ,table block size

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed? NO 
 
 - [ ] Any backward compatibility impacted? No
 
 - [ ] Document update required? No

 - [ ] Testing done   : Done
       Added UT for encoding scenario
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 


  