### PR TITLE
[HOTFIX] Use CG datamap to prune blocklet

### DIFF
--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonInputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonInputFormat.java
@@ -424,10 +424,10 @@ public abstract class CarbonInputFormat<T> extends FileInputFormat<Void, T> {
       // Again prune with CG datamap.
       if (distributedCG && dataMapJob != null) {
         prunedBlocklets =
-            executeDataMapJob(carbonTable, resolver, segmentIds, dataMapExprWrapper, dataMapJob,
+            executeDataMapJob(carbonTable, resolver, segmentIds, cgDataMapExprWrapper, dataMapJob,
                 partitionsToPrune);
       } else {
-        prunedBlocklets = dataMapExprWrapper.prune(segmentIds, partitionsToPrune);
+        prunedBlocklets = cgDataMapExprWrapper.prune(segmentIds, partitionsToPrune);
       }
     }
     // Now try to prune with FG DataMap.


### PR DESCRIPTION
Correct incorrect variable when pruning with CG datamap

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

