### PR TITLE
[CARBONDATA-2311][Streaming] Fix bug to avoid to append data to streaming finish segment

### DIFF
--- a/docs/streaming-guide.md
+++ b/docs/streaming-guide.md
@@ -133,7 +133,7 @@ streaming | The segment is running streaming ingestion
 streaming finish | The segment already finished streaming ingestion, <br /> it will be handed off to a segment in the columnar format
 
 ## Change segment status
-Use below command to change the status of "streaming" segment to "streaming finish" segment.
+Use below command to change the status of "streaming" segment to "streaming finish" segment. If the streaming application is running, this command will be blocked.
 ```sql
 ALTER TABLE streaming_table FINISH STREAMING
 ```

--- a/streaming/src/main/scala/org/apache/carbondata/streaming/StreamSinkFactory.scala
+++ b/streaming/src/main/scala/org/apache/carbondata/streaming/StreamSinkFactory.scala
@@ -17,6 +17,9 @@
 
 package org.apache.carbondata.streaming
 
+import java.io.IOException
+import java.util
+
 import scala.collection.JavaConverters._
 
 import org.apache.hadoop.conf.Configuration
@@ -24,10 +27,12 @@ import org.apache.spark.scheduler.{SparkListener, SparkListenerApplicationEnd}
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.execution.streaming.{CarbonAppendableStreamSink, Sink}
 
+import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.datastore.impl.FileFactory
 import org.apache.carbondata.core.dictionary.server.{DictionaryServer, NonSecureDictionaryServer}
 import org.apache.carbondata.core.dictionary.service.NonSecureDictionaryServiceProvider
+import org.apache.carbondata.core.locks.{CarbonLockFactory, ICarbonLock, LockUsage}
 import org.apache.carbondata.core.metadata.encoder.Encoding
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable
 import org.apache.carbondata.core.util.CarbonProperties
@@ -45,11 +50,41 @@ import org.apache.carbondata.streaming.segment.StreamSegment
  */
 object StreamSinkFactory {
 
+  val LOGGER = LogServiceFactory.getLogService(this.getClass.getCanonicalName)
+
+  val locks = new util.concurrent.ConcurrentHashMap[String, ICarbonLock]()
+
+  def lock(carbonTable: CarbonTable): Unit = {
+    val lock = CarbonLockFactory.getCarbonLockObj(carbonTable.getAbsoluteTableIdentifier,
+      LockUsage.STREAMING_LOCK)
+    if (lock.lockWithRetries()) {
+      locks.put(carbonTable.getTableUniqueName, lock)
+      LOGGER.info("Acquired the streaming lock for stream table: " + carbonTable.getDatabaseName +
+                  "." + carbonTable.getTableName)
+    } else {
+      LOGGER.error("Not able to acquire the streaming lock for stream table:" +
+        carbonTable.getDatabaseName + "." + carbonTable.getTableName)
+      throw new IOException(
+        "Not able to acquire the streaming lock for stream table: " +
+        carbonTable.getDatabaseName + "." + carbonTable.getTableName)
+    }
+  }
+
+  def unLock(tableUniqueName: String): Unit = {
+    val lock = locks.remove(tableUniqueName)
+    if (lock != null) {
+      lock.unlock()
+    }
+  }
+
   def createStreamTableSink(
       sparkSession: SparkSession,
       hadoopConf: Configuration,
       carbonTable: CarbonTable,
       parameters: Map[String, String]): Sink = {
+
+    lock(carbonTable)
+
     validateParameters(parameters)
 
     // build load model


### PR DESCRIPTION

At the begin of each micro batch, check the status of current segment.if the status is streaming, continue to use this segment
if the status is streaming finish, open new streaming segment to accept new streaming data

This closes #2135

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

