### PR TITLE
[CARBONDATA-2016] Exception displays while executing compaction with alter query

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/scan/executor/util/RestructureUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/executor/util/RestructureUtil.java
@@ -178,8 +178,7 @@ public class RestructureUtil {
     if (isDefaultValueNull(defaultValue)) {
       dictionaryDefaultValue = CarbonCommonConstants.MEMBER_DEFAULT_VAL_SURROGATE_KEY;
     } else {
-      dictionaryDefaultValue =
-          CarbonCommonConstants.MEMBER_DEFAULT_VAL_SURROGATE_KEY + 1;
+      dictionaryDefaultValue = CarbonCommonConstants.MEMBER_DEFAULT_VAL_SURROGATE_KEY + 1;
     }
     return dictionaryDefaultValue;
   }
@@ -285,11 +284,17 @@ public class RestructureUtil {
   public static Object getMeasureDefaultValue(ColumnSchema columnSchema, byte[] defaultValue) {
     Object measureDefaultValue = null;
     if (!isDefaultValueNull(defaultValue)) {
-      String value = null;
+      String value;
       DataType dataType = columnSchema.getDataType();
-      if (dataType == DataTypes.SHORT || dataType == DataTypes.INT || dataType == DataTypes.LONG) {
+      if (dataType == DataTypes.SHORT) {
+        value = new String(defaultValue, Charset.forName(CarbonCommonConstants.DEFAULT_CHARSET));
+        measureDefaultValue = Short.valueOf(value);
+      } else if (dataType == DataTypes.LONG) {
         value = new String(defaultValue, Charset.forName(CarbonCommonConstants.DEFAULT_CHARSET));
         measureDefaultValue = Long.parseLong(value);
+      } else if (dataType == DataTypes.INT) {
+        value = new String(defaultValue, Charset.forName(CarbonCommonConstants.DEFAULT_CHARSET));
+        measureDefaultValue = Integer.parseInt(value);
       } else if (DataTypes.isDecimal(dataType)) {
         BigDecimal decimal = DataTypeUtil.byteToBigDecimal(defaultValue);
         if (columnSchema.getScale() > decimal.scale()) {

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/iud/HorizontalCompactionTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/iud/HorizontalCompactionTestCase.scala
@@ -350,8 +350,39 @@ class HorizontalCompactionTestCase extends QueryTest with BeforeAndAfterAll {
     )
     sql("""drop table dest2""")
   }
+  test("test the compaction after alter command") // As per bug Carbondata-2016
+  {
+      sql(
+        "CREATE TABLE CUSTOMER1 ( C_CUSTKEY INT , C_NAME STRING , C_ADDRESS STRING , C_NATIONKEY INT , C_PHONE STRING , C_ACCTBAL DECIMAL(15,2) , C_MKTSEGMENT STRING , C_COMMENT STRING) stored by 'carbondata'")
 
+      sql(
+        "insert into customer1 values(1,'vandana','noida',1,'123456789',45987.78,'hello','comment')")
 
+      sql(
+        "insert into customer1 values(2,'vandana','noida',2,'123456789',487.78,'hello','comment')")
+
+      sql(
+        " insert into customer1 values(3,'geetika','delhi',3,'123456789',487897.78,'hello','comment')")
+
+      sql(
+        "insert into customer1 values(4,'sangeeta','delhi',3,'123456789',48789.78,'hello','comment')")
+
+      sql(
+        "alter table customer1 add columns (shortfield short) TBLPROPERTIES ('DEFAULT.VALUE.shortfield'='32767')")
+
+      sql(
+        "alter table customer1 add columns (intfield int) TBLPROPERTIES ('DEFAULT.VALUE.intfield'='2147483647')")
+
+      sql(
+        "alter table customer1 add columns (longfield bigint) TBLPROPERTIES ('DEFAULT.VALUE.longfield'='9223372036854775807')")
+
+      sql("alter table customer1 compact 'minor' ").show()
+
+    checkAnswer(sql("select shortfield from customer1"),Seq(Row(32767),Row(32767),Row(32767),Row(32767)))
+    checkAnswer(sql("select intfield from customer1"),Seq(Row(2147483647),Row(2147483647),Row(2147483647),Row(2147483647)))
+    checkAnswer(sql("select longfield from customer1"),Seq(Row(9223372036854775807L),Row(9223372036854775807L),Row(9223372036854775807L),Row(9223372036854775807L)))
+
+  }
   override def afterAll {
     CarbonProperties.getInstance()
       .addProperty(CarbonCommonConstants.ENABLE_VECTOR_READER , "true")
@@ -360,6 +391,7 @@ class HorizontalCompactionTestCase extends QueryTest with BeforeAndAfterAll {
     CarbonProperties.getInstance()
       .addProperty(CarbonCommonConstants.isHorizontalCompactionEnabled , "true")
     sql("""drop table if exists t_carbn01""")
+    sql("""drop table if exists customer1""")
   }
 
 }


### PR DESCRIPTION
**Root Cause**
When we apply the alter table command to add column with default value it is storing it as long object,it is wrongly written in restructure util we should get the value as the same type
as that of datatype of columnschema in restructure util earlier in master branch in restuctureutil class if our data type is long or short or int we are always returning back a long object which is wong due to same reason compaction was failing
if it was applied after alter table add columns command with default value because in sortdatarows there was mismatch between data type and its corresponding value

**Testing:**
1.mvn clean install is passing
2.added new test case for same