### PR TITLE
[CARBONDATA-2371] Add Profiler output in EXPLAIN command

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datamap/DataMapChooser.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/DataMapChooser.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import org.apache.carbondata.common.annotations.InterfaceAudience;
@@ -69,19 +70,20 @@ public class DataMapChooser {
   /**
    * Return a chosen datamap based on input filter. See {@link DataMapChooser}
    */
-  public DataMapExprWrapper choose(CarbonTable carbonTable, FilterResolverIntf resolverIntf)
+  public DataMapExprWrapper choose(CarbonTable carbonTable, FilterResolverIntf filter)
       throws IOException {
-    if (resolverIntf != null) {
-      Expression expression = resolverIntf.getFilterExpression();
+    Objects.requireNonNull(carbonTable);
+    if (filter != null) {
+      Expression expression = filter.getFilterExpression();
       // First check for FG datamaps if any exist
       List<TableDataMap> allDataMapFG =
           DataMapStoreManager.getInstance().getAllVisibleDataMap(carbonTable, DataMapLevel.FG);
-      ExpressionTuple tuple = selectDataMap(expression, allDataMapFG, resolverIntf);
+      ExpressionTuple tuple = selectDataMap(expression, allDataMapFG, filter);
       if (tuple.dataMapExprWrapper == null) {
         // Check for CG datamap
         List<TableDataMap> allDataMapCG =
             DataMapStoreManager.getInstance().getAllVisibleDataMap(carbonTable, DataMapLevel.CG);
-        tuple = selectDataMap(expression, allDataMapCG, resolverIntf);
+        tuple = selectDataMap(expression, allDataMapCG, filter);
       }
       if (tuple.dataMapExprWrapper != null) {
         return tuple.dataMapExprWrapper;
@@ -89,8 +91,7 @@ public class DataMapChooser {
     }
     // Return the default datamap if no other datamap exists.
     return new DataMapExprWrapperImpl(
-        DataMapStoreManager.getInstance().getDefaultDataMap(carbonTable),
-        resolverIntf);
+        DataMapStoreManager.getInstance().getDefaultDataMap(carbonTable), filter);
   }
 
   /**

--- a/core/src/main/java/org/apache/carbondata/core/datamap/dev/expr/AndDataMapExprWrapper.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/dev/expr/AndDataMapExprWrapper.java
@@ -24,6 +24,7 @@ import org.apache.carbondata.core.datamap.DataMapLevel;
 import org.apache.carbondata.core.datamap.Segment;
 import org.apache.carbondata.core.indexstore.ExtendedBlocklet;
 import org.apache.carbondata.core.indexstore.PartitionSpec;
+import org.apache.carbondata.core.metadata.schema.table.DataMapSchema;
 import org.apache.carbondata.core.scan.filter.resolver.FilterResolverIntf;
 
 /**
@@ -94,7 +95,12 @@ public class AndDataMapExprWrapper implements DataMapExprWrapper {
     return wrappers;
   }
 
-  @Override public DataMapLevel getDataMapType() {
-    return left.getDataMapType();
+  @Override public DataMapLevel getDataMapLevel() {
+    return left.getDataMapLevel();
   }
+
+  @Override public DataMapSchema getDataMapSchema() {
+    return left.getDataMapSchema();
+  }
+
 }

--- a/core/src/main/java/org/apache/carbondata/core/datamap/dev/expr/DataMapExprWrapper.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/dev/expr/DataMapExprWrapper.java
@@ -24,6 +24,7 @@ import org.apache.carbondata.core.datamap.DataMapLevel;
 import org.apache.carbondata.core.datamap.Segment;
 import org.apache.carbondata.core.indexstore.ExtendedBlocklet;
 import org.apache.carbondata.core.indexstore.PartitionSpec;
+import org.apache.carbondata.core.metadata.schema.table.DataMapSchema;
 import org.apache.carbondata.core.scan.filter.resolver.FilterResolverIntf;
 
 /**
@@ -71,9 +72,13 @@ public interface DataMapExprWrapper extends Serializable {
   FilterResolverIntf getFilterResolverIntf(String uniqueId);
 
   /**
-   * Get the datamap type.
-   * @return
+   * Get the datamap level.
    */
-  DataMapLevel getDataMapType();
+  DataMapLevel getDataMapLevel();
+
+  /**
+   * Get the datamap schema
+   */
+  DataMapSchema getDataMapSchema();
 
 }

--- a/core/src/main/java/org/apache/carbondata/core/datamap/dev/expr/DataMapExprWrapperImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/dev/expr/DataMapExprWrapperImpl.java
@@ -27,6 +27,7 @@ import org.apache.carbondata.core.datamap.Segment;
 import org.apache.carbondata.core.datamap.TableDataMap;
 import org.apache.carbondata.core.indexstore.ExtendedBlocklet;
 import org.apache.carbondata.core.indexstore.PartitionSpec;
+import org.apache.carbondata.core.metadata.schema.table.DataMapSchema;
 import org.apache.carbondata.core.scan.filter.resolver.FilterResolverIntf;
 
 public class DataMapExprWrapperImpl implements DataMapExprWrapper {
@@ -83,7 +84,12 @@ public class DataMapExprWrapperImpl implements DataMapExprWrapper {
     return wrappers;
   }
 
-  @Override public DataMapLevel getDataMapType() {
+  @Override public DataMapLevel getDataMapLevel() {
     return dataMap.getDataMapFactory().getDataMapType();
   }
+
+  @Override public DataMapSchema getDataMapSchema() {
+    return dataMap.getDataMapSchema();
+  }
+
 }

--- a/core/src/main/java/org/apache/carbondata/core/datamap/dev/expr/OrDataMapExprWrapper.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/dev/expr/OrDataMapExprWrapper.java
@@ -26,6 +26,7 @@ import org.apache.carbondata.core.datamap.DataMapLevel;
 import org.apache.carbondata.core.datamap.Segment;
 import org.apache.carbondata.core.indexstore.ExtendedBlocklet;
 import org.apache.carbondata.core.indexstore.PartitionSpec;
+import org.apache.carbondata.core.metadata.schema.table.DataMapSchema;
 import org.apache.carbondata.core.scan.filter.resolver.FilterResolverIntf;
 
 /**
@@ -91,7 +92,11 @@ public class OrDataMapExprWrapper implements DataMapExprWrapper {
   }
 
 
-  @Override public DataMapLevel getDataMapType() {
-    return left.getDataMapType();
+  @Override public DataMapLevel getDataMapLevel() {
+    return left.getDataMapLevel();
+  }
+
+  @Override public DataMapSchema getDataMapSchema() {
+    return left.getDataMapSchema();
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/AggregationDataMapSchema.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/AggregationDataMapSchema.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.carbondata.core.metadata.schema.datamap.DataMapClassProvider;
 import org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema;
 import org.apache.carbondata.core.metadata.schema.table.column.ParentColumnTableRelation;
 import org.apache.carbondata.core.preagg.TimeSeriesFunctionEnum;
@@ -358,6 +359,11 @@ public class AggregationDataMapSchema extends DataMapSchema {
     if (null == this.aggExpToColumnMapping) {
       this.aggExpToColumnMapping = aggExpToColumnMapping;
     }
+  }
+
+  public DataMapClassProvider getProvider() {
+    return isTimeseriesDataMap ?
+        DataMapClassProvider.TIMESERIES : DataMapClassProvider.PREAGGREGATE;
   }
 
   @Override public boolean equals(Object o) {

--- a/core/src/main/java/org/apache/carbondata/core/profiler/ExplainCollector.java
+++ b/core/src/main/java/org/apache/carbondata/core/profiler/ExplainCollector.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.core.profiler;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.carbondata.common.annotations.InterfaceAudience;
+import org.apache.carbondata.core.metadata.schema.table.DataMapSchema;
+
+/**
+ * An information collector used for EXPLAIN command, to print out
+ * SQL rewrite and pruning information.
+ * This class is a singleton, not supporting concurrent EXPLAIN command
+ */
+@InterfaceAudience.Internal
+public class ExplainCollector {
+
+  private static ExplainCollector INSTANCE = null;
+
+  private List<String> olapDataMapProviders = new ArrayList<>();
+  private List<String> olapDataMapNames = new ArrayList<>();
+
+  // mapping of thread name to map of table name to pruning info
+  private Map<String, Map<String, TablePruningInfo>> scans = new ConcurrentHashMap<>();
+
+  private ExplainCollector() {
+  }
+
+  public static boolean enabled() {
+    return INSTANCE != null;
+  }
+
+  public static void setup() {
+    INSTANCE = new ExplainCollector();
+  }
+
+  public static void remove() {
+    if (enabled()) {
+      INSTANCE = null;
+    }
+  }
+
+  public static ExplainCollector get() {
+    return INSTANCE;
+  }
+
+  public static void recordMatchedOlapDataMap(String dataMapProvider, String dataMapName) {
+    if (enabled()) {
+      Objects.requireNonNull(dataMapProvider);
+      Objects.requireNonNull(dataMapName);
+      ExplainCollector profiler = get();
+      profiler.olapDataMapProviders.add(dataMapProvider);
+      profiler.olapDataMapNames.add(dataMapName);
+    }
+  }
+
+  public static void addPruningInfo(String tableName) {
+    if (enabled()) {
+      ExplainCollector profiler = get();
+      String threadName = Thread.currentThread().getName();
+      if (!profiler.scans.containsKey(threadName)) {
+        Map<String, TablePruningInfo> map = new HashMap<>();
+        map.put(tableName, new TablePruningInfo());
+        profiler.scans.put(threadName, map);
+      }
+    }
+  }
+
+  public static void setFilterStatement(String filterStatement) {
+    if (enabled()) {
+      TablePruningInfo scan = getCurrentTablePruningInfo();
+      scan.setFilterStatement(filterStatement);
+    }
+  }
+
+  public static void recordDefaultDataMapPruning(DataMapSchema dataMapSchema, int numBlocklets) {
+    if (enabled()) {
+      TablePruningInfo scan = getCurrentTablePruningInfo();
+      scan.setNumBlockletsAfterDefaultPruning(dataMapSchema, numBlocklets);
+    }
+  }
+
+  public static void recordCGDataMapPruning(DataMapSchema dataMapSchema, int numBlocklets) {
+    if (enabled()) {
+      TablePruningInfo scan = getCurrentTablePruningInfo();
+      scan.setNumBlockletsAfterCGPruning(dataMapSchema, numBlocklets);
+    }
+  }
+
+  public static void recordFGDataMapPruning(DataMapSchema dataMapSchema, int numBlocklets) {
+    if (enabled()) {
+      TablePruningInfo scan = getCurrentTablePruningInfo();
+      scan.setNumBlockletsAfterFGPruning(dataMapSchema, numBlocklets);
+    }
+  }
+
+  public static void addTotalBlocklets(int numBlocklets) {
+    if (enabled()) {
+      TablePruningInfo scan = getCurrentTablePruningInfo();
+      scan.addTotalBlocklets(numBlocklets);
+    }
+  }
+
+  /**
+   * Return the current TablePruningInfo (It is the last one in the map, since it is in
+   * single thread)
+   */
+  private static TablePruningInfo getCurrentTablePruningInfo() {
+    String threadName = Thread.currentThread().getName();
+    if (!get().scans.containsKey(threadName)) {
+      throw new IllegalStateException();
+    }
+
+    Iterator<TablePruningInfo> iterator = get().scans.get(threadName).values().iterator();
+    TablePruningInfo output = null;
+    while (iterator.hasNext()) {
+      output = iterator.next();
+    }
+    return output;
+  }
+
+  public static String getFormatedOutput() {
+    return get().toString();
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder builder = new StringBuilder();
+    for (int i = 0; i < olapDataMapProviders.size(); i++) {
+      if (i == 0) {
+        builder.append("Query rewrite based on DataMap:").append("\n");
+      }
+      builder.append(" - ").append(olapDataMapNames.get(i)).append(" (")
+          .append(olapDataMapProviders.get(i)).append(")").append("\n");
+    }
+    for (Map.Entry<String, Map<String, TablePruningInfo>> allThreads : scans.entrySet()) {
+      for (Map.Entry<String, TablePruningInfo> entry : allThreads.getValue().entrySet()) {
+        builder.append("Table Scan on ").append(entry.getKey()).append("\n")
+            .append(entry.getValue().toString());
+      }
+    }
+    return builder.toString();
+  }
+
+}

--- a/core/src/main/java/org/apache/carbondata/core/profiler/TablePruningInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/profiler/TablePruningInfo.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.core.profiler;
+
+import org.apache.carbondata.common.annotations.InterfaceAudience;
+import org.apache.carbondata.core.metadata.schema.table.DataMapSchema;
+
+/**
+ * Used for EXPLAIN command
+ */
+@InterfaceAudience.Internal
+public class TablePruningInfo {
+
+  private int totalBlocklets;
+  private String filterStatement;
+
+  private DataMapSchema defaultDataMap;
+  private int numBlockletsAfterDefaultPruning;
+
+  private DataMapSchema cgDataMap;
+  private int numBlockletsAfterCGPruning;
+
+  private DataMapSchema fgDataMap;
+  private int numBlockletsAfterFGPruning;
+
+  void addTotalBlocklets(int numBlocklets) {
+    this.totalBlocklets += numBlocklets;
+  }
+
+  void setFilterStatement(String filterStatement) {
+    this.filterStatement = filterStatement;
+  }
+
+  void setNumBlockletsAfterDefaultPruning(DataMapSchema dataMapSchema, int numBlocklets) {
+    this.defaultDataMap = dataMapSchema;
+    this.numBlockletsAfterDefaultPruning = numBlocklets;
+  }
+
+  void setNumBlockletsAfterCGPruning(DataMapSchema dataMapSchema, int numBlocklets) {
+    this.cgDataMap = dataMapSchema;
+    this.numBlockletsAfterCGPruning = numBlocklets;
+  }
+
+  void setNumBlockletsAfterFGPruning(DataMapSchema dataMapSchema, int numBlocklets) {
+    this.fgDataMap = dataMapSchema;
+    this.numBlockletsAfterFGPruning = numBlocklets;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder builder = new StringBuilder();
+    builder
+        .append(" - total blocklets: ").append(totalBlocklets).append("\n")
+        .append(" - filter: ").append(filterStatement).append("\n");
+    if (defaultDataMap != null) {
+      int skipBlocklets = totalBlocklets - numBlockletsAfterDefaultPruning;
+      builder
+          .append(" - pruned by Main DataMap").append("\n")
+          .append("     skipped blocklets: ").append(skipBlocklets).append("\n");
+    }
+    if (cgDataMap != null) {
+      int skipBlocklets = numBlockletsAfterDefaultPruning - numBlockletsAfterCGPruning;
+      builder
+          .append(" - pruned by CG DataMap").append("\n")
+          .append("     name: ").append(cgDataMap.getDataMapName()).append("\n")
+          .append("     provider: ").append(cgDataMap.getProviderName()).append("\n")
+          .append("     skipped blocklets: ").append(skipBlocklets).append("\n");
+    }
+    if (fgDataMap != null) {
+      int skipBlocklets;
+      if (numBlockletsAfterCGPruning != 0) {
+        skipBlocklets = numBlockletsAfterCGPruning - numBlockletsAfterFGPruning;
+      } else {
+        skipBlocklets = numBlockletsAfterDefaultPruning - numBlockletsAfterFGPruning;
+      }
+      builder
+          .append(" - pruned by FG DataMap").append("\n")
+          .append("     name: ").append(fgDataMap.getDataMapName()).append("\n")
+          .append("     provider: ").append(fgDataMap.getProviderName()).append("\n")
+          .append("     skipped blocklets: ").append(skipBlocklets).append("\n");
+    }
+    return builder.toString();
+  }
+}

--- a/core/src/main/java/org/apache/carbondata/core/profiler/TablePruningInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/profiler/TablePruningInfo.java
@@ -71,15 +71,15 @@ public class TablePruningInfo {
       int skipBlocklets = totalBlocklets - numBlockletsAfterDefaultPruning;
       builder
           .append(" - pruned by Main DataMap").append("\n")
-          .append("     skipped blocklets: ").append(skipBlocklets).append("\n");
+          .append("    - skipped blocklets: ").append(skipBlocklets).append("\n");
     }
     if (cgDataMap != null) {
       int skipBlocklets = numBlockletsAfterDefaultPruning - numBlockletsAfterCGPruning;
       builder
           .append(" - pruned by CG DataMap").append("\n")
-          .append("     name: ").append(cgDataMap.getDataMapName()).append("\n")
-          .append("     provider: ").append(cgDataMap.getProviderName()).append("\n")
-          .append("     skipped blocklets: ").append(skipBlocklets).append("\n");
+          .append("    - name: ").append(cgDataMap.getDataMapName()).append("\n")
+          .append("    - provider: ").append(cgDataMap.getProviderName()).append("\n")
+          .append("    - skipped blocklets: ").append(skipBlocklets).append("\n");
     }
     if (fgDataMap != null) {
       int skipBlocklets;
@@ -90,9 +90,9 @@ public class TablePruningInfo {
       }
       builder
           .append(" - pruned by FG DataMap").append("\n")
-          .append("     name: ").append(fgDataMap.getDataMapName()).append("\n")
-          .append("     provider: ").append(fgDataMap.getProviderName()).append("\n")
-          .append("     skipped blocklets: ").append(skipBlocklets).append("\n");
+          .append("    - name: ").append(fgDataMap.getDataMapName()).append("\n")
+          .append("    - provider: ").append(fgDataMap.getProviderName()).append("\n")
+          .append("    - skipped blocklets: ").append(skipBlocklets).append("\n");
     }
     return builder.toString();
   }

--- a/core/src/main/java/org/apache/carbondata/core/scan/expression/MatchExpression.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/expression/MatchExpression.java
@@ -63,6 +63,6 @@ public class MatchExpression extends Expression {
 
   @Override
   public String getStatement() {
-    return queryString;
+    return "TEXT_MATCH('" + queryString + "')";
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/resolver/resolverinfo/visitor/RangeNoDictionaryTypeVisitor.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/resolver/resolverinfo/visitor/RangeNoDictionaryTypeVisitor.java
@@ -65,7 +65,7 @@ public class RangeNoDictionaryTypeVisitor extends NoDictionaryTypeVisitor
           }
           evaluateResultListFinal.add(result.getString());
         }
-        // evaluateResultListFinal.add(metadata.getExpression().evaluate().getListAsString());
+        // evaluateResultListFinal.add(metadata.getFilterExpression().evaluate().getListAsString());
         if (!metadata.isIncludeFilter() && !evaluateResultListFinal
             .contains(CarbonCommonConstants.MEMBER_DEFAULT_VAL)) {
           evaluateResultListFinal.add(CarbonCommonConstants.MEMBER_DEFAULT_VAL);

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/datamap/lucene/LuceneFineGrainDataMapSuite.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/datamap/lucene/LuceneFineGrainDataMapSuite.scala
@@ -35,8 +35,6 @@ class LuceneFineGrainDataMapSuite extends QueryTest with BeforeAndAfterAll {
   val file2 = resourcesPath + "/datamap_input.csv"
 
   override protected def beforeAll(): Unit = {
-    //n should be about 5000000 of reset if size is default 1024
-    val n = 15000
     LuceneFineGrainDataMapSuite.createFile(file2)
     sql("create database if not exists lucene")
     CarbonProperties.getInstance()
@@ -578,6 +576,49 @@ class LuceneFineGrainDataMapSuite extends QueryTest with BeforeAndAfterAll {
     sql("INSERT OVERWRITE TABLE table1 select *from datamap_test where TEXT_MATCH('name:n*')")
     checkAnswer(sql("select count(*) from table1"),Seq(Row(10000)))
     sql("drop datamap dm on table datamap_test")
+  }
+
+  test("explain query with lucene datamap") {
+    sql("drop table if exists main")
+    CarbonProperties.getInstance().addProperty(CarbonCommonConstants.BLOCKLET_SIZE, "8")
+    sql(
+      """
+        | CREATE TABLE main(id INT, name STRING, city STRING, age INT)
+        | STORED BY 'carbondata'
+        | TBLPROPERTIES('SORT_COLUMNS'='city,name')
+      """.stripMargin)
+    sql(
+      s"""
+         | CREATE DATAMAP dm ON TABLE main
+         | USING 'lucene'
+         | DMProperties('TEXT_COLUMNS'='name , city')
+      """.stripMargin)
+
+    val file1 = resourcesPath + "/main.csv"
+    LuceneFineGrainDataMapSuite.createFile(file1, 1000000)
+
+    sql(s"LOAD DATA LOCAL INPATH '$file1' INTO TABLE main OPTIONS('header'='false')")
+
+    sql("EXPLAIN SELECT * FROM main WHERE TEXT_MATCH('name:bob')").show(false)
+    val rows = sql("EXPLAIN SELECT * FROM main WHERE TEXT_MATCH('name:bob')").collect()
+
+    assertResult(
+      """== CarbonData Profiler ==
+        |Table Scan on main
+        | - total blocklets: 1
+        | - filter: TEXT_MATCH('name:bob')
+        | - pruned by Main DataMap
+        |     skipped blocklets: 0
+        | - pruned by FG DataMap
+        |     name: dm
+        |     provider: lucene
+        |     skipped blocklets: 1
+        |""".stripMargin)(rows(0).getString(0))
+
+    LuceneFineGrainDataMapSuite.deleteFile(file1)
+    sql("drop datamap dm on table main")
+    CarbonProperties.getInstance().addProperty(
+      CarbonCommonConstants.BLOCKLET_SIZE, CarbonCommonConstants.BLOCKLET_SIZE_DEFAULT_VAL)
   }
 
   override protected def afterAll(): Unit = {

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/datamap/lucene/LuceneFineGrainDataMapSuite.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/datamap/lucene/LuceneFineGrainDataMapSuite.scala
@@ -608,11 +608,11 @@ class LuceneFineGrainDataMapSuite extends QueryTest with BeforeAndAfterAll {
         | - total blocklets: 1
         | - filter: TEXT_MATCH('name:bob')
         | - pruned by Main DataMap
-        |     skipped blocklets: 0
+        |    - skipped blocklets: 0
         | - pruned by FG DataMap
-        |     name: dm
-        |     provider: lucene
-        |     skipped blocklets: 1
+        |    - name: dm
+        |    - provider: lucene
+        |    - skipped blocklets: 1
         |""".stripMargin)(rows(0).getString(0))
 
     LuceneFineGrainDataMapSuite.deleteFile(file1)

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggregateTableSelection.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggregateTableSelection.scala
@@ -389,7 +389,7 @@ class TestPreAggregateTableSelection extends SparkQueryTest with BeforeAndAfterA
         | - total blocklets: 1
         | - filter: none
         | - pruned by Main DataMap
-        |     skipped blocklets: 0
+        |    - skipped blocklets: 0
         |""".stripMargin)(rows(0).getString(0))
   }
 
@@ -403,7 +403,7 @@ class TestPreAggregateTableSelection extends SparkQueryTest with BeforeAndAfterA
         | - total blocklets: 1
         | - filter: none
         | - pruned by Main DataMap
-        |     skipped blocklets: 0
+        |    - skipped blocklets: 0
         |""".stripMargin)(rows(0).getString(0))
   }
 
@@ -418,7 +418,7 @@ class TestPreAggregateTableSelection extends SparkQueryTest with BeforeAndAfterA
         | - total blocklets: 1
         | - filter: (maintable_name <> null and maintable_name = a)
         | - pruned by Main DataMap
-        |     skipped blocklets: 1
+        |    - skipped blocklets: 1
         |""".stripMargin)(rows(0).getString(0))
 
   }
@@ -428,19 +428,20 @@ class TestPreAggregateTableSelection extends SparkQueryTest with BeforeAndAfterA
                 "where t1.name = t2.name and t1.id < 3 group by t1.city"
     sql(query).show(false)
     val rows = sql(query).collect()
-    assertResult(
-      """== CarbonData Profiler ==
+    assert(rows(0).getString(0).contains(
+      """
         |Table Scan on maintable
         | - total blocklets: 1
         | - filter: ((id <> null and id < 3) and name <> null)
         | - pruned by Main DataMap
-        |     skipped blocklets: 0
+        |    - skipped blocklets: 0""".stripMargin))
+    assert(rows(0).getString(0).contains(
+      """
         |Table Scan on maintableavg
         | - total blocklets: 1
         | - filter: name <> null
         | - pruned by Main DataMap
-        |     skipped blocklets: 0
-        |""".stripMargin)(rows(0).getString(0))
+        |    - skipped blocklets: 0""".stripMargin))
 
   }
 

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggregateTableSelection.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggregateTableSelection.scala
@@ -16,6 +16,8 @@
  */
 package org.apache.carbondata.integration.spark.testsuite.preaggregate
 
+import java.io.File
+
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.datasources.LogicalRelation
 import org.apache.spark.sql.hive.CarbonRelation
@@ -377,6 +379,69 @@ class TestPreAggregateTableSelection extends SparkQueryTest with BeforeAndAfterA
       "maintabledict group by year")
     val df = sql("select year,avg(year) from maintabledict group by year")
     checkAnswer(df, Seq(Row(10,10.0)))
