### PR TITLE
[HOTFIX] Ignore batchsort testcase for hive partition table

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/standardpartition/StandardPartitionGlobalSortTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/standardpartition/StandardPartitionGlobalSortTestCase.scala
@@ -927,7 +927,7 @@ class StandardPartitionGlobalSortTestCase extends QueryTest with BeforeAndAfterA
     assert(exMessage.getMessage.contains("day is not a valid partition column in table default.partitionnocolumn"))
   }
 
-  test("data loading with default partition in static partition table with batchsort") {
+  ignore("data loading with default partition in static partition table with batchsort") {
     sql("DROP TABLE IF EXISTS partitiondefaultbatchsort")
     sql(
       """


### PR DESCRIPTION
Testcase `"data loading with default partition in static partition table with batchsort"` is having CI random failure.
Ignoring this testcase temporarily. It will be add back after fixing it.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

