### PR TITLE
[CARBONDATA-2278] Save the datamaps to system folder of warehouse.

### DIFF
--- a/common/src/main/java/org/apache/carbondata/common/exceptions/sql/NoSuchDataMapException.java
+++ b/common/src/main/java/org/apache/carbondata/common/exceptions/sql/NoSuchDataMapException.java
@@ -36,4 +36,8 @@ public class NoSuchDataMapException extends MalformedCarbonCommandException {
   public NoSuchDataMapException(String dataMapName, String tableName) {
     super("Datamap with name " + dataMapName + " does not exist under table " + tableName);
   }
+
+  public NoSuchDataMapException(String dataMapName) {
+    super("Datamap with name " + dataMapName + " does not exist");
+  }
 }

--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -1618,6 +1618,11 @@ public final class CarbonCommonConstants {
    */
   public static final String CARBON_INVISIBLE_SEGMENTS_PRESERVE_COUNT_DEFAULT = "200";
 
+  /**
+   * System older location to store system level data like datamap schema and status files.
+   */
+  public static final String CARBON_SYSTEM_FOLDER_LOCATION = "carbon.system.folder.location";
+
   private CarbonCommonConstants() {
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/datamap/DataMapCatalog.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/DataMapCatalog.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.core.datamap;
+
+import org.apache.carbondata.core.metadata.schema.table.DataMapSchema;
+
+/**
+ * This is the interface for inmemory catalog registry for datamap.
+ * @since 1.4.0
+ */
+public interface DataMapCatalog<T> {
+
+  /**
+   * Register schema to the catalog.
+   * @param dataMapSchema
+   */
+  void registerSchema(DataMapSchema dataMapSchema);
+
+  /**
+   * Unregister schema from catalog.
+   * @param dataMapName
+   */
+  void unregisterSchema(String dataMapName);
+
+  /**
+   * List all registered schema catalogs
+   * @return
+   */
+  T[] listAllSchema();
+
+  /**
+   * It reloads/removes all registered schema catalogs
+   */
+  void refresh();
+
+}

--- a/core/src/main/java/org/apache/carbondata/core/datamap/DataMapCatalog.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/DataMapCatalog.java
@@ -17,12 +17,14 @@
 
 package org.apache.carbondata.core.datamap;
 
+import org.apache.carbondata.common.annotations.InterfaceAudience;
 import org.apache.carbondata.core.metadata.schema.table.DataMapSchema;
 
 /**
  * This is the interface for inmemory catalog registry for datamap.
  * @since 1.4.0
  */
+@InterfaceAudience.Internal
 public interface DataMapCatalog<T> {
 
   /**

--- a/core/src/main/java/org/apache/carbondata/core/datamap/DataMapProvider.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/DataMapProvider.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.carbondata.datamap;
+package org.apache.carbondata.core.datamap;
 
 import java.io.IOException;
 
@@ -23,9 +23,6 @@ import org.apache.carbondata.common.annotations.InterfaceAudience;
 import org.apache.carbondata.common.exceptions.sql.MalformedDataMapCommandException;
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
 import org.apache.carbondata.core.metadata.schema.table.DataMapSchema;
-import org.apache.carbondata.processing.exception.DataLoadingException;
-
-import org.apache.spark.sql.SparkSession;
 
 /**
  * DataMap is a accelerator for certain type of query. Developer can add new DataMap
@@ -63,29 +60,29 @@ public interface DataMapProvider {
    * This is called when user creates datamap, for example "CREATE DATAMAP dm ON TABLE mainTable"
    * Implementation should initialize metadata for datamap, like creating table
    */
-  void initMeta(CarbonTable mainTable, DataMapSchema dataMapSchema, String ctasSqlStatement,
-      SparkSession sparkSession) throws MalformedDataMapCommandException, IOException;
+  void initMeta(CarbonTable mainTable, DataMapSchema dataMapSchema, String ctasSqlStatement)
+      throws MalformedDataMapCommandException, IOException;
 
   /**
    * Initialize a datamap's data.
    * This is called when user creates datamap, for example "CREATE DATAMAP dm ON TABLE mainTable"
    * Implementation should initialize data for datamap, like creating data folders
    */
-  void initData(CarbonTable mainTable, SparkSession sparkSession);
+  void initData(CarbonTable mainTable);
 
   /**
-   * Opposite operation of {@link #initMeta(CarbonTable, DataMapSchema, String, SparkSession)}.
+   * Opposite operation of {@link #initMeta(CarbonTable, DataMapSchema, String)}.
    * This is called when user drops datamap, for example "DROP DATAMAP dm ON TABLE mainTable"
    * Implementation should clean all meta for the datamap
    */
-  void freeMeta(CarbonTable mainTable, DataMapSchema dataMapSchema, SparkSession sparkSession);
+  void freeMeta(CarbonTable mainTable, DataMapSchema dataMapSchema) throws IOException;
 
   /**
-   * Opposite operation of {@link #initData(CarbonTable, SparkSession)}.
+   * Opposite operation of {@link #initData(CarbonTable)}.
    * This is called when user drops datamap, for example "DROP DATAMAP dm ON TABLE mainTable"
    * Implementation should clean all data for the datamap
    */
-  void freeData(CarbonTable mainTable, DataMapSchema dataMapSchema, SparkSession sparkSession);
+  void freeData(CarbonTable mainTable, DataMapSchema dataMapSchema);
 
   /**
    * Rebuild the datamap by loading all existing data from mainTable
@@ -93,13 +90,19 @@ public interface DataMapProvider {
    * 1. after datamap creation and if `autoRefreshDataMap` is set to true
    * 2. user manually trigger refresh datamap command
    */
-  void rebuild(CarbonTable mainTable, SparkSession sparkSession) throws DataLoadingException;
+  void rebuild(CarbonTable mainTable) throws IOException;
 
   /**
    * Build the datamap incrementally by loading specified segment data
    * This is called when user manually trigger refresh datamap
    */
-  void incrementalBuild(CarbonTable mainTable, String[] segmentIds, SparkSession sparkSession)
-    throws DataLoadingException;
+  void incrementalBuild(CarbonTable mainTable, String[] segmentIds)
+    throws IOException;
+
+  /**
+   * Provide the datamap catalog instance or null if this datamap not required to rewrite
+   * the query.
+   */
+  DataMapCatalog createDataMapCatalog();
 
 }

--- a/core/src/main/java/org/apache/carbondata/core/datamap/IndexDataMapProvider.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/IndexDataMapProvider.java
@@ -119,7 +119,8 @@ public class IndexDataMapProvider implements DataMapProvider {
     return dataMapFactory;
   }
 
-  @Override public DataMapCatalog createDataMapCatalog() {
+  @Override
+  public DataMapCatalog createDataMapCatalog() {
     // TODO create abstract class and move the default implementation there.
     return null;
   }

--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/datamap/DataMapClassProvider.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/datamap/DataMapClassProvider.java
@@ -20,13 +20,13 @@ package org.apache.carbondata.core.metadata.schema.datamap;
 /**
  * type for create datamap
  * The syntax of datamap creation is as follows.
- * CREATE DATAMAP IF NOT EXISTS dataMapName ON TABLE tableName USING 'DataMapProvider'
+ * CREATE DATAMAP IF NOT EXISTS dataMapName ON TABLE tableName USING 'DataMapClassProvider'
  * DMPROPERTIES('KEY'='VALUE') AS SELECT COUNT(COL1) FROM tableName
  *
  * Please refer {{org.apache.spark.sql.parser.CarbonSpark2SqlParser}}
  */
 
-public enum DataMapProvider {
+public enum DataMapClassProvider {
   PREAGGREGATE("org.apache.carbondata.core.datamap.AggregateDataMap", "preaggregate"),
   TIMESERIES("org.apache.carbondata.core.datamap.TimeSeriesDataMap", "timeseries");
 
@@ -40,7 +40,7 @@ public enum DataMapProvider {
    */
   private String shortName;
 
-  DataMapProvider(String className, String shortName) {
+  DataMapClassProvider(String className, String shortName) {
     this.className = className;
     this.shortName = shortName;
   }
@@ -59,7 +59,7 @@ public enum DataMapProvider {
         dataMapClass.equalsIgnoreCase(shortName)));
   }
 
-  public static DataMapProvider getDataMapProvider(String dataMapClass) {
+  public static DataMapClassProvider getDataMapProvider(String dataMapClass) {
     if (TIMESERIES.isEqual(dataMapClass)) {
       return TIMESERIES;
     } else if (PREAGGREGATE.isEqual(dataMapClass)) {

--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/DataMapSchema.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/DataMapSchema.java
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.carbondata.core.metadata.schema.table;
 
 import java.io.DataInput;
@@ -21,35 +22,38 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
-import org.apache.carbondata.core.metadata.schema.datamap.DataMapProvider;
+import org.apache.carbondata.core.metadata.schema.datamap.DataMapClassProvider;
+
+import com.google.gson.Gson;
 
 /**
- * Child schema class to maintain the child table details inside parent table
+ * It is the new schama of datamap and it has less fields compare to {{@link DataMapSchema}}
  */
 public class DataMapSchema implements Serializable, Writable {
 
-  private static final long serialVersionUID = 6577149126264181553L;
+  private static final long serialVersionUID = -8394577999061329687L;
 
   protected String dataMapName;
 
   /**
    * There are two kind of DataMaps:
    * 1. Index DataMap: provider name is class name of implementation class of DataMapFactory
-   * 2. OLAP DataMap: provider name is one of the {@link DataMapProvider#shortName}
+   * 2. OLAP DataMap: provider name is one of the {@link DataMapClassProvider#shortName}
    */
-  private String providerName;
+  protected String providerName;
 
   /**
-   * identifier of the parent table
+   * identifiers of the mapped table
    */
-  private RelationIdentifier relationIdentifier;
+  protected RelationIdentifier relationIdentifier;
 
   /**
-   * child table schema
+   * Query which is used to create a datamap. This is optional in case of index datamap.
    */
-  protected TableSchema childSchema;
+  protected String ctasQuery;
 
   /**
    * relation properties
@@ -57,46 +61,84 @@ public class DataMapSchema implements Serializable, Writable {
   protected Map<String, String> properties;
 
   /**
-   * WARN: This constructor should be used by deserialization only
+   * Identifiers of parent tables
    */
-  public DataMapSchema() {
-  }
+  protected List<RelationIdentifier> parentTables;
+
+  /**
+   * child table schema
+   */
+  protected TableSchema childSchema;
+
 
   public DataMapSchema(String dataMapName, String providerName) {
     this.dataMapName = dataMapName;
     this.providerName = providerName;
   }
 
-  public String getProviderName() {
-    return providerName;
-  }
-
-  public TableSchema getChildSchema() {
-    return childSchema;
-  }
-
-  public RelationIdentifier getRelationIdentifier() {
-    return relationIdentifier;
-  }
-
-  public Map<String, String> getProperties() {
-    return properties;
+  public DataMapSchema() {
   }
 
   public String getDataMapName() {
     return dataMapName;
   }
 
+  public void setDataMapName(String dataMapName) {
+    this.dataMapName = dataMapName;
+  }
+
+  public String getProviderName() {
+    return providerName;
+  }
+
+  public void setProviderName(String providerName) {
+    this.providerName = providerName;
+  }
+
+  public RelationIdentifier getRelationIdentifier() {
+    return relationIdentifier;
+  }
+
   public void setRelationIdentifier(RelationIdentifier relationIdentifier) {
     this.relationIdentifier = relationIdentifier;
   }
 
-  public void setChildSchema(TableSchema childSchema) {
-    this.childSchema = childSchema;
+  public String getCtasQuery() {
+    return ctasQuery;
+  }
+
+  public void setCtasQuery(String ctasQuery) {
+    this.ctasQuery = ctasQuery;
+  }
+
+  public Map<String, String> getProperties() {
+    return properties;
   }
 
   public void setProperties(Map<String, String> properties) {
     this.properties = properties;
+  }
+
+  public void setPropertiesJson(Gson gson, String propertiesJson) {
+    if (propertiesJson != null) {
+      this.properties = gson.fromJson(propertiesJson, Map.class);
+    }
+  }
+
+  public void setParentTables(List<RelationIdentifier> parentTables) {
+    this.parentTables = parentTables;
+  }
+
+  public List<RelationIdentifier> getParentTables() {
+    return parentTables;
+  }
+
+  public TableSchema getChildSchema() {
+    return childSchema;
+  }
+
+  public void setChildSchema(TableSchema childSchema) {
+    this.childSchema = childSchema;
   }
 
   /**
@@ -104,8 +146,8 @@ public class DataMapSchema implements Serializable, Writable {
    * @return
    */
   public boolean isIndexDataMap() {
-    if (providerName.equalsIgnoreCase(DataMapProvider.PREAGGREGATE.getShortName()) ||
-        providerName.equalsIgnoreCase(DataMapProvider.TIMESERIES.getShortName())) {
+    if (providerName.equalsIgnoreCase(DataMapClassProvider.PREAGGREGATE.getShortName()) ||
+        providerName.equalsIgnoreCase(DataMapClassProvider.TIMESERIES.getShortName())) {
       return false;
     } else {
       return true;
@@ -158,4 +200,5 @@ public class DataMapSchema implements Serializable, Writable {
       this.properties.put(key, value);
     }
   }
+
 }

--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/DataMapSchemaFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/DataMapSchemaFactory.java
@@ -16,7 +16,7 @@
  */
 package org.apache.carbondata.core.metadata.schema.table;
 
-import org.apache.carbondata.core.metadata.schema.datamap.DataMapProvider;
+import org.apache.carbondata.core.metadata.schema.datamap.DataMapClassProvider;
 
 public class DataMapSchemaFactory {
   public static final DataMapSchemaFactory INSTANCE = new DataMapSchemaFactory();
@@ -28,9 +28,9 @@ public class DataMapSchemaFactory {
    * @return data map schema
    */
   public DataMapSchema getDataMapSchema(String dataMapName, String providerName) {
-    if (providerName.equalsIgnoreCase(DataMapProvider.PREAGGREGATE.toString())) {
+    if (providerName.equalsIgnoreCase(DataMapClassProvider.PREAGGREGATE.toString())) {
       return new AggregationDataMapSchema(dataMapName, providerName);
-    } else if (providerName.equalsIgnoreCase(DataMapProvider.TIMESERIES.toString())) {
+    } else if (providerName.equalsIgnoreCase(DataMapClassProvider.TIMESERIES.toString())) {
       return new AggregationDataMapSchema(dataMapName, providerName);
     } else {
       return new DataMapSchema(dataMapName, providerName);

--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/DataMapSchemaStorageProvider.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/DataMapSchemaStorageProvider.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.core.metadata.schema.table;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.apache.carbondata.common.annotations.InterfaceAudience;
+import org.apache.carbondata.core.metadata.schema.table.DataMapSchema;
+
+/**
+ *It is used to save/retreive/drop datamap schema from storage medium like disk or DB.
+ * Here dataMapName must be unique across whole store.
+ *
+ * @since 1.4.0
+ */
+@InterfaceAudience.Internal
+public interface DataMapSchemaStorageProvider {
+
+  /**
+   * Save the schema to storage medium.
+   * @param dataMapSchema
+   */
+  void saveSchema(DataMapSchema dataMapSchema) throws IOException;
+
+  /**
+   * Retrieve the schema by using dataMapName.
+   * @param dataMapName
+   */
+  DataMapSchema retrieveSchema(String dataMapName) throws IOException;
+
+  /**
+   * Retrieve schemas by using the list of datamap names
+   * @param dataMapNames
+   * @return
+   * @throws IOException
+   */
+  List<DataMapSchema> retrieveSchemas(List<String> dataMapNames) throws IOException;
+
+  /**
+   * Retrieve all schemas
+   * @return
+   * @throws IOException
+   */
+  List<DataMapSchema> retrieveAllSchemas() throws IOException;
+
+  /**
+   * Drop the schema from the storage by using dataMapName.
+   * @param dataMapName
+   */
+  void dropSchema(String dataMapName) throws IOException;
+
+}

--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/DiskBasedDMSchemaStorageProvider.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/DiskBasedDMSchemaStorageProvider.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.core.metadata.schema.table;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.carbondata.core.constants.CarbonCommonConstants;
+import org.apache.carbondata.core.datastore.filesystem.CarbonFile;
+import org.apache.carbondata.core.datastore.filesystem.CarbonFileFilter;
+import org.apache.carbondata.core.datastore.impl.FileFactory;
+import org.apache.carbondata.core.util.CarbonUtil;
+
+import com.google.gson.Gson;
+
+/**
+ * Stores datamap schema in disk as json format
+ */
+public class DiskBasedDMSchemaStorageProvider implements DataMapSchemaStorageProvider {
+
+  private String storePath;
+
+  public DiskBasedDMSchemaStorageProvider(String storePath) {
+    this.storePath = storePath;
+  }
+
+  @Override public void saveSchema(DataMapSchema dataMapSchema) throws IOException {
+    BufferedWriter brWriter = null;
+    DataOutputStream dataOutputStream = null;
+    Gson gsonObjectToWrite = new Gson();
+    String schemaPath =
+        storePath + CarbonCommonConstants.FILE_SEPARATOR + dataMapSchema.getDataMapName()
+            + ".dmschema";
+    FileFactory.FileType fileType = FileFactory.getFileType(schemaPath);
+    if (FileFactory.isFileExist(schemaPath, fileType)) {
+      throw new IOException(
+          "DataMap with name " + dataMapSchema.getDataMapName() + " already exists in storage");
+    }
+    // write the datamap shema in json format.
+    try {
+      FileFactory.mkdirs(storePath, fileType);
+      FileFactory.createNewFile(schemaPath, fileType);
+      dataOutputStream =
+          FileFactory.getDataOutputStream(schemaPath, fileType);
+      brWriter = new BufferedWriter(new OutputStreamWriter(dataOutputStream,
+          Charset.forName(CarbonCommonConstants.DEFAULT_CHARSET)));
+
+      String metadataInstance = gsonObjectToWrite.toJson(dataMapSchema);
+      brWriter.write(metadataInstance);
+    } finally {
+      if (null != brWriter) {
+        brWriter.flush();
+      }
+      CarbonUtil.closeStreams(dataOutputStream, brWriter);
+    }
+  }
+
+  @Override public DataMapSchema retrieveSchema(String dataMapName) throws IOException {
+    if (!dataMapName.endsWith(".dmschema")) {
+      dataMapName = dataMapName + ".dmschema";
+    }
+    String schemaPath =
+        storePath + CarbonCommonConstants.FILE_SEPARATOR + dataMapName;
+    if (!FileFactory.isFileExist(schemaPath, FileFactory.getFileType(schemaPath))) {
+      throw new IOException("DataMap with name " + dataMapName + " does not exists in storage");
+    }
+
+    Gson gsonObjectToRead = new Gson();
+    DataInputStream dataInputStream = null;
+    BufferedReader buffReader = null;
+    InputStreamReader inStream = null;
+    try {
+      dataInputStream =
+          FileFactory.getDataInputStream(schemaPath, FileFactory.getFileType(schemaPath));
+      inStream = new InputStreamReader(dataInputStream,
+          Charset.forName(CarbonCommonConstants.DEFAULT_CHARSET));
+      buffReader = new BufferedReader(inStream);
+      return gsonObjectToRead.fromJson(buffReader, DataMapSchema.class);
+    } finally {
+      CarbonUtil.closeStreams(buffReader, inStream, dataInputStream);
+    }
+
+  }
+
+  @Override public List<DataMapSchema> retrieveSchemas(List<String> dataMapNames)
+      throws IOException {
+    List<DataMapSchema> dataMapSchemas = new ArrayList<>(dataMapNames.size());
+    for (String dataMapName : dataMapNames) {
+      dataMapSchemas.add(retrieveSchema(dataMapName));
+    }
+    return dataMapSchemas;
+  }
+
+  @Override public List<DataMapSchema> retrieveAllSchemas() throws IOException {
+    List<DataMapSchema> dataMapSchemas = new ArrayList<>();
+    CarbonFile carbonFile = FileFactory.getCarbonFile(storePath);
+    CarbonFile[] carbonFiles = carbonFile.listFiles(new CarbonFileFilter() {
+      @Override public boolean accept(CarbonFile file) {
+        return file.getName().endsWith(".dmschema");
+      }
+    });
+
+    for (CarbonFile file :carbonFiles) {
+      dataMapSchemas.add(retrieveSchema(file.getName()));
+    }
+    return dataMapSchemas;
+  }
+
+  @Override public void dropSchema(String dataMapName) throws IOException {
+    String schemaPath =
+        storePath + CarbonCommonConstants.FILE_SEPARATOR + dataMapName + ".dmschema";
+    if (!FileFactory.isFileExist(schemaPath, FileFactory.getFileType(schemaPath))) {
+      throw new IOException("DataMap with name " + dataMapName + " does not exists in storage");
+    }
+
+    if (!FileFactory.deleteFile(schemaPath, FileFactory.getFileType(schemaPath))) {
+      throw new IOException("DataMap with name " + dataMapName + " cannot be deleted");
+    }
+  }
+}

--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/DiskBasedDMSchemaStorageProvider.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/DiskBasedDMSchemaStorageProvider.java
@@ -47,7 +47,8 @@ public class DiskBasedDMSchemaStorageProvider implements DataMapSchemaStoragePro
     this.storePath = storePath;
   }
 
-  @Override public void saveSchema(DataMapSchema dataMapSchema) throws IOException {
+  @Override
+  public void saveSchema(DataMapSchema dataMapSchema) throws IOException {
     BufferedWriter brWriter = null;
     DataOutputStream dataOutputStream = null;
     Gson gsonObjectToWrite = new Gson();
@@ -78,7 +79,8 @@ public class DiskBasedDMSchemaStorageProvider implements DataMapSchemaStoragePro
     }
   }
 
-  @Override public DataMapSchema retrieveSchema(String dataMapName) throws IOException {
+  @Override
+  public DataMapSchema retrieveSchema(String dataMapName) throws IOException {
     if (!dataMapName.endsWith(".dmschema")) {
       dataMapName = dataMapName + ".dmschema";
     }
@@ -105,7 +107,8 @@ public class DiskBasedDMSchemaStorageProvider implements DataMapSchemaStoragePro
 
   }
 
-  @Override public List<DataMapSchema> retrieveSchemas(List<String> dataMapNames)
+  @Override
+  public List<DataMapSchema> retrieveSchemas(List<String> dataMapNames)
       throws IOException {
     List<DataMapSchema> dataMapSchemas = new ArrayList<>(dataMapNames.size());
     for (String dataMapName : dataMapNames) {
@@ -114,7 +117,8 @@ public class DiskBasedDMSchemaStorageProvider implements DataMapSchemaStoragePro
     return dataMapSchemas;
   }
 
-  @Override public List<DataMapSchema> retrieveAllSchemas() throws IOException {
+  @Override
+  public List<DataMapSchema> retrieveAllSchemas() throws IOException {
     List<DataMapSchema> dataMapSchemas = new ArrayList<>();
     CarbonFile carbonFile = FileFactory.getCarbonFile(storePath);
     CarbonFile[] carbonFiles = carbonFile.listFiles(new CarbonFileFilter() {
@@ -129,7 +133,8 @@ public class DiskBasedDMSchemaStorageProvider implements DataMapSchemaStoragePro
     return dataMapSchemas;
   }
 
-  @Override public void dropSchema(String dataMapName) throws IOException {
+  @Override
+  public void dropSchema(String dataMapName) throws IOException {
     String schemaPath =
         storePath + CarbonCommonConstants.FILE_SEPARATOR + dataMapName + ".dmschema";
     if (!FileFactory.isFileExist(schemaPath, FileFactory.getFileType(schemaPath))) {

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
@@ -1447,4 +1447,17 @@ public final class CarbonProperties {
     }
     return preserveCnt;
   }
+  /**
+   * Get the configured system folder location.
+   * @return
+   */
+  public String getSystemFolderLocation() {
+    String systemLocation = CarbonProperties.getInstance()
+        .getProperty(CarbonCommonConstants.CARBON_SYSTEM_FOLDER_LOCATION);
+    if (systemLocation == null) {
+      systemLocation = getStorePath();
+    }
+    return systemLocation + CarbonCommonConstants.FILE_SEPARATOR + "_system";
+  }
+
 }

--- a/integration/spark-common-cluster-test/src/test/scala/org/apache/carbondata/cluster/sdv/generated/TimeSeriesPreAggregateTestCase.scala
+++ b/integration/spark-common-cluster-test/src/test/scala/org/apache/carbondata/cluster/sdv/generated/TimeSeriesPreAggregateTestCase.scala
@@ -23,7 +23,7 @@ import org.scalatest.BeforeAndAfterEach
 import org.scalatest.Matchers._
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants
-import org.apache.carbondata.core.metadata.schema.datamap.DataMapProvider.TIMESERIES
+import org.apache.carbondata.core.metadata.schema.datamap.DataMapClassProvider.TIMESERIES
 import org.apache.carbondata.core.util.CarbonProperties
 
 class TimeSeriesPreAggregateTestCase extends QueryTest with BeforeAndAfterEach {

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggCreateCommand.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggCreateCommand.scala
@@ -30,7 +30,7 @@ import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.common.exceptions.sql.{MalformedCarbonCommandException, MalformedDataMapCommandException}
 import org.apache.carbondata.core.metadata.encoder.Encoding
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable
-import org.apache.carbondata.core.metadata.schema.datamap.DataMapProvider.TIMESERIES
+import org.apache.carbondata.core.metadata.schema.datamap.DataMapClassProvider.TIMESERIES
 import org.apache.carbondata.core.util.CarbonProperties
 
 class TestPreAggCreateCommand extends QueryTest with BeforeAndAfterAll {

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggregateTableSelection.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggregateTableSelection.scala
@@ -23,7 +23,7 @@ import org.apache.spark.sql.{CarbonDatasourceHadoopRelation, Row}
 import org.apache.spark.sql.test.util.QueryTest
 import org.scalatest.BeforeAndAfterAll
 
-import org.apache.carbondata.core.metadata.schema.datamap.DataMapProvider.TIMESERIES
+import org.apache.carbondata.core.metadata.schema.datamap.DataMapClassProvider.TIMESERIES
 
 class TestPreAggregateTableSelection extends QueryTest with BeforeAndAfterAll {
 

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/timeseries/TestTimeSeriesCreateTable.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/timeseries/TestTimeSeriesCreateTable.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.test.util.QueryTest
 import org.scalatest.BeforeAndAfterAll
 
 import org.apache.carbondata.common.exceptions.sql.{MalformedCarbonCommandException, MalformedDataMapCommandException}
-import org.apache.carbondata.core.metadata.schema.datamap.DataMapProvider.TIMESERIES
+import org.apache.carbondata.core.metadata.schema.datamap.DataMapClassProvider.TIMESERIES
 
 class TestTimeSeriesCreateTable extends QueryTest with BeforeAndAfterAll {
 

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/timeseries/TestTimeseriesCompaction.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/timeseries/TestTimeseriesCompaction.scala
@@ -22,7 +22,7 @@ import org.scalatest.BeforeAndAfterAll
 import org.scalatest.Matchers._
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants
-import org.apache.carbondata.core.metadata.schema.datamap.DataMapProvider.TIMESERIES
+import org.apache.carbondata.core.metadata.schema.datamap.DataMapClassProvider.TIMESERIES
 import org.apache.carbondata.core.util.CarbonProperties
 
 class TestTimeseriesCompaction extends QueryTest with BeforeAndAfterAll {

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/timeseries/TestTimeseriesDataLoad.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/timeseries/TestTimeseriesDataLoad.scala
@@ -26,7 +26,7 @@ import org.scalatest.BeforeAndAfterAll
 
 import org.apache.carbondata.common.exceptions.sql.MalformedDataMapCommandException
 import org.apache.carbondata.core.constants.CarbonCommonConstants
-import org.apache.carbondata.core.metadata.schema.datamap.DataMapProvider.TIMESERIES
+import org.apache.carbondata.core.metadata.schema.datamap.DataMapClassProvider.TIMESERIES
 import org.apache.carbondata.core.util.CarbonProperties
 
 class TestTimeseriesDataLoad extends QueryTest with BeforeAndAfterAll {

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/timeseries/TestTimeseriesTableSelection.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/timeseries/TestTimeseriesTableSelection.scala
@@ -25,7 +25,7 @@ import org.apache.spark.util.SparkUtil4Test
 import org.scalatest.BeforeAndAfterAll
 
 import org.apache.carbondata.common.exceptions.sql.MalformedCarbonCommandException
-import org.apache.carbondata.core.metadata.schema.datamap.DataMapProvider.TIMESERIES
+import org.apache.carbondata.core.metadata.schema.datamap.DataMapClassProvider.TIMESERIES
 
 class TestTimeseriesTableSelection extends QueryTest with BeforeAndAfterAll {
 

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datamap/DataMapWriterSuite.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datamap/DataMapWriterSuite.scala
@@ -93,7 +93,7 @@ class DataMapWriterSuite extends QueryTest with BeforeAndAfterAll {
   test("test write datamap 2 pages") {
     sql(s"CREATE TABLE carbon1(c1 STRING, c2 STRING, c3 INT) STORED BY 'org.apache.carbondata.format'")
     // register datamap writer
-    sql(s"CREATE DATAMAP test ON TABLE carbon1 USING '${classOf[C2DataMapFactory].getName}'")
+    sql(s"CREATE DATAMAP test1 ON TABLE carbon1 USING '${classOf[C2DataMapFactory].getName}'")
     val df = buildTestData(33000)
 
     // save dataframe to carbon file
@@ -119,7 +119,7 @@ class DataMapWriterSuite extends QueryTest with BeforeAndAfterAll {
 
   test("test write datamap 2 blocklet") {
     sql(s"CREATE TABLE carbon2(c1 STRING, c2 STRING, c3 INT) STORED BY 'org.apache.carbondata.format'")
-    sql(s"CREATE DATAMAP test ON TABLE carbon2 USING '${classOf[C2DataMapFactory].getName}'")
+    sql(s"CREATE DATAMAP test2 ON TABLE carbon2 USING '${classOf[C2DataMapFactory].getName}'")
 
     CarbonProperties.getInstance()
       .addProperty("carbon.blockletgroup.size.in.mb", "1")

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/CarbonScalaUtil.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/CarbonScalaUtil.scala
@@ -30,6 +30,7 @@ import org.apache.spark.sql.catalyst.catalog.CatalogTablePartition
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.execution.command.{DataTypeInfo, UpdateTableModel}
 import org.apache.spark.sql.types._
+import org.apache.spark.util.CarbonReflectionUtils
 
 import org.apache.carbondata.common.exceptions.sql.MalformedCarbonCommandException
 import org.apache.carbondata.common.logging.LogService
@@ -40,7 +41,7 @@ import org.apache.carbondata.core.keygenerator.directdictionary.DirectDictionary
 import org.apache.carbondata.core.metadata.ColumnIdentifier
 import org.apache.carbondata.core.metadata.datatype.{DataType => CarbonDataType, DataTypes => CarbonDataTypes, StructField => CarbonStructField}
 import org.apache.carbondata.core.metadata.encoder.Encoding
-import org.apache.carbondata.core.metadata.schema.table.CarbonTable
+import org.apache.carbondata.core.metadata.schema.table.{CarbonTable, DataMapSchemaStorageProvider}
 import org.apache.carbondata.core.metadata.schema.table.column.{CarbonColumn, ColumnSchema}
 import org.apache.carbondata.core.util.DataTypeUtil
 import org.apache.carbondata.processing.exception.DataLoadingException
@@ -628,5 +629,16 @@ object CarbonScalaUtil {
       case e: Exception =>
         // ignore it
     }
+  }
+
+  /**
+   * Create datamap provider using class name
+   */
+  def createDataMapProvider(className: String, sparkSession: SparkSession,
+      storageProvider: DataMapSchemaStorageProvider): Object = {
+    CarbonReflectionUtils.createObject(
+      className,
+      sparkSession,
+      storageProvider)._1.asInstanceOf[Object]
   }
 }

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/CarbonScalaUtil.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/CarbonScalaUtil.scala
@@ -342,7 +342,7 @@ object CarbonScalaUtil {
    */
   def updatePartitions(
       partitionSpec: Map[String, String],
-  table: CarbonTable): Map[String, String] = {
+      table: CarbonTable): Map[String, String] = {
     val cacheProvider: CacheProvider = CacheProvider.getInstance
     val forwardDictionaryCache: Cache[DictionaryColumnUniqueIdentifier, Dictionary] =
       cacheProvider.createCache(CacheType.FORWARD_DICTIONARY)

--- a/integration/spark2/src/main/java/org/apache/carbondata/datamap/DataMapManager.java
+++ b/integration/spark2/src/main/java/org/apache/carbondata/datamap/DataMapManager.java
@@ -17,10 +17,17 @@
 
 package org.apache.carbondata.datamap;
 
+import org.apache.carbondata.core.datamap.DataMapProvider;
+import org.apache.carbondata.core.datamap.IndexDataMapProvider;
 import org.apache.carbondata.core.metadata.schema.table.DataMapSchema;
+import org.apache.carbondata.core.metadata.schema.table.DataMapSchemaStorageProvider;
+import org.apache.carbondata.core.metadata.schema.table.DiskBasedDMSchemaStorageProvider;
+import org.apache.carbondata.core.util.CarbonProperties;
 
-import static org.apache.carbondata.core.metadata.schema.datamap.DataMapProvider.PREAGGREGATE;
-import static org.apache.carbondata.core.metadata.schema.datamap.DataMapProvider.TIMESERIES;
+import static org.apache.carbondata.core.metadata.schema.datamap.DataMapClassProvider.PREAGGREGATE;
+import static org.apache.carbondata.core.metadata.schema.datamap.DataMapClassProvider.TIMESERIES;
+
+import org.apache.spark.sql.SparkSession;
 
 public class DataMapManager {
 
@@ -36,18 +43,24 @@ public class DataMapManager {
   }
 
   /**
-   * Return a DataMapProvider instance for specified dataMapSchema.
+   * Return a DataMapClassProvider instance for specified dataMapSchema.
    */
-  public DataMapProvider getDataMapProvider(DataMapSchema dataMapSchema) {
+  public DataMapProvider getDataMapProvider(DataMapSchema dataMapSchema,
+      SparkSession sparkSession) {
     DataMapProvider provider;
     if (dataMapSchema.getProviderName().equalsIgnoreCase(PREAGGREGATE.toString())) {
-      provider = new PreAggregateDataMapProvider();
+      provider = new PreAggregateDataMapProvider(sparkSession);
     } else if (dataMapSchema.getProviderName().equalsIgnoreCase(TIMESERIES.toString())) {
-      provider = new TimeseriesDataMapProvider();
+      provider = new TimeseriesDataMapProvider(sparkSession);
     } else {
-      provider = new IndexDataMapProvider();
+      provider = new IndexDataMapProvider(getDataMapSchemaStorageProvider());
     }
     return provider;
+  }
+
+  private DataMapSchemaStorageProvider getDataMapSchemaStorageProvider() {
+    return new DiskBasedDMSchemaStorageProvider(
+        CarbonProperties.getInstance().getSystemFolderLocation());
   }
 
 }

--- a/integration/spark2/src/main/java/org/apache/carbondata/datamap/TimeseriesDataMapProvider.java
+++ b/integration/spark2/src/main/java/org/apache/carbondata/datamap/TimeseriesDataMapProvider.java
@@ -32,9 +32,13 @@ import scala.Tuple2;
 @InterfaceAudience.Internal
 public class TimeseriesDataMapProvider extends PreAggregateDataMapProvider {
 
+  public TimeseriesDataMapProvider(SparkSession sparkSession) {
+    super(sparkSession);
+  }
+
   @Override
-  public void initMeta(CarbonTable mainTable, DataMapSchema dataMapSchema, String ctasSqlStatement,
-      SparkSession sparkSession) {
+  public void initMeta(CarbonTable mainTable, DataMapSchema dataMapSchema,
+      String ctasSqlStatement) {
     Map<String, String> dmProperties = dataMapSchema.getProperties();
     String dmProviderName = dataMapSchema.getProviderName();
     TimeSeriesUtil.validateTimeSeriesGranularity(dmProperties, dmProviderName);

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/datamap/CarbonDataMapShowCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/datamap/CarbonDataMapShowCommand.scala
@@ -17,21 +17,24 @@
 
 package org.apache.spark.sql.execution.command.datamap
 
+import java.util
+
 import scala.collection.JavaConverters._
 
 import org.apache.spark.sql.{CarbonEnv, Row, SparkSession}
+import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
 import org.apache.spark.sql.execution.command.{Checker, DataCommand}
 import org.apache.spark.sql.types.StringType
 
+import org.apache.carbondata.core.datamap.DataMapStoreManager
+import org.apache.carbondata.core.metadata.schema.table.DataMapSchema
+
 /**
  * Show the datamaps on the table
- * @param databaseNameOp
- * @param tableName
+ * @param tableIdentifier
  */
-case class CarbonDataMapShowCommand(
-    databaseNameOp: Option[String],
-    tableName: String)
+case class CarbonDataMapShowCommand(tableIdentifier: Option[TableIdentifier])
   extends DataCommand {
 
   override def output: Seq[Attribute] = {
@@ -41,9 +44,23 @@ case class CarbonDataMapShowCommand(
   }
 
   override def processData(sparkSession: SparkSession): Seq[Row] = {
-    Checker.validateTableExists(databaseNameOp, tableName, sparkSession)
-    val carbonTable = CarbonEnv.getCarbonTable(databaseNameOp, tableName)(sparkSession)
-    val schemaList = carbonTable.getTableInfo.getDataMapSchemaList
+    tableIdentifier match {
+      case Some(table) =>
+        Checker.validateTableExists(table.database, table.table, sparkSession)
+        val carbonTable = CarbonEnv.getCarbonTable(table)(sparkSession)
+        if (carbonTable.hasDataMapSchema) {
+          val schemaList = carbonTable.getTableInfo.getDataMapSchemaList
+          convertToRow(schemaList)
+        } else {
+          convertToRow(DataMapStoreManager.getInstance().getAllDataMapSchemas(carbonTable))
+        }
+      case _ =>
+        convertToRow(DataMapStoreManager.getInstance().getAllDataMapSchemas)
+    }
+
+  }
+
+  private def convertToRow(schemaList: util.List[DataMapSchema]) = {
     if (schemaList != null && schemaList.size() > 0) {
       schemaList.asScala.map { s =>
         var table = "(NA)"

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/datamap/CarbonDropDataMapCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/datamap/CarbonDropDataMapCommand.scala
@@ -29,121 +29,155 @@ import org.apache.spark.sql.execution.command.preaaggregate.PreAggregateUtil
 import org.apache.carbondata.common.exceptions.MetadataProcessException
 import org.apache.carbondata.common.exceptions.sql.{MalformedCarbonCommandException, NoSuchDataMapException}
 import org.apache.carbondata.common.logging.{LogService, LogServiceFactory}
+import org.apache.carbondata.core.datamap.{DataMapProvider, DataMapStoreManager}
 import org.apache.carbondata.core.locks.{CarbonLockUtil, ICarbonLock, LockUsage}
 import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier
 import org.apache.carbondata.core.metadata.converter.ThriftWrapperSchemaConverterImpl
 import org.apache.carbondata.core.metadata.schema.table.{CarbonTable, DataMapSchema}
-import org.apache.carbondata.datamap.{DataMapManager, DataMapProvider}
+import org.apache.carbondata.datamap.DataMapManager
 import org.apache.carbondata.events._
 
 /**
  * Drops the datamap and any related tables associated with the datamap
  * @param dataMapName
  * @param ifExistsSet
- * @param databaseNameOp
- * @param tableName
+ * @param table
  */
 case class CarbonDropDataMapCommand(
     dataMapName: String,
     ifExistsSet: Boolean,
-    databaseNameOp: Option[String],
-    tableName: String,
+    table: Option[TableIdentifier],
     forceDrop: Boolean = false)
   extends AtomicRunnableCommand {
 
   private val LOGGER: LogService = LogServiceFactory.getLogService(this.getClass.getCanonicalName)
   private var dataMapProvider: DataMapProvider = _
-  private var mainTable: CarbonTable = _
-  private var dataMapSchema: DataMapSchema = _
+  var mainTable: CarbonTable = _
+  var dataMapSchema: DataMapSchema = _
 
   override def processMetadata(sparkSession: SparkSession): Seq[Row] = {
-    val dbName = CarbonEnv.getDatabaseName(databaseNameOp)(sparkSession)
-    val locksToBeAcquired = List(LockUsage.METADATA_LOCK)
-    val carbonEnv = CarbonEnv.getInstance(sparkSession)
-    val catalog = carbonEnv.carbonMetastore
-    val tablePath = CarbonEnv.getTablePath(databaseNameOp, tableName)(sparkSession)
-    val tableIdentifier =
-      AbsoluteTableIdentifier.from(tablePath, dbName.toLowerCase, tableName.toLowerCase)
-    catalog.checkSchemasModifiedTimeAndReloadTable(TableIdentifier(tableName, Some(dbName)))
-    val carbonLocks: scala.collection.mutable.ListBuffer[ICarbonLock] = ListBuffer()
-    try {
-      locksToBeAcquired foreach {
-        lock => carbonLocks += CarbonLockUtil.getLockObject(tableIdentifier, lock)
+    if (table.isDefined) {
+      val databaseNameOp = table.get.database
+      val tableName = table.get.table
+      val dbName = CarbonEnv.getDatabaseName(databaseNameOp)(sparkSession)
+      val locksToBeAcquired = List(LockUsage.METADATA_LOCK)
+      val carbonEnv = CarbonEnv.getInstance(sparkSession)
+      val catalog = carbonEnv.carbonMetastore
+      val tablePath = CarbonEnv.getTablePath(databaseNameOp, tableName)(sparkSession)
+      val tableIdentifier =
+        AbsoluteTableIdentifier.from(tablePath, dbName.toLowerCase, tableName.toLowerCase)
+      catalog.checkSchemasModifiedTimeAndReloadTable(TableIdentifier(tableName, Some(dbName)))
+      if (mainTable == null) {
+        mainTable = try {
+          CarbonEnv.getCarbonTable(databaseNameOp, tableName)(sparkSession)
+        } catch {
+          case ex: NoSuchTableException =>
+            throwMetadataException(dbName, tableName,
+              s"Dropping datamap $dataMapName failed: ${ ex.getMessage }")
+            null
+        }
       }
-      LOGGER.audit(s"Deleting datamap [$dataMapName] under table [$tableName]")
-      val carbonTable: Option[CarbonTable] = try {
-        Some(CarbonEnv.getCarbonTable(databaseNameOp, tableName)(sparkSession))
-      } catch {
-        case ex: NoSuchTableException =>
-          throw new MetadataProcessException(s"Dropping datamap $dataMapName failed", ex)
+      if (forceDrop && mainTable != null && dataMapSchema != null) {
+        if (dataMapSchema != null) {
+          dataMapProvider = DataMapManager.get.getDataMapProvider(dataMapSchema, sparkSession)
+        }
+        // TODO do a check for existance before dropping
+        dataMapProvider.freeMeta(mainTable, dataMapSchema)
+        return Seq.empty
       }
-      // If datamap to be dropped in parent table then drop the datamap from metastore and remove
-      // entry from parent table.
-      // If force drop is true then remove the datamap from hivemetastore. No need to remove from
-      // parent as the first condition would have taken care of it.
-      if (carbonTable.isDefined && carbonTable.get.getTableInfo.getDataMapSchemaList.size() > 0) {
-        mainTable = carbonTable.get
-        val dataMapSchemaOp = mainTable.getTableInfo.getDataMapSchemaList.asScala.zipWithIndex.
-          find(_._1.getDataMapName.equalsIgnoreCase(dataMapName))
-        if (dataMapSchemaOp.isDefined) {
-          dataMapSchema = dataMapSchemaOp.get._1
-          val operationContext = new OperationContext
-          val dropDataMapPreEvent =
-            DropDataMapPreEvent(
-              Some(dataMapSchema),
-              ifExistsSet,
-              sparkSession)
-          OperationListenerBus.getInstance.fireEvent(dropDataMapPreEvent, operationContext)
-          mainTable.getTableInfo.getDataMapSchemaList.remove(dataMapSchemaOp.get._2)
-          val schemaConverter = new ThriftWrapperSchemaConverterImpl
-          PreAggregateUtil.updateSchemaInfo(
-            mainTable,
-            schemaConverter.fromWrapperToExternalTableInfo(
-              mainTable.getTableInfo,
-              dbName,
-              tableName))(sparkSession)
-          dataMapProvider = DataMapManager.get.getDataMapProvider(dataMapSchema)
-          dataMapProvider.freeMeta(mainTable, dataMapSchema, sparkSession)
+      val carbonLocks: scala.collection.mutable.ListBuffer[ICarbonLock] = ListBuffer()
+      try {
+        locksToBeAcquired foreach {
+          lock => carbonLocks += CarbonLockUtil.getLockObject(tableIdentifier, lock)
+        }
+        LOGGER.audit(s"Deleting datamap [$dataMapName] under table [$tableName]")
+        // If datamap to be dropped in parent table then drop the datamap from metastore and remove
+        // entry from parent table.
+        // If force drop is true then remove the datamap from hivemetastore. No need to remove from
+        // parent as the first condition would have taken care of it.
+        if (mainTable != null && mainTable.getTableInfo.getDataMapSchemaList.size() > 0) {
+          val dataMapSchemaOp = mainTable.getTableInfo.getDataMapSchemaList.asScala.zipWithIndex.
+            find(_._1.getDataMapName.equalsIgnoreCase(dataMapName))
+          if (dataMapSchemaOp.isDefined) {
+            dataMapSchema = dataMapSchemaOp.get._1
+            val operationContext = new OperationContext
+            val dropDataMapPreEvent =
+              DropDataMapPreEvent(
+                Some(dataMapSchema),
+                ifExistsSet,
+                sparkSession)
+            OperationListenerBus.getInstance.fireEvent(dropDataMapPreEvent, operationContext)
+            mainTable.getTableInfo.getDataMapSchemaList.remove(dataMapSchemaOp.get._2)
+            val schemaConverter = new ThriftWrapperSchemaConverterImpl
+            PreAggregateUtil.updateSchemaInfo(
+              mainTable,
+              schemaConverter.fromWrapperToExternalTableInfo(
+                mainTable.getTableInfo,
+                dbName,
+                tableName))(sparkSession)
+            if (dataMapProvider == null) {
+              dataMapProvider = DataMapManager.get.getDataMapProvider(dataMapSchema, sparkSession)
+            }
+            dataMapProvider.freeMeta(mainTable, dataMapSchema)
 
-          // fires the event after dropping datamap from main table schema
-          val dropDataMapPostEvent =
-            DropDataMapPostEvent(
-              Some(dataMapSchema),
-              ifExistsSet,
-              sparkSession)
-          OperationListenerBus.getInstance.fireEvent(dropDataMapPostEvent, operationContext)
-        } else if (!ifExistsSet) {
-          throw new NoSuchDataMapException(dataMapName, tableName)
+            // fires the event after dropping datamap from main table schema
+            val dropDataMapPostEvent =
+              DropDataMapPostEvent(
+                Some(dataMapSchema),
+                ifExistsSet,
+                sparkSession)
+            OperationListenerBus.getInstance.fireEvent(dropDataMapPostEvent, operationContext)
+          } else if (!ifExistsSet) {
+            throw new NoSuchDataMapException(dataMapName, tableName)
+          }
+        } else if (mainTable != null &&
+                   mainTable.getTableInfo.getDataMapSchemaList.size() == 0) {
+          if (!ifExistsSet) {
+            throw new NoSuchDataMapException(dataMapName, tableName)
+          }
         }
-      } else if (carbonTable.isDefined &&
-                 carbonTable.get.getTableInfo.getDataMapSchemaList.size() == 0) {
-        if (!ifExistsSet) {
-          throw new NoSuchDataMapException(dataMapName, tableName)
+      } catch {
+        case e: NoSuchDataMapException =>
+          throw e
+        case ex: Exception =>
+          LOGGER.error(ex, s"Dropping datamap $dataMapName failed")
+          throwMetadataException(dbName, tableName,
+            s"Dropping datamap $dataMapName failed: ${ ex.getMessage }")
+      }
+      finally {
+        if (carbonLocks.nonEmpty) {
+          val unlocked = carbonLocks.forall(_.unlock())
+          if (unlocked) {
+            LOGGER.info("Table MetaData Unlocked Successfully")
+          }
         }
       }
-    } catch {
-      case e: NoSuchDataMapException =>
-        throw e
-      case ex: Exception =>
-        LOGGER.error(ex, s"Dropping datamap $dataMapName failed")
-        throwMetadataException(dbName, tableName,
-          s"Dropping datamap $dataMapName failed: ${ex.getMessage}")
-    }
-    finally {
-      if (carbonLocks.nonEmpty) {
-        val unlocked = carbonLocks.forall(_.unlock())
-        if (unlocked) {
-          LOGGER.info("Table MetaData Unlocked Successfully")
+    } else {
+      if (dataMapSchema == null) {
+        val schema = DataMapStoreManager.getInstance().getAllDataMapSchemas.asScala.find{dm =>
+          dm.getDataMapName.equalsIgnoreCase(dataMapName)
+        }
+        dataMapSchema = schema match {
+          case Some(dmSchema) => dmSchema
+          case _ => null
         }
       }
+      if (dataMapSchema != null) {
+        // TODO do a check for existance before dropping
+        dataMapProvider = DataMapManager.get.getDataMapProvider(dataMapSchema, sparkSession)
+        dataMapProvider.freeMeta(mainTable, dataMapSchema)
+      } else if (!ifExistsSet) {
+        new MalformedCarbonCommandException(s"DataMap $dataMapName does not exist")
+      }
     }
-    Seq.empty
+
+      Seq.empty
   }
 
   override def processData(sparkSession: SparkSession): Seq[Row] = {
     // delete the table folder
     if (dataMapProvider != null) {
-      dataMapProvider.freeData(mainTable, dataMapSchema, sparkSession)
+      dataMapProvider.freeData(mainTable, dataMapSchema)
     }
     Seq.empty
   }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/timeseries/TimeSeriesUtil.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/timeseries/TimeSeriesUtil.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.execution.command.{DataMapField, Field}
 
 import org.apache.carbondata.common.exceptions.sql.{MalformedCarbonCommandException, MalformedDataMapCommandException}
 import org.apache.carbondata.core.metadata.datatype.DataTypes
-import org.apache.carbondata.core.metadata.schema.datamap.DataMapProvider.TIMESERIES
+import org.apache.carbondata.core.metadata.schema.datamap.DataMapClassProvider.TIMESERIES
 import org.apache.carbondata.core.metadata.schema.datamap.Granularity
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable
 import org.apache.carbondata.core.preagg.TimeSeriesUDF

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSpark2SqlParser.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSpark2SqlParser.scala
@@ -150,13 +150,19 @@ class CarbonSpark2SqlParser extends CarbonDDLSqlParser {
    */
   protected lazy val createDataMap: Parser[LogicalPlan] =
     CREATE ~> DATAMAP ~> opt(IF ~> NOT ~> EXISTS) ~ ident ~
-    (ON ~ TABLE) ~  (ident <~ ".").? ~ ident ~
+    opt(ontable) ~
     (USING ~> stringLit) ~ (DMPROPERTIES ~> "(" ~> repsep(loadOptions, ",") <~ ")").? ~
     (AS ~> restInput).? <~ opt(";") ^^ {
-      case ifnotexists ~ dmname ~ ontable ~ dbName ~ tableName ~ className ~ dmprops ~ query =>
+      case ifnotexists ~ dmname ~ tableIdent ~ className ~ dmprops ~ query =>
+
         val map = dmprops.getOrElse(List[(String, String)]()).toMap[String, String]
-        CarbonCreateDataMapCommand(
-          dmname, TableIdentifier(tableName, dbName), className, map, query, ifnotexists.isDefined)
+        CarbonCreateDataMapCommand(dmname, tableIdent, className, map, query, ifnotexists.isDefined)
+    }
+
+  protected lazy val ontable: Parser[TableIdentifier] =
+    ON ~> TABLE ~>  (ident <~ ".").? ~ ident ^^ {
+      case dbName ~ tableName =>
+        TableIdentifier(tableName, dbName)
     }
 
   /**
@@ -164,10 +170,9 @@ class CarbonSpark2SqlParser extends CarbonDDLSqlParser {
    * DROP DATAMAP IF EXISTS datamapName ON TABLE tablename
    */
   protected lazy val dropDataMap: Parser[LogicalPlan] =
-    DROP ~> DATAMAP ~> opt(IF ~> EXISTS) ~ ident ~ (ON ~ TABLE) ~
-    (ident <~ ".").? ~ ident <~ opt(";")  ^^ {
-      case ifexists ~ dmname ~ ontable ~ dbName ~ tableName =>
-        CarbonDropDataMapCommand(dmname, ifexists.isDefined, dbName, tableName)
+    DROP ~> DATAMAP ~> opt(IF ~> EXISTS) ~ ident ~ opt(ontable) <~ opt(";")  ^^ {
+      case ifexists ~ dmname ~ tableIdent =>
+        CarbonDropDataMapCommand(dmname, ifexists.isDefined, tableIdent)
     }
 
   /**
@@ -175,9 +180,9 @@ class CarbonSpark2SqlParser extends CarbonDDLSqlParser {
    * SHOW DATAMAP ON TABLE tableName
    */
   protected lazy val showDataMap: Parser[LogicalPlan] =
-    SHOW ~> DATAMAP ~> ON ~> TABLE ~> (ident <~ ".").? ~ ident <~ opt(";") ^^ {
-      case databaseName ~ tableName =>
-        CarbonDataMapShowCommand(convertDbNameToLowerCase(databaseName), tableName.toLowerCase())
+    SHOW ~> DATAMAP ~> opt(ontable) <~ opt(";") ^^ {
+      case tableIdent =>
+        CarbonDataMapShowCommand(tableIdent)
     }
 
   protected lazy val deleteRecords: Parser[LogicalPlan] =

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSpark2SqlParser.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSpark2SqlParser.scala
@@ -145,7 +145,7 @@ class CarbonSpark2SqlParser extends CarbonDDLSqlParser {
 
   /**
    * The syntax of datamap creation is as follows.
-   * CREATE DATAMAP IF NOT EXISTS datamapName ON TABLE tableName USING 'DataMapClassName'
+   * CREATE DATAMAP IF NOT EXISTS datamapName [ON TABLE tableName] USING 'DataMapClassName'
    * DMPROPERTIES('KEY'='VALUE') AS SELECT COUNT(COL1) FROM tableName
    */
   protected lazy val createDataMap: Parser[LogicalPlan] =
@@ -167,7 +167,7 @@ class CarbonSpark2SqlParser extends CarbonDDLSqlParser {
 
   /**
    * The below syntax is used to drop the datamap.
-   * DROP DATAMAP IF EXISTS datamapName ON TABLE tablename
+   * DROP DATAMAP IF EXISTS datamapName [ON TABLE tablename]
    */
   protected lazy val dropDataMap: Parser[LogicalPlan] =
     DROP ~> DATAMAP ~> opt(IF ~> EXISTS) ~ ident ~ opt(ontable) <~ opt(";")  ^^ {
@@ -177,7 +177,7 @@ class CarbonSpark2SqlParser extends CarbonDDLSqlParser {
 
   /**
    * The syntax of show datamap is used to show datamaps on the table
-   * SHOW DATAMAP ON TABLE tableName
+   * SHOW DATAMAP [ON TABLE tableName]
    */
   protected lazy val showDataMap: Parser[LogicalPlan] =
     SHOW ~> DATAMAP ~> opt(ontable) <~ opt(";") ^^ {


### PR DESCRIPTION
**Problem** 
Currently, datamap schema is saved inside the main table schema itself. This approach cannot satisfy if a datamap belongs to more than one table. For suppose if we need to create a datamap joining 2 tables then we cannot keep the datamap schema under any one table. 
And also accessing the datamaps required to read the main table schema every time, it is not well optimized. And if we need to create multiple datamaps for a table then all datamaps need to store under the schema of that table so the size of main table schema grows and impacts the performance.

**Solution**
Make the datamap schema independent of main table schema. And store the schema under `_system` folder location. This location is configurable by using carbon property `carbon.system.folder.location` , by default, it stores under the store location.
Created datamap schema in JSON format for better readability. And has the interfaces to store it in database but not given any implementation to it in this PR.
Made `on table <tablename>`  for datamap  DDL as optional , so now user can create/drop or show datamaps without `on table ` option. 

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 
 - [x] Any backward compatibility impacted?
 
 - [x] Document update required?

 - [x] Testing done
        Tests added
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

