### PR TITLE
[CARBONDATA-2289] If carbon merge index is enabled then after IUD ope…

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/indexstore/BlockletDataMapIndexStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/BlockletDataMapIndexStore.java
@@ -118,7 +118,13 @@ public class BlockletDataMapIndexStore
             .getIndexFileName(), indexFileStore.getFileData(identifier.getIndexFileName()));
     for (DataFileFooter footer : indexInfo) {
       String blockPath = footer.getBlockInfo().getTableBlockInfo().getFilePath();
-      blockMetaInfoMap.put(blockPath, createBlockMetaInfo(blockPath));
+      if (FileFactory.isFileExist(blockPath)) {
+        blockMetaInfoMap.put(blockPath, createBlockMetaInfo(blockPath));
+      } else {
+        LOGGER.warn("Skipping invalid block " + footer.getBlockInfo().getBlockUniqueName()
+            + " The block does not exist. The block might be got deleted due to clean up post"
+            + " update/delete operation over table.");
+      }
     }
     return blockMetaInfoMap;
   }

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/CarbonIndexFileMergeTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/CarbonIndexFileMergeTestCase.scala
@@ -178,6 +178,17 @@ class CarbonIndexFileMergeTestCase
     checkAnswer(sql("""Select count(*) from nonindexmerge"""), rows)
   }
 
+  test("Query should not fail after iud operation on a table having merge indexes") {
+    sql("drop table if exists mitable")
+    sql("create table mitable(id int, issue date) stored by 'carbondata'")
+    sql("insert into table mitable select '1','2000-02-01'")
+    val table = CarbonMetadata.getInstance().getCarbonTable("default", "mitable")
+    new CarbonIndexFileMergeWriter()
+      .mergeCarbonIndexFilesOfSegment("0", table.getTablePath, false)
+    sql("update mitable set(id)=(2) where issue = '2000-02-01'").show()
+    sql("clean files for table mitable")
+    sql("select * from mitable").show()
+  }
   private def getIndexFileCount(tableName: String, segment: String): Int = {
     val table = CarbonMetadata.getInstance().getCarbonTable(tableName)
     val path = CarbonTablePath


### PR DESCRIPTION
…ration if some blocks of a segment is deleted, then during query and IUD operation the driver is throwing FileNotFoundException while preparing BlockMetaInfo.
Solution:
Skiping the invalid(deleted) blocks and logig the same as warning.
Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [X] Any interfaces changed?
 None
 - [X] Any backward compatibility impacted?
 None
 - [X] Document update required?
None
 - [X] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       Added functional test for the same
 - [X] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
None
