### PR TITLE
[CARBONDATA-2320][Datamap] Fix error in luncene coarse grain datamap suite

### DIFF
--- a/datamap/lucene/src/test/scala/org/apache/carbondata/datamap/lucene/LuceneCoarseGrainDataMapSuite.scala
+++ b/datamap/lucene/src/test/scala/org/apache/carbondata/datamap/lucene/LuceneCoarseGrainDataMapSuite.scala
@@ -20,10 +20,6 @@ package org.apache.carbondata.datamap.lucene
 import org.apache.spark.sql.test.util.QueryTest
 import org.scalatest.BeforeAndAfterAll
 
-import org.apache.carbondata.core.datamap.DataMapStoreManager
-import org.apache.carbondata.core.metadata.CarbonMetadata
-import org.apache.carbondata.core.metadata.schema.table.DataMapSchema
-
 class LuceneCoarseGrainDataMapSuite extends QueryTest with BeforeAndAfterAll {
 
   val file2 = resourcesPath + "/datamap_input.csv"
@@ -55,6 +51,7 @@ class LuceneCoarseGrainDataMapSuite extends QueryTest with BeforeAndAfterAll {
       s"""
          | CREATE DATAMAP dm ON TABLE datamap_test
          | USING '${classOf[LuceneCoarseGrainDataMapFactory].getName}'
+         | DMProperties('TEXT_COLUMNS'='name,city')
       """.stripMargin)
 
     sql(s"LOAD DATA LOCAL INPATH '$file2' INTO TABLE datamap_test OPTIONS('header'='false')")


### PR DESCRIPTION
add DM-properties while creating datamap, otherwise the test will fail

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 `NO`
 - [x] Any backward compatibility impacted?
  `NO`
 - [x] Document update required?
 `NO`
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
 `NO, only fixed test error`
        - How it is tested? Please attach test report.
`Tested in local`
        - Is it a performance related change? Please attach the performance test report.
`NO`
        - Any additional information to help reviewers in testing this change.
       `NO` 
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
`Not related`
