### PR TITLE
[CARBONDATA-2334] Added Property enabling user to block partitioning of Pre-Aggregate t…

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggCreateCommand.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggCreateCommand.scala
@@ -274,7 +274,7 @@ class TestPreAggCreateCommand extends QueryTest with BeforeAndAfterAll {
            | GROUP BY dob,name
        """.stripMargin)
     }
-    assert(e.getMessage.contains("Only 'path' dmproperty is allowed for this datamap"))
+    assert(e.getMessage.contains("Only 'path' and 'partitioning' dmproperties are allowed for this datamap"))
     sql("DROP TABLE IF EXISTS maintabletime")
   }
 

--- a/integration/spark2/src/main/java/org/apache/carbondata/datamap/DataMapProperty.java
+++ b/integration/spark2/src/main/java/org/apache/carbondata/datamap/DataMapProperty.java
@@ -28,5 +28,6 @@ public class DataMapProperty {
   /**
    * Used to specify the store location of the datamap
    */
+  public static final String PARTITIONING = "partitioning";
   public static final String PATH = "path";
 }

--- a/integration/spark2/src/main/java/org/apache/carbondata/datamap/PreAggregateDataMapProvider.java
+++ b/integration/spark2/src/main/java/org/apache/carbondata/datamap/PreAggregateDataMapProvider.java
@@ -52,10 +52,11 @@ public class PreAggregateDataMapProvider implements DataMapProvider {
   private void validateDmProperty(DataMapSchema dataMapSchema)
       throws MalformedDataMapCommandException {
     if (!dataMapSchema.getProperties().isEmpty()) {
-      if (dataMapSchema.getProperties().size() > 1 ||
-          !dataMapSchema.getProperties().containsKey(DataMapProperty.PATH)) {
+      if (dataMapSchema.getProperties().size() > 2 || (
+              !dataMapSchema.getProperties().containsKey(DataMapProperty.PATH) &&
+                      !dataMapSchema.getProperties().containsKey(DataMapProperty.PARTITIONING))) {
         throw new MalformedDataMapCommandException(
-            "Only 'path' dmproperty is allowed for this datamap");
+                "Only 'path' and 'partitioning' dmproperties are allowed for this datamap");
       }
     }
   }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/preaaggregate/PreAggregateTableHelper.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/preaaggregate/PreAggregateTableHelper.scala
@@ -67,7 +67,10 @@ case class PreAggregateTableHelper(
     val partitionInfo = parentTable.getPartitionInfo
     val fields = fieldRelationMap.keySet.toSeq
     val tableProperties = mutable.Map[String, String]()
-    val parentPartitionColumns = if (parentTable.isHivePartitionTable) {
+    val usePartitioning = dataMapProperties.getOrDefault("partitioning", "true").toBoolean
+    val parentPartitionColumns = if (!usePartitioning) {
+      Seq.empty
+    } else if (parentTable.isHivePartitionTable) {
       partitionInfo.getColumnSchemaList.asScala.map(_.getColumnName)
     } else {
       Seq()


### PR DESCRIPTION
While creating PreAgg table, in DMPROPERTIES, 'partitioning'='false' will disable partitioning of the Pre-Aggregate table

 - [x] Any interfaces changed?
 NA
 - [x] Any backward compatibility impacted?
 NA
 - [x] Document update required?
NA
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
Added UT test case
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA
