### PR TITLE
[CARBONDATA-1967][PARTITION] Fix autocompaction and auto merge index in partition tables

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/util/path/CarbonTablePath.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/path/CarbonTablePath.java
@@ -111,10 +111,7 @@ public class CarbonTablePath extends Path {
   }
 
   /**
-   * check if it is carbon partitionmap file matching extension
-   *
-   * @param fileNameWithPath
-   * @return boolean
+   * Return true if the fileNameWithPath ends with partition map file extension name
    */
   public static boolean isPartitionMapFile(String fileNameWithPath) {
     int pos = fileNameWithPath.lastIndexOf('.');

--- a/core/src/main/java/org/apache/carbondata/core/util/path/CarbonTablePath.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/path/CarbonTablePath.java
@@ -111,6 +111,20 @@ public class CarbonTablePath extends Path {
   }
 
   /**
+   * check if it is carbon partitionmap file matching extension
+   *
+   * @param fileNameWithPath
+   * @return boolean
+   */
+  public static boolean isPartitionMapFile(String fileNameWithPath) {
+    int pos = fileNameWithPath.lastIndexOf('.');
+    if (pos != -1) {
+      return fileNameWithPath.substring(pos).startsWith(PARTITION_MAP_EXT);
+    }
+    return false;
+  }
+
+  /**
    * check if it is carbon index file matching extension
    *
    * @param fileNameWithPath

--- a/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -712,7 +712,7 @@ object CarbonDataRDDFactory {
   /**
    * Trigger compaction after data load
    */
-  private def handleSegmentMerging(
+  def handleSegmentMerging(
       sqlContext: SQLContext,
       carbonLoadModel: CarbonLoadModel,
       carbonTable: CarbonTable,

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonLoadDataCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonLoadDataCommand.scala
@@ -377,7 +377,8 @@ case class CarbonLoadDataCommand(
           sparkSession,
           carbonLoadModel,
           hadoopConf,
-          loadDataFrame, operationContext)
+          loadDataFrame,
+          operationContext)
       } finally {
         server match {
           case Some(dictServer) =>
@@ -457,11 +458,6 @@ case class CarbonLoadDataCommand(
    * Loads the data in a hive partition way. This method uses InsertIntoTable command to load data
    * into partitoned data. The table relation would be converted to HadoopFSRelation to let spark
    * handling the partitioning.
-   * @param sparkSession
-   * @param carbonLoadModel
-   * @param hadoopConf
-   * @param dataFrame
-   * @return
    */
   private def loadDataWithPartition(sparkSession: SparkSession,
       carbonLoadModel: CarbonLoadModel,
@@ -660,7 +656,8 @@ case class CarbonLoadDataCommand(
     } catch {
       case e: Exception =>
         throw new Exception(
-          "Dataload is success. Auto-Compaction has failed. Please check logs.")
+          "Dataload is success. Auto-Compaction has failed. Please check logs.",
+          e)
     }
   }
 

--- a/processing/src/main/java/org/apache/carbondata/processing/util/DeleteLoadFolders.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/util/DeleteLoadFolders.java
@@ -65,7 +65,8 @@ public final class DeleteLoadFolders {
 
           @Override public boolean accept(CarbonFile file) {
             return (CarbonTablePath.isCarbonDataFile(file.getName())
-                || CarbonTablePath.isCarbonIndexFile(file.getName()));
+                || CarbonTablePath.isCarbonIndexFile(file.getName())
+                || CarbonTablePath.isPartitionMapFile(file.getName()));
           }
         });
 


### PR DESCRIPTION
Auto compaction is not working in case of the partition table and merge index files are merging always even though it is configured as false.

Solution:
Auto compaction code is added after finishing of partition loading. And also merge index configuration is checked before going for index merging.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

