### PR TITLE
[CARBONDATA-2137] Delete query performance improved

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/locks/HdfsFileLock.java
+++ b/core/src/main/java/org/apache/carbondata/core/locks/HdfsFileLock.java
@@ -85,7 +85,7 @@ public class HdfsFileLock extends AbstractCarbonLock {
       return true;
 
     } catch (IOException e) {
-      LOGGER.error(e, e.getMessage());
+      LOGGER.info(e.getMessage());
       return false;
     }
   }

--- a/core/src/main/java/org/apache/carbondata/core/locks/LocalFileLock.java
+++ b/core/src/main/java/org/apache/carbondata/core/locks/LocalFileLock.java
@@ -118,7 +118,7 @@ public class LocalFileLock extends AbstractCarbonLock {
         return false;
       }
     } catch (IOException e) {
-      LOGGER.error(e, e.getMessage());
+      LOGGER.info(e.getMessage());
       return false;
     }
 

--- a/core/src/main/java/org/apache/carbondata/core/mutate/DeleteDeltaBlockDetails.java
+++ b/core/src/main/java/org/apache/carbondata/core/mutate/DeleteDeltaBlockDetails.java
@@ -19,7 +19,10 @@ package org.apache.carbondata.core.mutate;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 
 import org.apache.carbondata.common.logging.LogService;
 import org.apache.carbondata.common.logging.LogServiceFactory;
@@ -31,7 +34,7 @@ public class DeleteDeltaBlockDetails implements Serializable {
 
   private static final long serialVersionUID = 1206104914918495724L;
 
-  private List<DeleteDeltaBlockletDetails> blockletDetails;
+  private Map<String, DeleteDeltaBlockletDetails> blockletDetailsMap;
   private String blockName;
 
   /**
@@ -42,7 +45,7 @@ public class DeleteDeltaBlockDetails implements Serializable {
 
   public DeleteDeltaBlockDetails(String blockName) {
     this.blockName = blockName;
-    blockletDetails = new ArrayList<DeleteDeltaBlockletDetails>();
+    blockletDetailsMap = new TreeMap<>();
   }
 
   public String getBlockName() {
@@ -68,15 +71,25 @@ public class DeleteDeltaBlockDetails implements Serializable {
   }
 
   public List<DeleteDeltaBlockletDetails> getBlockletDetails() {
-    return blockletDetails;
+
+    List<DeleteDeltaBlockletDetails> deleteDeltaBlockletDetailsList = new ArrayList<>();
+    Iterator<Map.Entry<String, DeleteDeltaBlockletDetails>> iterator =
+        blockletDetailsMap.entrySet().iterator();
+    while (iterator.hasNext()) {
+      deleteDeltaBlockletDetailsList.add(iterator.next().getValue());
+    }
+    return deleteDeltaBlockletDetailsList;
   }
 
   public boolean addBlockletDetails(DeleteDeltaBlockletDetails blocklet) {
-    int index = blockletDetails.indexOf(blocklet);
-    if (blockletDetails.isEmpty() || index == -1) {
-      return blockletDetails.add(blocklet);
+    DeleteDeltaBlockletDetails deleteDeltaBlockletDetails =
+        blockletDetailsMap.get(blocklet.getBlockletKey());
+    if (null == deleteDeltaBlockletDetails) {
+      blockletDetailsMap.put(blocklet.getBlockletKey(), blocklet);
+      return true;
     } else {
-      return blockletDetails.get(index).addDeletedRows(blocklet.getDeletedRows());
+      deleteDeltaBlockletDetails.addDeletedRows(blocklet.getDeletedRows());
+      return true;
     }
   }
 


### PR DESCRIPTION
**Following is the configuration used :**

SPARK_EXECUTOR_MEMORY : 200G
SPARK_DRIVER_MEMORY : 20G
SPARK_EXECUTOR_CORES : 32
SPARK_EXECUTOR_INSTANCEs : 3

**Earlier it was taking 20 minute now it is taking approx 5 minute**

 - [X] Any interfaces changed? No
 
 - [X] Any backward compatibility impacted? No
 
 - [X] Document update required? No

 - [X] Testing done
       Manual testing done
 - [X] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.  NA

