### PR TITLE
 [WIP][CARBONDATA-2129][CARBONDATA-2094][CARBONDATA-1516] Carbon should give a remind when user use old syntax to create timeseries pre-aggregate table

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/timeseries/TestTimeSeriesOldSyntaxSuite.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/timeseries/TestTimeSeriesOldSyntaxSuite.scala
@@ -1,0 +1,198 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.integration.spark.testsuite.timeseries
+
+import org.apache.carbondata.core.constants.CarbonCommonConstants
+import org.apache.spark.sql.test.util.QueryTest
+import org.scalatest.BeforeAndAfterEach
+import org.apache.carbondata.core.metadata.schema.datamap.DataMapProvider.TIMESERIES
+import org.apache.carbondata.core.util.CarbonProperties
+
+class TestTimeSeriesOldSyntaxSuite extends QueryTest with BeforeAndAfterEach {
+
+  val timeSeries = TIMESERIES.toString
+
+  override def beforeEach: Unit = {
+    sql("DROP TABLE IF EXISTS mainTable")
+    sql(
+      """
+        | CREATE TABLE IF NOT EXISTS mainTable(
+        | imei STRING,
+        | age INT,
+        | mac STRING ,
+        | prodate TIMESTAMP,
+        | update TIMESTAMP,
+        | gamepoint DOUBLE,
+        | contrid DOUBLE) 
+        | stored by 'carbondata'
+      """.stripMargin)
+  }
+
+  override def afterEach: Unit = {
+    sql("DROP TABLE IF EXISTS mainTable")
+  }
+
+  test("test timeseries old syntax 1: don't support timeseries.eventTime") {
+    val e = intercept[Exception] {
+      sql(
+        s"""
+           | CREATE DATAMAP agg2 ON table mainTable
+           | USING '$timeSeries'
+           | DMPROPERTIES (
+           |     'timeseries.eventTime'='prodate',
+           |     'timeseries.hierarchy'='hour=1,day=1,month=1,year=1')
+           | AS SELECT prodate, mac
+           | FROM mainTable
+           | GROUP BY prodate,mac
+        """.stripMargin)
+    }
+    assert(e.getMessage.equals(
+      "Don't support old syntax: timeseries.eventtime, please use event_time"))
+  }
+
+  test("test timeseries old syntax 2: don't support timeseries.eventTime") {
+    val e = intercept[Exception] {
+      sql(
+        s"""
+           | CREATE DATAMAP agg2 ON table mainTable
+           | USING '$timeSeries'
+           | DMPROPERTIES (
+           |     'timeseries.eventTime'='prodate',
+           |     'hour_granularity'='1')
+           | AS SELECT prodate, mac
+           | FROM mainTable
+           | GROUP BY prodate,mac
+        """.stripMargin)
+    }
+    assert(e.getMessage.equals(
+      "Don't support old syntax: timeseries.eventtime, please use event_time"))
+  }
+
+  test("test timeseries old syntax 3: don't support timeseries.hierarchy") {
+    val e = intercept[Exception] {
+      sql(
+        s"""
+           | CREATE DATAMAP agg2 ON table mainTable
+           | USING '$timeSeries'
+           | DMPROPERTIES (
+           |     'event_Time'='prodate',
+           |     'timeseries.hierarchy'='hour=1,day=1,month=1,year=1')
+           | AS SELECT prodate, mac
+           | FROM mainTable
+           | GROUP BY prodate,mac
+        """.stripMargin)
+    }
+    assert(e.getMessage.equals(
+      "Don't support old syntax: timeseries.hierarchy, please use different granularity"))
+  }
+
+  test("test timeseries old syntax 4:  support new syntax as contrast ") {
+    CarbonProperties.getInstance().addProperty(CarbonCommonConstants.CARBON_SHOW_DATAMAPS,"false")
+    sql(
+      s"""
+         | CREATE DATAMAP agg2_hour ON table mainTable
+         | USING '$timeSeries'
+         | DMPROPERTIES (
+         |     'event_Time'='prodate',
+         |     'hour_granularity'='1')
+         | AS SELECT prodate, mac
+         | FROM mainTable
+         | GROUP BY prodate,mac
+        """.stripMargin)
+
+    checkExistence(sql("SHOW TABLES"), false, "maintable_agg2_hour")
+    checkExistence(sql("SHOW DATAMAP ON TABLE mainTable"), true, "maintable_agg2_hour")
+    CarbonProperties.getInstance().addProperty(CarbonCommonConstants.CARBON_SHOW_DATAMAPS, CarbonCommonConstants.CARBON_SHOW_DATAMAPS_DEFAULT)
+  }
+
+  test("test timeseries old syntax 5: new show tables strategy as contrast") {
+    CarbonProperties.getInstance().addProperty(CarbonCommonConstants.CARBON_SHOW_DATAMAPS,"false")
+    sql(
+      s"""
+         | CREATE DATAMAP preagg_sum
+         | ON TABLE mainTable
+         | USING 'preaggregate'
+         | AS SELECT mac,AVG(age)
+         | FROM mainTable
+         | GROUP BY mac
+       """.stripMargin)
+    sql(
+      s"""
+         | CREATE DATAMAP agg2_second ON TABLE mainTable
+         | USING '$timeSeries'
+         | DMPROPERTIES ('event_time'='prodate', 'second_granularity'='1')
+         | AS SELECT prodate, mac
+         | FROM mainTable
+         | GROUP BY prodate,mac
+       """.stripMargin)
+    sql(
+      s"""
+         | CREATE DATAMAP agg2_minute ON TABLE mainTable
+         | USING '$timeSeries'
+         | DMPROPERTIES ('event_time'='prodate', 'minute_granularity'='1')
+         | AS SELECT prodate, mac
+         | FROM mainTable
+         | GROUP BY prodate,mac
+       """.stripMargin)
+    sql(
+      s"""
+         | CREATE DATAMAP agg2_hour ON TABLE mainTable
+         | USING '$timeSeries'
+         | DMPROPERTIES ('event_time'='prodate', 'hour_granularity'='1')
+         | AS SELECT prodate, mac
+         | FROM mainTable
+         | GROUP BY prodate,mac
+       """.stripMargin)
+    sql(
+      s"""
+         | CREATE DATAMAP agg2_day ON TABLE mainTable
+         | USING '$timeSeries'
+         | DMPROPERTIES ('event_time'='prodate', 'day_granularity'='1')
+         | AS SELECT prodate, mac
+         | FROM mainTable
+         | GROUP BY prodate,mac
+       """.stripMargin)
+    sql(
+      s"""
+         | CREATE DATAMAP agg2_month ON TABLE mainTable
+         | USING '$timeSeries'
+         | DMPROPERTIES ('event_time'='prodate', 'month_granularity'='1')
+         | AS SELECT prodate, mac
+         | FROM mainTable
+         | GROUP BY prodate,mac
+       """.stripMargin)
+    sql(
+      s"""
+         | CREATE DATAMAP agg2_year ON TABLE mainTable
+         | USING '$timeSeries'
+         | DMPROPERTIES ('event_time'='prodate', 'year_granularity'='1')
+         | AS SELECT prodate, mac
+         | FROM mainTable
+         | GROUP BY prodate,mac
+       """.stripMargin)
+
+    checkExistence(sql("SHOW TABLES"), false,
+      "maintable_preagg_sum", "maintable_agg2_second", "maintable_agg2_minute", "maintable_agg2_day",
+      "maintable_agg2_hour", "maintable_agg2_month", "maintable_agg2_year")
+
+    checkExistence(sql("SHOW DATAMAP ON TABLE mainTable"), true,
+      "maintable_preagg_sum", "maintable_agg2_second", "maintable_agg2_minute", "maintable_agg2_day",
+      "maintable_agg2_hour", "maintable_agg2_month", "maintable_agg2_year")
+    CarbonProperties.getInstance().addProperty(CarbonCommonConstants.CARBON_SHOW_DATAMAPS, CarbonCommonConstants.CARBON_SHOW_DATAMAPS_DEFAULT)
+  }
+
+}

