### PR TITLE
[CARBONDATA-2381] Improve compaction performance by filling batch result in columnar format and performing IO at blocklet level

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -21,6 +21,8 @@ import java.nio.charset.Charset;
 
 import org.apache.carbondata.core.util.CarbonProperty;
 
+import org.apache.hadoop.classification.InterfaceStability;
+
 public final class CarbonCommonConstants {
   /**
    * surrogate value of null
@@ -1539,10 +1541,12 @@ public final class CarbonCommonConstants {
    * memory.
    */
   @CarbonProperty
+  @InterfaceStability.Evolving
   public static final String CARBON_ENABLE_PAGE_LEVEL_READER_IN_COMPACTION =
       "carbon.enable.page.level.reader.in.compaction";
 
-  public static final String CARBON_ENABLE_PAGE_LEVEL_READER_IN_COMPACTION_DEFAULT = "true";
+  // Note: If this property is set to true it can impact compaction performance as IO will increase
+  public static final String CARBON_ENABLE_PAGE_LEVEL_READER_IN_COMPACTION_DEFAULT = "false";
 
   @CarbonProperty
   public static final String IN_MEMORY_STORAGE_FOR_SORTED_DATA_IN_MB =

--- a/core/src/main/java/org/apache/carbondata/core/scan/collector/ResultCollectorFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/collector/ResultCollectorFactory.java
@@ -26,6 +26,7 @@ import org.apache.carbondata.core.scan.collector.impl.RestructureBasedDictionary
 import org.apache.carbondata.core.scan.collector.impl.RestructureBasedRawResultCollector;
 import org.apache.carbondata.core.scan.collector.impl.RestructureBasedVectorResultCollector;
 import org.apache.carbondata.core.scan.executor.infos.BlockExecutionInfo;
+import org.apache.carbondata.core.stats.QueryStatisticsModel;
 
 /**
  * This class will provide the result collector instance based on the required type
@@ -45,31 +46,37 @@ public class ResultCollectorFactory {
    * @return
    */
   public static AbstractScannedResultCollector getScannedResultCollector(
-      BlockExecutionInfo blockExecutionInfo) {
+      BlockExecutionInfo blockExecutionInfo, QueryStatisticsModel queryStatisticsModel) {
     AbstractScannedResultCollector scannerResultAggregator = null;
     if (blockExecutionInfo.isRawRecordDetailQuery()) {
       if (blockExecutionInfo.isRestructuredBlock()) {
         LOGGER.info("Restructure based raw collector is used to scan and collect the data");
-        scannerResultAggregator = new RestructureBasedRawResultCollector(blockExecutionInfo);
+        scannerResultAggregator =
+            new RestructureBasedRawResultCollector(blockExecutionInfo, queryStatisticsModel);
       } else {
         LOGGER.info("Row based raw collector is used to scan and collect the data");
-        scannerResultAggregator = new RawBasedResultCollector(blockExecutionInfo);
+        scannerResultAggregator =
+            new RawBasedResultCollector(blockExecutionInfo, queryStatisticsModel);
       }
     } else if (blockExecutionInfo.isVectorBatchCollector()) {
       if (blockExecutionInfo.isRestructuredBlock()) {
         LOGGER.info("Restructure dictionary vector collector is used to scan and collect the data");
-        scannerResultAggregator = new RestructureBasedVectorResultCollector(blockExecutionInfo);
+        scannerResultAggregator =
+            new RestructureBasedVectorResultCollector(blockExecutionInfo, queryStatisticsModel);
       } else {
         LOGGER.info("Vector based dictionary collector is used to scan and collect the data");
-        scannerResultAggregator = new DictionaryBasedVectorResultCollector(blockExecutionInfo);
+        scannerResultAggregator =
+            new DictionaryBasedVectorResultCollector(blockExecutionInfo, queryStatisticsModel);
       }
     } else {
       if (blockExecutionInfo.isRestructuredBlock()) {
         LOGGER.info("Restructure based dictionary collector is used to scan and collect the data");
-        scannerResultAggregator = new RestructureBasedDictionaryResultCollector(blockExecutionInfo);
+        scannerResultAggregator =
+            new RestructureBasedDictionaryResultCollector(blockExecutionInfo, queryStatisticsModel);
       } else {
         LOGGER.info("Row based dictionary collector is used to scan and collect the data");
-        scannerResultAggregator = new DictionaryBasedResultCollector(blockExecutionInfo);
+        scannerResultAggregator =
+            new DictionaryBasedResultCollector(blockExecutionInfo, queryStatisticsModel);
       }
     }
     return scannerResultAggregator;

--- a/core/src/main/java/org/apache/carbondata/core/scan/collector/impl/DictionaryBasedResultCollector.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/collector/impl/DictionaryBasedResultCollector.java
@@ -32,6 +32,7 @@ import org.apache.carbondata.core.scan.filter.GenericQueryType;
 import org.apache.carbondata.core.scan.model.QueryDimension;
 import org.apache.carbondata.core.scan.model.QueryMeasure;
 import org.apache.carbondata.core.scan.result.AbstractScannedResult;
+import org.apache.carbondata.core.stats.QueryStatisticsModel;
 import org.apache.carbondata.core.util.CarbonUtil;
 import org.apache.carbondata.core.util.DataTypeUtil;
 
@@ -71,8 +72,9 @@ public class DictionaryBasedResultCollector extends AbstractScannedResultCollect
 
   protected Map<Integer, GenericQueryType> comlexDimensionInfoMap;
 
-  public DictionaryBasedResultCollector(BlockExecutionInfo blockExecutionInfos) {
-    super(blockExecutionInfos);
+  public DictionaryBasedResultCollector(BlockExecutionInfo blockExecutionInfos,
+      QueryStatisticsModel queryStatisticsModel) {
+    super(blockExecutionInfos, queryStatisticsModel);
     queryDimensions = tableBlockExecutionInfos.getQueryDimensions();
     queryMeasures = tableBlockExecutionInfos.getQueryMeasures();
     initDimensionAndMeasureIndexesForFillingData();

--- a/core/src/main/java/org/apache/carbondata/core/scan/collector/impl/DictionaryBasedVectorResultCollector.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/collector/impl/DictionaryBasedVectorResultCollector.java
@@ -29,6 +29,7 @@ import org.apache.carbondata.core.scan.result.AbstractScannedResult;
 import org.apache.carbondata.core.scan.result.vector.CarbonColumnarBatch;
 import org.apache.carbondata.core.scan.result.vector.ColumnVectorInfo;
 import org.apache.carbondata.core.scan.result.vector.MeasureDataVectorProcessor;
+import org.apache.carbondata.core.stats.QueryStatisticsModel;
 
 /**
  * It is not a collector it is just a scanned result holder.
@@ -51,8 +52,9 @@ public class DictionaryBasedVectorResultCollector extends AbstractScannedResultC
 
   protected ColumnVectorInfo[] implictColumnInfo;
 
-  public DictionaryBasedVectorResultCollector(BlockExecutionInfo blockExecutionInfos) {
-    super(blockExecutionInfos);
+  public DictionaryBasedVectorResultCollector(BlockExecutionInfo blockExecutionInfos,
+      QueryStatisticsModel queryStatisticsModel) {
+    super(blockExecutionInfos, queryStatisticsModel);
     // initialize only if the current block is not a restructured block else the initialization
     // will be taken care by RestructureBasedVectorResultCollector
     if (!blockExecutionInfos.isRestructuredBlock()) {

--- a/core/src/main/java/org/apache/carbondata/core/scan/collector/impl/RawBasedResultCollector.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/collector/impl/RawBasedResultCollector.java
@@ -25,24 +25,18 @@ import org.apache.carbondata.core.scan.executor.infos.BlockExecutionInfo;
 import org.apache.carbondata.core.scan.model.QueryMeasure;
 import org.apache.carbondata.core.scan.result.AbstractScannedResult;
 import org.apache.carbondata.core.scan.wrappers.ByteArrayWrapper;
+import org.apache.carbondata.core.stats.QueryStatistic;
+import org.apache.carbondata.core.stats.QueryStatisticsConstants;
+import org.apache.carbondata.core.stats.QueryStatisticsModel;
 
 /**
  * It is not a collector it is just a scanned result holder.
  */
 public class RawBasedResultCollector extends AbstractScannedResultCollector {
 
-  protected ByteArrayWrapper wrapper;
-
-  protected byte[] dictionaryKeyArray;
-
-  protected byte[][] noDictionaryKeyArray;
-
-  protected byte[][] complexTypeKeyArray;
-
-  protected byte[] implicitColumnByteArray;
-
-  public RawBasedResultCollector(BlockExecutionInfo blockExecutionInfos) {
-    super(blockExecutionInfos);
+  public RawBasedResultCollector(BlockExecutionInfo blockExecutionInfos,
+      QueryStatisticsModel queryStatisticsModel) {
+    super(blockExecutionInfos, queryStatisticsModel);
   }
 
   /**
@@ -50,39 +44,114 @@ public class RawBasedResultCollector extends AbstractScannedResultCollector {
    * it will keep track of how many record is processed, to handle limit scenario
    */
   @Override public List<Object[]> collectData(AbstractScannedResult scannedResult, int batchSize) {
+    long startTime = System.currentTimeMillis();
     List<Object[]> listBasedResult = new ArrayList<>(batchSize);
     QueryMeasure[] queryMeasures = tableBlockExecutionInfos.getQueryMeasures();
     // scan the record and add to list
-    int rowCounter = 0;
-    while (scannedResult.hasNext() && rowCounter < batchSize) {
-      scanResultAndGetData(scannedResult);
-      if (scannedResult.containsDeletedRow(scannedResult.getCurrentRowId())) {
-        continue;
-      }
-      prepareRow(scannedResult, listBasedResult, queryMeasures);
-      rowCounter++;
-    }
+    scanAndFillData(scannedResult, batchSize, listBasedResult, queryMeasures);
+    QueryStatistic resultPrepTime = queryStatisticsModel.getStatisticsTypeAndObjMap()
+        .get(QueryStatisticsConstants.RESULT_PREP_TIME);
+    resultPrepTime.addCountStatistic(QueryStatisticsConstants.RESULT_PREP_TIME,
+        resultPrepTime.getCount() + (System.currentTimeMillis() - startTime));
     return listBasedResult;
   }
 
-  protected void prepareRow(AbstractScannedResult scannedResult, List<Object[]> listBasedResult,
-      QueryMeasure[] queryMeasures) {
-    Object[] row = new Object[1 + queryMeasures.length];
-    wrapper = new ByteArrayWrapper();
-    wrapper.setDictionaryKey(dictionaryKeyArray);
-    wrapper.setNoDictionaryKeys(noDictionaryKeyArray);
-    wrapper.setComplexTypesKeys(complexTypeKeyArray);
-    wrapper.setImplicitColumnByteArray(implicitColumnByteArray);
-    row[0] = wrapper;
-    fillMeasureData(row, 1, scannedResult);
-    listBasedResult.add(row);
+  /**
+   * This method will scan and fill dimension and measure data
+   *
+   * @param scannedResult
+   * @param batchSize
+   * @param listBasedResult
+   * @param queryMeasures
+   */
+  protected void scanAndFillData(AbstractScannedResult scannedResult, int batchSize,
+      List<Object[]> listBasedResult, QueryMeasure[] queryMeasures) {
+    int numberOfPages = scannedResult.numberOfpages();
+    // loop will exit once the batchSize data has been read or the pages have been exhausted
+    while (scannedResult.getCurrentPageCounter() < numberOfPages) {
+      int currentPageRowCount = scannedResult.getCurrentPageRowCount();
+      if (currentPageRowCount == 0) {
+        scannedResult.incrementPageCounter();
+        continue;
+      }
+      int rowCounter = scannedResult.getRowCounter();
+      // getRowCounter holds total number rows processed. Calculate the
+      // Left over space through getRowCounter only.
+      int availableRows = currentPageRowCount - rowCounter;
+      // rows available in current page that can be processed from current page
+      int availableBatchRowCount = Math.min(batchSize, availableRows);
+      // this condition will be true if no data left in the current block/blocklet to be scanned
+      if (availableBatchRowCount < 1) {
+        break;
+      }
+      if (batchSize > availableRows) {
+        batchSize = batchSize - availableRows;
+      } else {
+        // this is done because in IUD cases actuals rows fetch can be less than batch size as
+        // some of the rows could have deleted. So in those cases batchSize need to be
+        // re initialized with left over value
+        batchSize = 0;
+      }
+      // fill dimension data
+      fillDimensionData(scannedResult, listBasedResult, queryMeasures, availableBatchRowCount);
+      fillMeasureData(scannedResult, listBasedResult);
+      // increment the number of rows scanned in scanned result statistics
+      incrementScannedResultRowCounter(scannedResult, availableBatchRowCount);
+      // assign the left over rows to batch size if the number of rows fetched are lesser
+      // than batchSize
+      if (listBasedResult.size() < availableBatchRowCount) {
+        batchSize += availableBatchRowCount - listBasedResult.size();
+      }
+    }
   }
 
-  protected void scanResultAndGetData(AbstractScannedResult scannedResult) {
-    dictionaryKeyArray = scannedResult.getDictionaryKeyArray();
-    noDictionaryKeyArray = scannedResult.getNoDictionaryKeyArray();
-    complexTypeKeyArray = scannedResult.getComplexTypeKeyArray();
-    implicitColumnByteArray = scannedResult.getBlockletId()
+  private void fillDimensionData(AbstractScannedResult scannedResult,
+      List<Object[]> listBasedResult, QueryMeasure[] queryMeasures, int batchSize) {
+    long startTime = System.currentTimeMillis();
+    List<byte[]> dictionaryKeyArrayBatch = scannedResult.getDictionaryKeyArrayBatch(batchSize);
+    List<byte[][]> noDictionaryKeyArrayBatch =
+        scannedResult.getNoDictionaryKeyArrayBatch(batchSize);
+    List<byte[][]> complexTypeKeyArrayBatch = scannedResult.getComplexTypeKeyArrayBatch(batchSize);
+    // it will same for one blocklet so can be computed only once
+    byte[] implicitColumnByteArray = scannedResult.getBlockletId()
         .getBytes(Charset.forName(CarbonCommonConstants.DEFAULT_CHARSET));
+    // Note: size check in for loop is for dictionaryKeyArrayBatch as this size can be lesser than
+    // batch size in case of IUD scenarios
+    for (int i = 0; i < dictionaryKeyArrayBatch.size(); i++) {
+      // 1 for ByteArrayWrapper object which will contain dictionary and no dictionary data
+      Object[] row = new Object[1 + queryMeasures.length];
+      ByteArrayWrapper wrapper = new ByteArrayWrapper();
+      wrapper.setDictionaryKey(dictionaryKeyArrayBatch.get(i));
+      wrapper.setNoDictionaryKeys(noDictionaryKeyArrayBatch.get(i));
+      wrapper.setComplexTypesKeys(complexTypeKeyArrayBatch.get(i));
+      wrapper.setImplicitColumnByteArray(implicitColumnByteArray);
+      row[0] = wrapper;
+      listBasedResult.add(row);
+    }
+    QueryStatistic dimensionFillingTime = queryStatisticsModel.getStatisticsTypeAndObjMap()
+        .get(QueryStatisticsConstants.DIMENSION_FILLING_TIME);
+    dimensionFillingTime.addCountStatistic(QueryStatisticsConstants.DIMENSION_FILLING_TIME,
+        dimensionFillingTime.getCount() + (System.currentTimeMillis() - startTime));
   }
+
+  private void fillMeasureData(AbstractScannedResult scannedResult,
+      List<Object[]> listBasedResult) {
+    long startTime = System.currentTimeMillis();
+    // if list is not empty after filling the dimension data then only fill the measure data
+    if (!listBasedResult.isEmpty()) {
+      fillMeasureDataBatch(listBasedResult, 1, scannedResult);
+    }
+    QueryStatistic measureFillingTime = queryStatisticsModel.getStatisticsTypeAndObjMap()
+        .get(QueryStatisticsConstants.MEASURE_FILLING_TIME);
+    measureFillingTime.addCountStatistic(QueryStatisticsConstants.MEASURE_FILLING_TIME,
+        measureFillingTime.getCount() + (System.currentTimeMillis() - startTime));
+  }
+
+  private void incrementScannedResultRowCounter(AbstractScannedResult scannedResult,
+      int batchSize) {
+    // increment row counter by batch size as those many number of rows have been processed at once
+    scannedResult.incrementCounter(batchSize);
+  }
+
 }
+

--- a/core/src/main/java/org/apache/carbondata/core/scan/collector/impl/RestructureBasedDictionaryResultCollector.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/collector/impl/RestructureBasedDictionaryResultCollector.java
@@ -25,6 +25,7 @@ import org.apache.carbondata.core.scan.executor.util.RestructureUtil;
 import org.apache.carbondata.core.scan.filter.GenericQueryType;
 import org.apache.carbondata.core.scan.model.QueryMeasure;
 import org.apache.carbondata.core.scan.result.AbstractScannedResult;
+import org.apache.carbondata.core.stats.QueryStatisticsModel;
 
 /**
  * class for handling restructure scenarios for filling result
@@ -33,8 +34,9 @@ public class RestructureBasedDictionaryResultCollector extends DictionaryBasedRe
 
   private Object[] measureDefaultValues = null;
 
-  public RestructureBasedDictionaryResultCollector(BlockExecutionInfo blockExecutionInfos) {
-    super(blockExecutionInfos);
+  public RestructureBasedDictionaryResultCollector(BlockExecutionInfo blockExecutionInfos,
+      QueryStatisticsModel queryStatisticsModel) {
+    super(blockExecutionInfos, queryStatisticsModel);
     queryDimensions = tableBlockExecutionInfos.getActualQueryDimensions();
     queryMeasures = tableBlockExecutionInfos.getActualQueryMeasures();
     measureDefaultValues = new Object[queryMeasures.length];

--- a/core/src/main/java/org/apache/carbondata/core/scan/collector/impl/RestructureBasedRawResultCollector.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/collector/impl/RestructureBasedRawResultCollector.java
@@ -33,6 +33,10 @@ import org.apache.carbondata.core.scan.executor.infos.BlockExecutionInfo;
 import org.apache.carbondata.core.scan.model.QueryDimension;
 import org.apache.carbondata.core.scan.model.QueryMeasure;
 import org.apache.carbondata.core.scan.result.AbstractScannedResult;
+import org.apache.carbondata.core.scan.wrappers.ByteArrayWrapper;
+import org.apache.carbondata.core.stats.QueryStatistic;
+import org.apache.carbondata.core.stats.QueryStatisticsConstants;
+import org.apache.carbondata.core.stats.QueryStatisticsModel;
 import org.apache.carbondata.core.util.CarbonUtil;
 
 import org.apache.commons.lang3.ArrayUtils;
@@ -59,8 +63,9 @@ public class RestructureBasedRawResultCollector extends RawBasedResultCollector 
    */
   private KeyGenerator updatedCurrentBlockKeyGenerator;
 
-  public RestructureBasedRawResultCollector(BlockExecutionInfo blockExecutionInfos) {
-    super(blockExecutionInfos);
+  public RestructureBasedRawResultCollector(BlockExecutionInfo blockExecutionInfos,
+      QueryStatisticsModel queryStatisticsModel) {
+    super(blockExecutionInfos, queryStatisticsModel);
     initRestructuredKeyGenerator();
     initCurrentBlockKeyGenerator();
   }
@@ -150,105 +155,110 @@ public class RestructureBasedRawResultCollector extends RawBasedResultCollector 
    * it will keep track of how many record is processed, to handle limit scenario
    */
   @Override public List<Object[]> collectData(AbstractScannedResult scannedResult, int batchSize) {
+    long startTime = System.currentTimeMillis();
     List<Object[]> listBasedResult = new ArrayList<>(batchSize);
     QueryMeasure[] queryMeasures = tableBlockExecutionInfos.getActualQueryMeasures();
     // scan the record and add to list
-    int rowCounter = 0;
-    while (scannedResult.hasNext() && rowCounter < batchSize) {
-      scanResultAndGetData(scannedResult);
-      if (scannedResult.containsDeletedRow(scannedResult.getCurrentRowId())) {
-        continue;
-      }
-      // re-fill dictionary and no dictionary key arrays for the newly added columns
-      if (dimensionInfo.isDictionaryColumnAdded()) {
-        dictionaryKeyArray = fillDictionaryKeyArrayWithLatestSchema(dictionaryKeyArray);
-      }
-      if (dimensionInfo.isNoDictionaryColumnAdded()) {
-        noDictionaryKeyArray = fillNoDictionaryKeyArrayWithLatestSchema(noDictionaryKeyArray);
-      }
-      prepareRow(scannedResult, listBasedResult, queryMeasures);
-      rowCounter++;
+    scanAndFillData(scannedResult, batchSize, listBasedResult, queryMeasures);
+    // re-fill dictionary and no dictionary key arrays for the newly added columns
+    if (dimensionInfo.isDictionaryColumnAdded()) {
+      fillDictionaryKeyArrayBatchWithLatestSchema(listBasedResult);
     }
+    if (dimensionInfo.isNoDictionaryColumnAdded()) {
+      fillNoDictionaryKeyArrayBatchWithLatestSchema(listBasedResult);
+    }
+    QueryStatistic resultPrepTime = queryStatisticsModel.getStatisticsTypeAndObjMap()
+        .get(QueryStatisticsConstants.RESULT_PREP_TIME);
+    resultPrepTime.addCountStatistic(QueryStatisticsConstants.RESULT_PREP_TIME,
+        resultPrepTime.getCount() + (System.currentTimeMillis() - startTime));
     return listBasedResult;
   }
 
   /**
    * This method will fill the dictionary key array with newly added dictionary columns if any
    *
-   * @param dictionaryKeyArray
+   * @param rows
    * @return
    */
-  private byte[] fillDictionaryKeyArrayWithLatestSchema(byte[] dictionaryKeyArray) {
-    QueryDimension[] actualQueryDimensions = tableBlockExecutionInfos.getActualQueryDimensions();
-    int newKeyArrayLength = dimensionInfo.getNewDictionaryColumnCount();
-    long[] keyArray = null;
-    if (null != updatedCurrentBlockKeyGenerator) {
-      keyArray = updatedCurrentBlockKeyGenerator.getKeyArray(dictionaryKeyArray);
-      newKeyArrayLength += keyArray.length;
-    }
-    long[] keyArrayWithNewAddedColumns = new long[newKeyArrayLength];
-    int existingColumnKeyArrayIndex = 0;
-    int newKeyArrayIndex = 0;
-    for (int i = 0; i < dimensionInfo.getDimensionExists().length; i++) {
-      if (CarbonUtil
-          .hasEncoding(actualQueryDimensions[i].getDimension().getEncoder(), Encoding.DICTIONARY)) {
-        // if dimension exists then add the key array value else add the default value
-        if (dimensionInfo.getDimensionExists()[i]) {
-          keyArrayWithNewAddedColumns[newKeyArrayIndex++] = keyArray[existingColumnKeyArrayIndex++];
-        } else {
-          long defaultValueAsLong;
-          Object defaultValue = dimensionInfo.getDefaultValues()[i];
-          if (null != defaultValue) {
-            defaultValueAsLong = ((Integer) defaultValue).longValue();
+  private void fillDictionaryKeyArrayBatchWithLatestSchema(List<Object[]> rows) {
+    for (Object[] row : rows) {
+      ByteArrayWrapper byteArrayWrapper = (ByteArrayWrapper) row[0];
+      byte[] dictKeyArray = byteArrayWrapper.getDictionaryKey();
+      QueryDimension[] actualQueryDimensions = tableBlockExecutionInfos.getActualQueryDimensions();
+      int newKeyArrayLength = dimensionInfo.getNewDictionaryColumnCount();
+      long[] keyArray = null;
+      if (null != updatedCurrentBlockKeyGenerator) {
+        keyArray = updatedCurrentBlockKeyGenerator.getKeyArray(dictKeyArray);
+        newKeyArrayLength += keyArray.length;
+      }
+      long[] keyArrayWithNewAddedColumns = new long[newKeyArrayLength];
+      int existingColumnKeyArrayIndex = 0;
+      int newKeyArrayIndex = 0;
+      for (int i = 0; i < dimensionInfo.getDimensionExists().length; i++) {
+        if (CarbonUtil.hasEncoding(actualQueryDimensions[i].getDimension().getEncoder(),
+            Encoding.DICTIONARY)) {
+          // if dimension exists then add the key array value else add the default value
+          if (dimensionInfo.getDimensionExists()[i]) {
+            keyArrayWithNewAddedColumns[newKeyArrayIndex++] =
+                keyArray[existingColumnKeyArrayIndex++];
           } else {
-            defaultValueAsLong = (long)CarbonCommonConstants.MEMBER_DEFAULT_VAL_SURROGATE_KEY;
+            long defaultValueAsLong;
+            Object defaultValue = dimensionInfo.getDefaultValues()[i];
+            if (null != defaultValue) {
+              defaultValueAsLong = ((Integer) defaultValue).longValue();
+            } else {
+              defaultValueAsLong = (long) CarbonCommonConstants.MEMBER_DEFAULT_VAL_SURROGATE_KEY;
+            }
+            keyArrayWithNewAddedColumns[newKeyArrayIndex++] = defaultValueAsLong;
           }
-          keyArrayWithNewAddedColumns[newKeyArrayIndex++] = defaultValueAsLong;
         }
       }
+      try {
+        dictKeyArray = restructuredKeyGenerator.generateKey(keyArrayWithNewAddedColumns);
+      } catch (KeyGenException e) {
+        throw new RuntimeException(e);
+      }
     }
-    try {
-      dictionaryKeyArray = restructuredKeyGenerator.generateKey(keyArrayWithNewAddedColumns);
-    } catch (KeyGenException e) {
-      LOGGER.error(e, e.getMessage());
-    }
-    return dictionaryKeyArray;
   }
 
   /**
    * This method will fill the no dictionary byte array with newly added no dictionary columns
    *
-   * @param noDictionaryKeyArray
+   * @param rows
    * @return
    */
-  private byte[][] fillNoDictionaryKeyArrayWithLatestSchema(byte[][] noDictionaryKeyArray) {
-    QueryDimension[] actualQueryDimensions = tableBlockExecutionInfos.getActualQueryDimensions();
-    byte[][] noDictionaryKeyArrayWithNewlyAddedColumns =
-        new byte[noDictionaryKeyArray.length + dimensionInfo.getNewNoDictionaryColumnCount()][];
-    int existingColumnValueIndex = 0;
-    int newKeyArrayIndex = 0;
-    for (int i = 0; i < dimensionInfo.getDimensionExists().length; i++) {
-      if (!actualQueryDimensions[i].getDimension().hasEncoding(Encoding.DICTIONARY)
-          && !actualQueryDimensions[i].getDimension().hasEncoding(Encoding.IMPLICIT)) {
-        // if dimension exists then add the byte array value else add the default value
-        if (dimensionInfo.getDimensionExists()[i]) {
-          noDictionaryKeyArrayWithNewlyAddedColumns[newKeyArrayIndex++] =
-              noDictionaryKeyArray[existingColumnValueIndex++];
-        } else {
-          byte[] newColumnDefaultValue = null;
-          Object defaultValue = dimensionInfo.getDefaultValues()[i];
-          if (null != defaultValue) {
-            newColumnDefaultValue = ((UTF8String) defaultValue).getBytes();
-          } else if (actualQueryDimensions[i].getDimension().getDataType() == DataTypes.STRING) {
-            newColumnDefaultValue =
-                UTF8String.fromString(CarbonCommonConstants.MEMBER_DEFAULT_VAL).getBytes();
+  private void fillNoDictionaryKeyArrayBatchWithLatestSchema(List<Object[]> rows) {
+    for (Object[] row : rows) {
+      ByteArrayWrapper byteArrayWrapper = (ByteArrayWrapper) row[0];
+      byte[][] noDictKeyArray = byteArrayWrapper.getNoDictionaryKeys();
+      QueryDimension[] actualQueryDimensions = tableBlockExecutionInfos.getActualQueryDimensions();
+      byte[][] noDictionaryKeyArrayWithNewlyAddedColumns =
+          new byte[noDictKeyArray.length + dimensionInfo.getNewNoDictionaryColumnCount()][];
+      int existingColumnValueIndex = 0;
+      int newKeyArrayIndex = 0;
+      for (int i = 0; i < dimensionInfo.getDimensionExists().length; i++) {
+        if (!actualQueryDimensions[i].getDimension().hasEncoding(Encoding.DICTIONARY)
+            && !actualQueryDimensions[i].getDimension().hasEncoding(Encoding.IMPLICIT)) {
+          // if dimension exists then add the byte array value else add the default value
+          if (dimensionInfo.getDimensionExists()[i]) {
+            noDictionaryKeyArrayWithNewlyAddedColumns[newKeyArrayIndex++] =
+                noDictKeyArray[existingColumnValueIndex++];
           } else {
-            newColumnDefaultValue = CarbonCommonConstants.EMPTY_BYTE_ARRAY;
+            byte[] newColumnDefaultValue = null;
+            Object defaultValue = dimensionInfo.getDefaultValues()[i];
+            if (null != defaultValue) {
+              newColumnDefaultValue = ((UTF8String) defaultValue).getBytes();
+            } else if (actualQueryDimensions[i].getDimension().getDataType() == DataTypes.STRING) {
+              newColumnDefaultValue =
+                  UTF8String.fromString(CarbonCommonConstants.MEMBER_DEFAULT_VAL).getBytes();
+            } else {
+              newColumnDefaultValue = CarbonCommonConstants.EMPTY_BYTE_ARRAY;
+            }
+            noDictionaryKeyArrayWithNewlyAddedColumns[newKeyArrayIndex++] = newColumnDefaultValue;
           }
-          noDictionaryKeyArrayWithNewlyAddedColumns[newKeyArrayIndex++] = newColumnDefaultValue;
         }
       }
+      byteArrayWrapper.setNoDictionaryKeys(noDictionaryKeyArrayWithNewlyAddedColumns);
     }
-    return noDictionaryKeyArrayWithNewlyAddedColumns;
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/scan/collector/impl/RestructureBasedVectorResultCollector.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/collector/impl/RestructureBasedVectorResultCollector.java
@@ -30,6 +30,7 @@ import org.apache.carbondata.core.scan.result.AbstractScannedResult;
 import org.apache.carbondata.core.scan.result.vector.CarbonColumnVector;
 import org.apache.carbondata.core.scan.result.vector.CarbonColumnarBatch;
 import org.apache.carbondata.core.scan.result.vector.ColumnVectorInfo;
+import org.apache.carbondata.core.stats.QueryStatisticsModel;
 
 import org.apache.spark.sql.types.Decimal;
 import org.apache.spark.unsafe.types.UTF8String;
@@ -41,8 +42,9 @@ public class RestructureBasedVectorResultCollector extends DictionaryBasedVector
 
   private Object[] measureDefaultValues = null;
 
-  public RestructureBasedVectorResultCollector(BlockExecutionInfo blockExecutionInfos) {
-    super(blockExecutionInfos);
+  public RestructureBasedVectorResultCollector(BlockExecutionInfo blockExecutionInfos,
+      QueryStatisticsModel queryStatisticsModel) {
+    super(blockExecutionInfos, queryStatisticsModel);
     queryDimensions = tableBlockExecutionInfos.getActualQueryDimensions();
     queryMeasures = tableBlockExecutionInfos.getActualQueryMeasures();
     measureDefaultValues = new Object[queryMeasures.length];

--- a/core/src/main/java/org/apache/carbondata/core/scan/executor/impl/AbstractQueryExecutor.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/executor/impl/AbstractQueryExecutor.java
@@ -118,9 +118,12 @@ public abstract class AbstractQueryExecutor<E> implements QueryExecutor<E> {
     queryProperties.executorService = Executors.newCachedThreadPool();
     // Initializing statistics list to record the query statistics
     // creating copy on write to handle concurrent scenario
-    queryProperties.queryStatisticsRecorder =
-        CarbonTimeStatisticsFactory.createExecutorRecorder(queryModel.getQueryId());
-    queryModel.setStatisticsRecorder(queryProperties.queryStatisticsRecorder);
+    queryProperties.queryStatisticsRecorder = queryModel.getStatisticsRecorder();
+    if (null == queryProperties.queryStatisticsRecorder) {
+      queryProperties.queryStatisticsRecorder =
+          CarbonTimeStatisticsFactory.createExecutorRecorder(queryModel.getQueryId());
+      queryModel.setStatisticsRecorder(queryProperties.queryStatisticsRecorder);
+    }
     QueryUtil.resolveQueryModel(queryModel);
     QueryStatistic queryStatistic = new QueryStatistic();
     // sort the block info

--- a/core/src/main/java/org/apache/carbondata/core/scan/processor/AbstractDataBlockIterator.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/processor/AbstractDataBlockIterator.java
@@ -98,7 +98,7 @@ public abstract class AbstractDataBlockIterator extends CarbonIterator<List<Obje
       blockletScanner = new NonFilterScanner(blockExecutionInfo, queryStatisticsModel);
     }
     this.scannerResultAggregator =
-        ResultCollectorFactory.getScannedResultCollector(blockExecutionInfo);
+        ResultCollectorFactory.getScannedResultCollector(blockExecutionInfo, queryStatisticsModel);
     this.batchSize = batchSize;
     this.executorService = executorService;
     this.nextBlock = new AtomicBoolean(false);

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/impl/FilterQueryScannedResult.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/impl/FilterQueryScannedResult.java
@@ -16,9 +16,12 @@
  */
 package org.apache.carbondata.core.scan.result.impl;
 
+import java.util.List;
+
 import org.apache.carbondata.core.scan.executor.infos.BlockExecutionInfo;
 import org.apache.carbondata.core.scan.result.AbstractScannedResult;
 import org.apache.carbondata.core.scan.result.vector.ColumnVectorInfo;
+import org.apache.carbondata.core.stats.QueryStatisticsModel;
 
 /**
  * Result provider class in case of filter query
@@ -27,8 +30,9 @@ import org.apache.carbondata.core.scan.result.vector.ColumnVectorInfo;
  */
 public class FilterQueryScannedResult extends AbstractScannedResult {
 
-  public FilterQueryScannedResult(BlockExecutionInfo tableBlockExecutionInfos) {
-    super(tableBlockExecutionInfos);
+  public FilterQueryScannedResult(BlockExecutionInfo tableBlockExecutionInfos,
+      QueryStatisticsModel queryStatisticsModel) {
+    super(tableBlockExecutionInfos, queryStatisticsModel);
   }
 
   /**
@@ -49,6 +53,10 @@ public class FilterQueryScannedResult extends AbstractScannedResult {
     return getDictionaryKeyIntegerArray(rowMapping[pageCounter][currentRow]);
   }
 
+  @Override public List<byte[]> getDictionaryKeyArrayBatch(int batchSize) {
+    throw new UnsupportedOperationException("Operation not supported");
+  }
+
   /**
    * Below method will be used to get the complex type key array
    *
@@ -56,6 +64,10 @@ public class FilterQueryScannedResult extends AbstractScannedResult {
    */
   @Override public byte[][] getComplexTypeKeyArray() {
     return getComplexTypeKeyArray(rowMapping[pageCounter][currentRow]);
+  }
+
+  @Override public List<byte[][]> getComplexTypeKeyArrayBatch(int batchSize) {
+    throw new UnsupportedOperationException("Operation not supported");
   }
 
   /**
@@ -76,6 +88,10 @@ public class FilterQueryScannedResult extends AbstractScannedResult {
    */
   @Override public String[] getNoDictionaryKeyStringArray() {
     return getNoDictionaryKeyStringArray(rowMapping[pageCounter][currentRow]);
+  }
+
+  @Override public List<byte[][]> getNoDictionaryKeyArrayBatch(int batchSize) {
+    throw new UnsupportedOperationException("Operation not supported");
   }
 
   /**

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/impl/NonFilterQueryScannedResult.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/impl/NonFilterQueryScannedResult.java
@@ -16,8 +16,12 @@
  */
 package org.apache.carbondata.core.scan.result.impl;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.apache.carbondata.core.scan.executor.infos.BlockExecutionInfo;
 import org.apache.carbondata.core.scan.result.AbstractScannedResult;
+import org.apache.carbondata.core.stats.QueryStatisticsModel;
 
 /**
  * Result provide class for non filter query
@@ -26,8 +30,9 @@ import org.apache.carbondata.core.scan.result.AbstractScannedResult;
  */
 public class NonFilterQueryScannedResult extends AbstractScannedResult {
 
-  public NonFilterQueryScannedResult(BlockExecutionInfo blockExecutionInfo) {
-    super(blockExecutionInfo);
+  public NonFilterQueryScannedResult(BlockExecutionInfo blockExecutionInfo,
+      QueryStatisticsModel queryStatisticsModel) {
+    super(blockExecutionInfo, queryStatisticsModel);
   }
 
   /**
@@ -48,6 +53,32 @@ public class NonFilterQueryScannedResult extends AbstractScannedResult {
     return getDictionaryKeyIntegerArray(currentRow);
   }
 
+  @Override public List<byte[]> getDictionaryKeyArrayBatch(int batchSize) {
+    // rowId from where computing need to start
+    int startRowId = currentRow + 1;
+    fillValidRowIdsBatchFilling(startRowId, batchSize);
+    List<byte[]> dictionaryKeyArrayList = new ArrayList<>(validRowIds.size());
+    int[] columnDataOffsets = null;
+    byte[] completeKey = null;
+    // everyTime it is initialized new as in case of prefetch it can modify the data
+    for (int i = 0; i < validRowIds.size(); i++) {
+      completeKey = new byte[fixedLengthKeySize];
+      dictionaryKeyArrayList.add(completeKey);
+    }
+    // initialize offset array onli if data is present
+    if (this.dictionaryColumnBlockIndexes.length > 0) {
+      columnDataOffsets = new int[validRowIds.size()];
+    }
+    for (int i = 0; i < this.dictionaryColumnBlockIndexes.length; i++) {
+      for (int j = 0; j < validRowIds.size(); j++) {
+        columnDataOffsets[j] += dimensionDataChunks[dictionaryColumnBlockIndexes[i]][pageCounter]
+            .fillChunkData(dictionaryKeyArrayList.get(j), columnDataOffsets[j], validRowIds.get(j),
+                columnGroupKeyStructureInfo.get(dictionaryColumnBlockIndexes[i]));
+      }
+    }
+    return dictionaryKeyArrayList;
+  }
+
   /**
    * Below method will be used to get the complex type key array
    *
@@ -55,6 +86,11 @@ public class NonFilterQueryScannedResult extends AbstractScannedResult {
    */
   @Override public byte[][] getComplexTypeKeyArray() {
     return getComplexTypeKeyArray(currentRow);
+  }
+
+  @Override public List<byte[][]> getComplexTypeKeyArrayBatch(int batchSize) {
+    List<byte[][]> complexTypeKeyArrayBatch = getComplexTypeKeyArrayBatch();
+    return complexTypeKeyArrayBatch;
   }
 
   /**
@@ -75,6 +111,34 @@ public class NonFilterQueryScannedResult extends AbstractScannedResult {
    */
   @Override public String[] getNoDictionaryKeyStringArray() {
     return getNoDictionaryKeyStringArray(currentRow);
+  }
+
+  /**
+   * Below method will be used to get the dimension key array
+   * for all the no dictionary dimension present in the query
+   * This method will fill the data column wise for the given batch size
+   *
+   * @return no dictionary keys for all no dictionary dimension
+   */
+  @Override public List<byte[][]> getNoDictionaryKeyArrayBatch(int batchSize) {
+    List<byte[][]> noDictionaryKeyArrayList = new ArrayList<>(validRowIds.size());
+    byte[][] noDictionaryColumnsKeys = null;
+    // everyTime it is initialized new as in case of prefetch it can modify the data
+    for (int i = 0; i < validRowIds.size(); i++) {
+      noDictionaryColumnsKeys = new byte[noDictionaryColumnBlockIndexes.length][];
+      noDictionaryKeyArrayList.add(noDictionaryColumnsKeys);
+    }
+    int columnPosition = 0;
+    for (int i = 0; i < this.noDictionaryColumnBlockIndexes.length; i++) {
+      for (int j = 0; j < validRowIds.size(); j++) {
+        byte[][] noDictionaryArray = noDictionaryKeyArrayList.get(j);
+        noDictionaryArray[columnPosition] =
+            dimensionDataChunks[noDictionaryColumnBlockIndexes[i]][pageCounter]
+                .getChunkData(validRowIds.get(j));
+      }
+      columnPosition++;
+    }
+    return noDictionaryKeyArrayList;
   }
 
   /**

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/iterator/AbstractDetailQueryResultIterator.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/iterator/AbstractDetailQueryResultIterator.java
@@ -296,6 +296,27 @@ public abstract class AbstractDetailQueryResultIterator<E> extends CarbonIterato
     queryStatisticsModel.getStatisticsTypeAndObjMap()
         .put(QueryStatisticsConstants.READ_BLOCKlET_TIME, readTime);
     queryStatisticsModel.getRecorder().recordStatistics(readTime);
+
+    // dimension filling time
+    QueryStatistic dimFilingTime = new QueryStatistic();
+    queryStatisticsModel.getStatisticsTypeAndObjMap()
+        .put(QueryStatisticsConstants.DIMENSION_FILLING_TIME, dimFilingTime);
+    queryStatisticsModel.getRecorder().recordStatistics(dimFilingTime);
+    // measure filling time
+    QueryStatistic measureFilingTime = new QueryStatistic();
+    queryStatisticsModel.getStatisticsTypeAndObjMap()
+        .put(QueryStatisticsConstants.MEASURE_FILLING_TIME, measureFilingTime);
+    queryStatisticsModel.getRecorder().recordStatistics(measureFilingTime);
+    // result preparation time
+    QueryStatistic resultPreparationTime = new QueryStatistic();
+    queryStatisticsModel.getStatisticsTypeAndObjMap()
+        .put(QueryStatisticsConstants.RESULT_PREP_TIME, resultPreparationTime);
+    queryStatisticsModel.getRecorder().recordStatistics(resultPreparationTime);
+    // page Io Time
+    QueryStatistic pageUncompressTime = new QueryStatistic();
+    queryStatisticsModel.getStatisticsTypeAndObjMap()
+        .put(QueryStatisticsConstants.PAGE_UNCOMPRESS_TIME, pageUncompressTime);
+    queryStatisticsModel.getRecorder().recordStatistics(pageUncompressTime);
   }
 
   public void processNextBatch(CarbonColumnarBatch columnarBatch) {

--- a/core/src/main/java/org/apache/carbondata/core/scan/scanner/AbstractBlockletScanner.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/scanner/AbstractBlockletScanner.java
@@ -54,7 +54,8 @@ public abstract class AbstractBlockletScanner implements BlockletScanner {
   @Override public AbstractScannedResult scanBlocklet(BlocksChunkHolder blocksChunkHolder)
       throws IOException, FilterUnsupportedException {
     long startTime = System.currentTimeMillis();
-    AbstractScannedResult scannedResult = new NonFilterQueryScannedResult(blockExecutionInfo);
+    AbstractScannedResult scannedResult =
+        new NonFilterQueryScannedResult(blockExecutionInfo, queryStatisticsModel);
     QueryStatistic totalBlockletStatistic = queryStatisticsModel.getStatisticsTypeAndObjMap()
         .get(QueryStatisticsConstants.TOTAL_BLOCKLET_NUM);
     totalBlockletStatistic.addCountStatistic(QueryStatisticsConstants.TOTAL_BLOCKLET_NUM,
@@ -167,7 +168,7 @@ public abstract class AbstractBlockletScanner implements BlockletScanner {
 
   @Override public AbstractScannedResult createEmptyResult() {
     if (emptyResult == null) {
-      emptyResult = new NonFilterQueryScannedResult(blockExecutionInfo);
+      emptyResult = new NonFilterQueryScannedResult(blockExecutionInfo, queryStatisticsModel);
       emptyResult.setNumberOfRows(new int[0]);
       emptyResult.setIndexes(new int[0][]);
     }

--- a/core/src/main/java/org/apache/carbondata/core/scan/scanner/impl/FilterScanner.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/scanner/impl/FilterScanner.java
@@ -183,7 +183,8 @@ public class FilterScanner extends AbstractBlockletScanner {
       return createEmptyResult();
     }
 
-    AbstractScannedResult scannedResult = new FilterQueryScannedResult(blockExecutionInfo);
+    AbstractScannedResult scannedResult =
+        new FilterQueryScannedResult(blockExecutionInfo, queryStatisticsModel);
     scannedResult.setBlockletId(
         blockExecutionInfo.getBlockId() + CarbonCommonConstants.FILE_SEPARATOR + blocksChunkHolder
             .getDataBlock().blockletId());

--- a/core/src/main/java/org/apache/carbondata/core/stats/QueryStatisticsConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/stats/QueryStatisticsConstants.java
@@ -58,6 +58,28 @@ public interface QueryStatisticsConstants {
 
   String PAGE_SCANNED = "The number of page scanned";
 
+  /**
+   * measure filling time includes time taken for reading all measures data from a given offset
+   * and adding each column data to an array. Includes total time for 1 query result iterator.
+   */
+  String MEASURE_FILLING_TIME = "measure filling time";
+
+  /**
+   * dimension filling time includes time taken for reading all dimensions data from a given offset
+   * and filling each column data to byte array. Includes total time for 1 query result iterator.
+   */
+  String DIMENSION_FILLING_TIME = "dimension filling time";
+
+  /**
+   * Time taken to uncompress a page data and decode dimensions and measures data in that page
+   */
+  String PAGE_UNCOMPRESS_TIME = "page uncompress time";
+
+  /**
+   * total of measure filling time, dimension filling time and page uncompressing time
+   */
+  String RESULT_PREP_TIME = "result preparation time";
+
   // clear no-use statistics timeout
   long CLEAR_STATISTICS_TIMEOUT = 60 * 1000 * 1000000L;
 

--- a/core/src/main/java/org/apache/carbondata/core/stats/QueryStatisticsRecorderImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/stats/QueryStatisticsRecorderImpl.java
@@ -99,6 +99,10 @@ public class QueryStatisticsRecorderImpl implements QueryStatisticsRecorder, Ser
     long total_pages = 0;
     long readTime = 0;
     long scannedPages = 0;
+    long measureFillingTime = 0L;
+    long dimensionFillingTime = 0L;
+    long resultPreparationTime = 0L;
+    long pageUncompressTime = 0L;
     try {
       for (QueryStatistic statistic : queryStatistics) {
         if (statistic.getMessage() != null) {
@@ -139,6 +143,18 @@ public class QueryStatisticsRecorderImpl implements QueryStatisticsRecorder, Ser
             case QueryStatisticsConstants.PAGE_SCANNED:
               scannedPages = statistic.getCount();
               break;
+            case QueryStatisticsConstants.DIMENSION_FILLING_TIME:
+              dimensionFillingTime += statistic.getCount();
+              break;
+            case QueryStatisticsConstants.MEASURE_FILLING_TIME:
+              measureFillingTime += statistic.getCount();
+              break;
+            case QueryStatisticsConstants.RESULT_PREP_TIME:
+              resultPreparationTime += statistic.getCount();
+              break;
+            case QueryStatisticsConstants.PAGE_UNCOMPRESS_TIME:
+              pageUncompressTime += statistic.getCount();
+              break;
             default:
               break;
           }
@@ -146,8 +162,9 @@ public class QueryStatisticsRecorderImpl implements QueryStatisticsRecorder, Ser
       }
       String headers =
           "task_id,load_blocks_time,load_dictionary_time,carbon_scan_time,carbon_IO_time, "
-              + "total_executor_time,scan_blocks_num,total_blocklets,"
-              + "valid_blocklets,total_pages,scanned_pages,valid_pages,result_size";
+              + "total_executor_time,scan_blocks_num,total_blocklets,valid_blocklets,"
+              + "total_pages,scanned_pages,valid_pages,result_size,dimension_filling_time,"
+              + "measure_filling_time,page_uncompress_time,result_preparation_time";
       List<String> values = new ArrayList<String>();
       values.add(queryIWthTask);
       values.add(load_blocks_time + "ms");
@@ -162,6 +179,10 @@ public class QueryStatisticsRecorderImpl implements QueryStatisticsRecorder, Ser
       values.add(String.valueOf(scannedPages));
       values.add(String.valueOf(valid_pages_blocklet));
       values.add(String.valueOf(result_size));
+      values.add(dimensionFillingTime + " ms");
+      values.add(measureFillingTime + " ms");
+      values.add(pageUncompressTime + " ms");
+      values.add(resultPreparationTime + " ms");
       StringBuilder tableInfo = new StringBuilder();
       String[] columns = headers.split(",");
       StringBuilder line = new StringBuilder("");

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonMergerRDD.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonMergerRDD.scala
@@ -80,6 +80,7 @@ class CarbonMergerRDD[K, V](
   val tableId = carbonMergerMapping.tableId
 
   override def internalCompute(theSplit: Partition, context: TaskContext): Iterator[(K, V)] = {
+    val startTime = System.currentTimeMillis()
     val LOGGER = LogServiceFactory.getLogService(this.getClass.getName)
     val iter = new Iterator[(K, V)] {
       val carbonTable = carbonLoadModel.getCarbonDataLoadSchema.getCarbonTable
@@ -239,7 +240,7 @@ class CarbonMergerRDD[K, V](
         // close all the query executor service and clean up memory acquired during query processing
         if (null != exec) {
           LOGGER.info("Cleaning up query resources acquired during compaction")
-          exec.finish()
+          exec.finish(startTime)
         }
         // clean up the resources for processor
         if (null != processor) {

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
@@ -381,6 +381,8 @@ class CarbonScanRDD(
         close()
         logStatistics(queryStartTime, model.getStatisticsRecorder)
       }
+      val recorder = CarbonTimeStatisticsFactory.createExecutorRecorder(model.getQueryId())
+      model.setStatisticsRecorder(recorder)
       // initialize the reader
       reader.initialize(inputSplit, attemptContext)
 


### PR DESCRIPTION
Problem: Compaction performance is slow as compared to data load

Analysis:
1. During compaction result filling is done in row format. Due to this as the number of columns increases the dimension and measure data filling time increases. This happens because in row filling we are not able to take advantage of OS cacheable buffers as we continuously read data for next column.
2. As compaction uses a page level reader flow wherein both IO and uncompression is done at page level, the IO and uncompression time increases in this model.

Solution:
1. Implement a columnar format filling data structure for compaction process for filling dimension and measure data.
2. Perform IO at blocklet level and uncompression at page level.

**Note:** **This PR contains the solution for point 1. For point 2 refer PR #2192 **

 - [ ] Any interfaces changed?
 No
 - [ ] Any backward compatibility impacted?
 No
 - [ ] Document update required?
No
 - [ ] Testing done
 Manually verified      
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA
