### PR TITLE
[CARBONDATA-2030]avg with Aggregate table for double data type is failed.

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggregateLoad.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggregateLoad.scala
@@ -262,5 +262,51 @@ class TestPreAggregateLoad extends QueryTest with BeforeAndAfterAll {
         .stripMargin)
     checkAnswer(sql("select * from maintable_preagg_sum"), Row(1, 52, "xyz"))
   }
+test("check load and select for avg double datatype") {
+  sql("drop table if exists maintbl ")
+  sql("create table maintbl(year int,month int,name string,salary double) stored by 'carbondata' tblproperties('sort_scope'='Global_sort','table_blocksize'='23','sort_columns'='month,year,name')")
+  sql("insert into maintbl select 10,11,'babu',12.89")
+  sql("insert into maintbl select 10,11,'babu',12.89")
+  sql("create datamap maintbl_douoble on table maintbl using 'preaggregate' as select name,avg(salary) from maintbl group by name")
+  checkAnswer(sql("select name,avg(salary) from maintbl group by name"), Row("babu", 12.89))
+}
+
+
+  test("check load and select for avg int datatype") {
+    sql("drop table if exists maintbl ")
+    sql("create table maintbl(year int,month int,name string,salary int) stored by 'carbondata' tblproperties('sort_scope'='Global_sort','table_blocksize'='23','sort_columns'='month,year,name')")
+    sql("insert into maintbl select 10,11,'babu',12")
+    sql("insert into maintbl select 10,11,'babu',12")
+    sql("create datamap maintbl_douoble on table maintbl using 'preaggregate' as select name,avg(salary) from maintbl group by name")
+    checkAnswer(sql("select name,avg(salary) from maintbl group by name"), Row("babu", 12.0))
+  }
+
+  test("check load and select for avg bigint datatype") {
+    sql("drop table if exists maintbl ")
+    sql("create table maintbl(year int,month int,name string,salary bigint) stored by 'carbondata' tblproperties('sort_scope'='Global_sort','table_blocksize'='23','sort_columns'='month,year,name')")
+    sql("insert into maintbl select 10,11,'babu',12")
+    sql("insert into maintbl select 10,11,'babu',12")
+    sql("create datamap maintbl_douoble on table maintbl using 'preaggregate' as select name,avg(salary) from maintbl group by name")
+    checkAnswer(sql("select name,avg(salary) from maintbl group by name"), Row("babu", 12.0))
+  }
+
+  test("check load and select for avg short datatype") {
+    sql("drop table if exists maintbl ")
+    sql("create table maintbl(year int,month int,name string,salary short) stored by 'carbondata' tblproperties('sort_scope'='Global_sort','table_blocksize'='23','sort_columns'='month,year,name')")
+    sql("insert into maintbl select 10,11,'babu',12")
+    sql("insert into maintbl select 10,11,'babu',12")
+    sql("create datamap maintbl_douoble on table maintbl using 'preaggregate' as select name,avg(salary) from maintbl group by name")
+    checkAnswer(sql("select name,avg(salary) from maintbl group by name"), Row("babu", 12.0))
+  }
+
+  test("check load and select for avg float datatype") {
+    sql("drop table if exists maintbl ")
+    sql("create table maintbl(year int,month int,name string,salary float) stored by 'carbondata' tblproperties('sort_scope'='Global_sort','table_blocksize'='23','sort_columns'='month,year,name')")
+    sql("insert into maintbl select 10,11,'babu',12")
+    sql("insert into maintbl select 10,11,'babu',12")
+    sql("create datamap maintbl_douoble on table maintbl using 'preaggregate' as select name,avg(salary) from maintbl group by name")
+    checkAnswer(sql("select name,avg(salary) from maintbl group by name"), Row("babu", 12.89))
+  }
+
 
 }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/preaaggregate/PreAggregateUtil.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/preaaggregate/PreAggregateUtil.scala
@@ -288,7 +288,7 @@ object PreAggregateUtil {
           "sum")
         list += createFieldForAggregateExpression(
           exp,
-          LongType,
+          changeDataType,
           carbonTable,
           newColumnName,
           "count")
@@ -301,7 +301,7 @@ object PreAggregateUtil {
           "sum")
         list += createFieldForAggregateExpression(
           exp,
-          LongType,
+          avg.dataType,
           carbonTable,
           newColumnName,
           "count")


### PR DESCRIPTION
avg with Aggregate table for double data type is failed.

Root Cause:- for avg column , agg table returns sum and count , sum col. data type is based on actual data type of the column but for count col. always  LongType .so while doing divide by it is failed in spark layer

Solution :- Change the return datatype for count also . use the same datatype sum column .

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 NA
 - [ ] Any backward compatibility impacted?
 NA
 - [ ] Document update required? NA

 - [ ] Testing done=Done
       Added UT.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

