### PR TITLE
[CARBONDATA-1522] Support preaggregate table creation and loading on streaming tables

### DIFF
--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableInputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableInputFormat.java
@@ -151,7 +151,6 @@ public class CarbonTableInputFormat<T> extends CarbonInputFormat<T> {
       if (validSegments.size() == 0) {
         return getSplitsOfStreaming(job, identifier, streamSegments);
       }
-
       List<Segment> filteredSegmentToAccess = getFilteredSegment(job, segments.getValidSegments(),
           true);
       if (filteredSegmentToAccess.size() == 0) {

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/CarbonIndexFileMergeTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/CarbonIndexFileMergeTestCase.scala
@@ -183,12 +183,13 @@ class CarbonIndexFileMergeTestCase
     sql("create table mitable(id int, issue date) stored by 'carbondata'")
     sql("insert into table mitable select '1','2000-02-01'")
     val table = CarbonMetadata.getInstance().getCarbonTable("default", "mitable")
-    new CarbonIndexFileMergeWriter()
+    new CarbonIndexFileMergeWriter(table)
       .mergeCarbonIndexFilesOfSegment("0", table.getTablePath, false)
     sql("update mitable set(id)=(2) where issue = '2000-02-01'").show()
     sql("clean files for table mitable")
     sql("select * from mitable").show()
   }
+
   private def getIndexFileCount(tableName: String, segment: String): Int = {
     val table = CarbonMetadata.getInstance().getCarbonTable(tableName)
     val path = CarbonTablePath

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/execution/streaming/CarbonAppendableStreamSink.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/execution/streaming/CarbonAppendableStreamSink.scala
@@ -176,6 +176,7 @@ class CarbonAppendableStreamSink(
       if (enableAutoHandoff) {
         StreamHandoffRDD.startStreamingHandoffThread(
           carbonLoadModel,
+          new OperationContext,
           sparkSession,
           false)
       }


### PR DESCRIPTION
1. Added support to create preaggregate datamap on streaming table.
2. Added support to load data into datamap after handoff is fired for streaming table
3. Added transaction support for datamap loading


Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [X] Any interfaces changed?
 
 - [X] Any backward compatibility impacted?
 
 - [X] Document update required?

 - [X] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [X] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

