### PR TITLE
[CARBONDATA-2300] Add ENABLE_UNSAFE_IN_QUERY_EXECUTION as a configuration parameter in presto integration

### DIFF
--- a/integration/presto/README.md
+++ b/integration/presto/README.md
@@ -18,7 +18,7 @@
 Please follow the below steps to query carbondata in presto
 
 ### Config presto server
-* Download presto server (0.186 is suggested and supported) : https://repo1.maven.org/maven2/com/facebook/presto/presto-server/
+* Download presto server (0.187 is suggested and supported) : https://repo1.maven.org/maven2/com/facebook/presto/presto-server/
 * Finish presto configuration following https://prestodb.io/docs/current/installation/deployment.html.
   A configuration example:
   ```
@@ -30,6 +30,8 @@ Please follow the below steps to query carbondata in presto
   query.max-memory-per-node=1GB
   discovery-server.enabled=true
   discovery.uri=http://localhost:8086
+  reorder-joins=true
+ 
   
   jvm.config:
   -server
@@ -60,9 +62,9 @@ Please follow the below steps to query carbondata in presto
   $ mvn -DskipTests -P{spark-version} -Dspark.version={spark-version-number} -Dhadoop.version={hadoop-version-number} clean package
   ```
   Replace the spark and hadoop version with the version used in your cluster.
-  For example, if you are using Spark 2.1.0 and Hadoop 2.7.2, you would like to compile using:
+  For example, if you are using Spark 2.2.1 and Hadoop 2.7.2, you would like to compile using:
   ```
-  mvn -DskipTests -Pspark-2.1 -Dspark.version=2.1.0 -Dhadoop.version=2.7.2 clean package
+  mvn -DskipTests -Pspark-2.2 -Dspark.version=2.2.1 -Dhadoop.version=2.7.2 clean package
   ```
 
   Secondly: Create a folder named 'carbondata' under $PRESTO_HOME$/plugin and
@@ -73,14 +75,16 @@ Please follow the below steps to query carbondata in presto
   ```
   connector.name=carbondata
   carbondata-store={schema-store-path}
+  enable.unsafe.in.query.processing=false
   carbon.unsafe.working.memory.in.mb={value}
   ```
   Replace the schema-store-path with the absolute path of the parent directory of the schema.
   For example, if you have a schema named 'default' stored in hdfs://namenode:9000/test/carbondata/,
   Then set carbondata-store=hdfs://namenode:9000/test/carbondata
   
-  carbon.unsafe.working.memory.in.mb property defines the limit for Unsafe Memory usage in Mega Bytes. Replace the value for it 
-  as per your need, if your tables are big you can increase the unsafe memory. The default value is 512 MB.
+  enable.unsafe.in.query.processing property by default is true in CarbonData system, the carbon.unsafe.working.memory.in.mb 
+  property defines the limit for Unsafe Memory usage in Mega Bytes, the default value is 512 MB.
+  If your tables are big you can increase the unsafe memory, or disable unsafe via setting enable.unsafe.in.query.processing=false.
 
   If you updated the jar balls or configuration files, make sure you have dispatched them
    to all the presto nodes and restarted the presto servers on the nodes. The updates will not take effect before restarting.

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/impl/CarbonTableConfig.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/impl/CarbonTableConfig.java
@@ -31,6 +31,7 @@ public class CarbonTableConfig {
   private String tablePath;
   private String storePath;
   private String unsafeMemoryInMb;
+  private String enableUnsafeInQueryExecution;
 
   @NotNull public String getDbPath() {
     return dbPath;
@@ -66,6 +67,16 @@ public class CarbonTableConfig {
   @Config("carbon.unsafe.working.memory.in.mb")
   public CarbonTableConfig setUnsafeMemoryInMb(String unsafeMemoryInMb) {
     this.unsafeMemoryInMb = unsafeMemoryInMb;
+    return this;
+  }
+
+  public String getEnableUnsafeInQueryExecution() {
+    return enableUnsafeInQueryExecution;
+  }
+
+  @Config("carbon.unsafe.working.memory.in.mb")
+  public CarbonTableConfig setEnableUnsafeInQueryExecution(String enableUnsafeInQueryExecution) {
+    this.enableUnsafeInQueryExecution = enableUnsafeInQueryExecution;
     return this;
   }
 }

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/impl/CarbonTableConfig.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/impl/CarbonTableConfig.java
@@ -74,7 +74,7 @@ public class CarbonTableConfig {
     return enableUnsafeInQueryExecution;
   }
 
-  @Config("carbon.unsafe.working.memory.in.mb")
+  @Config("enable.unsafe.in.query.processing")
   public CarbonTableConfig setEnableUnsafeInQueryExecution(String enableUnsafeInQueryExecution) {
     this.enableUnsafeInQueryExecution = enableUnsafeInQueryExecution;
     return this;

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/impl/CarbonTableReader.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/impl/CarbonTableReader.java
@@ -372,6 +372,11 @@ public class CarbonTableReader {
       CarbonProperties.getInstance().addProperty(CarbonCommonConstants.UNSAFE_WORKING_MEMORY_IN_MB,
           config.getUnsafeMemoryInMb());
     }
+    if(config.getEnableUnsafeInQueryExecution() != null) {
+      CarbonProperties.getInstance()
+          .addProperty(CarbonCommonConstants.ENABLE_UNSAFE_IN_QUERY_EXECUTION,
+          config.getEnableUnsafeInQueryExecution());
+    }
     CarbonTable carbonTable = tableCacheModel.carbonTable;
     TableInfo tableInfo = tableCacheModel.carbonTable.getTableInfo();
     Configuration config = new Configuration();

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/impl/CarbonTableReader.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/impl/CarbonTableReader.java
@@ -369,12 +369,13 @@ public class CarbonTableReader {
                                                      Expression filters)  {
     List<CarbonLocalInputSplit> result = new ArrayList<>();
     if(config.getUnsafeMemoryInMb() != null) {
-      CarbonProperties.getInstance().addProperty(CarbonCommonConstants.UNSAFE_WORKING_MEMORY_IN_MB,
+      CarbonProperties.getInstance().addProperty(
+          CarbonCommonConstants.UNSAFE_WORKING_MEMORY_IN_MB,
           config.getUnsafeMemoryInMb());
     }
     if(config.getEnableUnsafeInQueryExecution() != null) {
-      CarbonProperties.getInstance()
-          .addProperty(CarbonCommonConstants.ENABLE_UNSAFE_IN_QUERY_EXECUTION,
+      CarbonProperties.getInstance().addProperty(
+          CarbonCommonConstants.ENABLE_UNSAFE_IN_QUERY_EXECUTION,
           config.getEnableUnsafeInQueryExecution());
     }
     CarbonTable carbonTable = tableCacheModel.carbonTable;


### PR DESCRIPTION
Add ENABLE_UNSAFE_IN_QUERY_EXECUTION as a configuration parameter in presto integration
Provide this configuration parameter for users to disable the unsafe in query execution.


Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 NA
 - [X] Any backward compatibility impacted?
 YES
 - [X] Document update required?
YES
 - [X] Testing done
YES, Performance is better.
       
 - [X] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
YES

