### PR TITLE
[WIP][CARBONDATA-2083][CARBONDATA-1516] Timeseries pre-aggregate table should support hour !=1 and so on

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/preagg/TimeSeriesUDF.java
+++ b/core/src/main/java/org/apache/carbondata/core/preagg/TimeSeriesUDF.java
@@ -68,6 +68,7 @@ public class TimeSeriesUDF {
     calendar.setTimeInMillis(data.getTime());
     TimeSeriesFunctionEnum timeSeriesFunctionEnum =
         TimeSeriesFunctionEnum.valueOf(function.toUpperCase());
+    // TODO: support hour !=1 or minute !=1 and so on
     switch (timeSeriesFunctionEnum) {
       case SECOND:
         calendar.set(Calendar.MILLISECOND, 0);

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/timeseries/TestTimeSeriesCreateTable.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/timeseries/TestTimeSeriesCreateTable.scala
@@ -103,6 +103,21 @@ class TestTimeSeriesCreateTable extends QueryTest with BeforeAndAfterAll {
         assert(true)
     }
   }
+
+  val timeSeries = "preaggregate"
+
+  test("test timeseries create table 13: don't support hour=2") {
+    sql(
+      s"""create datamap agg1 on table mainTable using '$timeSeries'
+         |DMPROPERTIES (
+         |   'timeseries.eventTime'='dataTime',
+         |   'timeseries.hierarchy'='hour=2')
+         |as select dataTime, sum(age) from mainTable
+         |group by dataTime
+        """.stripMargin)
+    checkExistence(sql("show tables"), true, "maintable_agg1_hour")
+  }
+
   override def afterAll: Unit = {
     sql("drop table if exists mainTable")
   }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
@@ -67,6 +67,7 @@ class CarbonEnv {
     sparkSession.udf.register("preAggLoad", () => "")
 
     // added for handling timeseries function like hour, minute, day , month , year
+    // TODO: support hour !=1 or minute !=1 and so on
     sparkSession.udf.register("timeseries", new TimeSeriesFunction)
     synchronized {
       if (!initialized) {

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/timeseries/TimeSeriesUtil.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/timeseries/TimeSeriesUtil.scala
@@ -74,11 +74,11 @@ object TimeSeriesUtil {
           throw new MalformedCarbonCommandException(s"Not supported heirarchy type: ${ splits(0) }")
         }
         // validating hierarchy level is valid or not
-        if (!splits(1).equals("1")) {
-          throw new MalformedCarbonCommandException(
-            s"Unsupported Value for hierarchy:" +
-            s"${ splits(0) }=${ splits(1) }")
-        }
+//        if (!splits(1).equals("1")) {
+//          throw new MalformedCarbonCommandException(
+//            s"Unsupported Value for hierarchy:" +
+//            s"${ splits(0) }=${ splits(1) }")
+//        }
         (splits(0), splits(1))
     }
     // checking whether hierarchy is in proper order or not


### PR DESCRIPTION


Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 support hour  !=1
 - [ ] Any backward compatibility impacted?
 NA
 - [ ] Document update required?
NA
 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA
