### PR TITLE
[CARBONDATA-2260] CarbonThriftServer should support store carbon table on S3

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -61,6 +61,11 @@
       <artifactId>carbondata-spark2</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.carbondata</groupId>
+      <artifactId>carbondata-examples-spark2</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -61,11 +61,6 @@
       <artifactId>carbondata-spark2</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <dependency>
-      <groupId>org.apache.carbondata</groupId>
-      <artifactId>carbondata-examples-spark2</artifactId>
-      <version>${project.version}</version>
-    </dependency>
   </dependencies>
 
   <build>

--- a/integration/spark2/src/main/scala/org/apache/carbondata/spark/thriftserver/CarbonThriftServer.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/spark/thriftserver/CarbonThriftServer.scala
@@ -29,6 +29,11 @@ import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.util.CarbonProperties
 
+/**
+ * CarbonThriftServer support different modes:
+ * 1. read/write data from/to HDFS or local,it only needs configurate storePath
+ * 2. read/write data from/to S3, it needs provide access-key, secret-key, s3-endpoint
+ */
 object CarbonThriftServer {
 
   def main(args: Array[String]): Unit = {

--- a/integration/spark2/src/main/scala/org/apache/carbondata/spark/thriftserver/CarbonThriftServer.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/spark/thriftserver/CarbonThriftServer.scala
@@ -19,9 +19,11 @@ package org.apache.carbondata.spark.thriftserver
 
 import java.io.File
 
+import org.apache.hadoop.fs.s3a.Constants.{ACCESS_KEY, ENDPOINT, SECRET_KEY}
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.hive.thriftserver.HiveThriftServer2
+import org.slf4j.{Logger, LoggerFactory}
 
 import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.core.constants.CarbonCommonConstants
@@ -34,6 +36,13 @@ object CarbonThriftServer {
     import org.apache.spark.sql.CarbonSession._
 
     val sparkConf = new SparkConf(loadDefaults = true)
+
+    val logger: Logger = LoggerFactory.getLogger(this.getClass)
+    if (args.length != 0 && args.length != 1 && args.length != 4) {
+      logger.error("parameters: storePath [access-key] [secret-key] [s3-endpoint]")
+      System.exit(0)
+    }
+
     val builder = SparkSession
       .builder()
       .config(sparkConf)
@@ -55,7 +64,16 @@ object CarbonThriftServer {
 
     val storePath = if (args.length > 0) args.head else null
 
-    val spark = builder.getOrCreateCarbonSession(storePath)
+    val spark = if (args.length <= 1) {
+      builder.getOrCreateCarbonSession(storePath)
+    } else {
+      val (accessKey, secretKey, endpoint) = getKeyOnPrefix(args(0))
+      builder.config(accessKey, args(1))
+        .config(secretKey, args(2))
+        .config(endpoint, getS3EndPoint(args))
+        .getOrCreateCarbonSession(storePath)
+    }
+
     val warmUpTime = CarbonProperties.getInstance().getProperty("carbon.spark.warmUpTime", "5000")
     try {
       Thread.sleep(Integer.parseInt(warmUpTime))
@@ -68,6 +86,26 @@ object CarbonThriftServer {
     }
 
     HiveThriftServer2.startWithContext(spark.sqlContext)
+  }
+
+  def getKeyOnPrefix(path: String): (String, String, String) = {
+    val endPoint = "spark.hadoop." + ENDPOINT
+    if (path.startsWith(CarbonCommonConstants.S3A_PREFIX)) {
+      ("spark.hadoop." + ACCESS_KEY, "spark.hadoop." + SECRET_KEY, endPoint)
+    } else if (path.startsWith(CarbonCommonConstants.S3N_PREFIX)) {
+      ("spark.hadoop." + CarbonCommonConstants.S3N_ACCESS_KEY,
+        "spark.hadoop." + CarbonCommonConstants.S3N_SECRET_KEY, endPoint)
+    } else if (path.startsWith(CarbonCommonConstants.S3_PREFIX)) {
+      ("spark.hadoop." + CarbonCommonConstants.S3_ACCESS_KEY,
+        "spark.hadoop." + CarbonCommonConstants.S3_SECRET_KEY, endPoint)
+    } else {
+      throw new Exception("Incorrect Store Path")
+    }
+  }
+
+  def getS3EndPoint(args: Array[String]): String = {
+    if (args.length >= 4 && args(3).contains(".com")) args(3)
+    else ""
   }
 
 }


### PR DESCRIPTION
CarbonThriftServer should support store carbon table on S3
 - Add config for AK,SK,EndPoint when start carbonsession


Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 
 - [x] Any backward compatibility impacted?
 
 - [x] Document update required?

 - [x] Testing done
        Step 1: 
          start carbonThriftServer by  org.apache.carbondata.examples.CarbonThriftServerExample
          User should use themselves storePath, AK, SK and endPoint
      Step 2: 
          start beeline like:  beeline -u jdbc:hive2://IP:10000
         IP and port should provide
       Now it support running with local, HDFS and S3 mode
Test example:


```
root@ecs-909c:~# beeline -u jdbc:hive2://192.168.0.206:10000
Connecting to jdbc:hive2://192.168.0.206:10000
2018-03-17 17:44:29 INFO  Utils:310 - Supplied authorities: 192.168.0.206:10000
2018-03-17 17:44:29 INFO  Utils:397 - Resolved authority: 192.168.0.206:10000
2018-03-17 17:44:29 INFO  HiveConnection:203 - Will try to open client transport with JDBC Uri: jdbc:hive2://192.168.0.206:10000
Connected to: Spark SQL (version 2.2.1)
Driver: Hive JDBC (version 1.2.1.spark2)
Transaction isolation: TRANSACTION_REPEATABLE_READ
Beeline version 1.2.1.spark2 by Apache Hive
0: jdbc:hive2://192.168.0.206:10000>  Drop table if exists local_table2;
+---------+--+
| Result  |
+---------+--+
+---------+--+
No rows selected (21.205 seconds)
0: jdbc:hive2://192.168.0.206:10000>
0: jdbc:hive2://192.168.0.206:10000> CREATE TABLE if not exists local_table2( shortField SHORT, intField INT, bigintField LONG, doubleField DOUBLE, stringField STRING, timestampField TIMESTAMP, decimalField DECIMAL(18,2), dateField DATE, charField CHAR(5), floatField FLOAT ) STORED BY 'carbondata' LOCATION 's3a://carbonstore/local_table2'  TBLPROPERTIES('SORT_COLUMNS'='');
+---------+--+
| Result  |
+---------+--+
+---------+--+
No rows selected (1.296 seconds)
0: jdbc:hive2://192.168.0.206:10000>
0: jdbc:hive2://192.168.0.206:10000>
0: jdbc:hive2://192.168.0.206:10000> LOAD DATA LOCAL INPATH '/huawei/xubo/git/carbondata2/examples/spark2/src/main/resources/data1.csv' INTO TABLE local_table2 OPTIONS('HEADER'='true');
+---------+--+
| Result  |
+---------+--+
+---------+--+
No rows selected (3.339 seconds)
0: jdbc:hive2://192.168.0.206:10000>
0: jdbc:hive2://192.168.0.206:10000>  select * from local_table2;
+-------------+-----------+--------------+--------------+--------------+------------------------+---------------+-------------+------------+-------------+--+
| shortfield  | intfield  | bigintfield  | doublefield  | stringfield  |     timestampfield     | decimalfield  |  datefield  | charfield  | floatfield  |
+-------------+-----------+--------------+--------------+--------------+------------------------+---------------+-------------+------------+-------------+--+
| 1           | 10        | 1100         | 48.4         | spark        | 2015-04-23 12:01:01.0  | 1.23          | 2015-04-23  | aaa        | 2.5         |
| 5           | 17        | 1140         | 43.4         | spark        | 2015-07-27 12:01:02.0  | 3.45          | 2015-07-27  | bbb        | 2.5         |
| 1           | 11        | 1100         | 44.4         | flink        | 2015-05-23 12:01:03.0  | 23.23         | 2015-05-23  | ccc        | 2.5         |
| 1           | 10        | 1150         | 43.4         | spark        | 2015-07-24 12:01:04.0  | 254.12        | 2015-07-24  | ddd        | 2.5         |
| 1           | 10        | 1100         | 47.4         | spark        | 2015-07-23 12:01:05.0  | 876.14        | 2015-07-23  | eeee       | 3.5         |
| 3           | 14        | 1160         | 43.4         | hive         | 2015-07-26 12:01:06.0  | 3454.32       | 2015-07-26  | ff         | 2.5         |
| 2           | 10        | 1100         | 43.4         | impala       | 2015-07-23 12:01:07.0  | 456.98        | 2015-07-23  | ggg        | 2.5         |
| 1           | 10        | 1100         | 43.4         | spark        | 2015-05-23 12:01:08.0  | 32.53         | 2015-05-23  | hhh        | 2.5         |
| 4           | 16        | 1130         | 42.4         | impala       | 2015-07-23 12:01:09.0  | 67.23         | 2015-07-23  | iii        | 2.5         |
| 1           | 10        | 1100         | 43.4         | spark        | 2015-07-23 12:01:10.0  | 832.23        | 2015-07-23  | jjj        | 2.5         |
+-------------+-----------+--------------+--------------+--------------+------------------------+---------------+-------------+------------+-------------+--+
10 rows selected (0.959 seconds)
0: jdbc:hive2://192.168.0.206:10000>


```
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

