### PR TITLE
[CARBONDATA-2066] Add Local keyword when loading data to hive table

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/primitiveTypes/DoubleDataTypeTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/primitiveTypes/DoubleDataTypeTestCase.scala
@@ -82,7 +82,7 @@ class DoubleDataTypeTestCase extends QueryTest with BeforeAndAfterAll {
     sql("create table uniq_carbon(name string, double_column double) stored by 'carbondata' TBLPROPERTIES ('DICTIONARY_INCLUDE'='double_column')")
     sql(s"load data inpath '$resourcesPath/uniq.csv' into table uniq_carbon")
     sql("create table uniq_hive(name string, double_column double) ROW FORMAT DELIMITED FIELDS TERMINATED BY ','")
-    sql(s"load data inpath '$resourcesPath/uniqwithoutheader.csv' into table uniq_hive")
+    sql(s"load data local inpath '$resourcesPath/uniqwithoutheader.csv' into table uniq_hive")
     checkAnswer(sql("select * from uniq_carbon where double_column>=11"),
       sql("select * from uniq_hive where double_column>=11"))
   }


### PR DESCRIPTION
when "duplicate values" UT is run, uniqwithoutheader.csv file used to load into hive gets deleted.

 - [ ] Any interfaces changed?
 No
 - [ ] Any backward compatibility impacted?
 No
 - [ ] Document update required?
No
 - [ ] Testing done
Yes       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA