### PR TITLE
[CARBONDATA-2013] executing Alter rename to execution is failing for nonCarbonTable, results that table can not found in database

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/strategy/StreamingTableStrategy.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/strategy/StreamingTableStrategy.scala
@@ -72,9 +72,15 @@ private[sql] class StreamingTableStrategy(sparkSession: SparkSession) extends Sp
    * Validate whether Update operation is allowed for specified table in the command
    */
   private def rejectIfStreamingTable(tableIdentifier: TableIdentifier, operation: String): Unit = {
-    val streaming =
-      CarbonEnv.getCarbonTable(tableIdentifier.database, tableIdentifier.table)(sparkSession)
+    var streaming = false
+    try {
+      streaming = CarbonEnv.getCarbonTable(
+        tableIdentifier.database, tableIdentifier.table)(sparkSession)
         .isStreamingTable
+    } catch {
+      case e: Exception =>
+        streaming = false
+    }
     if (streaming) {
       throw new MalformedCarbonCommandException(
         s"$operation is not allowed for streaming table")

--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/restructure/vectorreader/AddColumnTestCases.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/restructure/vectorreader/AddColumnTestCases.scala
@@ -656,6 +656,19 @@ class AddColumnTestCases extends Spark2QueryTest with BeforeAndAfterAll {
     sql("drop table if exists preagg1")
   }
 
+  test("test rename textFileTable") {
+    sql("drop table if exists renameTextFileTable")
+    sql("drop table if exists new_renameTextFileTable")
+    sql("create table renameTextFileTable (id int,time string) row format delimited fields terminated by ',' stored as textfile ")
+    sql("alter table renameTextFileTable rename to new_renameTextFileTable")
+    checkAnswer(sql("DESC new_renameTextFileTable"),Seq(Row("id","int",null),Row("time","string",null)))
+    intercept[Exception] {
+      sql("select * from renameTextFileTable")
+    }
+    sql("drop table if exists new_renameTextFileTable")
+    sql("drop table if exists renameTextFileTable")
+  }
+
   override def afterAll {
     sql("DROP TABLE IF EXISTS addcolumntest")
     sql("DROP TABLE IF EXISTS hivetable")
@@ -670,6 +683,8 @@ class AddColumnTestCases extends Spark2QueryTest with BeforeAndAfterAll {
     sql("DROP TABLE IF EXISTS alter_sort_columns")
     sql("DROP TABLE IF EXISTS alter_no_dict")
     sql("drop table if exists NO_INVERTED_CARBON")
+    sql("drop table if exists new_renameTextFileTable")
+    sql("drop table if exists renameTextFileTable")
     sqlContext.setConf("carbon.enable.vector.reader", "false")
     CarbonProperties.getInstance().addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT,
       CarbonCommonConstants.CARBON_TIMESTAMP_DEFAULT_FORMAT)


### PR DESCRIPTION
Problem :-  Alter rename to execution is failing for nonCarbonTable
                  create table test(id int,time string) stored as textfile;
                  alter table test rename to new_test;
            => error in query : Table or view 'test' not found in database 'default'

Solution :-Alter execution operation is successful for all carbonTable and nonCarbonTable

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 No
 - [x] Any backward compatibility impacted?
 No
 - [x] Document update required?
No
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
     Unit test case added
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

