### PR TITLE
[CARBONDATA-2308] Support concurrent loading and compaction 

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonAlterTableCompactionCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonAlterTableCompactionCommand.scala
@@ -94,8 +94,8 @@ case class CarbonAlterTableCompactionCommand(
   }
 
   override def processData(sparkSession: SparkSession): Seq[Row] = {
-    if (SegmentStatusManager.isLoadInProgressInTable(table)) {
-      throw new ConcurrentOperationException(table, "loading", "compaction")
+    if (SegmentStatusManager.isOverwriteInProgressInTable(table)) {
+      throw new ConcurrentOperationException(table, "insert overwrite", "compaction")
     }
     operationContext.setProperty("compactionException", "true")
     var compactionType: CompactionType = null


### PR DESCRIPTION
When data loading (or insert into) is in progress, user should be able to do compaction on same table
This PR supports it.

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
