### PR TITLE
WIP:[CARBONDATA-2166][Tests] Fix bugs in default value of cutoff timestamp

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/keygenerator/directdictionary/timestamp/TimeStampGranularityConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/keygenerator/directdictionary/timestamp/TimeStampGranularityConstants.java
@@ -28,6 +28,10 @@ public interface TimeStampGranularityConstants {
    */
   String CARBON_CUTOFF_TIMESTAMP = "carbon.cutOffTimestamp";
   /**
+   * default value of cutoff timestamp
+   */
+  String CARBON_CUTOFF_TIMESTAMP_DEFAULT_VAL = "1970-01-01 05:30:00";
+  /**
    * The property to set the timestamp (ie milis) conversion to the SECOND, MINUTE, HOUR
    * or DAY level
    */

--- a/integration/spark-common-cluster-test/src/test/scala/org/apache/carbondata/cluster/sdv/generated/DataLoadingTestCase.scala
+++ b/integration/spark-common-cluster-test/src/test/scala/org/apache/carbondata/cluster/sdv/generated/DataLoadingTestCase.scala
@@ -27,6 +27,7 @@ import org.apache.spark.sql.test.TestQueryExecutor
 import org.scalatest.BeforeAndAfterAll
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants
+import org.apache.carbondata.core.keygenerator.directdictionary.timestamp.TimeStampGranularityConstants
 import org.apache.carbondata.core.util.CarbonProperties
 
 /**
@@ -1467,9 +1468,22 @@ class DataLoadingTestCase extends QueryTest with BeforeAndAfterAll {
      sql(s"""drop database if exists insertInto cascade""").collect
   }
 
+  private var cutoffTs: String = _
+
   override protected def beforeAll(): Unit = {
     sql(s"""drop table if exists uniqdata""").collect
     CarbonProperties.getInstance().addProperty(CarbonCommonConstants.CARBON_BADRECORDS_LOC,
       TestQueryExecutor.warehouse + "/baaaaaaadrecords")
+    cutoffTs = CarbonProperties.getInstance().getProperty(
+      TimeStampGranularityConstants.CARBON_CUTOFF_TIMESTAMP)
+    // in 2000_uniqData, the date before `CARBON_CUTOFF_TIMESTAMP_DEFAULT_VAL` is considered as bad record
+    CarbonProperties.getInstance().addProperty(
+      TimeStampGranularityConstants.CARBON_CUTOFF_TIMESTAMP,
+      TimeStampGranularityConstants.CARBON_CUTOFF_TIMESTAMP_DEFAULT_VAL)
+  }
+
+  override protected def afterAll(): Unit = {
+    CarbonProperties.getInstance().addProperty(
+      TimeStampGranularityConstants.CARBON_CUTOFF_TIMESTAMP, cutoffTs)
   }
 }

--- a/integration/spark-common-cluster-test/src/test/scala/org/apache/spark/sql/common/util/QueryTest.scala
+++ b/integration/spark-common-cluster-test/src/test/scala/org/apache/spark/sql/common/util/QueryTest.scala
@@ -34,6 +34,8 @@ import org.apache.spark.sql.{CarbonSession, DataFrame, Row, SQLContext}
 import org.scalatest.Suite
 
 import org.apache.carbondata.core.datastore.impl.FileFactory
+import org.apache.carbondata.core.keygenerator.directdictionary.timestamp.TimeStampGranularityConstants
+import org.apache.carbondata.core.util.CarbonProperties
 
 class QueryTest extends PlanTest with Suite {
 
@@ -41,6 +43,8 @@ class QueryTest extends PlanTest with Suite {
 
   val DOLLAR = "$"
 
+  // timezone is fixed for timestamp related tests
+  TimeZone.setDefault(TimeZone.getTimeZone("GMT"))
   // Add Locale setting
   Locale.setDefault(Locale.US)
 


### PR DESCRIPTION
1. Add default value of cutoff timestamp based on document
2. Fixed timezone for sdvtests

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 `NO`
 - [x] Any backward compatibility impacted?
`NO`
 - [x] Document update required?
`NO`
  - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
- [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       