+  }
+
+  test("explain projection query") {
+    val rows = sql("explain select name, age from mainTable").collect()
+    assertResult(
+      """== CarbonData Profiler ==
+        |Table Scan on maintable
+        | - total blocklets: 1
+        | - filter: none
+        | - pruned by Main DataMap
+        |     skipped blocklets: 0
+        |""".stripMargin)(rows(0).getString(0))
+  }
+
+  test("explain projection query hit datamap") {
+    val rows = sql("explain select name,sum(age) from mainTable group by name").collect()
+    assertResult(
+      """== CarbonData Profiler ==
+        |Query rewrite based on DataMap:
+        | - agg1 (preaggregate)
+        |Table Scan on maintable_agg1
+        | - total blocklets: 1
+        | - filter: none
+        | - pruned by Main DataMap
+        |     skipped blocklets: 0
+        |""".stripMargin)(rows(0).getString(0))
+  }
+
+  test("explain filter query") {
+    sql("explain select name,sum(age) from mainTable where name = 'a' group by name").show(false)
+    val rows = sql("explain select name,sum(age) from mainTable where name = 'a' group by name").collect()
+    assertResult(
+      """== CarbonData Profiler ==
+        |Query rewrite based on DataMap:
+        | - agg1 (preaggregate)
+        |Table Scan on maintable_agg1
+        | - total blocklets: 1
+        | - filter: (maintable_name <> null and maintable_name = a)
+        | - pruned by Main DataMap
+        |     skipped blocklets: 1
+        |""".stripMargin)(rows(0).getString(0))
+
+  }
+
+  test("explain query with multiple table") {
+    val query = "explain select t1.city,sum(t1.age) from mainTable t1, mainTableavg t2 " +
+                "where t1.name = t2.name and t1.id < 3 group by t1.city"
+    sql(query).show(false)
+    val rows = sql(query).collect()
+    assertResult(
+      """== CarbonData Profiler ==
+        |Table Scan on maintable
+        | - total blocklets: 1
+        | - filter: ((id <> null and id < 3) and name <> null)
+        | - pruned by Main DataMap
+        |     skipped blocklets: 0
+        |Table Scan on maintableavg
+        | - total blocklets: 1
+        | - filter: name <> null
+        | - pruned by Main DataMap
+        |     skipped blocklets: 0
+        |""".stripMargin)(rows(0).getString(0))
+
   }
 
   override def afterAll: Unit = {

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
@@ -44,7 +44,8 @@ import org.apache.carbondata.core.constants.{CarbonCommonConstants, CarbonCommon
 import org.apache.carbondata.core.datastore.block.Distributable
 import org.apache.carbondata.core.indexstore.PartitionSpec
 import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier
-import org.apache.carbondata.core.metadata.schema.table.TableInfo
+import org.apache.carbondata.core.metadata.schema.table.{CarbonTable, TableInfo}
+import org.apache.carbondata.core.profiler.ExplainCollector
 import org.apache.carbondata.core.scan.expression.Expression
 import org.apache.carbondata.core.scan.filter.FilterUtil
 import org.apache.carbondata.core.scan.model.QueryModel

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonExplainCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonExplainCommand.scala
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.command.table
+
+import org.apache.spark.sql.{Row, SparkSession}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
+import org.apache.spark.sql.catalyst.plans.logical.{Command, LogicalPlan, Union}
+import org.apache.spark.sql.execution.command.{ExplainCommand, MetadataCommand}
+import org.apache.spark.sql.types.StringType
+
+import org.apache.carbondata.core.profiler.ExplainCollector
+
+case class CarbonExplainCommand(
+    child: LogicalPlan,
+    override val output: Seq[Attribute] =
+    Seq(AttributeReference("plan", StringType, nullable = true)())
+) extends MetadataCommand {
+  override def processMetadata(sparkSession: SparkSession): Seq[Row] = {
+    val explainCommand = child.asInstanceOf[ExplainCommand]
+
+    val isCommand = explainCommand.logicalPlan match {
+      case _: Command => true
+      case Union(childern) if childern.forall(_.isInstanceOf[Command]) => true
+      case _ => false
+    }
+
+    if (explainCommand.logicalPlan.isStreaming || isCommand) {
+      explainCommand.run(sparkSession)
+    } else {
+      collectProfiler(sparkSession) ++ explainCommand.run(sparkSession)
+    }
+  }
+
+  private def collectProfiler(sparkSession: SparkSession): Seq[Row] = {
+    val queryExecution =
+      sparkSession.sessionState.executePlan(child.asInstanceOf[ExplainCommand].logicalPlan)
+    try {
+      ExplainCollector.setup()
+      queryExecution.toRdd.partitions
+      Seq(Row("== CarbonData Profiler ==\n" + ExplainCollector.getFormatedOutput))
+    } finally {
+      ExplainCollector.remove()
+    }
+  }
+}
+

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/datasources/SparkCarbonFileFormat.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/datasources/SparkCarbonFileFormat.scala
@@ -216,8 +216,6 @@ class SparkCarbonFileFormat extends FileFormat
 
         val model = format.createQueryModel(split, attemptContext)
 
-        var partition : java.util.List[PartitionSpec] = new java.util.ArrayList[PartitionSpec]()
-
         val segmentPath = CarbonTablePath.getSegmentPath(identifier.getTablePath(), "null")
         val readCommittedScope = new LatestFilesReadCommittedScope(
           identifier.getTablePath + "/Fact/Part0/Segment_null/")

--- a/integration/spark2/src/main/spark2.1/org/apache/spark/sql/hive/CarbonSessionState.scala
+++ b/integration/spark2/src/main/spark2.1/org/apache/spark/sql/hive/CarbonSessionState.scala
@@ -22,13 +22,13 @@ import org.apache.spark.sql.catalyst.analysis.{Analyzer, FunctionRegistry}
 import org.apache.spark.sql.catalyst.catalog.{CatalogStorageFormat, CatalogTablePartition, FunctionResourceLoader, GlobalTempViewManager, SessionCatalog}
 import org.apache.spark.sql.catalyst.expressions.{And, AttributeReference, BoundReference, Expression, InterpretedPredicate, PredicateSubquery, ScalarSubquery}
 import org.apache.spark.sql.catalyst.optimizer.Optimizer
-import org.apache.spark.sql.catalyst.parser.ParserInterface
+import org.apache.spark.sql.catalyst.parser.{ParserInterface, SqlBaseParser}
 import org.apache.spark.sql.catalyst.parser.ParserUtils.{string, _}
 import org.apache.spark.sql.catalyst.parser.SqlBaseParser.{CreateTableContext, ShowTablesContext}
 import org.apache.spark.sql.catalyst.plans.logical.{Filter, LogicalPlan, SubqueryAlias}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.{CatalystConf, TableIdentifier}
-import org.apache.spark.sql.execution.command.table.CarbonShowTablesCommand
+import org.apache.spark.sql.execution.command.table.{CarbonExplainCommand, CarbonShowTablesCommand}
 import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.execution.strategy.{CarbonLateDecodeStrategy, DDLStrategy, StreamingTableStrategy}
 import org.apache.spark.sql.execution.{SparkOptimizer, SparkSqlAstBuilder}
@@ -403,5 +403,9 @@ class CarbonSqlAstBuilder(conf: SQLConf, parser: CarbonSpark2SqlParser, sparkSes
           Option(ctx.pattern).map(string))
       }
     }
+  }
+
+  override def visitExplain(ctx: SqlBaseParser.ExplainContext): LogicalPlan = {
+    CarbonExplainCommand(super.visitExplain(ctx))
   }
 }

--- a/integration/spark2/src/main/spark2.2/org/apache/spark/sql/hive/CarbonSessionState.scala
+++ b/integration/spark2/src/main/spark2.2/org/apache/spark/sql/hive/CarbonSessionState.scala
@@ -26,8 +26,16 @@ import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.optimizer.Optimizer
 import org.apache.spark.sql.catalyst.parser.ParserInterface
 import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan}
+import org.apache.spark.sql.catalyst.parser.{ParserInterface, SqlBaseParser}
+import org.apache.spark.sql.catalyst.parser.ParserUtils.{string, withOrigin}
+import org.apache.spark.sql.catalyst.parser.SqlBaseParser.{AddTableColumnsContext, ChangeColumnContext, CreateHiveTableContext, CreateTableContext, ShowTablesContext}
+import org.apache.spark.sql.catalyst.plans.logical.{Filter, LogicalPlan, SubqueryAlias}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.datasources.{FindDataSourceTable, PreWriteCheck, ResolveSQLOnFile, _}
+import org.apache.spark.sql.execution.command._
+import org.apache.spark.sql.execution.command.schema.{CarbonAlterTableAddColumnCommand, CarbonAlterTableDataTypeChangeCommand}
+import org.apache.spark.sql.execution.command.table.{CarbonExplainCommand, CarbonShowTablesCommand}
+import org.apache.spark.sql.execution.datasources.{FindDataSourceTable, LogicalRelation, PreWriteCheck, ResolveSQLOnFile, _}
 import org.apache.spark.sql.execution.strategy.{CarbonLateDecodeStrategy, DDLStrategy, StreamingTableStrategy}
 import org.apache.spark.sql.hive.client.HiveClient
 import org.apache.spark.sql.internal.{SQLConf, SessionState}

