### PR TITLE
[CARBONDATA-1975] Wrong input metrics displayed for carbon

### DIFF
--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
@@ -379,7 +379,6 @@ class CarbonScanRDD(
           }
           havePair = false
           val value = reader.getCurrentValue
-          inputMetricsStats.updateByValue(value)
           value
         }
 

--- a/integration/spark2/src/main/scala/org/apache/spark/CarbonInputMetrics.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/CarbonInputMetrics.scala
@@ -78,10 +78,6 @@ class CarbonInputMetrics extends InitInputMetrics{
   }
 
   override def updateByValue(value: Object): Unit = {
-    value match {
-      case batch: ColumnarBatch =>
-        inputMetrics.incRecordsRead(batch.numRows())
-      case _ =>
-    }
+
   }
 }


### PR DESCRIPTION
Metrics is updated twice. And so it is displayed as twice the actual record size in Spark UI

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [x] Testing done
        Manual Testing
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

