### PR TITLE
[CARBONDATA-2313] fixed issue in query when multiple sdk writer's out…

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datamap/Segment.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/Segment.java
@@ -97,6 +97,10 @@ public class Segment implements Serializable {
     return segmentFileName;
   }
 
+  public ReadCommittedScope getReadCommittedScope() {
+    return readCommittedScope;
+  }
+
   public static List<Segment> toSegmentList(String[] segmentIds,
       ReadCommittedScope readCommittedScope) {
     List<Segment> list = new ArrayList<>(segmentIds.length);


### PR DESCRIPTION
problem: [Non-tranactional table] issue in query when multiple sdk writer's ouput files with same column name with same UUID is placed in single path

scenario: copy one set of sdk writer output, do select query. copy other set of sdk writer output with same column name and same UUID, do select query.
select query result's only first sets output.

root cause :  segment map was not updated with the latest files , if it is new files placed belong to  same segment.

solution: refresh the segment map, if there is a change in list of carobnindex files during each query for non transactional tables.


Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?NA
 
 - [ ] Any backward compatibility impacted?NA
 
 - [ ] Document update required?NA

 - [ ] Testing done. 
  done. updated the testcase with same uuid.
        
       


