### PR TITLE
[CARBONDATA-2100] Add query test case to check result of streaming handoff operation

### DIFF
--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/TestStreamingTableOperation.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/TestStreamingTableOperation.scala
@@ -527,8 +527,11 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
       Seq(Row(2 * 100))
     )
 
+    val resultBeforeHandoff = sql("select * from streaming.stream_table_handoff order by id, name").collect()
     sql("alter table streaming.stream_table_handoff compact 'streaming'")
     Thread.sleep(5000)
+    val resultAfterHandoff = sql("select * from streaming.stream_table_handoff order by id, name").collect()
+    assertResult(resultBeforeHandoff)(resultAfterHandoff)
     val newSegments = sql("show segments for table streaming.stream_table_handoff").collect()
     assert(newSegments.length == 3 || newSegments.length == 5)
     assertResult("Streaming")(newSegments((newSegments.length - 1) / 2).getString(1))


### PR DESCRIPTION
Add query test case to check result of streaming handoff operation

 - [x] Any interfaces changed?
 no
 - [x] Any backward compatibility impacted?
 no
 - [x] Document update required?
 no
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
           added
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
small changes
