### PR TITLE
[CARBONDATA-2031] Fix ArrayIndexOutOfBoundException when filter query is applied on column where all values are null and column is noinverted index column

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/ExcludeFilterExecuterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/ExcludeFilterExecuterImpl.java
@@ -378,6 +378,10 @@ public class ExcludeFilterExecuterImpl implements FilterExecuter {
     BitSet bitSet = new BitSet(numerOfRows);
     bitSet.flip(0, numerOfRows);
     byte[][] filterValues = dimColumnExecuterInfo.getExcludeFilterKeys();
+    // filterValues can be null when the dictionary chunk and surrogate size both are one
+    if (filterValues.length == 0) {
+      return bitSet;
+    }
     // binary search can only be applied if column is sorted
     if (isNaturalSorted) {
       int startIndex = 0;

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/dataload/TestNoInvertedIndexLoadAndQuery.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/dataload/TestNoInvertedIndexLoadAndQuery.scala
@@ -49,6 +49,7 @@ class TestNoInvertedIndexLoadAndQuery extends QueryTest with BeforeAndAfterAll {
     sql("DROP TABLE IF EXISTS index2")
     sql("DROP TABLE IF EXISTS hiveNoInvertedIndexTable")
     sql("DROP TABLE IF EXISTS carbonNoInvertedIndexTable")
+    sql("DROP TABLE IF EXISTS testNull")
   }
 
   test("no inverted index load and point query") {
@@ -281,10 +282,18 @@ class TestNoInvertedIndexLoadAndQuery extends QueryTest with BeforeAndAfterAll {
       true,"NOINVERTEDINDEX")
   }
 
+  test("filter query on dictionary and no inverted index column where all values are null"){
+    sql("""create table testNull (c1 string,c2 int,c3 string,c5 string) STORED BY 'carbondata' TBLPROPERTIES('DICTIONARY_INCLUDE'='C2','NO_INVERTED_INDEX'='C2')""")
+    sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/IUD/dest.csv' INTO table testNull OPTIONS('delimiter'=';','fileheader'='c1,c2,c3,c5')""")
+    sql("""select c2 from testNull where c2 is null""").show()
+    checkAnswer(sql("""select c2 from testNull where c2 is null"""), Seq(Row(null), Row(null), Row(null), Row(null), Row(null), Row(null)))
+  }
+
   override def afterAll {
     sql("drop table if exists index1")
     sql("drop table if exists index2")
     sql("drop table if exists indexFormat")
+    sql("drop table if exists testNull")
     clean
   }
 


### PR DESCRIPTION
PROBLEM:
Fix ArrayIndexOutOfBoundException when filter query is applied on column where all values are null and column is noinverted index column

when all the values are null in no inverted index column the number of exclude filter keys are null, hence just return the bitset if the exclude filters to be applied are none.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [X] Any interfaces changed?
   NA
 - [X] Any backward compatibility impacted?
   NA
 - [X] Document update required?
   NA
 - [X] Testing done
   UT is added
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

