### PR TITLE
[CARBONDATA-2037]Store carbondata locations in datamap to make the datamap retrieval faster

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/AlluxioCarbonFile.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/AlluxioCarbonFile.java
@@ -55,7 +55,8 @@ public class AlluxioCarbonFile extends AbstractDFSCarbonFile {
    * @param listStatus
    * @return
    */
-  private CarbonFile[] getFiles(FileStatus[] listStatus) {
+  @Override
+  protected CarbonFile[] getFiles(FileStatus[] listStatus) {
     if (listStatus == null) {
       return new CarbonFile[0];
     }
@@ -66,22 +67,6 @@ public class AlluxioCarbonFile extends AbstractDFSCarbonFile {
     return files;
   }
 
-  @Override
-  public CarbonFile[] listFiles() {
-    FileStatus[] listStatus = null;
-    try {
-      if (null != fileStatus && fileStatus.isDirectory()) {
-        Path path = fileStatus.getPath();
-        listStatus = path.getFileSystem(FileFactory.getConfiguration()).listStatus(path);
-      } else {
-        return new CarbonFile[0];
-      }
-    } catch (IOException e) {
-      LOGGER.error("Exception occured: " + e.getMessage());
-      return new CarbonFile[0];
-    }
-    return getFiles(listStatus);
-  }
 
   @Override
   public CarbonFile[] listFiles(final CarbonFileFilter fileFilter) {

--- a/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/CarbonFile.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/CarbonFile.java
@@ -34,6 +34,12 @@ public interface CarbonFile {
 
   CarbonFile[] listFiles();
 
+  /**
+   * It returns list of files with location details.
+   * @return
+   */
+  CarbonFile[] locationAwareListFiles() throws IOException;
+
   String getName();
 
   boolean isDirectory();
@@ -131,5 +137,11 @@ public interface CarbonFile {
 
   void setPermission(String directoryPath, FsPermission permission, String username, String group)
       throws IOException;
+
+  /**
+   * Returns locations of the file
+   * @return
+   */
+  String[] getLocations() throws IOException;
 
 }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/HDFSCarbonFile.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/HDFSCarbonFile.java
@@ -23,7 +23,6 @@ import java.util.List;
 
 import org.apache.carbondata.common.logging.LogService;
 import org.apache.carbondata.common.logging.LogServiceFactory;
-import org.apache.carbondata.core.datastore.impl.FileFactory;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
@@ -62,7 +61,8 @@ public class HDFSCarbonFile extends AbstractDFSCarbonFile {
    * @param listStatus
    * @return
    */
-  private CarbonFile[] getFiles(FileStatus[] listStatus) {
+  @Override
+  protected CarbonFile[] getFiles(FileStatus[] listStatus) {
     if (listStatus == null) {
       return new CarbonFile[0];
     }
@@ -71,23 +71,6 @@ public class HDFSCarbonFile extends AbstractDFSCarbonFile {
       files[i] = new HDFSCarbonFile(listStatus[i]);
     }
     return files;
-  }
-
-  @Override
-  public CarbonFile[] listFiles() {
-    FileStatus[] listStatus = null;
-    try {
-      if (null != fileStatus && fileStatus.isDirectory()) {
-        Path path = fileStatus.getPath();
-        listStatus = path.getFileSystem(FileFactory.getConfiguration()).listStatus(path);
-      } else {
-        return new CarbonFile[0];
-      }
-    } catch (IOException e) {
-      LOGGER.error("Exception occured: " + e.getMessage());
-      return new CarbonFile[0];
-    }
-    return getFiles(listStatus);
   }
 
   @Override

--- a/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/LocalCarbonFile.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/LocalCarbonFile.java
@@ -423,4 +423,12 @@ public class LocalCarbonFile implements CarbonFile {
   public void setPermission(String directoryPath, FsPermission permission, String username,
       String group) throws IOException {
   }
+
+  @Override public CarbonFile[] locationAwareListFiles() throws IOException {
+    return listFiles();
+  }
+
+  @Override public String[] getLocations() throws IOException {
+    return new String[]{"localhost"};
+  }
 }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/ViewFSCarbonFile.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/ViewFSCarbonFile.java
@@ -52,7 +52,8 @@ public class ViewFSCarbonFile extends AbstractDFSCarbonFile {
    * @param listStatus
    * @return
    */
-  private CarbonFile[] getFiles(FileStatus[] listStatus) {
+  @Override
+  protected CarbonFile[] getFiles(FileStatus[] listStatus) {
     if (listStatus == null) {
       return new CarbonFile[0];
     }
@@ -61,23 +62,6 @@ public class ViewFSCarbonFile extends AbstractDFSCarbonFile {
       files[i] = new ViewFSCarbonFile(listStatus[i]);
     }
     return files;
-  }
-
-  @Override
-  public CarbonFile[] listFiles() {
-    FileStatus[] listStatus = null;
-    try {
-      if (null != fileStatus && fileStatus.isDirectory()) {
-        Path path = fileStatus.getPath();
-        listStatus = path.getFileSystem(FileFactory.getConfiguration()).listStatus(path);
-      } else {
-        return new CarbonFile[0];
-      }
-    } catch (IOException ex) {
-      LOGGER.error("Exception occured" + ex.getMessage());
-      return new CarbonFile[0];
-    }
-    return getFiles(listStatus);
   }
 
   @Override

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/BlockletDataMapIndexStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/BlockletDataMapIndexStore.java
@@ -21,11 +21,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 
 import org.apache.carbondata.common.logging.LogService;
 import org.apache.carbondata.common.logging.LogServiceFactory;
@@ -38,7 +35,6 @@ import org.apache.carbondata.core.indexstore.blockletindex.BlockletDataMapModel;
 import org.apache.carbondata.core.indexstore.blockletindex.SegmentIndexFileStore;
 import org.apache.carbondata.core.memory.MemoryException;
 import org.apache.carbondata.core.metadata.PartitionMapFileStore;
-import org.apache.carbondata.core.util.CarbonThreadFactory;
 import org.apache.carbondata.core.util.path.CarbonTablePath;
 
 /**

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/BlockletDataMapIndexStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/BlockletDataMapIndexStore.java
@@ -31,6 +31,8 @@ import org.apache.carbondata.common.logging.LogService;
 import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.cache.Cache;
 import org.apache.carbondata.core.cache.CarbonLRUCache;
+import org.apache.carbondata.core.datastore.filesystem.CarbonFile;
+import org.apache.carbondata.core.datastore.impl.FileFactory;
 import org.apache.carbondata.core.indexstore.blockletindex.BlockletDataMap;
 import org.apache.carbondata.core.indexstore.blockletindex.BlockletDataMapModel;
 import org.apache.carbondata.core.indexstore.blockletindex.SegmentIndexFileStore;
@@ -80,11 +82,17 @@ public class BlockletDataMapIndexStore
         String segmentPath = CarbonTablePath.getSegmentPath(
             identifier.getAbsoluteTableIdentifier().getTablePath(),
             identifier.getSegmentId());
+        Map<String, String[]> locationMap = new HashMap<>();
+        CarbonFile carbonFile = FileFactory.getCarbonFile(segmentPath);
+        CarbonFile[] carbonFiles = carbonFile.locationAwareListFiles();
         SegmentIndexFileStore indexFileStore = new SegmentIndexFileStore();
-        indexFileStore.readAllIIndexOfSegment(segmentPath);
+        indexFileStore.readAllIIndexOfSegment(carbonFiles);
         PartitionMapFileStore partitionFileStore = new PartitionMapFileStore();
-        partitionFileStore.readAllPartitionsOfSegment(segmentPath);
-        dataMap = loadAndGetDataMap(identifier, indexFileStore, partitionFileStore);
+        partitionFileStore.readAllPartitionsOfSegment(carbonFiles, segmentPath);
+        for (CarbonFile file : carbonFiles) {
+          locationMap.put(file.getAbsolutePath(), file.getLocations());
+        }
+        dataMap = loadAndGetDataMap(identifier, indexFileStore, partitionFileStore, locationMap);
       } catch (MemoryException e) {
         LOGGER.error("memory exception when loading datamap: " + e.getMessage());
         throw new RuntimeException(e.getMessage(), e);
@@ -112,11 +120,8 @@ public class BlockletDataMapIndexStore
       if (missedIdentifiers.size() > 0) {
         Map<String, SegmentIndexFileStore> segmentIndexFileStoreMap = new HashMap<>();
         Map<String, PartitionMapFileStore> partitionFileStoreMap = new HashMap<>();
-        service =
-            Executors.newCachedThreadPool(
-                new CarbonThreadFactory("BlockletDataMapIndexStore:" + missedIdentifiers.get(0)
-                    .getAbsoluteTableIdentifier().getTableName()));
-        List<Future<BlockletDataMap>> futureList = new ArrayList<>();
+        Map<String, String[]> locationMap = new HashMap<>();
+
         for (TableBlockIndexUniqueIdentifier identifier: missedIdentifiers) {
           SegmentIndexFileStore indexFileStore =
               segmentIndexFileStoreMap.get(identifier.getSegmentId());
@@ -126,21 +131,20 @@ public class BlockletDataMapIndexStore
               identifier.getAbsoluteTableIdentifier().getTablePath(),
               identifier.getSegmentId());
           if (indexFileStore == null) {
+            CarbonFile carbonFile = FileFactory.getCarbonFile(segmentPath);
+            CarbonFile[] carbonFiles = carbonFile.locationAwareListFiles();
             indexFileStore = new SegmentIndexFileStore();
-            indexFileStore.readAllIIndexOfSegment(segmentPath);
+            indexFileStore.readAllIIndexOfSegment(carbonFiles);
             segmentIndexFileStoreMap.put(identifier.getSegmentId(), indexFileStore);
-          }
-          if (partitionFileStore == null) {
             partitionFileStore = new PartitionMapFileStore();
-            partitionFileStore.readAllPartitionsOfSegment(segmentPath);
+            partitionFileStore.readAllPartitionsOfSegment(carbonFiles, segmentPath);
             partitionFileStoreMap.put(identifier.getSegmentId(), partitionFileStore);
+            for (CarbonFile file : carbonFiles) {
+              locationMap.put(file.getAbsolutePath(), file.getLocations());
+            }
           }
-          BlockletDataMapLoader blockletDataMapLoader =
-              new BlockletDataMapLoader(identifier, indexFileStore, partitionFileStore);
-          futureList.add(service.submit(blockletDataMapLoader));
-        }
-        for (Future<BlockletDataMap> dataMapFuture : futureList) {
-          blockletDataMaps.add(dataMapFuture.get());
+          blockletDataMaps.add(
+              loadAndGetDataMap(identifier, indexFileStore, partitionFileStore, locationMap));
         }
       }
     } catch (Throwable e) {
@@ -180,27 +184,6 @@ public class BlockletDataMapIndexStore
   }
 
   /**
-   * This class is used to parallelize reading of index files.
-   */
-  private class BlockletDataMapLoader implements Callable<BlockletDataMap> {
-
-    private TableBlockIndexUniqueIdentifier identifier;
-    private SegmentIndexFileStore indexFileStore;
-    private PartitionMapFileStore partitionFileStore;
-
-    public BlockletDataMapLoader(TableBlockIndexUniqueIdentifier identifier,
-        SegmentIndexFileStore indexFileStore, PartitionMapFileStore partitionFileStore) {
-      this.identifier = identifier;
-      this.indexFileStore = indexFileStore;
-      this.partitionFileStore = partitionFileStore;
-    }
-
-    @Override public BlockletDataMap call() throws Exception {
-      return loadAndGetDataMap(identifier, indexFileStore, partitionFileStore);
-    }
-  }
-
-  /**
    * Below method will be used to load the segment of segments
    * One segment may have multiple task , so  table segment will be loaded
    * based on task id and will return the map of taksId to table segment
@@ -212,7 +195,8 @@ public class BlockletDataMapIndexStore
   private BlockletDataMap loadAndGetDataMap(
       TableBlockIndexUniqueIdentifier identifier,
       SegmentIndexFileStore indexFileStore,
-      PartitionMapFileStore partitionFileStore)
+      PartitionMapFileStore partitionFileStore,
+      Map<String, String[]> locationMap)
       throws IOException, MemoryException {
     String uniqueTableSegmentIdentifier =
         identifier.getUniqueTableSegmentIdentifier();
@@ -226,7 +210,7 @@ public class BlockletDataMapIndexStore
       dataMap.init(new BlockletDataMapModel(identifier.getFilePath(),
           indexFileStore.getFileData(identifier.getCarbonIndexFileName()),
           partitionFileStore.getPartitions(identifier.getCarbonIndexFileName()),
-          partitionFileStore.isPartionedSegment()));
+          partitionFileStore.isPartionedSegment(), locationMap));
       lruCache.put(identifier.getUniqueTableSegmentIdentifier(), dataMap,
           dataMap.getMemorySize());
     }

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/ExtendedBlocklet.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/ExtendedBlocklet.java
@@ -16,15 +16,6 @@
  */
 package org.apache.carbondata.core.indexstore;
 
-import java.io.IOException;
-
-import org.apache.carbondata.core.datastore.impl.FileFactory;
-
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.LocatedFileStatus;
-import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.RemoteIterator;
-
 /**
  * Detailed blocklet information
  */
@@ -50,25 +41,15 @@ public class ExtendedBlocklet extends Blocklet {
     this.detailInfo = detailInfo;
   }
 
-  /**
-   * It gets the hdfs block locations and length for this blocklet. It is used internally to get the
-   * locations for allocating tasks.
-   * @throws IOException
-   */
-  public void updateLocations() throws IOException {
-    Path path = new Path(getPath());
-    FileSystem fs = path.getFileSystem(FileFactory.getConfiguration());
-    RemoteIterator<LocatedFileStatus> iter = fs.listLocatedStatus(path);
-    LocatedFileStatus fileStatus = iter.next();
-    location = fileStatus.getBlockLocations()[0].getHosts();
-    length = fileStatus.getLen();
+  public void setLocation(String[] location) {
+    this.location = location;
   }
 
-  public String[] getLocations() throws IOException {
+  public String[] getLocations() {
     return location;
   }
 
-  public long getLength() throws IOException {
+  public long getLength() {
     return length;
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/UnsafeMemoryDMStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/UnsafeMemoryDMStore.java
@@ -168,7 +168,7 @@ public class UnsafeMemoryDMStore {
     }
   }
 
-  public DataMapRow getUnsafeRow(int index) {
+  public UnsafeDataMapRow getUnsafeRow(int index) {
     assert (index < rowCount);
     return new UnsafeDataMapRow(schema, memoryBlock, pointers[index]);
   }

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDMComparator.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDMComparator.java
@@ -63,7 +63,7 @@ public class BlockletDMComparator implements Comparator<DataMapRow> {
     int compareResult = 0;
     int processedNoDictionaryColumn = numberOfNoDictSortColumns;
     byte[][] firstBytes = splitKey(first.getByteArray(0));
-    byte[][] secondBytes = splitKey(first.getByteArray(0));
+    byte[][] secondBytes = splitKey(second.getByteArray(0));
     byte[] firstNoDictionaryKeys = firstBytes[1];
     ByteBuffer firstNoDictionaryKeyBuffer = ByteBuffer.wrap(firstNoDictionaryKeys);
     byte[] secondNoDictionaryKeys = secondBytes[1];

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMap.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMap.java
@@ -22,6 +22,7 @@ import java.io.DataInputStream;
 import java.io.DataOutput;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -139,16 +140,23 @@ public class BlockletDataMap implements DataMap, Cacheable {
         createSummarySchema(segmentProperties, blockletDataMapInfo.getPartitions(), schemaBinary);
       }
       TableBlockInfo blockInfo = fileFooter.getBlockInfo().getTableBlockInfo();
-      if (fileFooter.getBlockletList() == null) {
-        // This is old store scenario, here blocklet information is not available in  index file so
-        // load only block info
-        summaryRow =
-            loadToUnsafeBlock(fileFooter, segmentProperties, blockInfo.getFilePath(), summaryRow);
-      } else {
-        // Here it loads info about all blocklets of index
-
-        summaryRow = loadToUnsafe(fileFooter, segmentProperties, blockInfo.getFilePath(), summaryRow,
-            blockletDataMapInfo.getLocationMap().get(blockInfo.getFilePath()));
+      String[] locations = blockletDataMapInfo.getLocationMap().get(blockInfo.getFilePath());
+      // Here it loads info about all blocklets of index
+      // Only add if the file exists physically. There are scenarios which index file exists inside
+      // merge index but related carbondata files are deleted. In that case we first check whether
+      // the file exists physically or not
+      if (locations != null) {
+        if (fileFooter.getBlockletList() == null) {
+          // This is old store scenario, here blocklet information is not available in index file so
+          // load only block info
+          summaryRow =
+              loadToUnsafeBlock(fileFooter, segmentProperties, blockInfo.getFilePath(), summaryRow,
+                  locations);
+        } else {
+          summaryRow =
+              loadToUnsafe(fileFooter, segmentProperties, blockInfo.getFilePath(), summaryRow,
+                  locations);
+        }
       }
     }
     if (unsafeMemoryDMStore != null) {
@@ -227,9 +235,8 @@ public class BlockletDataMap implements DataMap, Cacheable {
         row.setByteArray(serializedData, ordinal++);
         // Add block footer offset, it is used if we need to read footer of block
         row.setLong(fileFooter.getBlockInfo().getTableBlockInfo().getBlockOffset(), ordinal++);
-        // Add location info
-        String locationStr = StringUtils.join(locations, ',');
-        row.setByteArray(locationStr.getBytes(CarbonCommonConstants.DEFAULT_CHARSET), ordinal);
+        setLocations(locations, row, ordinal);
+
         unsafeMemoryDMStore.addIndexRowToUnsafe(row);
       } catch (Exception e) {
         throw new RuntimeException(e);
@@ -239,13 +246,21 @@ public class BlockletDataMap implements DataMap, Cacheable {
     return summaryRow;
   }
 
+  private void setLocations(String[] locations, DataMapRow row, int ordinal)
+      throws UnsupportedEncodingException {
+    // Add location info
+    String locationStr = StringUtils.join(locations, ',');
+    row.setByteArray(locationStr.getBytes(CarbonCommonConstants.DEFAULT_CHARSET), ordinal);
+  }
+
   /**
    * Load information for the block.It is the case can happen only for old stores
    * where blocklet information is not available in index file. So load only block information
    * and read blocklet information in executor.
    */
   private DataMapRowImpl loadToUnsafeBlock(DataFileFooter fileFooter,
-      SegmentProperties segmentProperties, String filePath, DataMapRowImpl summaryRow) {
+      SegmentProperties segmentProperties, String filePath, DataMapRowImpl summaryRow,
+      String[] locations) {
     int[] minMaxLen = segmentProperties.getColumnsValueSize();
     BlockletIndex blockletIndex = fileFooter.getBlockletIndex();
     CarbonRowSchema[] schema = unsafeMemoryDMStore.getSchema();
@@ -294,8 +309,9 @@ public class BlockletDataMap implements DataMap, Cacheable {
     // add blocklet info
     row.setByteArray(new byte[0], ordinal++);
 
-    row.setLong(fileFooter.getBlockInfo().getTableBlockInfo().getBlockOffset(), ordinal);
+    row.setLong(fileFooter.getBlockInfo().getTableBlockInfo().getBlockOffset(), ordinal++);
     try {
+      setLocations(locations, row, ordinal);
       unsafeMemoryDMStore.addIndexRowToUnsafe(row);
     } catch (Exception e) {
       throw new RuntimeException(e);
@@ -569,7 +585,9 @@ public class BlockletDataMap implements DataMap, Cacheable {
 
   @Override
   public List<Blocklet> prune(FilterResolverIntf filterExp) {
-
+    if (unsafeMemoryDMStore.getRowCount() == 0) {
+      return new ArrayList<>();
+    }
     // getting the start and end index key based on filter for hitting the
     // selected block reference nodes based on filter resolver tree.
     if (LOGGER.isDebugEnabled()) {
@@ -609,8 +627,8 @@ public class BlockletDataMap implements DataMap, Cacheable {
     if (filterExp == null) {
       int rowCount = unsafeMemoryDMStore.getRowCount();
       for (int i = 0; i < rowCount; i++) {
-        DataMapRow unsafeRow = unsafeMemoryDMStore.getUnsafeRow(i);
-        blocklets.add(createBlocklet(unsafeRow, i));
+        DataMapRow safeRow = unsafeMemoryDMStore.getUnsafeRow(i).convertToSafeRow();
+        blocklets.add(createBlocklet(safeRow, i));
       }
     } else {
       int startIndex = findStartIndex(convertToRow(searchStartKey), comparator);
@@ -618,14 +636,14 @@ public class BlockletDataMap implements DataMap, Cacheable {
       FilterExecuter filterExecuter =
           FilterUtil.getFilterExecuterTree(filterExp, segmentProperties, null);
       while (startIndex <= endIndex) {
-        DataMapRow unsafeRow = unsafeMemoryDMStore.getUnsafeRow(startIndex);
-        String filePath = new String(unsafeRow.getByteArray(FILE_PATH_INDEX),
+        DataMapRow safeRow = unsafeMemoryDMStore.getUnsafeRow(startIndex).convertToSafeRow();
+        String filePath = new String(safeRow.getByteArray(FILE_PATH_INDEX),
             CarbonCommonConstants.DEFAULT_CHARSET_CLASS);
         boolean isValid =
-            addBlockBasedOnMinMaxValue(filterExecuter, getMinMaxValue(unsafeRow, MAX_VALUES_INDEX),
-                getMinMaxValue(unsafeRow, MIN_VALUES_INDEX), filePath, startIndex);
+            addBlockBasedOnMinMaxValue(filterExecuter, getMinMaxValue(safeRow, MAX_VALUES_INDEX),
+                getMinMaxValue(safeRow, MIN_VALUES_INDEX), filePath, startIndex);
         if (isValid) {
-          blocklets.add(createBlocklet(unsafeRow, startIndex));
+          blocklets.add(createBlocklet(safeRow, startIndex));
         }
         startIndex++;
       }
@@ -635,6 +653,9 @@ public class BlockletDataMap implements DataMap, Cacheable {
   }
 
   @Override public List<Blocklet> prune(FilterResolverIntf filterExp, List<String> partitions) {
+    if (unsafeMemoryDMStore.getRowCount() == 0) {
+      return new ArrayList<>();
+    }
     // First get the partitions which are stored inside datamap.
     List<String> storedPartitions = getPartitions();
     // if it has partitioned datamap but there is no partitioned information stored, it means
@@ -686,8 +707,8 @@ public class BlockletDataMap implements DataMap, Cacheable {
 
   public ExtendedBlocklet getDetailedBlocklet(String blockletId) {
     int index = Integer.parseInt(blockletId);
-    DataMapRow unsafeRow = unsafeMemoryDMStore.getUnsafeRow(index);
-    return createBlocklet(unsafeRow, index);
+    DataMapRow safeRow = unsafeMemoryDMStore.getUnsafeRow(index).convertToSafeRow();
+    return createBlocklet(safeRow, index);
   }
 
   private byte[][] getMinMaxValue(DataMapRow row, int index) {
@@ -712,19 +733,19 @@ public class BlockletDataMap implements DataMap, Cacheable {
     detailInfo.setSchemaUpdatedTimeStamp(row.getLong(SCHEMA_UPADATED_TIME_INDEX));
     byte[] byteArray = row.getByteArray(BLOCK_INFO_INDEX);
     BlockletInfo blockletInfo = null;
-    if (byteArray.length > 0) {
-      try {
+    try {
+      if (byteArray.length > 0) {
         blockletInfo = new BlockletInfo();
         ByteArrayInputStream stream = new ByteArrayInputStream(byteArray);
         DataInputStream inputStream = new DataInputStream(stream);
         blockletInfo.readFields(inputStream);
         inputStream.close();
-        blocklet.setLocation(
-            new String(row.getByteArray(LOCATIONS), CarbonCommonConstants.DEFAULT_CHARSET)
-                .split(","));
-      } catch (IOException e) {
-        throw new RuntimeException(e);
       }
+      blocklet.setLocation(
+          new String(row.getByteArray(LOCATIONS), CarbonCommonConstants.DEFAULT_CHARSET)
+              .split(","));
+    } catch (IOException e) {
+      throw new RuntimeException(e);
     }
     detailInfo.setBlockletInfo(blockletInfo);
     blocklet.setDetailInfo(detailInfo);

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMapModel.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMapModel.java
@@ -17,6 +17,7 @@
 package org.apache.carbondata.core.indexstore.blockletindex;
 
 import java.util.List;
+import java.util.Map;
 
 import org.apache.carbondata.core.datamap.dev.DataMapModel;
 
@@ -31,12 +32,15 @@ public class BlockletDataMapModel extends DataMapModel {
 
   private boolean partitionedSegment;
 
+  private Map<String, String[]> locationMap;
+
   public BlockletDataMapModel(String filePath, byte[] fileData, List<String> partitions,
-      boolean partitionedSegment) {
+      boolean partitionedSegment, Map<String, String[]> locationMap) {
     super(filePath);
     this.fileData = fileData;
     this.partitions = partitions;
     this.partitionedSegment = partitionedSegment;
+    this.locationMap = locationMap;
   }
 
   public byte[] getFileData() {
@@ -49,5 +53,9 @@ public class BlockletDataMapModel extends DataMapModel {
 
   public boolean isPartitionedSegment() {
     return partitionedSegment;
+  }
+
+  public Map<String, String[]> getLocationMap() {
+    return locationMap;
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/SegmentIndexFileStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/SegmentIndexFileStore.java
@@ -97,6 +97,23 @@ public class SegmentIndexFileStore {
   }
 
   /**
+   * Read all index files and keep the cache in it.
+   *
+   * @param carbonFiles
+   * @throws IOException
+   */
+  public void readAllIIndexOfSegment(CarbonFile[] carbonFiles) throws IOException {
+    CarbonFile[] carbonIndexFiles = getCarbonIndexFiles(carbonFiles);
+    for (int i = 0; i < carbonIndexFiles.length; i++) {
+      if (carbonIndexFiles[i].getName().endsWith(CarbonTablePath.MERGE_INDEX_FILE_EXT)) {
+        readMergeFile(carbonIndexFiles[i].getCanonicalPath());
+      } else if (carbonIndexFiles[i].getName().endsWith(CarbonTablePath.INDEX_FILE_EXT)) {
+        readIndexFile(carbonIndexFiles[i]);
+      }
+    }
+  }
+
+  /**
    * Read all index file names of the segment
    *
    * @param segmentPath
@@ -208,6 +225,23 @@ public class SegmentIndexFileStore {
             .endsWith(CarbonTablePath.MERGE_INDEX_FILE_EXT);
       }
     });
+  }
+
+  /**
+   * List all the index files of the segment.
+   *
+   * @param carbonFiles
+   * @return
+   */
+  public static CarbonFile[] getCarbonIndexFiles(CarbonFile[] carbonFiles) {
+    List<CarbonFile> indexFiles = new ArrayList<>();
+    for (CarbonFile file: carbonFiles) {
+      if (file.getName().endsWith(CarbonTablePath.INDEX_FILE_EXT) ||
+          file.getName().endsWith(CarbonTablePath.MERGE_INDEX_FILE_EXT)) {
+        indexFiles.add(file);
+      }
+    }
+    return indexFiles.toArray(new CarbonFile[indexFiles.size()]);
   }
 
   /**

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/row/DataMapRowImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/row/DataMapRowImpl.java
@@ -26,6 +26,8 @@ public class DataMapRowImpl extends DataMapRow {
 
   private Object[] data;
 
+  private int totalLengthInBytes;
+
   public DataMapRowImpl(CarbonRowSchema[] schemas) {
     super(schemas);
     this.data = new Object[schemas.length];
@@ -107,4 +109,15 @@ public class DataMapRowImpl extends DataMapRow {
     return (Double) data[ordinal];
   }
 
+  public void setTotalLengthInBytes(int totalLengthInBytes) {
+    this.totalLengthInBytes = totalLengthInBytes;
+  }
+
+  @Override public int getTotalSizeInBytes() {
+    if (totalLengthInBytes > 0) {
+      return totalLengthInBytes;
+    } else {
+      return super.getTotalSizeInBytes();
+    }
+  }
 }

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableInputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableInputFormat.java
@@ -20,7 +20,6 @@ package org.apache.carbondata.hadoop.api;
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.util.ArrayList;
@@ -780,15 +779,7 @@ public class CarbonTableInputFormat<T> extends FileInputFormat<Void, T> {
     return resultFilterredBlocks;
   }
 
-  private CarbonInputSplit convertToCarbonInputSplit(ExtendedBlocklet blocklet)
-      throws IOException {
-    try {
-      blocklet.updateLocations();
-    } catch (FileNotFoundException e) {
-      // In case of clean files there is a chance of carbondata file is deleted but index file
-      // exist inside merged file. So just return null.
-      return null;
-    }
+  private CarbonInputSplit convertToCarbonInputSplit(ExtendedBlocklet blocklet) throws IOException {
     org.apache.carbondata.hadoop.CarbonInputSplit split =
         org.apache.carbondata.hadoop.CarbonInputSplit.from(blocklet.getSegmentId(),
             blocklet.getBlockletId(), new FileSplit(new Path(blocklet.getPath()), 0,


### PR DESCRIPTION
Currently carbondata locations are getting from namenode for each query and that makes queries slower.  So this PR stores the block locations while loading datamap and retrieves from it.

NOTE : This PR depends on https://github.com/apache/carbondata/pull/1789 so first that need to be merged.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [X] Any interfaces changed?
 
 - [X] Any backward compatibility impacted?
 
 - [X] Document update required?

 - [X] Testing done
              
 - [X] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

