### PR TITLE
[CARBONDATA-2081] refresh cache across different session issue and schema after rename is not being updated  are fixed

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/schema/CarbonAlterTableRenameCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/schema/CarbonAlterTableRenameCommand.scala
@@ -122,6 +122,8 @@ private[sql] case class CarbonAlterTableRenameCommand(
       metastore.removeTableFromMetadata(oldDatabaseName, oldTableName)
       val hiveClient = sparkSession.sessionState.catalog.asInstanceOf[CarbonSessionCatalog]
         .getClient()
+      sparkSession.catalog.refreshTable(TableIdentifier(oldTableName,
+        Some(oldDatabaseName)).quotedString)
       hiveClient.runSqlHive(
           s"ALTER TABLE $oldDatabaseName.$oldTableName RENAME TO $oldDatabaseName.$newTableName")
       hiveClient.runSqlHive(

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonFileMetastore.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonFileMetastore.scala
@@ -221,6 +221,7 @@ class CarbonFileMetastore extends CarbonMetaStore {
       val schemaConverter = new ThriftWrapperSchemaConverterImpl
       val wrapperTableInfo =
         schemaConverter.fromExternalToWrapperTableInfo(tableInfo, dbName, tableName, tablePath)
+      CarbonMetadata.getInstance().removeTable(tableUniqueName)
       CarbonMetadata.getInstance().loadTableMetadata(wrapperTableInfo)
       val carbonTable = CarbonMetadata.getInstance().getCarbonTable(tableUniqueName)
       metadata.carbonTables += carbonTable
@@ -258,6 +259,7 @@ class CarbonFileMetastore extends CarbonMetaStore {
       oldTableIdentifier.getTableId)
     val path = createSchemaThriftFile(newAbsoluteTableIdentifier, thriftTableInfo)
     addTableCache(wrapperTableInfo, newAbsoluteTableIdentifier)
+
     path
   }
 

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonHiveMetaStore.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonHiveMetaStore.scala
@@ -51,13 +51,15 @@ class CarbonHiveMetaStore extends CarbonFileMetastore {
       absIdentifier: AbsoluteTableIdentifier,
       sparkSession: SparkSession): CarbonRelation = {
     val info = CarbonUtil.convertGsonToTableInfo(parameters.asJava)
-    if (info != null) {
+    val carbonRelation = if (info != null) {
       val table = CarbonTable.buildFromTableInfo(info)
       CarbonRelation(info.getDatabaseName, info.getFactTable.getTableName,
         CarbonSparkUtil.createSparkMeta(table), table)
     } else {
       super.createCarbonRelation(parameters, absIdentifier, sparkSession)
     }
+    carbonRelation.refresh()
+    carbonRelation
   }
 
 

--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/restructure/vectorreader/AddColumnTestCases.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/restructure/vectorreader/AddColumnTestCases.scala
@@ -669,6 +669,18 @@ class AddColumnTestCases extends Spark2QueryTest with BeforeAndAfterAll {
     sql("drop table if exists renameTextFileTable")
   }
 
+  test("test rename [create table, rename, create same table with different schema]"){
+    sql("drop table if exists t5")
+    sql("drop table if exists t6")
+
+    sql("create table t5 (c1 string, c2 int) stored by 'carbondata'")
+    sql("insert into t5 select 'asd',1")
+    sql("alter table t5 rename to t6")
+    sql("create table t5 (c1 string, c2 int,c3 string) stored by 'carbondata'")
+    sql("insert into t5 select 'asd',1,'sdf'")
+    checkAnswer(sql("select * from t5"),Seq(Row("asd",1,"sdf")))
+  }
+
   override def afterAll {
     sql("DROP TABLE IF EXISTS addcolumntest")
     sql("DROP TABLE IF EXISTS hivetable")


### PR DESCRIPTION
**Scenario: 1**

1. open spark-sql and beeline.
2. create main table in spark-sql
3. create preaggreagate table in beeline.
4. drop main table in spark-sql.
5. perform 'show tables' operation . PreAggregate table is still not deleted.

**Scenario: 2**

_perform following operation in same session:_
create table t5 (c1 string, c2 int) stored by 'carbondata'
insert into t5 select 'asd',1
alter table t5 rename to t6
create table t5 (c1 string, c2 int,c3 string) stored by 'carbondata'
insert into t5 select 'asd',1,'sdf' (query is failing)


 - [x] Any interfaces changed? No
 
 - [x] Any backward compatibility impacted? No
 
 - [x] Document update required? No

 - [x] Testing done
        UT added.
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. NA

