### PR TITLE
[CARBONDATA-2185]add InputMetrics for Streaming Reader

### DIFF
--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
@@ -345,6 +345,7 @@ class CarbonScanRDD(
           val streamReader = inputFormat.createRecordReader(inputSplit, attemptContext)
             .asInstanceOf[CarbonStreamRecordReader]
           streamReader.setVectorReader(vectorReader)
+          streamReader.setInputMetricsStats(inputMetricsStats)
           model.setStatisticsRecorder(
             CarbonTimeStatisticsFactory.createExecutorRecorder(model.getQueryId))
           streamReader.setQueryModel(model)


### PR DESCRIPTION
Issue:- Record count in Input Metrics is always 0 for Stream Reader. 

Solution :- InputMetricsStats object need to update for StreamReader with Record size . Also Need to handle when enableVector=false

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 NA
 - [ ] Any backward compatibility impacted?
 NA
 - [ ] Document update required?
NA
 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
           Manual Verification is done,since value displayed in SparkUI
        - How it is tested? Please attach test report.
         Manual Verification done
        - Is it a performance related change? Please attach the performance test report.
NA
        - Any additional information to help reviewers in testing this change.
       NA
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
  NA
