### PR TITLE
[CARBONDATA-2265] [DFX]-Load]: Load job fails if 1 folder contains 1000 files

### DIFF
--- a/processing/src/main/java/org/apache/carbondata/processing/store/writer/v3/BlockletDataHolder.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/writer/v3/BlockletDataHolder.java
@@ -24,24 +24,20 @@ import org.apache.carbondata.processing.store.TablePage;
 
 public class BlockletDataHolder {
   private List<EncodedTablePage> encodedTablePage;
-  private List<TablePage> rawTablePages;
   private long currentSize;
 
   public BlockletDataHolder() {
     this.encodedTablePage = new ArrayList<>();
-    this.rawTablePages = new ArrayList<>();
   }
 
   public void clear() {
     encodedTablePage.clear();
-    rawTablePages.clear();
     currentSize = 0;
   }
 
   public void addPage(TablePage rawTablePage) {
     EncodedTablePage encodedTablePage = rawTablePage.getEncodedTablePage();
     this.encodedTablePage.add(encodedTablePage);
-    this.rawTablePages.add(rawTablePage);
     currentSize += encodedTablePage.getEncodedSize();
   }
 
@@ -66,7 +62,4 @@ public class BlockletDataHolder {
     return encodedTablePage;
   }
 
-  public List<TablePage> getRawTablePages() {
-    return rawTablePages;
-  }
 }

--- a/processing/src/main/java/org/apache/carbondata/processing/store/writer/v3/CarbonFactDataWriterImplV3.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/writer/v3/CarbonFactDataWriterImplV3.java
@@ -189,9 +189,10 @@ public class CarbonFactDataWriterImplV3 extends AbstractFactDataWriter {
     } catch (IOException e) {
       LOGGER.error(e, "Problem while writing file");
       throw new CarbonDataWriterException("Problem while writing file", e);
+    } finally {
+      // clear the data holder
+      blockletDataHolder.clear();
     }
-    // clear the data holder
-    blockletDataHolder.clear();
 
   }
 


### PR DESCRIPTION
Problem : We are keeping the rawTablePages also in memory, but we are no where using it
Solution : Removed storing rawTablePages

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [x] Testing done
        Manual Testing
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

