### PR TITLE
[CARBONDATA-2148][CARBONDATA-2147] Add new Row parser: RowStreamParserImpl

### DIFF
--- a/examples/spark2/src/main/scala/org/apache/carbondata/examples/CarbonStructuredStreamingExample.scala
+++ b/examples/spark2/src/main/scala/org/apache/carbondata/examples/CarbonStructuredStreamingExample.scala
@@ -21,7 +21,7 @@ import java.io.{File, PrintWriter}
 import java.net.ServerSocket
 
 import org.apache.spark.sql.{CarbonEnv, SparkSession}
-import org.apache.spark.sql.streaming.{StreamingQuery, Trigger}
+import org.apache.spark.sql.streaming.{ProcessingTime, StreamingQuery}
 
 import org.apache.carbondata.core.util.path.{CarbonStorePath, CarbonTablePath}
 
@@ -165,7 +165,7 @@ object CarbonStructuredStreamingExample {
           // Write data from socket stream to carbondata file
           qry = readSocketDF.writeStream
             .format("carbondata")
-            .trigger(Trigger.ProcessingTime("5 seconds"))
+            .trigger(ProcessingTime("5 seconds"))
             .option("checkpointLocation", tablePath.getStreamingCheckpointDir)
             .option("dbName", "default")
             .option("tableName", "stream_table")

--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/TestStreamingTableOperation.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/TestStreamingTableOperation.scala
@@ -42,8 +42,8 @@ import org.apache.carbondata.streaming.parser.CarbonStreamParser
 
 case class FileElement(school: Array[String], age: Integer)
 case class StreamData(id: Integer, name: String, city: String, salary: java.lang.Float,
-    tax: BigDecimal, percent: java.lang.Double, birthday: Date,
-    register: Timestamp, updated: Timestamp,
+    tax: BigDecimal, percent: java.lang.Double, birthday: String,
+    register: String, updated: String,
     file: FileElement)
 
 class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
@@ -507,7 +507,7 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
     checkAnswer(
       sql("select * from stream_table_filter where id is null order by name"),
       Seq(Row(null, "", "", null, null, null, null, null, null),
-        Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Timestamp.valueOf("2010-01-01 10:01:01.0"))))
+        Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), null, Timestamp.valueOf("2010-01-01 10:01:01.0"))))
 
     checkAnswer(
       sql("select * from stream_table_filter where name = ''"),
@@ -515,7 +515,7 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
 
     checkAnswer(
       sql("select * from stream_table_filter where id is null and name <> ''"),
-      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Timestamp.valueOf("2010-01-01 10:01:01.0"))))
+      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), null, Timestamp.valueOf("2010-01-01 10:01:01.0"))))
 
     checkAnswer(
       sql("select * from stream_table_filter where city = ''"),
@@ -523,7 +523,7 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
 
     checkAnswer(
       sql("select * from stream_table_filter where id is null and city <> ''"),
-      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Timestamp.valueOf("2010-01-01 10:01:01.0"))))
+      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), null, Timestamp.valueOf("2010-01-01 10:01:01.0"))))
 
     checkAnswer(
       sql("select * from stream_table_filter where salary is null"),
@@ -531,7 +531,7 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
 
     checkAnswer(
       sql("select * from stream_table_filter where id is null and salary is not null"),
-      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Timestamp.valueOf("2010-01-01 10:01:01.0"))))
+      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), null, Timestamp.valueOf("2010-01-01 10:01:01.0"))))
 
     checkAnswer(
       sql("select * from stream_table_filter where tax is null"),
@@ -539,7 +539,7 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
 
     checkAnswer(
       sql("select * from stream_table_filter where id is null and tax is not null"),
-      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Timestamp.valueOf("2010-01-01 10:01:01.0"))))
+      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), null, Timestamp.valueOf("2010-01-01 10:01:01.0"))))
 
     checkAnswer(
       sql("select * from stream_table_filter where percent is null"),
@@ -547,7 +547,7 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
 
     checkAnswer(
       sql("select * from stream_table_filter where id is null and percent is not null"),
-      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Timestamp.valueOf("2010-01-01 10:01:01.0"))))
+      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), null, Timestamp.valueOf("2010-01-01 10:01:01.0"))))
 
     checkAnswer(
       sql("select * from stream_table_filter where birthday is null"),
@@ -555,7 +555,7 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
 
     checkAnswer(
       sql("select * from stream_table_filter where id is null and birthday is not null"),
-      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Timestamp.valueOf("2010-01-01 10:01:01.0"))))
+      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), null, Timestamp.valueOf("2010-01-01 10:01:01.0"))))
 
     checkAnswer(
       sql("select * from stream_table_filter where register is null"),
@@ -563,7 +563,7 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
 
     checkAnswer(
       sql("select * from stream_table_filter where id is null and register is not null"),
-      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Timestamp.valueOf("2010-01-01 10:01:01.0"))))
+      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), null, Timestamp.valueOf("2010-01-01 10:01:01.0"))))
 
     checkAnswer(
       sql("select * from stream_table_filter where updated is null"),
@@ -571,7 +571,7 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
 
     checkAnswer(
       sql("select * from stream_table_filter where id is null and updated is not null"),
-      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Timestamp.valueOf("2010-01-01 10:01:01.0"))))
+      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), null, Timestamp.valueOf("2010-01-01 10:01:01.0"))))
 
     // agg
     checkAnswer(
@@ -801,7 +801,7 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
     checkAnswer(
       sql("select * from stream_table_filter_complex where id is null order by name"),
       Seq(Row(null, "", "", null, null, null, null, null, null, Row(wrap(Array(null, null)), null)),
-        Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Row(wrap(Array("school_6", "school_66")), 6))))
+        Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), null, Timestamp.valueOf("2010-01-01 10:01:01.0"), Row(wrap(Array("school_6", "school_66")), 6))))
 
     checkAnswer(
       sql("select * from stream_table_filter_complex where name = ''"),
@@ -809,7 +809,7 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
 
     checkAnswer(
       sql("select * from stream_table_filter_complex where id is null and name <> ''"),
-      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Row(wrap(Array("school_6", "school_66")), 6))))
+      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), null, Timestamp.valueOf("2010-01-01 10:01:01.0"), Row(wrap(Array("school_6", "school_66")), 6))))
 
     checkAnswer(
       sql("select * from stream_table_filter_complex where city = ''"),
@@ -817,7 +817,7 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
 
     checkAnswer(
       sql("select * from stream_table_filter_complex where id is null and city <> ''"),
-      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Row(wrap(Array("school_6", "school_66")), 6))))
+      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), null, Timestamp.valueOf("2010-01-01 10:01:01.0"), Row(wrap(Array("school_6", "school_66")), 6))))
 
     checkAnswer(
       sql("select * from stream_table_filter_complex where salary is null"),
@@ -825,7 +825,7 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
 
     checkAnswer(
       sql("select * from stream_table_filter_complex where id is null and salary is not null"),
-      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Row(wrap(Array("school_6", "school_66")), 6))))
+      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), null, Timestamp.valueOf("2010-01-01 10:01:01.0"), Row(wrap(Array("school_6", "school_66")), 6))))
 
     checkAnswer(
       sql("select * from stream_table_filter_complex where tax is null"),
@@ -833,7 +833,7 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
 
     checkAnswer(
       sql("select * from stream_table_filter_complex where id is null and tax is not null"),
-      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Row(wrap(Array("school_6", "school_66")), 6))))
+      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), null, Timestamp.valueOf("2010-01-01 10:01:01.0"), Row(wrap(Array("school_6", "school_66")), 6))))
 
     checkAnswer(
       sql("select * from stream_table_filter_complex where percent is null"),
@@ -841,7 +841,7 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
 
     checkAnswer(
       sql("select * from stream_table_filter_complex where id is null and salary is not null"),
-      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Row(wrap(Array("school_6", "school_66")), 6))))
+      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), null, Timestamp.valueOf("2010-01-01 10:01:01.0"), Row(wrap(Array("school_6", "school_66")), 6))))
 
     checkAnswer(
       sql("select * from stream_table_filter_complex where birthday is null"),
@@ -849,7 +849,7 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
 
     checkAnswer(
       sql("select * from stream_table_filter_complex where id is null and birthday is not null"),
-      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Row(wrap(Array("school_6", "school_66")), 6))))
+      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), null, Timestamp.valueOf("2010-01-01 10:01:01.0"), Row(wrap(Array("school_6", "school_66")), 6))))
 
     checkAnswer(
       sql("select * from stream_table_filter_complex where register is null"),
@@ -857,7 +857,7 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
 
     checkAnswer(
       sql("select * from stream_table_filter_complex where id is null and register is not null"),
-      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Row(wrap(Array("school_6", "school_66")), 6))))
+      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), null, Timestamp.valueOf("2010-01-01 10:01:01.0"), Row(wrap(Array("school_6", "school_66")), 6))))
 
     checkAnswer(
       sql("select * from stream_table_filter_complex where updated is null"),
@@ -865,7 +865,7 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
 
     checkAnswer(
       sql("select * from stream_table_filter_complex where id is null and updated is not null"),
-      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Row(wrap(Array("school_6", "school_66")), 6))))
+      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), null, Timestamp.valueOf("2010-01-01 10:01:01.0"), Row(wrap(Array("school_6", "school_66")), 6))))
 
     // agg
     checkAnswer(
@@ -1170,7 +1170,7 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
                 // illegal number
                 stringBuilder.append(index.toString + "abc,name_" + index
                                      + ",city_" + index + "," + (10000.00 * index).toString + ",0.01,80.01" +
-                                     ",1990-01-01,2010-01-01 10:01:01,2010-01-01 10:01:01" +
+                                     ",1990-01-01,2010-01-0110:01:01,2010-01-01 10:01:01" +
                                      ",school_" + index + ":school_" + index + index + "$" + index)
               } else if (index == 9) {
                 stringBuilder.append(index.toString + ",name_" + index
@@ -1223,20 +1223,20 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
             .as[String]
             .map(_.split(","))
             .map { fields => {
-              val tmp = fields(9).split("\\$")
-              val file = FileElement(tmp(0).split(":"), tmp(1).toInt)
-              if (fields(1).equals("")) {
-                StreamData(null, null, null, null, null, null, null, null, null, null)
-              } else if (fields(1).equals("name_6")) {
-                StreamData(null, fields(1), fields(2), fields(3).toFloat,
-                    BigDecimal.valueOf(fields(4).toDouble), fields(5).toDouble,
-                    Date.valueOf(fields(6)), Timestamp.valueOf(fields(7)),
-                    Timestamp.valueOf(fields(8)), file)
+              if (fields.length == 0) {
+                StreamData(null, "", "", null, null, null, null, null, null, null)
               } else {
-                StreamData(fields(0).toInt, fields(1), fields(2), fields(3).toFloat,
-                    BigDecimal.valueOf(fields(4).toDouble), fields(5).toDouble,
-                    Date.valueOf(fields(6)), Timestamp.valueOf(fields(7)),
-                    Timestamp.valueOf(fields(8)), file)
+                val tmp = fields(9).split("\\$")
+                val file = FileElement(tmp(0).split(":"), tmp(1).toInt)
+                if (fields(1).equals("name_6")) {
+                  StreamData(null, fields(1), fields(2), fields(3).toFloat,
+                      BigDecimal.valueOf(fields(4).toDouble), fields(5).toDouble,
+                      fields(6), fields(7), fields(8), file)
+                } else {
+                  StreamData(fields(0).toInt, fields(1), fields(2), fields(3).toFloat,
+                      BigDecimal.valueOf(fields(4).toDouble), fields(5).toDouble,
+                      fields(6), fields(7), fields(8), file)
+                }
               }
             } }
 
@@ -1361,8 +1361,7 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
               val file = FileElement(tmp(0).split(":"), tmp(1).toInt)
               StreamData(fields(0).toInt, fields(1), fields(2), fields(3).toFloat,
                   BigDecimal.valueOf(fields(4).toDouble), fields(5).toDouble,
-                  Date.valueOf(fields(6)), Timestamp.valueOf(fields(7)),
-                  Timestamp.valueOf(fields(8)), file)
+                  fields(6), fields(7), fields(8), file)
             } }
 
           // Write data from socket stream to carbondata file

