### PR TITLE
[CARBONDATA-2221] Throw exception when dropTable failed in metastore

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonCreateTableCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonCreateTableCommand.scala
@@ -136,9 +136,12 @@ case class CarbonCreateTableCommand(
           case e: AnalysisException => throw e
           case e: Exception =>
             // call the drop table to delete the created table.
-            CarbonEnv.getInstance(sparkSession).carbonMetastore
-              .dropTable(tableIdentifier)(sparkSession)
-
+            try {
+              CarbonEnv.getInstance(sparkSession).carbonMetastore
+                .dropTable(tableIdentifier)(sparkSession)
+            } catch {
+              case _: Exception => // No operation
+            }
             val msg = s"Create table'$tableName' in database '$dbName' failed"
             LOGGER.audit(msg.concat(", ").concat(e.getMessage))
             LOGGER.error(e, msg)

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonFileMetastore.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonFileMetastore.scala
@@ -441,8 +441,8 @@ class CarbonFileMetastore extends CarbonMetaStore {
       checkSchemasModifiedTimeAndReloadTable(TableIdentifier(tableName, Some(dbName)))
 
       removeTableFromMetadata(dbName, tableName)
-      updateSchemasUpdatedTime(touchSchemaFileSystemTime())
       CarbonHiveMetadataUtil.invalidateAndDropTable(dbName, tableName, sparkSession)
+      updateSchemasUpdatedTime(touchSchemaFileSystemTime())
       // discard cached table info in cachedDataSourceTables
       val tableIdentifier = TableIdentifier(tableName, Option(dbName))
       sparkSession.sessionState.catalog.refreshTable(tableIdentifier)

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonHiveMetadataUtil.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonHiveMetadataUtil.scala
@@ -49,6 +49,7 @@ object CarbonHiveMetadataUtil {
         LOGGER.audit(
           s"Error While deleting the table $databaseName.$tableName during drop carbon table" +
           e.getMessage)
+        throw e
     }
   }
 


### PR DESCRIPTION
When dropping table, exception should be not ignored if dropTable failed in metastore. This PR throws the exception to the user.

 - [X] Any interfaces changed?
 No
 - [X] Any backward compatibility impacted?
 No
 - [X] Document update required?
No
 - [X] Testing done
Re-run all test
 - [X] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA
