### PR TITLE
[CARBONDATA-2022]Fixed table alias issue in PreAggregate

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggregateTableSelection.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggregateTableSelection.scala
@@ -240,10 +240,26 @@ class TestPreAggregateTableSelection extends QueryTest with BeforeAndAfterAll {
     sql("CREATE TABLE grouptable(id int, name string, city string, age string) STORED BY" +
         " 'org.apache.carbondata.format' TBLPROPERTIES('dictionary_include'='name,age')")
     sql(s"LOAD DATA LOCAL INPATH '$resourcesPath/measureinsertintotest.csv' into table grouptable")
-    sql("create datamap agg9 on table grouptable using 'preaggregate' as select sum(id) from grouptable group by city")
+    sql(
+      "create datamap agg9 on table grouptable using 'preaggregate' as select sum(id) from grouptable group by city")
     val df = sql("select sum(id) from grouptable group by city")
     preAggTableValidator(df.queryExecution.analyzed, "grouptable_agg9")
     checkAnswer(df, Seq(Row(3), Row(3), Row(4), Row(7)))
+  }
+
+  test("test PreAggregate table selection 30") {
+    val df = sql("select a.name from mainTable a group by a.name")
+    preAggTableValidator(df.queryExecution.analyzed, "maintable_agg0")
+  }
+
+  test("test PreAggregate table selection 31") {
+    val df = sql("select a.name as newName from mainTable a group by a.name")
+    preAggTableValidator(df.queryExecution.analyzed, "maintable_agg0")
+  }
+
+  test("test PreAggregate table selection 32") {
+    val df = sql("select a.name as newName from mainTable a  where a.name='vishal' group by a.name")
+    preAggTableValidator(df.queryExecution.analyzed, "maintable_agg0")
   }
 
   override def afterAll: Unit = {


### PR DESCRIPTION
**Problem:**Query with table alias is Not hitting pre Aggregate table.  
**Solution:** Problem is table alias query is plan is coming as SubQueryAlias(alias, SubqueryAlias) ans this case is not present in tranform query plan for pre aggregate 
 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Added UT for above case       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