--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/TestStreamingTableOperation.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/TestStreamingTableOperation.scala
@@ -37,6 +37,8 @@ import org.apache.carbondata.core.statusmanager.{FileFormat, SegmentStatus}
 import org.apache.carbondata.core.util.CarbonProperties
 import org.apache.carbondata.core.util.path.{CarbonStorePath, CarbonTablePath}
 import org.apache.carbondata.spark.exception.{MalformedCarbonCommandException, ProcessMetaDataException}
+import org.apache.carbondata.streaming.CarbonStreamException
+import org.apache.carbondata.streaming.parser.CarbonStreamParser
 
 class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
 
@@ -1225,6 +1227,8 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
             .option("bad_records_action", badRecordAction)
             .option("dbName", tableIdentifier.database.get)
             .option("tableName", tableIdentifier.table)
+            .option(CarbonStreamParser.CARBON_STREAM_PARSER,
+              "org.apache.carbondata.streaming.parser.CSVStreamParserImp")
             .option(CarbonCommonConstants.HANDOFF_SIZE, handoffSize)
             .option("timestampformat", CarbonCommonConstants.CARBON_TIMESTAMP_DEFAULT_FORMAT)
             .option(CarbonCommonConstants.ENABLE_AUTO_HANDOFF, autoHandoff)
@@ -1339,6 +1343,8 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
             .option("dbName", tableIdentifier.database.get)
             .option("tableName", tableIdentifier.table)
             .option("timestampformat", CarbonCommonConstants.CARBON_TIMESTAMP_DEFAULT_FORMAT)
+            .option(CarbonStreamParser.CARBON_STREAM_PARSER,
+              "org.apache.carbondata.streaming.parser.CSVStreamParserImp")
             .start()
 
           qry.awaitTermination()

