### PR TITLE
[CARBONDATA-2194] Exception is improper when use incorrect bad record action type

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/util/SessionParams.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/SessionParams.java
@@ -157,7 +157,7 @@ public class SessionParams implements Serializable {
           isValid = true;
         } catch (IllegalArgumentException iae) {
           throw new InvalidConfigurationException(
-              "The key " + key + " can have only either FORCE or IGNORE or REDIRECT.");
+              "The key " + key + " can have only either FORCE or IGNORE or REDIRECT or FAIL.");
         }
         break;
       case CARBON_OPTIONS_SORT_SCOPE:

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/badrecordloger/BadRecordLoggerTest.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/badrecordloger/BadRecordLoggerTest.scala
@@ -242,7 +242,7 @@ class BadRecordLoggerTest extends QueryTest with BeforeAndAfterAll {
           + "('bad_records_action'='FORCA', 'DELIMITER'= ',', 'QUOTECHAR'= '\"')");
     } catch {
       case ex: Exception =>
-        assert("option BAD_RECORDS_ACTION can have only either FORCE or IGNORE or REDIRECT"
+        assert("option BAD_RECORDS_ACTION can have only either FORCE or IGNORE or REDIRECT or FAIL"
           .equals(ex.getMessage))
     }
   }

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/standardpartition/StandardPartitionBadRecordLoggerTest.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/standardpartition/StandardPartitionBadRecordLoggerTest.scala
@@ -204,6 +204,23 @@ class StandardPartitionBadRecordLoggerTest extends QueryTest with BeforeAndAfter
     )
   }
 
+  test("test load ddl command") {
+    sql(
+      """CREATE TABLE IF NOT EXISTS dataloadOptionTests(ID BigInt, date Timestamp, country
+           String,
+          actual_price Double, Quantity int, sold_price Decimal(19,2)) STORED BY 'carbondata'
+      """)
+    val csvFilePath = s"$resourcesPath/badrecords/emptyTimeStampValue.csv"
+    try {
+      sql("LOAD DATA local inpath '" + csvFilePath + "' INTO TABLE dataloadOptionTests OPTIONS"
+        + "('bad_records_action'='FORCA', 'DELIMITER'= ',', 'QUOTECHAR'= '\"')");
+    } catch {
+      case ex: Exception =>
+        assert("option BAD_RECORDS_ACTION can have only either FORCE or IGNORE or REDIRECT or FAIL"
+          .equals(ex.getMessage))
+    }
+  }
+
   def drop(): Unit = {
     sql("drop table IF EXISTS sales")
     sql("drop table IF EXISTS serializable_values")

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
@@ -949,7 +949,7 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
       catch {
         case _: IllegalArgumentException =>
           throw new MalformedCarbonCommandException(
-            "option BAD_RECORDS_ACTION can have only either FORCE or IGNORE or REDIRECT")
+            "option BAD_RECORDS_ACTION can have only either FORCE or IGNORE or REDIRECT or FAIL")
       }
     }
     if (options.exists(_._1.equalsIgnoreCase("IS_EMPTY_DATA_BAD_RECORD"))) {


### PR DESCRIPTION
This PR added fail action: https://github.com/apache/carbondata/pull/332
but didn't add this bad record action type into exception when  use incorrect bad record action type

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 No
 - [ ] Any backward compatibility impacted?
 No
 - [ ] Document update required?
No
 - [ ] Testing done
     change the test case
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
No
