### PR TITLE
[CARBONDATA-2061] Check for only valid IN_PROGRESS segments

### DIFF
--- a/processing/src/main/java/org/apache/carbondata/processing/util/CarbonLoaderUtil.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/util/CarbonLoaderUtil.java
@@ -199,10 +199,14 @@ public final class CarbonLoaderUtil {
           // 2. If load or insert into operation is in progress and insert overwrite operation
           // is triggered
           for (LoadMetadataDetails entry : listOfLoadFolderDetails) {
-            if (entry.getSegmentStatus() == SegmentStatus.INSERT_OVERWRITE_IN_PROGRESS) {
+            if (entry.getSegmentStatus() == SegmentStatus.INSERT_OVERWRITE_IN_PROGRESS
+                && segmentStatusManager.checkIfValidLoadInProgress(
+                    absoluteTableIdentifier, entry.getLoadName())) {
               throw new RuntimeException("Already insert overwrite is in progress");
             } else if (newMetaEntry.getSegmentStatus() == SegmentStatus.INSERT_OVERWRITE_IN_PROGRESS
-                && entry.getSegmentStatus() == SegmentStatus.INSERT_IN_PROGRESS) {
+                && entry.getSegmentStatus() == SegmentStatus.INSERT_IN_PROGRESS
+                && segmentStatusManager.checkIfValidLoadInProgress(
+                    absoluteTableIdentifier, entry.getLoadName())) {
               throw new RuntimeException("Already insert into or load is in progress");
             }
           }


### PR DESCRIPTION
A **valid IN_PROGRESS** segment is the one for which data loading is going on.
An **invalid IN_PROGRESS** segment is the one for which load is already failed by some reasons like job killed, session closed, server restarted. But the tblstatus file is not updated with the current status. In these cases, tblstatus file will still hold IN_PROGRESS status. This is an INVALID status. These segments should be considered as stale segments.

**Problem:**
During operations like drop, delete segment, compaction, IUD there is a check for the IN_PROGRESS segments of a table. This check is simply checking the tblstatus file for IN_PROGRESS segments.

**Solution:**
The check should validate the IN_PROGRESS segments and decide on Valid and Invalid IN_PROGRESS segments.

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [x] Testing done
        Manual Testing
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

