### PR TITLE
[CARBONDATA-2075][CARBONDATA-1516] It should throw exception when drop datamap and the table or datamap  not exist

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggregateDrop.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggregateDrop.scala
@@ -20,6 +20,8 @@ package org.apache.carbondata.integration.spark.testsuite.preaggregate
 import org.apache.spark.sql.test.util.QueryTest
 import org.scalatest.BeforeAndAfterAll
 
+import org.apache.carbondata.spark.exception.NoSuchDataMapException
+
 class TestPreAggregateDrop extends QueryTest with BeforeAndAfterAll {
 
   override def beforeAll {
@@ -51,7 +53,7 @@ class TestPreAggregateDrop extends QueryTest with BeforeAndAfterAll {
   }
 
   test("drop datamap which is not existed") {
-    intercept[RuntimeException] {
+    intercept[NoSuchDataMapException] {
       sql("drop datamap newpreagg on table maintable")
     }
   }

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggregateDrop.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggregateDrop.scala
@@ -26,8 +26,6 @@ class TestPreAggregateDrop extends QueryTest with BeforeAndAfterAll {
 
   override def beforeAll {
     sql("drop table if exists maintable")
-    sql("drop datamap if exists preagg1 on table maintable")
-    sql("drop datamap if exists preagg2 on table maintable")
     sql("create table maintable (a string, b string, c string) stored by 'carbondata'")
   }
 
@@ -103,8 +101,6 @@ class TestPreAggregateDrop extends QueryTest with BeforeAndAfterAll {
   override def afterAll() {
     sql("drop table if exists maintable")
     sql("drop table if exists maintable1")
-    sql("drop datamap if exists preagg1 on table maintable")
-    sql("drop datamap if exists preagg2 on table maintable")
   }
   
 }

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/timeseries/TestTimeSeriesDropSuite.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/timeseries/TestTimeSeriesDropSuite.scala
@@ -18,8 +18,7 @@ package org.apache.carbondata.integration.spark.testsuite.timeseries
 
 import org.apache.spark.sql.test.util.QueryTest
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
-
-import org.apache.carbondata.spark.exception.MalformedCarbonCommandException
+import org.apache.carbondata.spark.exception.{MalformedCarbonCommandException, NoSuchDataMapException}
 
 class TestTimeSeriesDropSuite extends QueryTest with BeforeAndAfterAll with BeforeAndAfterEach{
 
@@ -36,7 +35,30 @@ class TestTimeSeriesDropSuite extends QueryTest with BeforeAndAfterAll with Befo
       """.stripMargin)
   }
 
-  test("test timeseries drop datamap 3: should support drop datamap") {
+
+  test("test timeseries drop datamap 1: drop datamap should throw exception if no datamap") {
+    // DROP DATAMAP DataMapName if the DataMapName not exists
+    checkExistence(sql("SHOW DATAMAP ON TABLE mainTable"), false, "agg1_month")
+    val e: Exception = intercept[Exception] {
+      sql(s"DROP DATAMAP agg1_month ON TABLE mainTable")
+    }
+    assert(e.getMessage.contains("Datamap with name agg1_month does not exist under table mainTable"))
+  }
+
+  test("test timeseries drop datamap 2: drop datamap should SUCCESS if haveIF EXISTS") {
+    // DROP DATAMAP DataMapName if the DataMapName not exists
+    checkExistence(sql("show datamap on table mainTable"), false, "agg1_month")
+    try {
+      sql(s"DROP DATAMAP IF EXISTS agg1_month ON TABLE mainTable")
+      assert(true)
+    } catch {
+      case e: Exception =>
+        println(e)
+        assert(false)
+    }
+  }
+
+  test("test timeseries drop datamap 3: drop datamap should throw proper exception") {
     sql(
       """create datamap agg1 on table mainTable
         |using 'preaggregate'

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/timeseries/TestTimeSeriesDropSuite.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/timeseries/TestTimeSeriesDropSuite.scala
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.integration.spark.testsuite.timeseries
+
+import org.apache.spark.sql.test.util.QueryTest
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
+
+import org.apache.carbondata.spark.exception.MalformedCarbonCommandException
+
+class TestTimeSeriesDropSuite extends QueryTest with BeforeAndAfterAll with BeforeAndAfterEach{
+
+  override def beforeAll: Unit = {
+    sql(s"DROP TABLE IF EXISTS mainTable")
+    sql(
+      """
+        | CREATE TABLE mainTable(
+        |   dataTime timestamp,
+        |   name string,
+        |   city string,
+        |   age int)
+        | STORED BY 'org.apache.carbondata.format'
+      """.stripMargin)
+  }
+
+  test("test timeseries drop datamap 3: should support drop datamap") {
+    sql(
+      """create datamap agg1 on table mainTable
+        |using 'preaggregate'
+        |DMPROPERTIES (
+        |   'timeseries.eventTime'='dataTime',
+        |   'timeseries.hierarchy'='month=1,year=1')
+        |as select dataTime, sum(age) from mainTable
+        |group by dataTime
+      """.stripMargin)
+
+    // Before DROP DATAMAP
+    checkExistence(sql("show datamap on table mainTable"), true, "agg1_month", "agg1_year")
+
+    // DROP DATAMAP DataMapName
+    sql(s"DROP DATAMAP agg1_month ON TABLE mainTable")
+    checkExistence(sql("show datamap on table mainTable"), false, "agg1_month")
+    val e: Exception = intercept[MalformedCarbonCommandException] {
+      sql(s"DROP DATAMAP agg1_month ON TABLE mainTable")
+    }
+    assert(e.getMessage.contains("Datamap with name agg1_month does not exist under table mainTable"))
+  }
+
+  override def afterAll: Unit = {
+    sql(s"DROP TABLE IF EXISTS mainTable")
+  }
+}

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datamap/TestDataMapCommand.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datamap/TestDataMapCommand.scala
@@ -90,7 +90,6 @@ class TestDataMapCommand extends QueryTest with BeforeAndAfterAll {
       CarbonProperties.getInstance()
         .addProperty(CarbonCommonConstants.ENABLE_HIVE_SCHEMA_META_STORE,
           "true")
-      sql("drop datamap if exists datamap_hiveMetaStoreTable on table hiveMetaStoreTable")
       sql("drop table if exists hiveMetaStoreTable")
       sql("create table hiveMetaStoreTable (a string, b string, c string) stored by 'carbondata'")
 
@@ -115,7 +114,6 @@ class TestDataMapCommand extends QueryTest with BeforeAndAfterAll {
       CarbonProperties.getInstance()
         .addProperty(CarbonCommonConstants.ENABLE_HIVE_SCHEMA_META_STORE,
           "true")
-      sql("drop datamap if exists datamap_hiveMetaStoreTable_1 on table hiveMetaStoreTable_1")
       sql("drop table if exists hiveMetaStoreTable_1")
       sql("create table hiveMetaStoreTable_1 (a string, b string, c string) stored by 'carbondata'")
 
@@ -213,7 +211,6 @@ class TestDataMapCommand extends QueryTest with BeforeAndAfterAll {
 
   test("test preaggregate load for decimal column for hivemetastore") {
     CarbonProperties.getInstance().addProperty(CarbonCommonConstants.ENABLE_HIVE_SCHEMA_META_STORE, "true")
-    sql("drop datamap if exists uniqdata_agg on table uniqdata")
     sql("CREATE TABLE uniqdata(CUST_ID int,CUST_NAME String,ACTIVE_EMUI_VERSION string,DOB timestamp,DOJ timestamp, BIGINT_COLUMN1 bigint,BIGINT_COLUMN2 bigint,DECIMAL_COLUMN1 decimal(30,10),DECIMAL_COLUMN2 decimal(36,10),Double_COLUMN1 double, Double_COLUMN2 double,INTEGER_COLUMN1 int) STORED BY 'org.apache.carbondata.format'")
     sql("insert into uniqdata select 9000,'CUST_NAME_00000','ACTIVE_EMUI_VERSION_00000','1970-01-01 01:00:03','1970-01-01 02:00:03',123372036854,-223372036854,12345678901.1234000000,22345678901.1234000000,11234567489.7976000000,-11234567489.7976000000,1")
     sql("create datamap uniqdata_agg on table uniqdata using 'preaggregate' as select min(DECIMAL_COLUMN1) from uniqdata group by DECIMAL_COLUMN1")

--- a/integration/spark-common/src/main/java/org/apache/carbondata/spark/exception/NoSuchDataMapException.java
+++ b/integration/spark-common/src/main/java/org/apache/carbondata/spark/exception/NoSuchDataMapException.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.spark.exception;
+
+/**
+ * if the dataMap does not exist, carbon should throw NoSuchDataMapException
+ */
+public class NoSuchDataMapException extends MalformedCarbonCommandException {
+
+    /**
+     * default serial version ID.
+     */
+    private static final long serialVersionUID = 1L;
+
+    public NoSuchDataMapException(String dataMapName, String tableName) {
+        super("Datamap with name " + dataMapName + " does not exist under table " + tableName);
+    }
+}

--- a/integration/spark-common/src/main/java/org/apache/carbondata/spark/exception/NoSuchDataMapException.java
+++ b/integration/spark-common/src/main/java/org/apache/carbondata/spark/exception/NoSuchDataMapException.java
@@ -22,12 +22,12 @@ package org.apache.carbondata.spark.exception;
  */
 public class NoSuchDataMapException extends MalformedCarbonCommandException {
 
-    /**
-     * default serial version ID.
-     */
-    private static final long serialVersionUID = 1L;
+  /**
+   * default serial version ID.
+   */
+  private static final long serialVersionUID = 1L;
 
-    public NoSuchDataMapException(String dataMapName, String tableName) {
-        super("Datamap with name " + dataMapName + " does not exist under table " + tableName);
-    }
+  public NoSuchDataMapException(String dataMapName, String tableName) {
+    super("Datamap with name " + dataMapName + " does not exist under table " + tableName);
+  }
 }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/datamap/CarbonDropDataMapCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/datamap/CarbonDropDataMapCommand.scala
@@ -26,7 +26,6 @@ import org.apache.spark.sql.catalyst.analysis.NoSuchTableException
 import org.apache.spark.sql.execution.command.AtomicRunnableCommand
 import org.apache.spark.sql.execution.command.preaaggregate.PreAggregateUtil
 import org.apache.spark.sql.execution.command.table.CarbonDropTableCommand
-import org.apache.spark.sql.hive.CarbonRelation
 
 import org.apache.carbondata.common.logging.{LogService, LogServiceFactory}
 import org.apache.carbondata.core.datamap.DataMapStoreManager
@@ -35,6 +34,7 @@ import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier
 import org.apache.carbondata.core.metadata.converter.ThriftWrapperSchemaConverterImpl
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable
 import org.apache.carbondata.events._
+import org.apache.carbondata.spark.exception.{MalformedCarbonCommandException, NoSuchDataMapException}
 
 /**
  * Drops the datamap and any related tables associated with the datamap
@@ -110,15 +110,17 @@ case class CarbonDropDataMapCommand(
               sparkSession)
           OperationListenerBus.getInstance.fireEvent(dropDataMapPostEvent, operationContext)
         } else if (!ifExistsSet) {
-          throw new IllegalArgumentException(
-            s"Datamap with name $dataMapName does not exist under table $tableName")
+          throw new NoSuchDataMapException(dataMapName, tableName)
         }
       }
 
     } catch {
+      case e: NoSuchDataMapException =>
+        throw e
       case ex: Exception =>
         LOGGER.error(ex, s"Dropping datamap $dataMapName failed")
-        sys.error(s"Dropping datamap $dataMapName failed: ${ ex.getMessage }")
+        throw new MalformedCarbonCommandException(
+          s"Dropping datamap $dataMapName failed: ${ex.getMessage}")
     }
     finally {
       if (carbonLocks.nonEmpty) {

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/datamap/CarbonDropDataMapCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/datamap/CarbonDropDataMapCommand.scala
@@ -112,7 +112,8 @@ case class CarbonDropDataMapCommand(
         } else if (!ifExistsSet) {
           throw new NoSuchDataMapException(dataMapName, tableName)
         }
-      } else if ((carbonTable.isDefined && carbonTable.get.getTableInfo.getDataMapSchemaList.size() == 0)) {
+      } else if ((carbonTable.isDefined &&
+        carbonTable.get.getTableInfo.getDataMapSchemaList.size() == 0)) {
         if (!ifExistsSet) {
           throw new NoSuchDataMapException(dataMapName, tableName)
         }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/datamap/CarbonDropDataMapCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/datamap/CarbonDropDataMapCommand.scala
@@ -72,8 +72,7 @@ case class CarbonDropDataMapCommand(
         Some(CarbonEnv.getCarbonTable(databaseNameOp, tableName)(sparkSession))
       } catch {
         case ex: NoSuchTableException =>
-          if (!ifExistsSet) throw ex
-          else None
+          throw ex
       }
       if (carbonTable.isDefined && carbonTable.get.getTableInfo.getDataMapSchemaList.size() > 0) {
         val dataMapSchema = carbonTable.get.getTableInfo.getDataMapSchemaList.asScala.zipWithIndex.

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/datamap/CarbonDropDataMapCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/datamap/CarbonDropDataMapCommand.scala
@@ -112,6 +112,10 @@ case class CarbonDropDataMapCommand(
         } else if (!ifExistsSet) {
           throw new NoSuchDataMapException(dataMapName, tableName)
         }
+      } else if ((carbonTable.isDefined && carbonTable.get.getTableInfo.getDataMapSchemaList.size() == 0)) {
+        if (!ifExistsSet) {
+          throw new NoSuchDataMapException(dataMapName, tableName)
+        }
       }
 
     } catch {


### PR DESCRIPTION
error 1: 

 It should throw no such datamap exception when drop datamap and the datamap does not exist    
not IllegalArgumentException or sys.err

It should throw NoSuchDataMapException that extends MalformedCarbonCommandException

error 2:
fix error: drop datamap should throw exception when carbonTable.get.getTableInfo.getDataMapSchemaList.size() == 0

error3: 
  DROP DATAMAP should throw exception if table not exist, even though there is IF EXISTS

We should check table first, and then check datamap when dropping datamap on table

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 No
 - [ ] Any backward compatibility impacted?
 No
 - [ ] Document update required?
No
 - [ ] Testing done
       add test case in TestTimeSeriesDropSuite 

 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

No