### PR TITLE
[CARBONDATA-2275]Query Failed for 0 byte deletedelta file

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/AbstractDFSCarbonFile.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/AbstractDFSCarbonFile.java
@@ -521,7 +521,10 @@ public abstract class AbstractDFSCarbonFile implements CarbonFile {
       RemoteIterator<LocatedFileStatus> iter =
           path.getFileSystem(FileFactory.getConfiguration()).listLocatedStatus(path);
       while (iter.hasNext()) {
-        listStatus.add(iter.next());
+        LocatedFileStatus fileStatus = iter.next();
+        if (fileStatus.getLen() > 0) {
+          listStatus.add(fileStatus);
+        }
       }
       return getFiles(listStatus.toArray(new FileStatus[listStatus.size()]));
     }

--- a/core/src/main/java/org/apache/carbondata/core/mutate/DeleteDeltaBlockDetails.java
+++ b/core/src/main/java/org/apache/carbondata/core/mutate/DeleteDeltaBlockDetails.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 
 import org.apache.carbondata.common.logging.LogService;
@@ -63,12 +64,15 @@ public class DeleteDeltaBlockDetails implements Serializable {
   }
 
   public List<DeleteDeltaBlockletDetails> getBlockletDetails() {
-
     List<DeleteDeltaBlockletDetails> deleteDeltaBlockletDetailsList = new ArrayList<>();
-    Iterator<Map.Entry<String, DeleteDeltaBlockletDetails>> iterator =
-        blockletDetailsMap.entrySet().iterator();
-    while (iterator.hasNext()) {
-      deleteDeltaBlockletDetailsList.add(iterator.next().getValue());
+    if (null != blockletDetailsMap) {
+      Set<Map.Entry<String, DeleteDeltaBlockletDetails>> entries = blockletDetailsMap.entrySet();
+      if (null != entries && !entries.isEmpty()) {
+        Iterator<Map.Entry<String, DeleteDeltaBlockletDetails>> iterator = entries.iterator();
+        while (iterator.hasNext()) {
+          deleteDeltaBlockletDetailsList.add(iterator.next().getValue());
+        }
+      }
     }
     return deleteDeltaBlockletDetailsList;
   }

--- a/core/src/main/java/org/apache/carbondata/core/statusmanager/SegmentUpdateStatusManager.java
+++ b/core/src/main/java/org/apache/carbondata/core/statusmanager/SegmentUpdateStatusManager.java
@@ -352,7 +352,7 @@ public class SegmentUpdateStatusManager {
 
       @Override public boolean accept(CarbonFile pathName) {
         String fileName = pathName.getName();
-        if (fileName.endsWith(extension)) {
+        if (fileName.endsWith(extension) && pathName.getSize() > 0) {
           String firstPart = fileName.substring(0, fileName.indexOf('.'));
           String blockName =
               firstPart.substring(0, firstPart.lastIndexOf(CarbonCommonConstants.HYPHEN));
@@ -402,7 +402,8 @@ public class SegmentUpdateStatusManager {
 
           @Override public boolean accept(CarbonFile pathName) {
             String fileName = pathName.getName();
-            if (fileName.endsWith(CarbonCommonConstants.DELETE_DELTA_FILE_EXT)) {
+            if (fileName.endsWith(CarbonCommonConstants.DELETE_DELTA_FILE_EXT)
+                && pathName.getSize() > 0) {
               String firstPart = fileName.substring(0, fileName.indexOf('.'));
               String blkName = firstPart.substring(0, firstPart.lastIndexOf("-"));
               long timestamp = Long.parseLong(

--- a/core/src/main/java/org/apache/carbondata/core/writer/CarbonDeleteDeltaWriterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/writer/CarbonDeleteDeltaWriterImpl.java
@@ -27,7 +27,6 @@ import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.datastore.impl.FileFactory;
 import org.apache.carbondata.core.mutate.DeleteDeltaBlockDetails;
-import org.apache.carbondata.core.util.CarbonUtil;
 
 import com.google.gson.Gson;
 
@@ -74,6 +73,7 @@ public class CarbonDeleteDeltaWriterImpl implements CarbonDeleteDeltaWriter {
       brWriter.write(value);
     } catch (IOException ioe) {
       LOGGER.error("Error message: " + ioe.getLocalizedMessage());
+      throw ioe;
     } finally {
       if (null != brWriter) {
         brWriter.flush();
@@ -81,7 +81,10 @@ public class CarbonDeleteDeltaWriterImpl implements CarbonDeleteDeltaWriter {
       if (null != dataOutStream) {
         dataOutStream.flush();
       }
-      CarbonUtil.closeStreams(brWriter, dataOutStream);
+      if (null != brWriter) {
+        brWriter.close();
+      }
+
     }
 
   }
@@ -103,6 +106,7 @@ public class CarbonDeleteDeltaWriterImpl implements CarbonDeleteDeltaWriter {
       brWriter.write(deletedData);
     } catch (IOException ioe) {
       LOGGER.error("Error message: " + ioe.getLocalizedMessage());
+      throw ioe;
     } finally {
       if (null != brWriter) {
         brWriter.flush();
@@ -110,7 +114,9 @@ public class CarbonDeleteDeltaWriterImpl implements CarbonDeleteDeltaWriter {
       if (null != dataOutStream) {
         dataOutStream.flush();
       }
-      CarbonUtil.closeStreams(brWriter, dataOutStream);
+      if (null != brWriter) {
+        brWriter.close();
+      }
     }
 
   }


### PR DESCRIPTION
When delete is failed on write step because of any exception from hdfs . Currently 0 bye deletedelta file is created and not getting cleaned up .

So when any Select Query is triggered , Select Query is failed

Root Cause:-

deletedelta of 0 size was considered for reader and while getting the hostname it has thrown IndexOutofBound
Even Writer is failed while flush /close (exception from hdfs) but Exception is not thrown back to caller which is making delete operation is success.
Solution :-

While reading ignore 0 size deletedelta file
When Writer is failed ,Throw Failure Exception to caller and show error on query client .
deletedelta of 0 byte will be handled in cleanup automatically in next delete/update .
 Any interfaces changed?
NA
 Any backward compatibility impacted?
NA
 Document update required?
NA
 Testing done
Please provide details on
- Whether new unit test cases have been added or why no new tests are required?
- How it is tested? Please attach test report.
- Is it a performance related change? Please attach the performance test report.
- Any additional information to help reviewers in testing this change.
Testing is Done Manually.
 For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.
NA