--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/TestStreamingTableOperation.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/TestStreamingTableOperation.scala
@@ -559,11 +559,12 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
 
     checkAnswer(
       sql("select * from stream_table_filter where register is null"),
-      Seq(Row(null, "", "", null, null, null, null, null, null)))
+      Seq(Row(null, "", "", null, null, null, null, null, null),
+        Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), null, Timestamp.valueOf("2010-01-01 10:01:01.0"))))
 
     checkAnswer(
       sql("select * from stream_table_filter where id is null and register is not null"),
-      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), null, Timestamp.valueOf("2010-01-01 10:01:01.0"))))
+      Seq())
 
     checkAnswer(
       sql("select * from stream_table_filter where updated is null"),
@@ -853,11 +854,12 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
 
     checkAnswer(
       sql("select * from stream_table_filter_complex where register is null"),
-      Seq(Row(null, "", "", null, null, null, null, null, null, Row(wrap(Array(null, null)), null))))
+      Seq(Row(null, "", "", null, null, null, null, null, null, Row(wrap(Array(null, null)), null)),
+        Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), null, Timestamp.valueOf("2010-01-01 10:01:01.0"), Row(wrap(Array("school_6", "school_66")), 6))))
 
     checkAnswer(
       sql("select * from stream_table_filter_complex where id is null and register is not null"),
-      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), null, Timestamp.valueOf("2010-01-01 10:01:01.0"), Row(wrap(Array("school_6", "school_66")), 6))))
+      Seq())
 
     checkAnswer(
       sql("select * from stream_table_filter_complex where updated is null"),

--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/TestStreamingTableWithRowParser.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/TestStreamingTableWithRowParser.scala
@@ -21,13 +21,12 @@ import java.io.{File, PrintWriter}
 import java.math.BigDecimal
 import java.net.{BindException, ServerSocket}
 import java.sql.{Date, Timestamp}
-import java.util.concurrent.Executors
 
 import scala.collection.mutable
 
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.hive.CarbonRelation
-import org.apache.spark.sql.{CarbonEnv, Row, SaveMode, SparkSession}
+import org.apache.spark.sql.{CarbonEnv, Row, SparkSession}
 import org.apache.spark.sql.streaming.{ProcessingTime, StreamingQuery}
 import org.apache.spark.sql.test.util.QueryTest
 import org.scalatest.BeforeAndAfterAll
@@ -36,9 +35,15 @@ import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.statusmanager.{FileFormat, SegmentStatus}
 import org.apache.carbondata.core.util.CarbonProperties
 import org.apache.carbondata.core.util.path.{CarbonStorePath, CarbonTablePath}
-import org.apache.carbondata.spark.exception.{MalformedCarbonCommandException, ProcessMetaDataException}
+import org.apache.carbondata.streaming.parser.CarbonStreamParser
 
-class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
+case class FileElement(school: Array[String], age: Integer)
+case class StreamData(id: Integer, name: String, city: String, salary: java.lang.Float,
+    tax: BigDecimal, percent: java.lang.Double, birthday: String,
+    register: String, updated: String,
+    file: FileElement)
+
+class TestStreamingTableWithRowParser extends QueryTest with BeforeAndAfterAll {
 
   private val spark = sqlContext.sparkSession
   private val dataFilePath = s"$resourcesPath/streamSample.csv"
@@ -50,235 +55,27 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
     CarbonProperties.getInstance().addProperty(
       CarbonCommonConstants.CARBON_DATE_FORMAT,
       CarbonCommonConstants.CARBON_DATE_DEFAULT_FORMAT)
-    sql("DROP DATABASE IF EXISTS streaming CASCADE")
-    sql("CREATE DATABASE streaming")
-    sql("USE streaming")
-    sql(
-      """
-        | CREATE TABLE source(
-        |    c1 string,
-        |    c2 int,
-        |    c3 string,
-        |    c5 string
-        | ) STORED BY 'org.apache.carbondata.format'
-        | TBLPROPERTIES ('streaming' = 'true')
-      """.stripMargin)
-    sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/IUD/dest.csv' INTO TABLE source""")
+    sql("DROP DATABASE IF EXISTS streaming1 CASCADE")
+    sql("CREATE DATABASE streaming1")
+    sql("USE streaming1")
 
     dropTable()
 
-    // 1. normal table not support streaming ingest
-    createTable(tableName = "batch_table", streaming = false, withBatchLoad = true)
-
-    // 2. streaming table with different input source
-    // file source
-    createTable(tableName = "stream_table_file", streaming = true, withBatchLoad = true)
-
-    // 3. streaming table with bad records
-    createTable(tableName = "bad_record_fail", streaming = true, withBatchLoad = true)
-
-    // 4. streaming frequency check
-    createTable(tableName = "stream_table_1s", streaming = true, withBatchLoad = true)
-
-    // 5. streaming table execute batch loading
-    // 6. detail query
-    // 8. compaction
-    // full scan + filter scan + aggregate query
     createTable(tableName = "stream_table_filter", streaming = true, withBatchLoad = true)
 
     createTableWithComplexType(
       tableName = "stream_table_filter_complex", streaming = true, withBatchLoad = true)
-
-    // 10. fault tolerant
-    createTable(tableName = "stream_table_tolerant", streaming = true, withBatchLoad = true)
-
-    // 11. table for delete segment test
-    createTable(tableName = "stream_table_delete_id", streaming = true, withBatchLoad = false)
-    createTable(tableName = "stream_table_delete_date", streaming = true, withBatchLoad = false)
-
-    // 12. reject alter streaming properties
-    // 13. handoff streaming segment and finish streaming
-    createTable(tableName = "stream_table_handoff", streaming = false, withBatchLoad = false)
-
-    // 15. auto handoff streaming segment
-    // 16. close streaming table
-    // 17. reopen streaming table after close
-    // 9. create new stream segment if current stream segment is full
-    createTable(tableName = "stream_table_reopen", streaming = true, withBatchLoad = false)
-
-    // 18. block drop table while streaming is in progress
-    createTable(tableName = "stream_table_drop", streaming = true, withBatchLoad = false)
-
-    // 19. block streaming on 'preaggregate' main table
-    createTable(tableName = "agg_table_block", streaming = false, withBatchLoad = false)
-  }
-
-  test("validate streaming property") {
-    sql(
-      """
-        | CREATE TABLE correct(
-        |    c1 string
-        | ) STORED BY 'org.apache.carbondata.format'
-        | TBLPROPERTIES ('streaming' = 'true')
-      """.stripMargin)
-    sql("DROP TABLE correct")
-    sql(
-      """
-        | CREATE TABLE correct(
-        |    c1 string
-        | ) STORED BY 'org.apache.carbondata.format'
-        | TBLPROPERTIES ('streaming' = 'false')
-      """.stripMargin)
-    sql("DROP TABLE correct")
-    intercept[MalformedCarbonCommandException] {
-      sql(
-        """
-          | create table wrong(
-          |    c1 string
-          | ) STORED BY 'org.apache.carbondata.format'
-          | TBLPROPERTIES ('streaming' = 'invalid')
-        """.stripMargin)
-    }
-  }
-
-  test("test blocking update and delete operation on streaming table") {
-    intercept[MalformedCarbonCommandException] {
-      sql("""UPDATE source d SET (d.c2) = (d.c2 + 1) WHERE d.c1 = 'a'""").show()
-    }
-    intercept[MalformedCarbonCommandException] {
-      sql("""DELETE FROM source WHERE d.c1 = 'a'""").show()
-    }
-  }
-
-  test("test blocking alter table operation on streaming table") {
-    intercept[MalformedCarbonCommandException] {
-      sql("""ALTER TABLE source ADD COLUMNS (c6 string)""").show()
-    }
-    intercept[MalformedCarbonCommandException] {
-      sql("""ALTER TABLE source DROP COLUMNS (c1)""").show()
-    }
-    intercept[MalformedCarbonCommandException] {
-      sql("""ALTER TABLE source RENAME to t""").show()
-    }
-    intercept[MalformedCarbonCommandException] {
-      sql("""ALTER TABLE source CHANGE c1 c1 int""").show()
-    }
   }
 
   override def afterAll {
     dropTable()
     sql("USE default")
-    sql("DROP DATABASE IF EXISTS streaming CASCADE")
+    sql("DROP DATABASE IF EXISTS streaming1 CASCADE")
   }
 
   def dropTable(): Unit = {
-    sql("drop table if exists streaming.batch_table")
-    sql("drop table if exists streaming.stream_table_file")
-    sql("drop table if exists streaming.bad_record_fail")
-    sql("drop table if exists streaming.stream_table_1s")
-    sql("drop table if exists streaming.stream_table_filter ")
-    sql("drop table if exists streaming.stream_table_filter_complex")
-    sql("drop table if exists streaming.stream_table_tolerant")
-    sql("drop table if exists streaming.stream_table_delete_id")
-    sql("drop table if exists streaming.stream_table_delete_date")
-    sql("drop table if exists streaming.stream_table_handoff")
-    sql("drop table if exists streaming.stream_table_reopen")
-    sql("drop table if exists streaming.stream_table_drop")
-    sql("drop table if exists streaming.agg_table_block")
-    sql("drop table if exists streaming.agg_table_block_agg0")
-  }
-
-  // normal table not support streaming ingest
-  test("normal table not support streaming ingest and alter normal table's streaming property") {
-    // alter normal table's streaming property
-    val msg = intercept[MalformedCarbonCommandException](sql("alter table streaming.batch_table set tblproperties('streaming'='false')"))
-    assertResult("Streaming property value is incorrect")(msg.getMessage)
-
-    val identifier = new TableIdentifier("batch_table", Option("streaming"))
-    val carbonTable = CarbonEnv.getInstance(spark).carbonMetastore.lookupRelation(identifier)(spark)
-      .asInstanceOf[CarbonRelation].metaData.carbonTable
-    val tablePath = CarbonStorePath.getCarbonTablePath(carbonTable.getAbsoluteTableIdentifier)
-    var server: ServerSocket = null
-    try {
-      server = getServerSocket
-      val thread1 = createWriteSocketThread(server, 2, 10, 1)
-      thread1.start()
-      // use thread pool to catch the exception of sink thread
-      val pool = Executors.newSingleThreadExecutor()
-      val thread2 = createSocketStreamingThread(spark, server.getLocalPort, tablePath, identifier)
-      val future = pool.submit(thread2)
-      Thread.sleep(1000)
-      thread1.interrupt()
-      val msg = intercept[Exception] {
-        future.get()
-      }
-      assert(msg.getMessage.contains("is not a streaming table"))
-    } finally {
-      if (server != null) {
-        server.close()
-      }
-    }
-  }
-
-  // input source: file
-  test("streaming ingest from file source") {
-    val identifier = new TableIdentifier("stream_table_file", Option("streaming"))
-    val carbonTable = CarbonEnv.getInstance(spark).carbonMetastore.lookupRelation(identifier)(spark)
-      .asInstanceOf[CarbonRelation].metaData.carbonTable
-    val tablePath = CarbonStorePath.getCarbonTablePath(carbonTable.getAbsoluteTableIdentifier)
-    val csvDataDir = new File("target/csvdata").getCanonicalPath
-    // streaming ingest 10 rows
-    generateCSVDataFile(spark, idStart = 10, rowNums = 10, csvDataDir)
-    val thread = createFileStreamingThread(spark, tablePath, csvDataDir, intervalSecond = 1,
-      identifier)
-    thread.start()
-    Thread.sleep(2000)
-    generateCSVDataFile(spark, idStart = 30, rowNums = 10, csvDataDir)
-    Thread.sleep(5000)
-    thread.interrupt()
-    checkAnswer(
-      sql("select count(*) from streaming.stream_table_file"),
-      Seq(Row(25))
-    )
-
-    val row = sql("select * from streaming.stream_table_file order by id").head()
-    val exceptedRow = Row(10, "name_10", "city_10", 100000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Timestamp.valueOf("2010-01-01 10:01:01.0"))
-    assertResult(exceptedRow)(row)
-  }
-
-  // bad records
-  test("streaming table with bad records action: fail") {
-    executeStreamingIngest(
-      tableName = "bad_record_fail",
-      batchNums = 2,
-      rowNumsEachBatch = 10,
-      intervalOfSource = 1,
-      intervalOfIngest = 1,
-      continueSeconds = 8,
-      generateBadRecords = true,
-      badRecordAction = "fail",
-      autoHandoff = false
-    )
-    val result = sql("select count(*) from streaming.bad_record_fail").collect()
-    assert(result(0).getLong(0) < 10 + 5)
-  }
-
-  // ingest with different interval
-  test("1 row per 1 second interval") {
-    executeStreamingIngest(
-      tableName = "stream_table_1s",
-      batchNums = 3,
-      rowNumsEachBatch = 1,
-      intervalOfSource = 1,
-      intervalOfIngest = 1,
-      continueSeconds = 6,
-      generateBadRecords = false,
-      badRecordAction = "force",
-      autoHandoff = false
-    )
-    val result = sql("select count(*) from streaming.stream_table_1s").collect()
-    // 20 seconds can't ingest all data, exists data delay
-    assert(result(0).getLong(0) > 5)
+    sql("drop table if exists streaming1.stream_table_filter")
+    sql("drop table if exists streaming1.stream_table_filter_complex")
   }
 
   test("query on stream table with dictionary, sort_columns") {
@@ -295,7 +92,7 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
     )
 
     // non-filter
-    val result = sql("select * from streaming.stream_table_filter order by id, name").collect()
+    val result = sql("select * from streaming1.stream_table_filter order by id, name").collect()
     assert(result != null)
     assert(result.length == 55)
     // check one row of streaming data
@@ -499,7 +296,7 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
     checkAnswer(
       sql("select * from stream_table_filter where id is null order by name"),
       Seq(Row(null, "", "", null, null, null, null, null, null),
-        Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Timestamp.valueOf("2010-01-01 10:01:01.0"))))
+        Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), null, Timestamp.valueOf("2010-01-01 10:01:01.0"))))
 
     checkAnswer(
       sql("select * from stream_table_filter where name = ''"),
@@ -507,7 +304,7 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
 
     checkAnswer(
       sql("select * from stream_table_filter where id is null and name <> ''"),
-      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Timestamp.valueOf("2010-01-01 10:01:01.0"))))
+      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), null, Timestamp.valueOf("2010-01-01 10:01:01.0"))))
 
     checkAnswer(
       sql("select * from stream_table_filter where city = ''"),
@@ -515,7 +312,7 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
 
     checkAnswer(
       sql("select * from stream_table_filter where id is null and city <> ''"),
-      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Timestamp.valueOf("2010-01-01 10:01:01.0"))))
+      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), null, Timestamp.valueOf("2010-01-01 10:01:01.0"))))
 
     checkAnswer(
       sql("select * from stream_table_filter where salary is null"),
@@ -523,7 +320,7 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
 
     checkAnswer(
       sql("select * from stream_table_filter where id is null and salary is not null"),
-      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Timestamp.valueOf("2010-01-01 10:01:01.0"))))
+      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), null, Timestamp.valueOf("2010-01-01 10:01:01.0"))))
 
     checkAnswer(
       sql("select * from stream_table_filter where tax is null"),
@@ -531,7 +328,7 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
 
     checkAnswer(
       sql("select * from stream_table_filter where id is null and tax is not null"),
-      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Timestamp.valueOf("2010-01-01 10:01:01.0"))))
+      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), null, Timestamp.valueOf("2010-01-01 10:01:01.0"))))
 
     checkAnswer(
       sql("select * from stream_table_filter where percent is null"),
@@ -539,7 +336,7 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
 
     checkAnswer(
       sql("select * from stream_table_filter where id is null and percent is not null"),
-      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Timestamp.valueOf("2010-01-01 10:01:01.0"))))
+      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), null, Timestamp.valueOf("2010-01-01 10:01:01.0"))))
 
     checkAnswer(
       sql("select * from stream_table_filter where birthday is null"),
@@ -547,15 +344,16 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
 
     checkAnswer(
       sql("select * from stream_table_filter where id is null and birthday is not null"),
-      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Timestamp.valueOf("2010-01-01 10:01:01.0"))))
+      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), null, Timestamp.valueOf("2010-01-01 10:01:01.0"))))
 
     checkAnswer(
       sql("select * from stream_table_filter where register is null"),
-      Seq(Row(null, "", "", null, null, null, null, null, null)))
+      Seq(Row(null, "", "", null, null, null, null, null, null),
+        Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), null, Timestamp.valueOf("2010-01-01 10:01:01.0"))))
 
     checkAnswer(
       sql("select * from stream_table_filter where id is null and register is not null"),
-      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Timestamp.valueOf("2010-01-01 10:01:01.0"))))
+      Seq())
 
     checkAnswer(
       sql("select * from stream_table_filter where updated is null"),
@@ -563,7 +361,7 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
 
     checkAnswer(
       sql("select * from stream_table_filter where id is null and updated is not null"),
-      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Timestamp.valueOf("2010-01-01 10:01:01.0"))))
+      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), null, Timestamp.valueOf("2010-01-01 10:01:01.0"))))
 
     // agg
     checkAnswer(
@@ -588,12 +386,12 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
       executeBatchLoad("stream_table_filter")
     }
     checkAnswer(
-      sql("select count(*) from streaming.stream_table_filter"),
+      sql("select count(*) from streaming1.stream_table_filter"),
       Seq(Row(25 * 2 + 5 + 5 * 3)))
 
