### PR TITLE
[CARBONDATA-2378][CarbonSearch] Support enable/disable search mode in ThriftServer

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/detailquery/SearchModeTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/detailquery/SearchModeTestCase.scala
@@ -99,4 +99,11 @@ class SearchModeTestCase extends QueryTest with BeforeAndAfterAll {
     checkSearchAnswer("select city, count(*) from main group by city")
   }
 
+  test("set search mode") {
+    sql("set carbon.search.enabled = true")
+    assert(sqlContext.sparkSession.asInstanceOf[CarbonSession].isSearchModeEnabled)
+    checkSearchAnswer("select id from main where id = '3' limit 10")
+    sql("set carbon.search.enabled = false")
+    assert(!sqlContext.sparkSession.asInstanceOf[CarbonSession].isSearchModeEnabled)
+  }
 }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSession.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSession.scala
@@ -110,7 +110,7 @@ class CarbonSession(@transient val sc: SparkContext,
     )
   }
 
-  private def isSearchModeEnabled = carbonStore != null
+  def isSearchModeEnabled = carbonStore != null
 
   /**
    * Run SparkSQL directly

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSession.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSession.scala
@@ -110,7 +110,7 @@ class CarbonSession(@transient val sc: SparkContext,
     )
   }
 
-  def isSearchModeEnabled = carbonStore != null
+  def isSearchModeEnabled: Boolean = carbonStore != null
 
   /**
    * Run SparkSQL directly

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/hive/execution/command/CarbonHiveCommands.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/hive/execution/command/CarbonHiveCommands.scala
@@ -17,7 +17,7 @@
 
 package org.apache.spark.sql.hive.execution.command
 
-import org.apache.spark.sql.{CarbonEnv, Row, SparkSession}
+import org.apache.spark.sql.{CarbonEnv, CarbonSession, Row, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.NoSuchDatabaseException
 import org.apache.spark.sql.catalyst.expressions.Attribute
@@ -72,6 +72,15 @@ case class CarbonSetCommand(command: SetCommand)
     command.kv match {
       case Some((key, Some(value))) =>
         CarbonSetCommand.validateAndSetValue(sessionParms, key, value)
+
+        // handle search mode start/stop for ThriftServer usage
+        if (key.equalsIgnoreCase(CarbonCommonConstants.CARBON_SEARCH_MODE_ENABLE)) {
+          if (value.equalsIgnoreCase("true")) {
+            sparkSession.asInstanceOf[CarbonSession].startSearchMode()
+          } else {
+            sparkSession.asInstanceOf[CarbonSession].stopSearchMode()
+          }
+        }
       case _ =>
 
     }


### PR DESCRIPTION
User can enable or disable search mode when using ThriftServer, by using:
`set carbon.search.enabled = true` or `set carbon.search.enabled = false`

 - [X] Any interfaces changed?
 No
 - [X] Any backward compatibility impacted?
 No
 - [X] Document update required?
Yes
 - [X] Testing done
Test case added
 - [X] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA