### PR TITLE
  [CARBONDATA-2379] Support SearchModeExample run in cluster

### DIFF
--- a/examples/spark2/src/main/scala/org/apache/carbondata/benchmark/SimpleQueryBenchmark.scala
+++ b/examples/spark2/src/main/scala/org/apache/carbondata/benchmark/SimpleQueryBenchmark.scala
@@ -314,9 +314,13 @@ object SimpleQueryBenchmark {
     val rootPath = new File(this.getClass.getResource("/").getPath
         + "../../../..").getCanonicalPath
     val storeLocation = s"$rootPath/examples/spark2/target/store"
+    val master = Option(System.getProperty("spark.master"))
+      .orElse(sys.env.get("MASTER"))
+      .orElse(Option("local[8]"))
+
     val spark = SparkSession
         .builder()
-        .master("local")
+        .master(master.get)
         .enableHiveSupport()
         .config("spark.driver.host", "127.0.0.1")
         .getOrCreateCarbonSession(storeLocation)

--- a/store/search/src/main/scala/org/apache/spark/rpc/Master.scala
+++ b/store/search/src/main/scala/org/apache/spark/rpc/Master.scala
@@ -210,7 +210,7 @@ class Master(sparkConf: SparkConf, port: Int) {
 
   /**
    * Prune data by using CarbonInputFormat.getSplit
-   * Return a mapping of hostname to list of block
+   * Return a mapping of host address to list of block
    */
   private def pruneBlock(
       table: CarbonTable,


### PR DESCRIPTION
    1.support SeachModeExample running in the cluster
    2.change the worker hostname to hostAddress
    3. support run ConcurrentQueryBenchmark with search mode 
    4. remove read.close, which maybe lead to JVM crash 


Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 No
 - [x] Any backward compatibility impacted?
 No
 - [x] Document update required?
No
 - [x] Testing done
       Please see the example test case
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
    No

