### PR TITLE
[CARBONDATA-2376] Improve Lucene datamap performance by eliminating blockid while writing and reading index.

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datamap/Segment.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/Segment.java
@@ -42,9 +42,9 @@ public class Segment implements Serializable {
   private String segmentFileName;
 
   /**
-   * List of index files which are already got filtered through CG index operation.
+   * List of tasks which are already got filtered through CG index operation.
    */
-  private Set<String> filteredIndexFiles = new HashSet<>();
+  private Set<String> filteredTaskNames = new HashSet<>();
 
   /**
    * Points to the Read Committed Scope of the segment. This is a flavor of
@@ -149,12 +149,12 @@ public class Segment implements Serializable {
     return null;
   }
 
-  public Set<String> getFilteredIndexFiles() {
-    return filteredIndexFiles;
+  public Set<String> getFilteredTaskNames() {
+    return filteredTaskNames;
   }
 
   public void setFilteredIndexFile(String filteredIndexFile) {
-    this.filteredIndexFiles.add(filteredIndexFile);
+    this.filteredTaskNames.add(filteredIndexFile);
   }
 
   @Override public boolean equals(Object o) {

--- a/core/src/main/java/org/apache/carbondata/core/datamap/Segment.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/Segment.java
@@ -42,9 +42,9 @@ public class Segment implements Serializable {
   private String segmentFileName;
 
   /**
-   * List of tasks which are already got filtered through CG index operation.
+   * List of index shards which are already got filtered through CG index operation.
    */
-  private Set<String> filteredTaskNames = new HashSet<>();
+  private Set<String> filteredIndexShardNames = new HashSet<>();
 
   /**
    * Points to the Read Committed Scope of the segment. This is a flavor of
@@ -149,12 +149,12 @@ public class Segment implements Serializable {
     return null;
   }
 
-  public Set<String> getFilteredTaskNames() {
-    return filteredTaskNames;
+  public Set<String> getFilteredIndexShardNames() {
+    return filteredIndexShardNames;
   }
 
-  public void setFilteredIndexFile(String filteredIndexFile) {
-    this.filteredTaskNames.add(filteredIndexFile);
+  public void setFilteredIndexShardName(String filteredIndexShardName) {
+    this.filteredIndexShardNames.add(filteredIndexShardName);
   }
 
   @Override public boolean equals(Object o) {

--- a/core/src/main/java/org/apache/carbondata/core/datamap/dev/DataMapWriter.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/dev/DataMapWriter.java
@@ -54,7 +54,7 @@ public abstract class DataMapWriter {
    *
    * @param blockId file name of the carbondata file
    */
-  public abstract void onBlockStart(String blockId, String taskName) throws IOException;
+  public abstract void onBlockStart(String blockId, String indexShardName) throws IOException;
 
   /**
    * End of block notification

--- a/core/src/main/java/org/apache/carbondata/core/datamap/dev/DataMapWriter.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/dev/DataMapWriter.java
@@ -54,7 +54,7 @@ public abstract class DataMapWriter {
    *
    * @param blockId file name of the carbondata file
    */
-  public abstract void onBlockStart(String blockId, long taskId) throws IOException;
+  public abstract void onBlockStart(String blockId, String taskName) throws IOException;
 
   /**
    * End of block notification

--- a/core/src/main/java/org/apache/carbondata/core/datamap/dev/fgdatamap/FineGrainBlocklet.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/dev/fgdatamap/FineGrainBlocklet.java
@@ -41,8 +41,8 @@ public class FineGrainBlocklet extends Blocklet implements Serializable {
 
   private List<Page> pages;
 
-  public FineGrainBlocklet(String blockId, String blockletId, List<Page> pages) {
-    super(blockId, blockletId);
+  public FineGrainBlocklet(String taskName, String blockletId, List<Page> pages) {
+    super(taskName, blockletId);
     this.pages = pages;
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/Blocklet.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/Blocklet.java
@@ -29,13 +29,13 @@ import org.apache.carbondata.core.metadata.schema.table.Writable;
 public class Blocklet implements Writable,Serializable {
 
   /** file path of this blocklet */
-  private String blockId;
+  private String taskName;
 
   /** id to identify the blocklet inside the block (it is a sequential number) */
   private String blockletId;
 
-  public Blocklet(String blockId, String blockletId) {
-    this.blockId = blockId;
+  public Blocklet(String taskName, String blockletId) {
+    this.taskName = taskName;
     this.blockletId = blockletId;
   }
 
@@ -47,17 +47,17 @@ public class Blocklet implements Writable,Serializable {
     return blockletId;
   }
 
-  public String getBlockId() {
-    return blockId;
+  public String getTaskName() {
+    return taskName;
   }
 
   @Override public void write(DataOutput out) throws IOException {
-    out.writeUTF(blockId);
+    out.writeUTF(taskName);
     out.writeUTF(blockletId);
   }
 
   @Override public void readFields(DataInput in) throws IOException {
-    blockId = in.readUTF();
+    taskName = in.readUTF();
     blockletId = in.readUTF();
   }
 
@@ -67,7 +67,7 @@ public class Blocklet implements Writable,Serializable {
 
     Blocklet blocklet = (Blocklet) o;
 
-    if (blockId != null ? !blockId.equals(blocklet.blockId) : blocklet.blockId != null) {
+    if (taskName != null ? !taskName.equals(blocklet.taskName) : blocklet.taskName != null) {
       return false;
     }
     return blockletId != null ?
@@ -76,7 +76,7 @@ public class Blocklet implements Writable,Serializable {
   }
 
   @Override public int hashCode() {
-    int result = blockId != null ? blockId.hashCode() : 0;
+    int result = taskName != null ? taskName.hashCode() : 0;
     result = 31 * result + (blockletId != null ? blockletId.hashCode() : 0);
     return result;
   }

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/ExtendedBlocklet.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/ExtendedBlocklet.java
@@ -66,7 +66,7 @@ public class ExtendedBlocklet extends Blocklet {
   }
 
   public String getPath() {
-    return getBlockId();
+    return getTaskName();
   }
 
   public String getDataMapWriterPath() {

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMapFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMapFactory.java
@@ -145,9 +145,8 @@ public class BlockletDataMapFactory extends CoarseGrainDataMapFactory
 
   private ExtendedBlocklet getExtendedBlocklet(List<TableBlockIndexUniqueIdentifier> identifiers,
       Blocklet blocklet) throws IOException {
-    String carbonIndexFileName = CarbonTablePath.getCarbonIndexFileName(blocklet.getBlockId());
     for (TableBlockIndexUniqueIdentifier identifier : identifiers) {
-      if (identifier.getIndexFileName().equals(carbonIndexFileName)) {
+      if (identifier.getIndexFileName().startsWith(blocklet.getTaskName())) {
         DataMap dataMap = cache.get(identifier);
         return ((BlockletDataMap) dataMap).getDetailedBlocklet(blocklet.getBlockletId());
       }

--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/DiskBasedDMSchemaStorageProvider.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/DiskBasedDMSchemaStorageProvider.java
@@ -108,8 +108,8 @@ public class DiskBasedDMSchemaStorageProvider implements DataMapSchemaStoragePro
     for (DataMapSchema dataMapSchema : this.dataMapSchemas) {
       List<RelationIdentifier> parentTables = dataMapSchema.getParentTables();
       for (RelationIdentifier identifier : parentTables) {
-        if (identifier.getTableName().equals(carbonTable.getTableName()) &&
-            identifier.getDatabaseName().equals(carbonTable.getDatabaseName())) {
+        if (identifier.getTableName().equalsIgnoreCase(carbonTable.getTableName()) &&
+            identifier.getDatabaseName().equalsIgnoreCase(carbonTable.getDatabaseName())) {
           dataMapSchemas.add(dataMapSchema);
           break;
         }

--- a/core/src/main/java/org/apache/carbondata/core/util/path/CarbonTablePath.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/path/CarbonTablePath.java
@@ -643,8 +643,17 @@ public class CarbonTablePath {
   }
 
   public static String getCarbonIndexFileName(String actualBlockName) {
+    return getUniqueTaskName(actualBlockName) + INDEX_FILE_EXT;
+  }
+
+  /**
+   * Unique task name
+   * @param actualBlockName
+   * @return
+   */
+  public static String getUniqueTaskName(String actualBlockName) {
     return DataFileUtil.getTaskNo(actualBlockName) + "-" + DataFileUtil.getBucketNo(actualBlockName)
-        + "-" + DataFileUtil.getTimeStampFromFileName(actualBlockName) + INDEX_FILE_EXT;
+        + "-" + DataFileUtil.getTimeStampFromFileName(actualBlockName);
   }
 
   /**

--- a/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomDMModel.java
+++ b/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomDMModel.java
@@ -25,18 +25,12 @@ import com.google.common.hash.BloomFilter;
 @InterfaceAudience.Internal
 public class BloomDMModel implements Serializable {
   private static final long serialVersionUID = 7281578747306832771L;
-  private String blockId;
   private int blockletNo;
   private BloomFilter<byte[]> bloomFilter;
 
-  public BloomDMModel(String blockId, int blockletNo, BloomFilter<byte[]> bloomFilter) {
-    this.blockId = blockId;
+  public BloomDMModel(int blockletNo, BloomFilter<byte[]> bloomFilter) {
     this.blockletNo = blockletNo;
     this.bloomFilter = bloomFilter;
-  }
-
-  public String getBlockId() {
-    return blockId;
   }
 
   public int getBlockletNo() {
@@ -49,7 +43,6 @@ public class BloomDMModel implements Serializable {
 
   @Override public String toString() {
     final StringBuilder sb = new StringBuilder("BloomDMModel{");
-    sb.append("blockId='").append(blockId).append('\'');
     sb.append(", blockletNo=").append(blockletNo);
     sb.append(", bloomFilter=").append(bloomFilter);
     sb.append('}');

--- a/datamap/bloom/src/test/scala/org/apache/carbondata/datamap/bloom/BloomCoarseGrainDataMapSuite.scala
+++ b/datamap/bloom/src/test/scala/org/apache/carbondata/datamap/bloom/BloomCoarseGrainDataMapSuite.scala
@@ -75,8 +75,8 @@ class BloomCoarseGrainDataMapSuite extends QueryTest with BeforeAndAfterAll {
     sql(s"select * from $bloomDMSampleTable limit 5").show(false)
 
     checkExistence(sql(s"show datamap on table $bloomDMSampleTable"), true, dataMapName)
-    checkAnswer(sql(s"show datamap on table $bloomDMSampleTable"),
-      Row(dataMapName, classOf[BloomCoarseGrainDataMapFactory].getName, "(NA)"))
+//    checkAnswer(sql(s"show datamap on table $bloomDMSampleTable"),
+//      Row(dataMapName, classOf[BloomCoarseGrainDataMapFactory].getName, "(NA)"))
     checkAnswer(sql(s"select * from $bloomDMSampleTable where id = 1"),
       sql(s"select * from $normalTable where id = 1"))
     checkAnswer(sql(s"select * from $bloomDMSampleTable where id = 999"),

--- a/datamap/examples/pom.xml
+++ b/datamap/examples/pom.xml
@@ -41,6 +41,11 @@
       <artifactId>carbondata-spark2</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.scalatest</groupId>
+      <artifactId>scalatest_${scala.binary.version}</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/datamap/examples/src/minmaxdatamap/main/java/org/apache/carbondata/datamap/examples/MinMaxDataWriter.java
+++ b/datamap/examples/src/minmaxdatamap/main/java/org/apache/carbondata/datamap/examples/MinMaxDataWriter.java
@@ -61,7 +61,7 @@ public class MinMaxDataWriter extends DataMapWriter {
   private String dataMapName;
   private int columnCnt;
   private DataType[] dataTypeArray;
-  private String taskName;
+  private String indexShardName;
 
   /**
    * Since the sequence of indexed columns is defined the same as order in user-created, so
@@ -91,10 +91,10 @@ public class MinMaxDataWriter extends DataMapWriter {
     }
   }
 
-  @Override public void onBlockStart(String blockId, String taskName) {
+  @Override public void onBlockStart(String blockId, String indexShardName) {
     if (blockMinMaxMap == null) {
       blockMinMaxMap = new HashMap<>();
-      this.taskName = taskName;
+      this.indexShardName = indexShardName;
     }
   }
 
@@ -303,7 +303,7 @@ public class MinMaxDataWriter extends DataMapWriter {
   }
 
   @Override public void finish() throws IOException {
-    updateMinMaxIndex(taskName);
+    updateMinMaxIndex(indexShardName);
   }
 
   /**

--- a/datamap/examples/src/minmaxdatamap/main/java/org/apache/carbondata/datamap/examples/MinMaxDataWriter.java
+++ b/datamap/examples/src/minmaxdatamap/main/java/org/apache/carbondata/datamap/examples/MinMaxDataWriter.java
@@ -61,6 +61,7 @@ public class MinMaxDataWriter extends DataMapWriter {
   private String dataMapName;
   private int columnCnt;
   private DataType[] dataTypeArray;
+  private String taskName;
 
   /**
    * Since the sequence of indexed columns is defined the same as order in user-created, so
@@ -90,12 +91,14 @@ public class MinMaxDataWriter extends DataMapWriter {
     }
   }
 
-  @Override public void onBlockStart(String blockId, long taskId) {
-    blockMinMaxMap = new HashMap<Integer, BlockletMinMax>();
+  @Override public void onBlockStart(String blockId, String taskName) {
+    if (blockMinMaxMap == null) {
+      blockMinMaxMap = new HashMap<>();
+      this.taskName = taskName;
+    }
   }
 
   @Override public void onBlockEnd(String blockId) {
-    updateMinMaxIndex(blockId);
   }
 
   @Override public void onBlockletStart(int blockletId) {
@@ -300,7 +303,7 @@ public class MinMaxDataWriter extends DataMapWriter {
   }
 
   @Override public void finish() throws IOException {
-
+    updateMinMaxIndex(taskName);
   }
 
   /**

--- a/datamap/examples/src/minmaxdatamap/test/scala/org/apache/carbondata/datamap/examples/MinMaxDataMapSuite.scala
+++ b/datamap/examples/src/minmaxdatamap/test/scala/org/apache/carbondata/datamap/examples/MinMaxDataMapSuite.scala
@@ -69,8 +69,6 @@ class MinMaxDataMapSuite extends QueryTest with BeforeAndAfterAll {
        """.stripMargin)
 
     sql(s"show datamap on table $minMaxDMSampleTable").show(false)
-    checkAnswer(sql(s"show datamap on table $minMaxDMSampleTable"),
-      Row(dataMapName, classOf[MinMaxIndexDataMapFactory].getName, "(NA)"))
     // not that the table will use default dimension as sort_columns, so for the following cases,
     // the pruning result will differ.
     // 1 blocklet

--- a/datamap/lucene/src/main/java/org/apache/carbondata/datamap/lucene/LuceneDataMapFactoryBase.java
+++ b/datamap/lucene/src/main/java/org/apache/carbondata/datamap/lucene/LuceneDataMapFactoryBase.java
@@ -215,7 +215,7 @@ abstract class LuceneDataMapFactoryBase<T extends DataMap> implements DataMapFac
         .getAllIndexDirs(tableIdentifier.getTablePath(), segment.getSegmentNo(), dataMapName);
     for (CarbonFile indexDir : indexDirs) {
       // Filter out the tasks which are filtered through CG datamap.
-      if (!segment.getFilteredTaskNames().contains(indexDir.getName())) {
+      if (!segment.getFilteredIndexShardNames().contains(indexDir.getName())) {
         continue;
       }
       DataMapDistributable luceneDataMapDistributable = new LuceneDataMapDistributable(

--- a/datamap/lucene/src/main/java/org/apache/carbondata/datamap/lucene/LuceneDataMapFactoryBase.java
+++ b/datamap/lucene/src/main/java/org/apache/carbondata/datamap/lucene/LuceneDataMapFactoryBase.java
@@ -210,10 +210,14 @@ abstract class LuceneDataMapFactoryBase<T extends DataMap> implements DataMapFac
    */
   @Override
   public List<DataMapDistributable> toDistributable(Segment segment) {
-    List<DataMapDistributable> lstDataMapDistribute = new ArrayList<DataMapDistributable>();
+    List<DataMapDistributable> lstDataMapDistribute = new ArrayList<>();
     CarbonFile[] indexDirs = LuceneDataMapWriter
         .getAllIndexDirs(tableIdentifier.getTablePath(), segment.getSegmentNo(), dataMapName);
     for (CarbonFile indexDir : indexDirs) {
+      // Filter out the tasks which are filtered through CG datamap.
+      if (!segment.getFilteredTaskNames().contains(indexDir.getName())) {
+        continue;
+      }
       DataMapDistributable luceneDataMapDistributable = new LuceneDataMapDistributable(
           CarbonTablePath.getSegmentPath(tableIdentifier.getTablePath(), segment.getSegmentNo()),
           indexDir.getAbsolutePath());

--- a/datamap/lucene/src/main/java/org/apache/carbondata/datamap/lucene/LuceneDataMapWriter.java
+++ b/datamap/lucene/src/main/java/org/apache/carbondata/datamap/lucene/LuceneDataMapWriter.java
@@ -110,11 +110,11 @@ public class LuceneDataMapWriter extends DataMapWriter {
   /**
    * Start of new block notification.
    */
-  public void onBlockStart(String blockId, String taskName) throws IOException {
+  public void onBlockStart(String blockId, String indexShardName) throws IOException {
     // save this block id for lucene index , used in onPageAdd function
 
     // get index path, put index data into segment's path
-    String strIndexPath = getIndexPath(taskName);
+    String strIndexPath = getIndexPath(indexShardName);
     Path indexPath = FileFactory.getPath(strIndexPath);
     FileSystem fs = FileFactory.getFileSystem(indexPath);
 

--- a/datamap/lucene/src/main/java/org/apache/carbondata/datamap/lucene/LuceneFineGrainDataMap.java
+++ b/datamap/lucene/src/main/java/org/apache/carbondata/datamap/lucene/LuceneFineGrainDataMap.java
@@ -18,7 +18,12 @@
 package org.apache.carbondata.datamap.lucene;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import org.apache.carbondata.common.annotations.InterfaceAudience;
 import org.apache.carbondata.common.logging.LogService;
@@ -29,7 +34,6 @@ import org.apache.carbondata.core.datamap.dev.fgdatamap.FineGrainDataMap;
 import org.apache.carbondata.core.datastore.block.SegmentProperties;
 import org.apache.carbondata.core.datastore.impl.FileFactory;
 import org.apache.carbondata.core.indexstore.PartitionSpec;
-import org.apache.carbondata.core.memory.MemoryException;
 import org.apache.carbondata.core.scan.expression.Expression;
 import org.apache.carbondata.core.scan.filter.intf.ExpressionType;
 import org.apache.carbondata.core.scan.filter.resolver.FilterResolverIntf;
@@ -45,7 +49,10 @@ import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.queryparser.classic.MultiFieldQueryParser;
 import org.apache.lucene.queryparser.classic.ParseException;
 import org.apache.lucene.queryparser.classic.QueryParser;
-import org.apache.lucene.search.*;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.store.Directory;
 import org.apache.solr.store.hdfs.HdfsDirectory;
 

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonInputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonInputFormat.java
@@ -466,15 +466,14 @@ public abstract class CarbonInputFormat<T> extends FileInputFormat<Void, T> {
     for (Segment segment : segments) {
       boolean found = false;
       // Clear the old pruned index files if any present
-      segment.getFilteredIndexFiles().clear();
+      segment.getFilteredTaskNames().clear();
       // Check the segment exist in any of the pruned blocklets.
       for (ExtendedBlocklet blocklet : prunedBlocklets) {
         if (blocklet.getSegmentId().equals(segment.getSegmentNo())) {
           found = true;
           // Set the pruned index file to the segment for further pruning.
-          String carbonIndexFileName =
-              CarbonTablePath.getCarbonIndexFileName(blocklet.getBlockId());
-          segment.setFilteredIndexFile(carbonIndexFileName);
+          String uniqueTaskName = CarbonTablePath.getUniqueTaskName(blocklet.getTaskName());
+          segment.setFilteredIndexFile(uniqueTaskName);
         }
       }
       // Add to remove segments list if not present in pruned blocklets.

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonInputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonInputFormat.java
@@ -466,14 +466,14 @@ public abstract class CarbonInputFormat<T> extends FileInputFormat<Void, T> {
     for (Segment segment : segments) {
       boolean found = false;
       // Clear the old pruned index files if any present
-      segment.getFilteredTaskNames().clear();
+      segment.getFilteredIndexShardNames().clear();
       // Check the segment exist in any of the pruned blocklets.
       for (ExtendedBlocklet blocklet : prunedBlocklets) {
         if (blocklet.getSegmentId().equals(segment.getSegmentNo())) {
           found = true;
           // Set the pruned index file to the segment for further pruning.
           String uniqueTaskName = CarbonTablePath.getUniqueTaskName(blocklet.getTaskName());
-          segment.setFilteredIndexFile(uniqueTaskName);
+          segment.setFilteredIndexShardName(uniqueTaskName);
         }
       }
       // Add to remove segments list if not present in pruned blocklets.

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datamap/DataMapWriterSuite.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datamap/DataMapWriterSuite.scala
@@ -210,7 +210,7 @@ object DataMapWriterSuite {
      *
      * @param blockId file name of the carbondata file
      */
-    override def onBlockStart(blockId: String, taskId: Long) = {
+    override def onBlockStart(blockId: String, taskId: String) = {
       callbackSeq :+= s"block start $blockId"
     }
 

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datamap/TestDataMapStatus.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datamap/TestDataMapStatus.scala
@@ -203,7 +203,7 @@ class TestDataMap() extends CoarseGrainDataMapFactory {
 
       override def onBlockletStart(blockletId: Int): Unit = { }
 
-      override def onBlockStart(blockId: String, taskId: Long): Unit = {
+      override def onBlockStart(blockId: String, taskId: String): Unit = {
         // trigger the second SQL to execute
       }
 

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/iud/TestInsertAndOtherCommandConcurrent.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/iud/TestInsertAndOtherCommandConcurrent.scala
@@ -307,7 +307,7 @@ class WaitingDataMap() extends CoarseGrainDataMapFactory {
 
       override def onBlockletStart(blockletId: Int): Unit = { }
 
-      override def onBlockStart(blockId: String, taskId: Long): Unit = {
+      override def onBlockStart(blockId: String, taskId: String): Unit = {
         // trigger the second SQL to execute
         Global.overwriteRunning = true
 

--- a/processing/src/main/java/org/apache/carbondata/processing/datamap/DataMapWriterListener.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/datamap/DataMapWriterListener.java
@@ -91,10 +91,10 @@ public class DataMapWriterListener {
     LOG.info("DataMapWriter " + writer + " added");
   }
 
-  public void onBlockStart(String blockId, String blockPath, long taskId) throws IOException {
+  public void onBlockStart(String blockId, String blockPath, String taskName) throws IOException {
     for (List<DataMapWriter> writers : registry.values()) {
       for (DataMapWriter writer : writers) {
-        writer.onBlockStart(blockId, taskId);
+        writer.onBlockStart(blockId, taskName);
       }
     }
   }

--- a/processing/src/main/java/org/apache/carbondata/processing/store/writer/AbstractFactDataWriter.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/writer/AbstractFactDataWriter.java
@@ -250,8 +250,8 @@ public abstract class AbstractFactDataWriter implements CarbonFactDataWriter {
   private void notifyDataMapBlockStart() {
     if (listener != null) {
       try {
-        listener.onBlockStart(carbonDataFileName, carbonDataFileHdfsPath,
-            model.getCarbonDataFileAttributes().getTaskId());
+        String taskName = CarbonTablePath.getUniqueTaskName(carbonDataFileName);
+        listener.onBlockStart(carbonDataFileName, carbonDataFileHdfsPath, taskName);
       } catch (IOException e) {
         throw new CarbonDataWriterException("Problem while writing datamap", e);
       }
@@ -266,7 +266,6 @@ public abstract class AbstractFactDataWriter implements CarbonFactDataWriter {
         throw new CarbonDataWriterException("Problem while writing datamap", e);
       }
     }
-    blockletId = 0;
   }
 
   /**


### PR DESCRIPTION
This PR is depends on PR https://github.com/apache/carbondata/pull/2204
Problem:
Currently DataMap interface implementations use blockid and blockletid while writing index files, Actually blockid is not needed to store in index files as it only requires blockletid.  So it adds more memory and disk size to write index files.

Solution:
Use taskname as index name to identify the indexname. And filter the blocklets directly by avoiding blockids.And pass the taskName as indexname to identify the blockid from blocletdatamap.

Corrected the implementations of  LuceneDatamap, CGDataMap, FGDataMap and MinMaxDataMap

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

