### PR TITLE
[CARBONDATA-2249] Fixed bug for querying data through presto

### DIFF
--- a/integration/presto/pom.xml
+++ b/integration/presto/pom.xml
@@ -493,6 +493,11 @@
       <artifactId>spark-catalyst_${scala.binary.version}</artifactId>
       <version>${spark.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.lz4</groupId>
+      <artifactId>lz4-java</artifactId>
+      <version>1.4.0</version>
+    </dependency>
 
   </dependencies>
 


### PR DESCRIPTION
Added lz4 dependency in presto's pom.xml as it was throwing an exception when the store location for presto is local.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

