### PR TITLE
[CARBONDATA-2329] Non Serializable extra info in session is overwritten from stale thread

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonSessionInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonSessionInfo.java
@@ -60,11 +60,9 @@ public class CarbonSessionInfo implements Serializable, Cloneable {
     CarbonSessionInfo newObj = new CarbonSessionInfo();
     newObj.setSessionParams(sessionParams.clone());
     newObj.setThreadParams(threadParams.clone());
-    Map<String, Object> nonSerializableExtraInfo = getNonSerializableExtraInfo();
-    for (Map.Entry<String, Object> entry : nonSerializableExtraInfo.entrySet()) {
-      nonSerializableExtraInfo.put(entry.getKey(), entry.getValue());
+    for (Map.Entry<String, Object> entry : getNonSerializableExtraInfo().entrySet()) {
+      newObj.getNonSerializableExtraInfo().put(entry.getKey(), entry.getValue());
     }
-    newObj.setNonSerializableExtraInfo(nonSerializableExtraInfo);
     return newObj;
   }
 

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
@@ -82,11 +82,9 @@ class CarbonEnv {
         // update carbon session parameters , preserve thread parameters
         val currentThreadSesssionInfo = ThreadLocalSessionInfo.getCarbonSessionInfo
         carbonSessionInfo = new CarbonSessionInfo()
-        sessionParams = carbonSessionInfo.getSessionParams
         if (currentThreadSesssionInfo != null) {
           carbonSessionInfo.setThreadParams(currentThreadSesssionInfo.getThreadParams)
         }
-        carbonSessionInfo.setSessionParams(sessionParams)
         ThreadLocalSessionInfo.setCarbonSessionInfo(carbonSessionInfo)
         val config = new CarbonSQLConf(sparkSession)
         if (sparkSession.conf.getOption(CarbonCommonConstants.ENABLE_UNSAFE_SORT).isEmpty) {

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSession.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSession.scala
@@ -292,11 +292,7 @@ object CarbonSession {
       // copy all the thread parameters to apply to session parameters
       currentThreadSessionInfo.getThreadParams.getAll.asScala
         .foreach(entry => carbonSessionInfo.getSessionParams.addProperty(entry._1, entry._2))
-      currentThreadSessionInfo.getNonSerializableExtraInfo.asScala
-        .foreach(entry => carbonSessionInfo.getNonSerializableExtraInfo.put(entry._1, entry._2))
       carbonSessionInfo.setThreadParams(currentThreadSessionInfo.getThreadParams)
-      carbonSessionInfo
-        .setNonSerializableExtraInfo(currentThreadSessionInfo.getNonSerializableExtraInfo)
     }
     // preserve thread parameters across call
     ThreadLocalSessionInfo.setCarbonSessionInfo(carbonSessionInfo)


### PR DESCRIPTION
Problem:
         1. Non Serializable extra info is copied from thread which causes stale data from old session when the thread is reused by spark.
         2. CarboSessionInfo clone is not copying Non serializable info to new object which can damage session level values if local query thread updates values.

Solution: Remove logic to copy Non Serializable extra info and fix clone logic

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 No
 - [ ] Any backward compatibility impacted?
 No
 - [ ] Document update required?
No
 - [ ] Testing done
        Tested in local cluster       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA
