### PR TITLE
[CARBONDATA-2261] Support Set segment command for Streaming Table

### DIFF
--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableInputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableInputFormat.java
@@ -358,6 +358,7 @@ public class CarbonTableInputFormat<T> extends FileInputFormat<Void, T> {
     if (getValidateSegmentsToAccess(job.getConfiguration())) {
       List<Segment> validSegments = segments.getValidSegments();
       streamSegments = segments.getStreamSegments();
+      streamSegments = getFilteredSegment(job,streamSegments);
       if (validSegments.size() == 0) {
         return getSplitsOfStreaming(job, identifier, streamSegments);
       }
@@ -366,7 +367,7 @@ public class CarbonTableInputFormat<T> extends FileInputFormat<Void, T> {
 
       List<Segment> filteredSegmentToAccess = getFilteredSegment(job, segments.getValidSegments());
       if (filteredSegmentToAccess.size() == 0) {
-        return new ArrayList<>(0);
+        return getSplitsOfStreaming(job, identifier, streamSegments);
       } else {
         setSegmentsToAccess(job.getConfiguration(), filteredSegmentToAccess);
       }

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
@@ -130,6 +130,10 @@ class CarbonScanRDD(
       if (batchPartitions.isEmpty) {
         streamPartitions.toArray
       } else {
+        logInfo(
+          s"""
+             | Identified no.of Streaming Blocks: ${streamPartitions.size},
+          """.stripMargin)
         // should keep the order by index of partition
         batchPartitions.appendAll(streamPartitions)
         batchPartitions.toArray

--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/TestStreamingTableOperation.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/TestStreamingTableOperation.scala
@@ -997,6 +997,36 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
       sql("select count(*) from streaming.stream_table_handoff"),
       Seq(Row(2 * 100))
     )
+    try{
+      sql("set carbon.input.segments.streaming.stream_table_handoff = 1")
+      checkAnswer(
+        sql("select count(*) from streaming.stream_table_handoff"),
+        Seq(Row(100))
+      )
+      sql("set carbon.input.segments.streaming.stream_table_handoff = *")
+      checkAnswer(
+        sql("select count(*) from streaming.stream_table_handoff"),
+        Seq(Row(2 * 100))
+      )
+      sql("set carbon.input.segments.streaming.stream_table_handoff = 2")
+      checkAnswer(
+        sql("select count(*) from streaming.stream_table_handoff"),
+        Seq(Row(1 * 100))
+      )
+      sql("set carbon.input.segments.streaming.stream_table_handoff = 1,2")
+      checkAnswer(
+        sql("select count(*) from streaming.stream_table_handoff"),
+        Seq(Row(2 * 100))
+      )
+      sql("set carbon.input.segments.streaming.stream_table_handoff = 3")
+      checkAnswer(
+        sql("select count(*) from streaming.stream_table_handoff"),
+        Seq(Row(0))
+      )
+    }
+    finally {
+      sql("set carbon.input.segments.streaming.stream_table_handoff = *")
+    }
   }
 
   test("auto hand off, close and reopen streaming table") {


### PR DESCRIPTION
Problem Statement :- Currently Set Segment  is not supported for Streaming Segments . 
This PR is to support Set segment command for "Streaming " ,"Streaming Finished" segments 


 - [ ] Any interfaces changed? 
No
 
 - [ ] Any backward compatibility impacted?
 No
 - [ ] Document update required?
No
 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        added UT
   - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       UT added
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA
