### PR TITLE
[CARBONDATA-1976][PARTITION] Support combination of dynamic and static partitions. And fix concurrent partition load issue.

### DIFF
--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonOutputCommitter.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonOutputCommitter.java
@@ -83,7 +83,13 @@ public class CarbonOutputCommitter extends FileOutputCommitter {
    * @throws IOException
    */
   @Override public void commitJob(JobContext context) throws IOException {
-    super.commitJob(context);
+    try {
+      super.commitJob(context);
+    } catch (IOException e) {
+      // ignore, in case of concurrent load it try to remove temporary folders by other load may
+      // cause file not found exception. This will not impact carbon load,
+      LOGGER.warn(e.getMessage());
+    }
     boolean overwriteSet = CarbonTableOutputFormat.isOverwriteSet(context.getConfiguration());
     CarbonLoadModel loadModel = CarbonTableOutputFormat.getLoadModel(context.getConfiguration());
     LoadMetadataDetails newMetaEntry = loadModel.getCurrentLoadMetadataDetail();

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/standardpartition/StandardPartitionTableDropTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/standardpartition/StandardPartitionTableDropTestCase.scala
@@ -155,6 +155,33 @@ class StandardPartitionTableDropTestCase extends QueryTest with BeforeAndAfterAl
 
   }
 
+
+  test("dropping all partition on table and do compaction") {
+    sql(
+      """
+        | CREATE TABLE partitionallcompaction (empno int, empname String, designation String,
+        |  workgroupcategory int, workgroupcategoryname String, deptno int,
+        |  projectjoindate Timestamp, projectenddate Date,attendance int,
+        |  utilization int,salary int)
+        | PARTITIONED BY (deptname String,doj Timestamp,projectcode int)
+        | STORED BY 'org.apache.carbondata.format'
+      """.stripMargin)
+    sql(s"""LOAD DATA local inpath '$resourcesPath/data.csv' INTO TABLE partitionallcompaction OPTIONS('DELIMITER'= ',', 'QUOTECHAR'= '"')""")
+    sql(s"""LOAD DATA local inpath '$resourcesPath/data.csv' INTO TABLE partitionallcompaction OPTIONS('DELIMITER'= ',', 'QUOTECHAR'= '"')""")
+    sql(s"""LOAD DATA local inpath '$resourcesPath/data.csv' INTO TABLE partitionallcompaction OPTIONS('DELIMITER'= ',', 'QUOTECHAR'= '"')""")
+    sql(s"""LOAD DATA local inpath '$resourcesPath/data.csv' INTO TABLE partitionallcompaction OPTIONS('DELIMITER'= ',', 'QUOTECHAR'= '"')""")
+    sql(s"""ALTER TABLE partitionallcompaction DROP PARTITION(deptname='Learning')""")
+    sql(s"""ALTER TABLE partitionallcompaction DROP PARTITION(deptname='configManagement')""")
+    sql(s"""ALTER TABLE partitionallcompaction DROP PARTITION(deptname='network')""")
+    sql(s"""ALTER TABLE partitionallcompaction DROP PARTITION(deptname='protocol')""")
+    sql(s"""ALTER TABLE partitionallcompaction DROP PARTITION(deptname='security')""")
+    assert(sql(s"""SHOW PARTITIONS partitionallcompaction""").collect().length == 0)
+    sql("ALTER TABLE partitionallcompaction COMPACT 'MAJOR'").collect()
+    checkAnswer(
+      sql(s"""select count (*) from partitionallcompaction"""),
+      Seq(Row(0)))
+  }
+
   override def afterAll = {
     dropTable
   }
@@ -167,6 +194,7 @@ class StandardPartitionTableDropTestCase extends QueryTest with BeforeAndAfterAl
     sql("drop table if exists partitionmany")
     sql("drop table if exists partitionshow")
     sql("drop table if exists staticpartition")
+    sql("drop table if exists partitionallcompaction")
   }
 
 }

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDropPartitionRDD.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDropPartitionRDD.scala
@@ -37,13 +37,16 @@ case class CarbonDropPartition(rddId: Int, val idx: Int, segmentPath: String)
  * @param sc
  * @param tablePath
  * @param segments segments to be merged
+ * @param partialMatch If it is true then even the partial partition spec matches also can be
+ *                      dropped
  */
 class CarbonDropPartitionRDD(
     sc: SparkContext,
     tablePath: String,
     segments: Seq[String],
     partitions: Seq[String],
-    uniqueId: String)
+    uniqueId: String,
+    partialMatch: Boolean)
   extends CarbonRDD[String](sc, Nil) {
 
   override def getPartitions: Array[Partition] = {
@@ -60,7 +63,8 @@ class CarbonDropPartitionRDD(
       new PartitionMapFileStore().dropPartitions(
         split.segmentPath,
         partitions.toList.asJava,
-        uniqueId)
+        uniqueId,
+        partialMatch)
 
       var havePair = false
       var finished = false

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
@@ -998,10 +998,10 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
       case _ => ("", "")
     }
 
-  protected lazy val partitions: Parser[(String, String)] =
-    (ident <~ "=") ~ stringLit ^^ {
+  protected lazy val partitions: Parser[(String, Option[String])] =
+    (ident <~ "=".?) ~ stringLit.? ^^ {
       case opt ~ optvalue => (opt.trim, optvalue)
-      case _ => ("", "")
+      case _ => ("", None)
     }
 
   protected lazy val valueOptions: Parser[(Int, Int)] =

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSpark2SqlParser.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSpark2SqlParser.scala
@@ -361,7 +361,7 @@ class CarbonSpark2SqlParser extends CarbonDDLSqlParser {
           validateOptions(optionsList)
         }
         val optionsMap = optionsList.getOrElse(List.empty[(String, String)]).toMap
-        val partitionSpec = partitions.getOrElse(List.empty[(String, String)]).toMap
+        val partitionSpec = partitions.getOrElse(List.empty[(String, Option[String])]).toMap
         CarbonLoadDataCommand(
           databaseNameOp = convertDbNameToLowerCase(databaseNameOp),
           tableName = tableName,
@@ -374,7 +374,7 @@ class CarbonSpark2SqlParser extends CarbonDDLSqlParser {
           updateModel = None,
           tableInfoOp = None,
           internalOptions = Map.empty,
-          partition = partitionSpec.map { case (key, value) => (key, Some(value))})
+          partition = partitionSpec)
     }
 
   protected lazy val deleteLoadsByID: Parser[LogicalPlan] =


### PR DESCRIPTION
Support combination of dynamic and static partitions. 
Like user can give as follows
```
 sql(s"""LOAD DATA local inpath '$resourcesPath/data.csv' INTO TABLE loadstaticpartitiondynamic 
 PARTITION(empno='1', empname) OPTIONS('DELIMITER'= ',', 'QUOTECHAR'= '"')""")
```
And fix the concurrent partition load issue as sometimes it gives file not found exception while deleting temporary folders.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [X] Any interfaces changed? NO
 
 - [X] Any backward compatibility impacted? NO
 
 - [X] Document update required? NO

 - [X] Testing done
       Tests added
       
 - [X] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

