### PR TITLE
[CARBONDATA-2077][CARBONDATA-1516] it should throw no such table exception when drop datamap and the table does not exist

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/timeseries/TestTimeSeriesDropSuite.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/timeseries/TestTimeSeriesDropSuite.scala
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.integration.spark.testsuite.timeseries
+
+import org.apache.spark.sql.test.util.QueryTest
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
+
+class TestTimeSeriesDropSuite extends QueryTest with BeforeAndAfterAll with BeforeAndAfterEach{
+
+  override def beforeAll: Unit = {
+    sql(s"DROP TABLE IF EXISTS mainTable")
+    sql(
+      """
+        | CREATE TABLE mainTable(
+        |   dataTime timestamp,
+        |   name string,
+        |   city string,
+        |   age int)
+        | STORED BY 'org.apache.carbondata.format'
+      """.stripMargin)
+  }
+
+  test("test timeseries drop datamap: drop datamap should throw exception if table not exist") {
+    // DROP DATAMAP DataMapName if the DataMapName not exists and
+    checkExistence(sql("SHOW DATAMAP ON TABLE mainTable"), false, "agg1_month")
+    val e: Exception = intercept[Exception] {
+      sql(s"DROP DATAMAP agg1_month ON TABLE mainTableNotExist")
+    }
+    assert(e.getMessage.contains(
+      "Dropping datamap agg1_month failed: Table or view 'maintablenotexist' not found "))
+  }
+
+  test("test timeseries drop datamap: should throw exception if table not exist with IF EXISTS") {
+    // DROP DATAMAP DataMapName if the DataMapName not exists
+    // DROP DATAMAP should throw exception if table not exist, even though there is IF EXISTS"
+    checkExistence(sql("SHOW DATAMAP ON TABLE mainTable"), false, "agg1_month")
+    val e: Exception = intercept[Exception] {
+      sql(s"DROP DATAMAP IF EXISTS agg1_month ON TABLE mainTableNotExist")
+    }
+    assert(e.getMessage.contains(
+      "Dropping datamap agg1_month failed: Table or view 'maintablenotexist' not found "))
+  }
+
+  override def afterAll: Unit = {
+    sql(s"DROP TABLE IF EXISTS mainTable")
+  }
+}

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datamap/TestDataMapCommand.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datamap/TestDataMapCommand.scala
@@ -90,7 +90,6 @@ class TestDataMapCommand extends QueryTest with BeforeAndAfterAll {
       CarbonProperties.getInstance()
         .addProperty(CarbonCommonConstants.ENABLE_HIVE_SCHEMA_META_STORE,
           "true")
-      sql("drop datamap if exists datamap_hiveMetaStoreTable on table hiveMetaStoreTable")
       sql("drop table if exists hiveMetaStoreTable")
       sql("create table hiveMetaStoreTable (a string, b string, c string) stored by 'carbondata'")
 
@@ -115,7 +114,6 @@ class TestDataMapCommand extends QueryTest with BeforeAndAfterAll {
       CarbonProperties.getInstance()
         .addProperty(CarbonCommonConstants.ENABLE_HIVE_SCHEMA_META_STORE,
           "true")
-      sql("drop datamap if exists datamap_hiveMetaStoreTable_1 on table hiveMetaStoreTable_1")
       sql("drop table if exists hiveMetaStoreTable_1")
       sql("create table hiveMetaStoreTable_1 (a string, b string, c string) stored by 'carbondata'")
 
@@ -213,7 +211,6 @@ class TestDataMapCommand extends QueryTest with BeforeAndAfterAll {
 
   test("test preaggregate load for decimal column for hivemetastore") {
     CarbonProperties.getInstance().addProperty(CarbonCommonConstants.ENABLE_HIVE_SCHEMA_META_STORE, "true")
-    sql("drop datamap if exists uniqdata_agg on table uniqdata")
     sql("CREATE TABLE uniqdata(CUST_ID int,CUST_NAME String,ACTIVE_EMUI_VERSION string,DOB timestamp,DOJ timestamp, BIGINT_COLUMN1 bigint,BIGINT_COLUMN2 bigint,DECIMAL_COLUMN1 decimal(30,10),DECIMAL_COLUMN2 decimal(36,10),Double_COLUMN1 double, Double_COLUMN2 double,INTEGER_COLUMN1 int) STORED BY 'org.apache.carbondata.format'")
     sql("insert into uniqdata select 9000,'CUST_NAME_00000','ACTIVE_EMUI_VERSION_00000','1970-01-01 01:00:03','1970-01-01 02:00:03',123372036854,-223372036854,12345678901.1234000000,22345678901.1234000000,11234567489.7976000000,-11234567489.7976000000,1")
     sql("create datamap uniqdata_agg on table uniqdata using 'preaggregate' as select min(DECIMAL_COLUMN1) from uniqdata group by DECIMAL_COLUMN1")

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/datamap/CarbonDropDataMapCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/datamap/CarbonDropDataMapCommand.scala
@@ -72,8 +72,7 @@ case class CarbonDropDataMapCommand(
         Some(CarbonEnv.getCarbonTable(databaseNameOp, tableName)(sparkSession))
       } catch {
         case ex: NoSuchTableException =>
-          if (!ifExistsSet) throw ex
-          else None
+          throw ex
       }
       if (carbonTable.isDefined && carbonTable.get.getTableInfo.getDataMapSchemaList.size() > 0) {
         val dataMapSchema = carbonTable.get.getTableInfo.getDataMapSchemaList.asScala.zipWithIndex.


### PR DESCRIPTION

DROP DATAMAP should throw exception if table not exist, even though there is IF EXISTS

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 No
 - [ ] Any backward compatibility impacted?
 NO
 - [ ] Document update required?
NO
 - [ ] Testing done
add test case in TestTimeSeriesDropSuite 
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
No
