### PR TITLE
[HOTFIX] Fix streaming test case issue for file input source

### DIFF
--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/TestStreamingTableOperation.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/TestStreamingTableOperation.scala
@@ -235,6 +235,9 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
       sql("select count(*) from streaming.stream_table_file"),
       Seq(Row(25))
     )
+
+    val row = sql("select * from streaming.stream_table_file order by id").head()
+    assertResult(Row(10, "name_10", "city_10", 100000.0))(row)
   }
 
   // bad records
@@ -877,13 +880,7 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
           .add("file", "string")
         var qry: StreamingQuery = null
         try {
-          val readSocketDF = spark.readStream
-            .format("csv")
-            .option("sep", ",")
-            .schema(inputSchema)
-            .option("path", csvDataDir)
-            .option("header", "false")
-            .load()
+          val readSocketDF = spark.readStream.text(csvDataDir)
 
           // Write data from socket stream to carbondata file
           qry = readSocketDF.writeStream


### PR DESCRIPTION
Issue:
the result of streaming ingestion from file input source are all null.

solution:
using text function to read text file instead of CSV.

 - [x] Any interfaces changed?
 
 - [x] Any backward compatibility impacted?
 
 - [x] Document update required?

 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

