### PR TITLE
[CARBONDATA-1999] Block drop table and delete streaming segment while streaming is in progress

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/statusmanager/SegmentStatusManager.java
+++ b/core/src/main/java/org/apache/carbondata/core/statusmanager/SegmentStatusManager.java
@@ -495,8 +495,13 @@ public class SegmentStatusManager {
           }
           // if the segment status is overwrite in progress, then no need to delete that.
           if (SegmentStatus.INSERT_OVERWRITE_IN_PROGRESS == loadMetadata.getSegmentStatus()) {
-            LOG.error("Cannot delete the segemnt " + loadId + " which is load overwrite " +
+            LOG.error("Cannot delete the segment " + loadId + " which is load overwrite " +
                     "in progress");
+            invalidLoadIds.add(loadId);
+            return invalidLoadIds;
+          }
+          if (SegmentStatus.STREAMING == loadMetadata.getSegmentStatus()) {
+            LOG.error("Cannot delete the segment " + loadId + " which is streaming in progress");
             invalidLoadIds.add(loadId);
             return invalidLoadIds;
           }
@@ -541,6 +546,11 @@ public class SegmentStatusManager {
         if (SegmentStatus.COMPACTED == loadMetadata.getSegmentStatus()) {
           LOG.info("Ignoring the segment : " + loadMetadata.getLoadName()
               + "as the segment has been compacted.");
+          continue;
+        }
+        if (SegmentStatus.STREAMING == loadMetadata.getSegmentStatus()) {
+          LOG.info("Ignoring the segment : " + loadMetadata.getLoadName()
+              + "as the segment is streaming in progress.");
           continue;
         }
         if (SegmentStatus.MARKED_FOR_DELETE != loadMetadata.getSegmentStatus() &&

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonDropTableCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonDropTableCommand.scala
@@ -55,6 +55,10 @@ case class CarbonDropTableCommand(
       }
       LOGGER.audit(s"Deleting table [$tableName] under database [$dbName]")
       carbonTable = CarbonEnv.getCarbonTable(databaseNameOp, tableName)(sparkSession)
+      if (carbonTable.isStreamingTable) {
+        // streaming table should acquire streaming.lock
+        carbonLocks += CarbonLockUtil.getLockObject(identifier, LockUsage.STREAMING_LOCK)
+      }
       val relationIdentifiers = carbonTable.getTableInfo.getParentRelationIdentifiers
       if (relationIdentifiers != null && !relationIdentifiers.isEmpty) {
         if (!dropChildTable) {

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/strategy/DDLStrategy.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/strategy/DDLStrategy.scala
@@ -223,7 +223,7 @@ class DDLStrategy(sparkSession: SparkSession) extends SparkStrategy {
         if (property.isDefined) {
           if (!property.get._2.trim.equalsIgnoreCase("true")) {
             throw new MalformedCarbonCommandException(
-              "Streaming property can not be changed to 'false' once it is 'true'")
+              "Streaming property can not be changed once it is 'true'")
           }
         }
         ExecutedCommandExec(CarbonAlterTableSetCommand(tableName, properties, isView)) :: Nil


### PR DESCRIPTION
1. Block drop table while streaming is in progress
2. Block delete streaming segment 

 - [x] Any interfaces changed?
 no
 - [x] Any backward compatibility impacted?
 no
 - [x] Document update required?
  yes
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
          added
        - How it is tested? Please attach test report.
          ut
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
small changes
