### PR TITLE
[CARBONDATA-2269]Support Query On PreAggregate table created on streaming table

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstantsInternal.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstantsInternal.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.core.constants;
+
+/**
+ * Below class will be used to keep all the internal property constants,
+ * which will be used internally. These property will not be exposed to users
+ */
+public interface CarbonCommonConstantsInternal {
+
+  String QUERY_ON_PRE_AGG_STREAMING = "carbon.query.on.preagg.streaming.";
+
+}

--- a/core/src/main/java/org/apache/carbondata/core/util/SessionParams.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/SessionParams.java
@@ -26,6 +26,7 @@ import org.apache.carbondata.common.logging.LogService;
 import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.cache.CacheProvider;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
+import org.apache.carbondata.core.constants.CarbonCommonConstantsInternal;
 import org.apache.carbondata.core.constants.CarbonLoadOptionConstants;
 import org.apache.carbondata.core.exception.InvalidConfigurationException;
 
@@ -202,6 +203,8 @@ public class SessionParams implements Serializable {
         } else if (key.startsWith(CarbonCommonConstants.VALIDATE_CARBON_INPUT_SEGMENTS)) {
           isValid = true;
         } else if (key.equalsIgnoreCase(CarbonCommonConstants.SUPPORT_DIRECT_QUERY_ON_DATAMAP)) {
+          isValid = true;
+        } else if (key.startsWith(CarbonCommonConstantsInternal.QUERY_ON_PRE_AGG_STREAMING)) {
           isValid = true;
         } else {
           throw new InvalidConfigurationException(

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonInputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonInputFormat.java
@@ -26,6 +26,7 @@ import java.util.BitSet;
 import java.util.List;
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
+import org.apache.carbondata.core.constants.CarbonCommonConstantsInternal;
 import org.apache.carbondata.core.datamap.DataMapChooser;
 import org.apache.carbondata.core.datamap.DataMapLevel;
 import org.apache.carbondata.core.datamap.Segment;
@@ -233,6 +234,16 @@ public abstract class CarbonInputFormat<T> extends FileInputFormat<Void, T> {
     if (!segmentNumbersFromProperty.trim().equals("*")) {
       CarbonInputFormat
           .setSegmentsToAccess(conf, Segment.toSegmentList(segmentNumbersFromProperty.split(",")));
+    }
+  }
+
+  /**
+   * Set `CARBON_INPUT_SEGMENTS` from property to configuration
+   */
+  public static void setQuerySegment(Configuration conf, String segmentList) {
+    if (!segmentList.trim().equals("*")) {
+      CarbonInputFormat
+          .setSegmentsToAccess(conf, Segment.toSegmentList(segmentList.split(",")));
     }
   }
 
@@ -544,5 +555,24 @@ public abstract class CarbonInputFormat<T> extends FileInputFormat<Void, T> {
       throw new InvalidConfigurationException("Table name is not set");
     }
     return tableName;
+  }
+
+  public static void setAccessStreamingSegments(Configuration configuration, Boolean validate)
+      throws InvalidConfigurationException {
+    configuration.set(
+        CarbonCommonConstantsInternal.QUERY_ON_PRE_AGG_STREAMING + "." + getDatabaseName(
+            configuration) + "." + getTableName(configuration), validate.toString());
+  }
+
+  public static boolean getAccessStreamingSegments(Configuration configuration) {
+    try {
+      return configuration.get(
+          CarbonCommonConstantsInternal.QUERY_ON_PRE_AGG_STREAMING + "." + getDatabaseName(
+              configuration) + "." + getTableName(
+                  configuration), "false").equalsIgnoreCase("true");
+
+    } catch (InvalidConfigurationException e) {
+      return false;
+    }
   }
 }

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggStreaming.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggStreaming.scala
@@ -1,0 +1,79 @@
+package org.apache.carbondata.integration.spark.testsuite.preaggregate
+
+import org.apache.spark.sql.CarbonDatasourceHadoopRelation
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Union}
+import org.apache.spark.sql.execution.datasources.LogicalRelation
+import org.apache.spark.sql.test.util.QueryTest
+import org.scalatest.{BeforeAndAfterAll, Ignore}
+
+
+@Ignore
+class TestPreAggStreaming extends QueryTest with BeforeAndAfterAll {
+  override def beforeAll: Unit = {
+    sql("drop table if exists mainTable")
+    sql("CREATE TABLE mainTable(id int, name string, city string, age string) STORED BY 'org.apache.carbondata.format'")
+    sql("create datamap agg0 on table mainTable using 'preaggregate' as select name from mainTable group by name")
+    sql("create datamap agg1 on table mainTable using 'preaggregate' as select name,sum(age) from mainTable group by name")
+    sql("create datamap agg2 on table mainTable using 'preaggregate' as select name,avg(age) from mainTable group by name")
+    sql("create datamap agg3 on table mainTable using 'preaggregate' as select name,sum(CASE WHEN age=35 THEN id ELSE 0 END) from mainTable group by name")
+  }
+
+  test("Test Streaming table plan with only projection column") {
+    val df = sql("select name from maintable group by name")
+    assert(validateStreamingTablePlan(df.queryExecution.analyzed))
+  }
+
+  test("Test Streaming table plan with only projection column and order by") {
+    val df = sql("select name from maintable group by name")
+    assert(validateStreamingTablePlan(df.queryExecution.analyzed))
+  }
+
+  test("Test Streaming table plan with sum aggregator") {
+    val df = sql("select name, sum(age) from maintable group by name order by name")
+    assert(validateStreamingTablePlan(df.queryExecution.analyzed))
+  }
+
+  test("Test Streaming table plan with sum aggregator and order by") {
+    val df = sql("select name, sum(age) from maintable group by name order by name")
+    assert(validateStreamingTablePlan(df.queryExecution.analyzed))
+  }
+
+  test("Test Streaming table plan with avg aggregator") {
+    val df = sql("select name, avg(age) from maintable group by name")
+    assert(validateStreamingTablePlan(df.queryExecution.analyzed))
+  }
+
+  test("Test Streaming table plan with expression ") {
+    val df = sql("select name, sum(CASE WHEN age=35 THEN id ELSE 0 END) from maintable group by name order by name")
+    assert(validateStreamingTablePlan(df.queryExecution.analyzed))
+  }
+
+  /**
+   * Below method will be used validate whether plan is already updated in case of streaming table
+   * In case of streaming table it will add UnionNode to get the data from fact and aggregate both
+   * as aggregate table will be updated after each handoff.
+   * So if plan is already updated no need to transform the plan again
+   * @param logicalPlan
+   * query plan
+   * @return whether need to update the query plan or not
+   */
+  def validateStreamingTablePlan(logicalPlan: LogicalPlan) : Boolean = {
+    var isChildTableExists: Boolean = false
+    logicalPlan.transform {
+      case union @ Union(Seq(plan1, plan2)) =>
+        plan2.collect{
+          case logicalRelation: LogicalRelation if
+          logicalRelation.relation.isInstanceOf[CarbonDatasourceHadoopRelation] &&
+          logicalRelation.relation.asInstanceOf[CarbonDatasourceHadoopRelation].carbonTable
+            .isChildDataMap =>
+            isChildTableExists = false
+        }
+        union
+    }
+    isChildTableExists
+  }
+
+  override def afterAll: Unit = {
+    sql("drop table if exists mainTable")
+  }
+}

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/hive/execution/command/CarbonHiveCommands.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/hive/execution/command/CarbonHiveCommands.scala
@@ -25,7 +25,7 @@ import org.apache.spark.sql.execution.command._
 import org.apache.spark.sql.execution.command.table.CarbonDropTableCommand
 
 import org.apache.carbondata.common.exceptions.sql.MalformedCarbonCommandException
