### PR TITLE
[CARBONDATA-2071] Added block size to BblockletDataMap while initialising

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/indexstore/BlockMetaInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/BlockMetaInfo.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.core.indexstore;
+
+/**
+ * Holds the metadata info of the block.
+ */
+public class BlockMetaInfo {
+
+  /**
+   * HDFS locations of a block
+   */
+  private String[] locationInfo;
+
+  /**
+   * Size of block
+   */
+  private long size;
+
+  public BlockMetaInfo(String[] locationInfo, long size) {
+    this.locationInfo = locationInfo;
+    this.size = size;
+  }
+
+  public String[] getLocationInfo() {
+    return locationInfo;
+  }
+
+  public long getSize() {
+    return size;
+  }
+}
+

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/BlockletDataMapIndexStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/BlockletDataMapIndexStore.java
@@ -78,7 +78,7 @@ public class BlockletDataMapIndexStore
         String segmentPath = CarbonTablePath.getSegmentPath(
             identifier.getAbsoluteTableIdentifier().getTablePath(),
             identifier.getSegmentId());
-        Map<String, String[]> locationMap = new HashMap<>();
+        Map<String, BlockMetaInfo> blockMetaInfoMap = new HashMap<>();
         CarbonFile carbonFile = FileFactory.getCarbonFile(segmentPath);
         CarbonFile[] carbonFiles = carbonFile.locationAwareListFiles();
         SegmentIndexFileStore indexFileStore = new SegmentIndexFileStore();
@@ -86,9 +86,11 @@ public class BlockletDataMapIndexStore
         PartitionMapFileStore partitionFileStore = new PartitionMapFileStore();
         partitionFileStore.readAllPartitionsOfSegment(carbonFiles, segmentPath);
         for (CarbonFile file : carbonFiles) {
-          locationMap.put(file.getAbsolutePath(), file.getLocations());
+          blockMetaInfoMap
+              .put(file.getAbsolutePath(), new BlockMetaInfo(file.getLocations(), file.getSize()));
         }
-        dataMap = loadAndGetDataMap(identifier, indexFileStore, partitionFileStore, locationMap);
+        dataMap =
+            loadAndGetDataMap(identifier, indexFileStore, partitionFileStore, blockMetaInfoMap);
       } catch (MemoryException e) {
         LOGGER.error("memory exception when loading datamap: " + e.getMessage());
         throw new RuntimeException(e.getMessage(), e);
@@ -116,7 +118,7 @@ public class BlockletDataMapIndexStore
       if (missedIdentifiers.size() > 0) {
         Map<String, SegmentIndexFileStore> segmentIndexFileStoreMap = new HashMap<>();
         Map<String, PartitionMapFileStore> partitionFileStoreMap = new HashMap<>();
-        Map<String, String[]> locationMap = new HashMap<>();
+        Map<String, BlockMetaInfo> blockMetaInfoMap = new HashMap<>();
 
         for (TableBlockIndexUniqueIdentifier identifier: missedIdentifiers) {
           SegmentIndexFileStore indexFileStore =
@@ -136,11 +138,12 @@ public class BlockletDataMapIndexStore
             partitionFileStore.readAllPartitionsOfSegment(carbonFiles, segmentPath);
             partitionFileStoreMap.put(identifier.getSegmentId(), partitionFileStore);
             for (CarbonFile file : carbonFiles) {
-              locationMap.put(file.getAbsolutePath(), file.getLocations());
+              blockMetaInfoMap.put(file.getAbsolutePath(),
+                  new BlockMetaInfo(file.getLocations(), file.getSize()));
             }
           }
           blockletDataMaps.add(
-              loadAndGetDataMap(identifier, indexFileStore, partitionFileStore, locationMap));
+              loadAndGetDataMap(identifier, indexFileStore, partitionFileStore, blockMetaInfoMap));
         }
       }
     } catch (Throwable e) {
@@ -192,7 +195,7 @@ public class BlockletDataMapIndexStore
       TableBlockIndexUniqueIdentifier identifier,
       SegmentIndexFileStore indexFileStore,
       PartitionMapFileStore partitionFileStore,
-      Map<String, String[]> locationMap)
+      Map<String, BlockMetaInfo> blockMetaInfoMap)
       throws IOException, MemoryException {
     String uniqueTableSegmentIdentifier =
         identifier.getUniqueTableSegmentIdentifier();
@@ -206,7 +209,7 @@ public class BlockletDataMapIndexStore
       dataMap.init(new BlockletDataMapModel(identifier.getFilePath(),
           indexFileStore.getFileData(identifier.getCarbonIndexFileName()),
           partitionFileStore.getPartitions(identifier.getCarbonIndexFileName()),
-          partitionFileStore.isPartionedSegment(), locationMap));
+          partitionFileStore.isPartionedSegment(), blockMetaInfoMap));
       lruCache.put(identifier.getUniqueTableSegmentIdentifier(), dataMap,
           dataMap.getMemorySize());
     }
