### PR TITLE
[CARBONDATA-2058] Block append data to streaming segment after writing exception

### DIFF
--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/streaming/CarbonStreamRecordWriter.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/streaming/CarbonStreamRecordWriter.java
@@ -319,4 +319,8 @@ public class CarbonStreamRecordWriter extends RecordWriter<Void, Object> {
   public String getFileName() {
     return fileName;
   }
+
+  public void setHasException(boolean hasException) {
+    this.hasException = hasException;
+  }
 }

--- a/streaming/src/main/java/org/apache/carbondata/streaming/segment/StreamSegment.java
+++ b/streaming/src/main/java/org/apache/carbondata/streaming/segment/StreamSegment.java
@@ -248,6 +248,7 @@ public class StreamSegment {
       if (writer != null) {
         LOGGER.error(ex, "Failed to append batch data to stream segment: " +
             writer.getSegmentDir());
+        writer.setHasException(true);
       }
       throw ex;
     } finally {


### PR DESCRIPTION
If  CarbonStreamRecordWriter happened an exception, mark hasException attribute to avoid appending data to the segment.

 - [x] Any interfaces changed?
 no
 - [x] Any backward compatibility impacted?
 no
 - [x] Document update required?
 no
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
         bugfix
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
small changes
