### PR TITLE
[CARBONDATA-2251] Refactored sdv testcase

### DIFF
--- a/integration/spark-common-cluster-test/src/test/scala/org/apache/carbondata/cluster/sdv/generated/QueriesBVATestCase.scala
+++ b/integration/spark-common-cluster-test/src/test/scala/org/apache/carbondata/cluster/sdv/generated/QueriesBVATestCase.scala
@@ -7821,8 +7821,9 @@ class QueriesBVATestCase extends QueryTest with BeforeAndAfterAll {
   //BVA_SPL_DATA_TIMESTAMP_212
   test("BVA_SPL_DATA_TIMESTAMP_212", Include) {
 
-    checkAnswer(s"""select histogram_numeric(c6_Timestamp,2) from Test_Boundary""",
-      s"""select histogram_numeric(c6_Timestamp,2) from Test_Boundary_hive""", "QueriesBVATestCase_BVA_SPL_DATA_TIMESTAMP_212")
+    checkAnswer(s"""select sum(y),x from (select cast(hist.x as int) as x, cast(hist.y as bigint) as y from (select histogram_numeric(c6_Timestamp,2) as hist_table from Test_Boundary ) t lateral view explode(hist_table) exploded_table as hist) group by x""",
+      s"""select sum(y),x from (select cast(hist.x as int) as x, cast(hist.y as bigint) as y from (select histogram_numeric(c6_Timestamp,2) as hist_table from Test_Boundary_hive ) t lateral view explode(hist_table) exploded_table as hist) group by x""", "QueriesBVATestCase_BVA_SPL_DATA_TIMESTAMP_212")
+
 
   }
 

--- a/integration/spark-common-cluster-test/src/test/scala/org/apache/carbondata/cluster/sdv/generated/QueriesBasicTestCase.scala
+++ b/integration/spark-common-cluster-test/src/test/scala/org/apache/carbondata/cluster/sdv/generated/QueriesBasicTestCase.scala
@@ -4275,8 +4275,8 @@ class QueriesBasicTestCase extends QueryTest with BeforeAndAfterAll {
   //PushUP_FILTER_uniqdata_TC079
   test("PushUP_FILTER_uniqdata_TC079", Include) {
 
-    checkAnswer(s"""select histogram_numeric(1,2) from uniqdata where CUST_ID IS NULL or DOB IS NOT NULL or BIGINT_COLUMN1 =1233720368578 or DECIMAL_COLUMN1 = 12345678901.1234000058 or Double_COLUMN1 = 1.12345674897976E10 or INTEGER_COLUMN1 IS NULL """,
-      s"""select histogram_numeric(1,2) from uniqdata_hive where CUST_ID IS NULL or DOB IS NOT NULL or BIGINT_COLUMN1 =1233720368578 or DECIMAL_COLUMN1 = 12345678901.1234000058 or Double_COLUMN1 = 1.12345674897976E10 or INTEGER_COLUMN1 IS NULL """, "QueriesBasicTestCase_PushUP_FILTER_uniqdata_TC079")
+    checkAnswer(s"""select sum(y),x from (select cast(hist.x as int) as x, cast(hist.y as bigint) as y from (select histogram_numeric(1,2) as hist_table from uniqdata where CUST_ID IS NULL or DOB IS NOT NULL or BIGINT_COLUMN1 =1233720368578 or DECIMAL_COLUMN1 = 12345678901.1234000058 or Double_COLUMN1 = 1.12345674897976E10 or INTEGER_COLUMN1 IS NULL) t lateral view explode(hist_table) exploded_table as hist) group by x""",
+      s"""select sum(y),x from (select cast(hist.x as int) as x, cast(hist.y as bigint) as y from (select histogram_numeric(1,2) as hist_table from uniqdata_hive where CUST_ID IS NULL or DOB IS NOT NULL or BIGINT_COLUMN1 =1233720368578 or DECIMAL_COLUMN1 = 12345678901.1234000058 or Double_COLUMN1 = 1.12345674897976E10 or INTEGER_COLUMN1 IS NULL) t lateral view explode(hist_table) exploded_table as hist) group by x""", "QueriesBasicTestCase_PushUP_FILTER_uniqdata_TC079")
 
   }
 
@@ -4284,8 +4284,8 @@ class QueriesBasicTestCase extends QueryTest with BeforeAndAfterAll {
   //PushUP_FILTER_uniqdata_TC080
   test("PushUP_FILTER_uniqdata_TC080", Include) {
 
-    checkAnswer(s"""select histogram_numeric(1,2) from uniqdata where upper(CUST_NAME)=15 or upper(CUST_NAME) is NULL or upper(CUST_NAME) is NOT NULL""",
-      s"""select histogram_numeric(1,2) from uniqdata_hive where upper(CUST_NAME)=15 or upper(CUST_NAME) is NULL or upper(CUST_NAME) is NOT NULL""", "QueriesBasicTestCase_PushUP_FILTER_uniqdata_TC080")
+    checkAnswer(s"""select sum(y),x from (select cast(hist.x as int) as x, cast(hist.y as bigint) as y from (select histogram_numeric(1,2) as hist_table from uniqdata where upper(CUST_NAME)=15 or upper(CUST_NAME) is NULL or upper(CUST_NAME) is NOT NULL) t lateral view explode(hist_table) exploded_table as hist) group by x""",
+      s"""select sum(y),x from (select cast(hist.x as int) as x, cast(hist.y as bigint) as y from (select histogram_numeric(1,2) as hist_table from uniqdata_hive where upper(CUST_NAME)=15 or upper(CUST_NAME) is NULL or upper(CUST_NAME) is NOT NULL) t lateral view explode(hist_table) exploded_table as hist) group by x""", "QueriesBasicTestCase_PushUP_FILTER_uniqdata_TC080")
 
   }
 
@@ -9411,8 +9411,8 @@ class QueriesBasicTestCase extends QueryTest with BeforeAndAfterAll {
   //TC_487
   test("TC_487", Include) {
 
-    checkAnswer(s"""select histogram_numeric(1, 5000)from carbon_automation""",
-      s"""select histogram_numeric(1, 5000)from carbon_automation_hive""", "QueriesBasicTestCase_TC_487")
+    checkAnswer(s"""select sum(y),x from (select cast(hist.x as int) as x, cast(hist.y as bigint) as y from (select histogram_numeric(1, 5000) as A_hist from carbon_automation) t lateral view explode(A_hist) exploded_table as hist) group by x""",
+     s"""select sum(y),x from (select cast(hist.x as int) as x, cast(hist.y as bigint) as y from (select histogram_numeric(1, 5000)as A_hist from carbon_automation_hive) t lateral view explode(A_hist) exploded_table as hist) group by x""","QueriesBasicTestCase_TC_487")
 
   }
 
@@ -9420,8 +9420,8 @@ class QueriesBasicTestCase extends QueryTest with BeforeAndAfterAll {
   //TC_488
   test("TC_488", Include) {
 
-    checkAnswer(s"""select histogram_numeric(1, 1000)from carbon_automation""",
-      s"""select histogram_numeric(1, 1000)from carbon_automation_hive""", "QueriesBasicTestCase_TC_488")
+    checkAnswer(s"""select sum(y),x from (select cast(hist.x as int) as x, cast(hist.y as bigint) as y from (select histogram_numeric(1, 1000) as A_hist from carbon_automation) t lateral view explode(A_hist) exploded_table as hist) group by x""",
+      s"""select sum(y),x from (select cast(hist.x as int) as x, cast(hist.y as bigint) as y from (select histogram_numeric(1, 1000)as A_hist from carbon_automation_hive) t lateral view explode(A_hist) exploded_table as hist) group by x""","QueriesBasicTestCase_TC_488")
 
   }
 
@@ -9429,8 +9429,8 @@ class QueriesBasicTestCase extends QueryTest with BeforeAndAfterAll {
   //TC_489
   test("TC_489", Include) {
 
-    checkAnswer(s"""select histogram_numeric(1, 500)from carbon_automation""",
-      s"""select histogram_numeric(1, 500)from carbon_automation_hive""", "QueriesBasicTestCase_TC_489")
+    checkAnswer(s"""select sum(y),x from (select cast(hist.x as int) as x, cast(hist.y as bigint) as y from (select histogram_numeric(1, 500) as A_hist from carbon_automation) t lateral view explode(A_hist) exploded_table as hist) group by x""",
+      s"""select sum(y),x from (select cast(hist.x as int) as x, cast(hist.y as bigint) as y from (select histogram_numeric(1, 500)as A_hist from carbon_automation_hive) t lateral view explode(A_hist) exploded_table as hist) group by x""","QueriesBasicTestCase_TC_489")
 
   }
 
@@ -9438,8 +9438,8 @@ class QueriesBasicTestCase extends QueryTest with BeforeAndAfterAll {
   //TC_490
   test("TC_490", Include) {
 
-    checkAnswer(s"""select histogram_numeric(1, 500)from carbon_automation""",
-      s"""select histogram_numeric(1, 500)from carbon_automation_hive""", "QueriesBasicTestCase_TC_490")
+    checkAnswer(s"""select sum(y),x from (select cast(hist.x as int) as x, cast(hist.y as bigint) as y from (select histogram_numeric(1, 100) as A_hist from carbon_automation) t lateral view explode(A_hist) exploded_table as hist) group by x""",
+      s"""select sum(y),x from (select cast(hist.x as int) as x, cast(hist.y as bigint) as y from (select histogram_numeric(1, 100)as A_hist from carbon_automation_hive) t lateral view explode(A_hist) exploded_table as hist) group by x""","QueriesBasicTestCase_TC_490")
 
   }
 

--- a/integration/spark-common-cluster-test/src/test/scala/org/apache/carbondata/cluster/sdv/generated/TimeSeriesPreAggregateTestCase.scala
+++ b/integration/spark-common-cluster-test/src/test/scala/org/apache/carbondata/cluster/sdv/generated/TimeSeriesPreAggregateTestCase.scala
@@ -18,23 +18,26 @@
 
 package org.apache.carbondata.cluster.sdv.generated
 
+import java.util.TimeZone
+
 import org.apache.spark.sql.test.util.QueryTest
-import org.scalatest.BeforeAndAfterEach
+import org.scalatest.BeforeAndAfterAll
 import org.scalatest.Matchers._
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.metadata.schema.datamap.DataMapClassProvider.TIMESERIES
 import org.apache.carbondata.core.util.CarbonProperties
 
-class TimeSeriesPreAggregateTestCase extends QueryTest with BeforeAndAfterEach {
+class TimeSeriesPreAggregateTestCase extends QueryTest with BeforeAndAfterAll {
 
   val timeSeries = TIMESERIES.toString
-
+  val timeZonePre = TimeZone.getDefault
   val csvPath = s"$resourcesPath/Data/timeseriestest.csv"
-  override def beforeEach: Unit = {
+  override def beforeAll: Unit = {
     CarbonProperties.getInstance()
       .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT,
         CarbonCommonConstants.CARBON_TIMESTAMP_DEFAULT_FORMAT)
+    TimeZone.setDefault(TimeZone.getTimeZone(System.getProperty("user.timezone")))
     sql("drop table if exists mainTable")
     sql(
       "CREATE TABLE mainTable(mytime timestamp, name string, age int) STORED BY 'org.apache" +
@@ -152,7 +155,6 @@ class TimeSeriesPreAggregateTestCase extends QueryTest with BeforeAndAfterEach {
 
   //test case for compaction
   test("TimeSeriesPreAggregateTestCase_007") {
-    beforeEach
     sql(s"LOAD DATA LOCAL INPATH '$csvPath' into table mainTable")
     sql(s"LOAD DATA LOCAL INPATH '$csvPath' into table mainTable")
     sql(s"LOAD DATA LOCAL INPATH '$csvPath' into table mainTable")
@@ -182,7 +184,8 @@ class TimeSeriesPreAggregateTestCase extends QueryTest with BeforeAndAfterEach {
     segmentNamesyear should equal(Array("3", "2", "1", "0.1", "0"))
   }
 
-  override def afterEach: Unit = {
+  override def afterAll: Unit = {
+    TimeZone.setDefault(timeZonePre)
     sql("drop table if exists mainTable")
 
   }

--- a/processing/src/main/java/org/apache/carbondata/processing/util/CarbonLoaderUtil.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/util/CarbonLoaderUtil.java
@@ -282,6 +282,7 @@ public final class CarbonLoaderUtil {
           if (!found) {
             LOGGER.error("Entry not found to update " + newMetaEntry + " From list :: "
                 + listOfLoadFolderDetails);
+            throw new IOException("Entry not found to update in the table status file");
           }
           listOfLoadFolderDetails.set(indexToOverwriteNewMetaEntry, newMetaEntry);
         }


### PR DESCRIPTION
1. MergeIndex test case in sdv fails if executed with a different number of executors or in standalone spark.
2. Changes test case having Hive UDAF like histogram_numeric having unexpected behavior. so recommended way to write test cases using aggregation. 

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed? No
 
 - [ ] Any backward compatibility impacted? No
 
 - [ ] Document update required? No

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

