### PR TITLE
[CARBONDATA-2246][DataLoad] Fix exhausted memory problem during unsafe data loading

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/dataload/TestLoadDataWithUnsafeMemory.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/dataload/TestLoadDataWithUnsafeMemory.scala
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.integration.spark.testsuite.dataload
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.test.util.QueryTest
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Ignore}
+
+import org.apache.carbondata.core.constants.CarbonCommonConstants
+import org.apache.carbondata.core.util.CarbonProperties
+
+/**
+ * test data load with unsafe memory.
+ * The CI env may not have so much memory, so disable this test case for now.
+ * Ps: seen from CI result, the sdvTests works fine
+ */
+@Ignore
+class TestLoadDataWithUnsafeMemory extends QueryTest
+  with BeforeAndAfterEach with BeforeAndAfterAll {
+  val originUnsafeSortStatus: String = CarbonProperties.getInstance()
+    .getProperty(CarbonCommonConstants.ENABLE_UNSAFE_SORT,
+      CarbonCommonConstants.ENABLE_UNSAFE_SORT_DEFAULT)
+  val originUnsafeMemForSort: String = CarbonProperties.getInstance()
+    .getProperty(CarbonCommonConstants.IN_MEMORY_FOR_SORT_DATA_IN_MB,
+      CarbonCommonConstants.IN_MEMORY_FOR_SORT_DATA_IN_MB_DEFAULT)
+  val originUnsafeMemForWorking: String = CarbonProperties.getInstance()
+    .getProperty(CarbonCommonConstants.UNSAFE_WORKING_MEMORY_IN_MB,
+      CarbonCommonConstants.UNSAFE_WORKING_MEMORY_IN_MB_DEFAULT)
+  val originUnsafeSizeForChunk: String = CarbonProperties.getInstance()
+    .getProperty(CarbonCommonConstants.OFFHEAP_SORT_CHUNK_SIZE_IN_MB,
+      CarbonCommonConstants.OFFHEAP_SORT_CHUNK_SIZE_IN_MB_DEFAULT)
+  val targetTable = "table_unsafe_memory"
+
+
+  override def beforeEach(): Unit = {
+    sql(s"drop table if exists $targetTable ")
+  }
+
+  override def afterEach(): Unit = {
+    sql(s"drop table if exists $targetTable ")
+  }
+
+  override protected def beforeAll(): Unit = {
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.ENABLE_UNSAFE_SORT, "true")
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.IN_MEMORY_FOR_SORT_DATA_IN_MB, "1024")
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.UNSAFE_WORKING_MEMORY_IN_MB, "512")
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.OFFHEAP_SORT_CHUNK_SIZE_IN_MB, "512")
+  }
+
+  override def afterAll(): Unit = {
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.ENABLE_UNSAFE_SORT, originUnsafeSortStatus)
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.IN_MEMORY_FOR_SORT_DATA_IN_MB, originUnsafeMemForSort)
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.UNSAFE_WORKING_MEMORY_IN_MB, originUnsafeMemForWorking)
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.OFFHEAP_SORT_CHUNK_SIZE_IN_MB, originUnsafeSizeForChunk)
+  }
+
+  private def testSimpleTable(): Unit = {
+    // This number is chosen to reproduce issue CARBONDATA-2246. It was choose on purpose that the
+    // records in memory will consume about two more unsafe-row-pages and the last one will exhaust
+    // the working memory.
+    val lineNum: Int = 70002
+    val df = {
+      import sqlContext.implicits._
+      sqlContext.sparkContext.parallelize((1 to lineNum).reverse)
+        .map(x => (s"a$x", s"b$x", s"c$x", 12.3 + x, x, System.currentTimeMillis(), s"d$x"))
+        .toDF("c1", "c2", "c3", "c4", "c5", "c6", "c7")
+    }
+
+    df.write
+      .format("carbondata")
+      .option("tableName", targetTable)
+      .option("SORT_COLUMNS", "c1,c3")
+      .save()
+
+    checkAnswer(sql(s"select count(*) from $targetTable"), Row(lineNum))
+    checkAnswer(sql(s"select count(*) from $targetTable where c5 > 5000"), Row(lineNum - 5000))
+  }
+
+  // see CARBONDATA-2246
+  test("unsafe sort with chunk size equal to working memory") {
+    testSimpleTable()
+  }
+}

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/sort/impl/UnsafeBatchParallelReadMergeSorterImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/sort/impl/UnsafeBatchParallelReadMergeSorterImpl.java
@@ -328,7 +328,7 @@ public class UnsafeBatchParallelReadMergeSorterImpl extends AbstractMergeSorter 
             .recordDictionaryValuesTotalTime(parameters.getPartitionID(),
                 System.currentTimeMillis());
         return false;
-      } catch (InterruptedException e) {
+      } catch (Exception e) {
         throw new CarbonDataLoadingException(e);
       }
     }

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/sort/impl/UnsafeParallelReadMergeSorterImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/sort/impl/UnsafeParallelReadMergeSorterImpl.java
@@ -166,7 +166,7 @@ public class UnsafeParallelReadMergeSorterImpl extends AbstractMergeSorter {
       CarbonTimeStatisticsFactory.getLoadStatisticsInstance()
           .recordDictionaryValuesTotalTime(parameters.getPartitionID(), System.currentTimeMillis());
       return false;
-    } catch (InterruptedException e) {
+    } catch (Exception e) {
       throw new CarbonDataLoadingException(e);
     }
   }


### PR DESCRIPTION
If the size of unsafe row page equals to that of working memory, the
last page will exhaust the working memory and carbondata will suffer 'not
enough memory' problem when we convert data to columnar format.

All unsafe pages should be spilled to disk or moved to unsafe sort memory
instead of be kept in unsafe working memory.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 `NO`
 - [x] Any backward compatibility impacted?
  `NO`
 - [x] Document update required?
 `NO`
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
`Tests added`
        - How it is tested? Please attach test report.
`Tested in local machine`
        - Is it a performance related change? Please attach the performance test report.
`NO`
        - Any additional information to help reviewers in testing this change.
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

