### PR TITLE
[CARBONDATA-2346] Added fix for NULL error while dropping partition with multiple Pre-Aggregate tables

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/preaaggregate/PreAggregateListeners.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/preaaggregate/PreAggregateListeners.scala
@@ -206,7 +206,7 @@ object AlterTableDropPartitionMetaListener extends OperationEventListener{
           val partitionColExists = partitionsToBeDropped.forall {
             partition =>
               childColumns.exists { childColumn =>
-                  childColumn.getAggFunction.isEmpty &&
+                  childColumn.getAggFunction.isEmpty && childColumn.getParentColumnTableRelations != null &&
                   childColumn.getParentColumnTableRelations.asScala.head.getColumnName.
                     equals(partition)
               }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/preaaggregate/PreAggregateListeners.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/preaaggregate/PreAggregateListeners.scala
@@ -206,7 +206,8 @@ object AlterTableDropPartitionMetaListener extends OperationEventListener{
           val partitionColExists = partitionsToBeDropped.forall {
             partition =>
               childColumns.exists { childColumn =>
-                  childColumn.getAggFunction.isEmpty && childColumn.getParentColumnTableRelations != null &&
+                  childColumn.getAggFunction.isEmpty &&
+                    childColumn.getParentColumnTableRelations != null &&
                   childColumn.getParentColumnTableRelations.asScala.head.getColumnName.
                     equals(partition)
               }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/preaaggregate/PreAggregateTableHelper.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/preaaggregate/PreAggregateTableHelper.scala
@@ -76,7 +76,9 @@ case class PreAggregateTableHelper(
     val partitionerFields = fieldRelationMap.collect {
       case (field, dataMapField) if parentPartitionColumns
         .exists(parentCol =>
-          parentCol.equals(dataMapField.columnTableRelationList.get.head.parentColumnName) &&
+          /* For count(*) while Pre-Aggregate table creation,columnTableRelationList was null */
+          dataMapField.columnTableRelationList.getOrElse(Seq()).nonEmpty &&
+            parentCol.equals(dataMapField.columnTableRelationList.get.head.parentColumnName) &&
           dataMapField.aggregateFunction.isEmpty) =>
         (PartitionerField(field.name.get,
           field.dataType,


### PR DESCRIPTION
1. While dropping Partitions when multiple Pre-Aggregate tables are created, partitions to be dropped was considered null (getParentColumnTableRelations = null)
2. Fixed issue of failure to Create Pre-Aggregate table with count(*) as column list was considered null

 - [x] Any interfaces changed?
 NA
 - [x] Any backward compatibility impacted?
 NA
 - [x] Document update required?
NA
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
Added UT test cases  
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA
