### PR TITLE
[CARBONDATA-2036] Fix the insert static partition with integer values prefix with 0 not working

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -1299,11 +1299,6 @@ public final class CarbonCommonConstants {
 
   @CarbonProperty
   public static final String CARBON_CUSTOM_BLOCK_DISTRIBUTION = "carbon.custom.block.distribution";
-  public static final String CARBON_CUSTOM_BLOCK_DISTRIBUTION_DEFAULT = "false";
-
-  @CarbonProperty
-  public static final String CARBON_COMBINE_SMALL_INPUT_FILES = "carbon.mergeSmallFileRead.enable";
-  public static final String CARBON_COMBINE_SMALL_INPUT_FILES_DEFAULT = "false";
 
   public static final int DICTIONARY_DEFAULT_CARDINALITY = 1;
   @CarbonProperty
@@ -1404,9 +1399,38 @@ public final class CarbonCommonConstants {
 
   public static final String USE_DISTRIBUTED_DATAMAP_DEFAULT = "false";
 
-  public static final String CARBON_USE_BLOCKLET_DISTRIBUTION = "carbon.blocklet.distribution";
+  /**
+   * This property defines how the tasks are splitted/combined and launch spark tasks during query
+   */
+  @CarbonProperty
+  public static final String CARBON_TASK_DISTRIBUTION = "carbon.task.distribution";
 
-  public static final String CARBON_USE_BLOCKLET_DISTRIBUTION_DEFAULT = "true";
+  /**
+   * It combines the available blocks as per the maximum available tasks in the cluster.
+   */
+  public static final String CARBON_TASK_DISTRIBUTION_CUSTOM = "custom";
+
+  /**
+   * It creates the splits as per the number of blocks/carbondata files available for query.
+   */
+  public static final String CARBON_TASK_DISTRIBUTION_BLOCK = "block";
+
+  /**
+   * It creates the splits as per the number of blocklets available for query.
+   */
+  public static final String CARBON_TASK_DISTRIBUTION_BLOCKLET = "blocklet";
+
+  /**
+   * It merges all the small files and create tasks as per the configurable partition size.
+   */
+  public static final String CARBON_TASK_DISTRIBUTION_MERGE_FILES = "merge_small_files";
+
+  /**
+   * Default task distribution.
+   */
+  public static final String CARBON_TASK_DISTRIBUTION_DEFAULT = CARBON_TASK_DISTRIBUTION_BLOCK;
+
+
   /**
    * The property to configure the mdt file folder path, earlier it was pointing to the
    * fixed carbon store path. This is needed in case of the federation setup when user removes

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/UnsafeMemoryDMStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/UnsafeMemoryDMStore.java
@@ -66,20 +66,24 @@ public class UnsafeMemoryDMStore {
    * @param rowSize
    */
   private void ensureSize(int rowSize) throws MemoryException {
-    if (runningLength + rowSize >= allocatedSize) {
-      MemoryBlock allocate =
-          UnsafeMemoryManager.allocateMemoryWithRetry(taskId, allocatedSize + capacity);
-      getUnsafe().copyMemory(memoryBlock.getBaseObject(), memoryBlock.getBaseOffset(),
-          allocate.getBaseObject(), allocate.getBaseOffset(), runningLength);
-      UnsafeMemoryManager.INSTANCE.freeMemory(taskId, memoryBlock);
-      allocatedSize = allocatedSize + capacity;
-      memoryBlock = allocate;
+    while (runningLength + rowSize >= allocatedSize) {
+      increaseMemory();
     }
     if (this.pointers.length <= rowCount + 1) {
       int[] newPointer = new int[pointers.length + 1000];
       System.arraycopy(pointers, 0, newPointer, 0, pointers.length);
       this.pointers = newPointer;
     }
+  }
+
+  private void increaseMemory() throws MemoryException {
+    MemoryBlock allocate =
+        UnsafeMemoryManager.allocateMemoryWithRetry(taskId, allocatedSize + capacity);
+    getUnsafe().copyMemory(memoryBlock.getBaseObject(), memoryBlock.getBaseOffset(),
+        allocate.getBaseObject(), allocate.getBaseOffset(), runningLength);
+    UnsafeMemoryManager.INSTANCE.freeMemory(taskId, memoryBlock);
+    allocatedSize = allocatedSize + capacity;
+    memoryBlock = allocate;
   }
 
   /**

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/UnsafeMemoryDMStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/UnsafeMemoryDMStore.java
@@ -36,7 +36,7 @@ public class UnsafeMemoryDMStore {
 
   private MemoryBlock memoryBlock;
 
-  private static int capacity = 8 * 1024 * 1024;
+  private static int capacity = 8 * 1024;
 
   private int allocatedSize;
 

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
@@ -35,25 +35,7 @@ import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.constants.CarbonLoadOptionConstants;
 import org.apache.carbondata.core.constants.CarbonV3DataFormatConstants;
 import org.apache.carbondata.core.metadata.ColumnarFormatVersion;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.BLOCKLET_SIZE;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_COMBINE_SMALL_INPUT_FILES;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_CUSTOM_BLOCK_DISTRIBUTION;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_DATA_FILE_VERSION;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_DATE_FORMAT;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_EXECUTOR_STARTUP_TIMEOUT;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_PREFETCH_BUFFERSIZE;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_SORT_FILE_WRITE_BUFFER_SIZE;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.CSV_READ_BUFFER_SIZE;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.ENABLE_AUTO_HANDOFF;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.ENABLE_UNSAFE_SORT;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.ENABLE_VECTOR_READER;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.HANDOFF_SIZE;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.LOCK_TYPE;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.NUM_CORES;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.NUM_CORES_BLOCK_SORT;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.SORT_INTERMEDIATE_FILES_LIMIT;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.SORT_SIZE;
+import static org.apache.carbondata.core.constants.CarbonCommonConstants.*;
 import static org.apache.carbondata.core.constants.CarbonV3DataFormatConstants.BLOCKLET_SIZE_IN_MB;
 import static org.apache.carbondata.core.constants.CarbonV3DataFormatConstants.NUMBER_OF_COLUMN_TO_READ_IN_IO;
 
@@ -151,8 +133,8 @@ public final class CarbonProperties {
       case HANDOFF_SIZE:
         validateHandoffSize();
         break;
-      case CARBON_COMBINE_SMALL_INPUT_FILES:
-        validateCombineSmallInputFiles();
+      case CARBON_TASK_DISTRIBUTION:
+        validateCarbonTaskDistribution();
         break;
       // The method validate the validity of configured carbon.timestamp.format value
       // and reset to default value if validation fail
@@ -199,7 +181,7 @@ public final class CarbonProperties {
     validateLockType();
     validateCarbonCSVReadBufferSizeByte();
     validateHandoffSize();
-    validateCombineSmallInputFiles();
+    validateCarbonTaskDistribution();
     // The method validate the validity of configured carbon.timestamp.format value
     // and reset to default value if validation fail
     validateTimeFormatKey(CARBON_TIMESTAMP_FORMAT,
@@ -361,22 +343,24 @@ public final class CarbonProperties {
     if (!isValidBooleanValue) {
       LOGGER.warn("The custom block distribution value \"" + customBlockDistributionStr
           + "\" is invalid. Using the default value \""
-          + CarbonCommonConstants.CARBON_CUSTOM_BLOCK_DISTRIBUTION_DEFAULT);
-      carbonProperties.setProperty(CARBON_CUSTOM_BLOCK_DISTRIBUTION,
-          CarbonCommonConstants.CARBON_CUSTOM_BLOCK_DISTRIBUTION_DEFAULT);
+          + false);
+      carbonProperties.setProperty(CARBON_CUSTOM_BLOCK_DISTRIBUTION, "false");
     }
   }
 
-  private void validateCombineSmallInputFiles() {
-    String combineSmallInputFilesStr =
-        carbonProperties.getProperty(CARBON_COMBINE_SMALL_INPUT_FILES);
-    boolean isValidBooleanValue = CarbonUtil.validateBoolean(combineSmallInputFilesStr);
-    if (!isValidBooleanValue) {
-      LOGGER.warn("The combine small files value \"" + combineSmallInputFilesStr
+  private void validateCarbonTaskDistribution() {
+    String carbonTaskDistribution = carbonProperties.getProperty(CARBON_TASK_DISTRIBUTION);
+    boolean isValid = carbonTaskDistribution != null && (
+        carbonTaskDistribution.equalsIgnoreCase(CARBON_TASK_DISTRIBUTION_MERGE_FILES)
+            || carbonTaskDistribution.equalsIgnoreCase(CARBON_TASK_DISTRIBUTION_BLOCKLET)
+            || carbonTaskDistribution.equalsIgnoreCase(CARBON_TASK_DISTRIBUTION_BLOCK)
+            || carbonTaskDistribution.equalsIgnoreCase(CARBON_TASK_DISTRIBUTION_CUSTOM));
+    if (!isValid) {
+      LOGGER.warn("The carbon task distribution value \"" + carbonTaskDistribution
           + "\" is invalid. Using the default value \""
-          + CarbonCommonConstants.CARBON_COMBINE_SMALL_INPUT_FILES_DEFAULT);
-      carbonProperties.setProperty(CARBON_COMBINE_SMALL_INPUT_FILES,
-          CarbonCommonConstants.CARBON_COMBINE_SMALL_INPUT_FILES_DEFAULT);
+          + CarbonCommonConstants.CARBON_TASK_DISTRIBUTION_DEFAULT);
+      carbonProperties.setProperty(CARBON_TASK_DISTRIBUTION,
+          CarbonCommonConstants.CARBON_TASK_DISTRIBUTION_DEFAULT);
     }
   }
 

--- a/core/src/test/java/org/apache/carbondata/core/CarbonPropertiesValidationTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/CarbonPropertiesValidationTest.java
@@ -77,7 +77,7 @@ public class CarbonPropertiesValidationTest extends TestCase {
     String valueAfterValidation =
         carbonProperties.getProperty(CarbonCommonConstants.CARBON_CUSTOM_BLOCK_DISTRIBUTION);
     assertTrue(valueBeforeValidation.equals(valueAfterValidation));
-    assertTrue(CarbonCommonConstants.CARBON_CUSTOM_BLOCK_DISTRIBUTION_DEFAULT
+    assertTrue("false"
         .equalsIgnoreCase(valueAfterValidation));
   }
 

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/standardpartition/StandardPartitionTableOverwriteTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/standardpartition/StandardPartitionTableOverwriteTestCase.scala
@@ -176,7 +176,7 @@ class StandardPartitionTableOverwriteTestCase extends QueryTest with BeforeAndAf
 
 
   override def afterAll = {
-//    dropTable
+    dropTable
   }
 
   def dropTable = {

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/standardpartition/StandardPartitionTableOverwriteTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/standardpartition/StandardPartitionTableOverwriteTestCase.scala
@@ -155,9 +155,28 @@ class StandardPartitionTableOverwriteTestCase extends QueryTest with BeforeAndAf
     checkAnswer(sql("select count(*) from weather6"), Seq(Row(2)))
   }
 
+  test("Test overwrite static partition with wrong int value") {
+    sql(
+      """
+        | CREATE TABLE weather7 (type String)
+        | PARTITIONED BY (year int, month int, day int)
+        | STORED BY 'org.apache.carbondata.format'
+      """.stripMargin)
+
+    sql("insert into weather7 partition(year=2014, month=05, day=25) select 'rainy'")
+    sql("insert into weather7 partition(year=2014, month=04, day=23) select 'cloudy'")
+    sql("insert overwrite table weather7 partition(year=2014, month=05, day=25) select 'sunny'")
+    checkExistence(sql("select * from weather7"), true, "sunny")
+    checkAnswer(sql("select count(*) from weather7"), Seq(Row(2)))
+    sql("insert into weather7 partition(year=2014, month, day) select 'rainy1',06,25")
+    sql("insert into weather7 partition(year=2014, month=01, day) select 'rainy2',27")
+    sql("insert into weather7 partition(year=2014, month=01, day=02) select 'rainy3'")
+    checkAnswer(sql("select count(*) from weather7 where month=1"), Seq(Row(2)))
+  }
+
 
   override def afterAll = {
-    dropTable
+//    dropTable
   }
 
   def dropTable = {
@@ -168,6 +187,7 @@ class StandardPartitionTableOverwriteTestCase extends QueryTest with BeforeAndAf
     sql("drop table if exists insertstaticpartitiondynamic")
     sql("drop table if exists partitionallcompaction")
     sql("drop table if exists weather6")
+    sql("drop table if exists weather7")
   }
 
 }

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
@@ -145,7 +145,9 @@ class CarbonScanRDD(
       statistic.addStatistics(QueryStatisticsConstants.BLOCK_ALLOCATION, System.currentTimeMillis)
       statisticRecorder.recordStatisticsForDriver(statistic, queryId)
       statistic = new QueryStatistic()
-
+      val carbonDistribution = CarbonProperties.getInstance().getProperty(
+        CarbonCommonConstants.CARBON_TASK_DISTRIBUTION,
+        CarbonCommonConstants.CARBON_TASK_DISTRIBUTION_DEFAULT)
       // If bucketing is enabled on table then partitions should be grouped based on buckets.
       if (bucketedTable != null) {
         var i = 0
@@ -161,101 +163,106 @@ class CarbonScanRDD(
           i += 1
           result.add(partition)
         }
-      } else if (CarbonProperties.getInstance()
-        .getProperty(CarbonCommonConstants.CARBON_CUSTOM_BLOCK_DISTRIBUTION,
-          CarbonCommonConstants.CARBON_CUSTOM_BLOCK_DISTRIBUTION_DEFAULT).toBoolean) {
-        // create a list of block based on split
-        val blockList = splits.asScala.map(_.asInstanceOf[Distributable])
+      } else {
+        val useCustomDistribution =
+          CarbonProperties.getInstance().getProperty(
+            CarbonCommonConstants.CARBON_CUSTOM_BLOCK_DISTRIBUTION,
+            "false").toBoolean ||
+          carbonDistribution.equalsIgnoreCase(CarbonCommonConstants.CARBON_TASK_DISTRIBUTION_CUSTOM)
+        if (useCustomDistribution) {
+          // create a list of block based on split
+          val blockList = splits.asScala.map(_.asInstanceOf[Distributable])
 
-        // get the list of executors and map blocks to executors based on locality
-        val activeNodes = DistributionUtil.ensureExecutorsAndGetNodeList(blockList, sparkContext)
+          // get the list of executors and map blocks to executors based on locality
+          val activeNodes = DistributionUtil.ensureExecutorsAndGetNodeList(blockList, sparkContext)
 
-        // divide the blocks among the tasks of the nodes as per the data locality
-        val nodeBlockMapping = CarbonLoaderUtil.nodeBlockTaskMapping(blockList.asJava, -1,
-          parallelism, activeNodes.toList.asJava)
-        var i = 0
-        // Create Spark Partition for each task and assign blocks
-        nodeBlockMapping.asScala.foreach { case (node, blockList) =>
-          blockList.asScala.foreach { blocksPerTask =>
-            val splits = blocksPerTask.asScala.map(_.asInstanceOf[CarbonInputSplit])
-            if (blocksPerTask.size() != 0) {
-              val multiBlockSplit =
-                new CarbonMultiBlockSplit(identifier, splits.asJava, Array(node))
-              val partition = new CarbonSparkPartition(id, i, multiBlockSplit)
-              result.add(partition)
-              i += 1
+          // divide the blocks among the tasks of the nodes as per the data locality
+          val nodeBlockMapping = CarbonLoaderUtil.nodeBlockTaskMapping(blockList.asJava, -1,
+            parallelism, activeNodes.toList.asJava)
+          var i = 0
+          // Create Spark Partition for each task and assign blocks
+          nodeBlockMapping.asScala.foreach { case (node, blockList) =>
+            blockList.asScala.foreach { blocksPerTask =>
+              val splits = blocksPerTask.asScala.map(_.asInstanceOf[CarbonInputSplit])
+              if (blocksPerTask.size() != 0) {
+                val multiBlockSplit =
+                  new CarbonMultiBlockSplit(identifier, splits.asJava, Array(node))
+                val partition = new CarbonSparkPartition(id, i, multiBlockSplit)
+                result.add(partition)
+                i += 1
+              }
             }
           }
-        }
-        noOfNodes = nodeBlockMapping.size
-      } else if (CarbonProperties.getInstance().getProperty(
-        CarbonCommonConstants.CARBON_USE_BLOCKLET_DISTRIBUTION,
-        CarbonCommonConstants.CARBON_USE_BLOCKLET_DISTRIBUTION_DEFAULT).toBoolean) {
-        // Use blocklet distribution
-        // Randomize the blocklets for better shuffling
-        Random.shuffle(splits.asScala).zipWithIndex.foreach { splitWithIndex =>
-          val multiBlockSplit =
-            new CarbonMultiBlockSplit(identifier,
-              Seq(splitWithIndex._1.asInstanceOf[CarbonInputSplit]).asJava,
-              splitWithIndex._1.getLocations)
-          val partition = new CarbonSparkPartition(id, splitWithIndex._2, multiBlockSplit)
-          result.add(partition)
-        }
-      } else if (CarbonProperties.getInstance().getProperty(
-        CarbonCommonConstants.CARBON_COMBINE_SMALL_INPUT_FILES,
-        CarbonCommonConstants.CARBON_COMBINE_SMALL_INPUT_FILES_DEFAULT).toBoolean) {
-
-        // sort blocks in reverse order of length
-        val blockSplits = splits
-          .asScala
-          .map(_.asInstanceOf[CarbonInputSplit])
-          .groupBy(f => f.getBlockPath)
-          .map { blockSplitEntry =>
-            new CarbonMultiBlockSplit(identifier,
-              blockSplitEntry._2.asJava,
-              blockSplitEntry._2.flatMap(f => f.getLocations).distinct.toArray)
-          }.toArray.sortBy(_.getLength)(implicitly[Ordering[Long]].reverse)
-
-        val defaultMaxSplitBytes = sessionState(spark).conf.filesMaxPartitionBytes
-        val openCostInBytes = sessionState(spark).conf.filesOpenCostInBytes
-        val defaultParallelism = spark.sparkContext.defaultParallelism
-        val totalBytes = blockSplits.map(_.getLength + openCostInBytes).sum
-        val bytesPerCore = totalBytes / defaultParallelism
-
-        val maxSplitBytes = Math.min(defaultMaxSplitBytes, Math.max(openCostInBytes, bytesPerCore))
-        LOGGER.info(s"Planning scan with bin packing, max size: $maxSplitBytes bytes, " +
-                    s"open cost is considered as scanning $openCostInBytes bytes.")
-
-        val currentFiles = new ArrayBuffer[CarbonMultiBlockSplit]
-        var currentSize = 0L
-
-        def closePartition(): Unit = {
-          if (currentFiles.nonEmpty) {
-            result.add(combineSplits(currentFiles, currentSize, result.size()))
+          noOfNodes = nodeBlockMapping.size
+        } else if (carbonDistribution.equalsIgnoreCase(
+            CarbonCommonConstants.CARBON_TASK_DISTRIBUTION_BLOCKLET)) {
+          // Use blocklet distribution
+          // Randomize the blocklets for better shuffling
+          Random.shuffle(splits.asScala).zipWithIndex.foreach { splitWithIndex =>
+            val multiBlockSplit =
+              new CarbonMultiBlockSplit(identifier,
+                Seq(splitWithIndex._1.asInstanceOf[CarbonInputSplit]).asJava,
+                splitWithIndex._1.getLocations)
+            val partition = new CarbonSparkPartition(id, splitWithIndex._2, multiBlockSplit)
+            result.add(partition)
           }
-          currentFiles.clear()
-          currentSize = 0
-        }
+        } else if (carbonDistribution.equalsIgnoreCase(
+            CarbonCommonConstants.CARBON_TASK_DISTRIBUTION_MERGE_FILES)) {
 
-        blockSplits.foreach { file =>
-          if (currentSize + file.getLength > maxSplitBytes) {
-            closePartition()
+          // sort blocks in reverse order of length
+          val blockSplits = splits
+            .asScala
+            .map(_.asInstanceOf[CarbonInputSplit])
+            .groupBy(f => f.getBlockPath)
+            .map { blockSplitEntry =>
+              new CarbonMultiBlockSplit(identifier,
+                blockSplitEntry._2.asJava,
+                blockSplitEntry._2.flatMap(f => f.getLocations).distinct.toArray)
+            }.toArray.sortBy(_.getLength)(implicitly[Ordering[Long]].reverse)
+
+          val defaultMaxSplitBytes = sessionState(spark).conf.filesMaxPartitionBytes
+          val openCostInBytes = sessionState(spark).conf.filesOpenCostInBytes
+          val defaultParallelism = spark.sparkContext.defaultParallelism
+          val totalBytes = blockSplits.map(_.getLength + openCostInBytes).sum
+          val bytesPerCore = totalBytes / defaultParallelism
+
+          val maxSplitBytes = Math
+            .min(defaultMaxSplitBytes, Math.max(openCostInBytes, bytesPerCore))
+          LOGGER.info(s"Planning scan with bin packing, max size: $maxSplitBytes bytes, " +
+                      s"open cost is considered as scanning $openCostInBytes bytes.")
+
+          val currentFiles = new ArrayBuffer[CarbonMultiBlockSplit]
+          var currentSize = 0L
+
+          def closePartition(): Unit = {
+            if (currentFiles.nonEmpty) {
+              result.add(combineSplits(currentFiles, currentSize, result.size()))
+            }
+            currentFiles.clear()
+            currentSize = 0
           }
-          // Add the given file to the current partition.
-          currentSize += file.getLength + openCostInBytes
-          currentFiles += file
-        }
-        closePartition()
-      } else {
-        // Use block distribution
-        splits.asScala.map(_.asInstanceOf[CarbonInputSplit])
-          .groupBy(f => f.getBlockPath).values.zipWithIndex.foreach { splitWithIndex =>
-          val multiBlockSplit =
-            new CarbonMultiBlockSplit(identifier,
-              splitWithIndex._1.asJava,
-              splitWithIndex._1.flatMap(f => f.getLocations).distinct.toArray)
-          val partition = new CarbonSparkPartition(id, splitWithIndex._2, multiBlockSplit)
-          result.add(partition)
+
+          blockSplits.foreach { file =>
+            if (currentSize + file.getLength > maxSplitBytes) {
+              closePartition()
+            }
+            // Add the given file to the current partition.
+            currentSize += file.getLength + openCostInBytes
+            currentFiles += file
+          }
+          closePartition()
+        } else {
+          // Use block distribution
+          splits.asScala.map(_.asInstanceOf[CarbonInputSplit]).groupBy { f =>
+            f.getSegmentId.concat(f.getBlockPath)
+          }.values.zipWithIndex.foreach { splitWithIndex =>
+            val multiBlockSplit =
+              new CarbonMultiBlockSplit(identifier,
+                splitWithIndex._1.asJava,
+                splitWithIndex._1.flatMap(f => f.getLocations).distinct.toArray)
+            val partition = new CarbonSparkPartition(id, splitWithIndex._2, multiBlockSplit)
+            result.add(partition)
+          }
         }
       }
 

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/CarbonScalaUtil.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/CarbonScalaUtil.scala
@@ -177,9 +177,9 @@ object CarbonScalaUtil {
       return null
     }
     dataType match {
-      case TimestampType =>
+      case TimestampType if timeStampFormat != null =>
         DateTimeUtils.timestampToString(timeStampFormat.parse(value).getTime * 1000)
-      case DateType =>
+      case DateType if dateFormat != null =>
         DateTimeUtils.dateToString(
           (dateFormat.parse(value).getTime / DateTimeUtils.MILLIS_PER_DAY).toInt)
       case ShortType => value.toShort.toString
@@ -233,16 +233,18 @@ object CarbonScalaUtil {
       serializationNullFormat: String,
       badRecordAction: String,
       isEmptyBadRecord: Boolean): Map[String, String] = {
+    val hivedefaultpartition = "__HIVE_DEFAULT_PARTITION__"
     partitionSpec.map{ case (col, pvalue) =>
       // replace special string with empty value.
-      val value = if (pvalue.equals(CarbonCommonConstants.MEMBER_DEFAULT_VAL)) {
+      val value = if (pvalue == null) {
+        hivedefaultpartition
+      } else if (pvalue.equals(CarbonCommonConstants.MEMBER_DEFAULT_VAL)) {
         ""
       } else {
         pvalue
       }
       val carbonColumn = table.getColumnByName(table.getTableName, col.toLowerCase)
       val dataType = CarbonScalaUtil.convertCarbonToSparkDataType(carbonColumn.getDataType)
-      val hivedefaultpartition = "__HIVE_DEFAULT_PARTITION__"
       try {
         if (isEmptyBadRecord && value.length == 0 &&
             badRecordAction.equalsIgnoreCase(LoggerAction.IGNORE.toString) &&

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonLoadDataCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonLoadDataCommand.scala
@@ -243,7 +243,7 @@ case class CarbonLoadDataCommand(
       } catch {
         case CausedBy(ex: NoRetryException) =>
           // update the load entry in table status file for changing the status to marked for delete
-          if (isUpdateTableStatusRequired && !table.isHivePartitionTable) {
+          if (isUpdateTableStatusRequired) {
             CarbonLoaderUtil.updateTableStatusForFailure(carbonLoadModel)
           }
           LOGGER.error(ex, s"Dataload failure for $dbName.$tableName")
@@ -254,7 +254,7 @@ case class CarbonLoadDataCommand(
         case ex: Exception =>
           LOGGER.error(ex)
           // update the load entry in table status file for changing the status to marked for delete
-          if (isUpdateTableStatusRequired && !table.isHivePartitionTable) {
+          if (isUpdateTableStatusRequired) {
             CarbonLoaderUtil.updateTableStatusForFailure(carbonLoadModel)
           }
           LOGGER.audit(s"Dataload failure for $dbName.$tableName. Please check the logs")

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/mutation/CarbonProjectForUpdateCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/mutation/CarbonProjectForUpdateCommand.scala
@@ -143,7 +143,7 @@ private[sql] case class CarbonProjectForUpdateCommand(
         CarbonUpdateUtil.cleanStaleDeltaFiles(carbonTable, e.compactionTimeStamp.toString)
 
       case e: Exception =>
-        LOGGER.error("Exception in update operation" + e)
+        LOGGER.error(e, "Exception in update operation")
         // ****** start clean up.
         // In case of failure , clean all related delete delta files
         CarbonUpdateUtil.cleanStaleDeltaFiles(carbonTable, currentTime + "")

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonMetaStore.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonMetaStore.scala
@@ -182,10 +182,10 @@ object CarbonMetaStoreFactory {
   def createCarbonMetaStore(conf: RuntimeConfig): CarbonMetaStore = {
     val readSchemaFromHiveMetaStore = readSchemaFromHive(conf)
     if (readSchemaFromHiveMetaStore) {
-      LOGGER.info("Hive based carbon metastore is enabled")
+      LOGGER.audit("Hive based carbon metastore is enabled")
       new CarbonHiveMetaStore()
     } else {
-      LOGGER.info("File based carbon metastore is enabled")
+      LOGGER.audit("File based carbon metastore is enabled")
       new CarbonFileMetastore()
     }
   }

--- a/integration/spark2/src/main/spark2.1/CarbonSQLConf.scala
+++ b/integration/spark2/src/main/spark2.1/CarbonSQLConf.scala
@@ -42,11 +42,11 @@ class CarbonSQLConf(sparkSession: SparkSession) {
           CarbonCommonConstants.ENABLE_UNSAFE_SORT_DEFAULT).toBoolean)
     val CARBON_CUSTOM_BLOCK_DISTRIBUTION =
       SQLConfigBuilder(CarbonCommonConstants.CARBON_CUSTOM_BLOCK_DISTRIBUTION)
-        .doc("To enable/ disable carbon custom block distribution.")
-        .booleanConf
+        .doc("To set carbon task distribution.")
+        .stringConf
         .createWithDefault(carbonProperties
-          .getProperty(CarbonCommonConstants.CARBON_CUSTOM_BLOCK_DISTRIBUTION,
-            CarbonCommonConstants.CARBON_CUSTOM_BLOCK_DISTRIBUTION_DEFAULT).toBoolean)
+          .getProperty(CarbonCommonConstants.CARBON_TASK_DISTRIBUTION,
+            CarbonCommonConstants.CARBON_TASK_DISTRIBUTION_DEFAULT))
     val BAD_RECORDS_LOGGER_ENABLE =
       SQLConfigBuilder(CarbonLoadOptionConstants.CARBON_OPTIONS_BAD_RECORDS_LOGGER_ENABLE)
         .doc("To enable/ disable carbon bad record logger.")
@@ -117,8 +117,8 @@ class CarbonSQLConf(sparkSession: SparkSession) {
         CarbonCommonConstants.ENABLE_UNSAFE_SORT_DEFAULT).toBoolean)
     sparkSession.conf.set(CarbonCommonConstants.CARBON_CUSTOM_BLOCK_DISTRIBUTION,
       carbonProperties
-        .getProperty(CarbonCommonConstants.CARBON_CUSTOM_BLOCK_DISTRIBUTION,
-          CarbonCommonConstants.CARBON_CUSTOM_BLOCK_DISTRIBUTION_DEFAULT).toBoolean)
+        .getProperty(CarbonCommonConstants.CARBON_TASK_DISTRIBUTION,
+          CarbonCommonConstants.CARBON_TASK_DISTRIBUTION_DEFAULT))
     sparkSession.conf.set(CarbonLoadOptionConstants.CARBON_OPTIONS_BAD_RECORDS_LOGGER_ENABLE,
       CarbonLoadOptionConstants.CARBON_OPTIONS_BAD_RECORDS_LOGGER_ENABLE_DEFAULT.toBoolean)
     sparkSession.conf.set(CarbonLoadOptionConstants.CARBON_OPTIONS_BAD_RECORDS_ACTION,

--- a/integration/spark2/src/main/spark2.2/CarbonSqlConf.scala
+++ b/integration/spark2/src/main/spark2.2/CarbonSqlConf.scala
@@ -41,11 +41,11 @@ class CarbonSQLConf(sparkSession: SparkSession) {
           CarbonCommonConstants.ENABLE_UNSAFE_SORT_DEFAULT).toBoolean)
     val CARBON_CUSTOM_BLOCK_DISTRIBUTION =
       buildConf(CarbonCommonConstants.CARBON_CUSTOM_BLOCK_DISTRIBUTION)
-        .doc("To enable/ disable carbon custom block distribution.")
-        .booleanConf
+        .doc("To set carbon task distribution.")
+        .stringConf
         .createWithDefault(carbonProperties
-          .getProperty(CarbonCommonConstants.CARBON_CUSTOM_BLOCK_DISTRIBUTION,
-            CarbonCommonConstants.CARBON_CUSTOM_BLOCK_DISTRIBUTION_DEFAULT).toBoolean)
+          .getProperty(CarbonCommonConstants.CARBON_TASK_DISTRIBUTION,
+            CarbonCommonConstants.CARBON_TASK_DISTRIBUTION_DEFAULT))
     val BAD_RECORDS_LOGGER_ENABLE =
       buildConf(CarbonLoadOptionConstants.CARBON_OPTIONS_BAD_RECORDS_LOGGER_ENABLE)
         .doc("To enable/ disable carbon bad record logger.")
@@ -116,8 +116,8 @@ class CarbonSQLConf(sparkSession: SparkSession) {
         CarbonCommonConstants.ENABLE_UNSAFE_SORT_DEFAULT).toBoolean)
     sparkSession.conf.set(CarbonCommonConstants.CARBON_CUSTOM_BLOCK_DISTRIBUTION,
       carbonProperties
-        .getProperty(CarbonCommonConstants.CARBON_CUSTOM_BLOCK_DISTRIBUTION,
-          CarbonCommonConstants.CARBON_CUSTOM_BLOCK_DISTRIBUTION_DEFAULT).toBoolean)
+        .getProperty(CarbonCommonConstants.CARBON_TASK_DISTRIBUTION,
+          CarbonCommonConstants.CARBON_TASK_DISTRIBUTION_DEFAULT))
     sparkSession.conf.set(CarbonLoadOptionConstants.CARBON_OPTIONS_BAD_RECORDS_LOGGER_ENABLE,
       CarbonLoadOptionConstants.CARBON_OPTIONS_BAD_RECORDS_LOGGER_ENABLE_DEFAULT.toBoolean)
     sparkSession.conf.set(CarbonLoadOptionConstants.CARBON_OPTIONS_BAD_RECORDS_ACTION,


### PR DESCRIPTION
When trying to insert overwrite on the static partition with 0 at first on int column has an issue.
Example : 
create table test(d1 string) partition by (c1 int, c2 int, c3 int)
And use insert overwrite table partition(01, 02, 03) select "s1"
 
The above case has a problem as 01 is not converting to an actual integer to partition map file.
Solution : 
Convert the partition values to corresponding datatype value before adding to partition file.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [X] Any interfaces changed?
 
 - [X] Any backward compatibility impacted?
 
 - [X] Document update required?

 - [X] Testing done
       Tests added
       
 - [X] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

