### PR TITLE
[CARBONDATA-1973] User Should not Be able to give the duplicate column name in partitio…

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/standardpartition/StandardPartitionTableQueryTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/standardpartition/StandardPartitionTableQueryTestCase.scala
@@ -239,6 +239,11 @@ class StandardPartitionTableQueryTestCase extends QueryTest with BeforeAndAfterA
     sql(s"""LOAD DATA local inpath '$resourcesPath/data.csv' INTO TABLE staticpartitionload partition(empname='ravi') OPTIONS('DELIMITER'= ',', 'QUOTECHAR'= '"')""")
   }
 
+test("Creation of partition table should fail if the colname in table schema and partition column is same even if both are case sensitive"){
+  intercept[Exception]{
+    sql("CREATE TABLE uniqdata_char2(name char,id int) partitioned by (NAME char)stored by 'carbondata' ")
+  }
+}
 
   private def verifyPartitionInfo(frame: DataFrame, partitionNames: Seq[String]) = {
     val plan = frame.queryExecution.sparkPlan

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSparkSqlParser.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSparkSqlParser.scala
@@ -200,7 +200,11 @@ class CarbonHelperSqlAstBuilder(conf: SQLConf,
          throw new MalformedCarbonCommandException("Error: Invalid partition definition")
       }
       // partition columns should not be part of the schema
-      val badPartCols = partitionFields.map(_.partitionColumn).toSet.intersect(colNames.toSet)
+      val badPartCols = partitionFields
+        .map(_.partitionColumn.toLowerCase)
+        .toSet
+        .intersect(colNames.map(_.toLowerCase).toSet)
+
       if (badPartCols.nonEmpty) {
         operationNotAllowed(s"Partition columns should not be specified in the schema: " +
                             badPartCols.map("\"" + _ + "\"").mkString("[", ",", "]"),


### PR DESCRIPTION
**Jira Link: https://issues.apache.org/jira/browse/CARBONDATA-1973**

**User Should not Be able to give the duplicate column name in partition even if its case sensitive,hive also does the same** 

1.carbon.sql("CREATE TABLE uniqdata_char2(name char,id int) partitioned by (NAME char)stored by 'carbondata' ")
 name [uniqdata_char2]
18/01/03 12:44:44 WARN HiveExternalCatalog: Couldn't find corresponding Hive SerDe for data source provider org.apache.spark.sql.CarbonSource. Persisting data source table `default`.`uniqdata_char2` into Hive metastore in Spark SQL specific format, which is NOT compatible with Hive.
18/01/03 12:44:44 AUDIT CarbonCreateTableCommand: [anubhav-Vostro-3559][anubhav][Thread-1]Table created with Database name [default] and Table name [uniqdata_char2]
res30: org.apache.spark.sql.DataFrame = []

as we can see table get created successfully

2.try same thing on hive

carbon.sql("CREATE TABLE uniqdata_char2_hive(name char,id int) partitioned by (NAME char) ")
it gives exception

org.apache.spark.sql.AnalysisException: Found duplicate column(s) in table definition of `uniqdata_char2_hive`: name;
  at org.apache.spark.sql.execution.datasources.AnalyzeCreateTable.org$apache$spark$sql$execution$datasources$AnalyzeCreateTable$$failAnalysis(rules.scala:198)

behaviour of carbondata should be similiar to hive
  