### PR TITLE
[CARBONDATA-2032][DataLoad] directly write carbon data files to HDFS

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonLoadOptionConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonLoadOptionConstants.java
@@ -134,4 +134,9 @@ public final class CarbonLoadOptionConstants {
    * row delimiter for each sort column bounds
    */
   public static final String SORT_COLUMN_BOUNDS_ROW_DELIMITER = ";";
+
+  @CarbonProperty
+  public static final String ENABLE_CARBON_LOAD_DIRECT_WRITE_HDFS
+      = "carbon.load.directWriteHdfs.enabled";
+  public static final String ENABLE_CARBON_LOAD_DIRECT_WRITE_HDFS_DEFAULT = "false";
 }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/AbstractDFSCarbonFile.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/AbstractDFSCarbonFile.java
@@ -357,7 +357,8 @@ public abstract class AbstractDFSCarbonFile implements CarbonFile {
     }
   }
 
-  @Override public DataOutputStream getDataOutputStream(String path, FileFactory.FileType fileType)
+  @Override
+  public DataOutputStream getDataOutputStream(String path, FileFactory.FileType fileType)
       throws IOException {
     path = path.replace("\\", "/");
     Path pt = new Path(path);
@@ -365,15 +366,26 @@ public abstract class AbstractDFSCarbonFile implements CarbonFile {
     return fs.create(pt, true);
   }
 
-  @Override public DataOutputStream getDataOutputStream(String path, FileFactory.FileType fileType,
+  @Override
+  public DataOutputStream getDataOutputStream(String path, FileFactory.FileType fileType,
       int bufferSize, long blockSize) throws IOException {
     path = path.replace("\\", "/");
     Path pt = new Path(path);
-    FileSystem fs = pt.getFileSystem(FileFactory.getConfiguration());
-    return fs.create(pt, true, bufferSize, fs.getDefaultReplication(pt), blockSize);
+    short replication = pt.getFileSystem(FileFactory.getConfiguration()).getDefaultReplication(pt);
+    return getDataOutputStream(path, fileType, bufferSize, blockSize, replication);
   }
 
-  @Override public DataOutputStream getDataOutputStream(String path, FileFactory.FileType fileType,
+  @Override
+  public DataOutputStream getDataOutputStream(String path, FileFactory.FileType fileType,
+      int bufferSize, long blockSize, short replication) throws IOException {
+    path = path.replace("\\", "/");
+    Path pt = new Path(path);
+    FileSystem fs = pt.getFileSystem(FileFactory.getConfiguration());
+    return fs.create(pt, true, bufferSize, replication, blockSize);
+  }
+
+  @Override
+  public DataOutputStream getDataOutputStream(String path, FileFactory.FileType fileType,
       int bufferSize, String compressor) throws IOException {
     path = path.replace("\\", "/");
     Path pt = new Path(path);
@@ -518,7 +530,8 @@ public abstract class AbstractDFSCarbonFile implements CarbonFile {
    */
   protected abstract CarbonFile[] getFiles(FileStatus[] listStatus);
 
-  @Override public String[] getLocations() throws IOException {
+  @Override
+  public String[] getLocations() throws IOException {
     BlockLocation[] blkLocations;
     if (fileStatus instanceof LocatedFileStatus) {
       blkLocations = ((LocatedFileStatus)fileStatus).getBlockLocations();
@@ -528,5 +541,21 @@ public abstract class AbstractDFSCarbonFile implements CarbonFile {
     }
 
     return blkLocations[0].getHosts();
+  }
+
+  @Override
+  public boolean setReplication(String filePath, short replication) throws IOException {
+    filePath = filePath.replace("\\", "/");
+    Path path = new Path(filePath);
+    FileSystem fs = path.getFileSystem(FileFactory.getConfiguration());
+    return fs.setReplication(path, replication);
+  }
+
+  @Override
+  public short getDefaultReplication(String filePath) throws IOException {
+    filePath = filePath.replace("\\", "/");
+    Path path = new Path(filePath);
+    FileSystem fs = path.getFileSystem(FileFactory.getConfiguration());
+    return fs.getDefaultReplication(path);
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/CarbonFile.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/CarbonFile.java
@@ -106,6 +106,18 @@ public interface CarbonFile {
 
   /**
    * get data output stream
+   * @param path file path
+   * @param fileType file type
+   * @param bufferSize write buffer size
+   * @param blockSize block size
+   * @param replication replication for this file
+   * @return data output stream
+   * @throws IOException if error occurs
+   */
+  DataOutputStream getDataOutputStream(String path, FileFactory.FileType fileType, int bufferSize,
+      long blockSize, short replication) throws IOException;
+  /**
+   * get data output stream
    * @param path
    * @param fileType
    * @param bufferSize
@@ -141,4 +153,21 @@ public interface CarbonFile {
    */
   String[] getLocations() throws IOException;
 
+  /**
+   * set the replication factor for this file
+   *
+   * @param filePath file path
+   * @param replication replication
+   * @return true, if success; false, if failed
+   * @throws IOException if error occurs
+   */
+  boolean setReplication(String filePath, short replication) throws IOException;
+
+  /**
+   * get the default replication for this file
+   * @param filePath file path
+   * @return replication factor
+   * @throws IOException if error occurs
+   */
+  short getDefaultReplication(String filePath) throws IOException;
 }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/LocalCarbonFile.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/LocalCarbonFile.java
@@ -309,21 +309,30 @@ public class LocalCarbonFile implements CarbonFile {
     return new DataInputStream(new BufferedInputStream(fis));
   }
 
-  @Override public DataOutputStream getDataOutputStream(String path, FileFactory.FileType fileType)
+  @Override
+  public DataOutputStream getDataOutputStream(String path, FileFactory.FileType fileType)
       throws IOException {
     path = path.replace("\\", "/");
     path = FileFactory.getUpdatedFilePath(path, FileFactory.FileType.LOCAL);
     return new DataOutputStream(new BufferedOutputStream(new FileOutputStream(path)));
   }
 
-  @Override public DataOutputStream getDataOutputStream(String path, FileFactory.FileType fileType,
+  @Override
+  public DataOutputStream getDataOutputStream(String path, FileFactory.FileType fileType,
       int bufferSize, long blockSize) throws IOException {
+    return getDataOutputStream(path, fileType, bufferSize, blockSize, (short) 1);
+  }
+
+  @Override
+  public DataOutputStream getDataOutputStream(String path, FileFactory.FileType fileType,
+      int bufferSize, long blockSize, short replication) throws IOException {
     path = path.replace("\\", "/");
     path = FileFactory.getUpdatedFilePath(path, fileType);
     return new DataOutputStream(new BufferedOutputStream(new FileOutputStream(path), bufferSize));
   }
 
-  @Override public DataOutputStream getDataOutputStream(String path, FileFactory.FileType fileType,
+  @Override
+  public DataOutputStream getDataOutputStream(String path, FileFactory.FileType fileType,
       int bufferSize, String compressor) throws IOException {
     path = path.replace("\\", "/");
     path = FileFactory.getUpdatedFilePath(path, fileType);
@@ -425,5 +434,16 @@ public class LocalCarbonFile implements CarbonFile {
 
   @Override public String[] getLocations() throws IOException {
     return new String[]{"localhost"};
+  }
+
+  @Override
+  public boolean setReplication(String filePath, short replication) throws IOException {
+    // local carbon file does not need replication
+    return true;
+  }
+
+  @Override
+  public short getDefaultReplication(String filePath) throws IOException {
+    return 1;
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/impl/FileFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/impl/FileFactory.java
@@ -151,6 +151,21 @@ public final class FileFactory {
   }
 
   /**
+   * get data output stream
+   * @param path file path
+   * @param fileType file type
+   * @param bufferSize write buffer size
+   * @param blockSize block size
+   * @param replication replication
+   * @return data output stream
+   * @throws IOException if error occurs
+   */
+  public static DataOutputStream getDataOutputStream(String path, FileType fileType, int bufferSize,
+      long blockSize, short replication) throws IOException {
+    return getCarbonFile(path).getDataOutputStream(path, fileType, bufferSize, blockSize,
+        replication);
+  }
+  /**
    * get data out put stream
    * @param path
    * @param fileType
@@ -457,4 +472,30 @@ public final class FileFactory {
     }
   }
 
+  /**
+   * set the file replication
+   *
+   * @param path file path
+   * @param fileType file type
+   * @param replication replication
+   * @return true, if success; false, if failed
+   * @throws IOException if error occurs
+   */
+  public static boolean setReplication(String path, FileFactory.FileType fileType,
+      short replication) throws IOException {
+    return getCarbonFile(path, fileType).setReplication(path, replication);
+  }
+
+  /**
+   * get the default replication
+   *
+   * @param path file path
+   * @param fileType file type
+   * @return replication
+   * @throws IOException if error occurs
+   */
+  public static short getDefaultReplication(String path, FileFactory.FileType fileType)
+      throws IOException {
+    return getCarbonFile(path, fileType).getDefaultReplication(path);
+  }
 }

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
@@ -2448,6 +2448,33 @@ public final class CarbonUtil {
   }
 
   /**
+   * This method will complete the remaining hdfs replications
+   *
+   * @param fileName hdfs file name
+   * @param fileType filetype
+   * @throws CarbonDataWriterException if error occurs
+   */
+  public static void completeRemainingHdfsReplicas(String fileName, FileFactory.FileType fileType)
+    throws CarbonDataWriterException {
+    try {
+      long startTime = System.currentTimeMillis();
+      short replication = FileFactory.getDefaultReplication(fileName, fileType);
+      if (1 == replication) {
+        return;
+      }
+      boolean replicateFlag = FileFactory.setReplication(fileName, fileType, replication);
+      if (!replicateFlag) {
+        LOGGER.error("Failed to set replication for " + fileName + " with factor " + replication);
+      }
+      LOGGER.info(
+          "Total copy time (ms) to copy file " + fileName + " is " + (System.currentTimeMillis()
+              - startTime));
+    } catch (IOException e) {
+      throw new CarbonDataWriterException("Problem while completing remaining HDFS backups", e);
+    }
+  }
+
+  /**
    * This method will read the local carbon data file and write to carbon data file in HDFS
    *
    * @param carbonStoreFilePath

--- a/hadoop/src/test/java/org/apache/carbondata/hadoop/test/util/StoreCreator.java
+++ b/hadoop/src/test/java/org/apache/carbondata/hadoop/test/util/StoreCreator.java
@@ -432,30 +432,6 @@ public class StoreCreator {
 
     writeLoadMetadata(loadModel.getCarbonDataLoadSchema(), loadModel.getTableName(), loadModel.getTableName(),
         new ArrayList<LoadMetadataDetails>());
-
-    String segLocation =
-        storeLocation + "/" + databaseName + "/" + tableName + "/Fact/Part0/Segment_0";
-    File file = new File(segLocation);
-    File factFile = null;
-    File[] folderList = file.listFiles();
-    File folder = null;
-    for (int i = 0; i < folderList.length; i++) {
-      if (folderList[i].isDirectory()) {
-        folder = folderList[i];
-      }
-    }
-    if (folder.isDirectory()) {
-      File[] files = folder.listFiles();
-      for (int i = 0; i < files.length; i++) {
-        if (!files[i].isDirectory() && files[i].getName().startsWith("part")) {
-          factFile = files[i];
-          break;
-        }
-      }
-      //      Files.copy(factFile.toPath(), file.toPath(), REPLACE_EXISTING);
-      factFile.renameTo(new File(segLocation + "/" + factFile.getName()));
-      CarbonUtil.deleteFoldersAndFiles(folder);
-    }
   }
 
   public static void writeLoadMetadata(CarbonDataLoadSchema schema, String databaseName,

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/dataload/TestLoadDataGeneral.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/dataload/TestLoadDataGeneral.scala
@@ -29,7 +29,7 @@ import org.apache.carbondata.core.datastore.impl.FileFactory
 import org.apache.carbondata.core.metadata.CarbonMetadata
 import org.apache.spark.sql.test.util.QueryTest
 
-import org.apache.carbondata.core.constants.CarbonCommonConstants
+import org.apache.carbondata.core.constants.{CarbonCommonConstants, CarbonLoadOptionConstants}
 import org.apache.carbondata.core.util.CarbonProperties
 
 class TestLoadDataGeneral extends QueryTest with BeforeAndAfterEach {
@@ -242,6 +242,24 @@ class TestLoadDataGeneral extends QueryTest with BeforeAndAfterEach {
     checkAnswer(sql("select * from stale"), Row("k"))
   }
 
+  test("test data loading with directly writing fact data to hdfs") {
+    val originStatus = CarbonProperties.getInstance().getProperty(
+      CarbonLoadOptionConstants.ENABLE_CARBON_LOAD_DIRECT_WRITE_HDFS,
+      CarbonLoadOptionConstants.ENABLE_CARBON_LOAD_DIRECT_WRITE_HDFS_DEFAULT)
+    CarbonProperties.getInstance().addProperty(
+      CarbonLoadOptionConstants.ENABLE_CARBON_LOAD_DIRECT_WRITE_HDFS, "true")
+
+    val testData = s"$resourcesPath/sample.csv"
+    sql(s"LOAD DATA LOCAL INPATH '$testData' into table loadtest")
+    checkAnswer(
+      sql("SELECT COUNT(*) FROM loadtest"),
+      Seq(Row(6))
+    )
+
+    CarbonProperties.getInstance().addProperty(
+      CarbonLoadOptionConstants.ENABLE_CARBON_LOAD_DIRECT_WRITE_HDFS,
+      originStatus)
+  }
   override def afterEach {
     sql("DROP TABLE if exists loadtest")
     sql("drop table if exists invalidMeasures")

--- a/processing/src/main/java/org/apache/carbondata/processing/util/CarbonLoaderUtil.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/util/CarbonLoaderUtil.java
@@ -63,6 +63,7 @@ import org.apache.carbondata.processing.merger.NodeMultiBlockRelation;
 import static org.apache.carbondata.core.enums.EscapeSequences.*;
 
 import com.google.gson.Gson;
+import org.apache.commons.lang3.StringUtils;
 
 public final class CarbonLoaderUtil {
 
@@ -957,9 +958,13 @@ public final class CarbonLoaderUtil {
             infos.add(block);
             nodeCapacity++;
             if (LOGGER.isDebugEnabled()) {
-              LOGGER.debug(
-                  "First Assignment iteration: " + ((TableBlockInfo) block).getFilePath() + '-'
-                      + ((TableBlockInfo) block).getBlockLength() + "-->" + activeExecutor);
+              try {
+                LOGGER.debug("First Assignment iteration: block("
+                    + StringUtils.join(block.getLocations(), ", ")
+                    + ")-->" + activeExecutor);
+              } catch (IOException e) {
+                LOGGER.error(e);
+              }
             }
             remainingBlocks.remove(block);
           } else {

--- a/processing/src/test/java/org/apache/carbondata/processing/StoreCreator.java
+++ b/processing/src/test/java/org/apache/carbondata/processing/StoreCreator.java
@@ -406,29 +406,6 @@ public class StoreCreator {
 
     writeLoadMetadata(loadModel.getCarbonDataLoadSchema(), loadModel.getTableName(), loadModel.getTableName(),
         new ArrayList<LoadMetadataDetails>());
-
-    String segLocation =
-        storeLocation + "/" + databaseName + "/" + tableName + "/Fact/Part0/Segment_0";
-    File file = new File(segLocation);
-    File factFile = null;
-    File[] folderList = file.listFiles();
-    File folder = null;
-    for (int i = 0; i < folderList.length; i++) {
-      if (folderList[i].isDirectory()) {
-        folder = folderList[i];
-      }
-    }
-    if (folder.isDirectory()) {
-      File[] files = folder.listFiles();
-      for (int i = 0; i < files.length; i++) {
-        if (!files[i].isDirectory() && files[i].getName().startsWith("part")) {
-          factFile = files[i];
-          break;
-        }
-      }
-      factFile.renameTo(new File(segLocation + "/" + factFile.getName()));
-      CarbonUtil.deleteFoldersAndFiles(folder);
-    }
   }
 
   public static void writeLoadMetadata(CarbonDataLoadSchema schema, String databaseName,


### PR DESCRIPTION
Currently in data loading, carbondata write the final data files to local disk and then copy it to HDFS.
For saving disk IO, carbondata can skip this procedure and directly write these files to HDFS.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 `Only internal interfaces has been changed`
 - [x] Any backward compatibility impacted?
 `No`
 - [x] Document update required?
`No`
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
`No`
        - How it is tested? Please attach test report.
`Tested in local node and a 3-nodes cluster`
        - Is it a performance related change? Please attach the performance test report.
`Yes. The disk IO has been decreased by 11% and the data loading performance has not been affected.`
        - Any additional information to help reviewers in testing this change.
`No`
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
`Not related`
