### PR TITLE
[CARBONDATA-2183]fix compaction when segment is delete during compaction and remove unnecessary parameters in functions

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/AbstractDFSCarbonFile.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/AbstractDFSCarbonFile.java
@@ -461,11 +461,6 @@ public abstract  class AbstractDFSCarbonFile implements CarbonFile {
   }
 
   @Override
-  public void setPermission(String directoryPath, FsPermission permission, String username,
-      String group) throws IOException {
-  }
-
-  @Override
   public CarbonFile[] listFiles() {
     FileStatus[] listStatus = null;
     try {

--- a/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/CarbonFile.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/CarbonFile.java
@@ -135,9 +135,6 @@ public interface CarbonFile {
 
   boolean createNewLockFile(String filePath, FileFactory.FileType fileType) throws IOException;
 
-  void setPermission(String directoryPath, FsPermission permission, String username, String group)
-      throws IOException;
-
   /**
    * Returns locations of the file
    * @return

--- a/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/LocalCarbonFile.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/LocalCarbonFile.java
@@ -419,11 +419,6 @@ public class LocalCarbonFile implements CarbonFile {
     return file.createNewFile();
   }
 
-  @Override
-  public void setPermission(String directoryPath, FsPermission permission, String username,
-      String group) throws IOException {
-  }
-
   @Override public CarbonFile[] locationAwareListFiles() throws IOException {
     return listFiles();
   }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/impl/FileFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/impl/FileFactory.java
@@ -448,9 +448,4 @@ public final class FileFactory {
     }
   }
 
-  public static void setPermission(String directoryPath, FsPermission permission, String username,
-      String group) throws IOException {
-    getCarbonFile(directoryPath).setPermission(directoryPath, permission, username, group);
-  }
-
 }

--- a/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonTableCompactor.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonTableCompactor.scala
@@ -271,7 +271,11 @@ class CarbonTableCompactor(carbonLoadModel: CarbonLoadModel,
           false
       }
       operationContext.setProperty("commitComplete", commitComplete)
-      if (!statusFileUpdation && !commitComplete) {
+      // here either of the conditions can be true, when delete segment is fired after compaction
+      // has started, statusFileUpdation will be false , but at the same time commitComplete can be
+      // true because compaction for all datamaps will be finished at a time to the maximum level
+      // possible (level 1, 2 etc). so we need to check for either condition
+      if (!statusFileUpdation || !commitComplete) {
         LOGGER.audit(s"Compaction request failed for table ${ carbonLoadModel.getDatabaseName }." +
                      s"${ carbonLoadModel.getTableName }")
         LOGGER.error(s"Compaction request failed for table ${ carbonLoadModel.getDatabaseName }." +


### PR DESCRIPTION
**Problem:**
when compaction is started and job is running, and parallelly the segment involved in the compaction is deleted using DeleteSegmentByID, then compaction is success.

**Solution:**
when compaction is started and job is running, and parallelly the segment involved in the compaction is deleted using DeleteSegmentByID, then compaction should be aborted and failed. and proper error message should thrown to user. THis PR also removes the unnecessary parameters in functions.

 - [x] Any interfaces changed?
 NA
 - [x] Any backward compatibility impacted?
 NA
 - [x] Document update required?
NA
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA
