### PR TITLE
[CARBONDATA-2386]Fix Query performance issue with PreAggregate table

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datamap/Segment.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/Segment.java
@@ -54,6 +54,11 @@ public class Segment implements Serializable {
   private ReadCommittedScope readCommittedScope;
 
   /**
+   * keeps all the details about segments
+   */
+  private LoadMetadataDetails loadMetadataDetails;
+
+  /**
    * ReadCommittedScope will be null. So getCommittedIndexFile will not work and will throw
    * a NullPointerException. In case getCommittedIndexFile is need to be accessed then
    * use the other constructor and pass proper ReadCommittedScope.
@@ -76,6 +81,19 @@ public class Segment implements Serializable {
     this.segmentNo = segmentNo;
     this.segmentFileName = segmentFileName;
     this.readCommittedScope = readCommittedScope;
+  }
+
+  /**
+   * @param segmentNo
+   * @param segmentFileName
+   * @param readCommittedScope
+   */
+  public Segment(String segmentNo, String segmentFileName, ReadCommittedScope readCommittedScope,
+      LoadMetadataDetails loadMetadataDetails) {
+    this.segmentNo = segmentNo;
+    this.segmentFileName = segmentFileName;
+    this.readCommittedScope = readCommittedScope;
+    this.loadMetadataDetails = loadMetadataDetails;
   }
 
   /**
@@ -174,5 +192,9 @@ public class Segment implements Serializable {
     } else {
       return segmentNo;
     }
+  }
+
+  public LoadMetadataDetails getLoadMetadataDetails() {
+    return loadMetadataDetails;
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/statusmanager/SegmentStatusManager.java
+++ b/core/src/main/java/org/apache/carbondata/core/statusmanager/SegmentStatusManager.java
@@ -141,7 +141,7 @@ public class SegmentStatusManager {
           // check for merged loads.
           if (null != segment.getMergedLoadName()) {
             Segment seg = new Segment(segment.getMergedLoadName(), segment.getSegmentFile(),
-                readCommittedScope);
+                readCommittedScope, segment);
             if (!listOfValidSegments.contains(seg)) {
               listOfValidSegments.add(seg);
             }
@@ -164,7 +164,8 @@ public class SegmentStatusManager {
             continue;
           }
           listOfValidSegments.add(
-              new Segment(segment.getLoadName(), segment.getSegmentFile(), readCommittedScope));
+              new Segment(segment.getLoadName(), segment.getSegmentFile(), readCommittedScope,
+                  segment));
         } else if ((SegmentStatus.LOAD_FAILURE == segment.getSegmentStatus()
             || SegmentStatus.COMPACTED == segment.getSegmentStatus()
             || SegmentStatus.MARKED_FOR_DELETE == segment.getSegmentStatus())) {

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/preaaggregate/PreAggregateUtil.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/preaaggregate/PreAggregateUtil.scala
@@ -745,8 +745,8 @@ object PreAggregateUtil {
    * @param aggExp aggregate expression
    * @return list of fields
    */
-  def validateAggregateFunctionAndGetFields(aggExp: AggregateExpression,
-      addCastForCount: Boolean = true): Seq[AggregateExpression] = {
+  def validateAggregateFunctionAndGetFields(aggExp: AggregateExpression)
+  : Seq[AggregateExpression] = {
     aggExp.aggregateFunction match {
       case Sum(MatchCastExpression(exp: Expression, changeDataType: DataType)) =>
         Seq(AggregateExpression(Sum(Cast(
@@ -783,23 +783,14 @@ object PreAggregateUtil {
       // in case of average need to return two columns
       // sum and count of the column to added during table creation to support rollup
       case Average(MatchCastExpression(exp: Expression, changeDataType: DataType)) =>
-        val sum = AggregateExpression(Sum(Cast(
+        Seq(AggregateExpression(Sum(Cast(
           exp,
           changeDataType)),
           aggExp.mode,
-          aggExp.isDistinct)
-        val count = if (!addCastForCount) {
+          aggExp.isDistinct),
           AggregateExpression(Count(exp),
             aggExp.mode,
-            aggExp.isDistinct)
-        } else {
-          AggregateExpression(Count(Cast(
-            exp,
-            changeDataType)),
-            aggExp.mode,
-            aggExp.isDistinct)
-        }
-        Seq(sum, count)
+            aggExp.isDistinct))
       // in case of average need to return two columns
       // sum and count of the column to added during table creation to support rollup
       case Average(exp: Expression) =>

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonPreAggregateRules.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonPreAggregateRules.scala
@@ -1762,7 +1762,7 @@ case class CarbonPreAggregateDataLoadingRules(sparkSession: SparkSession)
           case alias@Alias(aggExp: AggregateExpression, name) =>
             // get the updated expression for avg convert it to two expression
             // sum and count
-            val expressions = PreAggregateUtil.validateAggregateFunctionAndGetFields(aggExp, false)
+            val expressions = PreAggregateUtil.validateAggregateFunctionAndGetFields(aggExp)
             // if size is more than one then it was for average
             if(expressions.size > 1) {
               val sumExp = PreAggregateUtil.normalizeExprId(

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonRelation.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonRelation.scala
@@ -176,10 +176,11 @@ case class CarbonRelation(
           var size = 0L
           // for each segment calculate the size
           segments.foreach {validSeg =>
-            if (validSeg.getSegmentFileName != null) {
-              size = size + CarbonUtil.getSizeOfSegment(
-                carbonTable.getTablePath,
-                new Segment(validSeg.getSegmentNo, validSeg.getSegmentFileName))
+            // for older store
+            if (null != validSeg.getLoadMetadataDetails.getDataSize &&
+                null != validSeg.getLoadMetadataDetails.getIndexSize) {
+              size = size + validSeg.getLoadMetadataDetails.getDataSize.toLong +
+                     validSeg.getLoadMetadataDetails.getIndexSize.toLong
             } else {
               size = size + FileFactory.getDirectorySize(
                 CarbonTablePath.getSegmentPath(tablePath, validSeg.getSegmentNo))


### PR DESCRIPTION
**Problem:** Query on pre aggregate table is consuming too much time.
**Root cause:** Time consumption to calculate size of selecting the smallest Pre-Aggregate table is approximately 76 seconds. This is because index file is being read when segment file is present to compute the size of Pre-Aggregate table 
**Solution:** Read table status and get the size of data file and index file for valid segments. For older segments were datasize and indexsize is not present calculate the size of store folder
 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
       Tested in Cluster with 2 billion rows and 16 aggregate tables
Older Time:76 seconds
New Time: 6 seconds
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

