### PR TITLE
[CARBONDATA-2143] Fixed query memory leak issue for task failure during initialization of record reader

### DIFF
--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/AbstractRecordReader.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/AbstractRecordReader.java
@@ -36,8 +36,10 @@ public abstract class AbstractRecordReader<T> extends RecordReader<Void, T> {
    */
   public void logStatistics(int recordCount, QueryStatisticsRecorder recorder) {
     // result size
-    QueryStatistic queryStatistic = new QueryStatistic();
-    queryStatistic.addCountStatistic(QueryStatisticsConstants.RESULT_SIZE, recordCount);
-    recorder.recordStatistics(queryStatistic);
+    if (null != recorder) {
+      QueryStatistic queryStatistic = new QueryStatistic();
+      queryStatistic.addCountStatistic(QueryStatisticsConstants.RESULT_SIZE, recordCount);
+      recorder.recordStatistics(queryStatistic);
+    }
   }
 }


### PR DESCRIPTION
**Problem:**
Whenever a query is executed, in the internalCompute method of CarbonScanRdd class record reader is initialized. A task completion listener is attached to each task after initialization of the record reader.
During record reader initialization, queryResultIterator is initialized and one blocklet is processed. The blocklet processed will use available unsafe memory.
Lets say there are 100 columns and 80 columns get the space but there is no space left for the remaining columns to be stored in the unsafe memory. This will result is memory exception and record reader initialization will fail leading to failure in query.
In the above case the unsafe memory allocated for 80 columns will not be freed and will always remain occupied till the JVM process persists.

**Impact**
It is memory leak in the system and can lead to query failures for queries executed after one one query fails due to the above reason.

**Solution:**
Attach the task completion listener before record reader initialization so that if the query fails at the very first instance after using unsafe memory, still that memory will be cleared.

 - [ ] Any interfaces changed?
 No
 - [ ] Any backward compatibility impacted?
 No
 - [ ] Document update required?
No
 - [ ] Testing done
Manually tested       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA
