### PR TITLE
[CARBONDATA-2112] Fixed bug for select operation on datamap with avg and a column name

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/AggregationDataMapSchema.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/AggregationDataMapSchema.java
@@ -151,7 +151,8 @@ public class AggregationDataMapSchema extends DataMapSchema {
       List<ParentColumnTableRelation> parentColumnTableRelations =
           columnSchema.getParentColumnTableRelations();
       if (null != parentColumnTableRelations && parentColumnTableRelations.size() == 1
-          && parentColumnTableRelations.get(0).getColumnName().equals(columName)) {
+          && parentColumnTableRelations.get(0).getColumnName().equals(columName) &&
+          columnSchema.getColumnName().endsWith(columName)) {
         return columnSchema;
       }
     }

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggregateLoad.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggregateLoad.scala
@@ -405,4 +405,15 @@ test("check load and select for avg double datatype") {
     sql("drop table if exists maintable")
   }
 
+  test("check load and select for avg int datatype and group by") {
+    sql("drop table if exists maintable ")
+    sql("CREATE TABLE maintable(id int, city string, age int) stored by 'carbondata'")
+    sql(s"LOAD DATA LOCAL INPATH '$testData' into table maintable")
+    sql(s"LOAD DATA LOCAL INPATH '$testData' into table maintable")
+    sql(s"LOAD DATA LOCAL INPATH '$testData' into table maintable")
+    val rows = sql("select age,avg(age) from maintable group by age").collect()
+    sql("create datamap maintbl_douoble on table maintable using 'preaggregate' as select avg(age) from maintable group by age")
+    checkAnswer(sql("select age,avg(age) from maintable group by age"), rows)
+  }
+
 }


### PR DESCRIPTION
**Problem**: When applying select operation(having a column name and an aggregate function) on a table having a datamap, the data was coming out to be wrong as the group by expression and aggregate expression were created incorrectly.

**Solution**: While creating the aggregate and group by expression, we were getting the child column related to parent column name which was coming out to be wrong so added a new check there to get the correct child column.

1. Refactored code to get child column by parent column name for select operation in datamap
2. Added related test case

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

