### PR TITLE
[CARBONDATA-2294] Partition preaggregate support

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/metadata/SegmentFileStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/SegmentFileStore.java
@@ -579,13 +579,15 @@ public class SegmentFileStore {
    * @throws IOException
    */
   public static void commitDropPartitions(CarbonTable carbonTable, String uniqueId,
-      List<String> toBeUpdatedSegments, List<String> toBeDeleteSegments) throws IOException {
+      List<String> toBeUpdatedSegments, List<String> toBeDeleteSegments,
+      String uuid) throws IOException {
     if (toBeDeleteSegments.size() > 0 || toBeUpdatedSegments.size() > 0) {
       Set<Segment> segmentSet = new HashSet<>(
           new SegmentStatusManager(carbonTable.getAbsoluteTableIdentifier())
               .getValidAndInvalidSegments().getValidSegments());
       CarbonUpdateUtil.updateTableMetadataStatus(segmentSet, carbonTable, uniqueId, true,
-          Segment.toSegmentList(toBeDeleteSegments), Segment.toSegmentList(toBeUpdatedSegments));
+          Segment.toSegmentList(toBeDeleteSegments), Segment.toSegmentList(toBeUpdatedSegments),
+          uuid);
     }
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/mutate/CarbonUpdateUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/mutate/CarbonUpdateUtil.java
@@ -184,7 +184,7 @@ public class CarbonUpdateUtil {
       CarbonTable table, String updatedTimeStamp, boolean isTimestampUpdationRequired,
       List<Segment> segmentsToBeDeleted) {
     return updateTableMetadataStatus(updatedSegmentsList, table, updatedTimeStamp,
-        isTimestampUpdationRequired, segmentsToBeDeleted, new ArrayList<Segment>());
+        isTimestampUpdationRequired, segmentsToBeDeleted, new ArrayList<Segment>(), "");
   }
 
   /**
@@ -198,12 +198,13 @@ public class CarbonUpdateUtil {
    */
   public static boolean updateTableMetadataStatus(Set<Segment> updatedSegmentsList,
       CarbonTable table, String updatedTimeStamp, boolean isTimestampUpdationRequired,
-      List<Segment> segmentsToBeDeleted, List<Segment> segmentFilesTobeUpdated) {
+      List<Segment> segmentsToBeDeleted, List<Segment> segmentFilesTobeUpdated, String uuid) {
 
     boolean status = false;
     String metaDataFilepath = table.getMetadataPath();
     AbsoluteTableIdentifier identifier = table.getAbsoluteTableIdentifier();
-    String tableStatusPath = CarbonTablePath.getTableStatusFilePath(identifier.getTablePath());
+    String tableStatusPath =
+        CarbonTablePath.getTableStatusFilePathWithUUID(identifier.getTablePath(), uuid);
     SegmentStatusManager segmentStatusManager = new SegmentStatusManager(identifier);
 
     ICarbonLock carbonLock = segmentStatusManager.getTableStatusLock();
@@ -570,7 +571,7 @@ public class CarbonUpdateUtil {
           UUID,
           false,
           new ArrayList<Segment>(),
-          segmentFilesToBeUpdatedLatest);
+          segmentFilesToBeUpdatedLatest, "");
     }
 
     // delete the update table status files which are old.

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonSessionInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonSessionInfo.java
@@ -21,8 +21,6 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.carbondata.core.exception.InvalidConfigurationException;
-
 /**
  * This class maintains carbon session information details
  */
