### PR TITLE
[CARBONDATA-2119]deserialization issue for carbonloadmodel

### DIFF
--- a/processing/src/main/java/org/apache/carbondata/processing/loading/model/CarbonDataLoadSchema.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/model/CarbonDataLoadSchema.java
@@ -57,7 +57,7 @@ public class CarbonDataLoadSchema implements Serializable {
    */
   public CarbonTable getCarbonTable() {
     if (!updatedDataTypes) {
-      CarbonTable.updateTableInfo(carbonTable.getTableInfo());
+      carbonTable = CarbonTable.buildFromTableInfo(carbonTable.getTableInfo());
       updatedDataTypes = true;
     }
     return carbonTable;


### PR DESCRIPTION
Problem:
Load model was not getting de-serialized in the executor due to which 2 different carbon table objects were being created.
Solution:
Reconstruct carbonTable from tableInfo if not already created.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
NA 
 - [x] Any backward compatibility impacted?
 NA
 - [x] Document update required?
NA
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

