### PR TITLE
[CARBONDATA-2387]Primitive AVRO Datatype Checking

### DIFF
--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/AvroCarbonWriter.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/AvroCarbonWriter.java
@@ -85,11 +85,15 @@ class AvroCarbonWriter extends CarbonWriter {
       case LONG:
       case DOUBLE:
       case STRING:
+      case FLOAT:
         out.append(fieldValue.toString());
+        break;
+      case NULL:
+        out.append("");
         break;
       default:
         throw new UnsupportedOperationException();
-      // TODO: convert complex type
+        // TODO: convert complex type
     }
     return out.toString();
   }

--- a/store/sdk/src/test/java/org/apache/carbondata/sdk/file/AvroCarbonWriterTest.java
+++ b/store/sdk/src/test/java/org/apache/carbondata/sdk/file/AvroCarbonWriterTest.java
@@ -94,7 +94,84 @@ public class AvroCarbonWriterTest {
 
   @Test
   public void testWriteAllPrimitive() throws IOException {
-    // TODO
+    FileUtils.deleteDirectory(new File(path));
+
+    // Avro schema
+    // Supported Primitive Datatype.
+    // 1. Boolean
+    // 2. Int
+    // 3. long
+    // 4. float -> To carbon Internally it is double.
+    // 5. double
+    // 6. String
+
+    // Not Supported
+    // 1.NULL Datatype
+    // 2.Bytes
+
+    String avroSchema = "{\n" + "  \"name\" : \"myrecord\",\n"
+        + "  \"namespace\": \"org.apache.parquet.avro\",\n" + "  \"type\" : \"record\",\n"
+        + "  \"fields\" : [ "
+        + " {\n" + "    \"name\" : \"myboolean\",\n" + "    \"type\" : \"boolean\"\n  },"
+        + " {\n" + "    \"name\" : \"myint\",\n" + "    \"type\" : \"int\"\n" + "  }, "
+        + " {\n    \"name\" : \"mylong\",\n" + "    \"type\" : \"long\"\n" + "  },"
+        + " {\n   \"name\" : \"myfloat\",\n" + "    \"type\" : \"float\"\n" + "  }, "
+        + " {\n \"name\" : \"mydouble\",\n" + "    \"type\" : \"double\"\n" + "  },"
+        + " {\n \"name\" : \"mystring\",\n" + "    \"type\" : \"string\"\n" + "  }\n" + "] }";
+
+    String json = "{"
+        + "\"myboolean\":true, "
+        + "\"myint\": 10, "
+        + "\"mylong\": 7775656565,"
+        + " \"myfloat\": 0.2, "
+        + "\"mydouble\": 44.56, "
+        + "\"mystring\":\"Ajantha\"}";
+
+
+    // conversion to GenericData.Record
+    JsonAvroConverter converter = new JsonAvroConverter();
+    GenericData.Record record = converter.convertToGenericDataRecord(
+        json.getBytes(CharEncoding.UTF_8), new Schema.Parser().parse(avroSchema));
+
+    Field[] fields = new Field[6];
+    // fields[0] = new Field("mynull", DataTypes.NULL);
+    fields[0] = new Field("myboolean", DataTypes.BOOLEAN);
+    fields[1] = new Field("myint", DataTypes.INT);
+    fields[2] = new Field("mylong", DataTypes.LONG);
+    fields[3] = new Field("myfloat", DataTypes.DOUBLE);
+    fields[4] = new Field("mydouble", DataTypes.DOUBLE);
+    fields[5] = new Field("mystring", DataTypes.STRING);
+
+
+    try {
+      CarbonWriter writer = CarbonWriter.builder()
+          .withSchema(new org.apache.carbondata.sdk.file.Schema(fields))
+          .outputPath(path)
+          .isTransactionalTable(true)
+          .buildWriterForAvroInput();
+
+      for (int i = 0; i < 100; i++) {
+        writer.write(record);
+      }
+      writer.close();
+    } catch (Exception e) {
+      e.printStackTrace();
+      Assert.fail(e.getMessage());
+    }
+
+    File segmentFolder = new File(CarbonTablePath.getSegmentPath(path, "null"));
+    Assert.assertTrue(segmentFolder.exists());
+
+    File[] dataFiles = segmentFolder.listFiles(new FileFilter() {
+      @Override public boolean accept(File pathname) {
+        return pathname.getName().endsWith(CarbonCommonConstants.FACT_FILE_EXT);
+      }
+    });
+
+    Assert.assertNotNull(dataFiles);
+    Assert.assertEquals(1, dataFiles.length);
+
+    FileUtils.deleteDirectory(new File(path));
   }
 
   @Test


### PR DESCRIPTION
Test case added to check all the primitive datatype support of AVRO and its corresponding mapping with carbon datatypes. 

 Supported Primitive Datatype.
     1. Boolean
     2. Int
     3. long
     4. float -> To carbon Internally it is double.
     5. double
     6. String

     Not Supported
     1.NULL Datatype
     2.Bytes

 - [x] Any interfaces changed?
 
 - [x] Any backward compatibility impacted?
 
 - [x] Document update required?

 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

