### PR TITLE
[CARBONDATA-2155][CARBONDATA-2152] [Presto] Fixed IS NULL not working correctly on string datatype with dictionary include in presto

### DIFF
--- a/integration/presto/src/main/scala/org/apache/carbondata/presto/CarbonDictionaryDecodeReadSupport.scala
+++ b/integration/presto/src/main/scala/org/apache/carbondata/presto/CarbonDictionaryDecodeReadSupport.scala
@@ -93,7 +93,12 @@ class CarbonDictionaryDecodeReadSupport[T] extends CarbonReadSupport[T] {
     while (chunks.hasNext) {
       {
         val value: Array[Byte] = chunks.next
-        sliceArray(count) = wrappedBuffer(value, 0, value.length)
+        if(count ==1) {
+          sliceArray(count) = null
+        }
+        else {
+          sliceArray(count) = wrappedBuffer(value, 0, value.length)
+        }
         count += 1
       }
     }

--- a/integration/presto/src/test/resources/alldatatype.csv
+++ b/integration/presto/src/test/resources/alldatatype.csv
@@ -9,3 +9,4 @@ ID,date,country,name,phonetype,serialname,salary,bonus,monthlyBonus,dob,shortfie
 8,2015-07-30,china,geetika,phone1848,ASD57308,15007.500,500.88,200.97,2008-09-21 11:10:06,10,true
 9,2015-07-18,china,ravindra,phone706,ASD86717,15008.00,700.999,45.25,2009-06-19 15:10:06,1,true
 9,2015/07/18,china,jitesh,phone706,ASD86717,15008.00,500.414,11.655,2001-08-29 13:09:03,12,true
+

--- a/integration/presto/src/test/scala/org/apache/carbondata/presto/integrationtest/PrestoAllDataTypeTest.scala
+++ b/integration/presto/src/test/scala/org/apache/carbondata/presto/integrationtest/PrestoAllDataTypeTest.scala
@@ -34,6 +34,34 @@ class PrestoAllDataTypeTest extends FunSuiteLike with BeforeAndAfterAll {
                                   + "../../../..").getCanonicalPath
   private val storePath = s"$rootPath/integration/presto/target/store"
 
+
+  // Table schema:
+  // +-------------+----------------+-------------+------------+
+  // | Column name | Data type      | Column type | Dictionary |
+  // +-------------+----------------+--------------+-----------+
+  // | id          | string         | dimension   | yes        |
+  // +-------------+----------------+-------------+------------+
+  // | date        | date           | dimension   | yes        |
+  // +-------------+----------------+-------------+------------+
+  // | country     | string         | dimension   | yes        |
+  // +-------------+----------------+-------------+-------------
+  // | name        | string         | dimension   | yes        |
+  // +-------------+----------------+-------------+-------------
+  // | phonetype   | string         | dimension   | yes        |
+  // +-------------+----------------+-------------+-------------
+  // | serialname  | string         | dimension   | true       |
+  // +-------------+----------------+-------------+-------------
+  // | bonus       |short decimal   | measure     | false      |
+  // +-------------+----------------+-------------+-------------
+  // | monthlyBonus| longdecimal    | measure     | false      |
+  // +-------------+----------------+-------------+-------------
+  // | dob         | timestamp      | dimension   | true       |
+  // +-------------+----------------+-------------+------------+
+  // | shortField  | shortfield     | measure     | true       |
+  // +-------------+----------------+-------------+-------------
+  // |isCurrentEmp | boolean        | measure     | true       |
+  // +-------------+----------------+-------------+------------+
+
   override def beforeAll: Unit = {
     import org.apache.carbondata.presto.util.CarbonDataStoreCreator
     CarbonDataStoreCreator
@@ -50,7 +78,7 @@ class PrestoAllDataTypeTest extends FunSuiteLike with BeforeAndAfterAll {
   test("test the result for count(*) in presto") {
     val actualResult: List[Map[String, Any]] = PrestoServer
       .executeQuery("SELECT COUNT(*) AS RESULT FROM TESTDB.TESTTABLE ")
-    val expectedResult: List[Map[String, Any]] = List(Map("RESULT" -> 10))
+    val expectedResult: List[Map[String, Any]] = List(Map("RESULT" -> 11))
     assert(actualResult.equals(expectedResult))
   }
   test("test the result for count() clause with distinct operator in presto") {
@@ -160,7 +188,9 @@ class PrestoAllDataTypeTest extends FunSuiteLike with BeforeAndAfterAll {
       Map("NAME" -> "liang"),
       Map("NAME" -> "prince"),
       Map("NAME" -> "ravindra"),
-      Map("NAME" -> "sahil"))
+      Map("NAME" -> "sahil"),
+      Map("NAME" -> null)
+    )
     assert(actualResult.equals(expectedResult))
   }
   test("select DATE type with order by clause") {
@@ -175,7 +205,9 @@ class PrestoAllDataTypeTest extends FunSuiteLike with BeforeAndAfterAll {
       Map("DATE" -> "2015-07-28"),
       Map("DATE" -> "2015-07-29"),
       Map("DATE" -> "2015-07-30"),
-      Map("DATE" -> null))
+      Map("DATE" -> null),
+      Map("DATE" -> null)
+    )
 
     assert(actualResult.filterNot(_.get("DATE") == null).zipWithIndex.forall {
       case (map, index) => map.get("DATE").toString
@@ -194,7 +226,9 @@ class PrestoAllDataTypeTest extends FunSuiteLike with BeforeAndAfterAll {
       Map("ID" -> 6),
       Map("ID" -> 7),
       Map("ID" -> 8),
-      Map("ID" -> 9))
+      Map("ID" -> 9),
+      Map("ID" -> null)
+    )
 
     assert(actualResult.equals(expectedResult))
 
@@ -345,7 +379,7 @@ class PrestoAllDataTypeTest extends FunSuiteLike with BeforeAndAfterAll {
   test("test for null operator on date data type") {
     val actualResult: List[Map[String, Any]] = PrestoServer
       .executeQuery("SELECT ID FROM TESTDB.TESTTABLE WHERE DATE IS NULL")
-    val expectedResult: List[Map[String, Any]] = List(Map("ID" -> 9))
+    val expectedResult: List[Map[String, Any]] = List(Map("ID" -> 9),Map("ID" -> null))
     assert(actualResult.equals(expectedResult))
 
   }
@@ -390,7 +424,7 @@ class PrestoAllDataTypeTest extends FunSuiteLike with BeforeAndAfterAll {
     val actualResult: List[Map[String, Any]] = PrestoServer
       .executeQuery(
         "SELECT ID from testdb.testtable WHERE SHORTFIELD IS NULL ORDER BY SHORTFIELD ")
-    val expectedResult: List[Map[String, Any]] = List(Map("ID" -> 7))
+    val expectedResult: List[Map[String, Any]] = List(Map("ID" -> 7),Map("ID" -> null))
 
     assert(actualResult.equals(expectedResult))
   }
@@ -450,4 +484,17 @@ class PrestoAllDataTypeTest extends FunSuiteLike with BeforeAndAfterAll {
       .executeQuery("SELECT id AS RESULT FROM TESTDB.TESTTABLE WHERE isCurrentEmployee is NOT null AND ID>8")
     assert(actualResult.head("RESULT").toString.toInt==9)
   }
+  test("test the is null operator when null is included in string data type dictionary_include"){
+    // See CARBONDATA-2155
+    val actualResult: List[Map[String, Any]] = PrestoServer.executeQuery("SELECT SERIALNAME  FROM TESTDB.TESTTABLE WHERE SERIALNAME IS NULL")
+    assert(actualResult equals List(Map("SERIALNAME" -> null)))
+  }
+  test("test the min function when null is included in string data type with dictionary_include"){
+    // See CARBONDATA-2152
+    val actualResult = PrestoServer.executeQuery("SELECT MIN(SERIALNAME) FROM TESTDB.TESTTABLE")
+    val expectedResult = List(Map("_col0" -> "ASD14875"))
+
+    assert(actualResult.equals(expectedResult))
+  }
+
 }


### PR DESCRIPTION
Fixed IS NULL not working correctly on string datatype with dictionary_include in presto integration
Fixed Min function working incorrectly for string type with dictionary include in presto integration

**Problem**: 
1.When Creating SliceArrayBlock In CarbonDictionaryDeocdeReadSupport We are not inserting null values In SliceArrayBlock,Carbon Internaly represents Null Value in Dictionary As @NU#LL$! So When Creating SliceArrayBlock using dictionary chunk if we are getting the first chunk it will always be MEMBER_DEFAULT_VAL which is represented as @NU#LL$!,then we should add null
as value in our slicearrayblock

2.**Bug releated to test cases** :Our carbondatastore creator was not filling our dict value with @NU#LL$! in the first position of dict file that  was causing test cases to fails after changes are done in carbondictionarydecodereadsupport 

**Solution**:
 1. When Creating SliceArrayBlock using dictionary chunk if we are getting the first chunk it will always be MEMBER_DEFAULT_VAL which is represented as @NU#LL$!,then we should add null

 2. **Testing-Only** : Refactored the CarbonDataStoreCreator Code to fill our dict value with @NU#LL$! in the  first position of dict file it was causing test cases to fail with the changes in code in this pr which should be there to make sure that test cases run smoothly

**Testing Results**:

**CARBONDATA-2152**

**presto:default> select min(l_shipmode) from lineitem;**
 **_col0 
**-------**
 **AIR**   
**(1 row)****

**Query 20180410_113517_00000_jpvh5, FINISHED, 1 node**
**Splits: 18 total, 18 done (100.00%)**
**0:02 [10K rows, 10KB] [4.26K rows/s, 4.24KB/s]**

**CARBONDATA-2155**

**presto:default> select l_shipmode from lineitem where l_shipmode is NULL;**
 ****l_shipmode** 
**------------**
 **NULL**       
**(1 row)****

**Query 20180410_113824_00002_jpvh5, FINISHED, 1 node
Splits: 17 total, 17 done (100.00%)
0:00 [10K rows, 10KB] [22.7K rows/s, 22.6KB/s]**


Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 
 - [x] Any backward compatibility impacted?
 
 - [x] Document update required?

 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?yes new test 
        cases are added
        - How it is tested? Please attach test report.
          testing is done manually 
        - Is it a performance related change? Please attach the performance test report
           no.
        - Any additional information to help reviewers in testing this change.
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

