### PR TITLE
[CARBONDATA-2193] Support register analyzer and optimizer rules for DataMap

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggregateTableSelection.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggregateTableSelection.scala
@@ -230,6 +230,7 @@ class TestPreAggregateTableSelection extends QueryTest with BeforeAndAfterAll {
     val df = sql("select name, sum(age) from filtertable where age = '29' group by name, age")
     preAggTableValidator(df.queryExecution.analyzed, "filtertable_agg9")
     checkAnswer(df, Row("vishal", 29))
+    sql("drop table filtertable")
   }
 
   test("test PreAggregate table selection 29") {
@@ -247,6 +248,7 @@ class TestPreAggregateTableSelection extends QueryTest with BeforeAndAfterAll {
     val df = sql("select sum(id) from grouptable group by city")
     preAggTableValidator(df.queryExecution.analyzed, "grouptable_agg9")
     checkAnswer(df, Seq(Row(3), Row(3), Row(4), Row(7)))
+    sql("drop table grouptable")
   }
 
   test("test PreAggregate table selection 30") {

--- a/integration/spark2/src/main/java/org/apache/carbondata/datamap/DataMapManager.java
+++ b/integration/spark2/src/main/java/org/apache/carbondata/datamap/DataMapManager.java
@@ -18,6 +18,8 @@
 package org.apache.carbondata.datamap;
 
 import org.apache.carbondata.core.metadata.schema.table.DataMapSchema;
+import org.apache.carbondata.datamap.preaggregate.PreAggregateDataMapProvider;
+import org.apache.carbondata.datamap.timeseries.TimeseriesDataMapProvider;
 
 import static org.apache.carbondata.core.metadata.schema.datamap.DataMapProvider.PREAGGREGATE;
 import static org.apache.carbondata.core.metadata.schema.datamap.DataMapProvider.TIMESERIES;

--- a/integration/spark2/src/main/java/org/apache/carbondata/datamap/MVDataMapRules.java
+++ b/integration/spark2/src/main/java/org/apache/carbondata/datamap/MVDataMapRules.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.datamap;
+
+import org.apache.carbondata.common.annotations.InterfaceAudience;
+import org.apache.carbondata.common.annotations.InterfaceStability;
+
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.catalyst.rules.Rule;
+
+/**
+ * Analyzer rules and Optimizer rules provided by DataMap implementation.
+ * These rules will be set to {@link SparkSession} during query execution.
+ */
+@InterfaceAudience.Developer("DataMap")
+@InterfaceStability.Unstable
+public interface MVDataMapRules {
+
+  Rule<LogicalPlan>[] getAnalyzerRules(SparkSession sparkSession);
+  Rule<LogicalPlan>[] getOptimizerRules(SparkSession sparkSession);
+}

--- a/integration/spark2/src/main/java/org/apache/carbondata/datamap/preaggregate/PreAggregateDataMapProvider.java
+++ b/integration/spark2/src/main/java/org/apache/carbondata/datamap/preaggregate/PreAggregateDataMapProvider.java
@@ -15,12 +15,14 @@
  * limitations under the License.
  */
 
-package org.apache.carbondata.datamap;
+package org.apache.carbondata.datamap.preaggregate;
 
 import org.apache.carbondata.common.annotations.InterfaceAudience;
 import org.apache.carbondata.common.exceptions.sql.MalformedDataMapCommandException;
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
 import org.apache.carbondata.core.metadata.schema.table.DataMapSchema;
+import org.apache.carbondata.datamap.DataMapProperty;
+import org.apache.carbondata.datamap.DataMapProvider;
 
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.execution.command.preaaggregate.PreAggregateTableHelper;

--- a/integration/spark2/src/main/java/org/apache/carbondata/datamap/preaggregate/PreaggregateMVDataMapRules.java
+++ b/integration/spark2/src/main/java/org/apache/carbondata/datamap/preaggregate/PreaggregateMVDataMapRules.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.datamap.preaggregate;
+
+import org.apache.carbondata.datamap.MVDataMapRules;
+
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.catalyst.rules.Rule;
+import org.apache.spark.sql.hive.CarbonPreAggregateDataLoadingRules;
+import org.apache.spark.sql.hive.CarbonPreAggregateQueryRules;
+
+public class PreaggregateMVDataMapRules implements MVDataMapRules {
+
+  @Override
+  public Rule<LogicalPlan>[] getAnalyzerRules(SparkSession sparkSession) {
+    return new Rule[] {
+        new CarbonPreAggregateDataLoadingRules(sparkSession),
+        new CarbonPreAggregateQueryRules(sparkSession)
+    };
+  }
+
+  @Override
+  public Rule<LogicalPlan>[] getOptimizerRules(SparkSession sparkSession) {
+    return new Rule[0];
+  }
+}

--- a/integration/spark2/src/main/java/org/apache/carbondata/datamap/preaggregate/PreaggregateMVDataMapRules.java
+++ b/integration/spark2/src/main/java/org/apache/carbondata/datamap/preaggregate/PreaggregateMVDataMapRules.java
@@ -17,6 +17,7 @@
 
 package org.apache.carbondata.datamap.preaggregate;
 
+import org.apache.carbondata.common.annotations.InterfaceAudience;
 import org.apache.carbondata.datamap.MVDataMapRules;
 
 import org.apache.spark.sql.SparkSession;
@@ -25,6 +26,7 @@ import org.apache.spark.sql.catalyst.rules.Rule;
 import org.apache.spark.sql.hive.CarbonPreAggregateDataLoadingRules;
 import org.apache.spark.sql.hive.CarbonPreAggregateQueryRules;
 
+@InterfaceAudience.Internal
 public class PreaggregateMVDataMapRules implements MVDataMapRules {
 
   @Override

--- a/integration/spark2/src/main/java/org/apache/carbondata/datamap/timeseries/TimeseriesDataMapProvider.java
+++ b/integration/spark2/src/main/java/org/apache/carbondata/datamap/timeseries/TimeseriesDataMapProvider.java
@@ -15,13 +15,14 @@
  * limitations under the License.
  */
 
-package org.apache.carbondata.datamap;
+package org.apache.carbondata.datamap.timeseries;
 
 import java.util.Map;
 
 import org.apache.carbondata.common.annotations.InterfaceAudience;
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
 import org.apache.carbondata.core.metadata.schema.table.DataMapSchema;
+import org.apache.carbondata.datamap.preaggregate.PreAggregateDataMapProvider;
 
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.execution.command.preaaggregate.PreAggregateTableHelper;

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSession.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSession.scala
@@ -20,6 +20,7 @@ import java.io.File
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.spark.{SparkConf, SparkContext}
@@ -77,10 +78,10 @@ class CarbonSession(@transient val sc: SparkContext,
 
   // materialized view rules, currently one datamap is supported: PreaggregateDataMap
   @transient
-  private var mvDataMapRules: mutable.Seq[MVDataMapRules] = mutable.Seq()
+  private var mvDataMapRules = ArrayBuffer[MVDataMapRules]()
 
-  def addMVDataMapRules(rules: Seq[MVDataMapRules]): Unit =
-    mvDataMapRules = mvDataMapRules ++ rules
+  def addMVDataMapRules(rules: ArrayBuffer[MVDataMapRules]): Unit =
+    mvDataMapRules ++= rules
 
   def getMVDataMapRules: Seq[MVDataMapRules] = mvDataMapRules
 }
@@ -89,7 +90,7 @@ object CarbonSession {
 
   implicit class CarbonBuilder(builder: Builder) {
 
-    private var mvDataMap: mutable.Seq[MVDataMapRules] = mutable.Seq()
+    private var mvDataMap = ArrayBuffer[MVDataMapRules]()
 
     def getOrCreateCarbonSession(): SparkSession = {
       getOrCreateCarbonSession(null, null)
@@ -206,13 +207,13 @@ object CarbonSession {
     private def addDataMapRules(session: CarbonSession) = {
       // by default, enable PreaggregateDataMap
       if (mvDataMap.isEmpty) {
-        mvDataMap = mvDataMap :+ new PreaggregateMVDataMapRules
+        mvDataMap += new PreaggregateMVDataMapRules
       }
       session.addMVDataMapRules(mvDataMap)
     }
 
     def enableMVDataMap(mvDataMapRules: MVDataMapRules): CarbonBuilder = {
-      mvDataMap = mvDataMap :+ mvDataMapRules
+      mvDataMap += mvDataMapRules
       this
     }
 

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSession.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSession.scala
@@ -76,6 +76,7 @@ class CarbonSession(@transient val sc: SparkContext,
   }
 
   // materialized view rules, currently one datamap is supported: PreaggregateDataMap
+  @transient
   private var mvDataMapRules: mutable.Seq[MVDataMapRules] = mutable.Seq()
 
   def addMVDataMapRules(rules: Seq[MVDataMapRules]): Unit =

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonPreAggregateRules.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonPreAggregateRules.scala
@@ -160,7 +160,7 @@ case class CarbonPreAggregateQueryRules(sparkSession: SparkSession) extends Rule
    * @param plan child plan
    * @return updated plan
    */
-  def updatePlan(plan: LogicalPlan) : LogicalPlan = {
+  private def updatePlan(plan: LogicalPlan) : LogicalPlan = {
     val updatedPlan = plan transform {
       case Aggregate(grp, aggExp, child) =>
         Aggregate(
@@ -190,7 +190,7 @@ case class CarbonPreAggregateQueryRules(sparkSession: SparkSession) extends Rule
    * @param sortExp sort order expression in query
    * @return updated sort expression
    */
-  def updateSortExpression(sortExp : Seq[SortOrder]) : Seq[SortOrder] = {
+  private def updateSortExpression(sortExp : Seq[SortOrder]) : Seq[SortOrder] = {
      sortExp map { order =>
       SortOrder(order.child transform  {
         case attr: AttributeReference =>
@@ -213,7 +213,7 @@ case class CarbonPreAggregateQueryRules(sparkSession: SparkSession) extends Rule
    * @param expressions sequence of expression like group by
    * @return updated expressions
    */
-  def updateExpression(expressions : Seq[Expression]) : Seq[Expression] = {
+  private def updateExpression(expressions : Seq[Expression]) : Seq[Expression] = {
     expressions map { expression =>
       expression transform {
         case attr: AttributeReference =>
@@ -258,7 +258,7 @@ case class CarbonPreAggregateQueryRules(sparkSession: SparkSession) extends Rule
    * @param logicalPlan parent logical plan
    * @return transformed plan
    */
-  def transformPreAggQueryPlan(logicalPlan: LogicalPlan): LogicalPlan = {
+  private def transformPreAggQueryPlan(logicalPlan: LogicalPlan): LogicalPlan = {
     val updatedPlan = logicalPlan.transform {
       case agg@Aggregate(
         grExp,
@@ -493,7 +493,8 @@ case class CarbonPreAggregateQueryRules(sparkSession: SparkSession) extends Rule
    * @param parentLogicalPlan parent logical relation
    * @return if plan is valid then aggregation data map schema and its relation plan
    */
-  def getChildDataMapForTransformation(queryColumns: scala.collection.mutable.HashSet[QueryColumn],
+  private def getChildDataMapForTransformation(
+      queryColumns: scala.collection.mutable.HashSet[QueryColumn],
       aggregateExpressions: scala.collection.mutable.HashSet[AggregateExpression],
       carbonTable: CarbonTable,
       parentLogicalPlan: LogicalPlan): (AggregationDataMapSchema, LogicalPlan) = {
@@ -576,7 +577,7 @@ case class CarbonPreAggregateQueryRules(sparkSession: SparkSession) extends Rule
    * @param queryAggExpLogicalPlans query agg expression logical plan
    * @return valid data map
    */
-  def validateAggregateExpression(selectedDataMap: DataMapSchema,
+  private def validateAggregateExpression(selectedDataMap: DataMapSchema,
       carbonTable: CarbonTable,
       parentLogicalPlan: LogicalPlan,
       queryAggExpLogicalPlans: Seq[AggregateExpression]): Boolean = {
@@ -598,7 +599,7 @@ case class CarbonPreAggregateQueryRules(sparkSession: SparkSession) extends Rule
    * @param parentLogicalPlan logical relation of actual plan
    * @return map of logical plan for each aggregate expression in child query and its column mapping
    */
-  def getExpressionToColumnMapping(selectedDataMap: DataMapSchema,
+  private def getExpressionToColumnMapping(selectedDataMap: DataMapSchema,
       carbonTable: CarbonTable,
       parentLogicalPlan: LogicalPlan): mutable.Set[AggExpToColumnMappingModel] = {
     val aggDataMapSchema = selectedDataMap.asInstanceOf[AggregationDataMapSchema]
@@ -647,7 +648,8 @@ case class CarbonPreAggregateQueryRules(sparkSession: SparkSession) extends Rule
    * @param logicalPlan logical plan
    * @return list of aggregate expression
    */
-  def getAggregateExpFromChildDataMap(logicalPlan: LogicalPlan): Seq[AggregateExpression] = {
+  private def getAggregateExpFromChildDataMap(
+      logicalPlan: LogicalPlan): Seq[AggregateExpression] = {
     val list = scala.collection.mutable.ListBuffer.empty[AggregateExpression]
     logicalPlan match {
       case _@Aggregate(_, aggExp, _) =>
@@ -667,7 +669,7 @@ case class CarbonPreAggregateQueryRules(sparkSession: SparkSession) extends Rule
    * @param carbonTable parent table
    * @return is specific segment is present in session params
    */
-  def isSpecificSegmentNotPresent(carbonTable: CarbonTable) : Boolean = {
+  private def isSpecificSegmentNotPresent(carbonTable: CarbonTable) : Boolean = {
     val carbonSessionInfo = ThreadLocalSessionInfo.getCarbonSessionInfo
     if (carbonSessionInfo != null) {
       carbonSessionInfo.getSessionParams
@@ -687,7 +689,7 @@ case class CarbonPreAggregateQueryRules(sparkSession: SparkSession) extends Rule
    * @param carbonTable parent table
    * @return isvalid filter expression for aggregate
    */
-  def extractColumnFromExpression(expression: Expression,
+  private def extractColumnFromExpression(expression: Expression,
       queryColumns: scala.collection.mutable.HashSet[QueryColumn],
       carbonTable: CarbonTable,
       isFilterColumn: Boolean = false) {
@@ -743,7 +745,7 @@ case class CarbonPreAggregateQueryRules(sparkSession: SparkSession) extends Rule
    * null and when it cannot be null
    * @return child attribute reference
    */
-  def getChildAttributeReference(dataMapSchema: DataMapSchema,
+  private def getChildAttributeReference(dataMapSchema: DataMapSchema,
       attributeReference: AttributeReference,
       attributes: Seq[AttributeReference],
       canBeNull: Boolean = false,
@@ -790,7 +792,7 @@ case class CarbonPreAggregateQueryRules(sparkSession: SparkSession) extends Rule
    * updated child logical plan,
    * updated filter expression if present in actual plan)
    */
-  def getUpdatedExpressions(groupingExpressions: Seq[Expression],
+  private def getUpdatedExpressions(groupingExpressions: Seq[Expression],
       aggregateExpressions: Seq[NamedExpression],
       child: LogicalPlan, filterExpression: Option[Expression] = None,
       aggDataMapSchema: AggregationDataMapSchema,
@@ -966,7 +968,7 @@ case class CarbonPreAggregateQueryRules(sparkSession: SparkSession) extends Rule
    * @param parentLogicalPlan logical relation
    * @return updated expression
    */
-  def getUpdatedAggregateExpressionForChild(aggExp: AggregateExpression,
+  private def getUpdatedAggregateExpressionForChild(aggExp: AggregateExpression,
       dataMapSchema: AggregationDataMapSchema,
       attributes: Seq[AttributeReference],
       parentTable: CarbonTable,
@@ -1036,7 +1038,7 @@ case class CarbonPreAggregateQueryRules(sparkSession: SparkSession) extends Rule
    * @param parentLogicalRelation parent table relation
    * @return tuple of carbon table
    */
-  def getCarbonTable(parentLogicalRelation: LogicalRelation): CarbonTable = {
+  private def getCarbonTable(parentLogicalRelation: LogicalRelation): CarbonTable = {
     val carbonTable = parentLogicalRelation.relation.asInstanceOf[CarbonDatasourceHadoopRelation]
       .carbonRelation
       .metaData.carbonTable
@@ -1051,7 +1053,7 @@ case class CarbonPreAggregateQueryRules(sparkSession: SparkSession) extends Rule
    * @param queryColumns list of attributes
    * @return plan is valid
    */
-  def extractQueryColumnsFromAggExpression(groupByExpression: Seq[Expression],
+  private def extractQueryColumnsFromAggExpression(groupByExpression: Seq[Expression],
       aggregateExpressions: Seq[NamedExpression],
       carbonTable: CarbonTable,
       queryColumns: scala.collection.mutable.HashSet[QueryColumn],
@@ -1120,7 +1122,7 @@ case class CarbonPreAggregateQueryRules(sparkSession: SparkSession) extends Rule
    * @param isFilterColumn is filter is applied on column
    * @return query column
    */
-  def getQueryColumn(columnName: String,
+  private def getQueryColumn(columnName: String,
       carbonTable: CarbonTable,
       isFilterColumn: Boolean = false,
       timeseriesFunction: String = ""): QueryColumn = {

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/test/Spark2TestQueryExecutor.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/test/Spark2TestQueryExecutor.scala
@@ -25,6 +25,7 @@ import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.datastore.impl.FileFactory
 import org.apache.carbondata.core.util.CarbonProperties
+import org.apache.carbondata.datamap.preaggregate.PreaggregateMVDataMapRules
 
 /**
  * This class is a sql executor of unit test case for spark version 2.x.
@@ -69,6 +70,7 @@ object Spark2TestQueryExecutor {
     .enableHiveSupport()
     .config("spark.sql.warehouse.dir", warehouse)
     .config("spark.sql.crossJoin.enabled", "true")
+    .enableMVDataMap(new PreaggregateMVDataMapRules)
     .getOrCreateCarbonSession(null, TestQueryExecutor.metastoredb)
   if (warehouse.startsWith("hdfs://")) {
     System.setProperty(CarbonCommonConstants.HDFS_TEMP_LOCATION, warehouse)


### PR DESCRIPTION
This PR is based on #1987 
User can register analyzer and optimizer rules when creating CarbonSession, for example:

```
  val spark = SparkSession
    .builder()
    .config(conf)
    .master(TestQueryExecutor.masterUrl)
    .appName("Spark2TestQueryExecutor")
    .enableHiveSupport()
    .enableMVDataMap(new PreaggregateMVDataMapRules)
    .getOrCreateCarbonSession()
```

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