--- a/integration/spark2/src/main/java/org/apache/carbondata/datamap/TimeseriesDataMapProvider.java
+++ b/integration/spark2/src/main/java/org/apache/carbondata/datamap/TimeseriesDataMapProvider.java
@@ -37,6 +37,7 @@ public class TimeseriesDataMapProvider extends PreAggregateDataMapProvider {
       SparkSession sparkSession) {
     Map<String, String> dmProperties = dataMapSchema.getProperties();
     String dmProviderName = dataMapSchema.getProviderName();
+    TimeSeriesUtil.validateOldSyntax(dmProperties);
     TimeSeriesUtil.validateTimeSeriesGranularity(dmProperties, dmProviderName);
     Tuple2<String, String> details =
         TimeSeriesUtil.getTimeSeriesGranularityDetails(dmProperties, dmProviderName);

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/timeseries/TimeSeriesUtil.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/timeseries/TimeSeriesUtil.scala
@@ -96,6 +96,25 @@ object TimeSeriesUtil {
   }
 
   /**
+   * Validate old time series pre-aggregate create table syntax,
+   * carbon will give a remind if user use old syntax
+   *
+   * @param dmProperties datamap properties
+   */
+  def validateOldSyntax(dmProperties: java.util.Map[String, String]): Unit = {
+    val oldEventTime = "timeseries.eventtime"
+    val oldHierarchy = "timeseries.hierarchy"
+    if (dmProperties.containsKey(oldEventTime)) {
+      throw new MalformedDataMapCommandException(
+        s"Don't support old syntax: $oldEventTime, please use $TIMESERIES_EVENTTIME")
+    }
+    if (dmProperties.containsKey(oldHierarchy)) {
+      throw new MalformedDataMapCommandException(
+        s"Don't support old syntax: $oldHierarchy, please use different granularity")
+    }
+  }
+
+  /**
    * get TimeSeries Granularity key and value
    * check the value
    *


### PR DESCRIPTION
After optimizing syntax for creating timeseries pre-aggregate table in https://issues.apache.org/jira/browse/CARBONDATA-2088, there are still old syntax were used, like: https://issues.apache.org/jira/browse/CARBONDATA-2094

Carbon should give a remind when user use old syntax to create timeseries pre-aggregate table.

We give a exception when user use the old syntax, because carbon don't support now.


Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 
 - [x] Any backward compatibility impacted?
 
 - [x] Document update required?

 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

