### PR TITLE
[CARBONDATA-2238][DataLoad] Merge and spill in-memory pages if memory is not enough

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonLoadOptionConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonLoadOptionConstants.java
@@ -139,4 +139,16 @@ public final class CarbonLoadOptionConstants {
   public static final String ENABLE_CARBON_LOAD_DIRECT_WRITE_HDFS
       = "carbon.load.directWriteHdfs.enabled";
   public static final String ENABLE_CARBON_LOAD_DIRECT_WRITE_HDFS_DEFAULT = "false";
+
+  /**
+   * If the sort memory is insufficient, spill inmemory pages to disk.
+   * The total amount of pages is at most the specified percentage of total sort memory. Default
+   * value 0 means that no pages will be spilled and the newly incoming pages will be spilled,
+   * whereas value 1 means that all pages will be spilled and newly incoming pages will be loaded
+   * into sort memory.
+   */
+  @CarbonProperty
+  public static final String CARBON_LOAD_SORT_MEMORY_SPILL_PERCENTAGE
+      = "carbon.load.sortMemory.spill.percentage";
+  public static final String CARBON_LOAD_SORT_MEMORY_SPILL_PERCENTAGE_DEFAULT = "0";
 }

--- a/core/src/main/java/org/apache/carbondata/core/memory/UnsafeSortMemoryManager.java
+++ b/core/src/main/java/org/apache/carbondata/core/memory/UnsafeSortMemoryManager.java
@@ -120,6 +120,14 @@ public class UnsafeSortMemoryManager {
   }
 
   /**
+   * total usable memory for sort memory manager
+   * @return size in bytes
+   */
+  public long getUsableMemory() {
+    return totalMemory;
+  }
+
+  /**
    * Below method will be used to allocate dummy memory
    * this will be used to allocate first and then used when u need
    *

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/dataload/TestLoadDataWithUnsafeMemory.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/dataload/TestLoadDataWithUnsafeMemory.scala
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.integration.spark.testsuite.dataload
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.test.util.QueryTest
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Ignore}
+
+import org.apache.carbondata.core.constants.CarbonCommonConstants
+import org.apache.carbondata.core.util.CarbonProperties
+
+/**
+ * test data load with unsafe memory.
+ * The CI env may not have so much memory, so disable this test case for now.
+ * Ps: seen from CI result, the sdvTests works fine
+ */
+@Ignore
+class TestLoadDataWithUnsafeMemory extends QueryTest
+  with BeforeAndAfterEach with BeforeAndAfterAll {
+  val originUnsafeSortStatus: String = CarbonProperties.getInstance()
+    .getProperty(CarbonCommonConstants.ENABLE_UNSAFE_SORT,
+      CarbonCommonConstants.ENABLE_UNSAFE_SORT_DEFAULT)
+  val originUnsafeMemForSort: String = CarbonProperties.getInstance()
+    .getProperty(CarbonCommonConstants.IN_MEMORY_FOR_SORT_DATA_IN_MB,
+      CarbonCommonConstants.IN_MEMORY_FOR_SORT_DATA_IN_MB_DEFAULT)
+  val originUnsafeMemForWorking: String = CarbonProperties.getInstance()
+    .getProperty(CarbonCommonConstants.UNSAFE_WORKING_MEMORY_IN_MB,
+      CarbonCommonConstants.UNSAFE_WORKING_MEMORY_IN_MB_DEFAULT)
+  val originUnsafeSizeForChunk: String = CarbonProperties.getInstance()
+    .getProperty(CarbonCommonConstants.OFFHEAP_SORT_CHUNK_SIZE_IN_MB,
+      CarbonCommonConstants.OFFHEAP_SORT_CHUNK_SIZE_IN_MB_DEFAULT)
+  val targetTable = "table_unsafe_memory"
+
+
+  override def beforeEach(): Unit = {
+    sql(s"drop table if exists $targetTable ")
+  }
+
+  override def afterEach(): Unit = {
+    sql(s"drop table if exists $targetTable ")
+  }
+
+  override protected def beforeAll(): Unit = {
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.ENABLE_UNSAFE_SORT, "true")
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.IN_MEMORY_FOR_SORT_DATA_IN_MB, "1024")
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.UNSAFE_WORKING_MEMORY_IN_MB, "512")
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.OFFHEAP_SORT_CHUNK_SIZE_IN_MB, "512")
+  }
+
+  override def afterAll(): Unit = {
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.ENABLE_UNSAFE_SORT, originUnsafeSortStatus)
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.IN_MEMORY_FOR_SORT_DATA_IN_MB, originUnsafeMemForSort)
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.UNSAFE_WORKING_MEMORY_IN_MB, originUnsafeMemForWorking)
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.OFFHEAP_SORT_CHUNK_SIZE_IN_MB, originUnsafeSizeForChunk)
+  }
+
+  private def testSimpleTable(): Unit = {
+    // This number is chosen to reproduce issue CARBONDATA-2246. It was choose on purpose that the
+    // records in memory will consume about two more unsafe-row-pages and the last one will exhaust
+    // the working memory.
+    val lineNum: Int = 70002
+    val df = {
+      import sqlContext.implicits._
+      sqlContext.sparkContext.parallelize((1 to lineNum).reverse)
+        .map(x => (s"a$x", s"b$x", s"c$x", 12.3 + x, x, System.currentTimeMillis(), s"d$x"))
+        .toDF("c1", "c2", "c3", "c4", "c5", "c6", "c7")
+    }
+
+    df.write
+      .format("carbondata")
+      .option("tableName", targetTable)
+      .option("SORT_COLUMNS", "c1,c3")
+      .save()
+
+    checkAnswer(sql(s"select count(*) from $targetTable"), Row(lineNum))
+    checkAnswer(sql(s"select count(*) from $targetTable where c5 > 5000"), Row(lineNum - 5000))
+  }
+
+  // see CARBONDATA-2246
+  test("unsafe sort with chunk size equal to working memory") {
+    testSimpleTable()
+  }
+}

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/sort/impl/UnsafeBatchParallelReadMergeSorterImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/sort/impl/UnsafeBatchParallelReadMergeSorterImpl.java
@@ -33,7 +33,6 @@ import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.datastore.exception.CarbonDataWriterException;
 import org.apache.carbondata.core.datastore.row.CarbonRow;
-import org.apache.carbondata.core.memory.MemoryException;
 import org.apache.carbondata.core.util.CarbonProperties;
 import org.apache.carbondata.core.util.CarbonTimeStatisticsFactory;
 import org.apache.carbondata.processing.loading.exception.CarbonDataLoadingException;
@@ -212,7 +211,7 @@ public class UnsafeBatchParallelReadMergeSorterImpl extends AbstractMergeSorter 
 
       try {
         sortDataRow.initialize();
-      } catch (MemoryException e) {
+      } catch (Exception e) {
         throw new CarbonDataLoadingException(e);
       }
       batchCount++;

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/sort/impl/UnsafeBatchParallelReadMergeSorterImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/sort/impl/UnsafeBatchParallelReadMergeSorterImpl.java
@@ -328,7 +328,7 @@ public class UnsafeBatchParallelReadMergeSorterImpl extends AbstractMergeSorter 
             .recordDictionaryValuesTotalTime(parameters.getPartitionID(),
                 System.currentTimeMillis());
         return false;
-      } catch (InterruptedException e) {
+      } catch (Exception e) {
         throw new CarbonDataLoadingException(e);
       }
     }

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/sort/impl/UnsafeParallelReadMergeSorterImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/sort/impl/UnsafeParallelReadMergeSorterImpl.java
@@ -166,7 +166,7 @@ public class UnsafeParallelReadMergeSorterImpl extends AbstractMergeSorter {
       CarbonTimeStatisticsFactory.getLoadStatisticsInstance()
           .recordDictionaryValuesTotalTime(parameters.getPartitionID(), System.currentTimeMillis());
       return false;
-    } catch (InterruptedException e) {
+    } catch (Exception e) {
       throw new CarbonDataLoadingException(e);
     }
   }

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/sort/impl/UnsafeParallelReadMergeSorterImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/sort/impl/UnsafeParallelReadMergeSorterImpl.java
@@ -28,7 +28,6 @@ import org.apache.carbondata.common.logging.LogService;
 import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.datastore.exception.CarbonDataWriterException;
 import org.apache.carbondata.core.datastore.row.CarbonRow;
