### PR TITLE
[CARBONDATA-2150] Unwanted updatetable status files are being generated for the delete operation where no records are deleted

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/iud/DeleteCarbonTableTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/iud/DeleteCarbonTableTestCase.scala
@@ -17,8 +17,10 @@
 package org.apache.carbondata.spark.testsuite.iud
 
 import org.apache.spark.sql.test.util.QueryTest
-import org.apache.spark.sql.{Row, SaveMode}
+import org.apache.spark.sql.{CarbonEnv, Row, SaveMode}
 import org.scalatest.BeforeAndAfterAll
+
+import org.apache.carbondata.core.datastore.impl.FileFactory
 
 
 class DeleteCarbonTableTestCase extends QueryTest with BeforeAndAfterAll {
@@ -178,6 +180,24 @@ class DeleteCarbonTableTestCase extends QueryTest with BeforeAndAfterAll {
     sql("clean files for table select_after_clean")
     checkAnswer(sql("""select * from select_after_clean"""),
       Seq(Row(1, "abc"), Row(3, "uhj"), Row(4, "frg")))
+  }
+
+  test("test number of update table status files after delete query where no records are deleted") {
+    sql("drop table if exists update_status_files")
+    sql("create table update_status_files(name string,age int) stored by 'carbondata'")
+    sql("insert into update_status_files select 'abc',1")
+    sql("insert into update_status_files select 'def',2")
+    sql("insert into update_status_files select 'xyz',4")
+    sql("insert into update_status_files select 'abc',6")
+    sql("alter table update_status_files compact 'minor'")
+    sql("delete from update_status_files where age=3").show()
+    sql("delete from update_status_files where age=5").show()
+    val carbonTable = CarbonEnv
+      .getCarbonTable(Some("iud_db"), "update_status_files")(sqlContext.sparkSession)
+    val metaPath = carbonTable.getMetaDataFilepath
+    val files = FileFactory.getCarbonFile(metaPath)
+    assert(files.listFiles().length == 2)
+    sql("drop table update_status_files")
   }
 
 

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/events/CreateDatabaseEvents.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/events/CreateDatabaseEvents.scala
@@ -17,11 +17,15 @@
 
 package org.apache.carbondata.events
 
+import org.apache.spark.SparkContext
+
 
 case class CreateDatabasePreExecutionEvent(databaseName: String) extends Event
   with DatabaseEventInfo
 
-case class CreateDatabasePostExecutionEvent(databaseName: String, dataBasePath: String)
+case class CreateDatabasePostExecutionEvent(databaseName: String,
+    dataBasePath: String,
+    sparkContext: SparkContext)
   extends Event with DatabaseEventInfo
 
 case class CreateDatabaseAbortExecutionEvent(databaseName: String)

--- a/integration/spark-common/src/main/scala/org/apache/spark/util/FileUtils.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/util/FileUtils.scala
@@ -20,6 +20,7 @@ package org.apache.spark.util
 import java.io.{File, IOException}
 
 import org.apache.hadoop.conf.Configuration
+import org.apache.spark.SparkContext
 
 import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.core.constants.CarbonCommonConstants
@@ -106,13 +107,13 @@ object FileUtils {
     }
   }
 
-  def createDatabaseDirectory(dbName: String, storePath: String) {
+  def createDatabaseDirectory(dbName: String, storePath: String, sparkContext: SparkContext) {
     val databasePath: String = storePath + File.separator + dbName.toLowerCase
     val fileType = FileFactory.getFileType(databasePath)
     FileFactory.mkdirs(databasePath, fileType)
     val operationContext = new OperationContext
     val createDatabasePostExecutionEvent = new CreateDatabasePostExecutionEvent(dbName,
-      databasePath)
+      databasePath, sparkContext)
     OperationListenerBus.getInstance.fireEvent(createDatabasePostExecutionEvent, operationContext)
   }
 

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/mutation/DeleteExecution.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/mutation/DeleteExecution.scala
@@ -134,7 +134,7 @@ object DeleteExecution {
     ).collect()
 
     // if no loads are present then no need to do anything.
-    if (res.isEmpty) {
+    if (res.flatten.isEmpty) {
       return segmentsTobeDeleted
     }
 

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/strategy/DDLStrategy.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/strategy/DDLStrategy.scala
@@ -91,7 +91,7 @@ class DDLStrategy(sparkSession: SparkSession) extends SparkStrategy {
           case e: NoSuchDatabaseException =>
             CarbonProperties.getStorePath
         }
-        FileUtils.createDatabaseDirectory(dbName, dbLocation)
+        FileUtils.createDatabaseDirectory(dbName, dbLocation, sparkSession.sparkContext)
         ExecutedCommandExec(createDb) :: Nil
       case drop@DropDatabaseCommand(dbName, ifExists, isCascade) =>
         ExecutedCommandExec(CarbonDropDatabaseCommand(drop)) :: Nil


### PR DESCRIPTION
**Problem:**
Unwanted updatetable status files are being generated for the delete operation where no records are deleted

**Analysis:**
when the filter value for delete operation is less than the maximum value in that column, then getsplits() will return the block and hence in delete logic, it was creating update table status file even though delete operation was not done and added spark context to create database event

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 NA
 - [x] Any backward compatibility impacted?
 NA
 - [x] Document update required?
NA
 - [x] Testing done
test cases are added
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA
