### PR TITLE
[CARBONDATA-2266] Fixed All Examples are throwing Exception in current master branch

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
@@ -19,6 +19,8 @@ package org.apache.spark.sql
 
 import java.util.concurrent.ConcurrentHashMap
 
+import scala.util.Try
+
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException
 import org.apache.spark.sql.execution.command.preaaggregate._
@@ -171,8 +173,8 @@ object CarbonEnv {
   }
 
   def registerCommonListener(sparkSession: SparkSession): Unit = {
-    val clsName = sparkSession.sparkContext.conf
-      .get(CarbonCommonConstants.CARBON_COMMON_LISTENER_REGISTER_CLASSNAME)
+    val clsName = Try(sparkSession.sparkContext.conf
+      .get(CarbonCommonConstants.CARBON_COMMON_LISTENER_REGISTER_CLASSNAME)).toOption.getOrElse("")
     if (null != clsName && !clsName.isEmpty) {
       CarbonReflectionUtils.createObject(clsName)
     }


### PR DESCRIPTION
Fixed All Examples are throwing Exception in current master branch

**Problem**: Running all examples are showing same exception

 Exception in thread "main" java.util.NoSuchElementException: spark.carbon.common.listener.register.classname

**Solution**: initialise the property CARBON_COMMON_LISTENER_REGISTER_CLASSNAME with empty value when creating carbon session n example within its  config object

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 
 - [x] Any backward compatibility impacted?
 
 - [x] Document update required?

 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

