### PR TITLE
[CARBONDATA-2358] Fix overwrite mode in dataframe write data

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestLoadDataFrame.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestLoadDataFrame.scala
@@ -83,6 +83,8 @@ class TestLoadDataFrame extends QueryTest with BeforeAndAfterAll {
     sql("DROP TABLE IF EXISTS df_write_sort_column_not_specified")
     sql("DROP TABLE IF EXISTS df_write_specify_sort_column")
     sql("DROP TABLE IF EXISTS df_write_empty_sort_column")
+    sql("DROP TABLE IF EXISTS carbon_table_df")
+    sql("DROP TABLE IF EXISTS carbon_table_df1")
   }
 
 
@@ -117,6 +119,7 @@ class TestLoadDataFrame extends QueryTest with BeforeAndAfterAll {
     checkAnswer(
       sql("select count(*) from carbon1 where c3 > 500"), Row(31500)
     )
+    sql(s"describe formatted carbon1").show(true)
   }
 
   test("test load dataframe with saving csv uncompressed files") {
@@ -333,6 +336,51 @@ class TestLoadDataFrame extends QueryTest with BeforeAndAfterAll {
 
     val sortColumnValue = getSortColumnValue("df_write_empty_sort_column")
     assert(sortColumnValue.isEmpty)
+  }
+
+  test("test load dataframe while giving already created table") {
+
+    sql(s"create table carbon_table_df(c1 string, c2 string, c3 int) stored by 'carbondata'")
+    // save dataframe to carbon file
+    df.write
+      .format("carbondata")
+      .option("tableName", "carbon_table_df")
+      .option("tempCSV", "false")
+      .mode(SaveMode.Overwrite)
+      .save()
+
+    df.write
+      .format("carbondata")
+      .option("tableName", "carbon_table_df")
+      .option("tempCSV", "false")
+      .mode(SaveMode.Overwrite)
+      .save()
+    checkAnswer(
+      sql("select count(*) from carbon_table_df where c3 > 500"), Row(31500)
+    )
+  }
+
+  test("test load dataframe while giving already created table with delete segment") {
+
+    sql(s"create table carbon_table_df1(c1 string, c2 string, c3 int) stored by 'carbondata'")
+    // save dataframe to carbon file
+    df.write
+      .format("carbondata")
+      .option("tableName", "carbon_table_df1")
+      .option("tempCSV", "false")
+      .mode(SaveMode.Overwrite)
+      .save()
+
+    sql("delete from table carbon_table_df1 where segment.id in (0)")
+    df.write
+      .format("carbondata")
+      .option("tableName", "carbon_table_df1")
+      .option("tempCSV", "false")
+      .mode(SaveMode.Overwrite)
+      .save()
+    checkAnswer(
+      sql("select count(*) from carbon_table_df where c3 > 500"), Row(31500)
+    )
   }
 
   override def afterAll {

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/CarbonOption.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/CarbonOption.scala
@@ -60,5 +60,8 @@ class CarbonOption(options: Map[String, String]) {
   def isStreaming: Boolean =
     options.getOrElse("streaming", "false").toBoolean
 
+  def overwriteEnabled: Boolean =
+    options.getOrElse("overwrite", "false").toBoolean
+
   def toMap: Map[String, String] = options
 }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonDataFrameWriter.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonDataFrameWriter.scala
@@ -56,7 +56,7 @@ class CarbonDataFrameWriter(sqlContext: SQLContext, val dataFrame: DataFrame) {
       null,
       Seq(),
       Map("fileheader" -> header) ++ options.toMap,
-      isOverwriteTable = false,
+      isOverwriteTable = options.overwriteEnabled,
       null,
       Some(dataFrame)).run(sqlContext.sparkSession)
   }


### PR DESCRIPTION
DataFrame overwrite is not working properly if the table is already created.
Solution : Delete segments should not be used while overwriting dataframe , it should be atomic operation so overwrite option should be passed to load command internally.


Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
       Tests added
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

