### PR TITLE
[CARBONDATA-2262] Support the syntax of 'using CARBONDATA' to create table

### DIFF
--- a/examples/spark2/src/main/scala/org/apache/carbondata/examples/SparkSessionExample.scala
+++ b/examples/spark2/src/main/scala/org/apache/carbondata/examples/SparkSessionExample.scala
@@ -180,7 +180,6 @@ object SparkSessionExample {
     // Drop table
     sparksession.sql("DROP TABLE IF EXISTS sparksession_table")
     sparksession.sql("DROP TABLE IF EXISTS csv_table")
-    sparksession.sql("show tables").show()
 
     sparksession.stop()
   }

--- a/examples/spark2/src/main/scala/org/apache/carbondata/examples/SparkSessionExample.scala
+++ b/examples/spark2/src/main/scala/org/apache/carbondata/examples/SparkSessionExample.scala
@@ -63,126 +63,124 @@ object SparkSessionExample {
 
     sparksession.sparkContext.setLogLevel("ERROR")
 
-    for (keyWord <- Array("org.apache.spark.sql.CarbonSource", "carbondata")) {
-      // Create table
-      sparksession.sql("DROP TABLE IF EXISTS sparksession_table")
-      sparksession.sql(
-        s"""
-           | CREATE TABLE sparksession_table(
-           | shortField SHORT,
-           | intField INT,
-           | bigintField LONG,
-           | doubleField DOUBLE,
-           | stringField STRING,
-           | timestampField TIMESTAMP,
-           | decimalField DECIMAL(18,2),
-           | dateField DATE,
-           | charField CHAR(5)
-           | )
-           | USING $keyWord
-           | OPTIONS('DICTIONARY_INCLUDE'='dateField, charField',
-           | 'dbName'='default', 'tableName'='sparksession_table')
+    // Create table
+    sparksession.sql("DROP TABLE IF EXISTS sparksession_table")
+    sparksession.sql(
+      s"""
+         | CREATE TABLE sparksession_table(
+         | shortField SHORT,
+         | intField INT,
+         | bigintField LONG,
+         | doubleField DOUBLE,
+         | stringField STRING,
+         | timestampField TIMESTAMP,
+         | decimalField DECIMAL(18,2),
+         | dateField DATE,
+         | charField CHAR(5)
+         | )
+         | USING carbondata
+         | OPTIONS('DICTIONARY_INCLUDE'='dateField, charField',
+         | 'dbName'='default', 'tableName'='sparksession_table')
        """.stripMargin)
 
-      val path = s"$rootPath/examples/spark2/src/main/resources/data.csv"
+    val path = s"$rootPath/examples/spark2/src/main/resources/data.csv"
 
-      sparksession.sql("DROP TABLE IF EXISTS csv_table")
-      sparksession.sql(
-        s"""
-           | CREATE TABLE csv_table(
-           | shortField SHORT,
-           | intField INT,
-           | bigintField LONG,
-           | doubleField DOUBLE,
-           | stringField STRING,
-           | timestampField STRING,
-           | decimalField DECIMAL(18,2),
-           | dateField STRING,
-           | charField CHAR(5))
-           | ROW FORMAT DELIMITED FIELDS TERMINATED BY ','
+    sparksession.sql("DROP TABLE IF EXISTS csv_table")
+    sparksession.sql(
+      s"""
+         | CREATE TABLE csv_table(
+         | shortField SHORT,
+         | intField INT,
+         | bigintField LONG,
+         | doubleField DOUBLE,
+         | stringField STRING,
+         | timestampField STRING,
+         | decimalField DECIMAL(18,2),
+         | dateField STRING,
+         | charField CHAR(5))
+         | ROW FORMAT DELIMITED FIELDS TERMINATED BY ','
        """.stripMargin)
 
-      sparksession.sql(
-        s"""
-           | LOAD DATA LOCAL INPATH '$path'
-           | INTO TABLE csv_table
+    sparksession.sql(
+      s"""
+         | LOAD DATA LOCAL INPATH '$path'
+         | INTO TABLE csv_table
        """.stripMargin)
 
-      sparksession.sql("SELECT * FROM csv_table").show()
+    sparksession.sql("SELECT * FROM csv_table").show()
 
-      sparksession.sql(
-        s"""
-           | INSERT INTO TABLE sparksession_table
-           | SELECT shortField, intField, bigintField, doubleField, stringField,
-           | from_unixtime(unix_timestamp(timestampField,'yyyy/MM/dd HH:mm:ss')) timestampField,
-           | decimalField,from_unixtime(unix_timestamp(dateField,'yyyy/MM/dd')), charField
-           | FROM csv_table
+    sparksession.sql(
+      s"""
+         | INSERT INTO TABLE sparksession_table
+         | SELECT shortField, intField, bigintField, doubleField, stringField,
+         | from_unixtime(unix_timestamp(timestampField,'yyyy/MM/dd HH:mm:ss')) timestampField,
+         | decimalField,from_unixtime(unix_timestamp(dateField,'yyyy/MM/dd')), charField
+         | FROM csv_table
        """.stripMargin)
 
-      sparksession.sql("SELECT * FROM sparksession_table").show()
+    sparksession.sql("SELECT * FROM sparksession_table").show()
 
-      sparksession.sql(
-        s"""
-           | SELECT *
-           | FROM sparksession_table
-           | WHERE stringfield = 'spark' AND decimalField > 40
+    sparksession.sql(
+      s"""
+         | SELECT *
+         | FROM sparksession_table
+         | WHERE stringfield = 'spark' AND decimalField > 40
       """.stripMargin).show()
 
-      // Shows with raw data's timestamp format
-      sparksession.sql(
-        s"""
-           | SELECT
-           | stringField, date_format(timestampField, "yyyy/MM/dd HH:mm:ss") AS
-           | timestampField
-           | FROM sparksession_table WHERE length(stringField) = 5
+    // Shows with raw data's timestamp format
+    sparksession.sql(
+      s"""
+         | SELECT
+         | stringField, date_format(timestampField, "yyyy/MM/dd HH:mm:ss") AS
+         | timestampField
+         | FROM sparksession_table WHERE length(stringField) = 5
        """.stripMargin).show()
 
-      sparksession.sql(
-        s"""
-           | SELECT *
-           | FROM sparksession_table where date_format(dateField, "yyyy-MM-dd") = "2015-07-23"
+    sparksession.sql(
+      s"""
+         | SELECT *
+         | FROM sparksession_table where date_format(dateField, "yyyy-MM-dd") = "2015-07-23"
        """.stripMargin).show()
 
-      sparksession.sql("SELECT count(stringField) FROM sparksession_table").show()
+    sparksession.sql("SELECT count(stringField) FROM sparksession_table").show()
 
-      sparksession.sql(
-        s"""
-           | SELECT sum(intField), stringField
-           | FROM sparksession_table
-           | GROUP BY stringField
+    sparksession.sql(
+      s"""
+         | SELECT sum(intField), stringField
+         | FROM sparksession_table
+         | GROUP BY stringField
        """.stripMargin).show()
 
-      sparksession.sql(
-        s"""
-           | SELECT t1.*, t2.*
-           | FROM sparksession_table t1, sparksession_table t2
-           | WHERE t1.stringField = t2.stringField
+    sparksession.sql(
+      s"""
+         | SELECT t1.*, t2.*
+         | FROM sparksession_table t1, sparksession_table t2
+         | WHERE t1.stringField = t2.stringField
       """.stripMargin).show()
 
-      sparksession.sql(
-        s"""
-           | WITH t1 AS (
-           | SELECT * FROM sparksession_table
-           | UNION ALL
-           | SELECT * FROM sparksession_table
-           | )
-           | SELECT t1.*, t2.*
-           | FROM t1, sparksession_table t2
-           | WHERE t1.stringField = t2.stringField
+    sparksession.sql(
+      s"""
+         | WITH t1 AS (
+         | SELECT * FROM sparksession_table
+         | UNION ALL
+         | SELECT * FROM sparksession_table
+         | )
+         | SELECT t1.*, t2.*
+         | FROM t1, sparksession_table t2
+         | WHERE t1.stringField = t2.stringField
       """.stripMargin).show()
 
-      CarbonProperties.getInstance().addProperty(
-        CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT,
-        CarbonCommonConstants.CARBON_TIMESTAMP_DEFAULT_FORMAT)
-      CarbonProperties.getInstance().addProperty(
-        CarbonCommonConstants.CARBON_DATE_FORMAT,
-        CarbonCommonConstants.CARBON_DATE_DEFAULT_FORMAT)
+    CarbonProperties.getInstance().addProperty(
+      CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT,
+      CarbonCommonConstants.CARBON_TIMESTAMP_DEFAULT_FORMAT)
+    CarbonProperties.getInstance().addProperty(
+      CarbonCommonConstants.CARBON_DATE_FORMAT,
+      CarbonCommonConstants.CARBON_DATE_DEFAULT_FORMAT)
 
-      // Drop table
-      sparksession.sql("DROP TABLE IF EXISTS sparksession_table")
-      sparksession.sql("DROP TABLE IF EXISTS csv_table")
-      sparksession.sql("show tables").show()
-    }
+    // Drop table
+    sparksession.sql("DROP TABLE IF EXISTS sparksession_table")
+    sparksession.sql("DROP TABLE IF EXISTS csv_table")
+    sparksession.sql("show tables").show()
 
     sparksession.stop()
   }

--- a/integration/hive/src/main/scala/org/apache/carbondata/hive/CarbonHiveMetastoreListener.scala
+++ b/integration/hive/src/main/scala/org/apache/carbondata/hive/CarbonHiveMetastoreListener.scala
@@ -35,7 +35,7 @@ class CarbonHiveMetastoreListener(conf: Configuration) extends MetaStorePreEvent
         val tableProps = table.getParameters
         if (tableProps != null
           && (tableProps.get("spark.sql.sources.provider") == "org.apache.spark.sql.CarbonSource"
-          || tableProps.get("spark.sql.sources.provider").equalsIgnoreCase("CARBONDATA"))) {
+          || tableProps.get("spark.sql.sources.provider").equalsIgnoreCase("carbondata"))) {
           val numSchemaParts = tableProps.get("spark.sql.sources.schema.numParts")
           if (numSchemaParts != null && !numSchemaParts.isEmpty) {
             val parts = (0 until numSchemaParts.toInt).map { index =>
@@ -64,7 +64,7 @@ class CarbonHiveMetastoreListener(conf: Configuration) extends MetaStorePreEvent
         val tableProps = table.getParameters
         if (tableProps != null
           && (tableProps.get("spark.sql.sources.provider") == "org.apache.spark.sql.CarbonSource"
-          || tableProps.get("spark.sql.sources.provider").equalsIgnoreCase("CARBONDATA"))) {
+          || tableProps.get("spark.sql.sources.provider").equalsIgnoreCase("carbondata"))) {
           val numSchemaParts = tableProps.get("spark.sql.sources.schema.numParts")
           if (numSchemaParts != null && !numSchemaParts.isEmpty) {
             val schemaParts = (0 until numSchemaParts.toInt).map { index =>

--- a/integration/hive/src/main/scala/org/apache/carbondata/hive/CarbonHiveMetastoreListener.scala
+++ b/integration/hive/src/main/scala/org/apache/carbondata/hive/CarbonHiveMetastoreListener.scala
@@ -33,8 +33,9 @@ class CarbonHiveMetastoreListener(conf: Configuration) extends MetaStorePreEvent
       case CREATE_TABLE =>
         val table = preEventContext.asInstanceOf[PreCreateTableEvent].getTable
         val tableProps = table.getParameters
-        if (tableProps != null &&
-            tableProps.get("spark.sql.sources.provider") == "org.apache.spark.sql.CarbonSource") {
+        if (tableProps != null
+          && (tableProps.get("spark.sql.sources.provider") == "org.apache.spark.sql.CarbonSource"
+          || tableProps.get("spark.sql.sources.provider").equalsIgnoreCase("CARBONDATA"))) {
           val numSchemaParts = tableProps.get("spark.sql.sources.schema.numParts")
           if (numSchemaParts != null && !numSchemaParts.isEmpty) {
             val parts = (0 until numSchemaParts.toInt).map { index =>
@@ -61,8 +62,9 @@ class CarbonHiveMetastoreListener(conf: Configuration) extends MetaStorePreEvent
       case ALTER_TABLE =>
         val table = preEventContext.asInstanceOf[PreAlterTableEvent].getNewTable
         val tableProps = table.getParameters
-        if (tableProps != null &&
-            tableProps.get("spark.sql.sources.provider") == "org.apache.spark.sql.CarbonSource") {
+        if (tableProps != null
+          && (tableProps.get("spark.sql.sources.provider") == "org.apache.spark.sql.CarbonSource"
+          || tableProps.get("spark.sql.sources.provider").equalsIgnoreCase("CARBONDATA"))) {
           val numSchemaParts = tableProps.get("spark.sql.sources.schema.numParts")
           if (numSchemaParts != null && !numSchemaParts.isEmpty) {
             val schemaParts = (0 until numSchemaParts.toInt).map { index =>

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/sql/commands/UsingCarbondataSuite.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/sql/commands/UsingCarbondataSuite.scala
@@ -37,18 +37,18 @@ class UsingCarbondataSuite extends QueryTest with BeforeAndAfterEach {
   }
 
   test("CARBONDATA-2262: test check results of table with complex data type and bucketing") {
-    sql("drop table if exists create_source")
-    sql("create table create_source(intField int, stringField string, complexField array<int>) " +
+    sql("DROP TABLE IF EXISTS create_source")
+    sql("CREATE TABLE create_source(intField INT, stringField STRING, complexField ARRAY<INT>) " +
       "USING carbondata")
-    sql("""insert into create_source values(1,"source","1$2$3")""")
-    checkAnswer(sql("select * from create_source"), Row(1, "source", mutable.WrappedArray.newBuilder[Int].+=(1, 2, 3)))
-    sql("drop table if exists create_source")
+    sql("""INSERT INTO create_source VALUES(1,"source","1$2$3")""")
+    checkAnswer(sql("SELECT * FROM create_source"), Row(1, "source", mutable.WrappedArray.newBuilder[Int].+=(1, 2, 3)))
+    sql("DROP TABLE IF EXISTS create_source")
   }
 
   test("CARBONDATA-2262: Support the syntax of 'USING CarbonData' whithout tableName") {
-    sql("CREATE TABLE src_carbondata1(key INT, value STRING) using carbondata")
-    sql("insert into src_carbondata1 values(1,'source')")
-    checkAnswer(sql("select * from src_carbondata1"), Row(1, "source"))
+    sql("CREATE TABLE src_carbondata1(key INT, value STRING) USING carbondata")
+    sql("INSERT INTO src_carbondata1 VALUES(1,'source')")
+    checkAnswer(sql("SELECT * FROM src_carbondata1"), Row(1, "source"))
   }
 
    test("CARBONDATA-2262: Support the syntax of 'STORED AS carbondata, get data size and index size after minor compaction") {

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/sql/commands/UsingCarbondataSuite.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/sql/commands/UsingCarbondataSuite.scala
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.sql.commands
+
+import scala.collection.mutable
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.test.util.QueryTest
+import org.scalatest.BeforeAndAfterEach
+
+import org.apache.carbondata.core.constants.CarbonCommonConstants
+
+class UsingCarbondataSuite extends QueryTest with BeforeAndAfterEach {
+  override def beforeEach(): Unit = {
+    sql("DROP TABLE IF EXISTS src_carbondata1")
+    sql("DROP TABLE IF EXISTS tableSize3")
+  }
+
+  override def afterEach(): Unit = {
+    sql("DROP TABLE IF EXISTS src_carbondata1")
+    sql("DROP TABLE IF EXISTS tableSize3")
+  }
+
+  test("CARBONDATA-2262: test check results of table with complex data type and bucketing") {
+    sql("drop table if exists create_source")
+    sql("create table create_source(intField int, stringField string, complexField array<int>) " +
+      "USING CARBONDATA")
+    sql("""insert into create_source values(1,"source","1$2$3")""")
+    checkAnswer(sql("select * from create_source"), Row(1, "source", mutable.WrappedArray.newBuilder[Int].+=(1, 2, 3)))
+    sql("drop table if exists create_source")
+  }
+
+  test("CARBONDATA-2262: Support the syntax of 'USING CarbonData' whithout tableName") {
+    sql("CREATE TABLE src_carbondata1(key INT, value STRING) using CarbonData")
+    sql("insert into src_carbondata1 values(1,'source')")
+    checkAnswer(sql("select * from src_carbondata1"), Row(1, "source"))
+  }
+
+   test("CARBONDATA-2262: Support the syntax of 'STORED AS carbondata, get data size and index size after minor compaction") {
+    sql("CREATE TABLE tableSize3 (empno INT, workgroupcategory STRING, deptno INT, projectcode INT, attendance INT) USING carbondata")
+    sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/data.csv' INTO TABLE tableSize3 OPTIONS ('DELIMITER'= ',', 'QUOTECHAR'= '\"', 'FILEHEADER'='')""")
+    sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/data.csv' INTO TABLE tableSize3 OPTIONS ('DELIMITER'= ',', 'QUOTECHAR'= '\"', 'FILEHEADER'='')""")
+    sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/data.csv' INTO TABLE tableSize3 OPTIONS ('DELIMITER'= ',', 'QUOTECHAR'= '\"', 'FILEHEADER'='')""")
+    sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/data.csv' INTO TABLE tableSize3 OPTIONS ('DELIMITER'= ',', 'QUOTECHAR'= '\"', 'FILEHEADER'='')""")
+    sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/data.csv' INTO TABLE tableSize3 OPTIONS ('DELIMITER'= ',', 'QUOTECHAR'= '\"', 'FILEHEADER'='')""")
+    sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/data.csv' INTO TABLE tableSize3 OPTIONS ('DELIMITER'= ',', 'QUOTECHAR'= '\"', 'FILEHEADER'='')""")
+    sql("ALTER TABLE tableSize3 COMPACT 'minor'")
+    checkExistence(sql("DESCRIBE FORMATTED tableSize3"), true, CarbonCommonConstants.TABLE_DATA_SIZE)
+    checkExistence(sql("DESCRIBE FORMATTED tableSize3"), true, CarbonCommonConstants.TABLE_INDEX_SIZE)
+    val res3 = sql("DESCRIBE FORMATTED tableSize3").collect()
+      .filter(row => row.getString(0).contains(CarbonCommonConstants.TABLE_DATA_SIZE) ||
+        row.getString(0).contains(CarbonCommonConstants.TABLE_INDEX_SIZE))
+    assert(res3.length == 2)
+    res3.foreach(row => assert(row.getString(1).trim.toLong > 0))
+  }
+
+}

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/sql/commands/UsingCarbondataSuite.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/sql/commands/UsingCarbondataSuite.scala
@@ -39,14 +39,14 @@ class UsingCarbondataSuite extends QueryTest with BeforeAndAfterEach {
   test("CARBONDATA-2262: test check results of table with complex data type and bucketing") {
     sql("drop table if exists create_source")
     sql("create table create_source(intField int, stringField string, complexField array<int>) " +
-      "USING CARBONDATA")
+      "USING carbondata")
     sql("""insert into create_source values(1,"source","1$2$3")""")
     checkAnswer(sql("select * from create_source"), Row(1, "source", mutable.WrappedArray.newBuilder[Int].+=(1, 2, 3)))
     sql("drop table if exists create_source")
   }
 
   test("CARBONDATA-2262: Support the syntax of 'USING CarbonData' whithout tableName") {
-    sql("CREATE TABLE src_carbondata1(key INT, value STRING) using CarbonData")
+    sql("CREATE TABLE src_carbondata1(key INT, value STRING) using carbondata")
     sql("insert into src_carbondata1 values(1,'source')")
     checkAnswer(sql("select * from src_carbondata1"), Row(1, "source"))
   }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/strategy/DDLStrategy.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/strategy/DDLStrategy.scala
@@ -208,7 +208,7 @@ class DDLStrategy(sparkSession: SparkSession) extends SparkStrategy {
       case org.apache.spark.sql.execution.datasources.CreateTable(tableDesc, mode, None)
         if tableDesc.provider.get != DDLUtils.HIVE_PROVIDER
           && (tableDesc.provider.get.equals("org.apache.spark.sql.CarbonSource")
-          || tableDesc.provider.get.equalsIgnoreCase("CARBONDATA")) =>
+          || tableDesc.provider.get.equalsIgnoreCase("carbondata")) =>
         val updatedCatalog =
           CarbonSource.updateCatalogTableWithCarbonSchema(tableDesc, sparkSession)
         val cmd =
@@ -217,7 +217,7 @@ class DDLStrategy(sparkSession: SparkSession) extends SparkStrategy {
       case CreateDataSourceTableCommand(table, ignoreIfExists)
         if table.provider.get != DDLUtils.HIVE_PROVIDER
           && (table.provider.get.equals("org.apache.spark.sql.CarbonSource")
-          || table.provider.get.equalsIgnoreCase("CARBONDATA")) =>
+          || table.provider.get.equalsIgnoreCase("carbondata")) =>
         val updatedCatalog = CarbonSource.updateCatalogTableWithCarbonSchema(table, sparkSession)
         val cmd = CreateDataSourceTableCommand(updatedCatalog, ignoreIfExists)
         ExecutedCommandExec(cmd) :: Nil

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/strategy/DDLStrategy.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/strategy/DDLStrategy.scala
@@ -207,7 +207,8 @@ class DDLStrategy(sparkSession: SparkSession) extends SparkStrategy {
         ExecutedCommandExec(CarbonResetCommand()) :: Nil
       case org.apache.spark.sql.execution.datasources.CreateTable(tableDesc, mode, None)
         if tableDesc.provider.get != DDLUtils.HIVE_PROVIDER
-           && tableDesc.provider.get.equals("org.apache.spark.sql.CarbonSource") =>
+          && (tableDesc.provider.get.equals("org.apache.spark.sql.CarbonSource")
+          || tableDesc.provider.get.equalsIgnoreCase("CARBONDATA")) =>
         val updatedCatalog =
           CarbonSource.updateCatalogTableWithCarbonSchema(tableDesc, sparkSession)
         val cmd =
@@ -215,7 +216,8 @@ class DDLStrategy(sparkSession: SparkSession) extends SparkStrategy {
         ExecutedCommandExec(cmd) :: Nil
       case CreateDataSourceTableCommand(table, ignoreIfExists)
         if table.provider.get != DDLUtils.HIVE_PROVIDER
-           && table.provider.get.equals("org.apache.spark.sql.CarbonSource") =>
+          && (table.provider.get.equals("org.apache.spark.sql.CarbonSource")
+          || table.provider.get.equalsIgnoreCase("CARBONDATA")) =>
         val updatedCatalog = CarbonSource.updateCatalogTableWithCarbonSchema(table, sparkSession)
         val cmd = CreateDataSourceTableCommand(updatedCatalog, ignoreIfExists)
         ExecutedCommandExec(cmd) :: Nil

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonFileMetastore.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonFileMetastore.scala
@@ -157,7 +157,7 @@ class CarbonFileMetastore extends CarbonMetaStore {
           CarbonReflectionUtils.getFieldOfCatalogTable("tableMeta", c).asInstanceOf[CatalogTable]
         catalogTable.provider match {
           case Some(name) if (name.equals("org.apache.spark.sql.CarbonSource")
-            || name.equalsIgnoreCase("CARBONDATA")) => name
+            || name.equalsIgnoreCase("carbondata")) => name
           case _ => throw new NoSuchTableException(database, tableIdentifier.table)
         }
         val identifier: AbsoluteTableIdentifier = AbsoluteTableIdentifier.from(
@@ -551,7 +551,7 @@ class CarbonFileMetastore extends CarbonMetaStore {
           CarbonReflectionUtils.getFieldOfCatalogTable("tableMeta", c).asInstanceOf[CatalogTable]
         catalogTable.provider match {
           case Some(name) if (name.equals("org.apache.spark.sql.CarbonSource")
-            || name.equalsIgnoreCase("CARBONDATA")) => name
+            || name.equalsIgnoreCase("carbondata")) => name
           case _ =>
             throw new NoSuchTableException(tableIdentifier.database.get, tableIdentifier.table)
         }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonFileMetastore.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonFileMetastore.scala
@@ -156,7 +156,8 @@ class CarbonFileMetastore extends CarbonMetaStore {
         val catalogTable =
           CarbonReflectionUtils.getFieldOfCatalogTable("tableMeta", c).asInstanceOf[CatalogTable]
         catalogTable.provider match {
-          case Some(name) if name.equals("org.apache.spark.sql.CarbonSource") => name
+          case Some(name) if (name.equals("org.apache.spark.sql.CarbonSource")
+            || name.equalsIgnoreCase("CARBONDATA")) => name
           case _ => throw new NoSuchTableException(database, tableIdentifier.table)
         }
         val identifier: AbsoluteTableIdentifier = AbsoluteTableIdentifier.from(
@@ -549,7 +550,8 @@ class CarbonFileMetastore extends CarbonMetaStore {
         val catalogTable =
           CarbonReflectionUtils.getFieldOfCatalogTable("tableMeta", c).asInstanceOf[CatalogTable]
         catalogTable.provider match {
-          case Some(name) if name.equals("org.apache.spark.sql.CarbonSource") => name
+          case Some(name) if (name.equals("org.apache.spark.sql.CarbonSource")
+            || name.equalsIgnoreCase("CARBONDATA")) => name
           case _ =>
             throw new NoSuchTableException(tableIdentifier.database.get, tableIdentifier.table)
         }


### PR DESCRIPTION
Add new function to Support the syntax of 'using CARBONDATA' to create table, for example:

`CREATE TABLE src_carbondata1(key INT, value STRING) using carbondata `
Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 
 - [x] Any backward compatibility impacted?
 
 - [x] Document update required?

 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

