### PR TITLE
[CARBONDATA-2044] Documentation added 2 parameter

### DIFF
--- a/docs/configuration-parameters.md
+++ b/docs/configuration-parameters.md
@@ -127,7 +127,9 @@ This section provides the details of all the configurations required for CarbonD
 | Parameter | Default Value | Description |
 |--------------------------|---------------|-----------------------------------------------------------------------------------------------|
 | max.query.execution.time | 60 | Maximum time allowed for one query to be executed. The value is in minutes. |
-| carbon.enableMinMax | true | Min max is feature added to enhance query performance. To disable this feature, set it false. | 
+| carbon.enableMinMax | true | Min max is feature added to enhance query performance. To disable this feature, set it false. |
+| carbon.dynamicallocation.schedulertimeout | 5 | Specifies the maximum time (unit in seconds) the scheduler can wait for executor to be active. Minimum value is 5 sec and maximum value is 15 sec. |
+| carbon.scheduler.minregisteredresourcesratio | 0.8 | Specifies the minimum resource (executor) ratio needed for starting the block distribution. The default value is 0.8, which indicates 80% of the requested resource is allocated for starting block distribution.  The minimum value is 0.1 min and the maximum value is 1.0. | 
   
 * **Global Dictionary Configurations**
   


### PR DESCRIPTION
Added paramter for configurable wait time for requesting executors and minimum registered executors ratio to continue the block distribution.
