### PR TITLE
[CARBONDATA-2250][DataLoad] Reduce massive object generation in global sort

### DIFF
--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/load/DataLoadProcessBuilderOnSpark.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/load/DataLoadProcessBuilderOnSpark.scala
@@ -80,15 +80,14 @@ object DataLoadProcessBuilderOnSpark {
     // 3. Sort
     val configuration = DataLoadProcessBuilder.createConfiguration(model)
     val sortParameters = SortParameters.createSortParameters(configuration)
+    val rowComparator: Comparator[Array[AnyRef]] =
+      if (sortParameters.getNoDictionaryCount > 0) {
+        new NewRowComparator(sortParameters.getNoDictionaryDimnesionColumn)
+      } else {
+        new NewRowComparatorForNormalDims(sortParameters.getDimColCount)
+      }
     object RowOrdering extends Ordering[Array[AnyRef]] {
       def compare(rowA: Array[AnyRef], rowB: Array[AnyRef]): Int = {
-        val rowComparator: Comparator[Array[AnyRef]] =
-          if (sortParameters.getNoDictionaryCount > 0) {
-            new NewRowComparator(sortParameters.getNoDictionaryDimnesionColumn)
-          } else {
-            new NewRowComparatorForNormalDims(sortParameters.getDimColCount)
-          }
-
         rowComparator.compare(rowA, rowB)
       }
     }

--- a/processing/src/main/java/org/apache/carbondata/processing/sort/sortdata/NewRowComparator.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/sort/sortdata/NewRowComparator.java
@@ -17,11 +17,13 @@
 
 package org.apache.carbondata.processing.sort.sortdata;
 
+import java.io.Serializable;
 import java.util.Comparator;
 
 import org.apache.carbondata.core.util.ByteUtil.UnsafeComparer;
 
-public class NewRowComparator implements Comparator<Object[]> {
+public class NewRowComparator implements Comparator<Object[]>, Serializable {
+  private static final long serialVersionUID = -1739874611112709436L;
 
   /**
    * mapping of dictionary dimensions and no dictionary of sort_column.

--- a/processing/src/main/java/org/apache/carbondata/processing/sort/sortdata/NewRowComparatorForNormalDims.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/sort/sortdata/NewRowComparatorForNormalDims.java
@@ -16,13 +16,16 @@
  */
 package org.apache.carbondata.processing.sort.sortdata;
 
+import java.io.Serializable;
 import java.util.Comparator;
 
 /**
  * This class is used as comparator for comparing dims which are non high cardinality dims.
  * Here the dims will be in form of int[] (surrogates) so directly comparing the integers.
  */
-public class NewRowComparatorForNormalDims implements Comparator<Object[]> {
+public class NewRowComparatorForNormalDims implements Comparator<Object[]>, Serializable {
+  private static final long serialVersionUID = -1749874611112709432L;
+
   /**
    * dimension count
    */


### PR DESCRIPTION
Generate compatator outside the function, otherwise it will be generated
for every row

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 `NO`
 - [x] Any backward compatibility impacted?
  `NO`
 - [x] Document update required?
 `NO`
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
 `NO`
        - How it is tested? Please attach test report.
`Tested in local machine`
        - Is it a performance related change? Please attach the performance test report.
 `Performance should be slightly enhanced`
        - Any additional information to help reviewers in testing this change.
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

