### PR TITLE
[CARBONDATA-2375]  Added CG prune before FG prune.

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datamap/DataMapChooser.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/DataMapChooser.java
@@ -94,10 +94,10 @@ public class DataMapChooser {
   }
 
   /**
-   * Return a chosen datamap based on input filter. See {@link DataMapChooser}
+   * Return a chosen FG datamap based on input filter. See {@link DataMapChooser}
    */
-  public DataMapExprWrapper chooseFG(CarbonTable carbonTable, FilterResolverIntf resolverIntf)
-      throws IOException {
+  public DataMapExprWrapper chooseFGDataMap(CarbonTable carbonTable,
+      FilterResolverIntf resolverIntf) throws IOException {
     if (resolverIntf != null) {
       Expression expression = resolverIntf.getFilterExpression();
       // First check for FG datamaps if any exist
@@ -113,10 +113,10 @@ public class DataMapChooser {
   }
 
   /**
-   * Return a chosen datamap based on input filter. See {@link DataMapChooser}
+   * Return a chosen CG datamap based on input filter. See {@link DataMapChooser}
    */
-  public DataMapExprWrapper chooseCG(CarbonTable carbonTable, FilterResolverIntf resolverIntf)
-      throws IOException {
+  public DataMapExprWrapper chooseCGDataMap(CarbonTable carbonTable,
+      FilterResolverIntf resolverIntf) throws IOException {
     if (resolverIntf != null) {
       Expression expression = resolverIntf.getFilterExpression();
       // Check for CG datamap
@@ -124,15 +124,23 @@ public class DataMapChooser {
           DataMapStoreManager.getInstance().getAllDataMap(carbonTable, DataMapLevel.CG);
       ExpressionTuple tuple = selectDataMap(expression, allDataMapCG, resolverIntf);
       if (tuple.dataMapExprWrapper != null) {
-        return new AndDataMapExprWrapper(tuple.dataMapExprWrapper, new DataMapExprWrapperImpl(
-            DataMapStoreManager.getInstance().getDefaultDataMap(carbonTable),
-            resolverIntf), resolverIntf);
+        return tuple.dataMapExprWrapper;
       }
     }
+    return null;
+  }
+
+  /**
+   * Returns default blocklet datamap
+   * @param carbonTable
+   * @param resolverIntf
+   * @return
+   */
+  public DataMapExprWrapper getDefaultDataMap(CarbonTable carbonTable,
+      FilterResolverIntf resolverIntf) {
     // Return the default datamap if no other datamap exists.
     return new DataMapExprWrapperImpl(
-        DataMapStoreManager.getInstance().getDefaultDataMap(carbonTable),
-        resolverIntf);
+        DataMapStoreManager.getInstance().getDefaultDataMap(carbonTable), resolverIntf);
   }
 
   private ExpressionTuple selectDataMap(Expression expression, List<TableDataMap> allDataMap,

--- a/core/src/main/java/org/apache/carbondata/core/datamap/DataMapChooser.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/DataMapChooser.java
@@ -93,6 +93,48 @@ public class DataMapChooser {
         resolverIntf);
   }
 
+  /**
+   * Return a chosen datamap based on input filter. See {@link DataMapChooser}
+   */
+  public DataMapExprWrapper chooseFG(CarbonTable carbonTable, FilterResolverIntf resolverIntf)
+      throws IOException {
+    if (resolverIntf != null) {
+      Expression expression = resolverIntf.getFilterExpression();
+      // First check for FG datamaps if any exist
+      List<TableDataMap> allDataMapFG =
+          DataMapStoreManager.getInstance().getAllDataMap(carbonTable, DataMapLevel.FG);
+      ExpressionTuple tuple = selectDataMap(expression, allDataMapFG, resolverIntf);
+      if (tuple.dataMapExprWrapper != null) {
+        return tuple.dataMapExprWrapper;
+      }
+    }
+    // Return the default datamap if no other datamap exists.
+    return null;
+  }
+
+  /**
+   * Return a chosen datamap based on input filter. See {@link DataMapChooser}
+   */
+  public DataMapExprWrapper chooseCG(CarbonTable carbonTable, FilterResolverIntf resolverIntf)
+      throws IOException {
+    if (resolverIntf != null) {
+      Expression expression = resolverIntf.getFilterExpression();
+      // Check for CG datamap
+      List<TableDataMap> allDataMapCG =
+          DataMapStoreManager.getInstance().getAllDataMap(carbonTable, DataMapLevel.CG);
+      ExpressionTuple tuple = selectDataMap(expression, allDataMapCG, resolverIntf);
+      if (tuple.dataMapExprWrapper != null) {
+        return new AndDataMapExprWrapper(tuple.dataMapExprWrapper, new DataMapExprWrapperImpl(
+            DataMapStoreManager.getInstance().getDefaultDataMap(carbonTable),
+            resolverIntf), resolverIntf);
+      }
+    }
+    // Return the default datamap if no other datamap exists.
+    return new DataMapExprWrapperImpl(
+        DataMapStoreManager.getInstance().getDefaultDataMap(carbonTable),
+        resolverIntf);
+  }
+
   private ExpressionTuple selectDataMap(Expression expression, List<TableDataMap> allDataMap,
       FilterResolverIntf filterResolverIntf) {
     switch (expression.getFilterExpressionType()) {

--- a/core/src/main/java/org/apache/carbondata/core/datamap/Segment.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/Segment.java
@@ -19,9 +19,11 @@ package org.apache.carbondata.core.datamap;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import org.apache.carbondata.core.readcommitter.ReadCommittedScope;
 import org.apache.carbondata.core.statusmanager.LoadMetadataDetails;
@@ -38,6 +40,11 @@ public class Segment implements Serializable {
   private String segmentNo;
 
   private String segmentFileName;
+
+  /**
+   * List of index files which are already got filtered through CG index operation.
+   */
+  private Set<String> filteredIndexFiles = new HashSet<>();
 
   /**
    * Points to the Read Committed Scope of the segment. This is a flavor of
@@ -140,6 +147,14 @@ public class Segment implements Serializable {
       }
     }
     return null;
+  }
+
+  public Set<String> getFilteredIndexFiles() {
+    return filteredIndexFiles;
+  }
+
+  public void setFilteredIndexFile(String filteredIndexFile) {
+    this.filteredIndexFiles.add(filteredIndexFile);
   }
 
   @Override public boolean equals(Object o) {

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonInputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonInputFormat.java
@@ -355,31 +355,8 @@ public abstract class CarbonInputFormat<T> extends FileInputFormat<Void, T> {
     // get tokens for all the required FileSystem for table path
     TokenCache.obtainTokensForNamenodes(job.getCredentials(),
         new Path[] { new Path(carbonTable.getTablePath()) }, job.getConfiguration());
-    boolean distributedCG = Boolean.parseBoolean(CarbonProperties.getInstance()
-        .getProperty(CarbonCommonConstants.USE_DISTRIBUTED_DATAMAP,
-            CarbonCommonConstants.USE_DISTRIBUTED_DATAMAP_DEFAULT));
-    DataMapExprWrapper dataMapExprWrapper =
-        DataMapChooser.get().chooseCG(getOrCreateCarbonTable(job.getConfiguration()), resolver);
-    DataMapJob dataMapJob = getDataMapJob(job.getConfiguration());
-    List<PartitionSpec> partitionsToPrune = getPartitionsToPrune(job.getConfiguration());
-    List<ExtendedBlocklet> prunedBlocklets;
-    if (distributedCG) {
-      prunedBlocklets =
-          executeDataMapJob(carbonTable, resolver, segmentIds, dataMapExprWrapper, dataMapJob,
-              partitionsToPrune);
-    } else {
-      prunedBlocklets = dataMapExprWrapper.prune(segmentIds, partitionsToPrune);
-    }
-    dataMapExprWrapper =
-        DataMapChooser.get().chooseFG(getOrCreateCarbonTable(job.getConfiguration()), resolver);
-    if (dataMapExprWrapper != null &&
-        dataMapExprWrapper.getDataMapType() == DataMapLevel.FG &&
-        isFgDataMapPruningEnable(job.getConfiguration())) {
-      updateSegments(segmentIds, prunedBlocklets);
-      prunedBlocklets =
-          executeDataMapJob(carbonTable, resolver, segmentIds, dataMapExprWrapper, dataMapJob,
-              partitionsToPrune);
-    }
+    List<ExtendedBlocklet> prunedBlocklets =
+        getPrunedBlocklets(job, carbonTable, resolver, segmentIds);
 
     List<CarbonInputSplit> resultFilterredBlocks = new ArrayList<>();
     int partitionIndex = 0;
@@ -421,6 +398,50 @@ public abstract class CarbonInputFormat<T> extends FileInputFormat<Void, T> {
     return resultFilterredBlocks;
   }
 
+  /**
+   * Prune the blocklets using the filter expression with available datamaps.
+   */
+  private List<ExtendedBlocklet> getPrunedBlocklets(JobContext job, CarbonTable carbonTable,
+      FilterResolverIntf resolver, List<Segment> segmentIds) throws IOException {
+    boolean distributedCG = Boolean.parseBoolean(CarbonProperties.getInstance()
+        .getProperty(CarbonCommonConstants.USE_DISTRIBUTED_DATAMAP,
+            CarbonCommonConstants.USE_DISTRIBUTED_DATAMAP_DEFAULT));
+    DataMapJob dataMapJob = getDataMapJob(job.getConfiguration());
+    List<PartitionSpec> partitionsToPrune = getPartitionsToPrune(job.getConfiguration());
+    // First prune using default datamap on driver side.
+    DataMapExprWrapper dataMapExprWrapper = DataMapChooser.get()
+        .getDefaultDataMap(getOrCreateCarbonTable(job.getConfiguration()), resolver);
+    List<ExtendedBlocklet> prunedBlocklets =
+        dataMapExprWrapper.prune(segmentIds, partitionsToPrune);
+    // Get the available CG datamaps and prune further.
+    DataMapExprWrapper cgDataMapExprWrapper = DataMapChooser.get()
+        .chooseCGDataMap(getOrCreateCarbonTable(job.getConfiguration()), resolver);
+    if (cgDataMapExprWrapper != null) {
+      // Prune segments from already pruned blocklets
+      pruneSegments(segmentIds, prunedBlocklets);
+      // Again prune with CG datamap.
+      if (distributedCG && dataMapJob != null) {
+        prunedBlocklets =
+            executeDataMapJob(carbonTable, resolver, segmentIds, dataMapExprWrapper, dataMapJob,
+                partitionsToPrune);
+      } else {
+        prunedBlocklets = dataMapExprWrapper.prune(segmentIds, partitionsToPrune);
+      }
+    }
+    // Now try to prune with FG DataMap.
+    dataMapExprWrapper = DataMapChooser.get()
+        .chooseFGDataMap(getOrCreateCarbonTable(job.getConfiguration()), resolver);
+    if (dataMapExprWrapper != null && dataMapExprWrapper.getDataMapType() == DataMapLevel.FG
+        && isFgDataMapPruningEnable(job.getConfiguration()) && dataMapJob != null) {
+      // Prune segments from already pruned blocklets
+      pruneSegments(segmentIds, prunedBlocklets);
+      prunedBlocklets =
+          executeDataMapJob(carbonTable, resolver, segmentIds, dataMapExprWrapper, dataMapJob,
+              partitionsToPrune);
+    }
+    return prunedBlocklets;
+  }
+
   private List<ExtendedBlocklet> executeDataMapJob(CarbonTable carbonTable,
       FilterResolverIntf resolver, List<Segment> segmentIds, DataMapExprWrapper dataMapExprWrapper,
       DataMapJob dataMapJob, List<PartitionSpec> partitionsToPrune) throws IOException {
@@ -433,23 +454,33 @@ public abstract class CarbonInputFormat<T> extends FileInputFormat<Void, T> {
     return prunedBlocklets;
   }
 
-  private void updateSegments(List<Segment> segments, List<ExtendedBlocklet> prunedBlocklets) {
+  /**
+   * Prune the segments from the already pruned blocklets.
+   * @param segments
+   * @param prunedBlocklets
+   */
+  private void pruneSegments(List<Segment> segments, List<ExtendedBlocklet> prunedBlocklets) {
     List<Segment> toBeRemovedSegments = new ArrayList<>();
-    for (Segment segmentId : segments) {
+    for (Segment segment : segments) {
       boolean found = false;
+      // Clear the old pruned index files if any present
+      segment.getFilteredIndexFiles().clear();
+      // Check the segment exist in any of the pruned blocklets.
       for (ExtendedBlocklet blocklet : prunedBlocklets) {
-        if (blocklet.getSegmentId().equals(segmentId.getSegmentNo())) {
+        if (blocklet.getSegmentId().equals(segment.getSegmentNo())) {
           found = true;
+          // Set the pruned index file to the segment for further pruning.
           String carbonIndexFileName =
               CarbonTablePath.getCarbonIndexFileName(blocklet.getBlockId());
-          segmentId.setFilteredIndexFile(carbonIndexFileName);
+          segment.setFilteredIndexFile(carbonIndexFileName);
         }
       }
+      // Add to remove segments list if not present in pruned blocklets.
       if (!found) {
-        toBeRemovedSegments.add(segmentId);
+        toBeRemovedSegments.add(segment);
       }
     }
-
+    // Remove all segments which are already pruned from pruned blocklets
     segments.removeAll(toBeRemovedSegments);
   }
 


### PR DESCRIPTION
This PR adds CG prune before FG prune, and passes the pruned segments and indexfiles to FG DataMap for further pruning.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

