### PR TITLE
[CARBONDATA-2113]compatibility fix for v2

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonVersionConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonVersionConstants.java
@@ -49,6 +49,11 @@ public final class CarbonVersionConstants {
    */
   public static final String CARBONDATA_BUILD_DATE;
 
+  /**
+   * number of rows per blocklet column page default value for V2 version
+   */
+  public static final int NUMBER_OF_ROWS_PER_BLOCKLET_COLUMN_PAGE_DEFAULT_V2 = 120000;
+
   static {
     // create input stream for CARBONDATA_VERSION_INFO_FILE
     InputStream resourceStream = Thread.currentThread().getContextClassLoader()

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataRefNodeWrapper.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataRefNodeWrapper.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import org.apache.carbondata.core.cache.update.BlockletLevelDeleteDeltaDataCache;
 import org.apache.carbondata.core.constants.CarbonV3DataFormatConstants;
+import org.apache.carbondata.core.constants.CarbonVersionConstants;
 import org.apache.carbondata.core.datastore.DataRefNode;
 import org.apache.carbondata.core.datastore.FileHolder;
 import org.apache.carbondata.core.datastore.block.TableBlockInfo;
@@ -56,8 +57,16 @@ public class BlockletDataRefNodeWrapper implements DataRefNode {
       detailInfo.getBlockletInfo().setNumberOfPages(detailInfo.getPagesCount());
       detailInfo.setBlockletId(blockInfo.getDetailInfo().getBlockletId());
       int[] pageRowCount = new int[detailInfo.getPagesCount()];
-      int numberOfPagesCompletelyFilled = detailInfo.getRowCount()
-          / CarbonV3DataFormatConstants.NUMBER_OF_ROWS_PER_BLOCKLET_COLUMN_PAGE_DEFAULT;
+      int numberOfPagesCompletelyFilled = detailInfo.getRowCount();
+      // no. of rows to a page is 120000 in V2 and 32000 in V3, same is handled to get the number
+      // of pages filled
+      if (blockInfo.getVersion() == ColumnarFormatVersion.V2) {
+        numberOfPagesCompletelyFilled /=
+            CarbonVersionConstants.NUMBER_OF_ROWS_PER_BLOCKLET_COLUMN_PAGE_DEFAULT_V2;
+      } else {
+        numberOfPagesCompletelyFilled /=
+            CarbonV3DataFormatConstants.NUMBER_OF_ROWS_PER_BLOCKLET_COLUMN_PAGE_DEFAULT;
+      }
       int lastPageRowCount = detailInfo.getRowCount()
           % CarbonV3DataFormatConstants.NUMBER_OF_ROWS_PER_BLOCKLET_COLUMN_PAGE_DEFAULT;
       for (int i = 0; i < numberOfPagesCompletelyFilled; i++) {

--- a/core/src/main/java/org/apache/carbondata/core/mutate/CarbonUpdateUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/mutate/CarbonUpdateUtil.java
@@ -587,26 +587,24 @@ public class CarbonUpdateUtil {
    */
   private static void deleteStaleCarbonDataFiles(LoadMetadataDetails segment,
       CarbonFile[] allSegmentFiles, SegmentUpdateStatusManager updateStatusManager) {
-    boolean doForceDelete = true;
-    boolean isAbortedFile = true;
     CarbonFile[] invalidUpdateDeltaFiles = updateStatusManager
         .getUpdateDeltaFilesList(segment.getLoadName(), false,
             CarbonCommonConstants.UPDATE_DELTA_FILE_EXT, true, allSegmentFiles,
-            isAbortedFile);
+            true);
     // now for each invalid delta file need to check the query execution time out
     // and then delete.
     for (CarbonFile invalidFile : invalidUpdateDeltaFiles) {
-      compareTimestampsAndDelete(invalidFile, doForceDelete, false);
+      compareTimestampsAndDelete(invalidFile, true, false);
     }
     // do the same for the index files.
     CarbonFile[] invalidIndexFiles = updateStatusManager
         .getUpdateDeltaFilesList(segment.getLoadName(), false,
             CarbonCommonConstants.UPDATE_INDEX_FILE_EXT, true, allSegmentFiles,
-            isAbortedFile);
+            true);
     // now for each invalid index file need to check the query execution time out
     // and then delete.
     for (CarbonFile invalidFile : invalidIndexFiles) {
-      compareTimestampsAndDelete(invalidFile, doForceDelete, false);
+      compareTimestampsAndDelete(invalidFile, true, false);
     }
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/util/AbstractDataFileFooterConverter.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/AbstractDataFileFooterConverter.java
@@ -208,7 +208,8 @@ public abstract class AbstractDataFileFooterConverter {
     if (fileName.lastIndexOf("/") > 0) {
       fileName = fileName.substring(fileName.lastIndexOf("/"));
     }
-    tableBlockInfo.setFilePath(parentPath + "/" + fileName);
+    fileName = (CarbonCommonConstants.FILE_SEPARATOR + fileName).replaceAll("//", "/");
+    tableBlockInfo.setFilePath(parentPath + fileName);
     return tableBlockInfo;
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/util/DataFileFooterConverter2.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/DataFileFooterConverter2.java
@@ -141,6 +141,6 @@ public class DataFileFooterConverter2 extends AbstractDataFileFooterConverter {
   }
 
   @Override public List<ColumnSchema> getSchema(TableBlockInfo tableBlockInfo) throws IOException {
-    return null;
+    return new DataFileFooterConverter().getSchema(tableBlockInfo);
   }
 }


### PR DESCRIPTION
Fixes related to backword compatibility:

1) Count(*) issue: 
when count(*)  is run on old store where file format version is V2, it was unable to get the files, because when forming the filepath while creating the table block info object from index file info, the path was formed with double slash(//), beacuse in v2, local path was stored. so when trying to get this path with key, it was failing. So form the correct file path.

2) Select * issue:
when select * is run, then only the datachunck was considered as whole data and while uncompressing the measure data, it was failing. So, read proper data and datachunck before uncompressing.

3) Read Metadata file:
when readMetadataFile is called , the while reading the schema, it was explicitly returning null, so columns will be null and hence some nullpointerxception was coming. so do not return null, return proper schema, by reading the footer.

4) Vesion compatibility:
calculation the number of pages to be filled based on row count was not handled for V2 version, handled same, as no. of rows per page is different in V2 and V3

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 NA
 - [x] Any backward compatibility impacted?
 NA
 - [x] Document update required?
NA
 - [x] Testing done
manual testing
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

