### PR TITLE
[CARBONDATA-1970](Carbon1.3.0 - Spark 2.2) Use Spark 2.2.1 as default version for Profile Spark-2.2

### DIFF
--- a/integration/spark2/pom.xml
+++ b/integration/spark2/pom.xml
@@ -208,7 +208,7 @@
     <profile>
     <id>spark-2.2</id>
     <properties>
-      <spark.version>2.2.0</spark.version>
+      <spark.version>2.2.1</spark.version>
       <scala.binary.version>2.11</scala.binary.version>
       <scala.version>2.11.8</scala.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -514,7 +514,7 @@
     <profile>
       <id>spark-2.2</id>
       <properties>
-        <spark.version>2.2.0</spark.version>
+        <spark.version>2.2.1</spark.version>
         <scala.binary.version>2.11</scala.binary.version>
         <scala.version>2.11.8</scala.version>
       </properties>


### PR DESCRIPTION
Spark 2.2.1 had released for a while, and there were more than 200+ issues fixed, so it's better to upgrade spark 2.2.0 to 2.2.1 for profile spark-2.2.

The discussion about this on mailing list : [Should-we-use-Spark-2-2-1-as-default-version-for-Spark-2-2-supported](http://apache-carbondata-dev-mailing-list-archive.1130556.n5.nabble.com/Should-we-use-Spark-2-2-1-as-default-version-for-Spark-2-2-supported-td32713.html)

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 


  