### PR TITLE
[CARBONDATA-2038][Tests] use junit assertion in java tests

### DIFF
--- a/core/src/test/java/org/apache/carbondata/core/cache/dictionary/DictionaryByteArrayWrapperTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/cache/dictionary/DictionaryByteArrayWrapperTest.java
@@ -17,6 +17,7 @@
 package org.apache.carbondata.core.cache.dictionary;
 
 import net.jpountz.xxhash.XXHashFactory;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -37,29 +38,29 @@ public class DictionaryByteArrayWrapperTest {
 
   @Test public void equalsTestWithSameObject() {
     Boolean res = dictionaryByteArrayWrapper.equals(dictionaryByteArrayWrapper);
-    assert (res);
+    Assert.assertTrue(res);
   }
 
   @Test public void equalsTestWithString() {
     Boolean res = dictionaryByteArrayWrapper.equals("Rahul");
-    assert (!res);
+    Assert.assertTrue(!res);
   }
 
   @Test public void equalsTestWithXxHash32() {
     Boolean res = dictionaryByteArrayWrapper1.equals("Rahul");
-    assert (!res);
+    Assert.assertTrue(!res);
   }
 
   @Test public void equalsTestWithDictionaryByteArrayWrapper() {
     Boolean res =
         dictionaryByteArrayWrapper.equals(new DictionaryByteArrayWrapper("Rahul".getBytes()));
-    assert (res);
+    Assert.assertTrue(res);
   }
 
   @Test public void equalsTestWithDifferentLength() {
     Boolean res =
         dictionaryByteArrayWrapper.equals(new DictionaryByteArrayWrapper("Rahul ".getBytes()));
-    assert (!res);
+    Assert.assertTrue (!res);
   }
 
   @Test public void hashCodeTest() {

--- a/core/src/test/java/org/apache/carbondata/core/carbon/AbsoluteTableIdentifierTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/carbon/AbsoluteTableIdentifierTest.java
@@ -20,6 +20,7 @@ package org.apache.carbondata.core.carbon;
 import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
 import org.apache.carbondata.core.metadata.CarbonTableIdentifier;
 
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -46,37 +47,37 @@ public class AbsoluteTableIdentifierTest {
 
   @Test public void equalsTestWithSameInstance() {
     Boolean res = absoluteTableIdentifier.equals("wrong data");
-    assert (!res);
+    Assert.assertTrue(!res);
   }
 
   @Test public void equalsTestWithNullObject() {
     Boolean res = absoluteTableIdentifier.equals(null);
-    assert (!res);
+    Assert.assertTrue(!res);
   }
 
   @Test public void equalsTestWithotherObject() {
     Boolean res = absoluteTableIdentifier1.equals(absoluteTableIdentifier);
-    assert (!res);
+    Assert.assertTrue(!res);
   }
 
   @Test public void equalsTestWithSameObj() {
     Boolean res = absoluteTableIdentifier.equals(absoluteTableIdentifier);
-    assert (res);
+    Assert.assertTrue(res);
   }
 
   @Test public void equalsTestWithNullColumnIdentifier() {
     Boolean res = absoluteTableIdentifier1.equals(absoluteTableIdentifier2);
-    assert (!res);
+    Assert.assertTrue(!res);
   }
 
   @Test public void equalsTestWithEqualColumnIdentifier() {
     Boolean res = absoluteTableIdentifier3.equals(absoluteTableIdentifier4);
-    assert (!res);
+    Assert.assertTrue(!res);
   }
 
   @Test public void equalsTestWithEqualAbsoluteTableIdentifier() {
     Boolean res = absoluteTableIdentifier.equals(absoluteTableIdentifier4);
-    assert (res);
+    Assert.assertTrue(res);
   }
 
   @Test public void hashCodeTest() {
@@ -87,13 +88,13 @@ public class AbsoluteTableIdentifierTest {
 
   @Test public void gettablePathTest() {
     String res = absoluteTableIdentifier4.getTablePath();
-    assert (res.equals("storePath/databaseName/tableName"));
+    Assert.assertTrue(res.equals("storePath/databaseName/tableName"));
   }
 
   @Test public void fromTablePathTest() {
     AbsoluteTableIdentifier absoluteTableIdentifierTest =
         AbsoluteTableIdentifier.from("storePath/databaseName/tableName", "databaseName", "tableName");
-    assert (absoluteTableIdentifierTest.getTablePath()
+    Assert.assertTrue(absoluteTableIdentifierTest.getTablePath()
         .equals(absoluteTableIdentifier4.getTablePath()));
   }
 

--- a/core/src/test/java/org/apache/carbondata/core/carbon/CarbonTableIdentifierTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/carbon/CarbonTableIdentifierTest.java
@@ -18,6 +18,7 @@ package org.apache.carbondata.core.carbon;
 
 import org.apache.carbondata.core.metadata.CarbonTableIdentifier;
 
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -33,64 +34,64 @@ public class CarbonTableIdentifierTest {
 
   @Test public void equalsTestWithSameObject() {
     Boolean res = carbonTableIdentifier.equals(carbonTableIdentifier);
-    assert (res);
+    Assert.assertTrue(res);
   }
 
   @Test public void equalsTestWithSimilarObject() {
     CarbonTableIdentifier carbonTableIdentifierTest =
         new CarbonTableIdentifier("DatabseName", "tableName", "tableId");
     Boolean res = carbonTableIdentifier.equals(carbonTableIdentifierTest);
-    assert (res);
+    Assert.assertTrue(res);
   }
 
   @Test public void equalsTestWithNullrObject() {
     Boolean res = carbonTableIdentifier.equals(carbonTableIdentifier2);
-    assert (!res);
+    Assert.assertTrue(!res);
   }
 
   @Test public void equalsTestWithStringrObject() {
     Boolean res = carbonTableIdentifier.equals("different class object");
-    assert (!res);
+    Assert.assertTrue(!res);
   }
 
   @Test public void equalsTestWithoutDatabaseName() {
     CarbonTableIdentifier carbonTableIdentifierTest =
         new CarbonTableIdentifier(null, "tableName", "tableId");
     Boolean res = carbonTableIdentifierTest.equals(carbonTableIdentifier);
-    assert (!res);
+    Assert.assertTrue(!res);
   }
 
   @Test public void equalsTestWithoutTableId() {
     CarbonTableIdentifier carbonTableIdentifierTest =
         new CarbonTableIdentifier("DatabseName", "tableName", null);
     Boolean res = carbonTableIdentifierTest.equals(carbonTableIdentifier);
-    assert (!res);
+    Assert.assertTrue(!res);
   }
 
   @Test public void equalsTestWithDifferentTableId() {
     CarbonTableIdentifier carbonTableIdentifierTest =
         new CarbonTableIdentifier("DatabseName", "tableName", "diffTableId");
     Boolean res = carbonTableIdentifierTest.equals(carbonTableIdentifier);
-    assert (!res);
+    Assert.assertTrue(!res);
   }
 
   @Test public void equalsTestWithNullTableName() {
     CarbonTableIdentifier carbonTableIdentifierTest =
         new CarbonTableIdentifier("DatabseName", null, "tableId");
     Boolean res = carbonTableIdentifierTest.equals(carbonTableIdentifier);
-    assert (!res);
+    Assert.assertTrue(!res);
   }
 
   @Test public void equalsTestWithDifferentTableName() {
     CarbonTableIdentifier carbonTableIdentifierTest =
         new CarbonTableIdentifier("DatabseName", "diffTableName", "tableId");
     Boolean res = carbonTableIdentifierTest.equals(carbonTableIdentifier);
-    assert (!res);
+    Assert.assertTrue(!res);
   }
 
   @Test public void toStringTest() {
     String res = carbonTableIdentifier.toString();
     System.out.printf("sfdsdf " + res);
-    assert (res.equals("DatabseName_tableName"));
+    Assert.assertTrue(res.equals("DatabseName_tableName"));
   }
 }

--- a/core/src/test/java/org/apache/carbondata/core/carbon/ColumnIdentifierTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/carbon/ColumnIdentifierTest.java
@@ -19,6 +19,7 @@ package org.apache.carbondata.core.carbon;
 import org.apache.carbondata.core.metadata.ColumnIdentifier;
 import org.apache.carbondata.core.metadata.datatype.DataTypes;
 
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -46,43 +47,43 @@ public class ColumnIdentifierTest {
 
   @Test public void equalsTestwithSameObject() {
     Boolean res = columnIdentifier.equals(columnIdentifier);
-    assert (res);
+    Assert.assertTrue(res);
   }
 
   @Test public void equalsTestwithSimilarObject() {
     ColumnIdentifier columnIdentifierTest =
         new ColumnIdentifier("columnId", columnProperties, DataTypes.INT);
     Boolean res = columnIdentifier.equals(columnIdentifierTest);
-    assert (res);
+    Assert.assertTrue(res);
   }
 
   @Test public void equalsTestwithNullObject() {
     Boolean res = columnIdentifier.equals(null);
-    assert (!res);
+    Assert.assertTrue(!res);
   }
 
   @Test public void equalsTestwithStringObject() {
     Boolean res = columnIdentifier.equals("String Object");
-    assert (!res);
+    Assert.assertTrue(!res);
   }
 
   @Test public void equalsTestwithNullColumnId() {
     ColumnIdentifier columnIdentifierTest =
         new ColumnIdentifier(null, columnProperties, DataTypes.INT);
     Boolean res = columnIdentifierTest.equals(columnIdentifier);
-    assert (!res);
+    Assert.assertTrue(!res);
   }
 
   @Test public void equalsTestwithDiffColumnId() {
     ColumnIdentifier columnIdentifierTest =
         new ColumnIdentifier("diffColumnId", columnProperties, DataTypes.INT);
     Boolean res = columnIdentifierTest.equals(columnIdentifier);
-    assert (!res);
+    Assert.assertTrue(!res);
   }
 
   @Test public void toStringTest() {
     String res = columnIdentifier.toString();
-    assert (res.equals("ColumnIdentifier [columnId=columnId]"));
+    Assert.assertTrue(res.equals("ColumnIdentifier [columnId=columnId]"));
   }
 
   @Test public void getColumnPropertyTest() {
@@ -93,6 +94,6 @@ public class ColumnIdentifierTest {
   }
 
   @Test public void getColumnPropertyTestwithNull() {
-    assert (columnIdentifier.getColumnProperty("key").equals("value"));
+    Assert.assertTrue(columnIdentifier.getColumnProperty("key").equals("value"));
   }
 }

--- a/core/src/test/java/org/apache/carbondata/core/datastore/block/BlockInfoTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/datastore/block/BlockInfoTest.java
@@ -17,6 +17,8 @@
 package org.apache.carbondata.core.datastore.block;
 
 import org.apache.carbondata.core.metadata.ColumnarFormatVersion;
+
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -38,51 +40,51 @@ public class BlockInfoTest {
 
   @Test public void equalsTestwithSameObject() {
     Boolean res = blockInfo.equals(blockInfo);
-    assert (res);
+    Assert.assertTrue(res);
   }
 
   @Test public void equalsTestWithSimilarObject() {
     BlockInfo blockInfoTest =
         new BlockInfo(new TableBlockInfo("/filePath.carbondata", 6, "segmentId", null, 6, ColumnarFormatVersion.V1, null));
     Boolean res = blockInfo.equals(blockInfoTest);
-    assert (res);
+    Assert.assertTrue(res);
   }
 
   @Test public void equalsTestWithNullObject() {
     Boolean res = blockInfo.equals(null);
-    assert (!res);
+    Assert.assertTrue(!res);
   }
 
   @Test public void equalsTestWithStringObject() {
     Boolean res = blockInfo.equals("dummy");
-    assert (!res);
+    Assert.assertTrue(!res);
   }
 
   @Test public void equalsTestWithDifferentSegmentId() {
     BlockInfo blockInfoTest =
         new BlockInfo(new TableBlockInfo("/filePath.carbondata", 6, "diffSegmentId", null, 6, ColumnarFormatVersion.V1, null));
     Boolean res = blockInfo.equals(blockInfoTest);
-    assert (!res);
+    Assert.assertTrue(!res);
   }
 
   @Test public void equalsTestWithDifferentOffset() {
     BlockInfo blockInfoTest =
         new BlockInfo(new TableBlockInfo("/filePath.carbondata", 62, "segmentId", null, 6, ColumnarFormatVersion.V1, null));
     Boolean res = blockInfo.equals(blockInfoTest);
-    assert (!res);
+    Assert.assertTrue(!res);
   }
 
   @Test public void equalsTestWithDifferentBlockLength() {
     BlockInfo blockInfoTest =
         new BlockInfo(new TableBlockInfo("/filePath.carbondata", 6, "segmentId", null, 62, ColumnarFormatVersion.V1, null));
     Boolean res = blockInfo.equals(blockInfoTest);
-    assert (!res);
+    Assert.assertTrue(!res);
   }
 
   @Test public void equalsTestWithDiffFilePath() {
     BlockInfo blockInfoTest =
         new BlockInfo(new TableBlockInfo("/diffFilePath.carbondata", 6, "segmentId", null, 62, ColumnarFormatVersion.V1, null));
     Boolean res = blockInfoTest.equals(blockInfo);
-    assert (!res);
+    Assert.assertTrue(!res);
   }
 }

--- a/core/src/test/java/org/apache/carbondata/core/datastore/block/TableBlockInfoTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/datastore/block/TableBlockInfoTest.java
@@ -22,6 +22,7 @@ import mockit.MockUp;
 import org.apache.carbondata.core.metadata.ColumnarFormatVersion;
 import org.apache.carbondata.core.util.path.CarbonTablePath;
 
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -39,55 +40,55 @@ public class TableBlockInfoTest {
 
   @Test public void equalTestWithSameObject() {
     Boolean res = tableBlockInfo.equals(tableBlockInfo);
-    assert (res);
+    Assert.assertTrue(res);
   }
 
   @Test public void equalTestWithSimilarObject() {
     TableBlockInfo tableBlockInfoTest = new TableBlockInfo("filePath", 4, "segmentId", null, 6, ColumnarFormatVersion.V1, null);
     Boolean res = tableBlockInfo.equals(tableBlockInfoTest);
-    assert (res);
+    Assert.assertTrue(res);
   }
 
   @Test public void equalTestWithNullObject() {
     Boolean res = tableBlockInfo.equals(null);
-    assert (!res);
+    Assert.assertTrue(!res);
   }
 
   @Test public void equalTestWithStringObject() {
     Boolean res = tableBlockInfo.equals("dummyObject");
-    assert (!res);
+    Assert.assertTrue(!res);
   }
 
   @Test public void equlsTestWithDiffSegmentId() {
     TableBlockInfo tableBlockInfoTest = new TableBlockInfo("filePath", 4, "diffsegmentId", null, 6, ColumnarFormatVersion.V1, null);
     Boolean res = tableBlockInfo.equals(tableBlockInfoTest);
-    assert (!res);
+    Assert.assertTrue(!res);
   }
 
   @Test public void equlsTestWithDiffBlockOffset() {
     TableBlockInfo tableBlockInfoTest = new TableBlockInfo("filePath", 6, "segmentId", null, 6, ColumnarFormatVersion.V1, null);
     Boolean res = tableBlockInfo.equals(tableBlockInfoTest);
-    assert (!res);
+    Assert.assertTrue(!res);
   }
 
   @Test public void equalsTestWithDiffBlockLength() {
     TableBlockInfo tableBlockInfoTest = new TableBlockInfo("filePath", 4, "segmentId", null, 4, ColumnarFormatVersion.V1, null);
     Boolean res = tableBlockInfo.equals(tableBlockInfoTest);
-    assert (!res);
+    Assert.assertTrue(!res);
   }
 
   @Test public void equalsTestWithDiffBlockletNumber() {
     TableBlockInfo tableBlockInfoTest =
         new TableBlockInfo("filepath", 6, "segmentId", null, 6, new BlockletInfos(6, 3, 2), ColumnarFormatVersion.V1, null);
     Boolean res = tableBlockInfos.equals(tableBlockInfoTest);
-    assert (!res);
+    Assert.assertTrue(!res);
   }
 
   @Test public void equalsTestWithDiffFilePath() {
     TableBlockInfo tableBlockInfoTest =
         new TableBlockInfo("difffilepath", 6, "segmentId", null, 6, new BlockletInfos(6, 3, 2), ColumnarFormatVersion.V1, null);
     Boolean res = tableBlockInfos.equals(tableBlockInfoTest);
-    assert (!res);
+    Assert.assertTrue(!res);
   }
 
   @Test public void compareToTestForSegmentId() {

--- a/core/src/test/java/org/apache/carbondata/core/datastore/block/TableTaskInfoTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/datastore/block/TableTaskInfoTest.java
@@ -17,6 +17,8 @@
 package org.apache.carbondata.core.datastore.block;
 
 import org.apache.carbondata.core.metadata.ColumnarFormatVersion;
+
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -44,7 +46,7 @@ public class TableTaskInfoTest {
   @Test public void getLocationsTest() {
     String locations[] = { "loc1", "loc2", "loc3", "loc4", "loc5" };
     String res[] = tableTaskInfo.getLocations();
-    assert (Arrays.equals(locations, res));
+    Assert.assertTrue(Arrays.equals(locations, res));
   }
 
   @Test public void maxNoNodesTest() {
@@ -56,7 +58,7 @@ public class TableTaskInfoTest {
     locs.add("loc5");
 
     List<String> res = TableTaskInfo.maxNoNodes(tableBlockInfoList);
-    assert (res.equals(locs));
+    Assert.assertTrue(res.equals(locs));
   }
 
   @Test public void maxNoNodesTestForElse() {
@@ -73,6 +75,6 @@ public class TableTaskInfoTest {
     tableBlockInfoListTest.add(1, new TableBlockInfo("filePath", 2, "segmentID", locations1, 6, ColumnarFormatVersion.V1, null));
 
     List<String> res = TableTaskInfo.maxNoNodes(tableBlockInfoListTest);
-    assert (res.equals(locs));
+    Assert.assertTrue(res.equals(locs));
   }
 }

--- a/core/src/test/java/org/apache/carbondata/core/datastore/chunk/impl/ColumnGroupDimensionDataChunkTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/datastore/chunk/impl/ColumnGroupDimensionDataChunkTest.java
@@ -30,6 +30,8 @@ import org.apache.carbondata.core.keygenerator.mdkey.MultiDimKeyVarLengthGenerat
 import org.apache.carbondata.core.util.CarbonUtil;
 import org.apache.carbondata.core.scan.executor.infos.KeyStructureInfo;
 import org.apache.carbondata.core.scan.executor.util.QueryUtil;
+
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -69,7 +71,7 @@ public class ColumnGroupDimensionDataChunkTest {
   @Test public void getChunkDataTest() {
     byte[] b = { 34, 2 };
     byte res[] = columnGroupDimensionDataChunk.getChunkData(1);
-    assert (Arrays.equals(res, b));
+    Assert.assertTrue(Arrays.equals(res, b));
   }
 
   @Test public void fillConvertedChunkDataTest() {
@@ -80,7 +82,7 @@ public class ColumnGroupDimensionDataChunkTest {
     KeyStructureInfo keyStructureInfo = getKeyStructureInfo(ordinals, keyGenerator);
     keyStructureInfo.setMdkeyQueryDimensionOrdinal(new int[] { 2 });
     int res = columnGroupDimensionDataChunk.fillConvertedChunkData(2, 2, row, keyStructureInfo);
-    assert (Arrays.equals(row, expected));
+    Assert.assertTrue(Arrays.equals(row, expected));
   }
 
   /**

--- a/core/src/test/java/org/apache/carbondata/core/datastore/chunk/impl/FixedLengthDimensionDataChunkTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/datastore/chunk/impl/FixedLengthDimensionDataChunkTest.java
@@ -22,6 +22,8 @@ import static org.junit.Assert.assertEquals;
 import java.util.Arrays;
 
 import org.apache.carbondata.core.scan.executor.infos.KeyStructureInfo;
+
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -54,7 +56,7 @@ public class FixedLengthDimensionDataChunkTest {
   @Test public void getChunkDataTest() {
     byte expected[] = { 121, 32, 115, 116 };
     byte res[] = fixedLengthDimensionDataChunk.getChunkData(0);
-    assert (Arrays.equals(res, expected));
+    Assert.assertTrue(Arrays.equals(res, expected));
   }
 
   @Test public void fillConvertedChunkDataTest() {

--- a/core/src/test/java/org/apache/carbondata/core/keygenerator/columnar/impl/MultiDimKeyVarLengthEquiSplitGeneratorUnitTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/keygenerator/columnar/impl/MultiDimKeyVarLengthEquiSplitGeneratorUnitTest.java
@@ -47,7 +47,7 @@ public class MultiDimKeyVarLengthEquiSplitGeneratorUnitTest {
     byte[][] result_value = new byte[][] { { 16, 8, 24, 46, 76, 64 }, { 80, 36, 72, 48 } };
     byte[] key = new byte[] { 16, 8, 24, 46, 76, 64, 80, 36, 72, 48 };
     byte[][] result = multiDimKeyVarLengthEquiSplitGeneratorNew.splitKey(key);
-    assert (Arrays.deepEquals(result, result_value));
+    Assert.assertTrue(Arrays.deepEquals(result, result_value));
   }
 
   @Test public void testSplitKeyWithNewDimensionToSplitValue16() {
@@ -58,7 +58,7 @@ public class MultiDimKeyVarLengthEquiSplitGeneratorUnitTest {
     byte[][] result_value = new byte[][] { { 16, 8, 24, 46, 76, 64, 80, 36, 72, 48 } };
     byte[] key = new byte[] { 16, 8, 24, 46, 76, 64, 80, 36, 72, 48 };
     byte[][] result = multiDimKeyVarLengthEquiSplitGeneratorNew.splitKey(key);
-    assert (Arrays.deepEquals(result, result_value));
+    Assert.assertTrue(Arrays.deepEquals(result, result_value));
   }
 
   @Test public void testGenerateAndSplitKeyAndGetKeyArrayWithActualLogic() throws KeyGenException {
@@ -76,7 +76,7 @@ public class MultiDimKeyVarLengthEquiSplitGeneratorUnitTest {
         new byte[][] { { 1, 102, 20, 56 }, { 64 }, { 36, 18 }, { 16, 28 }, { 98, 93 } };
     byte[] key = new byte[] { 1, 102, 20, 56, 64, 36, 18, 16, 28, 98, 93 };
     byte[][] result = multiDimKeyVarLengthEquiSplitGenerator.splitKey(key);
-    assert (Arrays.deepEquals(result, result_value));
+    Assert.assertTrue(Arrays.deepEquals(result, result_value));
   }
 
   @Test public void testGetKeyArray() throws Exception {
@@ -90,7 +90,7 @@ public class MultiDimKeyVarLengthEquiSplitGeneratorUnitTest {
     byte[] result_value = new byte[] { 1, 102, 20, 56, 64, 36, 18, 16, 28, 98, 93 };
     byte[][] key = new byte[][] { { 1, 102, 20, 56, 64, 36, 18, 16, 28, 98, 93 } };
     byte[] result = multiDimKeyVarLengthEquiSplitGenerator.getKeyByteArray(key);
-    assert (Arrays.equals(result, result_value));
+    Assert.assertTrue(Arrays.equals(result, result_value));
   }
 
   /*
@@ -158,7 +158,7 @@ public class MultiDimKeyVarLengthEquiSplitGeneratorUnitTest {
   @Test public void testEqualsWithAnyObject() throws Exception {
     Object obj = new Object();
     boolean result = multiDimKeyVarLengthEquiSplitGenerator.equals(obj);
-    assert (!result);
+    Assert.assertTrue(!result);
   }
 
   @Test public void testEqualsWithDifferentValueMultiDimKeyVarLengthEquiSplitGeneratorObject()
@@ -167,7 +167,7 @@ public class MultiDimKeyVarLengthEquiSplitGeneratorUnitTest {
     byte dimensionsToSplit = 2;
     boolean result = multiDimKeyVarLengthEquiSplitGenerator
         .equals(new MultiDimKeyVarLengthEquiSplitGenerator(lens, dimensionsToSplit));
-    assert (!result);
+    Assert.assertTrue(!result);
   }
 
   @Test public void testEqualsWithSameValueMultiDimKeyVarLengthEquiSplitGeneratorObject()
@@ -176,7 +176,7 @@ public class MultiDimKeyVarLengthEquiSplitGeneratorUnitTest {
     byte dimensionsToSplit = 1;
     boolean result = multiDimKeyVarLengthEquiSplitGenerator
         .equals(new MultiDimKeyVarLengthEquiSplitGenerator(lens, dimensionsToSplit));
-    assert (result);
+    Assert.assertTrue(result);
   }
 
   /**
@@ -191,7 +191,7 @@ public class MultiDimKeyVarLengthEquiSplitGeneratorUnitTest {
     byte[][] result_value = new byte[][] { { 16, 8, 24, 46, 76, 64 }, { 80, 36, 72, 48 } };
     byte[] key = new byte[] { 16, 8, 24, 46, 76 };
     byte[][] result = multiDimKeyVarLengthEquiSplitGeneratorNew.splitKey(key);
-    assert (Arrays.deepEquals(result, result_value));
+    Assert.assertTrue(Arrays.deepEquals(result, result_value));
   }
 
 }

--- a/core/src/test/java/org/apache/carbondata/core/scan/executor/util/QueryUtilTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/scan/executor/util/QueryUtilTest.java
@@ -29,6 +29,7 @@ import junit.framework.TestCase;
 import mockit.Mock;
 import mockit.MockUp;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -135,14 +136,14 @@ public class QueryUtilTest extends TestCase {
     int[] dummyArray = { 1, 2, 3, 4, 5 };
     int searchInput = 6;
     boolean result = QueryUtil.searchInArray(dummyArray, searchInput);
-    assert (!result);
+    Assert.assertTrue(!result);
   }
 
   @Test public void testSearchInArrayWithSearchInputPresentInArray() {
     int[] dummyArray = { 1, 2, 3, 4, 5 };
     int searchInput = 1;
     boolean result = QueryUtil.searchInArray(dummyArray, searchInput);
-    assert (result);
+    Assert.assertTrue(result);
   }
 
   @Test public void testGetColumnGroupIdWhenOrdinalValueNotPresentInArrayIndex() {

--- a/core/src/test/java/org/apache/carbondata/core/scan/filter/FilterExpressionProcessorTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/scan/filter/FilterExpressionProcessorTest.java
@@ -19,6 +19,7 @@ import org.apache.carbondata.core.scan.expression.LiteralExpression;
 import org.apache.carbondata.core.scan.expression.conditional.InExpression;
 import org.apache.carbondata.core.scan.filter.intf.ExpressionType;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -60,7 +61,7 @@ public class FilterExpressionProcessorTest extends AbstractDictionaryCacheTest {
     Object result = method
         .invoke(filterExpressionProcessor, ExpressionType.EQUALS, false, equalToExpression, null,
             null);
-    assert (result.getClass().getName()
+    Assert.assertTrue(result.getClass().getName()
         .equals("org.apache.carbondata.core.scan.filter.resolver.ConditionalFilterResolverImpl"));
   }
 }

--- a/core/src/test/java/org/apache/carbondata/core/scan/filter/executer/IncludeFilterExecuterImplTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/scan/filter/executer/IncludeFilterExecuterImplTest.java
@@ -21,6 +21,8 @@ import java.util.BitSet;
 import org.apache.carbondata.core.datastore.chunk.DimensionColumnDataChunk;
 import org.apache.carbondata.core.datastore.chunk.impl.FixedLengthDimensionDataChunk;
 import org.apache.carbondata.core.util.CarbonUtil;
+
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -200,7 +202,7 @@ public class IncludeFilterExecuterImplTest extends TestCase {
     }
 
     if (filteredValueCnt >= 100) {
-      assert(newTime <= oldTime);
+      Assert.assertTrue(newTime <= oldTime);
     }
 
     System.out.println("old code performance time: " + oldTime + " ms");

--- a/core/src/test/java/org/apache/carbondata/core/scan/result/BatchResultTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/scan/result/BatchResultTest.java
@@ -22,6 +22,7 @@ import java.util.NoSuchElementException;
 
 import mockit.Mock;
 import mockit.MockUp;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -42,7 +43,7 @@ public class BatchResultTest {
     BatchResult rows = new BatchResult();
     rows.setRows(rowsList);
     Object[] result = rows.next();
-    assert (result.equals(rowsList.get(0)));
+    Assert.assertTrue(result.equals(rowsList.get(0)));
   }
 
   @Test(expected = NoSuchElementException.class) public void testNextWithNoSuchElementException() {
@@ -69,7 +70,7 @@ public class BatchResultTest {
     list.add(1, new Integer[] { 1, 2 });
     batchResult.setRows(list);
     boolean result = batchResult.hasNext();
-    assert (result);
+    Assert.assertTrue(result);
   }
 
   @Test public void testGetRawRow() {
@@ -77,7 +78,7 @@ public class BatchResultTest {
     list.add(0, new Integer[] { 1, 2 });
     batchResult.setRows(list);
     Object[] actualValue = batchResult.getRawRow(0);
-    assert (list.get(0) == actualValue);
+    Assert.assertTrue(list.get(0) == actualValue);
   }
 
   @Test public void testGetSize() {

--- a/core/src/test/java/org/apache/carbondata/core/scan/wrappers/ByteArrayWrapperTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/scan/wrappers/ByteArrayWrapperTest.java
@@ -17,6 +17,7 @@
 package org.apache.carbondata.core.scan.wrappers;
 
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -46,7 +47,7 @@ public class ByteArrayWrapperTest {
     byteArrayWrapper.setNoDictionaryKeys(noDictionaryKeys);
 
     int result = byteArrayWrapper.hashCode();
-    assert (29583456 == result);
+    Assert.assertTrue(29583456 == result);
   }
 
   @Test public void testEqualsWithOtherAsInstanceOfByteArrayWrapper() {

--- a/core/src/test/java/org/apache/carbondata/core/util/CarbonUtilTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/util/CarbonUtilTest.java
@@ -50,6 +50,7 @@ import mockit.Mock;
 import mockit.MockUp;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -1012,36 +1013,36 @@ public class CarbonUtilTest {
   public void testSplitSchemaStringToMapWithLessThanSplitLen() {
     String schema = generateString(399);
     Map<String, String> map = CarbonUtil.splitSchemaStringToMap(schema);
-    assert (map.size() == 2);
+    Assert.assertTrue(map.size() == 2);
     String schemaString = CarbonUtil.splitSchemaStringToMultiString(" ", "'", ",", schema);
-    assert (schemaString.length() > schema.length());
+    Assert.assertTrue(schemaString.length() > schema.length());
   }
 
   @Test
   public void testSplitSchemaStringToMapWithEqualThanSplitLen() {
     String schema = generateString(4000);
     Map<String, String> map = CarbonUtil.splitSchemaStringToMap(schema);
-    assert (map.size() == 2);
+    Assert.assertTrue(map.size() == 2);
     String schemaString = CarbonUtil.splitSchemaStringToMultiString(" ", "'", ",", schema);
-    assert (schemaString.length() > schema.length());
+    Assert.assertTrue(schemaString.length() > schema.length());
   }
 
   @Test
   public void testSplitSchemaStringToMapWithMoreThanSplitLen() {
     String schema = generateString(7999);
     Map<String, String> map = CarbonUtil.splitSchemaStringToMap(schema);
-    assert (map.size() == 3);
+    Assert.assertTrue(map.size() == 3);
     String schemaString = CarbonUtil.splitSchemaStringToMultiString(" ", "'", ",", schema);
-    assert (schemaString.length() > schema.length());
+    Assert.assertTrue(schemaString.length() > schema.length());
   }
 
   @Test
   public void testSplitSchemaStringToMapWithMultiplesOfSplitLen() {
     String schema = generateString(12000);
     Map<String, String> map = CarbonUtil.splitSchemaStringToMap(schema);
-    assert (map.size() == 4);
+    Assert.assertTrue(map.size() == 4);
     String schemaString = CarbonUtil.splitSchemaStringToMultiString(" ", "'", ",", schema);
-    assert (schemaString.length() > schema.length());
+    Assert.assertTrue(schemaString.length() > schema.length());
   }
 
   private String generateString(int length) {

--- a/core/src/test/java/org/apache/carbondata/core/util/DataTypeUtilTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/util/DataTypeUtilTest.java
@@ -24,6 +24,7 @@ import org.apache.carbondata.core.metadata.datatype.DataTypes;
 import org.apache.carbondata.core.metadata.schema.table.column.CarbonMeasure;
 import org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import static junit.framework.TestCase.assertEquals;
@@ -100,19 +101,19 @@ public class DataTypeUtilTest {
   @Test public void testGetDataBasedOnDataTypeForNoDictionaryColumn() {
     Object result = DataTypeUtil.getDataBasedOnDataTypeForNoDictionaryColumn(new byte[0],
         DataTypes.INT);
-    assert (result == null);
+    Assert.assertTrue(result == null);
     result = DataTypeUtil.getDataBasedOnDataTypeForNoDictionaryColumn(new byte[0],
         DataTypes.SHORT);
-    assert (result == null);
+    Assert.assertTrue(result == null);
     result = DataTypeUtil.getDataBasedOnDataTypeForNoDictionaryColumn(new byte[0],
         DataTypes.LONG);
-    assert (result == null);
+    Assert.assertTrue(result == null);
     result = DataTypeUtil.getDataBasedOnDataTypeForNoDictionaryColumn(new byte[0],
         DataTypes.TIMESTAMP);
-    assert (result == null);
+    Assert.assertTrue(result == null);
     result = DataTypeUtil.getDataBasedOnDataTypeForNoDictionaryColumn(new byte[0],
         DataTypes.STRING);
-    assert (result != null);
+    Assert.assertTrue(result != null);
   }
 
 }

--- a/hadoop/src/test/java/org/apache/carbondata/hadoop/ft/CarbonTableOutputFormatTest.java
+++ b/hadoop/src/test/java/org/apache/carbondata/hadoop/ft/CarbonTableOutputFormatTest.java
@@ -62,7 +62,7 @@ public class CarbonTableOutputFormatTest {
     runJob("");
     String segmentPath = CarbonTablePath.getSegmentPath(carbonLoadModel.getTablePath(), "0");
     File file = new File(segmentPath);
-    assert (file.exists());
+    Assert.assertTrue(file.exists());
     File[] listFiles = file.listFiles(new FilenameFilter() {
       @Override public boolean accept(File dir, String name) {
         return name.endsWith(".carbondata") ||
@@ -71,7 +71,7 @@ public class CarbonTableOutputFormatTest {
       }
     });
 
-    assert (listFiles.length == 2);
+    Assert.assertTrue(listFiles.length == 2);
   }
 
   @After


### PR DESCRIPTION
Java native assertion is affected by JVM parameter `-ea/-da`. It only
works with `-ea` specified. So we should replace it with Junit assertion
which always behaves the same.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 `NO`
 - [x] Any backward compatibility impacted?
  `NO`
 - [x] Document update required?
 `NO`
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
 `NO, only fix bugs in tests`
        - How it is tested? Please attach test report.
 `Tested in local node`
        - Is it a performance related change? Please attach the performance test report.
 `NO, only fix bugs in tests`
        - Any additional information to help reviewers in testing this change.
 `NO`
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
`Not related`
