### PR TITLE
[CARBONDATA-2304][Compaction] Prefetch rowbatch during compaction

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -1643,7 +1643,7 @@ public final class CarbonCommonConstants {
   public static final String CARBON_SEARCH_MODE_THREAD_DEFAULT = "3";
 
   /*
-   * whether to enable prefetch during compaction
+   * whether to enable prefetch for rowbatch to enhance row reconstruction during compaction
    */
   @CarbonProperty
   public static final String CARBON_COMPACTION_PREFETCH_ENABLE =

--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -1642,6 +1642,14 @@ public final class CarbonCommonConstants {
 
   public static final String CARBON_SEARCH_MODE_THREAD_DEFAULT = "3";
 
+  /*
+   * whether to enable prefetch during compaction
+   */
+  @CarbonProperty
+  public static final String CARBON_COMPACTION_PREFETCH_ENABLE =
+      "carbon.compaction.prefetch.enable";
+  public static final String CARBON_COMPACTION_PREFETCH_ENABLE_DEFAULT = "false";
+
   private CarbonCommonConstants() {
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/iterator/RawResultIterator.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/iterator/RawResultIterator.java
@@ -16,13 +16,22 @@
  */
 package org.apache.carbondata.core.scan.result.iterator;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
 import org.apache.carbondata.common.CarbonIterator;
 import org.apache.carbondata.common.logging.LogService;
 import org.apache.carbondata.common.logging.LogServiceFactory;
+import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.datastore.block.SegmentProperties;
 import org.apache.carbondata.core.keygenerator.KeyGenException;
 import org.apache.carbondata.core.scan.result.RowBatch;
 import org.apache.carbondata.core.scan.wrappers.ByteArrayWrapper;
+import org.apache.carbondata.core.util.CarbonProperties;
 
 /**
  * This is a wrapper iterator over the detail raw query iterator.
@@ -30,6 +39,11 @@ import org.apache.carbondata.core.scan.wrappers.ByteArrayWrapper;
  * This will handle the batch results and will iterate on the batches and give single row.
  */
 public class RawResultIterator extends CarbonIterator<Object[]> {
+  /**
+   * LOGGER
+   */
+  private static final LogService LOGGER =
+      LogServiceFactory.getLogService(RawResultIterator.class.getName());
 
   private final SegmentProperties sourceSegProperties;
 
@@ -39,86 +53,122 @@ public class RawResultIterator extends CarbonIterator<Object[]> {
    */
   private CarbonIterator<RowBatch> detailRawQueryResultIterator;
 
-  /**
-   * Counter to maintain the row counter.
-   */
-  private int counter = 0;
-
-  private Object[] currentConveretedRawRow = null;
-
-  /**
-   * LOGGER
-   */
-  private static final LogService LOGGER =
-      LogServiceFactory.getLogService(RawResultIterator.class.getName());
-
-  /**
-   * batch of the result.
-   */
-  private RowBatch batch;
+  private boolean prefetchEnabled;
+  private List<Object[]> currentBuffer;
+  private List<Object[]> backupBuffer;
+  private int currentIdxInBuffer;
+  private ExecutorService executorService;
+  private Future<Void> fetchFuture;
+  private Object[] currentRawRow = null;
+  private boolean isBackupFilled = false;
 
   public RawResultIterator(CarbonIterator<RowBatch> detailRawQueryResultIterator,
-      SegmentProperties sourceSegProperties, SegmentProperties destinationSegProperties) {
+      SegmentProperties sourceSegProperties, SegmentProperties destinationSegProperties,
+      boolean isStreamingHandOff) {
     this.detailRawQueryResultIterator = detailRawQueryResultIterator;
     this.sourceSegProperties = sourceSegProperties;
     this.destinationSegProperties = destinationSegProperties;
+    this.executorService = Executors.newFixedThreadPool(1);
+
+    if (!isStreamingHandOff) {
+      init();
+    }
+  }
+
+  private void init() {
+    this.prefetchEnabled = CarbonProperties.getInstance().getProperty(
+        CarbonCommonConstants.CARBON_COMPACTION_PREFETCH_ENABLE,
+        CarbonCommonConstants.CARBON_COMPACTION_PREFETCH_ENABLE_DEFAULT).equalsIgnoreCase("true");
+    try {
+      new RowsFetcher(false).call();
+      if (prefetchEnabled) {
+        this.fetchFuture = executorService.submit(new RowsFetcher(true));
+      }
+    } catch (Exception e) {
+      LOGGER.error(e, "Error occurs while fetching records");
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * fetch rows
+   */
+  private final class RowsFetcher implements Callable<Void> {
+    private boolean isBackupFilling;
+
+    private RowsFetcher(boolean isBackupFilling) {
+      this.isBackupFilling = isBackupFilling;
+    }
+
+    @Override
+    public Void call() throws Exception {
+      if (isBackupFilling) {
+        backupBuffer = fetchRows();
+        isBackupFilled = true;
+      } else {
+        currentBuffer = fetchRows();
+      }
+      return null;
+    }
+  }
+
+  private List<Object[]> fetchRows() {
+    if (detailRawQueryResultIterator.hasNext()) {
+      return detailRawQueryResultIterator.next().getRows();
+    } else {
+      return new ArrayList<>();
+    }
+  }
+
+  private void fillDataFromPrefetch() {
+    try {
+      if (currentIdxInBuffer >= currentBuffer.size() && 0 != currentIdxInBuffer) {
+        if (prefetchEnabled) {
+          if (!isBackupFilled) {
+            fetchFuture.get();
+          }
+          // copy backup buffer to current buffer and fill backup buffer asyn
+          currentIdxInBuffer = 0;
+          currentBuffer = backupBuffer;
+          isBackupFilled = false;
+          fetchFuture = executorService.submit(new RowsFetcher(true));
+        } else {
+          currentIdxInBuffer = 0;
+          new RowsFetcher(false).call();
+        }
+      }
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private void popRow() {
+    fillDataFromPrefetch();
+    currentRawRow = currentBuffer.get(currentIdxInBuffer);
+    currentIdxInBuffer++;
+  }
+
+  private void pickRow() {
+    fillDataFromPrefetch();
+    currentRawRow = currentBuffer.get(currentIdxInBuffer);
   }
 
   @Override public boolean hasNext() {
-
-    if (null == batch || checkIfBatchIsProcessedCompletely(batch)) {
-      if (detailRawQueryResultIterator.hasNext()) {
-        batch = null;
-        batch = detailRawQueryResultIterator.next();
-        counter = 0; // batch changed so reset the counter.
-      } else {
-        return false;
-      }
-    }
-
-    if (!checkIfBatchIsProcessedCompletely(batch)) {
+    fillDataFromPrefetch();
+    if (currentIdxInBuffer < currentBuffer.size()) {
       return true;
-    } else {
-      return false;
     }
+
+    return false;
   }
 
   @Override public Object[] next() {
-    if (null == batch) { // for 1st time
-      batch = detailRawQueryResultIterator.next();
-    }
-    if (!checkIfBatchIsProcessedCompletely(batch)) {
-      try {
-        if (null != currentConveretedRawRow) {
-          counter++;
-          Object[] currentConveretedRawRowTemp = this.currentConveretedRawRow;
-          currentConveretedRawRow = null;
-          return currentConveretedRawRowTemp;
-        }
-        return convertRow(batch.getRawRow(counter++));
-      } catch (KeyGenException e) {
-        LOGGER.error(e.getMessage());
-        return null;
-      }
-    } else { // completed one batch.
-      batch = null;
-      batch = detailRawQueryResultIterator.next();
-      counter = 0;
-    }
     try {
-      if (null != currentConveretedRawRow) {
-        counter++;
-        Object[] currentConveretedRawRowTemp = this.currentConveretedRawRow;
-        currentConveretedRawRow = null;
-        return currentConveretedRawRowTemp;
-      }
-
-      return convertRow(batch.getRawRow(counter++));
+      popRow();
+      return convertRow(this.currentRawRow);
     } catch (KeyGenException e) {
-      LOGGER.error(e.getMessage());
-      return null;
+      throw new RuntimeException(e);
     }
-
   }
 
   /**
@@ -126,19 +176,8 @@ public class RawResultIterator extends CarbonIterator<Object[]> {
    * @return
    */
   public Object[] fetchConverted() throws KeyGenException {
-    if (null != currentConveretedRawRow) {
-      return currentConveretedRawRow;
-    }
-    if (hasNext())
-    {
-      Object[] rawRow = batch.getRawRow(counter);
-      currentConveretedRawRow = convertRow(rawRow);
-      return currentConveretedRawRow;
-    }
-    else
-    {
-      return null;
-    }
+    pickRow();
+    return convertRow(this.currentRawRow);
   }
 
   private Object[] convertRow(Object[] rawRow) throws KeyGenException {
@@ -150,16 +189,9 @@ public class RawResultIterator extends CarbonIterator<Object[]> {
     return rawRow;
   }
 
-  /**
-   * To check if the batch is processed completely
-   * @param batch
-   * @return
-   */
-  private boolean checkIfBatchIsProcessedCompletely(RowBatch batch) {
-    if (counter < batch.getSize()) {
-      return false;
-    } else {
-      return true;
+  public void close() {
+    if (null != executorService) {
+      executorService.shutdownNow();
     }
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/iterator/RawResultIterator.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/iterator/RawResultIterator.java
@@ -142,18 +142,25 @@ public class RawResultIterator extends CarbonIterator<Object[]> {
     }
   }
 
+  /**
+   * populate a row with index counter increased
+   */
   private void popRow() {
     fillDataFromPrefetch();
     currentRawRow = currentBuffer.get(currentIdxInBuffer);
     currentIdxInBuffer++;
   }
 
+  /**
+   * populate a row with index counter unchanged
+   */
   private void pickRow() {
     fillDataFromPrefetch();
     currentRawRow = currentBuffer.get(currentIdxInBuffer);
   }
 
-  @Override public boolean hasNext() {
+  @Override
+  public boolean hasNext() {
     fillDataFromPrefetch();
     if (currentIdxInBuffer < currentBuffer.size()) {
       return true;
@@ -162,7 +169,8 @@ public class RawResultIterator extends CarbonIterator<Object[]> {
     return false;
   }
 
-  @Override public Object[] next() {
+  @Override
+  public Object[] next() {
     try {
       popRow();
       return convertRow(this.currentRawRow);

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/StreamHandoffRDD.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/StreamHandoffRDD.scala
@@ -69,10 +69,13 @@ class HandoffPartition(
 
 /**
  * package the record reader of the handoff segment to RawResultIterator
+ * todo: actually we should not extends rawResultIterator if we don't use any method or variable
+ * from it. We only use it to reduce duplicate code for compaction and handoff
+ * and we can extract it later
  */
 class StreamingRawResultIterator(
     recordReader: CarbonStreamRecordReader
-) extends RawResultIterator(null, null, null) {
+) extends RawResultIterator(null, null, null, true) {
 
   override def hasNext: Boolean = {
     recordReader.nextKeyValue()

--- a/processing/src/main/java/org/apache/carbondata/processing/merger/CarbonCompactionExecutor.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/merger/CarbonCompactionExecutor.java
@@ -117,7 +117,7 @@ public class CarbonCompactionExecutor {
         LOGGER.info("for task -" + task + "-block size is -" + list.size());
         queryModel.setTableBlockInfos(list);
         resultList.add(new RawResultIterator(executeBlockList(list), sourceSegProperties,
-            destinationSegProperties));
+            destinationSegProperties, false));
       }
     }
     return resultList;

--- a/processing/src/main/java/org/apache/carbondata/processing/merger/CompactionResultSortProcessor.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/merger/CompactionResultSortProcessor.java
@@ -235,6 +235,7 @@ public class CompactionResultSortProcessor extends AbstractResultProcessor {
           isRecordFound = true;
         }
       }
+      resultIterator.close();
     }
     try {
       sortDataRows.startSorting();

--- a/processing/src/main/java/org/apache/carbondata/processing/merger/RowResultMergerProcessor.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/merger/RowResultMergerProcessor.java
@@ -128,6 +128,7 @@ public class RowResultMergerProcessor extends AbstractResultProcessor {
         // index
         if (!iterator.hasNext()) {
           index--;
+          iterator.close();
           continue;
         }
         // add record to heap


### PR DESCRIPTION
Add a configuration to enable prefetch during compaction.

During compaction, carbondata will query on the segments and retrieve a row， then it will sort the rows and produce the final carbondata file.

Currently we find the poor performance in retrieving the rows, so adding prefetch for the rows will surely improve the compaction performance.

In my local tests, compacting 4 segments each with 100 thousand rows costs 30s with prefetch and 50s without prefetch.

In my tests in a larger cluster, compacting 6 segments each with 18GB raw data costs 45min with prefetch and 57min without prefetch.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 `NO`
 - [x] Any backward compatibility impacted?
 `NO`
 - [x] Document update required?
`Add a configuration, will update it later`
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
`Yes`
        - How it is tested? Please attach test report.
`Tested in local and a 3-node cluster`
        - Is it a performance related change? Please attach the performance test report.
`Compaction performance has been enhanced by 25+%`
        - Any additional information to help reviewers in testing this change.
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
`Not related`
