### PR TITLE
[CARBONDATA-2020] Fix avoid reading of all block information in driver for old stores.

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/block/TableBlockInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/block/TableBlockInfo.java
@@ -165,6 +165,25 @@ public class TableBlockInfo implements Distributable, Serializable {
   }
 
   /**
+   * Create copy of TableBlockInfo object
+   */
+  public TableBlockInfo copy() {
+    TableBlockInfo info = new TableBlockInfo();
+    info.filePath = filePath;
+    info.blockOffset = blockOffset;
+    info.blockLength = blockLength;
+    info.segmentId = segmentId;
+    info.blockletId = blockletId;
+    info.locations = locations;
+    info.version = version;
+    info.blockletInfos = blockletInfos;
+    info.blockStorageIdMap = blockStorageIdMap;
+    info.deletedDeltaFilePath = deletedDeltaFilePath;
+    info.detailInfo = detailInfo.copy();
+    return info;
+  }
+
+  /**
    * @return the filePath
    */
   public String getFilePath() {

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/IndexWrapper.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/IndexWrapper.java
@@ -16,14 +16,12 @@
  */
 package org.apache.carbondata.core.indexstore.blockletindex;
 
-import java.io.IOException;
 import java.util.List;
 
 import org.apache.carbondata.core.datastore.block.AbstractIndex;
 import org.apache.carbondata.core.datastore.block.SegmentProperties;
 import org.apache.carbondata.core.datastore.block.TableBlockInfo;
 import org.apache.carbondata.core.metadata.blocklet.DataFileFooter;
-import org.apache.carbondata.core.util.CarbonUtil;
 
 /**
  * Wrapper of abstract index
@@ -32,14 +30,8 @@ import org.apache.carbondata.core.util.CarbonUtil;
 public class IndexWrapper extends AbstractIndex {
 
   public IndexWrapper(List<TableBlockInfo> blockInfos) {
-    DataFileFooter fileFooter = null;
-    try {
-      fileFooter = CarbonUtil.readMetadatFile(blockInfos.get(0));
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
-    segmentProperties = new SegmentProperties(fileFooter.getColumnInTable(),
-        fileFooter.getSegmentInfo().getColumnCardinality());
+    segmentProperties = new SegmentProperties(blockInfos.get(0).getDetailInfo().getColumnSchemas(),
+        blockInfos.get(0).getDetailInfo().getDimLens());
     dataRefNode = new BlockletDataRefNodeWrapper(blockInfos, 0,
         segmentProperties.getDimensionColumnsValueSize());
   }

--- a/core/src/main/java/org/apache/carbondata/core/scan/executor/impl/AbstractQueryExecutor.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/executor/impl/AbstractQueryExecutor.java
@@ -42,12 +42,15 @@ import org.apache.carbondata.core.datastore.block.AbstractIndex;
 import org.apache.carbondata.core.datastore.block.SegmentProperties;
 import org.apache.carbondata.core.datastore.block.TableBlockInfo;
 import org.apache.carbondata.core.datastore.block.TableBlockUniqueIdentifier;
+import org.apache.carbondata.core.indexstore.BlockletDetailInfo;
 import org.apache.carbondata.core.indexstore.blockletindex.BlockletDataRefNodeWrapper;
 import org.apache.carbondata.core.indexstore.blockletindex.IndexWrapper;
 import org.apache.carbondata.core.keygenerator.KeyGenException;
 import org.apache.carbondata.core.keygenerator.KeyGenerator;
 import org.apache.carbondata.core.memory.UnsafeMemoryManager;
 import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
+import org.apache.carbondata.core.metadata.blocklet.BlockletInfo;
+import org.apache.carbondata.core.metadata.blocklet.DataFileFooter;
 import org.apache.carbondata.core.metadata.datatype.DataType;
 import org.apache.carbondata.core.metadata.encoder.Encoding;
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
@@ -135,7 +138,14 @@ public abstract class AbstractQueryExecutor<E> implements QueryExecutor<E> {
           tableBlockInfos = new ArrayList<>();
           listMap.put(blockInfo.getFilePath(), tableBlockInfos);
         }
-        tableBlockInfos.add(blockInfo);
+        BlockletDetailInfo blockletDetailInfo = blockInfo.getDetailInfo();
+        // This is the case of old stores where blocklet information is not available so read
+        // the blocklet information from block file
+        if (blockletDetailInfo.getBlockletInfo() == null) {
+          readAndFillBlockletInfo(blockInfo, tableBlockInfos, blockletDetailInfo);
+        } else {
+          tableBlockInfos.add(blockInfo);
+        }
       }
       for (List<TableBlockInfo> tableBlockInfos: listMap.values()) {
         indexList.add(new IndexWrapper(tableBlockInfos));
@@ -197,6 +207,30 @@ public abstract class AbstractQueryExecutor<E> implements QueryExecutor<E> {
         .addStatistics(QueryStatisticsConstants.LOAD_DICTIONARY, System.currentTimeMillis());
     queryProperties.queryStatisticsRecorder.recordStatistics(queryStatistic);
     queryModel.setColumnToDictionaryMapping(queryProperties.columnToDictionayMapping);
+  }
+
+  /**
+   * Read the file footer of block file and get the blocklets to query
+   */
+  private void readAndFillBlockletInfo(TableBlockInfo blockInfo,
+      List<TableBlockInfo> tableBlockInfos, BlockletDetailInfo blockletDetailInfo)
+      throws IOException {
+    blockInfo.setBlockOffset(blockletDetailInfo.getBlockFooterOffset());
+    blockInfo.setDetailInfo(null);
+    DataFileFooter fileFooter = CarbonUtil.readMetadatFile(blockInfo);
+    blockInfo.setDetailInfo(blockletDetailInfo);
+    List<BlockletInfo> blockletList = fileFooter.getBlockletList();
+    short count = 0;
+    for (BlockletInfo blockletInfo: blockletList) {
+      TableBlockInfo info = blockInfo.copy();
+      BlockletDetailInfo detailInfo = info.getDetailInfo();
+      detailInfo.setRowCount(blockletInfo.getNumberOfRows());
+      detailInfo.setBlockletInfo(blockletInfo);
+      detailInfo.setPagesCount((short) blockletInfo.getNumberOfPages());
+      detailInfo.setBlockletId(count);
+      tableBlockInfos.add(info);
+      count++;
+    }
   }
 
   private List<TableBlockUniqueIdentifier> prepareTableBlockUniqueIdentifier(

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/impl/CarbonLocalInputSplit.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/impl/CarbonLocalInputSplit.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.gson.Gson;
 import org.apache.hadoop.fs.Path;
 
+import java.io.IOException;
 import java.util.List;
 
 import org.apache.carbondata.core.indexstore.BlockletDetailInfo;
@@ -123,6 +124,11 @@ public class CarbonLocalInputSplit {
         carbonLocalInputSplit.getDeleteDeltaFiles());
     Gson gson = new Gson();
     BlockletDetailInfo blockletDetailInfo = gson.fromJson(carbonLocalInputSplit.detailInfo, BlockletDetailInfo.class);
+    try {
+      blockletDetailInfo.readColumnSchema(blockletDetailInfo.getColumnSchemaBinary());
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
     inputSplit.setDetailInfo(blockletDetailInfo);
     return inputSplit;
   }


### PR DESCRIPTION
Problem: 
For old stores prior to 1.2 version there is no blocklet information stored in carbonindex file. So the new code needs to read all carbondata files footers inside the driver to get the blocklet information.  That makes the first time queries become slower. As observed count(*) query was taking 2 swconds on old version and after upgrade it takes very long time.

Solution:
If there is no information blocklet available in carbonindex file then don't read carbondata files footer in driver side. Instead read carbondata files in executor to get the blocklet information.


Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [X] Any interfaces changed?
 
 - [X] Any backward compatibility impacted?
 
 - [X] Document update required?

 - [X] Testing done
              
 - [X] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

