### PR TITLE
[CARBONDATA-2296] Fix create datamap command with out on table syntax and correct the target location of test framework

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datamap/IndexDataMapProvider.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/IndexDataMapProvider.java
@@ -41,6 +41,10 @@ public class IndexDataMapProvider implements DataMapProvider {
   @Override
   public void initMeta(CarbonTable mainTable, DataMapSchema dataMapSchema, String ctasSqlStatement)
       throws MalformedDataMapCommandException, IOException {
+    if (mainTable == null) {
+      throw new MalformedDataMapCommandException(
+          "Parent table is required to create index datamap");
+    }
     ArrayList<RelationIdentifier> relationIdentifiers = new ArrayList<>();
     dataMapSchema.setParentTables(relationIdentifiers);
     relationIdentifiers.add(

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/datamap/CarbonCreateDataMapCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/datamap/CarbonCreateDataMapCommand.scala
@@ -55,7 +55,7 @@ case class CarbonCreateDataMapCommand(
         CarbonEnv.getCarbonTable(table.database, table.table)(sparkSession)
       case _ => null
     }
-    if (mainTable.getDataMapSchema(dataMapName) != null) {
+    if (mainTable != null && mainTable.getDataMapSchema(dataMapName) != null) {
       if (!ifNotExistsSet) {
         throw new MalformedDataMapCommandException(s"DataMap name '$dataMapName' already exist")
       } else {
@@ -64,7 +64,8 @@ case class CarbonCreateDataMapCommand(
     }
 
     dataMapSchema = new DataMapSchema(dataMapName, dmClassName)
-    if (mainTable.isStreamingTable &&
+    if (mainTable != null &&
+        mainTable.isStreamingTable &&
         !(dataMapSchema.getProviderName.equalsIgnoreCase(DataMapClassProvider.PREAGGREGATE.toString)
           || dataMapSchema.getProviderName
             .equalsIgnoreCase(DataMapClassProvider.TIMESERIES.toString))) {


### PR DESCRIPTION
Problem 
1 Create datamap command fails if user does not mention `on table` 
2 Test framework try to create metastore and store location in integration/spark-common location but if it runs from other modules like datamap it creates target location in wrong place.
Solution
Check the null for parent table if not present and always take the present module target location as store path location if it not under integration module.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

