### PR TITLE
[CARBONDATA-2145] Refactored PreAggregate functionality for dictionary include

### DIFF
--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchemaCommon.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchemaCommon.scala
@@ -548,7 +548,7 @@ class TableNewProcessor(cm: TableModel) {
         cm.dataMapRelation.get.get(field).get.columnTableRelationList.get(0).parentColumnName)
 
       val isDictionaryColumn = columnName.hasEncoding(Encoding.DICTIONARY)
-      val isAggFunPresent = if(isDictionaryColumn) {
+      val isAggFunPresent = if (isDictionaryColumn) {
         cm.dataMapRelation.get.get(field).get.aggregateFunction.equalsIgnoreCase("sum") ||
         cm.dataMapRelation.get.get(field).get.aggregateFunction.equals("avg") ||
         cm.dataMapRelation.get.get(field).get.aggregateFunction.equals("count")
@@ -557,11 +557,11 @@ class TableNewProcessor(cm: TableModel) {
         cm.dataMapRelation.get.get(field).get.aggregateFunction.equals("avg")
       }
 
-        if(!isAggFunPresent) {
+      if(!isAggFunPresent) {
           columnName.getEncoder
-        } else {
+      } else {
           new java.util.ArrayList[Encoding]()
-        }
+       }
       } else {
         new java.util.ArrayList[Encoding]()
       }

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchemaCommon.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchemaCommon.scala
@@ -542,15 +542,23 @@ class TableNewProcessor(cm: TableModel) {
       // getting the encoder from maintable so whatever encoding is applied in maintable
       // same encoder can be applied on aggregate table
       val encoders = if (getEncoderFromParent(field)) {
-        isAggFunPresent =
-          cm.dataMapRelation.get.get(field).get.aggregateFunction.equalsIgnoreCase("sum") ||
-          cm.dataMapRelation.get.get(field).get.aggregateFunction.equals("avg") ||
-          cm.dataMapRelation.get.get(field).get.aggregateFunction.equals("count")
+
+      val columnName = cm.parentTable.get.getColumnByName(
+        cm.parentTable.get.getTableName,
+        cm.dataMapRelation.get.get(field).get.columnTableRelationList.get(0).parentColumnName)
+
+      val isDictionaryColumn = columnName.hasEncoding(Encoding.DICTIONARY)
+      val isAggFunPresent = if(isDictionaryColumn) {
+        cm.dataMapRelation.get.get(field).get.aggregateFunction.equalsIgnoreCase("sum") ||
+        cm.dataMapRelation.get.get(field).get.aggregateFunction.equals("avg") ||
+        cm.dataMapRelation.get.get(field).get.aggregateFunction.equals("count")
+      } else {
+        cm.dataMapRelation.get.get(field).get.aggregateFunction.equalsIgnoreCase("sum") ||
+        cm.dataMapRelation.get.get(field).get.aggregateFunction.equals("avg")
+      }
+
         if(!isAggFunPresent) {
-          cm.parentTable.get.getColumnByName(
-            cm.parentTable.get.getTableName,
-            cm.dataMapRelation.get.get(field).get.columnTableRelationList.get(0).parentColumnName)
-            .getEncoder
+          columnName.getEncoder
         } else {
           new java.util.ArrayList[Encoding]()
         }


### PR DESCRIPTION
Description: Add the count to measure column only when the column is dictionary type in maintable.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed? No
 
 - [x] Any backward compatibility impacted? No
 
 - [x] Document update required? No

 - [x] Testing done 
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
            Ran already wriiten Unit Test case to test the functionality.
            Added Unit Test Case to check count on string type.

        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.  (N/A)

