### PR TITLE
[CARBONDATA-2237] Removing parsers thread local objects after parsing of carbon query

### DIFF
--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/CarbonScalaUtil.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/CarbonScalaUtil.scala
@@ -18,6 +18,7 @@
 package org.apache.carbondata.spark.util
 
 import java.{lang, util}
+import java.lang.ref.Reference
 import java.nio.charset.Charset
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -584,5 +585,46 @@ object CarbonScalaUtil {
     String.valueOf(Math.pow(10, 2).toInt + segmentId.toInt) +
     String.valueOf(Math.pow(10, 5).toInt + taskId) +
     String.valueOf(partitionNumber + Math.pow(10, 5).toInt)
+  }
+
+  /**
+   * Use reflection to clean the parser objects which are set in thread local to avoid memory issue
+   */
+  def cleanParserThreadLocals(): Unit = {
+    try {
+      // Get a reference to the thread locals table of the current thread
+      val thread = Thread.currentThread
+      val threadLocalsField = classOf[Thread].getDeclaredField("inheritableThreadLocals")
+      threadLocalsField.setAccessible(true)
+      val threadLocalTable = threadLocalsField.get(thread)
+      // Get a reference to the array holding the thread local variables inside the
+      // ThreadLocalMap of the current thread
+      val threadLocalMapClass = Class.forName("java.lang.ThreadLocal$ThreadLocalMap")
+      val tableField = threadLocalMapClass.getDeclaredField("table")
+      tableField.setAccessible(true)
+      val table = tableField.get(threadLocalTable)
+      // The key to the ThreadLocalMap is a WeakReference object. The referent field of this object
+      // is a reference to the actual ThreadLocal variable
+      val referentField = classOf[Reference[Thread]].getDeclaredField("referent")
+      referentField.setAccessible(true)
+      var i = 0
+      while (i < lang.reflect.Array.getLength(table)) {
+        // Each entry in the table array of ThreadLocalMap is an Entry object
+        val entry = lang.reflect.Array.get(table, i)
+        if (entry != null) {
+          // Get a reference to the thread local object and remove it from the table
+          val threadLocal = referentField.get(entry).asInstanceOf[ThreadLocal[_]]
+          if (threadLocal != null &&
+              threadLocal.getClass.getName.startsWith("scala.util.DynamicVariable")) {
+            threadLocal.remove()
+          }
+        }
+        i += 1
+      }
+      table
+    } catch {
+      case e: Exception =>
+        // ignore it
+    }
   }
 }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSpark2SqlParser.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSpark2SqlParser.scala
@@ -39,7 +39,7 @@ import org.apache.spark.util.CarbonReflectionUtils
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.spark.CarbonOption
 import org.apache.carbondata.spark.exception.MalformedCarbonCommandException
-import org.apache.carbondata.spark.util.CommonUtil
+import org.apache.carbondata.spark.util.{CarbonScalaUtil, CommonUtil}
 
 /**
  * TODO remove the duplicate code and add the common methods to common class.
@@ -52,16 +52,19 @@ class CarbonSpark2SqlParser extends CarbonDDLSqlParser {
       // Initialize the Keywords.
       initLexical
       phrase(start)(new lexical.Scanner(input)) match {
-        case Success(plan, _) => plan match {
-          case x: CarbonLoadDataCommand =>
-            x.inputSqlString = input
-            x
-          case x: CarbonAlterTableCompactionCommand =>
-            x.alterTableModel.alterSql = input
-            x
-          case logicalPlan => logicalPlan
+        case Success(plan, _) =>
+          CarbonScalaUtil.cleanParserThreadLocals()
+          plan match {
+            case x: CarbonLoadDataCommand =>
+              x.inputSqlString = input
+              x
+            case x: CarbonAlterTableCompactionCommand =>
+              x.alterTableModel.alterSql = input
+              x
+            case logicalPlan => logicalPlan
         }
         case failureOrError =>
+          CarbonScalaUtil.cleanParserThreadLocals()
           CarbonException.analysisException(failureOrError.toString)
       }
     }


### PR DESCRIPTION
In some scenarios where more sessions are created, there are many parser failure objects are accumulated in memory inside thread locals.

Solution: Remove the parser object from thread local after parsing of the query

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 
 - [x] Any backward compatibility impacted?
 
 - [x] Document update required?

 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

