### PR TITLE
[CARBONDATA-2125] like% filter is giving ArrayIndexOutOfBoundException in case of table having more pages

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RowLevelFilterExecuterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RowLevelFilterExecuterImpl.java
@@ -205,7 +205,10 @@ public class RowLevelFilterExecuterImpl implements FilterExecuter {
       } else {
         // specific for restructure case where default values need to be filled
         pageNumbers = blockChunkHolder.getDataBlock().numberOfPages();
-        numberOfRows = new int[] { blockChunkHolder.getDataBlock().nodeSize() };
+        numberOfRows = new int[pageNumbers];
+        for (int i = 0; i < pageNumbers; i++) {
+          numberOfRows[i] = blockChunkHolder.getDataBlock().getPageRowCount(i);
+        }
       }
     }
     if (msrColEvalutorInfoList.size() > 0) {
@@ -217,7 +220,10 @@ public class RowLevelFilterExecuterImpl implements FilterExecuter {
       } else {
         // specific for restructure case where default values need to be filled
         pageNumbers = blockChunkHolder.getDataBlock().numberOfPages();
-        numberOfRows = new int[] { blockChunkHolder.getDataBlock().nodeSize() };
+        numberOfRows = new int[pageNumbers];
+        for (int i = 0; i < pageNumbers; i++) {
+          numberOfRows[i] = blockChunkHolder.getDataBlock().getPageRowCount(i);
+        }
       }
     }
     BitSetGroup bitSetGroup = new BitSetGroup(pageNumbers);

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/TrueFilterExecutor.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/TrueFilterExecutor.java
@@ -39,7 +39,7 @@ public class TrueFilterExecutor implements FilterExecuter {
     BitSetGroup group = new BitSetGroup(numberOfPages);
     for (int i = 0; i < numberOfPages; i++) {
       BitSet set = new BitSet();
-      set.flip(0, blockChunkHolder.getDataBlock().nodeSize());
+      set.flip(0, blockChunkHolder.getDataBlock().getPageRowCount(i));
       group.setBitSet(set, i);
     }
     return group;


### PR DESCRIPTION
Problem: like% filter is giving ArrayIndexOutOfBoundException in case of table having more pages
Solution: In RowlevelFilter the number of rows should be filled based on the rows in a page.

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [x] Testing done
        Manual Testing
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

