### PR TITLE
[CARBONDATA-2208]Pre aggregate datamap creation is failing when count(*) present in query

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/util/path/CarbonTablePath.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/path/CarbonTablePath.java
@@ -75,7 +75,12 @@ public class CarbonTablePath extends Path {
    * @param carbonFilePath
    */
   public static String getFolderContainingFile(String carbonFilePath) {
-    return carbonFilePath.substring(0, carbonFilePath.lastIndexOf('/'));
+    int lastIndex = carbonFilePath.lastIndexOf('/');
+    // below code for handling windows environment
+    if (-1 == lastIndex) {
+      lastIndex = carbonFilePath.lastIndexOf(File.separator);
+    }
+    return carbonFilePath.substring(0, lastIndex);
   }
 
   /**

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggregateTableSelection.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggregateTableSelection.scala
@@ -49,6 +49,7 @@ class TestPreAggregateTableSelection extends QueryTest with BeforeAndAfterAll {
     sql("create datamap agg6 on table mainTable using 'preaggregate' as select name,min(age) from mainTable group by name")
     sql("create datamap agg7 on table mainTable using 'preaggregate' as select name,max(age) from mainTable group by name")
     sql("create datamap agg8 on table maintable using 'preaggregate' as select name, sum(id), avg(id) from maintable group by name")
+    sql("create datamap agg9 on table maintable using 'preaggregate' as select name, count(*) from maintable group by name")
     sql("CREATE TABLE mainTableavg(id int, name string, city string, age bigint) STORED BY 'org.apache.carbondata.format'")
     sql("create datamap agg0 on table mainTableavg using 'preaggregate' as select name,sum(age), avg(age) from mainTableavg group by name")
     sql(s"LOAD DATA LOCAL INPATH '$resourcesPath/measureinsertintotest.csv' into table mainTable")
@@ -64,6 +65,11 @@ class TestPreAggregateTableSelection extends QueryTest with BeforeAndAfterAll {
   test("test PreAggregate table selection 1") {
     val df = sql("select name from mainTable group by name")
     preAggTableValidator(df.queryExecution.analyzed, "maintable_agg0")
+  }
+
+  test("test PreAggregate table selection with count(*)") {
+    val df = sql("select name, count(*) from mainTable group by name")
+    preAggTableValidator(df.queryExecution.analyzed, "maintable_agg9")
   }
 
   test("test PreAggregate table selection 2") {
@@ -342,6 +348,7 @@ test("test PreAggregate table selection with timeseries and normal together") {
     sql("drop table if exists lineitem")
     sql("DROP TABLE IF EXISTS maintabletime")
     sql("DROP TABLE IF EXISTS maintabledict")
+    sql("DROP TABLE IF EXISTS mainTableavg")
   }
 
 }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/preaaggregate/PreAggregateUtil.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/preaaggregate/PreAggregateUtil.scala
@@ -346,11 +346,13 @@ object PreAggregateUtil {
         carbonTable)
     }
     // if parent column relation is of size more than one that means aggregate table
-    // column is derived from multiple column of main table
-    // or if expression is not a instance of attribute reference
+    // column is derived from multiple column of main table or if size is zero then it means
+    // column is present in select statement is some constants for example count(*)
+    // and if expression is not a instance of attribute reference
     // then use column name which is passed
     val columnName =
-    if (parentColumnsName.size > 1 && !expression.isInstanceOf[AttributeReference]) {
+    if ((parentColumnsName.size > 1 || parentColumnsName.isEmpty) &&
+        !expression.isInstanceOf[AttributeReference]) {
       newColumnName
     } else {
       expression.asInstanceOf[AttributeReference].name


### PR DESCRIPTION
Pre aggregate data map creation is failing with parsing error 

create datamap agg on table maintable using 'preaggregate' as select name, count(*) from maintable group by name

Fixed aggregate data map creation in widows environment
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
       Added UT
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

