### PR TITLE
[CARBONDATA-2082] Timeseries pre-aggregate table should support the blank space

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/timeseries/TestTimeSeriesCreateTable.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/timeseries/TestTimeSeriesCreateTable.scala
@@ -368,6 +368,82 @@ class TestTimeSeriesCreateTable extends QueryTest with BeforeAndAfterAll {
     assert(e.getMessage.contains("identifier matching regex"))
   }
 
+  test("test timeseries create table 33: support event_time and granularity key with space") {
+    sql("DROP DATAMAP IF EXISTS agg1_month ON TABLE maintable")
+    sql(
+      s"""CREATE DATAMAP agg1_month ON TABLE mainTable
+         |USING '$timeSeries'
+         |DMPROPERTIES (
+         |   ' event_time '='dataTime',
+         |   ' MONTH_GRANULARITY '='1')
+         |AS SELECT dataTime, SUM(age) FROM mainTable
+         |GROUP BY dataTime
+        """.stripMargin)
+    checkExistence(sql("SHOW DATAMAP ON TABLE maintable"), true, "maintable_agg1_month")
+    sql("DROP DATAMAP IF EXISTS agg1_month ON TABLE maintable")
+  }
+
+
+  test("test timeseries create table 34: support event_time value with space") {
+    sql("DROP DATAMAP IF EXISTS agg1_month ON TABLE maintable")
+    sql(
+      s"""CREATE DATAMAP agg1_month ON TABLE mainTable
+         |USING '$timeSeries'
+         |DMPROPERTIES (
+         |   'event_time '=' dataTime',
+         |   'MONTH_GRANULARITY '='1')
+         |AS SELECT dataTime, SUM(age) FROM mainTable
+         |GROUP BY dataTime
+        """.stripMargin)
+    checkExistence(sql("SHOW DATAMAP ON TABLE maintable"), true, "maintable_agg1_month")
+    sql("DROP DATAMAP IF EXISTS agg1_month ON TABLE maintable")
+  }
+
+  test("test timeseries create table 35: support granularity value with space") {
+    sql("DROP DATAMAP IF EXISTS agg1_month ON TABLE maintable")
+    sql(
+      s"""CREATE DATAMAP agg1_month ON TABLE mainTable
+         |USING '$timeSeries'
+         |DMPROPERTIES (
+         |   'event_time '='dataTime',
+         |   'MONTH_GRANULARITY '=' 1')
+         |AS SELECT dataTime, SUM(age) FROM mainTable
+         |GROUP BY dataTime
+        """.stripMargin)
+    checkExistence(sql("SHOW DATAMAP ON TABLE maintable"), true, "maintable_agg1_month")
+    sql("DROP DATAMAP IF EXISTS agg1_month ON TABLE maintable")
+  }
+
+  test("test timeseries create table 36: support event_time and granularity value with space") {
+    sql("DROP DATAMAP IF EXISTS agg1_month ON TABLE maintable")
+    sql(
+      s"""
+         | CREATE DATAMAP agg1_month ON TABLE mainTable
+         | USING '$timeSeries'
+         | DMPROPERTIES (
+         |   'EVENT_TIME'='dataTime   ',
+         |   'MONTH_GRANULARITY'=' 1  ')
+         | AS SELECT dataTime, SUM(age) FROM mainTable
+         | GROUP BY dataTime
+        """.stripMargin)
+    checkExistence(sql("SHOW DATAMAP ON TABLE maintable"), true, "maintable_agg1_month")
+  }
+
+  test("test timeseries create table 37:  unsupport event_time error value") {
+    sql("DROP DATAMAP IF EXISTS agg1_month ON TABLE maintable")
+    intercept[NullPointerException] {
+      sql(
+        s"""CREATE DATAMAP agg1_month ON TABLE mainTable USING '$timeSeries'
+           |DMPROPERTIES (
+           |   'event_time'='data Time',
+           |   'MONTH_GRANULARITY'='1')
+           |AS SELECT dataTime, SUM(age) FROM mainTable
+           |GROUP BY dataTime
+        """.stripMargin)
+    }
+    sql("DROP DATAMAP IF EXISTS agg1_month ON TABLE maintable")
+  }
+
   override def afterAll: Unit = {
     sql("DROP TABLE IF EXISTS mainTable")
   }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/timeseries/TimeSeriesUtil.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/timeseries/TimeSeriesUtil.scala
@@ -46,7 +46,7 @@ object TimeSeriesUtil {
     if (!eventTime.isDefined) {
       throw new MalformedCarbonCommandException("event_time not defined in time series")
     } else {
-      val carbonColumn = parentTable.getColumnByName(parentTable.getTableName, eventTime.get)
+      val carbonColumn = parentTable.getColumnByName(parentTable.getTableName, eventTime.get.trim)
       if (carbonColumn.getDataType != DataTypes.TIMESTAMP) {
         throw new MalformedCarbonCommandException(
           "Timeseries event time is only supported on Timestamp " +
@@ -110,7 +110,7 @@ object TimeSeriesUtil {
     val defaultValue = "1"
     for (granularity <- Granularity.values()) {
       if (dmProperties.get(granularity.getName).isDefined &&
-        dmProperties.get(granularity.getName).get.equalsIgnoreCase(defaultValue)) {
+        dmProperties.get(granularity.getName).get.trim.equalsIgnoreCase(defaultValue)) {
         return (granularity.toString.toLowerCase, dmProperties.get(granularity.getName).get)
       }
     }
@@ -168,10 +168,9 @@ object TimeSeriesUtil {
   /**
    * Below method will be used to validate whether timeseries column present in
    * select statement or not
-   * @param fieldMapping
-   *                     fields from select plan
-   * @param timeSeriesColumn
-   *                         timeseries column name
+   *
+   * @param fieldMapping     fields from select plan
+   * @param timeSeriesColumn timeseries column name
    */
   def validateEventTimeColumnExitsInSelect(fieldMapping: scala.collection.mutable
   .LinkedHashMap[Field, DataMapField],


### PR DESCRIPTION
Timeseries pre-aggregate table should support the blank space, including:

-    event_time
-    different franularity

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 No
 - [ ] Any backward compatibility impacted?
 No
 - [ ] Document update required?
No
 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

NO