### PR TITLE
[CARBONDATA-2258] Separate visible and invisible segments info into two files to reduce the size of tablestatus file.

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -1611,8 +1611,10 @@ public final class CarbonCommonConstants {
       "carbon.invisible.segments.preserve.count";
 
   /**
-   * default value is 20, it means that it will preserve 20 invisible segment info
+   * default value is 200, it means that it will preserve 200 invisible segment info
    * in tablestatus file.
+   * The size of one segment info is about 500 bytes, so the size of tablestatus file
+   * will remain at 100KB.
    */
   public static final String CARBON_INVISIBLE_SEGMENTS_PRESERVE_COUNT_DEFAULT = "200";
 

--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -1602,8 +1602,20 @@ public final class CarbonCommonConstants {
   // default value is 2 days
   public static final String CARBON_SEGMENT_LOCK_FILES_PRESERVE_HOURS_DEFAULT = "48";
 
+  /**
+   * The number of invisible segment info which will be preserved in tablestatus file,
+   * if it exceeds this value, they will be removed and write to tablestatus.history file.
+   */
+  @CarbonProperty
+  public static final String CARBON_INVISIBLE_SEGMENTS_PRESERVE_COUNT =
+      "carbon.invisible.segments.preserve.count";
+
+  /**
+   * default value is 20, it means that it will preserve 20 invisible segment info
+   * in tablestatus file.
+   */
+  public static final String CARBON_INVISIBLE_SEGMENTS_PRESERVE_COUNT_DEFAULT = "200";
+
   private CarbonCommonConstants() {
   }
 }
-
-

--- a/core/src/main/java/org/apache/carbondata/core/statusmanager/SegmentStatusManager.java
+++ b/core/src/main/java/org/apache/carbondata/core/statusmanager/SegmentStatusManager.java
@@ -1017,7 +1017,7 @@ public class SegmentStatusManager {
   }
 
   /**
-   * Append new invisible segment info to old list.
+   * Return an array containing all invisible segment entries in appendList and historyList.
    */
   public static LoadMetadataDetails[] appendLoadHistoryList(
       LoadMetadataDetails[] historyList,

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
@@ -1399,7 +1399,7 @@ public final class CarbonProperties {
     } catch (NumberFormatException exc) {
       LOGGER.error(
           "The heap memory pooling threshold bytes is invalid. Using the default value "
-              + CarbonCommonConstants.CARBON_HEAP_MEMORY_POOLING_THRESHOLD_BYTES_DEFAULT);
+          + CarbonCommonConstants.CARBON_HEAP_MEMORY_POOLING_THRESHOLD_BYTES_DEFAULT);
       thresholdSize = Integer.parseInt(
           CarbonCommonConstants.CARBON_HEAP_MEMORY_POOLING_THRESHOLD_BYTES_DEFAULT);
     }
@@ -1419,11 +1419,32 @@ public final class CarbonProperties {
       preserveSeconds = preserveHours * 3600 * 1000L;
     } catch (NumberFormatException exc) {
       LOGGER.error(
-          "The segment lock files preserv hours is invalid. Using the default value "
-              + CarbonCommonConstants.CARBON_SEGMENT_LOCK_FILES_PRESERVE_HOURS_DEFAULT);
+          "The value of '" + CarbonCommonConstants.CARBON_SEGMENT_LOCK_FILES_PRESERVE_HOURS
+          + "' is invalid. Using the default value "
+          + CarbonCommonConstants.CARBON_SEGMENT_LOCK_FILES_PRESERVE_HOURS_DEFAULT);
       preserveSeconds = Integer.parseInt(
           CarbonCommonConstants.CARBON_SEGMENT_LOCK_FILES_PRESERVE_HOURS_DEFAULT) * 3600 * 1000L;
     }
     return preserveSeconds;
