### PR TITLE
[CARBONDATA-2095]Copy data of GenericInternalRow for each iteration when converting stream segment to batch segment.

### DIFF
--- a/streaming/src/main/scala/org/apache/carbondata/streaming/StreamHandoffRDD.scala
+++ b/streaming/src/main/scala/org/apache/carbondata/streaming/StreamHandoffRDD.scala
@@ -75,11 +75,14 @@ class StreamingRawResultIterator(
   }
 
   override def next(): Array[Object] = {
-    recordReader
+    val rowTmp = recordReader
       .getCurrentValue
       .asInstanceOf[GenericInternalRow]
       .values
       .asInstanceOf[Array[Object]]
+    val row = new Array[Object](rowTmp.length)
+    System.arraycopy(rowTmp, 0, row, 0, rowTmp.length)
+    row
   }
 }
 


### PR DESCRIPTION
## Problem:
After handoff stream segment(ROW format) to batch segment (column format), data is incorrect, there are repetitive data.

## Solution:
Copy data of GenericInternalRow for each iteration when converting stream segment to batch segment.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

