### PR TITLE
[CARBONDATA-2380][DataMap] Support visible/invisible datamap for performance tuning

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -65,6 +65,7 @@ public final class CarbonCommonConstants {
    * key prefix for set command. 'carbon.datamap.visible.dbName.tableName.dmName = false' means
    * that the query on 'dbName.table' will not use the datamap 'dmName'
    */
+  @InterfaceStability.Unstable
   public static final String CARBON_DATAMAP_VISIBLE = "carbon.datamap.visible.";
 
   /**

--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -62,6 +62,12 @@ public final class CarbonCommonConstants {
   public static final String CARBON_INPUT_SEGMENTS = "carbon.input.segments.";
 
   /**
+   * key prefix for set command. 'carbon.datamap.visible.dbName.tableName.dmName = false' means
+   * that the query on 'dbName.table' will not use the datamap 'dmName'
+   */
+  public static final String CARBON_DATAMAP_VISIBLE = "carbon.datamap.visible.";
+
+  /**
    * Fetch and validate the segments.
    * Used for aggregate table load as segment validation is not required.
    */

--- a/core/src/main/java/org/apache/carbondata/core/datamap/DataMapChooser.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/DataMapChooser.java
@@ -75,12 +75,12 @@ public class DataMapChooser {
       Expression expression = resolverIntf.getFilterExpression();
       // First check for FG datamaps if any exist
       List<TableDataMap> allDataMapFG =
-          DataMapStoreManager.getInstance().getAllDataMap(carbonTable, DataMapLevel.FG);
+          DataMapStoreManager.getInstance().getAllVisibleDataMap(carbonTable, DataMapLevel.FG);
       ExpressionTuple tuple = selectDataMap(expression, allDataMapFG, resolverIntf);
       if (tuple.dataMapExprWrapper == null) {
         // Check for CG datamap
         List<TableDataMap> allDataMapCG =
-            DataMapStoreManager.getInstance().getAllDataMap(carbonTable, DataMapLevel.CG);
+            DataMapStoreManager.getInstance().getAllVisibleDataMap(carbonTable, DataMapLevel.CG);
         tuple = selectDataMap(expression, allDataMapCG, resolverIntf);
       }
       if (tuple.dataMapExprWrapper != null) {
@@ -102,7 +102,7 @@ public class DataMapChooser {
       Expression expression = resolverIntf.getFilterExpression();
       // First check for FG datamaps if any exist
       List<TableDataMap> allDataMapFG =
-          DataMapStoreManager.getInstance().getAllDataMap(carbonTable, DataMapLevel.FG);
+          DataMapStoreManager.getInstance().getAllVisibleDataMap(carbonTable, DataMapLevel.FG);
       ExpressionTuple tuple = selectDataMap(expression, allDataMapFG, resolverIntf);
       if (tuple.dataMapExprWrapper != null) {
         return tuple.dataMapExprWrapper;
@@ -121,7 +121,7 @@ public class DataMapChooser {
       Expression expression = resolverIntf.getFilterExpression();
       // Check for CG datamap
       List<TableDataMap> allDataMapCG =
-          DataMapStoreManager.getInstance().getAllDataMap(carbonTable, DataMapLevel.CG);
+          DataMapStoreManager.getInstance().getAllVisibleDataMap(carbonTable, DataMapLevel.CG);
       ExpressionTuple tuple = selectDataMap(expression, allDataMapCG, resolverIntf);
       if (tuple.dataMapExprWrapper != null) {
         return tuple.dataMapExprWrapper;

--- a/core/src/main/java/org/apache/carbondata/core/util/SessionParams.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/SessionParams.java
@@ -28,6 +28,7 @@ import org.apache.carbondata.core.cache.CacheProvider;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.constants.CarbonCommonConstantsInternal;
 import org.apache.carbondata.core.constants.CarbonLoadOptionConstants;
+import org.apache.carbondata.core.datamap.DataMapStoreManager;
 import org.apache.carbondata.core.exception.InvalidConfigurationException;
 
 import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_CUSTOM_BLOCK_DISTRIBUTION;
@@ -208,6 +209,16 @@ public class SessionParams implements Serializable, Cloneable {
           isValid = true;
         } else if (key.startsWith(CarbonCommonConstantsInternal.QUERY_ON_PRE_AGG_STREAMING)) {
           isValid = true;
+        } else if (key.startsWith(CarbonCommonConstants.CARBON_DATAMAP_VISIBLE)) {
+          String[] keyArray = key.split("\\.");
+          isValid = DataMapStoreManager.getInstance().isDataMapExist(
+              keyArray[keyArray.length - 3],
+              keyArray[keyArray.length - 2],
+              keyArray[keyArray.length - 1]);
+          if (!isValid) {
+            throw new InvalidConfigurationException(
+                String.format("Invalid configuration of %s, datamap does not exist", key));
+          }
         } else {
           throw new InvalidConfigurationException(
               "The key " + key + " not supported for dynamic configuration.");

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/hive/execution/command/CarbonHiveCommands.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/hive/execution/command/CarbonHiveCommands.scala
@@ -98,6 +98,14 @@ object CarbonSetCommand {
       sessionParams.addProperty(key.toLowerCase(), value)
     } else if (key.startsWith(CarbonCommonConstantsInternal.QUERY_ON_PRE_AGG_STREAMING)) {
       sessionParams.addProperty(key.toLowerCase(), value)
+    } else if (key.startsWith(CarbonCommonConstants.CARBON_DATAMAP_VISIBLE)) {
+      if (key.split("\\.").length == 6) {
+        sessionParams.addProperty(key.toLowerCase, value)
+      } else {
+        throw new MalformedCarbonCommandException("property should be in " +
+          "\" carbon.datamap.visible.<database_name>.<table_name>.<database_name>" +
+          " = <true/false> \" format")
+      }
     }
   }
 


### PR DESCRIPTION
Support making datamap visible/invisible through session env.
Invisible datamap will only be ignored during query and user can still
see this datmap and its data will be updated as normal.
We can specify a datamap as invisible by
'set carbon.datamap.invisible.dbName.tableName.dataMapName=false' and it
is only effective in this session.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 `Add internal interface for getting visible datamaps`
 - [x] Any backward compatibility impacted?
 `NO`
 - [x] Document update required?
 `NO`
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
`Test added`
        - How it is tested? Please attach test report.
`Tested in local`
        - Is it a performance related change? Please attach the performance test report.
`No`
        - Any additional information to help reviewers in testing this change.
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
`Not related`
