### PR TITLE
[CARBONDATA-2344][DataMap] Fix bugs in mapping blocklet to UnsafeDMStore rows

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMapFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMapFactory.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import org.apache.carbondata.core.cache.Cache;
 import org.apache.carbondata.core.cache.CacheProvider;
 import org.apache.carbondata.core.cache.CacheType;
+import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.datamap.DataMapDistributable;
 import org.apache.carbondata.core.datamap.DataMapMeta;
 import org.apache.carbondata.core.datamap.Segment;
@@ -126,9 +127,10 @@ public class BlockletDataMapFactory extends CoarseGrainDataMapFactory
     }
     List<TableBlockIndexUniqueIdentifier> identifiers =
         getTableBlockIndexUniqueIdentifiers(segment);
+    byte[] segId = segment.getSegmentNo().getBytes(CarbonCommonConstants.DEFAULT_CHARSET);
     // Retrieve each blocklets detail information from blocklet datamap
     for (Blocklet blocklet : blocklets) {
-      detailedBlocklets.add(getExtendedBlocklet(identifiers, blocklet));
+      detailedBlocklets.add(getExtendedBlocklet(segId, identifiers, blocklet));
     }
     return detailedBlocklets;
   }
@@ -141,18 +143,21 @@ public class BlockletDataMapFactory extends CoarseGrainDataMapFactory
     }
     List<TableBlockIndexUniqueIdentifier> identifiers =
         getTableBlockIndexUniqueIdentifiers(segment);
-    return getExtendedBlocklet(identifiers, blocklet);
+    return getExtendedBlocklet(
+        segment.getSegmentNo().getBytes(CarbonCommonConstants.DEFAULT_CHARSET),
+        identifiers,
+        blocklet);
   }
 
-  private ExtendedBlocklet getExtendedBlocklet(List<TableBlockIndexUniqueIdentifier> identifiers,
-      Blocklet blocklet) throws IOException {
+  private ExtendedBlocklet getExtendedBlocklet(byte[] segId,
+      List<TableBlockIndexUniqueIdentifier> identifiers, Blocklet blocklet) throws IOException {
     String carbonIndexFileName = CarbonTablePath.getCarbonIndexFileName(blocklet.getBlockId());
     for (TableBlockIndexUniqueIdentifier identifier : identifiers) {
       if (identifier.getIndexFileName().equals(carbonIndexFileName)) {
         DataMap dataMap = cache.get(identifier);
         String blockFileName = blocklet.getBlockId().substring(
             blocklet.getBlockId().lastIndexOf(File.separatorChar) + 1);
-        return ((BlockletDataMap) dataMap).getDetailedBlocklet(blockFileName,
+        return ((BlockletDataMap) dataMap).getDetailedBlocklet(segId, blockFileName,
             blocklet.getBlockletId());
       }
     }

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMapFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMapFactory.java
@@ -16,6 +16,7 @@
  */
 package org.apache.carbondata.core.indexstore.blockletindex;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -149,7 +150,10 @@ public class BlockletDataMapFactory extends CoarseGrainDataMapFactory
     for (TableBlockIndexUniqueIdentifier identifier : identifiers) {
       if (identifier.getIndexFileName().equals(carbonIndexFileName)) {
         DataMap dataMap = cache.get(identifier);
-        return ((BlockletDataMap) dataMap).getDetailedBlocklet(blocklet.getBlockletId());
+        String blockFileName = blocklet.getBlockId().substring(
+            blocklet.getBlockId().lastIndexOf(File.separatorChar) + 1);
+        return ((BlockletDataMap) dataMap).getDetailedBlocklet(blockFileName,
+            blocklet.getBlockletId());
       }
     }
     throw new IOException("Blocklet with blockid " + blocklet.getBlockletId() + " not found ");


### PR DESCRIPTION
In BlockletDataMap, carbondata stores DMRow in an array for each
blocklet. But currently carbondata accesses the DMRow only by
blockletId(0, 1, etc.), which will cause problem since different
block can have same blockletId.

This PR adds a map to map the blockId#blockletId to array index,
carbondata can access the DMRow by blockId and blockletId.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 `NO, only internal interfaces have been changed`
 - [x] Any backward compatibility impacted?
 `NO`
 - [x] Document update required?
`NO`
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
`NO`
        - How it is tested? Please attach test report.
`Tested in local`
        - Is it a performance related change? Please attach the performance test report.
`No`
        - Any additional information to help reviewers in testing this change.
 `NO`      
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
`Not related`
