### PR TITLE
[CARBONDATA-2241][Docs][BugFix] Updated Doc for query which will execute on datamap

### DIFF
--- a/docs/datamap/preaggregate-datamap-guide.md
+++ b/docs/datamap/preaggregate-datamap-guide.md
@@ -181,7 +181,7 @@ SELECT country, sex, sum(quantity), avg(price) from sales GROUP BY country, sex
 
 SELECT sex, sum(quantity) from sales GROUP BY sex
 
-SELECT sum(price), country from sales GROUP BY country
+SELECT avg(price), country from sales GROUP BY country
 ``` 
 
 will be transformed by CarbonData's query planner to query against pre-aggregate table 
@@ -211,7 +211,7 @@ tables are loaded successfully, if one of these loads fails, new data are not vi
 as if the load operation is not happened.   
 
 ## Querying data
-As a technique for query acceleration, Pre-aggregate tables cannot be queries directly. 
+As a technique for query acceleration, Pre-aggregate tables cannot be queried directly. 
 Queries are to be made on main table. While doing query planning, internally CarbonData will check 
 associated pre-aggregate tables with the main table, and do query plan transformation accordingly. 
 


### PR DESCRIPTION
Description: Below query is written in document: 
`SELECT sum(price), country from sales GROUP BY country`
and it is said that it will execute on datamap, but it will execute with main table and not datamap.

Fix: Corrected the query so that it will execute using datamap.


Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed? NA
 
 - [x] Any backward compatibility impacted? NA
 
 - [x] Document update required? NA

 - [x] Testing done NA
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. NA