--- a/integration/spark2/src/main/spark2.2/org/apache/spark/sql/hive/CarbonSqlAstBuilder.scala
+++ b/integration/spark2/src/main/spark2.2/org/apache/spark/sql/hive/CarbonSqlAstBuilder.scala
@@ -19,12 +19,13 @@ package org.apache.spark.sql.hive
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.parser.ParserUtils.{string, withOrigin}
+import org.apache.spark.sql.catalyst.parser.SqlBaseParser
 import org.apache.spark.sql.catalyst.parser.SqlBaseParser.{AddTableColumnsContext, ChangeColumnContext, CreateHiveTableContext, CreateTableContext, ShowTablesContext}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.SparkSqlAstBuilder
 import org.apache.spark.sql.execution.command.{AlterTableAddColumnsModel, AlterTableDataTypeChangeModel}
 import org.apache.spark.sql.execution.command.schema.{CarbonAlterTableAddColumnCommand, CarbonAlterTableDataTypeChangeCommand}
-import org.apache.spark.sql.execution.command.table.CarbonShowTablesCommand
+import org.apache.spark.sql.execution.command.table.{CarbonExplainCommand, CarbonShowTablesCommand}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.parser.{CarbonHelperSqlAstBuilder, CarbonSpark2SqlParser}
 import org.apache.spark.sql.types.DecimalType
@@ -120,5 +121,9 @@ class CarbonSqlAstBuilder(conf: SQLConf, parser: CarbonSpark2SqlParser, sparkSes
           Option(ctx.pattern).map(string))
       }
     }
+  }
+
+  override def visitExplain(ctx: SqlBaseParser.ExplainContext): LogicalPlan = {
+    CarbonExplainCommand(super.visitExplain(ctx))
   }
 }

--- a/store/search/src/main/java/org/apache/carbondata/store/worker/SearchRequestHandler.java
+++ b/store/search/src/main/java/org/apache/carbondata/store/worker/SearchRequestHandler.java
@@ -140,7 +140,7 @@ public class SearchRequestHandler {
     DataMapExprWrapper wrapper =
         DataMapChooser.get().choose(table, queryModel.getFilterExpressionResolverTree());
 
-    if (wrapper.getDataMapType() == DataMapLevel.FG) {
+    if (wrapper.getDataMapLevel() == DataMapLevel.FG) {
       List<Segment> segments = new LinkedList<>();
       for (CarbonInputSplit split : mbSplit.getAllSplits()) {
         segments.add(Segment.toSegment(


### PR DESCRIPTION
This PR should be merged after #2204 
Add support in EXPLAIN command to show the effeteness of datamap including query rewrite and blocklet pruning. By using this feature, user will have more information about how to tune the datamap for better query performance.

For example:
`explain select name,sum(age) from mainTable where city = 'shenzhen' group by name`
will print:
```
|== CarbonData Profiler ==
Query rewrite based on DataMap:
 - agg1 (preaggregate)
Table Scan on maintable_agg1
 - filter: (maintable_name <> null and maintable_name = a)
 - pruned by main index
 - all blocklets: 5
 - skipped blocklets: 3
```
 - [X] Any interfaces changed?
 No
 - [X] Any backward compatibility impacted?
 No
 - [X] Document update required?
Yes
 - [X] Testing done
 Testcase added
 - [X] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA
