### PR TITLE
[CARBONDATA-2123] Refactor datamap schema thrift and datamap provider to use short name and classname

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -1455,8 +1455,6 @@ public final class CarbonCommonConstants {
 
   public static final String BITSET_PIPE_LINE_DEFAULT = "true";
 
-
-  public static final String AGGREGATIONDATAMAPSCHEMA = "AggregateDataMapHandler";
   /*
    * The total size of carbon data
    */

--- a/core/src/main/java/org/apache/carbondata/core/metadata/converter/ThriftWrapperSchemaConverterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/converter/ThriftWrapperSchemaConverterImpl.java
@@ -343,7 +343,7 @@ public class ThriftWrapperSchemaConverterImpl implements SchemaConverter {
             .setDatabaseName(wrapperChildSchema.getRelationIdentifier().getDatabaseName());
         relationIdentifier.setTableName(wrapperChildSchema.getRelationIdentifier().getTableName());
         relationIdentifier.setTableId(wrapperChildSchema.getRelationIdentifier().getTableId());
-        thriftChildSchema.setChildTableIdentifer(relationIdentifier);
+        thriftChildSchema.setChildTableIdentifier(relationIdentifier);
       }
       thriftChildSchema.setProperties(wrapperChildSchema.getProperties());
       thriftChildSchema.setClassName(wrapperChildSchema.getClassName());
@@ -648,11 +648,11 @@ public class ThriftWrapperSchemaConverterImpl implements SchemaConverter {
     DataMapSchema childSchema = new DataMapSchema(thriftDataMapSchema.getDataMapName(),
         thriftDataMapSchema.getClassName());
     childSchema.setProperties(thriftDataMapSchema.getProperties());
-    if (null != thriftDataMapSchema.getChildTableIdentifer()) {
+    if (null != thriftDataMapSchema.getChildTableIdentifier()) {
       RelationIdentifier relationIdentifier =
-          new RelationIdentifier(thriftDataMapSchema.getChildTableIdentifer().getDatabaseName(),
-              thriftDataMapSchema.getChildTableIdentifer().getTableName(),
-              thriftDataMapSchema.getChildTableIdentifer().getTableId());
+          new RelationIdentifier(thriftDataMapSchema.getChildTableIdentifier().getDatabaseName(),
+              thriftDataMapSchema.getChildTableIdentifier().getTableName(),
+              thriftDataMapSchema.getChildTableIdentifier().getTableId());
       childSchema.setRelationIdentifier(relationIdentifier);
       childSchema.setChildSchema(
           fromExternalToWrapperTableSchema(thriftDataMapSchema.getChildTableSchema(),

--- a/core/src/main/java/org/apache/carbondata/core/metadata/converter/ThriftWrapperSchemaConverterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/converter/ThriftWrapperSchemaConverterImpl.java
@@ -343,7 +343,7 @@ public class ThriftWrapperSchemaConverterImpl implements SchemaConverter {
             .setDatabaseName(wrapperChildSchema.getRelationIdentifier().getDatabaseName());
         relationIdentifier.setTableName(wrapperChildSchema.getRelationIdentifier().getTableName());
         relationIdentifier.setTableId(wrapperChildSchema.getRelationIdentifier().getTableId());
-        thriftChildSchema.setRelationIdentifire(relationIdentifier);
+        thriftChildSchema.setChildTableIdentifer(relationIdentifier);
       }
       thriftChildSchema.setProperties(wrapperChildSchema.getProperties());
       thriftChildSchema.setClassName(wrapperChildSchema.getClassName());
@@ -648,11 +648,11 @@ public class ThriftWrapperSchemaConverterImpl implements SchemaConverter {
     DataMapSchema childSchema = new DataMapSchema(thriftDataMapSchema.getDataMapName(),
         thriftDataMapSchema.getClassName());
     childSchema.setProperties(thriftDataMapSchema.getProperties());
-    if (null != thriftDataMapSchema.getRelationIdentifire()) {
+    if (null != thriftDataMapSchema.getChildTableIdentifer()) {
       RelationIdentifier relationIdentifier =
-          new RelationIdentifier(thriftDataMapSchema.getRelationIdentifire().getDatabaseName(),
-              thriftDataMapSchema.getRelationIdentifire().getTableName(),
-              thriftDataMapSchema.getRelationIdentifire().getTableId());
+          new RelationIdentifier(thriftDataMapSchema.getChildTableIdentifer().getDatabaseName(),
+              thriftDataMapSchema.getChildTableIdentifer().getTableName(),
+              thriftDataMapSchema.getChildTableIdentifer().getTableId());
       childSchema.setRelationIdentifier(relationIdentifier);
       childSchema.setChildSchema(
           fromExternalToWrapperTableSchema(thriftDataMapSchema.getChildTableSchema(),

--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/datamap/DataMapProvider.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/datamap/DataMapProvider.java
@@ -50,7 +50,8 @@ public enum DataMapProvider {
   }
 
   private boolean isEqual(String dataMapClass) {
-    return (dataMapClass != null && (dataMapClass.equals(className) ||
+    return (dataMapClass != null &&
+        (dataMapClass.equals(className) ||
         dataMapClass.equalsIgnoreCase(shortName)));
   }
 
@@ -60,7 +61,7 @@ public enum DataMapProvider {
     } else if (PREAGGREGATE.isEqual(dataMapClass)) {
       return PREAGGREGATE;
     } else {
-      throw new UnsupportedOperationException("Unknown data map type " + dataMapClass);
+      throw new UnsupportedOperationException("Unknown datamap provider/class " + dataMapClass);
     }
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/datamap/DataMapProvider.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/datamap/DataMapProvider.java
@@ -27,6 +27,40 @@ package org.apache.carbondata.core.metadata.schema.datamap;
  */
 
 public enum DataMapProvider {
-  PREAGGREGATE,
-  TIMESERIES;
+  PREAGGREGATE("org.apache.carbondata.core.datamap.AggregateDataMap", "preaggregate"),
+  TIMESERIES("org.apache.carbondata.core.datamap.TimeSeriesDataMap", "timeseries");
+
+  /**
+   * Fully qualified class name of datamap
+   */
+  private String className;
+
+  /**
+   * Short name representation of datamap
+   */
+  private String shortName;
+
+  DataMapProvider(String className, String shortName) {
+    this.className = className;
+    this.shortName = shortName;
+  }
+
+  public String getClassName() {
+    return className;
+  }
+
+  private boolean isEqual(String dataMapClass) {
+    return (dataMapClass != null && (dataMapClass.equals(className) ||
+        dataMapClass.equalsIgnoreCase(shortName)));
+  }
+
+  public static DataMapProvider getDataMapProvider(String dataMapClass) {
+    if (TIMESERIES.isEqual(dataMapClass)) {
+      return TIMESERIES;
+    } else if (PREAGGREGATE.isEqual(dataMapClass)) {
+      return PREAGGREGATE;
+    } else {
+      throw new UnsupportedOperationException("Unknown data map type " + dataMapClass);
+    }
+  }
 }

--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/DataMapSchemaFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/DataMapSchemaFactory.java
@@ -16,7 +16,7 @@
  */
 package org.apache.carbondata.core.metadata.schema.table;
 
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.AGGREGATIONDATAMAPSCHEMA;
+import org.apache.carbondata.core.metadata.schema.datamap.DataMapProvider;
 
 public class DataMapSchemaFactory {
   public static final DataMapSchemaFactory INSTANCE = new DataMapSchemaFactory();
@@ -28,11 +28,11 @@ public class DataMapSchemaFactory {
    * @return data map schema
    */
   public DataMapSchema getDataMapSchema(String dataMapName, String className) {
-    switch (className) {
-      case AGGREGATIONDATAMAPSCHEMA:
-        return new AggregationDataMapSchema(dataMapName, className);
-      default:
-        return new DataMapSchema(dataMapName, className);
+    if (DataMapProvider.PREAGGREGATE.getClassName().equals(className) ||
+        DataMapProvider.TIMESERIES.getClassName().equals(className)) {
+      return new AggregationDataMapSchema(dataMapName, className);
+    } else {
+      return new DataMapSchema(dataMapName, className);
     }
   }
 }

--- a/format/src/main/thrift/schema.thrift
+++ b/format/src/main/thrift/schema.thrift
@@ -192,13 +192,13 @@ struct DataMapSchema  {
     1: required string dataMapName;
     // class name
     2: required string className;
+    // to maintain properties like select query, query type like groupby, join
+    3: optional map<string, string> properties;
     // relation indentifier
-    3: optional RelationIdentifier relationIdentifire;
+    4: optional RelationIdentifier childTableIdentifer;
     // in case of preaggregate it will be used to maintain the child schema
     // which will be usefull in case of query and data load
-    4: optional TableSchema childTableSchema;
-    // to maintain properties like select query, query type like groupby, join
-    5: optional map<string, string> properties;
+    5: optional TableSchema childTableSchema;
 }
 
 struct TableInfo{

--- a/format/src/main/thrift/schema.thrift
+++ b/format/src/main/thrift/schema.thrift
@@ -192,11 +192,13 @@ struct DataMapSchema  {
     1: required string dataMapName;
     // class name
     2: required string className;
-    // to maintain properties like select query, query type like groupby, join
+    // to maintain properties which are mentioned in DMPROPERTIES of DDL and also it
+    // stores properties of select query, query type like groupby, join in
+    // case of preaggregate/timeseries
     3: optional map<string, string> properties;
-    // relation indentifier
-    4: optional RelationIdentifier childTableIdentifer;
-    // in case of preaggregate it will be used to maintain the child schema
+    // relation identifier of a table which stores data of datamaps like preaggregate/timeseries.
+    4: optional RelationIdentifier childTableIdentifier;
+    // in case of preaggregate/timeseries datamap it will be used to maintain the child schema
     // which will be usefull in case of query and data load
     5: optional TableSchema childTableSchema;
 }

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggCreateCommand.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggCreateCommand.scala
@@ -296,7 +296,8 @@ class TestPreAggCreateCommand extends QueryTest with BeforeAndAfterAll {
           | GROUP BY column3,column5,column2
         """.stripMargin)
     }
-    assert(e.getMessage.contains("Unknown data map type abc"))
+    assert(e.getMessage.contains(
+      s"Unknown datamap provider/class abc"))
     sql("DROP DATAMAP IF EXISTS agg0 ON TABLE maintable")
   }
 

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/timeseries/TestTimeSeriesCreateTable.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/timeseries/TestTimeSeriesCreateTable.scala
@@ -201,7 +201,7 @@ class TestTimeSeriesCreateTable extends QueryTest with BeforeAndAfterAll {
           | GROUP BY dataTime
         """.stripMargin)
     }
-    assert(e.getMessage.equals("Unknown data map type abc"))
+    assert(e.getMessage.equals("Unknown datamap provider/class abc"))
   }
 
   test("test timeseries create table 12: USING and catch MalformedCarbonCommandException") {
@@ -216,7 +216,7 @@ class TestTimeSeriesCreateTable extends QueryTest with BeforeAndAfterAll {
           | GROUP BY dataTime
         """.stripMargin)
     }
-    assert(e.getMessage.equals("Unknown data map type abc"))
+    assert(e.getMessage.equals("Unknown datamap provider/class abc"))
   }
 
   test("test timeseries create table 13: Only one granularity level can be defined 1") {

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/datamap/CarbonCreateDataMapCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/datamap/CarbonCreateDataMapCommand.scala
@@ -116,7 +116,7 @@ case class CarbonCreateDataMapCommand(
         Seq.empty
       }
     } else {
-      throw new MalformedDataMapCommandException("Unknown data map type " + dmClassName)
+      throw new MalformedDataMapCommandException("Unknown datamap provider/class " + dmClassName)
     }
   }
 
@@ -129,7 +129,7 @@ case class CarbonCreateDataMapCommand(
         Seq.empty
       }
     } else {
-      throw new MalformedDataMapCommandException("Unknown data map type " + dmClassName)
+      throw new MalformedDataMapCommandException("Unknown datamap provider/class " + dmClassName)
     }
   }
 }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/datamap/CarbonCreateDataMapCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/datamap/CarbonCreateDataMapCommand.scala
@@ -24,6 +24,7 @@ import org.apache.spark.sql.execution.command.preaaggregate.CreatePreAggregateTa
 import org.apache.spark.sql.execution.command.timeseries.TimeSeriesUtil
 
 import org.apache.carbondata.common.logging.LogServiceFactory
+import org.apache.carbondata.core.metadata.schema.datamap.DataMapProvider
 import org.apache.carbondata.core.metadata.schema.datamap.DataMapProvider._
 import org.apache.carbondata.spark.exception.{MalformedCarbonCommandException, MalformedDataMapCommandException}
 
@@ -60,7 +61,14 @@ case class CarbonCreateDataMapCommand(
     } else {
       dmProperties
     }
-
+    val dataMapProvider = {
+      try {
+        DataMapProvider.getDataMapProvider(dmClassName)
+      } catch {
+        case e: UnsupportedOperationException =>
+          throw new MalformedDataMapCommandException(e.getMessage)
+      }
+    }
     if (sparkSession.sessionState.catalog.listTables(dbName)
       .exists(_.table.equalsIgnoreCase(tableName))) {
       LOGGER.audit(
@@ -70,16 +78,16 @@ case class CarbonCreateDataMapCommand(
       if (!ifNotExistsSet) {
         throw new TableAlreadyExistsException(dbName, tableName)
       }
-    } else if (dmClassName.equalsIgnoreCase(PREAGGREGATE.toString) ||
-      dmClassName.equalsIgnoreCase(TIMESERIES.toString)) {
+    } else {
       TimeSeriesUtil.validateTimeSeriesGranularity(newDmProperties, dmClassName)
-      createPreAggregateTableCommands = if (dmClassName.equalsIgnoreCase(TIMESERIES.toString)) {
+      createPreAggregateTableCommands = if (dataMapProvider == TIMESERIES) {
         val details = TimeSeriesUtil
           .getTimeSeriesGranularityDetails(newDmProperties, dmClassName)
         val updatedDmProperties = newDmProperties - details._1
-        CreatePreAggregateTableCommand(dataMapName,
+        CreatePreAggregateTableCommand(
+          dataMapName,
           tableIdentifier,
-          dmClassName,
+          dataMapProvider,
           updatedDmProperties,
           queryString.get,
           Some(details._1),
@@ -88,14 +96,12 @@ case class CarbonCreateDataMapCommand(
         CreatePreAggregateTableCommand(
           dataMapName,
           tableIdentifier,
-          dmClassName,
+          dataMapProvider,
           newDmProperties,
           queryString.get,
           ifNotExistsSet = ifNotExistsSet)
       }
       createPreAggregateTableCommands.processMetadata(sparkSession)
-    } else {
-      throw new MalformedDataMapCommandException("Unknown data map type " + dmClassName)
     }
     LOGGER.audit(s"DataMap $dataMapName successfully added to Table ${tableIdentifier.table}")
     Seq.empty

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/preaaggregate/CreatePreAggregateTableCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/preaaggregate/CreatePreAggregateTableCommand.scala
@@ -30,6 +30,7 @@ import org.apache.spark.sql.execution.command.timeseries.TimeSeriesUtil
 import org.apache.spark.sql.parser.CarbonSpark2SqlParser
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants
+import org.apache.carbondata.core.metadata.schema.datamap.DataMapProvider
 import org.apache.carbondata.core.metadata.schema.table.AggregationDataMapSchema
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable
 import org.apache.carbondata.core.statusmanager.{SegmentStatus, SegmentStatusManager}
@@ -46,7 +47,7 @@ import org.apache.carbondata.spark.util.DataLoadingUtil
 case class CreatePreAggregateTableCommand(
     dataMapName: String,
     parentTableIdentifier: TableIdentifier,
-    dmClassName: String,
+    dataMapProvider: DataMapProvider,
     dmProperties: Map[String, String],
     queryString: String,
     timeSeriesFunction: Option[String] = None,
@@ -125,7 +126,7 @@ case class CreatePreAggregateTableCommand(
     // child schema object which will be updated on parent table about the
     val childSchema = tableInfo.getFactTable.buildChildSchema(
       dataMapName,
-      CarbonCommonConstants.AGGREGATIONDATAMAPSCHEMA,
+      dataMapProvider.getClassName,
       tableInfo.getDatabaseName,
       queryString,
       "AGGREGATION")


### PR DESCRIPTION
Update schema thrift file for datamap schema to correct the typo errors and updated the names.
Added class name to schema file and updated short name for each enum.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 
 - [x] Any backward compatibility impacted?
 
 - [x] Document update required?

 - [x] Testing done
              
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