-import org.apache.carbondata.core.constants.CarbonCommonConstants
+import org.apache.carbondata.core.constants.{CarbonCommonConstants, CarbonCommonConstantsInternal}
 import org.apache.carbondata.core.util.{CarbonProperties, CarbonUtil, SessionParams}
 
 case class CarbonDropDatabaseCommand(command: DropDatabaseCommand)
@@ -81,7 +81,6 @@ case class CarbonSetCommand(command: SetCommand)
 
 object CarbonSetCommand {
   def validateAndSetValue(sessionParams: SessionParams, key: String, value: String): Unit = {
-
     val isCarbonProperty: Boolean = CarbonProperties.getInstance().isCarbonProperty(key)
     if (isCarbonProperty) {
       sessionParams.addProperty(key, value)
@@ -96,6 +95,8 @@ object CarbonSetCommand {
           ".<table_name>=<seg_id list> \" format.")
       }
     } else if (key.startsWith(CarbonCommonConstants.VALIDATE_CARBON_INPUT_SEGMENTS)) {
+      sessionParams.addProperty(key.toLowerCase(), value)
+    } else if (key.startsWith(CarbonCommonConstantsInternal.QUERY_ON_PRE_AGG_STREAMING)) {
       sessionParams.addProperty(key.toLowerCase(), value)
     }
   }


### PR DESCRIPTION
Support Query On Pre Aggregate table created on Streaming table
For querying the data on PreAggregate table on streaming table change the query plan to apply union of agg table and streaming segment of actual table to get the current data.
Query Example for streaming table:
**User Query:**
SELECT name, sum(Salary) as totalSalary
FROM maintable
**Updated Query:**
SELECT name, sum(totalSalary) FROM(
         SELECT name, sum(Salary) as totalSalary
         FROM maintable
         GROUP BY name
         UNION ALL
         SELECT maintable_name,sum(maintable_salary) as totalSalary
         FROM maintable_agg
         GROUP BY maintable_name)
GROUP BY name)

**User Query:**
SELECT name, AVG(Salary) as avgSalary
FROM maintable.
**Updated Query:**
SELECT name, Divide(sum(sumSalary)/sum(countsalary))
FROM(
    SELECT name, sum(Salary) as sumSalary,count(salary) countsalary
    FROM maintable
    GROUP BY name
    UNION ALL
    SELECT maintable_name,sum(maintable_salary) as sumSalary, count(maintable_salary) countsalary
   FROM maintable_agg
   GROUP BY maintable_name)
GROUP BY name)

 **User Query:**
   SELECT name, count(Salary) as countSalary
   FROM maintable.
**Updated Query:**
SELECT name, sum(countsalary)
FROM(
    SELECT name, count(Salary) as countSalary
    FROM maintable
    GROUP BY name
    UNION ALL
    SELECT maintable_name,sum(maintable_count)
    FROM maintable_agg
    GROUP BY maintable_name)
GROUP BY name)

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
       Added UT 
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