@@ -242,6 +245,24 @@ public class BlockletDataMapIndexStore
       BlockletDataMap cacheable =
           (BlockletDataMap) lruCache.get(segmentUniqueIdentifier.getUniqueTableSegmentIdentifier());
       cacheable.clear();
+    }
+  }
+
+  public static class BlockMetaInfo {
+    private String[] locationInfo;
+    private long size;
+
+    public BlockMetaInfo(String[] locationInfo, long size) {
+      this.locationInfo = locationInfo;
+      this.size = size;
+    }
+
+    public String[] getLocationInfo() {
+      return locationInfo;
+    }
+
+    public long getSize() {
+      return size;
     }
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/BlockletDataMapIndexStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/BlockletDataMapIndexStore.java
@@ -247,22 +247,4 @@ public class BlockletDataMapIndexStore
       cacheable.clear();
     }
   }
-
-  public static class BlockMetaInfo {
-    private String[] locationInfo;
-    private long size;
-
-    public BlockMetaInfo(String[] locationInfo, long size) {
-      this.locationInfo = locationInfo;
-      this.size = size;
-    }
-
-    public String[] getLocationInfo() {
-      return locationInfo;
-    }
-
-    public long getSize() {
-      return size;
-    }
-  }
 }

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/BlockletDetailInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/BlockletDetailInfo.java
@@ -56,6 +56,8 @@ public class BlockletDetailInfo implements Serializable, Writable {
 
   private byte[] columnSchemaBinary;
 
+  private long blockSize;
+
   public int getRowCount() {
     return rowCount;
   }
@@ -104,6 +106,14 @@ public class BlockletDetailInfo implements Serializable, Writable {
     this.schemaUpdatedTimeStamp = schemaUpdatedTimeStamp;
   }
 
+  public long getBlockSize() {
+    return blockSize;
+  }
+
+  public void setBlockSize(long blockSize) {
+    this.blockSize = blockSize;
+  }
+
   @Override public void write(DataOutput out) throws IOException {
     out.writeInt(rowCount);
     out.writeShort(pagesCount);
@@ -121,6 +131,7 @@ public class BlockletDetailInfo implements Serializable, Writable {
     out.writeLong(blockFooterOffset);
     out.writeInt(columnSchemaBinary.length);
     out.write(columnSchemaBinary);
+    out.writeLong(blockSize);
   }
 
   @Override public void readFields(DataInput in) throws IOException {
@@ -142,6 +153,7 @@ public class BlockletDetailInfo implements Serializable, Writable {
     byte[] schemaArray = new byte[bytesSize];
     in.readFully(schemaArray);
     readColumnSchema(schemaArray);
+    blockSize = in.readLong();
   }
 
   /**
@@ -177,6 +189,7 @@ public class BlockletDetailInfo implements Serializable, Writable {
     detailInfo.blockletInfo = blockletInfo;
     detailInfo.blockFooterOffset = blockFooterOffset;
     detailInfo.columnSchemas = columnSchemas;
+    detailInfo.blockSize = blockSize;
     return detailInfo;
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMap.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMap.java
@@ -40,8 +40,8 @@ import org.apache.carbondata.core.datamap.dev.DataMapModel;
 import org.apache.carbondata.core.datastore.IndexKey;
 import org.apache.carbondata.core.datastore.block.SegmentProperties;
 import org.apache.carbondata.core.datastore.block.TableBlockInfo;
+import org.apache.carbondata.core.indexstore.BlockMetaInfo;
 import org.apache.carbondata.core.indexstore.Blocklet;
-import org.apache.carbondata.core.indexstore.BlockletDataMapIndexStore;
 import org.apache.carbondata.core.indexstore.BlockletDetailInfo;
 import org.apache.carbondata.core.indexstore.ExtendedBlocklet;
 import org.apache.carbondata.core.indexstore.UnsafeMemoryDMStore;
@@ -149,7 +149,7 @@ public class BlockletDataMap implements DataMap, Cacheable {
         createSummarySchema(segmentProperties, blockletDataMapInfo.getPartitions(), schemaBinary);
       }
       TableBlockInfo blockInfo = fileFooter.getBlockInfo().getTableBlockInfo();
-      BlockletDataMapIndexStore.BlockMetaInfo blockMetaInfo =
+      BlockMetaInfo blockMetaInfo =
           blockletDataMapInfo.getBlockMetaInfoMap().get(blockInfo.getFilePath());
       // Here it loads info about all blocklets of index
       // Only add if the file exists physically. There are scenarios which index file exists inside
@@ -194,7 +194,7 @@ public class BlockletDataMap implements DataMap, Cacheable {
 
   private DataMapRowImpl loadToUnsafe(DataFileFooter fileFooter,
       SegmentProperties segmentProperties, String filePath, DataMapRowImpl summaryRow,
-      BlockletDataMapIndexStore.BlockMetaInfo blockMetaInfo, int relativeBlockletId) {
+      BlockMetaInfo blockMetaInfo, int relativeBlockletId) {
     int[] minMaxLen = segmentProperties.getColumnsValueSize();
     List<BlockletInfo> blockletList = fileFooter.getBlockletList();
     CarbonRowSchema[] schema = unsafeMemoryDMStore.getSchema();
@@ -282,7 +282,7 @@ public class BlockletDataMap implements DataMap, Cacheable {
    */
   private DataMapRowImpl loadToUnsafeBlock(DataFileFooter fileFooter,
       SegmentProperties segmentProperties, String filePath, DataMapRowImpl summaryRow,
-      BlockletDataMapIndexStore.BlockMetaInfo blockMetaInfo) {
+      BlockMetaInfo blockMetaInfo) {
     int[] minMaxLen = segmentProperties.getColumnsValueSize();
     BlockletIndex blockletIndex = fileFooter.getBlockletIndex();
     CarbonRowSchema[] schema = unsafeMemoryDMStore.getSchema();

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMapModel.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMapModel.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.carbondata.core.datamap.dev.DataMapModel;
+import org.apache.carbondata.core.indexstore.BlockletDataMapIndexStore;
 
 /**
  * It is the model object to keep the information to build or initialize BlockletDataMap.
@@ -32,15 +33,16 @@ public class BlockletDataMapModel extends DataMapModel {
 
   private boolean partitionedSegment;
 
-  private Map<String, String[]> locationMap;
+  Map<String, BlockletDataMapIndexStore.BlockMetaInfo> blockMetaInfoMap;
 
   public BlockletDataMapModel(String filePath, byte[] fileData, List<String> partitions,
-      boolean partitionedSegment, Map<String, String[]> locationMap) {
+      boolean partitionedSegment,
+      Map<String, BlockletDataMapIndexStore.BlockMetaInfo> blockMetaInfoMap) {
     super(filePath);
     this.fileData = fileData;
     this.partitions = partitions;
     this.partitionedSegment = partitionedSegment;
-    this.locationMap = locationMap;
+    this.blockMetaInfoMap = blockMetaInfoMap;
   }
 
   public byte[] getFileData() {
@@ -55,7 +57,7 @@ public class BlockletDataMapModel extends DataMapModel {
     return partitionedSegment;
   }
 
-  public Map<String, String[]> getLocationMap() {
-    return locationMap;
+  public Map<String, BlockletDataMapIndexStore.BlockMetaInfo> getBlockMetaInfoMap() {
+    return blockMetaInfoMap;
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMapModel.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMapModel.java
@@ -20,7 +20,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.carbondata.core.datamap.dev.DataMapModel;
-import org.apache.carbondata.core.indexstore.BlockletDataMapIndexStore;
+import org.apache.carbondata.core.indexstore.BlockMetaInfo;
 
 /**
  * It is the model object to keep the information to build or initialize BlockletDataMap.
@@ -33,11 +33,11 @@ public class BlockletDataMapModel extends DataMapModel {
 
   private boolean partitionedSegment;
 
-  Map<String, BlockletDataMapIndexStore.BlockMetaInfo> blockMetaInfoMap;
+  Map<String, BlockMetaInfo> blockMetaInfoMap;
 
   public BlockletDataMapModel(String filePath, byte[] fileData, List<String> partitions,
       boolean partitionedSegment,
-      Map<String, BlockletDataMapIndexStore.BlockMetaInfo> blockMetaInfoMap) {
+      Map<String, BlockMetaInfo> blockMetaInfoMap) {
     super(filePath);
     this.fileData = fileData;
     this.partitions = partitions;
@@ -57,7 +57,7 @@ public class BlockletDataMapModel extends DataMapModel {
     return partitionedSegment;
   }
 
-  public Map<String, BlockletDataMapIndexStore.BlockMetaInfo> getBlockMetaInfoMap() {
+  public Map<String, BlockMetaInfo> getBlockMetaInfoMap() {
     return blockMetaInfoMap;
   }
 }

--- a/hadoop/src/test/java/org/apache/carbondata/hadoop/streaming/CarbonStreamInputFormatTest.java
+++ b/hadoop/src/test/java/org/apache/carbondata/hadoop/streaming/CarbonStreamInputFormatTest.java
@@ -74,7 +74,7 @@ public class CarbonStreamInputFormatTest extends TestCase {
     CarbonInputSplit carbonInputSplit = new CarbonInputSplit();
     List<CarbonInputSplit> splitList = new ArrayList<>();
     splitList.add(carbonInputSplit);
-    return new CarbonMultiBlockSplit(identifier, splitList, new String[] { "localhost" },
+    return new CarbonMultiBlockSplit(splitList, new String[] { "localhost" },
         FileFormat.ROW_V1);
   }
 

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonIUDMergerRDD.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonIUDMergerRDD.scala
@@ -94,7 +94,7 @@ class CarbonIUDMergerRDD[K, V](
         val locations = validSplits.head.getLocations
         i += 1
         new CarbonSparkPartition(id, i,
-          new CarbonMultiBlockSplit(absoluteTableIdentifier, validSplits.asJava, locations))
+          new CarbonMultiBlockSplit(validSplits.asJava, locations))
       } else {
         null
       }

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonMergerRDD.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonMergerRDD.scala
@@ -433,7 +433,7 @@ class CarbonMergerRDD[K, V](
 
         if (blockletCount != 0) {
           val taskInfo = splitInfo.asInstanceOf[CarbonInputSplitTaskInfo]
-          val multiBlockSplit = new CarbonMultiBlockSplit(absoluteTableIdentifier,
+          val multiBlockSplit = new CarbonMultiBlockSplit(
             taskInfo.getCarbonInputSplitList,
             Array(nodeName))
           if (isPartitionTable) {

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanPartitionRDD.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanPartitionRDD.scala
@@ -115,7 +115,7 @@ class CarbonScanPartitionRDD(alterPartitionModel: AlterPartitionModel,
           val splits = blocksPerTask.asScala.map(_.asInstanceOf[CarbonInputSplit])
           if (blocksPerTask.size() != 0) {
             val multiBlockSplit =
-              new CarbonMultiBlockSplit(absoluteTableIdentifier, splits.asJava, Array(node))
+              new CarbonMultiBlockSplit(splits.asJava, Array(node))
             val partition = new CarbonSparkPartition(id, partition_num, multiBlockSplit)
             result.add(partition)
             partition_num += 1

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
@@ -111,7 +111,7 @@ class CarbonScanRDD(
       val streamPartitions: mutable.Buffer[Partition] =
         streamSplits.zipWithIndex.map { splitWithIndex =>
           val multiBlockSplit =
-            new CarbonMultiBlockSplit(identifier,
+            new CarbonMultiBlockSplit(
               Seq(splitWithIndex._1.asInstanceOf[CarbonInputSplit]).asJava,
               splitWithIndex._1.getLocations,
               FileFormat.ROW_V1)
@@ -156,7 +156,7 @@ class CarbonScanRDD(
         (0 until bucketedTable.getNumberOfBuckets).map { bucketId =>
           val bucketPartitions = bucketed.getOrElse(bucketId.toString, Nil)
           val multiBlockSplit =
-            new CarbonMultiBlockSplit(identifier,
+            new CarbonMultiBlockSplit(
               bucketPartitions.asJava,
               bucketPartitions.flatMap(_.getLocations).toArray)
           val partition = new CarbonSparkPartition(id, i, multiBlockSplit)
@@ -186,7 +186,7 @@ class CarbonScanRDD(
               val splits = blocksPerTask.asScala.map(_.asInstanceOf[CarbonInputSplit])
               if (blocksPerTask.size() != 0) {
                 val multiBlockSplit =
-                  new CarbonMultiBlockSplit(identifier, splits.asJava, Array(node))
+                  new CarbonMultiBlockSplit(splits.asJava, Array(node))
                 val partition = new CarbonSparkPartition(id, i, multiBlockSplit)
                 result.add(partition)
                 i += 1
@@ -200,7 +200,7 @@ class CarbonScanRDD(
           // Randomize the blocklets for better shuffling
           Random.shuffle(splits.asScala).zipWithIndex.foreach { splitWithIndex =>
             val multiBlockSplit =
-              new CarbonMultiBlockSplit(identifier,
+              new CarbonMultiBlockSplit(
                 Seq(splitWithIndex._1.asInstanceOf[CarbonInputSplit]).asJava,
                 splitWithIndex._1.getLocations)
             val partition = new CarbonSparkPartition(id, splitWithIndex._2, multiBlockSplit)
@@ -215,7 +215,7 @@ class CarbonScanRDD(
             .map(_.asInstanceOf[CarbonInputSplit])
             .groupBy(f => f.getBlockPath)
             .map { blockSplitEntry =>
-              new CarbonMultiBlockSplit(identifier,
+              new CarbonMultiBlockSplit(
                 blockSplitEntry._2.asJava,
                 blockSplitEntry._2.flatMap(f => f.getLocations).distinct.toArray)
             }.toArray.sortBy(_.getLength)(implicitly[Ordering[Long]].reverse)
@@ -257,7 +257,7 @@ class CarbonScanRDD(
             f.getSegmentId.concat(f.getBlockPath)
           }.values.zipWithIndex.foreach { splitWithIndex =>
             val multiBlockSplit =
-              new CarbonMultiBlockSplit(identifier,
+              new CarbonMultiBlockSplit(
                 splitWithIndex._1.asJava,
                 splitWithIndex._1.flatMap(f => f.getLocations).distinct.toArray)
             val partition = new CarbonSparkPartition(id, splitWithIndex._2, multiBlockSplit)
@@ -306,7 +306,7 @@ class CarbonScanRDD(
       .map(_._1)
       .toArray
 
-    val multiBlockSplit = new CarbonMultiBlockSplit(null, carbonInputSplits.asJava, locations)
+    val multiBlockSplit = new CarbonMultiBlockSplit(carbonInputSplits.asJava, locations)
     new CarbonSparkPartition(id, partitionId, multiBlockSplit)
   }
 


### PR DESCRIPTION
Added block size to blocklet datamap so that features like small file merge can use them

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [X] Any interfaces changed?
 
 - [X] Any backward compatibility impacted?
 
 - [X] Document update required?

 - [X] Testing done
             
 - [X] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

