### PR TITLE
[CARBONDATA-2010] Block streaming on main table of preaggregate datamap

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/CarbonTable.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/CarbonTable.java
@@ -733,6 +733,21 @@ public class CarbonTable implements Serializable {
     return streaming != null && streaming.equalsIgnoreCase("true");
   }
 
+  /**
+   * whether this table has aggregation DataMap or not
+   */
+  public boolean hasAggregationDataMap() {
+    List<DataMapSchema> dataMapSchemaList = tableInfo.getDataMapSchemaList();
+    if (dataMapSchemaList != null && !dataMapSchemaList.isEmpty()) {
+      for (DataMapSchema dataMapSchema : dataMapSchemaList) {
+        if (dataMapSchema instanceof AggregationDataMapSchema) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
   public int getDimensionOrdinalMax() {
     return dimensionOrdinalMax;
   }


### PR DESCRIPTION
If the table has 'preaggregate' DataMap, it doesn't support streaming now

 - [x] Any interfaces changed?
   no
 - [x] Any backward compatibility impacted?
   no
 - [x] Document update required?
   yes, i will add this limitation into
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
          added new ut
        - How it is tested? Please attach test report.
           CI run ut
        - Is it a performance related change? Please attach the performance test report.
           no
        - Any additional information to help reviewers in testing this change.
           added code comment
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
  small changes
