### PR TITLE
[CARBONDATA-2121] Remove tempCSV option for Carbon Dataframe writer

### DIFF
--- a/examples/spark2/src/main/scala/org/apache/carbondata/examples/CarbonBatchSparkStreamingExample.scala
+++ b/examples/spark2/src/main/scala/org/apache/carbondata/examples/CarbonBatchSparkStreamingExample.scala
@@ -173,7 +173,6 @@ object CarbonBatchSparkStreamingExample {
         df.write
           .format("carbondata")
           .option("tableName", tableName)
-          .option("tempCSV", "false")
           .option("compress", "true")
           .option("single_pass", "true")
           .mode(SaveMode.Append)

--- a/examples/spark2/src/main/scala/org/apache/carbondata/examples/CarbonDataFrameExample.scala
+++ b/examples/spark2/src/main/scala/org/apache/carbondata/examples/CarbonDataFrameExample.scala
@@ -56,7 +56,6 @@ object CarbonDataFrameExample {
       .format("carbondata")
       .option("tableName", "carbon_table")
       .option("compress", "true")
-      .option("tempCSV", "false")
       .mode(SaveMode.Overwrite)
       .save()
 

--- a/examples/spark2/src/main/scala/org/apache/carbondata/examples/CompareTest.scala
+++ b/examples/spark2/src/main/scala/org/apache/carbondata/examples/CompareTest.scala
@@ -275,7 +275,6 @@ object CompareTest {
       input.write
           .format("carbondata")
           .option("tableName", tableName)
-          .option("tempCSV", "false")
           .option("single_pass", "true")
           .option("dictionary_exclude", "id") // id is high cardinality column
           .option("table_blocksize", "32")

--- a/examples/spark2/src/main/scala/org/apache/carbondata/examples/ConcurrencyTest.scala
+++ b/examples/spark2/src/main/scala/org/apache/carbondata/examples/ConcurrencyTest.scala
@@ -188,7 +188,6 @@ object ConcurrencyTest {
       input.write
         .format("carbondata")
         .option("tableName", tableName)
-        .option("tempCSV", "false")
         .option("single_pass", "true")
         .option("dictionary_exclude", "id") // id is high cardinality column
         .option("table_blocksize", "32")

--- a/examples/spark2/src/main/scala/org/apache/carbondata/examples/DataUpdateDeleteExample.scala
+++ b/examples/spark2/src/main/scala/org/apache/carbondata/examples/DataUpdateDeleteExample.scala
@@ -69,7 +69,6 @@ object DataUpdateDeleteExample {
     df.write
       .format("carbondata")
       .option("tableName", "t3")
-      .option("tempCSV", "true")
       .option("compress", "true")
       .mode(SaveMode.Overwrite)
       .save()
@@ -83,7 +82,6 @@ object DataUpdateDeleteExample {
     df.write
       .format("carbondata")
       .option("tableName", "t5")
-      .option("tempCSV", "true")
       .option("compress", "true")
       .mode(SaveMode.Overwrite)
       .save()

--- a/examples/spark2/src/main/scala/org/apache/carbondata/examples/ExampleUtils.scala
+++ b/examples/spark2/src/main/scala/org/apache/carbondata/examples/ExampleUtils.scala
@@ -94,12 +94,11 @@ object ExampleUtils {
         .map(x => ("a", "b", x))
         .toDF("c1", "c2", "c3")
 
-    // save dataframe directl to carbon file without tempCSV
+    // save dataframe directl to carbon file
     df.write
       .format("carbondata")
       .option("tableName", tableName)
       .option("compress", "true")
-      .option("tempCSV", "false")
       .mode(mode)
       .save()
   }

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/primitiveTypes/DoubleDataTypeTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/primitiveTypes/DoubleDataTypeTestCase.scala
@@ -59,7 +59,6 @@ class DoubleDataTypeTestCase extends QueryTest with BeforeAndAfterAll {
     df.write
       .format("carbondata")
       .option("tableName", "doubleTypeCarbonTable")
-      .option("tempCSV", "false")
       .option("single_pass", "true")
       .option("dictionary_exclude", "city")
       .option("table_blocksize", "32")

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestLoadDataFrame.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestLoadDataFrame.scala
@@ -90,7 +90,6 @@ test("test the boolean data type"){
   booldf.write
     .format("carbondata")
     .option("tableName", "carbon10")
-    .option("tempCSV", "true")
     .option("compress", "true")
     .mode(SaveMode.Overwrite)
     .save()
@@ -104,7 +103,6 @@ test("test the boolean data type"){
     df.write
       .format("carbondata")
       .option("tableName", "carbon1")
-      .option("tempCSV", "true")
       .option("compress", "true")
       .mode(SaveMode.Overwrite)
       .save()
@@ -118,7 +116,6 @@ test("test the boolean data type"){
     df.write
       .format("carbondata")
       .option("tableName", "carbon2")
-      .option("tempCSV", "true")
       .option("compress", "false")
       .mode(SaveMode.Overwrite)
       .save()
@@ -132,7 +129,6 @@ test("test the boolean data type"){
     df.write
       .format("carbondata")
       .option("tableName", "carbon3")
-      .option("tempCSV", "false")
       .mode(SaveMode.Overwrite)
       .save()
     checkAnswer(
@@ -201,7 +197,6 @@ test("test the boolean data type"){
     df2.write
       .format("carbondata")
       .option("tableName", "carbon8")
-      .option("tempCSV", "false")
       .option("single_pass", "true")
       .option("compress", "false")
       .mode(SaveMode.Overwrite)
@@ -216,7 +211,6 @@ test("test the boolean data type"){
     df2.write
       .format("carbondata")
       .option("tableName", "carbon9")
-      .option("tempCSV", "true")
       .option("single_pass", "false")
       .option("compress", "false")
       .mode(SaveMode.Overwrite)
@@ -249,7 +243,6 @@ test("test the boolean data type"){
     dataFrame.write
       .format("carbondata")
       .option("tableName", "carbon11")
-      .option("tempCSV", "true")
       .option("single_pass", "false")
       .option("compress", "false")
       .option("streaming", "true")
@@ -275,7 +268,6 @@ test("test the boolean data type"){
     df2.write
       .format("carbondata")
       .option("tableName", tableName)
-      .option("tempCSV", "false")
       .option("single_pass", "false")
       .option("table_blocksize", "256")
       .option("compress", "false")

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestLoadWithSortTempCompressed.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestLoadWithSortTempCompressed.scala
@@ -73,7 +73,6 @@ class TestLoadWithSortTempCompressed extends QueryTest
     df.write
       .format("carbondata")
       .option("tableName", simpleTable)
-      .option("tempCSV", "true")
       .option("DICTIONARY_INCLUDE", "c1,c2")
       .option("SORT_COLUMNS", "c1,c3")
       .save()

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datamap/DataMapWriterSuite.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datamap/DataMapWriterSuite.scala
@@ -94,7 +94,6 @@ class DataMapWriterSuite extends QueryTest with BeforeAndAfterAll {
     df.write
       .format("carbondata")
       .option("tableName", "carbon1")
-      .option("tempCSV", "false")
       .option("sort_columns","c1")
       .mode(SaveMode.Overwrite)
       .save()
@@ -130,7 +129,6 @@ class DataMapWriterSuite extends QueryTest with BeforeAndAfterAll {
     df.write
       .format("carbondata")
       .option("tableName", "carbon2")
-      .option("tempCSV", "false")
       .option("sort_columns","c1")
       .option("SORT_SCOPE","GLOBAL_SORT")
       .mode(SaveMode.Overwrite)

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/iud/DeleteCarbonTableTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/iud/DeleteCarbonTableTestCase.scala
@@ -134,7 +134,6 @@ class DeleteCarbonTableTestCase extends QueryTest with BeforeAndAfterAll {
     df.write
       .format("carbondata")
       .option("tableName", "carbon2")
-      .option("tempCSV", "true")
       .option("compress", "true")
       .mode(SaveMode.Overwrite)
       .save()

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/iud/InsertOverwriteConcurrentTest.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/iud/InsertOverwriteConcurrentTest.scala
@@ -75,7 +75,6 @@ class InsertOverwriteConcurrentTest extends QueryTest with BeforeAndAfterAll wit
     df.write
       .format("carbondata")
       .option("tableName", tableName)
-      .option("tempCSV", "false")
       .mode(SaveMode.Overwrite)
       .save()
   }

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/iud/TestUpdateAndDeleteWithLargeData.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/iud/TestUpdateAndDeleteWithLargeData.scala
@@ -57,7 +57,6 @@ class TestUpdateAndDeleteWithLargeData extends QueryTest with BeforeAndAfterAll 
     df.write
       .format("carbondata")
       .option("tableName", "orders")
-      .option("tempCSV", "true")
       .option("compress", "true")
       .mode(SaveMode.Overwrite)
       .save()

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/iud/UpdateCarbonTableTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/iud/UpdateCarbonTableTestCase.scala
@@ -436,7 +436,6 @@ class UpdateCarbonTableTestCase extends QueryTest with BeforeAndAfterAll {
     df.write
       .format("carbondata")
       .option("tableName", "carbon1")
-      .option("tempCSV", "true")
       .option("compress", "true")
       .mode(SaveMode.Overwrite)
       .save()
@@ -470,8 +469,7 @@ class UpdateCarbonTableTestCase extends QueryTest with BeforeAndAfterAll {
     df.write
       .format("carbondata")
       .option("tableName", "study_carbondata")
-      .option("compress", "true")  // just valid when tempCSV is true
-      .option("tempCSV", "false")
+      .option("compress", "true")
       .option("single_pass", "true")
       .option("sort_scope", "LOCAL_SORT")
       .mode(SaveMode.Append)

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/CarbonOption.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/CarbonOption.scala
@@ -36,8 +36,6 @@ class CarbonOption(options: Map[String, String]) {
       "org.apache.carbondata.processing.partition.impl.SampleDataPartitionerImpl")
   }
 
-  def tempCSV: Boolean = options.getOrElse("tempCSV", "false").toBoolean
-
   def compress: Boolean = options.getOrElse("compress", "false").toBoolean
 
   def singlePass: Boolean = options.getOrElse("single_pass", "false").toBoolean

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonDataFrameWriter.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonDataFrameWriter.scala
@@ -17,16 +17,12 @@
 
 package org.apache.spark.sql
 
-import org.apache.hadoop.fs.Path
-import org.apache.hadoop.io.compress.GzipCodec
 import org.apache.spark.sql.execution.command.management.CarbonLoadDataCommand
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.util.CarbonException
 
 import org.apache.carbondata.common.logging.LogServiceFactory
-import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.metadata.datatype.{DataTypes => CarbonType}
-import org.apache.carbondata.core.util.CarbonProperties
 import org.apache.carbondata.spark.CarbonOption
 
 class CarbonDataFrameWriter(sqlContext: SQLContext, val dataFrame: DataFrame) {
@@ -46,88 +42,7 @@ class CarbonDataFrameWriter(sqlContext: SQLContext, val dataFrame: DataFrame) {
 
   private def writeToCarbonFile(parameters: Map[String, String] = Map()): Unit = {
     val options = new CarbonOption(parameters)
-    if (options.tempCSV) {
-      loadTempCSV(options)
-    } else {
-      loadDataFrame(options)
-    }
-  }
-
-  /**
-   * Firstly, saving DataFrame to CSV files
-   * Secondly, load CSV files
-   * @param options
-   */
-  private def loadTempCSV(options: CarbonOption): Unit = {
-    // temporary solution: write to csv file, then load the csv into carbon
-    val storePath = CarbonProperties.getStorePath
-    val tempCSVFolder = new StringBuilder(storePath).append(CarbonCommonConstants.FILE_SEPARATOR)
-      .append("tempCSV")
-      .append(CarbonCommonConstants.UNDERSCORE)
-      .append(CarbonEnv.getDatabaseName(options.dbName)(sqlContext.sparkSession))
-      .append(CarbonCommonConstants.UNDERSCORE)
-      .append(options.tableName)
-      .append(CarbonCommonConstants.UNDERSCORE)
-      .append(System.nanoTime())
-      .toString
-    writeToTempCSVFile(tempCSVFolder, options)
-
-    val tempCSVPath = new Path(tempCSVFolder)
-    val fs = tempCSVPath.getFileSystem(dataFrame.sqlContext.sparkContext.hadoopConfiguration)
-
-    def countSize(): Double = {
-      var size: Double = 0
-      val itor = fs.listFiles(tempCSVPath, true)
-      while (itor.hasNext) {
-        val f = itor.next()
-        if (f.getPath.getName.startsWith("part-")) {
-          size += f.getLen
-        }
-      }
-      size
-    }
-
-    LOGGER.info(s"temporary CSV file size: ${countSize / 1024 / 1024} MB")
-
-    try {
-      sqlContext.sql(makeLoadString(tempCSVFolder, options))
-    } finally {
-      fs.delete(tempCSVPath, true)
-    }
-  }
-
-  private def writeToTempCSVFile(tempCSVFolder: String, options: CarbonOption): Unit = {
-    val strRDD = dataFrame.rdd.mapPartitions { case iter =>
-      new Iterator[String] {
-        override def hasNext = iter.hasNext
-
-        def convertToCSVString(seq: Seq[Any]): String = {
-          val build = new java.lang.StringBuilder()
-          if (seq.head != null) {
-            build.append(seq.head.toString)
-          }
-          val itemIter = seq.tail.iterator
-          while (itemIter.hasNext) {
-            build.append(CarbonCommonConstants.COMMA)
-            val value = itemIter.next()
-            if (value != null) {
-              build.append(value.toString)
-            }
-          }
-          build.toString
-        }
-
-        override def next: String = {
-          convertToCSVString(iter.next.toSeq)
-        }
-      }
-    }
-
-    if (options.compress) {
-      strRDD.saveAsTextFile(tempCSVFolder, classOf[GzipCodec])
-    } else {
-      strRDD.saveAsTextFile(tempCSVFolder)
-    }
+    loadDataFrame(options)
   }
 
   /**
@@ -186,16 +101,6 @@ class CarbonDataFrameWriter(sqlContext: SQLContext, val dataFrame: DataFrame) {
        | ${ if (options.tablePath.nonEmpty) s"LOCATION '${options.tablePath.get}'" else ""}
        |  ${ if (property.nonEmpty) "TBLPROPERTIES (" + property + ")" else "" }
        |
-     """.stripMargin
-  }
-
-  private def makeLoadString(csvFolder: String, options: CarbonOption): String = {
-    val dbName = CarbonEnv.getDatabaseName(options.dbName)(sqlContext.sparkSession)
-    s"""
-       | LOAD DATA INPATH '$csvFolder'
-       | INTO TABLE $dbName.${options.tableName}
-       | OPTIONS ('FILEHEADER' = '${dataFrame.columns.mkString(",")}',
-       | 'SINGLE_PASS' = '${options.singlePass}')
      """.stripMargin
   }
 

--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/CarbonDataSourceSuite.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/CarbonDataSourceSuite.scala
@@ -119,7 +119,6 @@ class CarbonDataSourceSuite extends Spark2QueryTest with BeforeAndAfterAll {
     input.write
       .format("carbondata")
       .option("tableName", "testBigData")
-      .option("tempCSV", "false")
       .option("single_pass", "true")
       .option("dictionary_exclude", "id") // id is high cardinality column
       .mode(SaveMode.Overwrite)


### PR DESCRIPTION
TempCSV option creates csv temporary file which makes data loading slow. This PR removes it.

 - [X] Any interfaces changed?
 No
 - [X] Any backward compatibility impacted?
 No
 - [X] Document update required?
 No
 - [X] Testing done
no logic is changed, rerun all test
 - [X] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA