### PR TITLE
[WIP] [CARBONDATA-2252] Query performance slows down as the number of columns increases in like query with OR expression

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/filterexpr/AllDataTypesTestCaseFilter.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/filterexpr/AllDataTypesTestCaseFilter.scala
@@ -64,6 +64,48 @@ class AllDataTypesTestCaseFilter extends QueryTest with BeforeAndAfterAll {
       .sparkPlan
     assert(df.metadata.get("PushedFilters").get.contains("CarbonContainsWith"))
   }
+
+  test("verify like query contains with filter push down with OR expression") {
+    sql("drop table if exists like_contains_with")
+    sql(
+      s"""create table like_contains_with (id bigint, country string, hscode string, hsdes string,
+      |importer string, importer_address string, exporter string, exporter_address string, port
+      |string, product string, velus double, qty double, unit string, weight double, tel string,
+      |pro1 string, pro2 string, pro3 string, pro4 string, pro5 string, pro6 string, pro7 string)
+      | STORED BY 'org.apache.carbondata.format'
+      """.stripMargin)
+    val df = sql(
+      s"""select pro7,pro6,pro4,pro5,pro3,pro2,pro1 from like_contains_with where pro7 like '%15b%'
+      |or pro4 like '%9d%' or pro6 like '%a77h%' or pro5 like '%hina%' or pro3 like '%44d%' or
+      |pro2 like '%ro2%' or pro1 like '%cv%'
+      """.stripMargin)
+      .queryExecution
+      .sparkPlan
+    val pushedFilters: Option[String] = df.metadata.get("PushedFilters")
+    assert(!pushedFilters.isDefined)
+    sql("drop table if exists like_contains_with")
+  }
+
+  test("verify like query ends with filter push down with OR expression") {
+    sql("drop table if exists like_ends_with")
+    sql(
+      s"""create table like_ends_with (id bigint, country string, hscode string, hsdes string,
+        |importer string, importer_address string, exporter string, exporter_address string, port
+        |string, product string, velus double, qty double, unit string, weight double, tel string,
+        |pro1 string, pro2 string, pro3 string, pro4 string, pro5 string, pro6 string, pro7 string)
+        | STORED BY 'org.apache.carbondata.format'
+      """.stripMargin)
+    val df = sql(
+      s"""select pro7,pro6,pro4,pro5,pro3,pro2,pro1 from like_ends_with where pro7 like '%15b'
+          |or pro4 like '%9d' or pro6 like '%a77h' or pro5 like '%hina' or pro3 like '%44d' or
+          |pro2 like '%ro2' or pro1 like '%cv'
+      """.stripMargin)
+      .queryExecution
+      .sparkPlan
+    val pushedFilters: Option[String] = df.metadata.get("PushedFilters")
+    assert(!pushedFilters.isDefined)
+    sql("drop table if exists like_ends_with")
+  }
   
   override def afterAll {
     sql("drop table alldatatypestableFilter")

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/strategy/CarbonLateDecodeStrategy.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/strategy/CarbonLateDecodeStrategy.scala
@@ -626,9 +626,23 @@ private[sql] class CarbonLateDecodeStrategy extends SparkStrategy {
       case s@StartsWith(a: Attribute, Literal(v, t)) =>
         Some(sources.StringStartsWith(a.name, v.toString))
       case c@EndsWith(a: Attribute, Literal(v, t)) =>
-        Some(CarbonEndsWith(c))
+        // avoid OR expression with like query ends with push down to carbon. This is done to
+        // improve the query performance as spark will return the results faster to compared to
+        // carbon push down
+        if (or) {
+          None
+        } else {
+          Some(CarbonEndsWith(c))
+        }
       case c@Contains(a: Attribute, Literal(v, t)) =>
-        Some(CarbonContainsWith(c))
+        // avoid OR expression with like query contains with push down to carbon. This is done to
+        // improve the query performance as spark will return the results faster to compared to
+        // carbon push down
+        if (or) {
+          None
+        } else {
+          Some(CarbonContainsWith(c))
+        }
       case c@Literal(v, t) if (v == null) =>
         Some(FalseExpr())
       case others => None

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/optimizer/CarbonFilters.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/optimizer/CarbonFilters.scala
@@ -270,9 +270,23 @@ object CarbonFilters {
         case s@StartsWith(a: Attribute, Literal(v, t)) =>
           Some(sources.StringStartsWith(a.name, v.toString))
         case c@EndsWith(a: Attribute, Literal(v, t)) =>
-          Some(CarbonEndsWith(c))
+          // avoid OR expression with like query ends with push down to carbon. This is done to
+          // improve the query performance as spark will return the results faster to compared to
+          // carbon push down
+          if (or) {
+            None
+          } else {
+            Some(CarbonEndsWith(c))
+          }
         case c@Contains(a: Attribute, Literal(v, t)) =>
-          Some(CarbonContainsWith(c))
+          // avoid OR expression with like query contains with push down to carbon. This is done to
+          // improve the query performance as spark will return the results faster to compared to
+          // carbon push down
+          if (or) {
+            None
+          } else {
+            Some(CarbonContainsWith(c))
+          }
         case c@Cast(a: Attribute, _) =>
           Some(CastExpr(c))
         case c@Literal(v, t) if v == null =>


### PR DESCRIPTION
Problem: In case of OR condition with like query contains and ends with, the filter is getting pushed down to carbon layer because of which the query is slow as compared to spark applying the same filter on the results returned from carbon

Analysis: This is because in case of like query the execution is done by RowLevelFilterExecutorImpl which will compute the data row by row. As the number of columns will increase the computation time will increase thereby increasing the query time.

Fix: If there is any OR condition with like query, it is better to return back all the results to spark and let spark do the computation.

 - [ ] Any interfaces changed?
 No
 - [ ] Any backward compatibility impacted?
 No
 - [ ] Document update required?
No
 - [ ] Testing done
Added test cases       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA
