### PR TITLE
[CARBONDATA-2133] Fixed Exception displays after performing select query on newly added Boolean Type

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/scan/collector/impl/RestructureBasedVectorResultCollector.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/collector/impl/RestructureBasedVectorResultCollector.java
@@ -88,6 +88,7 @@ public class RestructureBasedVectorResultCollector extends DictionaryBasedVector
 
   /**
    * Gets the default value for each CarbonMeasure
+   *
    * @param carbonMeasure
    * @return
    */
@@ -95,8 +96,6 @@ public class RestructureBasedVectorResultCollector extends DictionaryBasedVector
     return RestructureUtil.getMeasureDefaultValueByType(carbonMeasure.getColumnSchema(),
         carbonMeasure.getDefaultValue());
   }
-
-
 
   @Override public List<Object[]> collectData(AbstractScannedResult scannedResult, int batchSize) {
     throw new UnsupportedOperationException("collectData is not supported here");
@@ -239,6 +238,8 @@ public class RestructureBasedVectorResultCollector extends DictionaryBasedVector
           } else if (DataTypes.isDecimal(dataType)) {
             vector.putDecimals(columnVectorInfo.vectorOffset, columnVectorInfo.size,
                 ((Decimal) defaultValue).toJavaBigDecimal(), measure.getPrecision());
+          } else if (dataType == DataTypes.BOOLEAN) {
+            vector.putBoolean(columnVectorInfo.vectorOffset, (Boolean) defaultValue);
           } else {
             vector.putDoubles(columnVectorInfo.vectorOffset, columnVectorInfo.size,
                 (double) defaultValue);

--- a/core/src/main/java/org/apache/carbondata/core/scan/executor/util/RestructureUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/executor/util/RestructureUtil.java
@@ -295,6 +295,9 @@ public class RestructureUtil {
       } else if (dataType == DataTypes.INT) {
         value = new String(defaultValue, Charset.forName(CarbonCommonConstants.DEFAULT_CHARSET));
         measureDefaultValue = Integer.parseInt(value);
+      } else if (dataType == DataTypes.BOOLEAN) {
+        value = new String(defaultValue, Charset.forName(CarbonCommonConstants.DEFAULT_CHARSET));
+        measureDefaultValue = Boolean.valueOf(value);
       } else if (DataTypes.isDecimal(dataType)) {
         BigDecimal decimal = DataTypeUtil.byteToBigDecimal(defaultValue);
         if (columnSchema.getScale() > decimal.scale()) {
@@ -323,7 +326,7 @@ public class RestructureUtil {
       byte[] defaultValue) {
     Object measureDefaultValue = null;
     if (!isDefaultValueNull(defaultValue)) {
-      String value = null;
+      String value;
       DataType dataType = columnSchema.getDataType();
       if (dataType == DataTypes.SHORT) {
         value = new String(defaultValue, Charset.forName(CarbonCommonConstants.DEFAULT_CHARSET));
@@ -334,6 +337,9 @@ public class RestructureUtil {
       } else if (dataType == DataTypes.LONG) {
         value = new String(defaultValue, Charset.forName(CarbonCommonConstants.DEFAULT_CHARSET));
         measureDefaultValue = Long.parseLong(value);
+      } else if (dataType == DataTypes.BOOLEAN) {
+        value = new String(defaultValue, Charset.forName(CarbonCommonConstants.DEFAULT_CHARSET));
+        measureDefaultValue = Boolean.valueOf(value);
       } else if (DataTypes.isDecimal(dataType)) {
         BigDecimal decimal = DataTypeUtil.byteToBigDecimal(defaultValue);
         if (columnSchema.getScale() > decimal.scale()) {

--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/restructure/AlterTableValidationTestCase.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/restructure/AlterTableValidationTestCase.scala
@@ -40,6 +40,10 @@ class AlterTableValidationTestCase extends Spark2QueryTest with BeforeAndAfterAl
     sql("drop table if exists restructure_bad")
     sql("drop table if exists restructure_badnew")
     sql("drop table if exists allKeyCol")
+    sql("drop table if exists testalterwithboolean")
+    sql("drop table if exists testalterwithbooleanwithoutdefaultvalue")
+
+
     // clean data folder
     CarbonProperties.getInstance()
     sql(
@@ -544,7 +548,20 @@ class AlterTableValidationTestCase extends Spark2QueryTest with BeforeAndAfterAl
     sql("drop table if exists restructure1")
     sql("drop table if exists restructure")
   }
-
+test("test alter command for boolean data type with correct default measure value") {
+  sql("create table testalterwithboolean(id int,name string) stored by 'carbondata' ")
+  sql("insert into testalterwithboolean values(1,'anubhav')  ")
+  sql(
+    "alter table testalterwithboolean add columns(booleanfield boolean) tblproperties('default.value.booleanfield'='true')")
+  checkAnswer(sql("select * from testalterwithboolean"),Seq(Row(1,"anubhav",true)))
+}
+  test("test alter command for boolean data type with out default measure value") {
+    sql("create table testalterwithbooleanwithoutdefaultvalue(id int,name string) stored by 'carbondata' ")
+    sql("insert into testalterwithbooleanwithoutdefaultvalue values(1,'anubhav')  ")
+    sql(
+      "alter table testalterwithbooleanwithoutdefaultvalue add columns(booleanfield boolean)")
+    checkAnswer(sql("select * from testalterwithbooleanwithoutdefaultvalue"),Seq(Row(1,"anubhav",null)))
+  }
   override def afterAll {
     sql("DROP TABLE IF EXISTS restructure")
     sql("drop table if exists table1")
@@ -558,5 +575,8 @@ class AlterTableValidationTestCase extends Spark2QueryTest with BeforeAndAfterAl
     sql("drop table if exists defaultSortColumnsWithAlter")
     sql("drop table if exists specifiedSortColumnsWithAlter")
     sql("drop table if exists allKeyCol")
+    sql("drop table if exists testalterwithboolean")
+    sql("drop table if exists testalterwithbooleanwithoutdefaultvalue")
+
   }
 }


### PR DESCRIPTION


**Problem** : In Restructure util and  RestructureBasedVectorResultCollector to get the default value of a measure type the case for boolean data type was missing,and in DataTypeUtil to store default value in bytes case of boolean data type was missing

**Solution**:Add the Required Cases

Be sure to do all of the following checklist to help us incorporate
your contribution quickly and easily:

- Any interfaces changed?
NA

 Any backward compatibility impacted?
NA

- Document update required?
NA

-Testing done
manual testing

Please provide details on
- Whether new unit test cases have been added or why no new tests are required?
yes

- How it is tested? Please attach test report.
mvn  -Pspark-2.1 clean install is passing

- Is it a performance related change? Please attach the performance test report.
no

- Any additional information to help reviewers in testing this change.
no
 For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
NA