### PR TITLE
[CARBONDATA-2296] Changed Test framework to take the folder location to generate store and met

### DIFF
--- a/integration/spark-common-cluster-test/src/test/scala/org/apache/carbondata/cluster/sdv/generated/CarbonV1toV3CompatabilityTestCase.scala
+++ b/integration/spark-common-cluster-test/src/test/scala/org/apache/carbondata/cluster/sdv/generated/CarbonV1toV3CompatabilityTestCase.scala
@@ -31,8 +31,8 @@ import org.apache.carbondata.core.util.CarbonProperties
 class CarbonV1toV3CompatabilityTestCase extends QueryTest with BeforeAndAfterAll {
 
   var localspark: CarbonSession = null
-  val storeLocation = s"${TestQueryExecutor.integrationPath}/spark-common-test/src/test/resources/Data/v1_version/store"
-  val metaLocation = s"${TestQueryExecutor.integrationPath}/spark-common-test/src/test/resources/Data/v1_version"
+  val storeLocation = s"${executor.integrationPath}/spark-common-test/src/test/resources/Data/v1_version/store"
+  val metaLocation = s"${executor.integrationPath}/spark-common-test/src/test/resources/Data/v1_version"
 
   override def beforeAll {
     sqlContext.sparkSession.stop()

--- a/integration/spark-common-cluster-test/src/test/scala/org/apache/carbondata/cluster/sdv/generated/SinglepassTestCase.scala
+++ b/integration/spark-common-cluster-test/src/test/scala/org/apache/carbondata/cluster/sdv/generated/SinglepassTestCase.scala
@@ -548,7 +548,7 @@ class SinglepassTestCase extends QueryTest with BeforeAndAfterAll {
 
 
       sql(
-        s"""LOAD DATA INPATH  '${TestQueryExecutor
+        s"""LOAD DATA INPATH  '${executor
           .integrationPath}/spark2/src/test/resources/bool/supportBooleanBadRecords.csv' into table uniqdata OPTIONS('DELIMITER'=',' , 'QUOTECHAR'='"','BAD_RECORDS_LOGGER_ENABLE'='TRUE', 'BAD_RECORDS_ACTION'='FAIL','FILEHEADER'='shortField,booleanField,intField,bigintField,doubleField,stringField,timestampField,decimalField,dateField,charField,floatField,complexData,booleanField2','SINGLE_Pass'='true')""".stripMargin)
         .collect
       checkAnswer(

--- a/integration/spark-common-cluster-test/src/test/scala/org/apache/carbondata/cluster/sdv/register/TestRegisterCarbonTable.scala
+++ b/integration/spark-common-cluster-test/src/test/scala/org/apache/carbondata/cluster/sdv/register/TestRegisterCarbonTable.scala
@@ -32,7 +32,7 @@ import org.apache.carbondata.spark.exception.ProcessMetaDataException
  *
  */
 class TestRegisterCarbonTable extends QueryTest with BeforeAndAfterAll {
-  var dbLocationCustom = TestQueryExecutor.warehouse +
+  var dbLocationCustom = executor.warehouse +
                          CarbonCommonConstants.FILE_SEPARATOR + "dbName"
   override def beforeAll {
     sql("drop database if exists carbon cascade")

--- a/integration/spark-common-cluster-test/src/test/scala/org/apache/carbondata/cluster/sdv/suite/SDVSuites.scala
+++ b/integration/spark-common-cluster-test/src/test/scala/org/apache/carbondata/cluster/sdv/suite/SDVSuites.scala
@@ -1,3 +1,4 @@
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -65,7 +66,7 @@ class SDVSuites extends Suites with BeforeAndAfterAll {
 
   override protected def afterAll() = {
     println("---------------- Stopping spark -----------------")
-    TestQueryExecutor.INSTANCE.stop()
+    executor.INSTANCE.stop()
     println("---------------- Stopped spark -----------------")
   }
 }
@@ -90,7 +91,7 @@ class SDVSuites1 extends Suites with BeforeAndAfterAll {
 
   override protected def afterAll() = {
     println("---------------- Stopping spark -----------------")
-    TestQueryExecutor.INSTANCE.stop()
+    executor.INSTANCE.stop()
     println("---------------- Stopped spark -----------------")
   }
 }
@@ -109,7 +110,7 @@ class SDVSuites2 extends Suites with BeforeAndAfterAll {
 
   override protected def afterAll() = {
     println("---------------- Stopping spark -----------------")
-    TestQueryExecutor.INSTANCE.stop()
+    executor.INSTANCE.stop()
     println("---------------- Stopped spark -----------------")
   }
 }
@@ -150,7 +151,7 @@ class SDVSuites3 extends Suites with BeforeAndAfterAll {
 
   override protected def afterAll() = {
     println("---------------- Stopping spark -----------------")
-    TestQueryExecutor.INSTANCE.stop()
+    executor.INSTANCE.stop()
     println("---------------- Stopped spark -----------------")
   }
 }
@@ -166,7 +167,7 @@ class SDVSuites4 extends Suites with BeforeAndAfterAll {
 
   override protected def afterAll() = {
     println("---------------- Stopping spark -----------------")
-    TestQueryExecutor.INSTANCE.stop()
+    executor.INSTANCE.stop()
     println("---------------- Stopped spark -----------------")
   }
 }

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestCreateTableAsSelect.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestCreateTableAsSelect.scala
@@ -151,8 +151,8 @@ class TestCreateTableAsSelect extends QueryTest with BeforeAndAfterAll {
       "create table ctas_tblproperties_test stored by 'carbondata' TBLPROPERTIES" +
         "('DICTIONARY_INCLUDE'='key', 'sort_scope'='global_sort') as select * from carbon_ctas_test")
     checkAnswer(sql("select * from ctas_tblproperties_test"), sql("select * from carbon_ctas_test"))
-    val carbonTable = CarbonEnv.getInstance(Spark2TestQueryExecutor.spark).carbonMetastore
-      .lookupRelation(Option("default"), "ctas_tblproperties_test")(Spark2TestQueryExecutor.spark)
+    val carbonTable = CarbonEnv.getInstance(sqlContext.sparkSession).carbonMetastore
+      .lookupRelation(Option("default"), "ctas_tblproperties_test")(sqlContext.sparkSession)
       .asInstanceOf[CarbonRelation].carbonTable
     val metadataFolderPath: CarbonFile = FileFactory.getCarbonFile(carbonTable.getMetadataPath)
     assert(metadataFolderPath.exists())

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestGlobalSortDataLoad.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestGlobalSortDataLoad.scala
@@ -25,7 +25,6 @@ import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.util.CarbonProperties
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.execution.BatchedDataSourceScanExec
-import org.apache.spark.sql.test.TestQueryExecutor.projectPath
 import org.apache.spark.sql.test.util.QueryTest
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 
@@ -310,7 +309,7 @@ class TestGlobalSortDataLoad extends QueryTest with BeforeAndAfterEach with Befo
   }
 
   test("Test with different date types") {
-    val path = s"$projectPath/examples/spark2/src/main/resources/data.csv"
+    val path = s"${executor.projectPath}/examples/spark2/src/main/resources/data.csv"
 
     sql("DROP TABLE IF EXISTS carbon_localsort_difftypes")
     sql(

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/standardpartition/StandardPartitionTableDropTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/standardpartition/StandardPartitionTableDropTestCase.scala
@@ -205,7 +205,7 @@ class StandardPartitionTableDropTestCase extends QueryTest with BeforeAndAfterAl
       sql(s"""select count (*) from originTable where empno=11"""))
     sql(s"""ALTER TABLE partitionone1 DROP PARTITION(empno='11')""")
     sql(s"CLEAN FILES FOR TABLE partitionone1").show()
-    assert(Files.notExists(Paths.get(TestQueryExecutor.warehouse + "/partitionone1/" + "empno=11"), LinkOption.NOFOLLOW_LINKS))
+    assert(Files.notExists(Paths.get(executor.warehouse + "/partitionone1/" + "empno=11"), LinkOption.NOFOLLOW_LINKS))
     sql("drop table if exists partitionone1")
   }
 

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/standardpartition/StandardPartitionTableQueryTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/standardpartition/StandardPartitionTableQueryTestCase.scala
@@ -249,7 +249,7 @@ test("Creation of partition table should fail if the colname in table schema and
   val exception = intercept[Exception]{
     sql("CREATE TABLE uniqdata_char2(name char,id int) partitioned by (NAME char)stored by 'carbondata' ")
   }
-  if(Spark2TestQueryExecutor.spark.version.startsWith("2.1.0")){
+  if(sqlContext.sparkSession.version.startsWith("2.1.0")){
     assert(exception.getMessage.contains("Operation not allowed: Partition columns should not be " +
                                          "specified in the schema: [\"name\"]"))
   }

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/test/util/QueryTest.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/test/util/QueryTest.scala
@@ -32,7 +32,11 @@ import org.apache.carbondata.core.util.CarbonProperties
 
 
 
-class QueryTest extends PlanTest {
+class QueryTest(targetLocation: String) extends PlanTest {
+
+  def this() {
+    this(null)
+  }
 
   val LOGGER = LogServiceFactory.getLogService(this.getClass.getCanonicalName)
 
@@ -110,16 +114,18 @@ class QueryTest extends PlanTest {
     }
   }
 
-  def sql(sqlText: String): DataFrame = TestQueryExecutor.INSTANCE.sql(sqlText)
+  def sql(sqlText: String): DataFrame = executor.INSTANCE.sql(sqlText)
 
-  val sqlContext: SQLContext = TestQueryExecutor.INSTANCE.sqlContext
+  val executor = TestQueryExecutor(targetLocation)
+
+  val sqlContext: SQLContext = executor.INSTANCE.sqlContext
 
   lazy val storeLocation = CarbonProperties.getInstance().
     getProperty(CarbonCommonConstants.STORE_LOCATION)
-  val resourcesPath = TestQueryExecutor.resourcesPath
-  val metastoredb = TestQueryExecutor.metastoredb
-  val integrationPath = TestQueryExecutor.integrationPath
-  val dblocation = TestQueryExecutor.location
+  val resourcesPath = executor.resourcesPath
+  val metastoredb = executor.metastoredb
+  val integrationPath = executor.integrationPath
+  val dblocation = executor.location
   val defaultParallelism = sqlContext.sparkContext.defaultParallelism
 }
 

--- a/integration/spark2/src/test/scala/org/apache/carbondata/spark/testsuite/booleantype/BooleanDataTypesFilterTest.scala
+++ b/integration/spark2/src/test/scala/org/apache/carbondata/spark/testsuite/booleantype/BooleanDataTypesFilterTest.scala
@@ -80,7 +80,7 @@ class BooleanDataTypesFilterTest extends QueryTest with BeforeAndAfterEach with 
     checkAnswer(sql("select count(*) from carbon_table where booleanField = true"),
       Row(4))
 
-    if (!Spark2TestQueryExecutor.spark.version.startsWith("2.2")) {
+    if (!sqlContext.sparkSession.version.startsWith("2.2")) {
       checkAnswer(sql("select count(*) from carbon_table where booleanField = 'true'"),
         Row(0))
 

--- a/integration/spark2/src/test/scala/org/apache/carbondata/spark/testsuite/booleantype/BooleanDataTypesLoadTest.scala
+++ b/integration/spark2/src/test/scala/org/apache/carbondata/spark/testsuite/booleantype/BooleanDataTypesLoadTest.scala
@@ -283,7 +283,7 @@ class BooleanDataTypesLoadTest extends QueryTest with BeforeAndAfterEach with Be
     checkAnswer(sql("select count(*) from boolean_table where booleanField = false or booleanField = true"),
       Row(10))
 
-    if (!Spark2TestQueryExecutor.spark.version.startsWith("2.2")) {
+    if (!sqlContext.sparkSession.version.startsWith("2.2")) {
       checkAnswer(sql("select count(*) from boolean_table where booleanField = 'true'"),
         Row(0))
 
@@ -373,7 +373,7 @@ class BooleanDataTypesLoadTest extends QueryTest with BeforeAndAfterEach with Be
     checkAnswer(sql("select count(*) from boolean_table where booleanField = false or booleanField = true"),
       Row(10))
 
-    if (!Spark2TestQueryExecutor.spark.version.startsWith("2.2")) {
+    if (!sqlContext.sparkSession.version.startsWith("2.2")) {
       checkAnswer(sql("select count(*) from boolean_table where booleanField = 'true'"),
         Row(0))
 

--- a/integration/spark2/src/test/scala/org/apache/carbondata/spark/util/DictionaryLRUCacheTestCase.scala
+++ b/integration/spark2/src/test/scala/org/apache/carbondata/spark/util/DictionaryLRUCacheTestCase.scala
@@ -39,8 +39,8 @@ class DictionaryLRUCacheTestCase extends Spark2QueryTest with BeforeAndAfterAll 
   var path : String = null
 
   def checkDictionaryAccessCount(databaseName: String, tableName: String): Unit = {
-    val carbonTable = CarbonEnv.getInstance(Spark2TestQueryExecutor.spark).carbonMetastore
-      .lookupRelation(Option(databaseName), tableName)(Spark2TestQueryExecutor.spark)
+    val carbonTable = CarbonEnv.getInstance(sqlContext.sparkSession).carbonMetastore
+      .lookupRelation(Option(databaseName), tableName)(sqlContext.sparkSession)
       .asInstanceOf[CarbonRelation].carbonTable
     val absoluteTableIdentifier = carbonTable.getAbsoluteTableIdentifier
 

--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/restructure/AlterTableRevertTestCase.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/restructure/AlterTableRevertTestCase.scala
@@ -54,9 +54,9 @@ class AlterTableRevertTestCase extends Spark2QueryTest with BeforeAndAfterAll {
 
   test("test to revert table name on failure") {
     val exception = intercept[ProcessMetaDataException] {
-      new File(TestQueryExecutor.warehouse + "/reverttest_fail").mkdir()
+      new File(executor.warehouse + "/reverttest_fail").mkdir()
       sql("alter table reverttest rename to reverttest_fail")
-      new File(TestQueryExecutor.warehouse + "/reverttest_fail").delete()
+      new File(executor.warehouse + "/reverttest_fail").delete()
     }
     val result = sql("select * from reverttest").count()
     assert(result.equals(1L))

--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/restructure/vectorreader/AddColumnTestCases.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/restructure/vectorreader/AddColumnTestCases.scala
@@ -298,7 +298,7 @@ class AddColumnTestCases extends Spark2QueryTest with BeforeAndAfterAll {
         "CREATE TABLE carbon_table(intField INT,stringField STRING,charField STRING,timestampField " +
         "TIMESTAMP)STORED BY 'carbondata' TBLPROPERTIES" +
         "('DICTIONARY_EXCLUDE'='charField')")
-      val lockFilePath = s"${ TestQueryExecutor.storeLocation }/default/carbon_table/meta.lock"
+      val lockFilePath = s"${ executor.storeLocation }/default/carbon_table/meta.lock"
       new File(lockFilePath).createNewFile()
       sql(
         "ALTER TABLE carbon_table ADD COLUMNS(newfield STRING) TBLPROPERTIES ('DEFAULT.VALUE.newfield'='c')")


### PR DESCRIPTION
Current test framework QueryTest will not take the location and it always generates the store and metastore at spark-commons/target location. There should be a way that QueryTest should take location so that other modules outside integration folder like datamaps can get benefitted

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
          
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