@@ -60,20 +58,8 @@ public class CarbonSessionInfo implements Serializable, Cloneable {
   public CarbonSessionInfo clone() throws CloneNotSupportedException {
     super.clone();
     CarbonSessionInfo newObj = new CarbonSessionInfo();
-    for (Map.Entry<String, String> entry : sessionParams.getAll().entrySet()) {
-      try {
-        newObj.getSessionParams().addProperty(entry.getKey(), entry.getValue(), false);
-      } catch (InvalidConfigurationException ex) {
-        ex.printStackTrace();
-      }
-    }
-    for (Map.Entry<String, String> entry : threadParams.getAll().entrySet()) {
-      try {
-        newObj.getThreadParams().addProperty(entry.getKey(), entry.getValue(), false);
-      } catch (InvalidConfigurationException ex) {
-        ex.printStackTrace();
-      }
-    }
+    newObj.setSessionParams(sessionParams.clone());
+    newObj.setThreadParams(threadParams.clone());
     Map<String, Object> nonSerializableExtraInfo = getNonSerializableExtraInfo();
     for (Map.Entry<String, Object> entry : nonSerializableExtraInfo.entrySet()) {
       nonSerializableExtraInfo.put(entry.getKey(), entry.getValue());

--- a/core/src/main/java/org/apache/carbondata/core/util/SessionParams.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/SessionParams.java
@@ -47,7 +47,7 @@ import static org.apache.carbondata.core.constants.CarbonLoadOptionConstants.CAR
 /**
  * This class maintains carbon session params
  */
-public class SessionParams implements Serializable {
+public class SessionParams implements Serializable, Cloneable {
 
   private static final LogService LOGGER =
       LogServiceFactory.getLogService(CacheProvider.class.getName());
@@ -228,4 +228,12 @@ public class SessionParams implements Serializable {
     sProps.clear();
   }
 
+  public SessionParams clone() throws CloneNotSupportedException {
+    super.clone();
+    SessionParams newObj = new SessionParams();
+    newObj.addedProps.putAll(this.addedProps);
+    newObj.sProps.putAll(this.sProps);
+    newObj.extraInfo.putAll(this.extraInfo);
+    return newObj;
+  }
 }

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/events/AlterTableEvents.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/events/AlterTableEvents.scala
@@ -17,8 +17,10 @@
 package org.apache.carbondata.events
 
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
 import org.apache.spark.sql.execution.command._
 
+import org.apache.carbondata.core.indexstore.PartitionSpec
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable
 import org.apache.carbondata.processing.loading.model.CarbonLoadModel
 
@@ -80,7 +82,6 @@ case class AlterTableDropColumnAbortEvent(
     carbonTable: CarbonTable,
     alterTableDropColumnModel: AlterTableDropColumnModel,
     sparkSession: SparkSession) extends Event with AlterTableDropColumnEventInfo
-
 
 /**
  *
@@ -231,3 +232,14 @@ case class PreAlterTableHivePartitionCommandEvent(sparkSession: SparkSession,
  */
 case class PostAlterTableHivePartitionCommandEvent(sparkSession: SparkSession,
     carbonTable: CarbonTable) extends Event with AlterTableHivePartitionInfo
+
+case class AlterTableDropPartitionMetaEvent(parentCarbonTable: CarbonTable,
+    specs: Seq[TablePartitionSpec],
+    ifExists: Boolean,
+    purge: Boolean,
+    retainData: Boolean)
+  extends Event with AlterTableDropPartitionEventInfo
+
+case class AlterTableDropPartitionPreStatusEvent(carbonTable: CarbonTable) extends Event
+
+case class AlterTableDropPartitionPostStatusEvent(carbonTable: CarbonTable) extends Event

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/events/Events.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/events/Events.scala
@@ -18,8 +18,10 @@
 package org.apache.carbondata.events
 
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
 import org.apache.spark.sql.execution.command.{AlterTableAddColumnsModel, AlterTableDataTypeChangeModel, AlterTableDropColumnModel, AlterTableRenameModel, CarbonMergerMapping}
 
+import org.apache.carbondata.core.indexstore.PartitionSpec
 import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable
 import org.apache.carbondata.processing.loading.model.CarbonLoadModel
@@ -67,6 +69,14 @@ trait DropTableEventInfo {
 trait AlterTableDropColumnEventInfo {
   val carbonTable: CarbonTable
   val alterTableDropColumnModel: AlterTableDropColumnModel
+}
+
+trait AlterTableDropPartitionEventInfo {
+  val parentCarbonTable: CarbonTable
+  val specs: Seq[TablePartitionSpec]
+  val ifExists: Boolean
+  val purge: Boolean
+  val retainData: Boolean
 }
 
 trait AlterTableDataTypeChangeEventInfo {

--- a/integration/spark-common/src/main/scala/org/apache/spark/util/PartitionUtils.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/util/PartitionUtils.scala
@@ -218,7 +218,7 @@ object PartitionUtils {
         alterPartitionModel.carbonLoadModel.getFactTimeStamp.toString,
         true,
         new util.ArrayList[Segment](0),
-        new util.ArrayList[Segment](segmentFiles))) {
+        new util.ArrayList[Segment](segmentFiles), "")) {
         throw new IOException("Data update failed due to failure in table status updation.")
       }
     }

--- a/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -449,7 +449,7 @@ object CarbonDataRDDFactory {
           updateModel.get.updatedTimeStamp + "",
           true,
           new util.ArrayList[Segment](0),
-          new util.ArrayList[Segment](segmentFiles))) {
+          new util.ArrayList[Segment](segmentFiles), "")) {
           LOGGER.audit("Data update is successful for " +
                        s"${ carbonLoadModel.getDatabaseName }.${ carbonLoadModel.getTableName }")
         } else {

--- a/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonTableCompactor.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonTableCompactor.scala
@@ -238,6 +238,8 @@ class CarbonTableCompactor(carbonLoadModel: CarbonLoadModel,
             carbonLoadModel.getFactTimeStamp.toString)
         }
       }
