### PR TITLE
[HOTFIX] Listeners not getting registered to the bus in CarbonSessionState Implementations

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datamap/TableDataMap.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/TableDataMap.java
@@ -36,7 +36,7 @@ import org.apache.carbondata.events.OperationEventListener;
  * DataMap at the table level, user can add any number of datamaps for one table. Depends
  * on the filter condition it can prune the blocklets.
  */
-public final class TableDataMap implements OperationEventListener {
+public final class TableDataMap extends OperationEventListener {
 
   private AbsoluteTableIdentifier identifier;
 
@@ -163,7 +163,7 @@ public final class TableDataMap implements OperationEventListener {
     return dataMapFactory;
   }
 
-  @Override public void onEvent(Event event, OperationContext opContext) {
+  @Override public void onEvent(Event event, OperationContext opContext) throws Exception {
     dataMapFactory.fireEvent(event);
   }
 

--- a/core/src/main/java/org/apache/carbondata/events/OperationEventListener.java
+++ b/core/src/main/java/org/apache/carbondata/events/OperationEventListener.java
@@ -19,7 +19,7 @@ package org.apache.carbondata.events;
 /**
  * Event listener interface which describes the possible events
  */
-public interface OperationEventListener {
+public abstract class OperationEventListener {
 
   /**
    * Called on a specified event occurrence
@@ -27,5 +27,22 @@ public interface OperationEventListener {
    * @param event
    * @param operationContext
    */
-  void onEvent(Event event, OperationContext operationContext) throws Exception;
+  protected abstract void onEvent(Event event, OperationContext operationContext) throws Exception;
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == null || !(obj instanceof OperationEventListener)) {
+      return false;
+    }
+    return getComparisonName().equals(((OperationEventListener) obj).getComparisonName());
+  }
+
+  private String getComparisonName() {
+    return getClass().getName();
+  }
+
+  @Override
+  public int hashCode() {
+    return getClass().hashCode();
+  }
 }

--- a/core/src/main/java/org/apache/carbondata/events/OperationListenerBus.java
+++ b/core/src/main/java/org/apache/carbondata/events/OperationListenerBus.java
@@ -37,7 +37,7 @@ public class OperationListenerBus {
   /**
    * Event map to hold all listeners corresponding to an event
    */
-  protected Map<String, List<OperationEventListener>> eventMap =
+  protected Map<String, CopyOnWriteArrayList<OperationEventListener>> eventMap =
       new ConcurrentHashMap<>(CarbonCommonConstants.DEFAULT_COLLECTION_SIZE);
 
   /**
@@ -57,12 +57,13 @@ public class OperationListenerBus {
       OperationEventListener operationEventListener) {
 
     String eventType = eventClass.getName();
-    List<OperationEventListener> operationEventListeners = eventMap.get(eventType);
+    CopyOnWriteArrayList<OperationEventListener> operationEventListeners = eventMap.get(eventType);
     if (null == operationEventListeners) {
       operationEventListeners = new CopyOnWriteArrayList<>();
       eventMap.put(eventType, operationEventListeners);
     }
-    operationEventListeners.add(operationEventListener);
+    // addIfAbsent will only add the listener if it is not already present in the List.
+    operationEventListeners.addIfAbsent(operationEventListener);
     return INSTANCE;
   }
 

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
@@ -21,6 +21,7 @@ import java.util.concurrent.ConcurrentHashMap
 
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException
+import org.apache.spark.sql.execution.command.preaaggregate._
 import org.apache.spark.sql.execution.command.timeseries.TimeSeriesFunction
 import org.apache.spark.sql.hive._
 
@@ -30,7 +31,8 @@ import org.apache.carbondata.core.datastore.impl.FileFactory
 import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable
 import org.apache.carbondata.core.util._
-import org.apache.carbondata.events.{CarbonEnvInitPreEvent, OperationContext, OperationListenerBus}
+import org.apache.carbondata.events._
+import org.apache.carbondata.processing.loading.events.LoadEvents.{LoadTablePreExecutionEvent, LoadTablePreStatusUpdateEvent}
 import org.apache.carbondata.spark.rdd.SparkReadSupport
 import org.apache.carbondata.spark.readsupport.SparkRowReadSupportImpl
 
@@ -121,6 +123,26 @@ object CarbonEnv {
       }
       carbonEnv
     }
+  }
+
+  /**
+   * Method to initialize Listeners to their respective events in the OperationListenerBus.
+   */
+  def initListeners(): Unit = {
+    OperationListenerBus.getInstance()
+      .addListener(classOf[LoadTablePreStatusUpdateEvent], LoadPostAggregateListener)
+      .addListener(classOf[DeleteSegmentByIdPreEvent], PreAggregateDeleteSegmentByIdPreListener)
+      .addListener(classOf[DeleteSegmentByDatePreEvent], PreAggregateDeleteSegmentByDatePreListener)
+      .addListener(classOf[UpdateTablePreEvent], UpdatePreAggregatePreListener)
+      .addListener(classOf[DeleteFromTablePreEvent], DeletePreAggregatePreListener)
+      .addListener(classOf[DeleteFromTablePreEvent], DeletePreAggregatePreListener)
+      .addListener(classOf[AlterTableDropColumnPreEvent], PreAggregateDropColumnPreListener)
+      .addListener(classOf[AlterTableRenamePreEvent], PreAggregateRenameTablePreListener)
+      .addListener(classOf[AlterTableDataTypeChangePreEvent], PreAggregateDataTypeChangePreListener)
+      .addListener(classOf[AlterTableAddColumnPreEvent], PreAggregateAddColumnsPreListener)
+      .addListener(classOf[LoadTablePreExecutionEvent], LoadPreAggregateTablePreListener)
+      .addListener(classOf[AlterTableCompactionPreStatusUpdateEvent],
+        AlterPreAggregateTableCompactionPostListener)
   }
 
   /**

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSession.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSession.scala
@@ -24,18 +24,13 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.scheduler.{SparkListener, SparkListenerApplicationEnd}
 import org.apache.spark.sql.SparkSession.Builder
-import org.apache.spark.sql.execution.command.preaaggregate._
 import org.apache.spark.sql.execution.streaming.CarbonStreamingQueryListener
 import org.apache.spark.sql.hive.execution.command.CarbonSetCommand
 import org.apache.spark.sql.internal.{SessionState, SharedState}
 import org.apache.spark.util.{CarbonReflectionUtils, Utils}
 
-import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.util.{CarbonProperties, CarbonSessionInfo, ThreadLocalSessionInfo}
-import org.apache.carbondata.events._
-import org.apache.carbondata.processing.loading.events.LoadEvents.{LoadTablePreExecutionEvent, LoadTablePreStatusUpdateEvent}
-import org.apache.carbondata.spark.util.CommonUtil
 
 /**
  * Session implementation for {org.apache.spark.sql.SparkSession}
@@ -74,10 +69,6 @@ class CarbonSession(@transient val sc: SparkContext,
 
   override def newSession(): SparkSession = {
     new CarbonSession(sparkContext, Some(sharedState))
-  }
-
-  if (existingSharedState.isEmpty) {
-    CarbonSession.initListeners()
   }
 
 }
@@ -247,20 +238,4 @@ object CarbonSession {
     ThreadLocalSessionInfo.setCarbonSessionInfo(carbonSessionInfo)
   }
 
-  def initListeners(): Unit = {
-    OperationListenerBus.getInstance()
-      .addListener(classOf[LoadTablePreStatusUpdateEvent], LoadPostAggregateListener)
-      .addListener(classOf[DeleteSegmentByIdPreEvent], PreAggregateDeleteSegmentByIdPreListener)
-      .addListener(classOf[DeleteSegmentByDatePreEvent], PreAggregateDeleteSegmentByDatePreListener)
-      .addListener(classOf[UpdateTablePreEvent], UpdatePreAggregatePreListener)
-      .addListener(classOf[DeleteFromTablePreEvent], DeletePreAggregatePreListener)
-      .addListener(classOf[DeleteFromTablePreEvent], DeletePreAggregatePreListener)
-      .addListener(classOf[AlterTableDropColumnPreEvent], PreAggregateDropColumnPreListener)
-      .addListener(classOf[AlterTableRenamePreEvent], PreAggregateRenameTablePreListener)
-      .addListener(classOf[AlterTableDataTypeChangePreEvent], PreAggregateDataTypeChangePreListener)
-      .addListener(classOf[AlterTableAddColumnPreEvent], PreAggregateAddColumnsPreListener)
-      .addListener(classOf[LoadTablePreExecutionEvent], LoadPreAggregateTablePreListener)
-      .addListener(classOf[AlterTableCompactionPreStatusUpdateEvent],
-        AlterPreAggregateTableCompactionPostListener)
-  }
 }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/datamap/CarbonDropDataMapCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/datamap/CarbonDropDataMapCommand.scala
@@ -36,7 +36,6 @@ import org.apache.carbondata.core.metadata.converter.ThriftWrapperSchemaConverte
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable
 import org.apache.carbondata.events._
 
-
 /**
  * Drops the datamap and any related tables associated with the datamap
  * @param dataMapName
@@ -80,7 +79,6 @@ case class CarbonDropDataMapCommand(
         val dataMapSchema = carbonTable.get.getTableInfo.getDataMapSchemaList.asScala.zipWithIndex.
           find(_._1.getDataMapName.equalsIgnoreCase(dataMapName))
         if (dataMapSchema.isDefined) {
-
           val operationContext = new OperationContext
           val dropDataMapPreEvent =
             DropDataMapPreEvent(
@@ -97,16 +95,13 @@ case class CarbonDropDataMapCommand(
               carbonTable.get.getTableInfo,
               dbName,
               tableName))(sparkSession)
-          if (dataMapSchema.isDefined) {
-            if (dataMapSchema.get._1.getRelationIdentifier != null) {
-              commandToRun = CarbonDropTableCommand(
-                ifExistsSet = true,
-                Some(dataMapSchema.get._1.getRelationIdentifier.getDatabaseName),
-                dataMapSchema.get._1.getRelationIdentifier.getTableName,
-                dropChildTable = true)
-              commandToRun.processMetadata(sparkSession)
-            }
-          }
+          commandToRun = CarbonDropTableCommand(
+            ifExistsSet = true,
+            Some(dataMapSchema.get._1.getRelationIdentifier.getDatabaseName),
+            dataMapSchema.get._1.getRelationIdentifier.getTableName,
+            dropChildTable = true
+          )
+          commandToRun.processMetadata(sparkSession)
           // fires the event after dropping datamap from main table schema
           val dropDataMapPostEvent =
             DropDataMapPostEvent(

--- a/integration/spark2/src/main/spark2.1/CarbonSessionState.scala
+++ b/integration/spark2/src/main/spark2.1/CarbonSessionState.scala
@@ -75,6 +75,9 @@ class CarbonSessionCatalog(
     env
   }
 
+  // Initialize all listeners to the Operation bus.
+  CarbonEnv.initListeners()
+
   /**
    * This method will invalidate carbonrelation from cache if carbon table is updated in
    * carbon catalog

--- a/integration/spark2/src/main/spark2.2/CarbonSessionState.scala
+++ b/integration/spark2/src/main/spark2.2/CarbonSessionState.scala
@@ -91,6 +91,9 @@ class CarbonSessionCatalog(
     carbonEnv
   }
 
+  // Initialize all listeners to the Operation bus.
+  CarbonEnv.initListeners()
+
 
   private def refreshRelationFromCache(identifier: TableIdentifier): Boolean = {
     var isRefreshed = false


### PR DESCRIPTION
**Problem:** Listeners are not getting registered if you create a new implementation of CarbonSessionState and add it to spark using configuration. In this case CarbonSession would not be created and thus listeners are not registered.

**Solution:** Register listeners in CarbonSessionState instead of CarbonSession.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 
 - [x] Any backward compatibility impacted?
 
 - [x] Document update required?

 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

