### PR TITLE
[CARBONDATA-2161]Compacted Segment of Streaming Table should update m…

### DIFF
--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/TestStreamingTableOperation.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/TestStreamingTableOperation.scala
@@ -637,6 +637,11 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
     assertResult(newSegments.length / 2)(newSegments.filter(_.getString(1).equals("Success")).length)
     assertResult(newSegments.length / 2)(newSegments.filter(_.getString(1).equals("Compacted")).length)
 
+    //Verify MergeTO column entry for compacted Segments
+    newSegments.filter(_.getString(1).equals("Compacted")).foreach{ rw =>
+      assertResult("Compacted")(rw.getString(1))
+      assertResult((Integer.parseInt(rw.getString(0))+2).toString)(rw.getString(4))
+    }
     checkAnswer(
       sql("select count(*) from streaming.stream_table_reopen"),
       Seq(Row(2 * 100 * 2))

--- a/streaming/src/main/scala/org/apache/carbondata/streaming/StreamHandoffRDD.scala
+++ b/streaming/src/main/scala/org/apache/carbondata/streaming/StreamHandoffRDD.scala
@@ -398,6 +398,7 @@ object StreamHandoffRDD {
           throw new Exception("Failed to update table status for streaming segment")
         } else {
           streamSegment.get.setSegmentStatus(SegmentStatus.COMPACTED)
+          streamSegment.get.setMergedLoadName(loadModel.getSegmentId)
         }
 
         // refresh table status file


### PR DESCRIPTION
Problem statement:- 

When Handoff is trigger , ROW file format will be converted into COLUMNAR and that segment status will be updated as "Compacted". But "Merged TO" column is not updated. 

Solution :- Along with Segment Status to "Compaction ",MergeTo Coloumn also will be updated which will tell that this Segment of Row File format is compacted /Converted to which Segment . 


Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
NO 
 - [ ] Any backward compatibility impacted?
 NO
 - [ ] Document update required?
NO
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
New Testcase is added
        - How it is tested? Please attach test report.
TestCase written 
        - Is it a performance related change? Please attach the performance test report.
NA
        - Any additional information to help reviewers in testing this change.
     NA  
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA
