### PR TITLE
[CARBONDATA-2337] Fix duplicately acquiring 'streaming.lock' error when integrating with spark-streaming.

### DIFF
--- a/integration/spark-common/src/main/scala/org/apache/carbondata/streaming/CarbonStreamSparkStreaming.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/streaming/CarbonStreamSparkStreaming.scala
@@ -27,7 +27,6 @@ import org.apache.spark.sql.execution.streaming.{CarbonAppendableStreamSink, Sin
 import org.apache.spark.streaming.Time
 
 import org.apache.carbondata.common.logging.LogServiceFactory
-import org.apache.carbondata.core.locks.{CarbonLockFactory, ICarbonLock, LockUsage}
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable
 
 /**
@@ -44,38 +43,16 @@ class CarbonStreamSparkStreamingWriter(val sparkSession: SparkSession,
 
   private var isInitialize: Boolean = false
 
-  private var lock: ICarbonLock = null
   private var carbonAppendableStreamSink: Sink = null
-
-  /**
-   * Acquired the lock for stream table
-   */
-  def lockStreamTable(): Unit = {
-    lock = CarbonLockFactory.getCarbonLockObj(carbonTable.getAbsoluteTableIdentifier,
-      LockUsage.STREAMING_LOCK)
-    if (lock.lockWithRetries()) {
-      LOGGER.info("Acquired the lock for stream table: " +
-                  carbonTable.getDatabaseName + "." +
-                  carbonTable.getTableName)
-    } else {
-      LOGGER.error("Not able to acquire the lock for stream table:" +
-                   carbonTable.getDatabaseName + "." + carbonTable.getTableName)
-      throw new InterruptedException(
-        "Not able to acquire the lock for stream table: " + carbonTable.getDatabaseName + "." +
-        carbonTable.getTableName)
-    }
-  }
 
   /**
    * unlock for stream table
    */
   def unLockStreamTable(): Unit = {
-    if (null != lock) {
-      lock.unlock()
-      LOGGER.info("unlock for stream table: " +
-                  carbonTable.getDatabaseName + "." +
-                  carbonTable.getTableName)
-    }
+    StreamSinkFactory.unLock(carbonTable.getTableUniqueName)
+    LOGGER.info("unlock for stream table: " +
+                carbonTable.getDatabaseName + "." +
+                carbonTable.getTableName)
   }
 
   def initialize(): Unit = {
@@ -84,8 +61,6 @@ class CarbonStreamSparkStreamingWriter(val sparkSession: SparkSession,
       configuration,
       carbonTable,
       extraOptions.toMap).asInstanceOf[CarbonAppendableStreamSink]
-
-    lockStreamTable()
 
     isInitialize = true
   }


### PR DESCRIPTION

After merged [PR2135](https://github.com/apache/carbondata/pull/2135), it will acquire 'streaming.lock' duplicately when integrating with spark-streaming.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?  No
 
 - [ ] Any backward compatibility impacted?   No
 
 - [ ] Document update required?   No

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