-import org.apache.carbondata.core.memory.MemoryException;
 import org.apache.carbondata.core.util.CarbonProperties;
 import org.apache.carbondata.core.util.CarbonThreadFactory;
 import org.apache.carbondata.core.util.CarbonTimeStatisticsFactory;
@@ -82,7 +81,7 @@ public class UnsafeParallelReadMergeSorterImpl extends AbstractMergeSorter {
     final int batchSize = CarbonProperties.getInstance().getBatchSize();
     try {
       sortDataRow.initialize();
-    } catch (MemoryException e) {
+    } catch (Exception e) {
       throw new CarbonDataLoadingException(e);
     }
     this.executorService = Executors.newFixedThreadPool(iterators.length,

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/sort/impl/UnsafeParallelReadMergeSorterWithColumnRangeImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/sort/impl/UnsafeParallelReadMergeSorterWithColumnRangeImpl.java
@@ -31,7 +31,6 @@ import org.apache.carbondata.common.logging.LogService;
 import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.datastore.row.CarbonRow;
-import org.apache.carbondata.core.memory.MemoryException;
 import org.apache.carbondata.core.metadata.schema.ColumnRangeInfo;
 import org.apache.carbondata.core.util.CarbonProperties;
 import org.apache.carbondata.core.util.CarbonTimeStatisticsFactory;
@@ -106,7 +105,7 @@ public class UnsafeParallelReadMergeSorterWithColumnRangeImpl extends AbstractMe
             new UnsafeSortDataRows(parameters, intermediateFileMergers[i], inMemoryChunkSizeInMB);
         sortDataRows[i].initialize();
       }
-    } catch (MemoryException e) {
+    } catch (Exception e) {
       throw new CarbonDataLoadingException(e);
     }
     ExecutorService executorService = Executors.newFixedThreadPool(iterators.length);

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/sort/unsafe/UnsafeSortDataRows.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/sort/unsafe/UnsafeSortDataRows.java
@@ -152,7 +152,7 @@ public class UnsafeSortDataRows {
     } else {
       LOGGER.info("trigger in-memory merge and spill for table " + parameters.getTableName());
       // merge and spill in-memory pages to disk if memory is not enough
-      unsafeInMemoryIntermediateFileMerger.triggerInmemoryMerging(true);
+      unsafeInMemoryIntermediateFileMerger.tryTriggerInmemoryMerging(true);
     }
     return new UnsafeCarbonRowPage(tableFieldStat, baseBlock, !isMemoryAvailable, taskId);
   }

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/sort/unsafe/merger/UnsafeIntermediateMerger.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/sort/unsafe/merger/UnsafeIntermediateMerger.java
@@ -18,6 +18,7 @@ package org.apache.carbondata.processing.loading.sort.unsafe.merger;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.ExecutionException;
@@ -29,6 +30,9 @@ import java.util.concurrent.TimeUnit;
 import org.apache.carbondata.common.logging.LogService;
 import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
+import org.apache.carbondata.core.constants.CarbonLoadOptionConstants;
+import org.apache.carbondata.core.memory.UnsafeSortMemoryManager;
+import org.apache.carbondata.core.util.CarbonProperties;
 import org.apache.carbondata.core.util.CarbonThreadFactory;
 import org.apache.carbondata.processing.loading.sort.unsafe.UnsafeCarbonRowPage;
 import org.apache.carbondata.processing.sort.exception.CarbonSortKeyAndGroupByException;