+  }
+
+  /**
+   * Get the number of invisible segment info which will be preserved in tablestatus file.
+   */
+  public int getInvisibleSegmentPreserveCount() {
+    int preserveCnt;
+    try {
+      preserveCnt = Integer.parseInt(CarbonProperties.getInstance()
+          .getProperty(CarbonCommonConstants.CARBON_INVISIBLE_SEGMENTS_PRESERVE_COUNT,
+              CarbonCommonConstants.CARBON_INVISIBLE_SEGMENTS_PRESERVE_COUNT_DEFAULT));
+    } catch (NumberFormatException exc) {
+      LOGGER.error(
+          "The value of '" + CarbonCommonConstants.CARBON_INVISIBLE_SEGMENTS_PRESERVE_COUNT
+          + "' is invalid. Using the default value "
+          + CarbonCommonConstants.CARBON_INVISIBLE_SEGMENTS_PRESERVE_COUNT_DEFAULT);
+      preserveCnt = Integer.parseInt(
+          CarbonCommonConstants.CARBON_INVISIBLE_SEGMENTS_PRESERVE_COUNT_DEFAULT);
+    }
+    return preserveCnt;
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/util/path/CarbonTablePath.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/path/CarbonTablePath.java
@@ -45,6 +45,7 @@ public class CarbonTablePath {
   private static final String LOCK_DIR = "LockFiles";
 
   public static final String TABLE_STATUS_FILE = "tablestatus";
+  public static final String TABLE_STATUS_HISTORY_FILE = "tablestatus.history";
   public static final String CARBON_DATA_EXT = ".carbondata";
   public static final String INDEX_FILE_EXT = ".carbonindex";
   public static final String MERGE_INDEX_FILE_EXT = ".carbonindexmerge";
@@ -662,5 +663,13 @@ public class CarbonTablePath {
    */
   public static boolean isSegmentLockFilePath(String lockFileName) {
     return lockFileName.startsWith(SEGMENT_PREFIX) && lockFileName.endsWith(LockUsage.LOCK);
+  }
+
+  /**
+   * Return table status history file path based on `tablePath`
+   */
+  public static String getTableStatusHistoryFilePath(String tablePath) {
+    return getMetadataPath(tablePath) + CarbonCommonConstants.FILE_SEPARATOR
+        + TABLE_STATUS_HISTORY_FILE;
   }
 }

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/MajorCompactionIgnoreInMinorTest.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/MajorCompactionIgnoreInMinorTest.scala
@@ -71,36 +71,6 @@ class MajorCompactionIgnoreInMinorTest extends QueryTest with BeforeAndAfterAll 
   }
 
   /**
-    * Test whether major compaction is not included in minor compaction.
-    */
-  test("delete merged folder and check segments") {
-    // delete merged segments
-    sql("clean files for table ignoremajor")
-
-    val carbonTable = CarbonMetadata.getInstance().getCarbonTable(
-      CarbonCommonConstants.DATABASE_DEFAULT_NAME,
-      "ignoremajor"
-    )
-    val absoluteTableIdentifier = carbonTable
-      .getAbsoluteTableIdentifier
-    val segmentStatusManager: SegmentStatusManager = new SegmentStatusManager(
-      absoluteTableIdentifier)
-
-    // merged segment should not be there
-    val segments = segmentStatusManager.getValidAndInvalidSegments.getValidSegments.asScala.map(_.getSegmentNo).toList
-    assert(segments.contains("0.1"))
-    assert(segments.contains("2.1"))
-    assert(!segments.contains("2"))
-    assert(!segments.contains("3"))
-    val cacheClient = new CacheClient()
-    val segmentIdentifier = new TableSegmentUniqueIdentifier(absoluteTableIdentifier, "2")
-    val wrapper: SegmentTaskIndexWrapper = cacheClient.getSegmentAccessClient.
-      getIfPresent(segmentIdentifier)
-    assert(null == wrapper)
-
-  }
-
-  /**
     * Delete should not work on compacted segment.
     */
   test("delete compacted segment and check status") {
@@ -139,6 +109,35 @@ class MajorCompactionIgnoreInMinorTest extends QueryTest with BeforeAndAfterAll 
     assertResult(SegmentStatus.COMPACTED)(segs(3).getSegmentStatus)
     // for segment 0.1 . should get deleted
     assertResult(SegmentStatus.MARKED_FOR_DELETE)(segs(2).getSegmentStatus)
+  }
+
+  /**
+    * Test whether major compaction is not included in minor compaction.
+    */
+  test("delete merged folder and check segments") {
+    // delete merged segments
+    sql("clean files for table ignoremajor")
+
+    val carbonTable = CarbonMetadata.getInstance().getCarbonTable(
+      CarbonCommonConstants.DATABASE_DEFAULT_NAME,
+      "ignoremajor"
+    )
+    val absoluteTableIdentifier = carbonTable
+      .getAbsoluteTableIdentifier
+    val segmentStatusManager: SegmentStatusManager = new SegmentStatusManager(
+      absoluteTableIdentifier)
+
+    // merged segment should not be there
+    val segments = segmentStatusManager.getValidAndInvalidSegments.getValidSegments.asScala.map(_.getSegmentNo).toList
+    assert(segments.contains("0.1"))
+    assert(segments.contains("2.1"))
+    assert(!segments.contains("2"))
+    assert(!segments.contains("3"))
+    val cacheClient = new CacheClient()
+    val segmentIdentifier = new TableSegmentUniqueIdentifier(absoluteTableIdentifier, "2")
+    val wrapper: SegmentTaskIndexWrapper = cacheClient.getSegmentAccessClient.
+      getIfPresent(segmentIdentifier)
+    assert(null == wrapper)
   }
 
   /**

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/MajorCompactionIgnoreInMinorTest.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/MajorCompactionIgnoreInMinorTest.scala
@@ -40,6 +40,9 @@ class MajorCompactionIgnoreInMinorTest extends QueryTest with BeforeAndAfterAll 
   val csvFilePath3 = s"$resourcesPath/compaction/compaction3.csv"
 
   override def beforeAll {
+  }
+
+  def createTableAndLoadData(): Unit = {
     CarbonProperties.getInstance().addProperty("carbon.compaction.level.threshold", "2,2")
     sql("drop table if exists  ignoremajor")
     CarbonProperties.getInstance()
@@ -67,13 +70,13 @@ class MajorCompactionIgnoreInMinorTest extends QueryTest with BeforeAndAfterAll 
     )
     sql("alter table ignoremajor compact 'minor'"
     )
-
   }
 
   /**
     * Delete should not work on compacted segment.
     */
   test("delete compacted segment and check status") {
+    createTableAndLoadData()
     intercept[Throwable] {
       sql("delete from table ignoremajor where segment.id in (2)")
     }
@@ -94,6 +97,7 @@ class MajorCompactionIgnoreInMinorTest extends QueryTest with BeforeAndAfterAll 
     * Delete should not work on compacted segment.
     */
   test("delete compacted segment by date and check status") {
+    createTableAndLoadData()
     sql(
       "delete from table ignoremajor where segment.starttime before " +
         " '2222-01-01 19:35:01'"
@@ -115,6 +119,7 @@ class MajorCompactionIgnoreInMinorTest extends QueryTest with BeforeAndAfterAll 
     * Test whether major compaction is not included in minor compaction.
     */
   test("delete merged folder and check segments") {
+    createTableAndLoadData()
     // delete merged segments
     sql("clean files for table ignoremajor")
 

--- a/integration/spark2/src/test/scala/org/apache/spark/util/CarbonCommandSuite.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/util/CarbonCommandSuite.scala
@@ -28,6 +28,8 @@ import org.apache.carbondata.api.CarbonStore
 import org.apache.carbondata.common.constants.LoggerAction
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.metadata.CarbonMetadata
+import org.apache.carbondata.core.statusmanager.LoadMetadataDetails
+import org.apache.carbondata.core.statusmanager.SegmentStatusManager
 import org.apache.carbondata.core.util.CarbonProperties
 
 class CarbonCommandSuite extends Spark2QueryTest with BeforeAndAfterAll {
@@ -163,6 +165,29 @@ class CarbonCommandSuite extends Spark2QueryTest with BeforeAndAfterAll {
     }.getMessage.contains("Delete segment operation is not supported on pre-aggregate tables")
     dropTable("preaggMain")
     dropTable("preagg1")
+  }
+
+  test("separate visible and invisible segments info into two files") {
+    val tableName = "test_tablestatus_history"
+    sql(s"drop table if exists ${tableName}")
+    sql(s"create table ${tableName} (name String, age int) stored by 'carbondata' "
+      + "TBLPROPERTIES('AUTO_LOAD_MERGE'='true','COMPACTION_LEVEL_THRESHOLD'='2,2')")
+    val carbonTable = CarbonMetadata.getInstance().getCarbonTable("default", tableName)
+    sql(s"insert into ${tableName} select 'abc1',1")
+    sql(s"insert into ${tableName} select 'abc2',2")
+    sql(s"insert into ${tableName} select 'abc3',3")
+    assert(sql(s"show segments for table ${tableName}").collect().length == 4)
+    var detail = SegmentStatusManager.readLoadMetadata(carbonTable.getMetadataPath)
+    var historyDetail = SegmentStatusManager.readLoadHistoryMetadata(carbonTable.getMetadataPath)
+    assert(detail.length == 4)
+    assert(historyDetail.length == 0)
+    sql(s"clean files for table ${tableName}")
+    assert(sql(s"show segments for table ${tableName}").collect().length == 3)
+    detail = SegmentStatusManager.readLoadMetadata(carbonTable.getMetadataPath)
+    historyDetail = SegmentStatusManager.readLoadHistoryMetadata(carbonTable.getMetadataPath)
+    assert(detail.length == 3)
+    assert(historyDetail.length == 1)
+    dropTable(tableName)
   }
 
   protected def dropTable(tableName: String): Unit ={

--- a/integration/spark2/src/test/scala/org/apache/spark/util/CarbonCommandSuite.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/util/CarbonCommandSuite.scala
@@ -182,7 +182,7 @@ class CarbonCommandSuite extends Spark2QueryTest with BeforeAndAfterAll {
     assert(detail.length == 4)
     assert(historyDetail.length == 0)
     sql(s"clean files for table ${tableName}")
-    assert(sql(s"show segments for table ${tableName}").collect().length == 3)
+    assert(sql(s"show segments for table ${tableName}").collect().length == 2)
     detail = SegmentStatusManager.readLoadMetadata(carbonTable.getMetadataPath)
     historyDetail = SegmentStatusManager.readLoadHistoryMetadata(carbonTable.getMetadataPath)
     assert(detail.length == 3)


### PR DESCRIPTION
The size of the tablestatus file is getting larger, there are many places will scan this file and it will impact the performance of reading this file.
According to the discussion on [thread](http://apache-carbondata-dev-mailing-list-archive.1130556.n5.nabble.com/The-size-of-the-tablestatus-file-is-getting-larger-does-it-impact-the-performance-of-reading-this-fi-td41941.html), it can *append* the
invisible segment list to the file called 'tablestatus.history' when execute
command 'CLEAN FILES FOR TABLE' (in method 'SegmentStatusManager.deleteLoadsAndUpdateMetadata') every time, separate visible and invisible segments into two files(tablestatus file and tablestatus.history file).

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed? No
 
 - [ ] Any backward compatibility impacted?  No
 
 - [ ] Document update required?

 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