-    sql("alter table streaming.stream_table_filter compact 'minor'")
+    sql("alter table streaming1.stream_table_filter compact 'minor'")
     Thread.sleep(5000)
-    val result1 = sql("show segments for table streaming.stream_table_filter").collect()
+    val result1 = sql("show segments for table streaming1.stream_table_filter").collect()
     result1.foreach { row =>
       if (row.getString(0).equals("1")) {
         assertResult(SegmentStatus.STREAMING.getMessage)(row.getString(1))
@@ -623,7 +421,7 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
     )
 
     // non-filter
-    val result = sql("select * from streaming.stream_table_filter_complex order by id, name").collect()
+    val result = sql("select * from streaming1.stream_table_filter_complex order by id, name").collect()
     assert(result != null)
     assert(result.length == 55)
     // check one row of streaming data
@@ -793,7 +591,7 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
     checkAnswer(
       sql("select * from stream_table_filter_complex where id is null order by name"),
       Seq(Row(null, "", "", null, null, null, null, null, null, Row(wrap(Array(null, null)), null)),
-        Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Row(wrap(Array("school_6", "school_66")), 6))))
+        Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), null, Timestamp.valueOf("2010-01-01 10:01:01.0"), Row(wrap(Array("school_6", "school_66")), 6))))
 
     checkAnswer(
       sql("select * from stream_table_filter_complex where name = ''"),
@@ -801,7 +599,7 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
 
     checkAnswer(
       sql("select * from stream_table_filter_complex where id is null and name <> ''"),
-      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Row(wrap(Array("school_6", "school_66")), 6))))
+      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), null, Timestamp.valueOf("2010-01-01 10:01:01.0"), Row(wrap(Array("school_6", "school_66")), 6))))
 
     checkAnswer(
       sql("select * from stream_table_filter_complex where city = ''"),
@@ -809,7 +607,7 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
 
     checkAnswer(
       sql("select * from stream_table_filter_complex where id is null and city <> ''"),
-      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Row(wrap(Array("school_6", "school_66")), 6))))
+      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), null, Timestamp.valueOf("2010-01-01 10:01:01.0"), Row(wrap(Array("school_6", "school_66")), 6))))
 
     checkAnswer(
       sql("select * from stream_table_filter_complex where salary is null"),
@@ -817,7 +615,7 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
 
     checkAnswer(
       sql("select * from stream_table_filter_complex where id is null and salary is not null"),
-      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Row(wrap(Array("school_6", "school_66")), 6))))
+      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), null, Timestamp.valueOf("2010-01-01 10:01:01.0"), Row(wrap(Array("school_6", "school_66")), 6))))
 
     checkAnswer(
       sql("select * from stream_table_filter_complex where tax is null"),
@@ -825,7 +623,7 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
 
     checkAnswer(
       sql("select * from stream_table_filter_complex where id is null and tax is not null"),
-      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Row(wrap(Array("school_6", "school_66")), 6))))
+      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), null, Timestamp.valueOf("2010-01-01 10:01:01.0"), Row(wrap(Array("school_6", "school_66")), 6))))
 
     checkAnswer(
       sql("select * from stream_table_filter_complex where percent is null"),
@@ -833,7 +631,7 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
 
     checkAnswer(
       sql("select * from stream_table_filter_complex where id is null and salary is not null"),
-      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Row(wrap(Array("school_6", "school_66")), 6))))
+      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), null, Timestamp.valueOf("2010-01-01 10:01:01.0"), Row(wrap(Array("school_6", "school_66")), 6))))
 
     checkAnswer(
       sql("select * from stream_table_filter_complex where birthday is null"),
@@ -841,15 +639,16 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
 
     checkAnswer(
       sql("select * from stream_table_filter_complex where id is null and birthday is not null"),
-      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Row(wrap(Array("school_6", "school_66")), 6))))
+      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), null, Timestamp.valueOf("2010-01-01 10:01:01.0"), Row(wrap(Array("school_6", "school_66")), 6))))
 
     checkAnswer(
       sql("select * from stream_table_filter_complex where register is null"),
-      Seq(Row(null, "", "", null, null, null, null, null, null, Row(wrap(Array(null, null)), null))))
+      Seq(Row(null, "", "", null, null, null, null, null, null, Row(wrap(Array(null, null)), null)),
+        Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), null, Timestamp.valueOf("2010-01-01 10:01:01.0"), Row(wrap(Array("school_6", "school_66")), 6))))
 
     checkAnswer(
       sql("select * from stream_table_filter_complex where id is null and register is not null"),
-      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Row(wrap(Array("school_6", "school_66")), 6))))
+      Seq())
 
     checkAnswer(
       sql("select * from stream_table_filter_complex where updated is null"),
@@ -857,7 +656,7 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
 
     checkAnswer(
       sql("select * from stream_table_filter_complex where id is null and updated is not null"),
-      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Row(wrap(Array("school_6", "school_66")), 6))))
+      Seq(Row(null, "name_6", "city_6", 60000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), null, Timestamp.valueOf("2010-01-01 10:01:01.0"), Row(wrap(Array("school_6", "school_66")), 6))))
 
     // agg
     checkAnswer(
@@ -876,265 +675,6 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
       Seq(Row("city_1", 2, 100000002, 10, 10000.0, 0.1),
         Row("city_2", 1, 100000002, 30, 0.2, 0.2),
         Row("city_3", 2, 100000006, 21, 30000.0, 0.3)))
