### PR TITLE
[CARBONDATA-2028] Select Query failed with preagg having timeseries and normal agg table together

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
@@ -2315,7 +2315,9 @@ public final class CarbonUtil {
     List<DataMapSchema> dataMapSchemaList = carbonTable.getTableInfo().getDataMapSchemaList();
     for (DataMapSchema dataMapSchema : dataMapSchemaList) {
       if (dataMapSchema instanceof AggregationDataMapSchema) {
-        return ((AggregationDataMapSchema) dataMapSchema).isTimeseriesDataMap();
+        if (((AggregationDataMapSchema) dataMapSchema).isTimeseriesDataMap()) {
+          return true;
+        }
       }
     }
     return false;


### PR DESCRIPTION
Select Query failed with preagg having timeseries and normal agg table together
Root Cause:-   hasTimeSeriesDataMap(CarbonTable carbonTable)  in CarbonUtil  returns result based on 1st DataMap  . 

Solution :- it should iterators all the DataMap and when finds timeseries datamap , then should returns the true. 

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed? NO
 
 - [ ] Any backward compatibility impacted?NO
 
 - [ ] Document update required?NO

 - [ ] Testing done  =Done
        
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