@@ -60,6 +64,10 @@ public class UnsafeIntermediateMerger {
   private List<File> procFiles;
 
   private List<Future<Void>> mergerTask;
+  /**
+   * size to be spilled in sort memory
+   */
+  private long spillSizeInSortMemory;
 
   public UnsafeIntermediateMerger(SortParameters parameters) {
     this.parameters = parameters;
@@ -70,6 +78,20 @@ public class UnsafeIntermediateMerger {
         new CarbonThreadFactory("UnsafeIntermediatePool:" + parameters.getTableName()));
     this.procFiles = new ArrayList<File>(CarbonCommonConstants.CONSTANT_SIZE_TEN);
     this.mergerTask = new ArrayList<>();
+
+    Integer spillPercentage;
+    try {
+      String spillPercentageStr = CarbonProperties.getInstance().getProperty(
+          CarbonLoadOptionConstants.CARBON_LOAD_SORT_MEMORY_SPILL_PERCENTAGE,
+          CarbonLoadOptionConstants.CARBON_LOAD_SORT_MEMORY_SPILL_PERCENTAGE_DEFAULT);
+      spillPercentage = Integer.valueOf(spillPercentageStr);
+    } catch (NumberFormatException e) {
+      spillPercentage = Integer.valueOf(
+          CarbonLoadOptionConstants.CARBON_LOAD_SORT_MEMORY_SPILL_PERCENTAGE_DEFAULT);
+    }
+
+    this.spillSizeInSortMemory =
+        UnsafeSortMemoryManager.INSTANCE.getUsableMemory() * spillPercentage / 100;
   }
 
   public void addDataChunkToMerge(UnsafeCarbonRowPage rowPage) {
@@ -120,27 +142,36 @@ public class UnsafeIntermediateMerger {
     mergerTask.add(executorService.submit(merger));
   }
 
-  public void triggerInmemoryMerging(boolean spillDisk) throws CarbonSortKeyAndGroupByException {
-    UnsafeCarbonRowPage[] localRowPages;
-    int totalRows = 0;
+  public void tryTriggerInmemoryMerging(boolean spillDisk)
+      throws CarbonSortKeyAndGroupByException {
+    List<UnsafeCarbonRowPage> pages2Merge = new ArrayList<>();
+    int totalRows2Merge = 0;
     synchronized (lockObject) {
-      totalRows = getTotalNumberOfRows(rowPages);
-      if (totalRows <= 0) {
-        return;
+      long sizeAdded = 0;
+      for (Iterator<UnsafeCarbonRowPage> iter = rowPages.iterator(); iter.hasNext(); ) {
+        UnsafeCarbonRowPage page = iter.next();
+        if (!spillDisk || sizeAdded + page.getDataBlock().size() < this.spillSizeInSortMemory) {
+          pages2Merge.add(page);
+          totalRows2Merge += page.getBuffer().getActualSize();
+          iter.remove();
+        } else {
+          break;
+        }
       }
-      localRowPages = rowPages.toArray(new UnsafeCarbonRowPage[rowPages.size()]);
-      this.rowPages = new ArrayList<>();
     }
-    if (LOGGER.isDebugEnabled()) {
-      LOGGER.debug("Sumitting request for intermediate merging of in-memory pages : "
-          + localRowPages.length);
+    if (pages2Merge.size() > 1) {
+      if (LOGGER.isDebugEnabled()) {
+        LOGGER.debug("Sumitting request for intermediate merging of in-memory pages : "
+            + pages2Merge.size());
+      }
+      startIntermediateMerging(pages2Merge.toArray(new UnsafeCarbonRowPage[pages2Merge.size()]),
+          totalRows2Merge, spillDisk);
     }
-    startIntermediateMerging(localRowPages, totalRows, spillDisk);
   }
 
   public void startInmemoryMergingIfPossible() throws CarbonSortKeyAndGroupByException {
     if (rowPages.size() >= parameters.getNumberOfIntermediateFileToBeMerged()) {
-      triggerInmemoryMerging(false);
+      tryTriggerInmemoryMerging(false);
     }
   }
 


### PR DESCRIPTION
Currently in carbondata, pages will be added to memory. If memory is not enough, newly incoming pages will be spilled to disk directly. This implementation will merge&spill the in-memory pages and make room for the newly incoming pages.

As a result, carbondata will spill less than before and spill bigger files instead of smaller files and the merge&sort of the pages is in-memory instead of spilled-file.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 `NO`
 - [x] Any backward compatibility impacted?
  `NO`
 - [x] Document update required?
 `NO`
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
 `NO`
        - How it is tested? Please attach test report.
 `Tested in local machine`
        - Is it a performance related change? Please attach the performance test report.
`Performance should be enhanced. We reduce the frequency of spill pages to disk and increase the data size for each spill. Also, the merge sort of pages is memory based instead of file based, so the performance will be enhanced.`
        - Any additional information to help reviewers in testing this change.
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

