### PR TITLE
[CARBONDATA-2298]Delete segment lock files before update metadata

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/statusmanager/SegmentStatusManager.java
+++ b/core/src/main/java/org/apache/carbondata/core/statusmanager/SegmentStatusManager.java
@@ -880,6 +880,8 @@ public class SegmentStatusManager {
       CarbonTable carbonTable,
       boolean isForceDeletion,
       List<PartitionSpec> partitionSpecs) throws IOException {
+    // delete the expired segment lock files
+    CarbonLockUtil.deleteExpiredSegmentLockFiles(carbonTable);
     if (isLoadDeletionRequired(carbonTable.getMetadataPath())) {
       AbsoluteTableIdentifier identifier = carbonTable.getAbsoluteTableIdentifier();
       ReturnTuple tuple = isUpdationRequired(isForceDeletion, carbonTable, identifier);
@@ -946,8 +948,6 @@ public class SegmentStatusManager {
         }
       }
     }
-    // delete the expired segment lock files
-    CarbonLockUtil.deleteExpiredSegmentLockFiles(carbonTable);
   }
 
   /**


### PR DESCRIPTION
If there are some COMPACTED segments and their last modified time is within one hour, the segment lock files deletion operation will not be executed.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?  No
 
 - [ ] Any backward compatibility impacted?  No
 
 - [ ] Document update required?  No

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

