### PR TITLE
[CARBONDATA-2046]agg Query failed when non supported aggregate is present in Query

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggregateTableSelection.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggregateTableSelection.scala
@@ -285,6 +285,20 @@ test("test PreAggregate table selection with timeseries and normal together") {
     preAggTableValidator(df.queryExecution.analyzed, "maintabletime_agg1_year")
 
   }
+
+  test("test table selection when unsupported aggregate function is present") {
+    sql("drop table if exists maintabletime")
+    sql(
+      "create table maintabletime(year int,month int,name string,salary int,dob string) stored" +
+      " by 'carbondata' tblproperties('sort_scope'='Global_sort','table_blocksize'='23'," +
+      "'sort_columns'='month,year,name')")
+    sql("insert into maintabletime select 10,11,'x',12,'2014-01-01 00:00:00'")
+    sql(
+      "create datamap agg0 on table maintabletime using 'preaggregate' as select name,sum(salary) from " +
+      "maintabletime group by name")
+
+    sql("select var_samp(name) from maintabletime  where name='Mikka' ")
+  }
   override def afterAll: Unit = {
     sql("drop table if exists mainTable")
     sql("drop table if exists lineitem")


### PR DESCRIPTION
Root Cause :- isValidPlan variable was getting overwritten by CarbonReflectionUtils.hasPredicateSubquery(expression) . 

Solution :- CarbonReflectionUtils.hasPredicateSubquery(expression) method should be called when isValidPlan  is true to avoid overwritten.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed? NO
 
 - [ ] Any backward compatibility impacted? NO
 
 - [ ] Document update required?
NO
 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
     Added UI 
   - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.  
 NA
        - Any additional information to help reviewers in testing this change.
      NA 
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA
