### PR TITLE
[CARBONDATA-2303] If dataload is failed for parition table then cleaned the files on command execution

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/AbstractDFSCarbonFile.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/AbstractDFSCarbonFile.java
@@ -514,6 +514,18 @@ public abstract class AbstractDFSCarbonFile implements CarbonFile {
   }
 
   @Override
+  public List<CarbonFile> listFiles(Boolean recursive) throws IOException {
+    RemoteIterator<LocatedFileStatus> listStatus = null;
+    if (null != fileStatus && fileStatus.isDirectory()) {
+      Path path = fileStatus.getPath();
+      listStatus = path.getFileSystem(FileFactory.getConfiguration()).listFiles(path, recursive);
+    } else {
+      return new ArrayList<CarbonFile>();
+    }
+    return getFiles(listStatus);
+  }
+
+  @Override
   public CarbonFile[] locationAwareListFiles() throws IOException {
     if (null != fileStatus && fileStatus.isDirectory()) {
       List<FileStatus> listStatus = new ArrayList<>();
@@ -532,6 +544,9 @@ public abstract class AbstractDFSCarbonFile implements CarbonFile {
    * Get the CarbonFiles from filestatus array
    */
   protected abstract CarbonFile[] getFiles(FileStatus[] listStatus);
+
+  protected abstract List<CarbonFile> getFiles(RemoteIterator<LocatedFileStatus> listStatus)
+      throws IOException;
 
   @Override
   public String[] getLocations() throws IOException {

--- a/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/AlluxioCarbonFile.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/AlluxioCarbonFile.java
@@ -27,7 +27,9 @@ import org.apache.carbondata.core.datastore.impl.FileFactory;
 
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
 
 
@@ -67,6 +69,16 @@ public class AlluxioCarbonFile extends AbstractDFSCarbonFile {
     return files;
   }
 
+  @Override
+  protected List<CarbonFile> getFiles(RemoteIterator<LocatedFileStatus> listStatus)
+      throws IOException {
+    List<CarbonFile> carbonFiles = new ArrayList<>();
+    while (listStatus.hasNext()) {
+      Path filePath = listStatus.next().getPath();
+      carbonFiles.add(new AlluxioCarbonFile(filePath));
+    }
+    return carbonFiles;
+  }
 
   @Override
   public CarbonFile[] listFiles(final CarbonFileFilter fileFilter) {

--- a/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/CarbonFile.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/CarbonFile.java
@@ -20,6 +20,7 @@ package org.apache.carbondata.core.datastore.filesystem;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.util.List;
 
 import org.apache.carbondata.core.datastore.impl.FileFactory;
 
@@ -33,6 +34,8 @@ public interface CarbonFile {
   CarbonFile[] listFiles(CarbonFileFilter fileFilter);
 
   CarbonFile[] listFiles();
+
+  List<CarbonFile> listFiles(Boolean recurssive) throws IOException;
 
   /**
    * It returns list of files with location details.

--- a/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/HDFSCarbonFile.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/HDFSCarbonFile.java
@@ -27,7 +27,9 @@ import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
 
 public class HDFSCarbonFile extends AbstractDFSCarbonFile {
@@ -71,6 +73,17 @@ public class HDFSCarbonFile extends AbstractDFSCarbonFile {
       files[i] = new HDFSCarbonFile(listStatus[i]);
     }
     return files;
+  }
+
+  @Override
+  protected List<CarbonFile> getFiles(RemoteIterator<LocatedFileStatus> listStatus)
+      throws IOException {
+    List<CarbonFile> carbonFiles = new ArrayList<>();
+    while (listStatus.hasNext()) {
+      Path filePath = listStatus.next().getPath();
+      carbonFiles.add(new HDFSCarbonFile(filePath));
+    }
+    return carbonFiles;
   }
 
   @Override

--- a/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/LocalCarbonFile.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/LocalCarbonFile.java
@@ -30,6 +30,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.channels.FileChannel;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
@@ -43,6 +46,7 @@ import net.jpountz.lz4.LZ4BlockInputStream;
 import net.jpountz.lz4.LZ4BlockOutputStream;
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorOutputStream;
+import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
@@ -154,6 +158,22 @@ public class LocalCarbonFile implements CarbonFile {
 
     return carbonFiles;
 
+  }
+
+  @Override
+  public List<CarbonFile> listFiles(Boolean recurssive) {
+    if (!file.isDirectory()) {
+      return new ArrayList<CarbonFile>();
+    }
+    Collection<File> fileCollection = FileUtils.listFiles(file, null, true);
+    if (fileCollection == null) {
+      return new ArrayList<CarbonFile>();
+    }
+    List<CarbonFile> carbonFiles = new ArrayList<CarbonFile>();
+    for (File file : fileCollection) {
+      carbonFiles.add(new LocalCarbonFile(file));
+    }
+    return carbonFiles;
   }
 
   @Override public boolean createNewFile() {

--- a/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/ViewFSCarbonFile.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/ViewFSCarbonFile.java
@@ -26,7 +26,9 @@ import org.apache.carbondata.core.datastore.impl.FileFactory;
 
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.fs.viewfs.ViewFileSystem;
 
 public class ViewFSCarbonFile extends AbstractDFSCarbonFile {
@@ -62,6 +64,17 @@ public class ViewFSCarbonFile extends AbstractDFSCarbonFile {
       files[i] = new ViewFSCarbonFile(listStatus[i]);
     }
     return files;
+  }
+
+  @Override
+  protected List<CarbonFile> getFiles(RemoteIterator<LocatedFileStatus> listStatus)
+      throws IOException {
+    List<CarbonFile> carbonFiles = new ArrayList<>();
+    while (listStatus.hasNext()) {
+      Path filePath = listStatus.next().getPath();
+      carbonFiles.add(new ViewFSCarbonFile(filePath));
+    }
+    return carbonFiles;
   }
 
   @Override

--- a/core/src/main/java/org/apache/carbondata/core/util/path/CarbonTablePath.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/path/CarbonTablePath.java
@@ -410,6 +410,24 @@ public class CarbonTablePath {
     }
 
     /**
+     * gets updated timestamp information from given carbon data file name
+     * and compares with given timestamp
+     *
+     * @param fileName
+     * @param timestamp
+     * @return
+     */
+    public static Boolean compareCarbonFileTimeStamp(String fileName, Long timestamp) {
+      int lastIndexOfHyphen = fileName.lastIndexOf("-");
+      int lastIndexOfDot = fileName.lastIndexOf(".");
+      if (lastIndexOfHyphen > 0 && lastIndexOfDot > 0) {
+        return fileName.substring(fileName.lastIndexOf("-") + 1, fileName.lastIndexOf("."))
+            .equals(timestamp.toString());
+      }
+      return false;
+    }
+
+    /**
      * Return the timestamp present in the delete delta file.
      */
     public static String getTimeStampFromDeleteDeltaFile(String fileName) {

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/api/CarbonStore.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/api/CarbonStore.scala
@@ -21,6 +21,7 @@ import java.lang.Long
 
 import scala.collection.JavaConverters._
 
+import org.apache.hadoop.fs.{LocatedFileStatus, Path, RemoteIterator}
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.util.CarbonException
@@ -29,13 +30,15 @@ import org.apache.spark.unsafe.types.UTF8String
 import org.apache.carbondata.common.exceptions.sql.MalformedCarbonCommandException
 import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.core.constants.CarbonCommonConstants
+import org.apache.carbondata.core.datastore.filesystem.CarbonFile
 import org.apache.carbondata.core.datastore.impl.FileFactory
 import org.apache.carbondata.core.indexstore.PartitionSpec
 import org.apache.carbondata.core.locks.{CarbonLockUtil, ICarbonLock, LockUsage}
 import org.apache.carbondata.core.metadata.{AbsoluteTableIdentifier, SegmentFileStore}
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable
 import org.apache.carbondata.core.mutate.CarbonUpdateUtil
-import org.apache.carbondata.core.statusmanager.SegmentStatusManager
+import org.apache.carbondata.core.statusmanager.{SegmentStatus, SegmentStatusManager}
+import org.apache.carbondata.core.util.path.CarbonTablePath
 
 object CarbonStore {
   private val LOGGER = LogServiceFactory.getLogService(this.getClass.getCanonicalName)
@@ -151,11 +154,78 @@ object CarbonStore {
         }
       }
     } finally {
+      if (currentTablePartitions.equals(None)) {
+        cleanUpPartitionFoldersRecurssively(carbonTable, List.empty[PartitionSpec])
+      } else {
+        cleanUpPartitionFoldersRecurssively(carbonTable, currentTablePartitions.get.toList)
+      }
+
       if (carbonCleanFilesLock != null) {
         CarbonLockUtil.fileUnlock(carbonCleanFilesLock, LockUsage.CLEAN_FILES_LOCK)
       }
     }
     LOGGER.audit(s"Clean files operation is success for $dbName.$tableName.")
+  }
+
+  /**
+   * delete partition folders recurssively
+   *
+   * @param carbonTable
+   * @param partitionSpecList
+   */
+  def cleanUpPartitionFoldersRecurssively(carbonTable: CarbonTable,
+      partitionSpecList: List[PartitionSpec]): Unit = {
+    if (carbonTable != null) {
+      val loadMetadataDetails = SegmentStatusManager
+        .readLoadMetadata(carbonTable.getMetadataPath)
+
+      val fileType = FileFactory.getFileType(carbonTable.getTablePath)
+      val carbonFile = FileFactory.getCarbonFile(carbonTable.getTablePath, fileType)
+
+      // list all files from table path
+      val listOfDefaultPartFilesIterator = carbonFile.listFiles(true)
+      loadMetadataDetails.foreach { metadataDetail =>
+        if (metadataDetail.getSegmentStatus.equals(SegmentStatus.MARKED_FOR_DELETE) &&
+            metadataDetail.getSegmentFile == null) {
+          val loadStartTime: Long = metadataDetail.getLoadStartTime
+          // delete all files of @loadStartTime from tablepath
+          cleanCarbonFilesInFolder(listOfDefaultPartFilesIterator, loadStartTime)
+          partitionSpecList.foreach {
+            partitionSpec =>
+              val partitionLocation = partitionSpec.getLocation
+              // For partition folder outside the tablePath
+              if (!partitionLocation.toString.startsWith(carbonTable.getTablePath)) {
+                val fileType = FileFactory.getFileType(partitionLocation.toString)
+                val partitionCarbonFile = FileFactory
+                  .getCarbonFile(partitionLocation.toString, fileType)
+                // list all files from partitionLoacation
+                val listOfExternalPartFilesIterator = partitionCarbonFile.listFiles(true)
+                // delete all files of @loadStartTime from externalPath
+                cleanCarbonFilesInFolder(listOfExternalPartFilesIterator, loadStartTime)
+              }
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   *
+   * @param carbonFiles
+   * @param timestamp
+   */
+  private def cleanCarbonFilesInFolder(carbonFiles: java.util.List[CarbonFile],
+      timestamp: Long): Unit = {
+    carbonFiles.asScala.foreach {
+      carbonFile =>
+        val filePath = carbonFile.getPath
+        val fileName = carbonFile.getName
+        if (CarbonTablePath.DataFileUtil.compareCarbonFileTimeStamp(fileName, timestamp)) {
+          // delete the file
+          FileFactory.deleteFile(filePath, FileFactory.getFileType(filePath))
+
+        }
+    }
   }
 
   // validates load ids


### PR DESCRIPTION
Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed? No
 
 - [x] Any backward compatibility impacted? No
 
 - [x] Document update required? No

 - [x] Testing done
        This scenario will occur conditionally , based on Environment . No need to add TestCase . Offline verified.
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.  NA

