### PR TITLE
[CARBONDATA-2292] Fix the problem of different module dependencies different version spark jar

### DIFF
--- a/integration/presto/pom.xml
+++ b/integration/presto/pom.xml
@@ -436,13 +436,13 @@
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-network-common_2.11</artifactId>
       <scope>test</scope>
-      <version>2.1.0</version>
+      <version>${spark.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_2.11</artifactId>
       <scope>test</scope>
-      <version>2.1.0</version>
+      <version>${spark.version}</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.hadoop</groupId>

--- a/integration/presto/pom.xml
+++ b/integration/presto/pom.xml
@@ -434,13 +434,13 @@
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-network-common_2.11</artifactId>
+      <artifactId>spark-network-common_${scala.binary.version}</artifactId>
       <scope>test</scope>
       <version>${spark.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_2.11</artifactId>
+      <artifactId>spark-core_${scala.binary.version}</artifactId>
       <scope>test</scope>
       <version>${spark.version}</version>
       <exclusions>


### PR DESCRIPTION
When select spark2.2 in profile, then dependencies jars will spark2.1.0 and spark2.2.1,, which maybe lead to conflict. Carbon should Fix the problem and keep one version

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

