### PR TITLE
[CARBONDATA-2012] Add support to load pre-aggregate in one transaction

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/LocalCarbonFile.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/LocalCarbonFile.java
@@ -233,7 +233,7 @@ public class LocalCarbonFile implements CarbonFile {
 
   @Override public boolean renameForce(String changetoName) {
     File destFile = new File(changetoName);
-    if (destFile.exists()) {
+    if (destFile.exists() && !file.getAbsolutePath().equals(destFile.getAbsolutePath())) {
       if (destFile.delete()) {
         return file.renameTo(new File(changetoName));
       }

--- a/core/src/main/java/org/apache/carbondata/core/statusmanager/SegmentStatusManager.java
+++ b/core/src/main/java/org/apache/carbondata/core/statusmanager/SegmentStatusManager.java
@@ -178,23 +178,42 @@ public class SegmentStatusManager {
    * @return
    */
   public static LoadMetadataDetails[] readLoadMetadata(String metadataFolderPath) {
+    String metadataFileName = metadataFolderPath + CarbonCommonConstants.FILE_SEPARATOR
+        + CarbonCommonConstants.LOADMETADATA_FILENAME;
+    return readTableStatusFile(metadataFileName);
+  }
+
+  /**
+   * Reads the table status file with the specified UUID if non empty.
+   */
+  public static LoadMetadataDetails[] readLoadMetadata(String metaDataFolderPath, String uuid) {
+    String tableStatusFileName;
+    if (uuid.isEmpty()) {
+      tableStatusFileName = metaDataFolderPath + CarbonCommonConstants.FILE_SEPARATOR
+          + CarbonCommonConstants.LOADMETADATA_FILENAME;
+    } else {
+      tableStatusFileName = metaDataFolderPath + CarbonCommonConstants.FILE_SEPARATOR
+          + CarbonCommonConstants.LOADMETADATA_FILENAME + CarbonCommonConstants.UNDERSCORE + uuid;
+    }
+    return readTableStatusFile(tableStatusFileName);
+  }
+
+  public static LoadMetadataDetails[] readTableStatusFile(String tableStatusPath) {
     Gson gsonObjectToRead = new Gson();
     DataInputStream dataInputStream = null;
     BufferedReader buffReader = null;
     InputStreamReader inStream = null;
-    String metadataFileName = metadataFolderPath + CarbonCommonConstants.FILE_SEPARATOR
-        + CarbonCommonConstants.LOADMETADATA_FILENAME;
     LoadMetadataDetails[] listOfLoadFolderDetailsArray;
     AtomicFileOperations fileOperation =
-        new AtomicFileOperationsImpl(metadataFileName, FileFactory.getFileType(metadataFileName));
+        new AtomicFileOperationsImpl(tableStatusPath, FileFactory.getFileType(tableStatusPath));
 
     try {
-      if (!FileFactory.isFileExist(metadataFileName, FileFactory.getFileType(metadataFileName))) {
+      if (!FileFactory.isFileExist(tableStatusPath, FileFactory.getFileType(tableStatusPath))) {
         return new LoadMetadataDetails[0];
       }
       dataInputStream = fileOperation.openForRead();
       inStream = new InputStreamReader(dataInputStream,
-              Charset.forName(CarbonCommonConstants.DEFAULT_CHARSET));
+          Charset.forName(CarbonCommonConstants.DEFAULT_CHARSET));
       buffReader = new BufferedReader(inStream);
       listOfLoadFolderDetailsArray =
           gsonObjectToRead.fromJson(buffReader, LoadMetadataDetails[].class);

--- a/core/src/main/java/org/apache/carbondata/core/util/path/CarbonTablePath.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/path/CarbonTablePath.java
@@ -252,6 +252,10 @@ public class CarbonTablePath extends Path {
     return getMetaDataDir() + File.separator + TABLE_STATUS_FILE;
   }
 
+  public String getTableStatusFilePathWithUUID(String uuid) {
+    return getTableStatusFilePath() + CarbonCommonConstants.UNDERSCORE + uuid;
+  }
+
   /**
    * Gets absolute path of data file
    *

--- a/core/src/main/java/org/apache/carbondata/core/util/path/CarbonTablePath.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/path/CarbonTablePath.java
@@ -253,7 +253,11 @@ public class CarbonTablePath extends Path {
   }
 
   public String getTableStatusFilePathWithUUID(String uuid) {
-    return getTableStatusFilePath() + CarbonCommonConstants.UNDERSCORE + uuid;
+    if (!uuid.isEmpty()) {
+      return getTableStatusFilePath() + CarbonCommonConstants.UNDERSCORE + uuid;
+    } else {
+      return getTableStatusFilePath();
+    }
   }
 
   /**

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonOutputCommitter.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonOutputCommitter.java
@@ -115,8 +115,12 @@ public class CarbonOutputCommitter extends FileOutputCommitter {
         LoadEvents.LoadTablePreStatusUpdateEvent event =
             new LoadEvents.LoadTablePreStatusUpdateEvent(carbonTable.getCarbonTableIdentifier(),
                 loadModel);
+        LoadEvents.LoadTablePostStatusUpdateEvent postStatusUpdateEvent =
+            new LoadEvents.LoadTablePostStatusUpdateEvent(loadModel);
         try {
           OperationListenerBus.getInstance().fireEvent(event, (OperationContext) operationContext);
+          OperationListenerBus.getInstance().fireEvent(postStatusUpdateEvent,
+              (OperationContext) operationContext);
         } catch (Exception e) {
           throw new IOException(e);
         }

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggregateMisc.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggregateMisc.scala
@@ -22,7 +22,6 @@ import org.scalatest.{BeforeAndAfterAll, Ignore}
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 
-@Ignore
 class TestPreAggregateMisc extends QueryTest with BeforeAndAfterAll {
   override def beforeAll: Unit = {
     sql("drop table if exists mainTable")

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggregateMisc.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggregateMisc.scala
@@ -22,6 +22,7 @@ import org.scalatest.{BeforeAndAfterAll, Ignore}
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 
+@Ignore
 class TestPreAggregateMisc extends QueryTest with BeforeAndAfterAll {
   override def beforeAll: Unit = {
     sql("drop table if exists mainTable")

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/events/AlterTableEvents.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/events/AlterTableEvents.scala
@@ -182,6 +182,16 @@ case class AlterTableCompactionPreStatusUpdateEvent(sparkSession: SparkSession,
     mergedLoadName: String) extends Event with AlterTableCompactionStatusUpdateEventInfo
 
 /**
+ * Compaction Event for handling post update status file operations, like committing child
+ * datamaps in one transaction
+ */
+case class AlterTableCompactionPostStatusUpdateEvent(
+    carbonTable: CarbonTable,
+    carbonMergerMapping: CarbonMergerMapping,
+    carbonLoadModel: CarbonLoadModel,
+    mergedLoadName: String) extends Event with AlterTableCompactionStatusUpdateEventInfo
+
+/**
  * Compaction Event for handling clean up in case of any compaction failure and abort the
  * operation, lister has to implement this event to handle failure scenarios
  *

--- a/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -39,6 +39,7 @@ import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.rdd.{DataLoadCoalescedRDD, DataLoadPartitionCoalescer, NewHadoopRDD, RDD}
 import org.apache.spark.sql.{AnalysisException, CarbonEnv, DataFrame, Row, SQLContext}
 import org.apache.spark.sql.execution.command.{CompactionModel, ExecutionErrors, UpdateTableModel}
+import org.apache.spark.sql.execution.command.preaaggregate.PreAggregateUtil
 import org.apache.spark.sql.hive.DistributionUtil
 import org.apache.spark.sql.optimizer.CarbonFilters
 import org.apache.spark.sql.util.CarbonException
@@ -62,7 +63,7 @@ import org.apache.carbondata.events.{OperationContext, OperationListenerBus}
 import org.apache.carbondata.processing.exception.DataLoadingException
 import org.apache.carbondata.processing.loading.FailureCauses
 import org.apache.carbondata.processing.loading.csvinput.{BlockDetails, CSVInputFormat, StringArrayWritable}
-import org.apache.carbondata.processing.loading.events.LoadEvents.LoadTablePreStatusUpdateEvent
+import org.apache.carbondata.processing.loading.events.LoadEvents.{LoadTablePostStatusUpdateEvent, LoadTablePreStatusUpdateEvent}
 import org.apache.carbondata.processing.loading.exception.{CarbonDataLoadingException, NoRetryException}
 import org.apache.carbondata.processing.loading.model.{CarbonDataLoadSchema, CarbonLoadModel}
 import org.apache.carbondata.processing.loading.sort.SortScopeOptions
@@ -491,9 +492,10 @@ object CarbonDataRDDFactory {
       }
       return
     }
+    val uniqueTableStatusId = operationContext.getProperty("uuid").asInstanceOf[String]
     if (loadStatus == SegmentStatus.LOAD_FAILURE) {
       // update the load entry in table status file for changing the status to marked for delete
-      CarbonLoaderUtil.updateTableStatusForFailure(carbonLoadModel)
+      CarbonLoaderUtil.updateTableStatusForFailure(carbonLoadModel, uniqueTableStatusId)
       LOGGER.info("********starting clean up**********")
       CarbonLoaderUtil.deleteSegment(carbonLoadModel, carbonLoadModel.getSegmentId.toInt)
       LOGGER.info("********clean up done**********")
@@ -508,7 +510,7 @@ object CarbonDataRDDFactory {
           status(0)._2._2.failureCauses == FailureCauses.BAD_RECORDS &&
           carbonLoadModel.getBadRecordsAction.split(",")(1) == LoggerAction.FAIL.name) {
         // update the load entry in table status file for changing the status to marked for delete
-        CarbonLoaderUtil.updateTableStatusForFailure(carbonLoadModel)
+        CarbonLoaderUtil.updateTableStatusForFailure(carbonLoadModel, uniqueTableStatusId)
         LOGGER.info("********starting clean up**********")
         CarbonLoaderUtil.deleteSegment(carbonLoadModel, carbonLoadModel.getSegmentId.toInt)
         LOGGER.info("********clean up done**********")
@@ -532,6 +534,8 @@ object CarbonDataRDDFactory {
       }
 
       writeDictionary(carbonLoadModel, result, writeAll = false)
+      operationContext.setProperty(carbonTable.getTableUniqueName + "_Segment",
+        carbonLoadModel.getSegmentId)
       val loadTablePreStatusUpdateEvent: LoadTablePreStatusUpdateEvent =
         new LoadTablePreStatusUpdateEvent(
         carbonTable.getCarbonTableIdentifier,
@@ -543,9 +547,21 @@ object CarbonDataRDDFactory {
           carbonLoadModel,
           loadStatus,
           newEntryLoadStatus,
-          overwriteTable)
-      if (!done) {
-        CarbonLoaderUtil.updateTableStatusForFailure(carbonLoadModel)
+          overwriteTable,
+          uniqueTableStatusId)
+      val loadTablePostStatusUpdateEvent: LoadTablePostStatusUpdateEvent =
+        new LoadTablePostStatusUpdateEvent(carbonLoadModel)
+      val commitComplete = try {
+        OperationListenerBus.getInstance()
+          .fireEvent(loadTablePostStatusUpdateEvent, operationContext)
+        true
+      } catch {
+        case ex: Exception =>
+          LOGGER.error(ex, "Problem while committing data maps")
+          false
+      }
+      if (!done && !commitComplete) {
+        CarbonLoaderUtil.updateTableStatusForFailure(carbonLoadModel, uniqueTableStatusId)
         LOGGER.info("********starting clean up**********")
         CarbonLoaderUtil.deleteSegment(carbonLoadModel, carbonLoadModel.getSegmentId.toInt)
         LOGGER.info("********clean up done**********")
@@ -805,7 +821,8 @@ object CarbonDataRDDFactory {
       carbonLoadModel: CarbonLoadModel,
       loadStatus: SegmentStatus,
       newEntryLoadStatus: SegmentStatus,
-      overwriteTable: Boolean): Boolean = {
+      overwriteTable: Boolean,
+      uuid: String = ""): Boolean = {
     val carbonTable = carbonLoadModel.getCarbonDataLoadSchema.getCarbonTable
     val metadataDetails = if (status != null && status.size > 0 && status(0) != null) {
       status(0)._2._1
@@ -820,7 +837,7 @@ object CarbonDataRDDFactory {
     CarbonLoaderUtil
       .addDataIndexSizeIntoMetaEntry(metadataDetails, carbonLoadModel.getSegmentId, carbonTable)
     val done = CarbonLoaderUtil.recordNewLoadMetadata(metadataDetails, carbonLoadModel, false,
-      overwriteTable)
+      overwriteTable, uuid)
     if (!done) {
       val errorMessage = s"Dataload failed due to failure in table status updation for" +
                          s" ${carbonLoadModel.getTableName}"
@@ -834,7 +851,6 @@ object CarbonDataRDDFactory {
     }
     done
   }
-
 
   /**
    * repartition the input data for partition table.

--- a/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -747,7 +747,8 @@ object CarbonDataRDDFactory {
       operationContext: OperationContext): Unit = {
     LOGGER.info(s"compaction need status is" +
                 s" ${ CarbonDataMergerUtil.checkIfAutoLoadMergingRequired(carbonTable) }")
-    if (CarbonDataMergerUtil.checkIfAutoLoadMergingRequired(carbonTable)) {
+    if (!carbonTable.isChildDataMap &&
+        CarbonDataMergerUtil.checkIfAutoLoadMergingRequired(carbonTable)) {
       LOGGER.audit(s"Compaction request received for table " +
                    s"${ carbonLoadModel.getDatabaseName }.${ carbonLoadModel.getTableName }")
       val compactionSize = 0

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
@@ -149,6 +149,7 @@ object CarbonEnv {
       .addListener(classOf[LoadMetadataEvent], LoadProcessMetaListener)
       .addListener(classOf[LoadMetadataEvent], CompactionProcessMetaListener)
       .addListener(classOf[LoadTablePostStatusUpdateEvent], CommitPreAggregateListener)
+      .addListener(classOf[AlterTableCompactionPostStatusUpdateEvent], CommitPreAggregateListener)
   }
 
   /**

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
@@ -33,7 +33,7 @@ import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable
 import org.apache.carbondata.core.util._
 import org.apache.carbondata.events._
-import org.apache.carbondata.processing.loading.events.LoadEvents.{LoadMetadataEvent, LoadTablePreExecutionEvent, LoadTablePreStatusUpdateEvent}
+import org.apache.carbondata.processing.loading.events.LoadEvents.{LoadMetadataEvent, LoadTablePostStatusUpdateEvent, LoadTablePreExecutionEvent, LoadTablePreStatusUpdateEvent}
 import org.apache.carbondata.spark.rdd.SparkReadSupport
 import org.apache.carbondata.spark.readsupport.SparkRowReadSupportImpl
 
@@ -148,6 +148,7 @@ object CarbonEnv {
         AlterPreAggregateTableCompactionPostListener)
       .addListener(classOf[LoadMetadataEvent], LoadProcessMetaListener)
       .addListener(classOf[LoadMetadataEvent], CompactionProcessMetaListener)
+      .addListener(classOf[LoadTablePostStatusUpdateEvent], CommitPreAggregateListener)
   }
 
   /**

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonLoadDataCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonLoadDataCommand.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.execution.command.management
 
 import java.text.SimpleDateFormat
 import java.util
+import java.util.UUID
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
@@ -35,8 +36,8 @@ import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.{InternalRow, TableIdentifier}
 import org.apache.spark.sql.catalyst.analysis.{NoSuchTableException, UnresolvedAttribute}
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
-import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, Expression}
-import org.apache.spark.sql.catalyst.plans.logical.{InsertIntoTable, LogicalPlan, Project}
+import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Expression}
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Project}
 import org.apache.spark.sql.execution.LogicalRDD
 import org.apache.spark.sql.execution.SQLExecution.EXECUTION_ID_KEY
 import org.apache.spark.sql.execution.command.{AtomicRunnableCommand, DataLoadTableFileMapping, UpdateTableModel}
@@ -119,6 +120,7 @@ case class CarbonLoadDataCommand(
     }
     Seq.empty
   }
+
   override def processData(sparkSession: SparkSession): Seq[Row] = {
     val LOGGER: LogService = LogServiceFactory.getLogService(this.getClass.getCanonicalName)
     val carbonProperty: CarbonProperties = CarbonProperties.getInstance()
@@ -176,7 +178,9 @@ case class CarbonLoadDataCommand(
       LOGGER.info(s"Deleting stale folders if present for table $dbName.$tableName")
       TableProcessingOperations.deletePartialLoadDataIfExist(table, false)
       var isUpdateTableStatusRequired = false
+      val uuid = Option(operationContext.getProperty("uuid")).getOrElse(UUID.randomUUID()).toString
       try {
+        operationContext.setProperty("uuid", uuid)
         val loadTablePreExecutionEvent: LoadTablePreExecutionEvent =
           new LoadTablePreExecutionEvent(
             table.getCarbonTableIdentifier,
@@ -194,7 +198,9 @@ case class CarbonLoadDataCommand(
         DataLoadingUtil.deleteLoadsAndUpdateMetadata(isForceDeletion = false, table)
         // add the start entry for the new load in the table status file
         if (updateModel.isEmpty && !table.isHivePartitionTable) {
-          CarbonLoaderUtil.readAndUpdateLoadProgressInTableMeta(carbonLoadModel, isOverwriteTable)
+          CarbonLoaderUtil.readAndUpdateLoadProgressInTableMeta(
+            carbonLoadModel,
+            isOverwriteTable)
           isUpdateTableStatusRequired = true
         }
         if (isOverwriteTable) {
@@ -252,7 +258,7 @@ case class CarbonLoadDataCommand(
         case CausedBy(ex: NoRetryException) =>
           // update the load entry in table status file for changing the status to marked for delete
           if (isUpdateTableStatusRequired) {
-            CarbonLoaderUtil.updateTableStatusForFailure(carbonLoadModel)
+            CarbonLoaderUtil.updateTableStatusForFailure(carbonLoadModel, uuid)
           }
           LOGGER.error(ex, s"Dataload failure for $dbName.$tableName")
           throw new RuntimeException(s"Dataload failure for $dbName.$tableName, ${ex.getMessage}")
@@ -263,7 +269,7 @@ case class CarbonLoadDataCommand(
           LOGGER.error(ex)
           // update the load entry in table status file for changing the status to marked for delete
           if (isUpdateTableStatusRequired) {
-            CarbonLoaderUtil.updateTableStatusForFailure(carbonLoadModel)
+            CarbonLoaderUtil.updateTableStatusForFailure(carbonLoadModel, uuid)
           }
           LOGGER.audit(s"Dataload failure for $dbName.$tableName. Please check the logs")
           throw ex

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonLoadDataCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonLoadDataCommand.scala
@@ -178,7 +178,16 @@ case class CarbonLoadDataCommand(
       LOGGER.info(s"Deleting stale folders if present for table $dbName.$tableName")
       TableProcessingOperations.deletePartialLoadDataIfExist(table, false)
       var isUpdateTableStatusRequired = false
-      val uuid = Option(operationContext.getProperty("uuid")).getOrElse(UUID.randomUUID()).toString
+      // if the table is child then extract the uuid from the operation context and the parent would
+      // already generated UUID.
+      // if parent table then generate a new UUID else use empty.
+      val uuid = if (table.isChildDataMap) {
+        Option(operationContext.getProperty("uuid")).getOrElse("").toString
+      } else if (table.hasAggregationDataMap) {
+        UUID.randomUUID().toString
+      } else {
+        ""
+      }
       try {
         operationContext.setProperty("uuid", uuid)
         val loadTablePreExecutionEvent: LoadTablePreExecutionEvent =

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/preaaggregate/CreatePreAggregateTableCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/preaaggregate/CreatePreAggregateTableCommand.scala
@@ -208,8 +208,9 @@ case class CreatePreAggregateTableCommand(
         parentTable,
         segmentToLoad = "*",
         validateSegments = true,
-        sparkSession,
-        loadCommand)
+        loadCommand,
+        isOverwrite = false,
+        sparkSession)
     }
     Seq.empty
   }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/preaaggregate/CreatePreAggregateTableCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/preaaggregate/CreatePreAggregateTableCommand.scala
@@ -205,7 +205,7 @@ case class CreatePreAggregateTableCommand(
       loadCommand.dataFrame = Some(PreAggregateUtil
         .getDataFrame(sparkSession, loadCommand.logicalPlan.get))
       PreAggregateUtil.startDataLoadForDataMap(
-        parentTable,
+        TableIdentifier(parentTable.getTableName, Some(parentTable.getDatabaseName)),
         segmentToLoad = "*",
         validateSegments = true,
         loadCommand,

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/preaaggregate/PreAggregateListeners.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/preaaggregate/PreAggregateListeners.scala
@@ -17,10 +17,12 @@
 
 package org.apache.spark.sql.execution.command.preaaggregate
 
+import java.util.UUID
+
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 
-import org.apache.spark.sql.{CarbonEnv, CarbonSession, SparkSession}
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.execution.command.AlterTableModel
 import org.apache.spark.sql.execution.command.management.{CarbonAlterTableCompactionCommand, CarbonLoadDataCommand}
@@ -30,12 +32,11 @@ import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.core.datastore.filesystem.{CarbonFile, CarbonFileFilter}
 import org.apache.carbondata.core.datastore.impl.FileFactory
 import org.apache.carbondata.core.metadata.schema.table.{AggregationDataMapSchema, CarbonTable}
+import org.apache.carbondata.core.statusmanager.{SegmentStatus, SegmentStatusManager}
 import org.apache.carbondata.core.util.CarbonUtil
 import org.apache.carbondata.core.util.path.CarbonTablePath
 import org.apache.carbondata.events._
-import org.apache.carbondata.processing.loading.events.LoadEvents.{LoadMetadataEvent, LoadTablePreExecutionEvent, LoadTablePreStatusUpdateEvent}
-import org.apache.carbondata.processing.loading.events.LoadEvents.{LoadTablePostStatusUpdateEvent, LoadTablePreExecutionEvent, LoadTablePreStatusUpdateEvent}
-import org.apache.carbondata.processing.loading.model.CarbonLoadModel
+import org.apache.carbondata.processing.loading.events.LoadEvents.{LoadMetadataEvent, LoadTablePostStatusUpdateEvent, LoadTablePreExecutionEvent, LoadTablePreStatusUpdateEvent}
 
 /**
  * below class will be used to create load command for compaction
@@ -77,9 +78,13 @@ object CompactionProcessMetaListener extends OperationEventListener {
           childDataFrame,
           false,
           sparkSession)
+        val uuid = Option(operationContext.getProperty("uuid")).
+          getOrElse(UUID.randomUUID()).toString
+        operationContext.setProperty("uuid", uuid)
         loadCommand.processMetadata(sparkSession)
         operationContext
           .setProperty(dataMapSchema.getChildSchema.getTableName + "_Compaction", loadCommand)
+        loadCommand.operationContext = operationContext
       }
     } else if (table.isChildDataMap) {
       val childTableName = table.getTableName
@@ -101,9 +106,13 @@ object CompactionProcessMetaListener extends OperationEventListener {
         childDataFrame,
         false,
         sparkSession)
+      val uuid = Option(operationContext.getProperty("uuid")).getOrElse("").toString
       loadCommand.processMetadata(sparkSession)
       operationContext.setProperty(table.getTableName + "_Compaction", loadCommand)
+      operationContext.setProperty("uuid", uuid)
+      loadCommand.operationContext = operationContext
     }
+
   }
 }
 
@@ -133,12 +142,17 @@ object LoadProcessMetaListener extends OperationEventListener {
         val sortedList = aggregationDataMapList.sortBy(_.getOrdinal)
         val parentTableName = table.getTableName
         val databaseName = table.getDatabaseName
+        // if the table is child then extract the uuid from the operation context and the parent
+        // would already generated UUID.
+        // if parent table then generate a new UUID else use empty.
+        val uuid =
+          Option(operationContext.getProperty("uuid")).getOrElse(UUID.randomUUID()).toString
         val list = scala.collection.mutable.ListBuffer.empty[AggregationDataMapSchema]
         for (dataMapSchema: AggregationDataMapSchema <- sortedList) {
           val childTableName = dataMapSchema.getRelationIdentifier.getTableName
           val childDatabaseName = dataMapSchema.getRelationIdentifier.getDatabaseName
           val childSelectQuery = if (!dataMapSchema.isTimeseriesDataMap) {
-            PreAggregateUtil.getChildQuery(dataMapSchema)
+            (PreAggregateUtil.getChildQuery(dataMapSchema), "")
           } else {
             // for timeseries rollup policy
             val tableSelectedForRollup = PreAggregateUtil.getRollupDataMapNameForTimeSeries(list,
@@ -146,18 +160,19 @@ object LoadProcessMetaListener extends OperationEventListener {
             list += dataMapSchema
             // if non of the rollup data map is selected hit the maintable and prepare query
             if (tableSelectedForRollup.isEmpty) {
-              PreAggregateUtil.createTimeSeriesSelectQueryFromMain(dataMapSchema.getChildSchema,
+              (PreAggregateUtil.createTimeSeriesSelectQueryFromMain(dataMapSchema.getChildSchema,
                 parentTableName,
-                databaseName)
+                databaseName), "")
             } else {
               // otherwise hit the select rollup datamap schema
-              PreAggregateUtil.createTimeseriesSelectQueryForRollup(dataMapSchema.getChildSchema,
+              (PreAggregateUtil.createTimeseriesSelectQueryForRollup(dataMapSchema.getChildSchema,
                 tableSelectedForRollup.get,
-                databaseName)
+                databaseName),
+                s"$databaseName.${tableSelectedForRollup.get.getChildSchema.getTableName}")
             }
           }
           val childDataFrame = sparkSession.sql(new CarbonSpark2SqlParser().addPreAggLoadFunction(
-            childSelectQuery)).drop("preAggLoad")
+            childSelectQuery._1)).drop("preAggLoad")
           val isOverwrite =
             operationContext.getProperty("isOverwrite").asInstanceOf[Boolean]
           val loadCommand = PreAggregateUtil.createLoadCommandForChild(
@@ -165,7 +180,10 @@ object LoadProcessMetaListener extends OperationEventListener {
             TableIdentifier(childTableName, Some(childDatabaseName)),
             childDataFrame,
             isOverwrite,
-            sparkSession)
+            sparkSession,
+            timeseriesParentTableName = childSelectQuery._2)
+          operationContext.setProperty("uuid", uuid)
+          loadCommand.operationContext.setProperty("uuid", uuid)
           loadCommand.processMetadata(sparkSession)
           operationContext.setProperty(dataMapSchema.getChildSchema.getTableName, loadCommand)
         }
@@ -200,9 +218,21 @@ object LoadPostAggregateListener extends OperationEventListener {
         val isOverwrite =
           operationContext.getProperty("isOverwrite").asInstanceOf[Boolean]
         childLoadCommand.operationContext = operationContext
+        val timeseriesParent = childLoadCommand.internalOptions.get("timeseriesParent")
+        val (parentTableIdentifier, segmentToLoad) =
+          if (timeseriesParent.isDefined && timeseriesParent.get.nonEmpty) {
+            val (parentTableDatabase, parentTableName) =
+              (timeseriesParent.get.split('.')(0), timeseriesParent.get.split('.')(1))
+            (TableIdentifier(parentTableName, Some(parentTableDatabase)),
+            operationContext.getProperty(
+              s"${parentTableDatabase}_${parentTableName}_Segment").toString)
+        } else {
+            (TableIdentifier(table.getTableName, Some(table.getDatabaseName)),
+              carbonLoadModel.getSegmentId)
+        }
         PreAggregateUtil.startDataLoadForDataMap(
-            table,
-            carbonLoadModel.getSegmentId,
+            parentTableIdentifier,
+            segmentToLoad,
             validateSegments = false,
             childLoadCommand,
             isOverwrite,
@@ -222,42 +252,34 @@ object CommitPreAggregateListener extends OperationEventListener {
 
   override protected def onEvent(event: Event,
       operationContext: OperationContext): Unit = {
-    val commitEvent = event.asInstanceOf[LoadTablePostStatusUpdateEvent]
-    val carbonLoadModel = commitEvent.getCarbonLoadModel
-    val uuid = operationContext.getProperty("uuid").toString
+    // The same listener is called for both compaction and load therefore getting the
+    // carbonLoadModel from the appropriate event.
+    val carbonLoadModel = event match {
+      case loadEvent: LoadTablePostStatusUpdateEvent =>
+        loadEvent.getCarbonLoadModel
+      case compactionEvent: AlterTableCompactionPostStatusUpdateEvent =>
+        compactionEvent.carbonLoadModel
+    }
+    val isCompactionFlow = Option(
+      operationContext.getProperty("isCompaction")).getOrElse("false").toString.toBoolean
     val dataMapSchemas =
       carbonLoadModel.getCarbonDataLoadSchema.getCarbonTable.getTableInfo.getDataMapSchemaList
     // extract all child LoadCommands
-    val childLoadCommands = dataMapSchemas.asScala.map { dataMapSchema =>
-      operationContext.getProperty(dataMapSchema.getChildSchema.getTableName)
-        .asInstanceOf[CarbonLoadDataCommand]
-    }
-    if (carbonLoadModel.getCarbonDataLoadSchema.getCarbonTable.isChildDataMap) {
-      val childCarbonTable = carbonLoadModel.getCarbonDataLoadSchema.getCarbonTable
-      val carbonTablePath =
-        new CarbonTablePath(childCarbonTable.getCarbonTableIdentifier,
-          childCarbonTable.getTablePath)
-      // Generate table status file name with UUID, forExample: tablestatus_1
-      val oldTableSchemaPath = carbonTablePath.getTableStatusFilePathWithUUID(uuid)
-      // Generate table status file name without UUID, forExample: tablestatus
-      val newTableSchemaPath = carbonTablePath.getTableStatusFilePath
-      // try to rename tablestatus_1 to tablestatus after taking backup of tablestatus by
-      // renaming to tablestatus_backup_1
-      val commitFailed =
-        !renameDataMapTableStatusFiles(oldTableSchemaPath, newTableSchemaPath, uuid)
-      // if renaming is not successful then rename tablestatus_backup_1 to tablestatus
-      if (commitFailed) {
-        val backupTableSchemaPath = carbonTablePath.getTableStatusFilePath + "_backup_" + uuid
-        val tableSchemaPath = carbonTablePath.getTableStatusFilePath
-        renameDataMapTableStatusFiles(backupTableSchemaPath, tableSchemaPath, "")
+    val childLoadCommands = if (!isCompactionFlow) {
+      // If not compaction flow then the key for load commands will be tableName
+        dataMapSchemas.asScala.map { dataMapSchema =>
+          operationContext.getProperty(dataMapSchema.getChildSchema.getTableName)
+            .asInstanceOf[CarbonLoadDataCommand]
+        }
+      } else {
+      // If not compaction flow then the key for load commands will be tableName_Compaction
+        dataMapSchemas.asScala.map { dataMapSchema =>
+          operationContext.getProperty(dataMapSchema.getChildSchema.getTableName + "_Compaction")
+            .asInstanceOf[CarbonLoadDataCommand]
+        }
       }
-      // after success/failure of commit delete all tablestatus files with UUID in their names.
-      // if commit failed then remove the segment directory
-      cleanUpStaleTableStatusFiles(Seq(childCarbonTable), operationContext, uuid, commitFailed)
-      if (commitFailed) {
-        sys.error("Failed to update table status for pre-aggregate table")
-      }
-    } else if (dataMapSchemas.size() > 0) {
+     if (dataMapSchemas.size() > 0) {
+       val uuid = operationContext.getProperty("uuid").toString
       // keep committing until one fails
       val renamedDataMaps = childLoadCommands.takeWhile { childLoadCommand =>
         val childCarbonTable = childLoadCommand.table
@@ -279,8 +301,10 @@ object CommitPreAggregateListener extends OperationEventListener {
             val carbonTable = loadCommand.table
             val carbonTablePath = new CarbonTablePath(carbonTable.getCarbonTableIdentifier,
               carbonTable.getTablePath)
+            // rename the backup tablestatus i.e tablestatus_backup_UUID to tablestatus
             val backupTableSchemaPath = carbonTablePath.getTableStatusFilePath + "_backup_" + uuid
             val tableSchemaPath = carbonTablePath.getTableStatusFilePath
+            markInProgressSegmentAsDeleted(backupTableSchemaPath, operationContext, loadCommand)
             renameDataMapTableStatusFiles(backupTableSchemaPath, tableSchemaPath, "")
         }
       }
@@ -288,12 +312,28 @@ object CommitPreAggregateListener extends OperationEventListener {
       // if commit failed then remove the segment directory
       cleanUpStaleTableStatusFiles(childLoadCommands.map(_.table),
         operationContext,
-        uuid,
-        commitFailed)
+        uuid)
       if (commitFailed) {
         sys.error("Failed to update table status for pre-aggregate table")
       }
     }
+
+
+  }
+
+  private def markInProgressSegmentAsDeleted(tableStatusFile: String,
+      operationContext: OperationContext,
+      loadDataCommand: CarbonLoadDataCommand): Unit = {
+    val loadMetaDataDetails = SegmentStatusManager.readTableStatusFile(tableStatusFile)
+    val segmentBeingLoaded =
+      operationContext.getProperty(loadDataCommand.table.getTableUniqueName + "_Segment").toString
+    val newDetails = loadMetaDataDetails.collect {
+      case detail if detail.getLoadName.equalsIgnoreCase(segmentBeingLoaded) =>
+        detail.setSegmentStatus(SegmentStatus.MARKED_FOR_DELETE)
+        detail
+      case others => others
+    }
+    SegmentStatusManager.writeLoadDetailsIntoFile(tableStatusFile, newDetails)
   }
 
   /**
@@ -303,7 +343,7 @@ object CommitPreAggregateListener extends OperationEventListener {
       destinationFileName: String, uuid: String) = {
     val oldCarbonFile = FileFactory.getCarbonFile(sourceFileName)
     val newCarbonFile = FileFactory.getCarbonFile(destinationFileName)
-    if (oldCarbonFile.exists() && newCarbonFile.delete()) {
+    if (oldCarbonFile.exists() && newCarbonFile.exists()) {
       val backUpPostFix = if (uuid.nonEmpty) {
         "_backup_" + uuid
       } else {
@@ -328,18 +368,11 @@ object CommitPreAggregateListener extends OperationEventListener {
   private def cleanUpStaleTableStatusFiles(
       childTables: Seq[CarbonTable],
       operationContext: OperationContext,
-      uuid: String,
-      removeSegmentDir: Boolean): Unit = {
+      uuid: String): Unit = {
     childTables.foreach { childTable =>
       val carbonTablePath = new CarbonTablePath(childTable.getCarbonTableIdentifier,
         childTable.getTablePath)
-      val segmentDirPath = carbonTablePath.getSegmentDir("0",
-        operationContext.getProperty(childTable.getTableUniqueName + "_Segment").toString)
       val metaDataDir = FileFactory.getCarbonFile(carbonTablePath.getMetadataDirectoryPath)
-      val segmentDir = FileFactory.getCarbonFile(segmentDirPath)
-      if (segmentDir.exists() && removeSegmentDir) {
-        segmentDir.delete()
-      }
       val tableStatusFiles = metaDataDir.listFiles(new CarbonFileFilter {
         override def accept(file: CarbonFile): Boolean = {
           file.getName.contains(uuid) || file.getName.contains("backup")
@@ -364,6 +397,7 @@ object AlterPreAggregateTableCompactionPostListener extends OperationEventListen
     val compactionEvent = event.asInstanceOf[AlterTableCompactionPreStatusUpdateEvent]
     val carbonTable = compactionEvent.carbonTable
     val compactionType = compactionEvent.carbonMergerMapping.campactionType
+    val carbonLoadModel = compactionEvent.carbonLoadModel
     val sparkSession = compactionEvent.sparkSession
     if (CarbonUtil.hasAggregationDataMap(carbonTable)) {
       carbonTable.getTableInfo.getDataMapSchemaList.asScala.foreach { dataMapSchema =>
@@ -374,6 +408,10 @@ object AlterPreAggregateTableCompactionPostListener extends OperationEventListen
           compactionType.toString,
           Some(System.currentTimeMillis()),
           "")
+        operationContext.setProperty(
+          dataMapSchema.getRelationIdentifier.getDatabaseName + "_" +
+          dataMapSchema.getRelationIdentifier.getTableName + "_Segment",
+          carbonLoadModel.getSegmentId)
         CarbonAlterTableCompactionCommand(alterTableModel, operationContext = operationContext)
           .run(sparkSession)
       }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/preaaggregate/PreAggregateUtil.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/preaaggregate/PreAggregateUtil.scala
@@ -35,13 +35,16 @@ import org.apache.spark.sql.types.DataType
 
 import org.apache.carbondata.common.logging.{LogService, LogServiceFactory}
 import org.apache.carbondata.core.constants.CarbonCommonConstants
+import org.apache.carbondata.core.datastore.filesystem.{CarbonFile, CarbonFileFilter}
+import org.apache.carbondata.core.datastore.impl.FileFactory
 import org.apache.carbondata.core.locks.{CarbonLockUtil, ICarbonLock, LockUsage}
 import org.apache.carbondata.core.metadata.converter.ThriftWrapperSchemaConverterImpl
 import org.apache.carbondata.core.metadata.schema.table.{AggregationDataMapSchema, CarbonTable, DataMapSchema, TableSchema}
 import org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema
 import org.apache.carbondata.core.util.CarbonUtil
-import org.apache.carbondata.core.util.path.CarbonStorePath
+import org.apache.carbondata.core.util.path.{CarbonStorePath, CarbonTablePath}
 import org.apache.carbondata.format.TableInfo
+import org.apache.carbondata.processing.loading.model.CarbonLoadModel
 import org.apache.carbondata.spark.exception.MalformedCarbonCommandException
 import org.apache.carbondata.spark.util.CommonUtil
 
@@ -584,8 +587,9 @@ object PreAggregateUtil {
       parentCarbonTable: CarbonTable,
       segmentToLoad: String,
       validateSegments: Boolean,
-      sparkSession: SparkSession,
-      loadCommand: CarbonLoadDataCommand): Unit = {
+      loadCommand: CarbonLoadDataCommand,
+      isOverwrite: Boolean,
+      sparkSession: SparkSession): Unit = {
     CarbonSession.threadSet(
       CarbonCommonConstants.CARBON_INPUT_SEGMENTS +
       parentCarbonTable.getDatabaseName + "." +
@@ -904,4 +908,5 @@ object PreAggregateUtil {
   def getDataFrame(sparkSession: SparkSession, child: LogicalPlan): DataFrame = {
     Dataset.ofRows(sparkSession, child)
   }
+
 }

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/events/LoadEvents.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/events/LoadEvents.java
@@ -147,6 +147,19 @@ public class LoadEvents {
       return carbonTable;
     }
   }
+
+  public static class LoadTablePostStatusUpdateEvent extends Event {
+    private CarbonLoadModel carbonLoadModel;
+
+    public LoadTablePostStatusUpdateEvent(CarbonLoadModel carbonLoadModel) {
+      this.carbonLoadModel = carbonLoadModel;
+    }
+
+    public CarbonLoadModel getCarbonLoadModel() {
+      return carbonLoadModel;
+    }
+  }
+
   /**
    * Class for handling clean up in case of any failure and abort the operation.
    */

--- a/processing/src/main/java/org/apache/carbondata/processing/util/CarbonLoaderUtil.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/util/CarbonLoaderUtil.java
@@ -150,6 +150,22 @@ public final class CarbonLoaderUtil {
   public static boolean recordNewLoadMetadata(LoadMetadataDetails newMetaEntry,
       CarbonLoadModel loadModel, boolean loadStartEntry, boolean insertOverwrite)
       throws IOException {
+    return recordNewLoadMetadata(newMetaEntry, loadModel, loadStartEntry, insertOverwrite, "");
+  }
+
+  /**
+   * This API will write the load level metadata for the loadmanagement module inorder to
+   * manage the load and query execution management smoothly.
+   *
+   * @param newMetaEntry
+   * @param loadModel
+   * @param uuid
+   * @return boolean which determines whether status update is done or not.
+   * @throws IOException
+   */
+  public static boolean recordNewLoadMetadata(LoadMetadataDetails newMetaEntry,
+      CarbonLoadModel loadModel, boolean loadStartEntry, boolean insertOverwrite, String uuid)
+      throws IOException {
     boolean status = false;
     AbsoluteTableIdentifier absoluteTableIdentifier =
         loadModel.getCarbonDataLoadSchema().getCarbonTable().getAbsoluteTableIdentifier();
@@ -159,7 +175,12 @@ public final class CarbonLoaderUtil {
     if (!FileFactory.isFileExist(metadataPath, fileType)) {
       FileFactory.mkdirs(metadataPath, fileType);
     }
-    String tableStatusPath = carbonTablePath.getTableStatusFilePath();
+    String tableStatusPath;
+    if (loadModel.getCarbonDataLoadSchema().getCarbonTable().isChildDataMap() && !uuid.isEmpty()) {
+      tableStatusPath = carbonTablePath.getTableStatusFilePathWithUUID(uuid);
+    } else {
+      tableStatusPath = carbonTablePath.getTableStatusFilePath();
+    }
     SegmentStatusManager segmentStatusManager = new SegmentStatusManager(absoluteTableIdentifier);
     ICarbonLock carbonLock = segmentStatusManager.getTableStatusLock();
     int retryCount = CarbonLockUtil
@@ -314,7 +335,6 @@ public final class CarbonLoaderUtil {
         new AtomicFileOperationsImpl(dataLoadLocation, FileFactory.getFileType(dataLoadLocation));
 
     try {
-
       dataOutputStream = writeOperation.openForWrite(FileWriteOperation.OVERWRITE);
       brWriter = new BufferedWriter(new OutputStreamWriter(dataOutputStream,
               Charset.forName(CarbonCommonConstants.DEFAULT_CHARSET)));
@@ -367,7 +387,7 @@ public final class CarbonLoaderUtil {
 
 
   public static void readAndUpdateLoadProgressInTableMeta(CarbonLoadModel model,
-      boolean insertOverwrite) throws IOException {
+      boolean insertOverwrite, String uuid) throws IOException {
     LoadMetadataDetails newLoadMetaEntry = new LoadMetadataDetails();
     SegmentStatus status = SegmentStatus.INSERT_IN_PROGRESS;
     if (insertOverwrite) {
@@ -379,18 +399,23 @@ public final class CarbonLoaderUtil {
     model.setFactTimeStamp(loadStartTime);
     CarbonLoaderUtil
         .populateNewLoadMetaEntry(newLoadMetaEntry, status, model.getFactTimeStamp(), false);
-    boolean entryAdded =
-        CarbonLoaderUtil.recordNewLoadMetadata(newLoadMetaEntry, model, true, insertOverwrite);
+    boolean entryAdded = CarbonLoaderUtil
+        .recordNewLoadMetadata(newLoadMetaEntry, model, true, insertOverwrite, uuid);
     if (!entryAdded) {
       throw new IOException("Dataload failed due to failure in table status updation for "
           + model.getTableName());
     }
   }
 
+  public static void readAndUpdateLoadProgressInTableMeta(CarbonLoadModel model,
+      boolean insertOverwrite) throws IOException {
+    readAndUpdateLoadProgressInTableMeta(model, insertOverwrite, "");
+  }
+
   /**
    * This method will update the load failure entry in the table status file
    */
-  public static void updateTableStatusForFailure(CarbonLoadModel model)
+  public static void updateTableStatusForFailure(CarbonLoadModel model, String uuid)
       throws IOException {
     // in case if failure the load status should be "Marked for delete" so that it will be taken
     // care during clean up
@@ -402,12 +427,20 @@ public final class CarbonLoaderUtil {
     }
     CarbonLoaderUtil
         .populateNewLoadMetaEntry(loadMetaEntry, loadStatus, model.getFactTimeStamp(), true);
-    boolean entryAdded =
-        CarbonLoaderUtil.recordNewLoadMetadata(loadMetaEntry, model, false, false);
+    boolean entryAdded = CarbonLoaderUtil.recordNewLoadMetadata(
+        loadMetaEntry, model, false, false, uuid);
     if (!entryAdded) {
       throw new IOException(
           "Failed to update failure entry in table status for " + model.getTableName());
     }
+  }
+
+  /**
+   * This method will update the load failure entry in the table status file with empty uuid.
+   */
+  public static void updateTableStatusForFailure(CarbonLoadModel model)
+      throws IOException {
+    updateTableStatusForFailure(model, "");
   }
 
   public static Dictionary getDictionary(DictionaryColumnUniqueIdentifier columnIdentifier)


### PR DESCRIPTION
Current if a table(t1) has 2 preaggregate table(p1,p2) then while loading all the pre-aggregate tables are committed(table status writing) and then the parent table is committed.

After this PR the flow would be like this:
1. load t1
2. load p1
3. load p2
4. write table status for p2 with transactionID
5. write table status for p1 with transactionID
6. rename tablestatus_UUID to tablestatus for p2
7. rename tablestatus_UUID to tablestatus for p1
8. write table status for t1

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [X] Any interfaces changed?
 
 - [X] Any backward compatibility impacted?
 
 - [X] Document update required?

 - [X] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [X] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

