### PR TITLE
[CARBONDATA-2020][Old Store Support] Add filter support for old store reading to improve query performance

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMap.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMap.java
@@ -659,8 +659,12 @@ public class BlockletDataMap implements DataMap, Cacheable {
       byte[][] minValue, String filePath, int blockletId) {
     BitSet bitSet = null;
     if (filterExecuter instanceof ImplicitColumnFilterExecutor) {
-      String uniqueBlockPath = filePath.substring(filePath.lastIndexOf("/Part") + 1)
-          + CarbonCommonConstants.FILE_SEPARATOR + blockletId;
+      String uniqueBlockPath = filePath.substring(filePath.lastIndexOf("/Part") + 1);
+      // this case will come in case of old store where index file does not contain the
+      // blocklet information
+      if (blockletId != -1) {
+        uniqueBlockPath = uniqueBlockPath + CarbonCommonConstants.FILE_SEPARATOR + blockletId;
+      }
       bitSet = ((ImplicitColumnFilterExecutor) filterExecuter)
           .isFilterValuesPresentInBlockOrBlocklet(maxValue, minValue, uniqueBlockPath);
     } else {

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataRefNodeWrapper.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataRefNodeWrapper.java
@@ -31,6 +31,7 @@ import org.apache.carbondata.core.datastore.chunk.reader.DimensionColumnChunkRea
 import org.apache.carbondata.core.datastore.chunk.reader.MeasureColumnChunkReader;
 import org.apache.carbondata.core.indexstore.BlockletDetailInfo;
 import org.apache.carbondata.core.metadata.ColumnarFormatVersion;
+import org.apache.carbondata.core.metadata.blocklet.index.BlockletIndex;
 
 /**
  * wrapper for blocklet data map data
@@ -91,11 +92,25 @@ public class BlockletDataRefNodeWrapper implements DataRefNode {
     return blockInfos.get(index).getDetailInfo().getBlockletId().toString();
   }
 
-  @Override public byte[][] getColumnsMaxValue() {
+  @Override
+  public byte[][] getColumnsMaxValue() {
+    BlockletIndex blockletIndex =
+        blockInfos.get(index).getDetailInfo().getBlockletInfo().getBlockletIndex();
+    // In case of blocklet distribution this will be null
+    if (null != blockletIndex) {
+      return blockletIndex.getMinMaxIndex().getMaxValues();
+    }
     return null;
   }
 
-  @Override public byte[][] getColumnsMinValue() {
+  @Override
+  public byte[][] getColumnsMinValue() {
+    BlockletIndex blockletIndex =
+        blockInfos.get(index).getDetailInfo().getBlockletInfo().getBlockletIndex();
+    // In case of blocklet distribution this will be null
+    if (null != blockletIndex) {
+      return blockletIndex.getMinMaxIndex().getMinValues();
+    }
     return null;
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/ImplicitIncludeFilterExecutorImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/ImplicitIncludeFilterExecutorImpl.java
@@ -70,7 +70,12 @@ public class ImplicitIncludeFilterExecutorImpl
     BitSet bitSet = new BitSet(1);
     boolean isScanRequired = false;
     String shortBlockId = CarbonTablePath.getShortBlockId(uniqueBlockPath);
-    if (dimColumnEvaluatorInfo.getFilterValues().getImplicitColumnFilterList()
+    if (uniqueBlockPath.endsWith(".carbondata")) {
+      if (dimColumnEvaluatorInfo.getFilterValues().getImplicitDriverColumnFilterList()
+          .contains(shortBlockId)) {
+        isScanRequired = true;
+      }
+    } else if (dimColumnEvaluatorInfo.getFilterValues().getImplicitColumnFilterList()
         .contains(shortBlockId)) {
       isScanRequired = true;
     }

--- a/core/src/main/java/org/apache/carbondata/core/scan/scanner/impl/FilterScanner.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/scanner/impl/FilterScanner.java
@@ -29,6 +29,7 @@ import org.apache.carbondata.core.datastore.page.ColumnPage;
 import org.apache.carbondata.core.scan.executor.infos.BlockExecutionInfo;
 import org.apache.carbondata.core.scan.expression.exception.FilterUnsupportedException;
 import org.apache.carbondata.core.scan.filter.executer.FilterExecuter;
+import org.apache.carbondata.core.scan.filter.executer.ImplicitColumnFilterExecutor;
 import org.apache.carbondata.core.scan.processor.BlocksChunkHolder;
 import org.apache.carbondata.core.scan.result.AbstractScannedResult;
 import org.apache.carbondata.core.scan.result.impl.FilterQueryScannedResult;
@@ -107,9 +108,20 @@ public class FilterScanner extends AbstractBlockletScanner {
         totalPagesScanned.getCount() + blocksChunkHolder.getDataBlock().numberOfPages());
     // apply min max
     if (isMinMaxEnabled) {
-      BitSet bitSet = this.filterExecuter
-          .isScanRequired(blocksChunkHolder.getDataBlock().getColumnsMaxValue(),
-              blocksChunkHolder.getDataBlock().getColumnsMinValue());
+      BitSet bitSet = null;
+      // check for implicit include filter instance
+      if (filterExecuter instanceof ImplicitColumnFilterExecutor) {
+        String blockletId = blockExecutionInfo.getBlockId() + CarbonCommonConstants.FILE_SEPARATOR
+            + blocksChunkHolder.getDataBlock().blockletId();
+        bitSet = ((ImplicitColumnFilterExecutor) filterExecuter)
+            .isFilterValuesPresentInBlockOrBlocklet(
+                blocksChunkHolder.getDataBlock().getColumnsMaxValue(),
+                blocksChunkHolder.getDataBlock().getColumnsMinValue(), blockletId);
+      } else {
+        bitSet = this.filterExecuter
+            .isScanRequired(blocksChunkHolder.getDataBlock().getColumnsMaxValue(),
+                blocksChunkHolder.getDataBlock().getColumnsMinValue());
+      }
       if (bitSet.isEmpty()) {
         CarbonUtil.freeMemory(blocksChunkHolder.getDimensionRawDataChunk(),
             blocksChunkHolder.getMeasureRawDataChunk());


### PR DESCRIPTION
**Problem**
For old stores blocklet level min/max comparison was not happening in the executor side due to which all the blocklets were getting scanned. This increased the IO and scanning time in the executor.

**Solution**
Modified code to retrieve the min/max value from blocklet node and use it for comparsion while scanning for valid blocklets.

**Note:** This PR need to be merged after #1796 

 - [ ] Any interfaces changed?
 No
 - [ ] Any backward compatibility impacted?
 No
 - [ ] Document update required?
No
 - [ ] Testing done
Yes. Manually verified       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA
