### PR TITLE
[CARBONDATA-2082][CARBONDATA-1516] Timeseries pre-aggregate table should support the blank space

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/timeseries/TestTimeSeriesCreateTable.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/timeseries/TestTimeSeriesCreateTable.scala
@@ -19,6 +19,8 @@ package org.apache.carbondata.integration.spark.testsuite.timeseries
 import org.apache.spark.sql.test.util.QueryTest
 import org.scalatest.{BeforeAndAfterAll, Ignore}
 
+import org.apache.carbondata.spark.exception.MalformedCarbonCommandException
+
 class TestTimeSeriesCreateTable extends QueryTest with BeforeAndAfterAll {
 
   override def beforeAll: Unit = {
@@ -103,6 +105,117 @@ class TestTimeSeriesCreateTable extends QueryTest with BeforeAndAfterAll {
         assert(true)
     }
   }
+
+  val timeSeries = "preaggregate"
+
+  test("test timeseries create table 12: hierarchy type with space") {
+    sql("drop table if exists mainTable")
+    sql(
+      """
+        | CREATE TABLE mainTable(dataTime timestamp, name string, city string, age int)
+        | STORED BY 'org.apache.carbondata.format'
+      """.stripMargin)
+
+    checkExistence(sql("show tables"), false, "maintable_agg1_second")
+    sql(
+      s"""
+         | create datamap agg1 on table mainTable using '$timeSeries'
+         | DMPROPERTIES (
+         |   'timeseries.eventTime'='dataTime',
+         |   'timeseries.hierarchy'='second= 1,hour=1,day=1,month=1,year=1')
+         | as select dataTime, sum(age) from mainTable
+         | group by dataTime
+       """.stripMargin)
+    checkExistence(sql("show tables"), true, "maintable_agg1_second")
+  }
+
+  test("test timeseries create table 13: hierarchy type with space") {
+    sql("drop table if exists mainTable")
+    sql(
+      """
+        | CREATE TABLE mainTable(dataTime timestamp, name string, city string, age int)
+        | STORED BY 'org.apache.carbondata.format'
+      """.stripMargin)
+
+    checkExistence(sql("show tables"), false, "maintable_agg1_second")
+    sql(
+      s"""
+         | create datamap agg1 on table mainTable using '$timeSeries'
+         | DMPROPERTIES (
+         |   'timeseries.eventTime'='dataTime',
+         |   'timeseries.hierarchy'='second=1 ,hour=1,day=1,month=1,year=1')
+         | as select dataTime, sum(age) from mainTable
+         | group by dataTime
+       """.stripMargin)
+    checkExistence(sql("show tables"), true, "maintable_agg1_second")
+  }
+
+  test("test timeseries create table 14: hierarchy type with space") {
+    sql("drop table if exists mainTable")
+    sql(
+      """
+        | CREATE TABLE mainTable(dataTime timestamp, name string, city string, age int)
+        | STORED BY 'org.apache.carbondata.format'
+      """.stripMargin)
+
+    checkExistence(sql("show tables"), false, "maintable_agg1_second")
+    sql(
+      s"""
+         | create datamap agg1 on table mainTable using '$timeSeries'
+         | DMPROPERTIES (
+         |   'timeseries.eventTime'='dataTime',
+         |   'timeseries.hierarchy'='second =1,hour=1,day=1,month=1,year=1')
+         | as select dataTime, sum(age) from mainTable
+         | group by dataTime
+       """.stripMargin)
+    checkExistence(sql("show tables"), true, "maintable_agg1_second")
+  }
+
+  test("test timeseries create table 15: hierarchy type with space") {
+    sql("drop table if exists mainTable")
+    sql(
+      """
+        | CREATE TABLE mainTable(dataTime timestamp, name string, city string, age int)
+        | STORED BY 'org.apache.carbondata.format'
+      """.stripMargin)
+
+    checkExistence(sql("show tables"), false, "maintable_agg1_second")
+    sql(
+      s"""
+         | create datamap agg1 on table mainTable using '$timeSeries'
+         | DMPROPERTIES (
+         |   'timeseries.eventTime'='dataTime',
+         |   'timeseries.hierarchy'='second  =1, hour=1   ,day=1,  month=1,  year=    1')
+         | as select dataTime, sum(age) from mainTable
+         | group by dataTime
+       """.stripMargin)
+    checkExistence(sql("show tables"), true, "maintable_agg1_second")
+  }
+
+  test("test timeseries create table 16: hierarchy type with space") {
+    sql("drop table if exists mainTable")
+    sql(
+      """
+        | CREATE TABLE mainTable(dataTime timestamp, name string, city string, age int)
+        | STORED BY 'org.apache.carbondata.format'
+      """.stripMargin)
+
+    checkExistence(sql("show tables"), false, "maintable_agg1_second")
+    val e = intercept[MalformedCarbonCommandException] {
+      sql(
+        s"""
+           |create datamap agg1 on table mainTable using '$timeSeries'
+           |DMPROPERTIES (
+           |   'timeseries.eventTime'='dataTime',
+           |   'timeseries.hierarchy'='secon d=1,hour=1,day=1,month=1,year=1')
+           |as select dataTime, sum(age) from mainTable
+           |group by dataTime
+         """.stripMargin)
+    }
+    assert(e.getMessage.contains("Not supported heirarchy type: secon d"))
+    checkExistence(sql("show tables"), false, "maintable_agg1_second")
+  }
+
   override def afterAll: Unit = {
     sql("drop table if exists mainTable")
   }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/timeseries/TimeSeriesUtil.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/timeseries/TimeSeriesUtil.scala
@@ -70,16 +70,16 @@ object TimeSeriesUtil {
       case f =>
         val splits = f.split("=")
         // checking hierarchy name is valid or not
-        if (!TimeSeriesUDF.INSTANCE.TIMESERIES_FUNCTION.contains(splits(0).toLowerCase)) {
-          throw new MalformedCarbonCommandException(s"Not supported heirarchy type: ${ splits(0) }")
+        if (!TimeSeriesUDF.INSTANCE.TIMESERIES_FUNCTION.contains(splits(0).trim.toLowerCase)) {
+          throw new MalformedCarbonCommandException(s"Not supported heirarchy type: ${splits(0)}")
         }
         // validating hierarchy level is valid or not
-        if (!splits(1).equals("1")) {
+        if (!splits(1).trim.equals("1")) {
           throw new MalformedCarbonCommandException(
             s"Unsupported Value for hierarchy:" +
-            s"${ splits(0) }=${ splits(1) }")
+              s"${splits(0)}=${splits(1)}")
         }
-        (splits(0), splits(1))
+        (splits(0).trim, splits(1).trim)
     }
     // checking whether hierarchy is in proper order or not
     // get the index of first hierarchy


### PR DESCRIPTION
Timeseries pre-aggregate table should support the blank space

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 No
 - [ ] Any backward compatibility impacted?
 No
 - [ ] Document update required?
No
 - [ ] Testing done
  add some new test cases
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
No
