### PR TITLE
[CARBONDATA-2274] fix for Partition table having more than 4 column giving zero record

### DIFF
--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/CarbonScalaUtil.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/CarbonScalaUtil.scala
@@ -23,6 +23,8 @@ import java.nio.charset.Charset
 import java.text.SimpleDateFormat
 import java.util.Date
 
+import scala.collection.mutable
+
 import com.univocity.parsers.common.TextParsingException
 import org.apache.spark.SparkException
 import org.apache.spark.sql._
@@ -339,13 +341,12 @@ object CarbonScalaUtil {
    * Update partition values as per the right date and time format
    * @return updated partition spec
    */
-  def updatePartitions(
-      partitionSpec: Map[String, String],
-  table: CarbonTable): Map[String, String] = {
+  def updatePartitions(partitionSpec: mutable.LinkedHashMap[String, String],
+      table: CarbonTable): mutable.LinkedHashMap[String, String] = {
     val cacheProvider: CacheProvider = CacheProvider.getInstance
     val forwardDictionaryCache: Cache[DictionaryColumnUniqueIdentifier, Dictionary] =
       cacheProvider.createCache(CacheType.FORWARD_DICTIONARY)
-    partitionSpec.map{ case (col, pvalue) =>
+    partitionSpec.map { case (col, pvalue) =>
       // replace special string with empty value.
       val value = if (pvalue == null) {
         hivedefaultpartition
@@ -385,11 +386,14 @@ object CarbonScalaUtil {
   def updatePartitions(
       parts: Seq[CatalogTablePartition],
       table: CarbonTable): Seq[CatalogTablePartition] = {
-    parts.map{ f =>
+    parts.map { f =>
+      val specLinkedMap: mutable.LinkedHashMap[String, String] = mutable.LinkedHashMap
+        .empty[String, String]
+      f.spec.foreach(fSpec => specLinkedMap.put(fSpec._1, fSpec._2))
       val changedSpec =
         updatePartitions(
-          f.spec,
-          table)
+          specLinkedMap,
+          table).toMap
       f.copy(spec = changedSpec)
     }.groupBy(p => p.spec).map(f => f._2.head).toSeq // Avoid duplicates by do groupby
   }


### PR DESCRIPTION
**Converting of Array[String,String] to Map[String, String] was giving wrong order of partition column. And we were using that sequence to create path.**

**So used LinkedHashMap to avoid reordering.**

 - [X] Any interfaces changed? NO
 
 - [x] Any backward compatibility impacted? No
 
 - [x] Document update required? No

 - [x] Testing done **UT added**
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. NA