-  }
-
-  test("test deleting streaming segment by ID while ingesting") {
-    executeStreamingIngest(
-      tableName = "stream_table_delete_id",
-      batchNums = 3,
-      rowNumsEachBatch = 100,
-      intervalOfSource = 5,
-      intervalOfIngest = 5,
-      continueSeconds = 18,
-      generateBadRecords = false,
-      badRecordAction = "force",
-      handoffSize = 1,
-      autoHandoff = false
-    )
-    val beforeDelete = sql("show segments for table streaming.stream_table_delete_id").collect()
-    val segmentIds1 = beforeDelete.filter(_.getString(1).equals("Streaming")).map(_.getString(0)).mkString(",")
-    val msg = intercept[Exception] {
-      sql(s"delete from table streaming.stream_table_delete_id where segment.id in ($segmentIds1) ")
-    }
-    assertResult(s"Delete segment by Id is failed. Invalid ID is: ${beforeDelete.length -1}")(msg.getMessage)
-
-    val segmentIds2 = beforeDelete.filter(_.getString(1).equals("Streaming Finish"))
-      .map(_.getString(0)).mkString(",")
-    sql(s"delete from table streaming.stream_table_delete_id where segment.id in ($segmentIds2) ")
-    val afterDelete = sql("show segments for table streaming.stream_table_delete_id").collect()
-    afterDelete.filter(!_.getString(1).equals("Streaming")).foreach { row =>
-      assertResult(SegmentStatus.MARKED_FOR_DELETE.getMessage)(row.getString(1))
-    }
-  }
-
-  test("test deleting streaming segment by date while ingesting") {
-    executeStreamingIngest(
-      tableName = "stream_table_delete_date",
-      batchNums = 3,
-      rowNumsEachBatch = 100,
-      intervalOfSource = 5,
-      intervalOfIngest = 5,
-      continueSeconds = 18,
-      generateBadRecords = false,
-      badRecordAction = "force",
-      handoffSize = 1,
-      autoHandoff = false
-    )
-    val beforeDelete = sql("show segments for table streaming.stream_table_delete_date").collect()
-    sql(s"delete from table streaming.stream_table_delete_date where segment.starttime before " +
-        s"'2999-10-01 01:00:00'")
-    val segmentIds = beforeDelete.filter(_.getString(1).equals("Streaming"))
-    assertResult(1)(segmentIds.length)
-    val afterDelete = sql("show segments for table streaming.stream_table_delete_date").collect()
-    afterDelete.filter(!_.getString(1).equals("Streaming")).foreach { row =>
-      assertResult(SegmentStatus.MARKED_FOR_DELETE.getMessage)(row.getString(1))
-    }
-  }
-
-  test("reject alter streaming properties and handoff 'streaming finish' segment to columnar segment") {
-    try {
-      sql("ALTER TABLE streaming.stream_table_handoff UNSET TBLPROPERTIES IF EXISTS ('streaming')")
-      assert(false, "unsupport to unset streaming property")
-    } catch {
-      case _ =>
-        assert(true)
-    }
-    try {
-      sql("ALTER TABLE streaming.stream_table_handoff SET TBLPROPERTIES('streaming'='true')")
-      executeStreamingIngest(
-        tableName = "stream_table_handoff",
-        batchNums = 2,
-        rowNumsEachBatch = 100,
-        intervalOfSource = 5,
-        intervalOfIngest = 5,
-        continueSeconds = 20,
-        generateBadRecords = false,
-        badRecordAction = "force",
-        handoffSize = 1L,
-        autoHandoff = false
-      )
-    } catch {
-      case _ =>
-        assert(false, "should support set table to streaming")
-    }
-
-    // alter streaming table's streaming property
-    val msg = intercept[MalformedCarbonCommandException](sql("alter table streaming.stream_table_handoff set tblproperties('streaming'='false')"))
-    assertResult("Streaming property can not be changed once it is 'true'")(msg.getMessage)
-
-    val segments = sql("show segments for table streaming.stream_table_handoff").collect()
-    assert(segments.length == 2 || segments.length == 3)
-    assertResult("Streaming")(segments(0).getString(1))
-    assertResult("Streaming Finish")(segments(1).getString(1))
-    checkAnswer(
-      sql("select count(*) from streaming.stream_table_handoff"),
-      Seq(Row(2 * 100))
-    )
-
-    val resultBeforeHandoff = sql("select * from streaming.stream_table_handoff order by id, name").collect()
-    sql("alter table streaming.stream_table_handoff compact 'streaming'")
-    Thread.sleep(5000)
-    val resultAfterHandoff = sql("select * from streaming.stream_table_handoff order by id, name").collect()
-    assertResult(resultBeforeHandoff)(resultAfterHandoff)
-    val newSegments = sql("show segments for table streaming.stream_table_handoff").collect()
-    assert(newSegments.length == 3 || newSegments.length == 5)
-    assertResult("Streaming")(newSegments((newSegments.length - 1) / 2).getString(1))
-    (0 until (newSegments.length - 1) / 2).foreach{ i =>
-      assertResult("Success")(newSegments(i).getString(1))
-    }
-    ((newSegments.length + 1) / 2 until newSegments.length).foreach{ i =>
-      assertResult("Compacted")(newSegments(i).getString(1))
-    }
-
-    sql("alter table streaming.stream_table_handoff finish streaming")
-    val newSegments1 = sql("show segments for table streaming.stream_table_handoff").collect()
-    assertResult("Streaming Finish")(newSegments1((newSegments.length - 1) / 2).getString(1))
-
-    checkAnswer(
-      sql("select count(*) from streaming.stream_table_handoff"),
-      Seq(Row(2 * 100))
-    )
-
-    try {
-      sql("ALTER TABLE stream_table_handoff SET TBLPROPERTIES('streaming'='false')")
-      assert(false, "unsupport disable streaming properties")
-    } catch {
-      case _ =>
-        assert(true)
-    }
-  }
-
-  test("auto hand off, close and reopen streaming table") {
-    executeStreamingIngest(
-      tableName = "stream_table_reopen",
-      batchNums = 2,
-      rowNumsEachBatch = 100,
-      intervalOfSource = 5,
-      intervalOfIngest = 5,
-      continueSeconds = 20,
-      generateBadRecords = false,
-      badRecordAction = "force",
-      handoffSize = 1L,
-      autoHandoff = false
-    )
-    val table1 =
-      CarbonEnv.getCarbonTable(Option("streaming"), "stream_table_reopen")(spark)
-    assertResult(true)(table1.isStreamingTable)
-
-    sql("alter table streaming.stream_table_reopen compact 'close_streaming'")
-
-    val segments =
-      sql("show segments for table streaming.stream_table_reopen").collect()
-    assert(segments.length == 4 || segments.length == 6)
-    assertResult(segments.length / 2)(segments.filter(_.getString(1).equals("Success")).length)
-    assertResult(segments.length / 2)(segments.filter(_.getString(1).equals("Compacted")).length)
-
-    checkAnswer(
-      sql("select count(*) from streaming.stream_table_reopen"),
-      Seq(Row(2 * 100))
-    )
-
-    val table2 =
-      CarbonEnv.getCarbonTable(Option("streaming"), "stream_table_reopen")(spark)
-    assertResult(false)(table2.isStreamingTable)
-
-    sql("ALTER TABLE streaming.stream_table_reopen SET TBLPROPERTIES('streaming'='true')")
-
-    val table3 =
-      CarbonEnv.getCarbonTable(Option("streaming"), "stream_table_reopen")(spark)
-    assertResult(true)(table3.isStreamingTable)
-
-    executeStreamingIngest(
-      tableName = "stream_table_reopen",
-      batchNums = 2,
-      rowNumsEachBatch = 100,
-      intervalOfSource = 5,
-      intervalOfIngest = 5,
-      continueSeconds = 20,
-      generateBadRecords = false,
-      badRecordAction = "force",
-      handoffSize = 1L,
-      autoHandoff = true
-    )
-    Thread.sleep(10000)
-    val newSegments1 =
-      sql("show segments for table streaming.stream_table_reopen").collect()
-    assert(newSegments1.length == 7 || newSegments1.length == 9 || newSegments1.length == 11)
-    assertResult(1)(newSegments1.filter(_.getString(1).equals("Streaming")).length)
-    assertResult((newSegments1.length - 1) / 2)(newSegments1.filter(_.getString(1).equals("Success")).length)
-    assertResult((newSegments1.length - 1) / 2)(newSegments1.filter(_.getString(1).equals("Compacted")).length)
-
-    sql("alter table streaming.stream_table_reopen compact 'close_streaming'")
-    val newSegments =
-      sql("show segments for table streaming.stream_table_reopen").collect()
-    assert(newSegments.length == 8 || newSegments.length == 10 || newSegments.length == 12)
-    assertResult(newSegments.length / 2)(newSegments.filter(_.getString(1).equals("Success")).length)
-    assertResult(newSegments.length / 2)(newSegments.filter(_.getString(1).equals("Compacted")).length)
-
-    //Verify MergeTO column entry for compacted Segments
-    newSegments.filter(_.getString(1).equals("Compacted")).foreach{ rw =>
-      assertResult("Compacted")(rw.getString(1))
-      assert(Integer.parseInt(rw.getString(0)) < Integer.parseInt(rw.getString(4)))
-    }
-    checkAnswer(
-      sql("select count(*) from streaming.stream_table_reopen"),
-      Seq(Row(2 * 100 * 2))
-    )
-  }
-
-  test("block drop streaming table while streaming is in progress") {
-    val identifier = new TableIdentifier("stream_table_drop", Option("streaming"))
-    val carbonTable = CarbonEnv.getInstance(spark).carbonMetastore.lookupRelation(identifier)(spark)
-      .asInstanceOf[CarbonRelation].metaData.carbonTable
-    val tablePath = CarbonStorePath.getCarbonTablePath(carbonTable.getAbsoluteTableIdentifier)
-    var server: ServerSocket = null
-    try {
-      server = getServerSocket
-      val thread1 = createWriteSocketThread(server, 2, 10, 3)
-      val thread2 = createSocketStreamingThread(spark, server.getLocalPort, tablePath, identifier, "force", 5, 1024L * 200, false)
-      thread1.start()
-      thread2.start()
-      Thread.sleep(1000)
-      val msg = intercept[ProcessMetaDataException] {
-        sql(s"drop table streaming.stream_table_drop")
-      }
-      assert(msg.getMessage.contains("Dropping table streaming.stream_table_drop failed: Acquire table lock failed after retry, please try after some time"))
-      thread1.interrupt()
-      thread2.interrupt()
-    } finally {
-      if (server != null) {
-        server.close()
-      }
-    }
-  }
-
-  test("do not support creating datamap on streaming table") {
-    assert(
-      intercept[MalformedCarbonCommandException](
-        sql("CREATE DATAMAP datamap ON TABLE source " +
-            "USING 'preaggregate'" +
-            " AS SELECT c1, sum(c2) FROM source GROUP BY c1")
-      ).getMessage.contains("Streaming table does not support creating datamap"))
-  }
-
-  test("check streaming property of table") {
-    checkExistence(sql("DESC FORMATTED batch_table"), true, "Streaming")
-    val result =
-      sql("DESC FORMATTED batch_table").collect().filter(_.getString(0).trim.equals("Streaming"))
-    assertResult(1)(result.length)
-    assertResult("false")(result(0).getString(1).trim)
-
-    checkExistence(sql("DESC FORMATTED stream_table_file"), true, "Streaming")
-    val resultStreaming = sql("DESC FORMATTED stream_table_file").collect()
-      .filter(_.getString(0).trim.equals("Streaming"))
-    assertResult(1)(resultStreaming.length)
-    assertResult("true")(resultStreaming(0).getString(1).trim)
-  }
-
-  test("block streaming for 'preaggregate' table") {
-    sql("create datamap agg_table_block_agg0 on table streaming.agg_table_block using 'preaggregate' as select city, count(name) from streaming.agg_table_block group by city")
-    val msg = intercept[MalformedCarbonCommandException](sql("ALTER TABLE streaming.agg_table_block SET TBLPROPERTIES('streaming'='true')"))
-    assertResult("The table has 'preaggregate' DataMap, it doesn't support streaming")(msg.getMessage)
   }
 
   def createWriteSocketThread(
@@ -1162,7 +702,7 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
                 // illegal number
                 stringBuilder.append(index.toString + "abc,name_" + index
                                      + ",city_" + index + "," + (10000.00 * index).toString + ",0.01,80.01" +
-                                     ",1990-01-01,2010-01-01 10:01:01,2010-01-01 10:01:01" +
+                                     ",1990-01-01,2010-01-0110:01:01,2010-01-01 10:01:01" +
                                      ",school_" + index + ":school_" + index + index + "$" + index)
               } else if (index == 9) {
                 stringBuilder.append(index.toString + ",name_" + index
@@ -1206,11 +746,31 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
       override def run(): Unit = {
         var qry: StreamingQuery = null
         try {
+          import spark.implicits._
           val readSocketDF = spark.readStream
             .format("socket")
             .option("host", "localhost")
             .option("port", port)
             .load()
+            .as[String]
+            .map(_.split(","))
+            .map { fields => {
+              if (fields.length == 0) {
+                StreamData(null, "", "", null, null, null, null, null, null, null)
+              } else {
+                val tmp = fields(9).split("\\$")
+                val file = FileElement(tmp(0).split(":"), tmp(1).toInt)
+                if (fields(1).equals("name_6")) {
+                  StreamData(null, fields(1), fields(2), fields(3).toFloat,
+                      BigDecimal.valueOf(fields(4).toDouble), fields(5).toDouble,
+                      fields(6), fields(7), fields(8), file)
+                } else {
+                  StreamData(fields(0).toInt, fields(1), fields(2), fields(3).toFloat,
+                      BigDecimal.valueOf(fields(4).toDouble), fields(5).toDouble,
+                      fields(6), fields(7), fields(8), file)
+                }
+              }
+            } }
 
           // Write data from socket stream to carbondata file
           qry = readSocketDF.writeStream
@@ -1223,6 +783,8 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
             .option(CarbonCommonConstants.HANDOFF_SIZE, handoffSize)
             .option("timestampformat", CarbonCommonConstants.CARBON_TIMESTAMP_DEFAULT_FORMAT)
             .option(CarbonCommonConstants.ENABLE_AUTO_HANDOFF, autoHandoff)
+            .option(CarbonStreamParser.CARBON_STREAM_PARSER,
+              "org.apache.carbondata.streaming.parser.RowStreamParserImp")
             .start()
           qry.awaitTermination()
         } catch {
@@ -1286,73 +848,10 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
     }
   }
 
-  def generateCSVDataFile(
-      spark: SparkSession,
-      idStart: Int,
-      rowNums: Int,
-      csvDirPath: String): Unit = {
-    // Create csv data frame file
-    val csvRDD = spark.sparkContext.parallelize(idStart until idStart + rowNums)
-      .map { id =>
-        (id,
-          "name_" + id,
-          "city_" + id,
-          10000.00 * id,
-          BigDecimal.valueOf(0.01),
-          80.01,
-          "1990-01-01",
-          "2010-01-01 10:01:01",
-          "2010-01-01 10:01:01",
-          "school_" + id + ":school_" + id + id + "$" + id)
-      }
-    val csvDataDF = spark.createDataFrame(csvRDD).toDF(
-      "id", "name", "city", "salary", "tax", "percent", "birthday", "register", "updated", "file")
-
-    csvDataDF.write
-      .option("header", "false")
-      .mode(SaveMode.Overwrite)
-      .csv(csvDirPath)
-  }
-
-  def createFileStreamingThread(
-      spark: SparkSession,
-      tablePath: CarbonTablePath,
-      csvDataDir: String,
-      intervalSecond: Int,
-      tableIdentifier: TableIdentifier): Thread = {
-    new Thread() {
-      override def run(): Unit = {
-        var qry: StreamingQuery = null
-        try {
-          val readSocketDF = spark.readStream.text(csvDataDir)
-
-          // Write data from socket stream to carbondata file
-          qry = readSocketDF.writeStream
-            .format("carbondata")
-            .trigger(ProcessingTime(s"${ intervalSecond } seconds"))
-            .option("checkpointLocation", tablePath.getStreamingCheckpointDir)
-            .option("dbName", tableIdentifier.database.get)
-            .option("tableName", tableIdentifier.table)
-            .option("timestampformat", CarbonCommonConstants.CARBON_TIMESTAMP_DEFAULT_FORMAT)
-            .start()
-
-          qry.awaitTermination()
-        } catch {
-          case _: InterruptedException =>
-            println("Done reading and writing streaming data")
-        } finally {
-          if (qry != null) {
-            qry.stop()
-          }
-        }
-      }
-    }
-  }
-
   def createTable(tableName: String, streaming: Boolean, withBatchLoad: Boolean): Unit = {
     sql(
       s"""
-         | CREATE TABLE streaming.$tableName(
+         | CREATE TABLE streaming1.$tableName(
          | id INT,
          | name STRING,
          | city STRING,
@@ -1380,7 +879,7 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
       withBatchLoad: Boolean): Unit = {
     sql(
       s"""
-         | CREATE TABLE streaming.$tableName(
+         | CREATE TABLE streaming1.$tableName(
          | id INT,
          | name STRING,
          | city STRING,
@@ -1407,7 +906,7 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
     sql(
       s"""
          | LOAD DATA LOCAL INPATH '$dataFilePath'
-         | INTO TABLE streaming.$tableName
+         | INTO TABLE streaming1.$tableName
          | OPTIONS('HEADER'='true')
          """.stripMargin)
   }

--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/TestStreamingTableWithRowParser.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/TestStreamingTableWithRowParser.scala
@@ -814,7 +814,7 @@ class TestStreamingTableWithRowParser extends QueryTest with BeforeAndAfterAll {
       handoffSize: Long = CarbonCommonConstants.HANDOFF_SIZE_DEFAULT,
       autoHandoff: Boolean = CarbonCommonConstants.ENABLE_AUTO_HANDOFF_DEFAULT.toBoolean
   ): Unit = {
-    val identifier = new TableIdentifier(tableName, Option("streaming"))
+    val identifier = new TableIdentifier(tableName, Option("streaming1"))
     val carbonTable = CarbonEnv.getInstance(spark).carbonMetastore.lookupRelation(identifier)(spark)
       .asInstanceOf[CarbonRelation].metaData.carbonTable
     val tablePath = CarbonStorePath.getCarbonTablePath(carbonTable.getAbsoluteTableIdentifier)

--- a/streaming/src/main/java/org/apache/carbondata/streaming/parser/CSVStreamParserImp.java
+++ b/streaming/src/main/java/org/apache/carbondata/streaming/parser/CSVStreamParserImp.java
@@ -26,7 +26,7 @@ import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.types.StructType;
 
 /**
- * CSV Stream Parser.
+ * CSV Stream Parser, it is also the default parser.
  */
 public class CSVStreamParserImp implements CarbonStreamParser {
 

--- a/streaming/src/main/java/org/apache/carbondata/streaming/parser/CSVStreamParserImp.java
+++ b/streaming/src/main/java/org/apache/carbondata/streaming/parser/CSVStreamParserImp.java
@@ -23,15 +23,16 @@ import com.univocity.parsers.csv.CsvParser;
 import com.univocity.parsers.csv.CsvParserSettings;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.types.StructType;
 
 /**
- * CSV Stream Parser, it is also the default parser.
+ * CSV Stream Parser.
  */
 public class CSVStreamParserImp implements CarbonStreamParser {
 
   private CsvParser csvParser;
 
-  @Override public void initialize(Configuration configuration) {
+  @Override public void initialize(Configuration configuration, StructType structType) {
     CsvParserSettings settings = CSVInputFormat.extractCsvParserSettings(configuration);
     csvParser = new CsvParser(settings);
   }

--- a/streaming/src/main/java/org/apache/carbondata/streaming/parser/CarbonStreamParser.java
+++ b/streaming/src/main/java/org/apache/carbondata/streaming/parser/CarbonStreamParser.java
@@ -29,7 +29,7 @@ public interface CarbonStreamParser {
   String CARBON_STREAM_PARSER = "carbon.stream.parser";
 
   String CARBON_STREAM_PARSER_DEFAULT =
-    "org.apache.carbondata.streaming.parser.RowStreamParserImp";
+      "org.apache.carbondata.streaming.parser.RowStreamParserImp";
 
   void initialize(Configuration configuration, StructType structType);
 

--- a/streaming/src/main/java/org/apache/carbondata/streaming/parser/CarbonStreamParser.java
+++ b/streaming/src/main/java/org/apache/carbondata/streaming/parser/CarbonStreamParser.java
@@ -29,7 +29,7 @@ public interface CarbonStreamParser {
   String CARBON_STREAM_PARSER = "carbon.stream.parser";
 
   String CARBON_STREAM_PARSER_DEFAULT =
-      "org.apache.carbondata.streaming.parser.RowStreamParserImp";
+      "org.apache.carbondata.streaming.parser.CSVStreamParserImp";
 
   void initialize(Configuration configuration, StructType structType);
 

--- a/streaming/src/main/java/org/apache/carbondata/streaming/parser/CarbonStreamParser.java
+++ b/streaming/src/main/java/org/apache/carbondata/streaming/parser/CarbonStreamParser.java
@@ -19,6 +19,7 @@ package org.apache.carbondata.streaming.parser;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.types.StructType;
 
 /**
  * Stream parser interface
@@ -27,9 +28,10 @@ public interface CarbonStreamParser {
 
   String CARBON_STREAM_PARSER = "carbon.stream.parser";
 
-  String CARBON_STREAM_PARSER_DEFAULT = "org.apache.carbondata.streaming.parser.CSVStreamParserImp";
+  String CARBON_STREAM_PARSER_DEFAULT =
+    "org.apache.carbondata.streaming.parser.RowStreamParserImp";
 
-  void initialize(Configuration configuration);
+  void initialize(Configuration configuration, StructType structType);
 
   Object[] parserRow(InternalRow value);
 

--- a/streaming/src/main/scala/org/apache/carbondata/streaming/parser/RowStreamParserImp.scala
+++ b/streaming/src/main/scala/org/apache/carbondata/streaming/parser/RowStreamParserImp.scala
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.streaming.parser
+
+import java.text.SimpleDateFormat
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.spark.sql.catalyst.encoders.{ExpressionEncoder, RowEncoder}
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types.StructType
+
+import org.apache.carbondata.core.constants.CarbonCommonConstants
+import org.apache.carbondata.processing.loading.constants.DataLoadProcessorConstants
+import org.apache.carbondata.spark.util.CarbonScalaUtil
+
+/**
+  * SparkSQL Row Stream Parser, it is also the default parser.
+  *
+  */
+class RowStreamParserImp extends CarbonStreamParser {
+
+  var configuration: Configuration = null
+  var structType: StructType = null
+  var encoder: ExpressionEncoder[Row] = null
+
+  var timeStampFormat: SimpleDateFormat = null
+  var dateFormat: SimpleDateFormat = null
+  var complexDelimiterLevel1: String = null
+  var complexDelimiterLevel2: String = null
+  var serializationNullFormat: String = null
+
+  override def initialize(configuration: Configuration, structType: StructType): Unit = {
+    this.configuration = configuration
+    this.structType = structType
+    this.encoder = RowEncoder.apply(this.structType).resolveAndBind()
+
+    this.timeStampFormat = new SimpleDateFormat(
+      this.configuration.get(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT))
+    this.dateFormat = new SimpleDateFormat(
+      this.configuration.get(CarbonCommonConstants.CARBON_DATE_FORMAT))
+    this.complexDelimiterLevel1 = this.configuration.get("carbon_complex_delimiter_level_1")
+    this.complexDelimiterLevel2 = this.configuration.get("carbon_complex_delimiter_level_2")
+    this.serializationNullFormat =
+      this.configuration.get(DataLoadProcessorConstants.SERIALIZATION_NULL_FORMAT)
+  }
+
+  override def parserRow(value: InternalRow): Array[Object] = {
+    this.encoder.fromRow(value).toSeq.map { x => {
+      CarbonScalaUtil.getString(x,
+        serializationNullFormat, complexDelimiterLevel1, complexDelimiterLevel2,
+        timeStampFormat, dateFormat)
+    } }.toArray
+  }
+
+  override def close(): Unit = {
+  }
+}

--- a/streaming/src/main/scala/org/apache/carbondata/streaming/parser/RowStreamParserImp.scala
+++ b/streaming/src/main/scala/org/apache/carbondata/streaming/parser/RowStreamParserImp.scala
@@ -30,7 +30,7 @@ import org.apache.carbondata.processing.loading.constants.DataLoadProcessorConst
 import org.apache.carbondata.spark.util.CarbonScalaUtil
 
 /**
- * SparkSQL Row Stream Parser, it is also the default parser.
+ * SparkSQL Row Stream Parser.
  */
 class RowStreamParserImp extends CarbonStreamParser {
 

--- a/streaming/src/main/scala/org/apache/carbondata/streaming/parser/RowStreamParserImp.scala
+++ b/streaming/src/main/scala/org/apache/carbondata/streaming/parser/RowStreamParserImp.scala
@@ -30,9 +30,8 @@ import org.apache.carbondata.processing.loading.constants.DataLoadProcessorConst
 import org.apache.carbondata.spark.util.CarbonScalaUtil
 
 /**
-  * SparkSQL Row Stream Parser, it is also the default parser.
-  *
-  */
+ * SparkSQL Row Stream Parser, it is also the default parser.
+ */
 class RowStreamParserImp extends CarbonStreamParser {
 
   var configuration: Configuration = null

--- a/streaming/src/main/scala/org/apache/spark/sql/execution/streaming/CarbonAppendableStreamSink.scala
+++ b/streaming/src/main/scala/org/apache/spark/sql/execution/streaming/CarbonAppendableStreamSink.scala
@@ -30,6 +30,7 @@ import org.apache.spark.internal.io.FileCommitProtocol.TaskCommitMessage
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.execution.{QueryExecution, SQLExecution}
+import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.{SerializableConfiguration, Utils}
 
 import org.apache.carbondata.common.CarbonIterator
@@ -44,6 +45,7 @@ import org.apache.carbondata.core.util.path.CarbonStorePath
 import org.apache.carbondata.events.{OperationContext, OperationListenerBus}
 import org.apache.carbondata.hadoop.streaming.CarbonStreamOutputFormat
 import org.apache.carbondata.hadoop.util.CarbonInputFormatUtil
+import org.apache.carbondata.processing.loading.constants.DataLoadProcessorConstants
 import org.apache.carbondata.processing.loading.events.LoadEvents.{LoadTablePostExecutionEvent, LoadTablePreExecutionEvent}
 import org.apache.carbondata.processing.loading.model.CarbonLoadModel
 import org.apache.carbondata.streaming.{CarbonStreamException, StreamHandoffRDD}
@@ -65,7 +67,8 @@ class CarbonAppendableStreamSink(
   private val carbonTablePath = CarbonStorePath
     .getCarbonTablePath(carbonTable.getAbsoluteTableIdentifier)
   private val fileLogPath = carbonTablePath.getStreamingLogDir
-  private val fileLog = new FileStreamSinkLog(FileStreamSinkLog.VERSION, sparkSession, fileLogPath)
+  private val fileLog = new FileStreamSinkLog(FileStreamSinkLog.VERSION,
+    sparkSession, fileLogPath)
   // prepare configuration
   private val hadoopConf = {
     val conf = sparkSession.sessionState.newHadoopConf()
@@ -73,6 +76,20 @@ class CarbonAppendableStreamSink(
     parameters.foreach { entry =>
       conf.set(entry._1, entry._2)
     }
+    // properties below will be used for default CarbonStreamParser
+    conf.set("carbon_complex_delimiter_level_1",
+      carbonLoadModel.getComplexDelimiterLevel1)
+    conf.set("carbon_complex_delimiter_level_2",
+      carbonLoadModel.getComplexDelimiterLevel2)
+    conf.set(
+      DataLoadProcessorConstants.SERIALIZATION_NULL_FORMAT,
+      carbonLoadModel.getSerializationNullFormat().split(",")(1))
+    conf.set(
+      CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT,
+      carbonLoadModel.getTimestampformat())
+    conf.set(
+      CarbonCommonConstants.CARBON_DATE_FORMAT,
+      carbonLoadModel.getDateFormat())
     conf
   }
   // segment max size(byte)
@@ -223,6 +240,7 @@ object CarbonAppendableStreamSink {
           server.get.initializeDictionaryGenerator(carbonTable)
         }
 
+        val rowSchema = queryExecution.analyzed.schema
         // write data file
         result = sparkSession.sparkContext.runJob(queryExecution.toRdd,
           (taskContext: TaskContext, iterator: Iterator[InternalRow]) => {
@@ -233,7 +251,8 @@ object CarbonAppendableStreamSink {
               sparkPartitionId = taskContext.partitionId(),
               sparkAttemptNumber = taskContext.attemptNumber(),
               committer,
-              iterator
+              iterator,
+              rowSchema
             )
           })
 
@@ -280,7 +299,8 @@ object CarbonAppendableStreamSink {
       sparkPartitionId: Int,
       sparkAttemptNumber: Int,
       committer: FileCommitProtocol,
-      iterator: Iterator[InternalRow]
+      iterator: Iterator[InternalRow],
+      rowSchema: StructType
   ): TaskCommitMessage = {
 
     val jobId = CarbonInputFormatUtil.getJobId(new Date, sparkStageId)
@@ -311,7 +331,7 @@ object CarbonAppendableStreamSink {
 
         val streamParser =
           Class.forName(parserName).newInstance.asInstanceOf[CarbonStreamParser]
-        streamParser.initialize(taskAttemptContext.getConfiguration)
+        streamParser.initialize(taskAttemptContext.getConfiguration, rowSchema)
 
         StreamSegment.appendBatchData(new InputIterator(iterator, streamParser),
           taskAttemptContext, carbonLoadModel)

--- a/streaming/src/main/scala/org/apache/spark/sql/execution/streaming/CarbonAppendableStreamSink.scala
+++ b/streaming/src/main/scala/org/apache/spark/sql/execution/streaming/CarbonAppendableStreamSink.scala
@@ -67,8 +67,7 @@ class CarbonAppendableStreamSink(
   private val carbonTablePath = CarbonStorePath
     .getCarbonTablePath(carbonTable.getAbsoluteTableIdentifier)
   private val fileLogPath = carbonTablePath.getStreamingLogDir
-  private val fileLog = new FileStreamSinkLog(FileStreamSinkLog.VERSION,
-    sparkSession, fileLogPath)
+  private val fileLog = new FileStreamSinkLog(FileStreamSinkLog.VERSION, sparkSession, fileLogPath)
   // prepare configuration
   private val hadoopConf = {
     val conf = sparkSession.sessionState.newHadoopConf()


### PR DESCRIPTION
Currently the default value of 'carbon.stream.parser' is CSVStreamParserImp, it transforms InternalRow(0) to Array[Object], InternalRow(0) represents the value of one line which is received from Socket. When it receives data from Kafka, the schema of InternalRow is changed, either it need to assemble the fields of kafka data Row into a String and stored it as InternalRow(0), or define a new parser to convert kafka data Row to Array[Object]. It needs the same operation for every table.

Solution:
Use a new parser called RowStreamParserImpl, this new parser will automatically convert InternalRow to Array[Object] according to the schema. In general, we will transform source data to a structed Row object, using this way, we do not need to define a parser for every table.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?  No
 
 - [ ] Any backward compatibility impacted?  No
 
 - [ ] Document update required?  No

 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