+      // Used to inform the commit listener that the commit is fired from compaction flow.
+      operationContext.setProperty("isCompaction", "true")
       // trigger event for compaction
       val alterTableCompactionPreStatusUpdateEvent =
       AlterTableCompactionPreStatusUpdateEvent(sc.sparkSession,
@@ -270,8 +272,6 @@ class CarbonTableCompactor(carbonLoadModel: CarbonLoadModel,
         carbonMergerMapping,
         carbonLoadModel,
         mergedLoadName)
-      // Used to inform the commit listener that the commit is fired from compaction flow.
-      operationContext.setProperty("isCompaction", "true")
       val commitComplete = try {
         // Once main table compaction is done and 0.1, 4.1, 8.1 is created commit will happen for
         // all the tables. The commit listener will compact the child tables until no more segments

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
@@ -170,6 +170,11 @@ object CarbonEnv {
       .addListener(classOf[LoadMetadataEvent], CompactionProcessMetaListener)
       .addListener(classOf[LoadTablePostStatusUpdateEvent], CommitPreAggregateListener)
       .addListener(classOf[AlterTableCompactionPostStatusUpdateEvent], CommitPreAggregateListener)
+      .addListener(classOf[AlterTableDropPartitionPreStatusEvent],
+        AlterTableDropPartitionPreStatusListener)
+      .addListener(classOf[AlterTableDropPartitionPostStatusEvent],
+        AlterTableDropPartitionPostStatusListener)
+      .addListener(classOf[AlterTableDropPartitionMetaEvent], AlterTableDropPartitionMetaListener)
   }
 
   def registerCommonListener(sparkSession: SparkSession): Unit = {

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/preaaggregate/PreAggregateUtil.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/preaaggregate/PreAggregateUtil.scala
@@ -593,7 +593,6 @@ object PreAggregateUtil {
       parentTableIdentifier.table, validateSegments.toString)
     CarbonSession.threadSet(CarbonCommonConstants.SUPPORT_DIRECT_QUERY_ON_DATAMAP,
       "true")
-    CarbonSession.updateSessionInfoToCurrentThread(sparkSession)
     try {
       loadCommand.processData(sparkSession)
     } finally {

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/datasources/SparkCarbonTableFormat.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/datasources/SparkCarbonTableFormat.scala
@@ -207,7 +207,9 @@ with Serializable {
           taskIdMap.put(path, partitionNumber)
         }
         val taskID = context.getTaskAttemptID.getTaskID.getId
-        CarbonScalaUtil.generateUniqueNumber(taskID, segmentId, partitionNumber)
+        // In case of compaction the segmentId will be like 1.1. Therefore replacing '.' with ""
+        // so that unique number can be generated
+        CarbonScalaUtil.generateUniqueNumber(taskID, segmentId.replace(".", ""), partitionNumber)
       }
 
       override def getFileExtension(context: TaskAttemptContext): String = {


### PR DESCRIPTION
1. Allow creation of aggregate table on partition and non-partition columns 
2. Support to load data into aggregate table after insertion into parent table is complete.
3. Support to compact aggregate tables if parent table is compacted.
4. If parent table partition is dropped then drop the same partition in child tables also.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 
 - [x] Any backward compatibility impacted?
 
 - [x] Document update required?

 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

