### PR TITLE
[CARBONDATA-2090] Fix the error message of alter streaming property

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/strategy/DDLStrategy.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/strategy/DDLStrategy.scala
@@ -231,9 +231,14 @@ class DDLStrategy(sparkSession: SparkSession) extends SparkStrategy {
         // TODO remove this limitation later
         val property = properties.find(_._1.equalsIgnoreCase("streaming"))
         if (property.isDefined) {
-          if (!property.get._2.trim.equalsIgnoreCase("true")) {
+          if (carbonTable.isStreamingTable) {
             throw new MalformedCarbonCommandException(
               "Streaming property can not be changed once it is 'true'")
+          } else {
+            if (!property.get._2.trim.equalsIgnoreCase("true")) {
+              throw new MalformedCarbonCommandException(
+                "Streaming property value is incorrect")
+            }
           }
         }
         ExecutedCommandExec(CarbonAlterTableSetCommand(tableName, properties, isView)) :: Nil

--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/TestStreamingTableOperation.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/TestStreamingTableOperation.scala
@@ -182,6 +182,10 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
 
   // normal table not support streaming ingest
   test("normal table not support streaming ingest") {
+    // alter normal table's streaming property
+    val msg = intercept[MalformedCarbonCommandException](sql("alter table streaming.batch_table set tblproperties('streaming'='false')"))
+    assertResult("Streaming property value is incorrect")(msg.getMessage)
+
     val identifier = new TableIdentifier("batch_table", Option("streaming"))
     val carbonTable = CarbonEnv.getInstance(spark).carbonMetastore.lookupRelation(identifier)(spark)
       .asInstanceOf[CarbonRelation].metaData.carbonTable
@@ -518,6 +522,11 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
       case _ =>
         assert(false, "should support set table to streaming")
     }
+
+    // alter streaming table's streaming property
+    val msg = intercept[MalformedCarbonCommandException](sql("alter table streaming.stream_table_handoff set tblproperties('streaming'='false')"))
+    assertResult("Streaming property can not be changed once it is 'true'")(msg.getMessage)
+
     val segments = sql("show segments for table streaming.stream_table_handoff").collect()
     assert(segments.length == 2 || segments.length == 3)
     assertResult("Streaming")(segments(0).getString(1))

--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/TestStreamingTableOperation.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/TestStreamingTableOperation.scala
@@ -181,7 +181,7 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
   }
 
   // normal table not support streaming ingest
-  test("normal table not support streaming ingest") {
+  test("normal table not support streaming ingest and alter normal table's streaming property") {
     // alter normal table's streaming property
     val msg = intercept[MalformedCarbonCommandException](sql("alter table streaming.batch_table set tblproperties('streaming'='false')"))
     assertResult("Streaming property value is incorrect")(msg.getMessage)


### PR DESCRIPTION
For the streaming table, should prompt "Streaming property can not be changed once it is 'true'".

For the normal table, should prompt "Streaming property value is incorrect" if the value is not 'true'.


 - [x] Any interfaces changed?
 no
 - [x] Any backward compatibility impacted?
 no
 - [x] Document update required?
  no
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
           ut added
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
small changes
