### PR TITLE
[CARBONDATA-2119] Fixed deserialization issues for carbonLoadModel

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/CarbonTable.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/CarbonTable.java
@@ -141,7 +141,7 @@ public class CarbonTable implements Serializable {
    *
    * @param tableInfo
    */
-  private static void updateTableInfo(TableInfo tableInfo) {
+  public static void updateTableInfo(TableInfo tableInfo) {
     List<DataMapSchema> dataMapSchemas = new ArrayList<>();
     for (DataMapSchema dataMapSchema : tableInfo.getDataMapSchemaList()) {
       DataMapSchema newDataMapSchema = DataMapSchemaFactory.INSTANCE

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/model/CarbonDataLoadSchema.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/model/CarbonDataLoadSchema.java
@@ -37,6 +37,11 @@ public class CarbonDataLoadSchema implements Serializable {
   private CarbonTable carbonTable;
 
   /**
+   * Used to determine if the dataTypes have already been updated or not.
+   */
+  private transient boolean updatedDataTypes;
+
+  /**
    * CarbonDataLoadSchema constructor which takes CarbonTable
    *
    * @param carbonTable
@@ -51,6 +56,10 @@ public class CarbonDataLoadSchema implements Serializable {
    * @return carbonTable
    */
   public CarbonTable getCarbonTable() {
+    if (!updatedDataTypes) {
+      CarbonTable.updateTableInfo(carbonTable.getTableInfo());
+      updatedDataTypes = true;
+    }
     return carbonTable;
   }
 


### PR DESCRIPTION
**Problem:**
Load model was not getting de-serialized in the executor due to which 2 different carbon table objects were being created.
**Solution:**
Reconstruct carbonTable from tableInfo if not already created.


Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [X] Any interfaces changed?
 
 - [X] Any backward compatibility impacted?
 
 - [X] Document update required?

 - [X] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [X] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

