### PR TITLE
[CARBONDATA-2201] NPE fixed while triggering the  LoadTablePreExecutionEvent before Streaming

### DIFF
--- a/streaming/src/main/scala/org/apache/carbondata/streaming/StreamSinkFactory.scala
+++ b/streaming/src/main/scala/org/apache/carbondata/streaming/StreamSinkFactory.scala
@@ -60,6 +60,7 @@ object StreamSinkFactory {
       parameters,
       "")
     // fire pre event before streamin is started
+    // in case of streaming options and optionsFinal can be same
     val operationContext = new OperationContext
     val loadTablePreExecutionEvent = new LoadTablePreExecutionEvent(
       carbonTable.getCarbonTableIdentifier,
@@ -67,7 +68,7 @@ object StreamSinkFactory {
       carbonLoadModel.getFactFilePath,
       false,
       parameters.asJava,
-      null,
+      parameters.asJava,
       false
     )
     OperationListenerBus.getInstance().fireEvent(loadTablePreExecutionEvent, operationContext)

--- a/streaming/src/main/scala/org/apache/spark/sql/execution/streaming/CarbonAppendableStreamSink.scala
+++ b/streaming/src/main/scala/org/apache/spark/sql/execution/streaming/CarbonAppendableStreamSink.scala
@@ -95,6 +95,7 @@ class CarbonAppendableStreamSink(
       val statistic = new QueryStatistic()
 
       // fire pre event on every batch add
+      // in case of streaming options and optionsFinal can be same
       val operationContext = new OperationContext
       val loadTablePreExecutionEvent = new LoadTablePreExecutionEvent(
         carbonTable.getCarbonTableIdentifier,
@@ -102,7 +103,7 @@ class CarbonAppendableStreamSink(
         carbonLoadModel.getFactFilePath,
         false,
         parameters.asJava,
-        null,
+        parameters.asJava,
         false
       )
       OperationListenerBus.getInstance().fireEvent(loadTablePreExecutionEvent, operationContext)


### PR DESCRIPTION
while triggering the LoadTablePreExecutionEvent we require options provided by user and the finalOptions . In case of streaming both are same. If we pass null . It may cause NPE.

 - [x] Any interfaces changed? **No**
 
 - [x] Any backward compatibility impacted? **No**
 
 - [x] Document update required? **No**

 - [x] Testing done  **NA. All test-case pass in CI is sufficient.**
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.  **NA**

