### PR TITLE
[CARBONDATA-2051] Added like query ends with and contains with filter push down suport to carbondata

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/filterexpr/AllDataTypesTestCaseFilter.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/filterexpr/AllDataTypesTestCaseFilter.scala
@@ -52,6 +52,18 @@ class AllDataTypesTestCaseFilter extends QueryTest with BeforeAndAfterAll {
       sql("select empno,empname from alldatatypestableFilter where regexp_replace(workgroupcategoryname, 'er', 'ment') != 'development'"),
       sql("select empno,empname from alldatatypestableFilter_hive where regexp_replace(workgroupcategoryname, 'er', 'ment') != 'development'"))
   }
+
+  test("verify like query ends with filter push down") {
+    val df = sql("select * from alldatatypestableFilter where empname like '%nandh'").queryExecution
+      .sparkPlan
+    assert(df.metadata.get("PushedFilters").get.contains("CarbonEndsWith"))
+  }
+
+  test("verify like query contains with filter push down") {
+    val df = sql("select * from alldatatypestableFilter where empname like '%nand%'").queryExecution
+      .sparkPlan
+    assert(df.metadata.get("PushedFilters").get.contains("CarbonContainsWith"))
+  }
   
   override def afterAll {
     sql("drop table alldatatypestableFilter")

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonBoundReference.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonBoundReference.scala
@@ -48,3 +48,11 @@ case class CarbonBoundReference(colExp: ColumnExpression, dataType: DataType, nu
 
   override def newInstance(): NamedExpression = throw new UnsupportedOperationException
 }
+
+case class CarbonEndsWith(expr: Expression) extends Filter {
+  override def references: Array[String] = null
+}
+
+case class CarbonContainsWith(expr: Expression) extends Filter {
+  override def references: Array[String] = null
+}

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/strategy/CarbonLateDecodeStrategy.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/strategy/CarbonLateDecodeStrategy.scala
@@ -612,6 +612,10 @@ private[sql] class CarbonLateDecodeStrategy extends SparkStrategy {
         CastExpressionOptimization.checkIfCastCanBeRemove(c)
       case StartsWith(a: Attribute, Literal(v, t)) =>
         Some(sources.StringStartsWith(a.name, v.toString))
+      case c@EndsWith(a: Attribute, Literal(v, t)) =>
+        Some(CarbonEndsWith(c))
+      case c@Contains(a: Attribute, Literal(v, t)) =>
+        Some(CarbonContainsWith(c))
       case others => None
     }
   }


### PR DESCRIPTION
**Problem**
Current like filter with start with expression is only pushed down to carbondata. In case of ends with and contains like filter all the data is given back to spark and then spark applies the filter on it.
This behavior is fine for the queries which has lesser number of queried columns. But as the number of columns and data increases there is performance impact because the data being sent to spark becomes more thereby increasing the IO. 
If like filter is push down then first filter column is read and blocks are pruned. In this cases the data returned to the spark is after applying the filter and only blocklets matching the data are fully read. This reduces IO and increases the query performance.

**Solution**
Modify code to push down like query with ends and contains with filter

 - [ ] Any interfaces changed?
 No
 - [ ] Any backward compatibility impacted?
 No
 - [ ] Document update required?
No
 - [ ] Testing done
Added test case to verify push down is happening
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA
