### PR TITLE
[CARBONDATA-2311][Streaming] Fix bug to avoid to append data to "streaming finish" segment

### DIFF
--- a/docs/streaming-guide.md
+++ b/docs/streaming-guide.md
@@ -133,7 +133,7 @@ streaming | The segment is running streaming ingestion
 streaming finish | The segment already finished streaming ingestion, <br /> it will be handed off to a segment in the columnar format
 
 ## Change segment status
-Use below command to change the status of "streaming" segment to "streaming finish" segment. If the streaming application is running and the user executed this command, it will create new streaming segment to accept the streaming data.
+Use below command to change the status of "streaming" segment to "streaming finish" segment. If the streaming application is running, this command will be blocked.
 ```sql
 ALTER TABLE streaming_table FINISH STREAMING
 ```

--- a/docs/streaming-guide.md
+++ b/docs/streaming-guide.md
@@ -133,7 +133,7 @@ streaming | The segment is running streaming ingestion
 streaming finish | The segment already finished streaming ingestion, <br /> it will be handed off to a segment in the columnar format
 
 ## Change segment status
-Use below command to change the status of "streaming" segment to "streaming finish" segment.
+Use below command to change the status of "streaming" segment to "streaming finish" segment. If the streaming application is running and the user executed this command, it will create new streaming segment to accept the streaming data.
 ```sql
 ALTER TABLE streaming_table FINISH STREAMING
 ```

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/streaming/StreamSinkFactory.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/streaming/StreamSinkFactory.scala
@@ -17,6 +17,7 @@
 
 package org.apache.carbondata.streaming
 
+import java.io.IOException
 import java.util
 
 import scala.collection.JavaConverters._
@@ -62,7 +63,7 @@ object StreamSinkFactory {
     } else {
       LOGGER.error("Not able to acquire the streaming lock for stream table:" +
         carbonTable.getDatabaseName + "." + carbonTable.getTableName)
-      throw new InterruptedException(
+      throw new IOException(
         "Not able to acquire the streaming lock for stream table: " +
         carbonTable.getDatabaseName + "." + carbonTable.getTableName)
     }

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/streaming/StreamSinkFactory.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/streaming/StreamSinkFactory.scala
@@ -19,13 +19,14 @@ package org.apache.carbondata.streaming
 
 import java.util
 
-import org.apache.carbondata.common.logging.LogServiceFactory
-
 import scala.collection.JavaConverters._
+
 import org.apache.hadoop.conf.Configuration
 import org.apache.spark.scheduler.{SparkListener, SparkListenerApplicationEnd}
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.execution.streaming.{CarbonAppendableStreamSink, Sink}
+
+import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.datastore.impl.FileFactory
 import org.apache.carbondata.core.dictionary.server.{DictionaryServer, NonSecureDictionaryServer}
@@ -56,14 +57,14 @@ object StreamSinkFactory {
       LockUsage.STREAMING_LOCK)
     if (lock.lockWithRetries()) {
       locks.put(carbonTable.getTableUniqueName, lock)
-      LOGGER.info("Acquired the streaming lock for stream table: " + carbonTable.getDatabaseName + "." +
-        carbonTable.getTableName)
+      LOGGER.info("Acquired the streaming lock for stream table: " + carbonTable.getDatabaseName +
+                  "." + carbonTable.getTableName)
     } else {
       LOGGER.error("Not able to acquire the streaming lock for stream table:" +
         carbonTable.getDatabaseName + "." + carbonTable.getTableName)
       throw new InterruptedException(
-        "Not able to acquire the streaming lock for stream table: " + carbonTable.getDatabaseName + "." +
-          carbonTable.getTableName)
+        "Not able to acquire the streaming lock for stream table: " +
+        carbonTable.getDatabaseName + "." + carbonTable.getTableName)
     }
   }
 

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/streaming/StreamSinkFactory.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/streaming/StreamSinkFactory.scala
@@ -129,10 +129,11 @@ object StreamSinkFactory {
     val segmentId = StreamSegment.open(carbonTable)
     val segmentDir = CarbonTablePath.getSegmentPath(carbonTable.getTablePath, segmentId)
     val fileType = FileFactory.getFileType(segmentDir)
-    if (!FileFactory.isFileExist(segmentDir, fileType)) {
+    val metadataPath = CarbonTablePath.getMetadataPath(carbonTable.getTablePath)
+    if (!FileFactory.isFileExist(metadataPath, fileType)) {
       // Create table directory path, in case of enabling hive metastore first load may not have
       // table folder created.
-      FileFactory.mkdirs(segmentDir, fileType)
+      FileFactory.mkdirs(metadataPath, fileType)
     }
     if (FileFactory.isFileExist(segmentDir, fileType)) {
       // recover fault

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/execution/streaming/CarbonAppendableStreamSink.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/execution/streaming/CarbonAppendableStreamSink.scala
@@ -17,7 +17,6 @@
 
 package org.apache.spark.sql.execution.streaming
 
-import java.io.IOException
 import java.util.Date
 
 import scala.collection.JavaConverters._


### PR DESCRIPTION
At the begin of each micro batch, check the status of current segment.
1. if the status is "streaming", continue to use this segment
2. if the status is "streaming finish", open new streaming segment to accept new streaming data

 - [x] Any interfaces changed?
 no
 - [x] Any backward compatibility impacted?
 no
 - [x] Document update required?
 yes, updated
 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
small changes
