### PR TITLE
[CARBONDATA-2391] [Compaction Thread Leak] Thread leak in compaction operation if prefetch is enabled and compaction process is killed

### DIFF
--- a/processing/src/main/java/org/apache/carbondata/processing/merger/CarbonCompactionExecutor.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/merger/CarbonCompactionExecutor.java
@@ -176,13 +176,20 @@ public class CarbonCompactionExecutor {
    * Below method will be used
    * for cleanup
    */
-  public void finish() {
+  public void close(List<RawResultIterator> rawResultIteratorList) {
     try {
+      // close all the iterators. Iterators might not closed in case of compaction failure
+      // or if process is killed
+      if (null != rawResultIteratorList) {
+        for (RawResultIterator rawResultIterator : rawResultIteratorList) {
+          rawResultIterator.close();
+        }
+      }
       for (QueryExecutor queryExecutor : queryExecutorList) {
         queryExecutor.finish();
       }
     } catch (QueryExecutionException e) {
-      LOGGER.error(e, "Problem while finish: ");
+      LOGGER.error(e, "Problem while close. Ignoring the exception");
     }
     clearDictionaryFromQueryModel();
   }

--- a/processing/src/main/java/org/apache/carbondata/processing/merger/RowResultMergerProcessor.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/merger/RowResultMergerProcessor.java
@@ -116,6 +116,7 @@ public class RowResultMergerProcessor extends AbstractResultProcessor {
         Object[] convertedRow = iterator.next();
         if (null == convertedRow) {
           index--;
+          iterator.close();
           continue;
         }
         if (!isDataPresent) {
@@ -140,6 +141,7 @@ public class RowResultMergerProcessor extends AbstractResultProcessor {
       while (true) {
         Object[] convertedRow = iterator.next();
         if (null == convertedRow) {
+          iterator.close();
           break;
         }
         // do it only once


### PR DESCRIPTION
Problem
Thread leak in compaction operation if prefetch is enabled and compaction process is killed

Analysis
During compaction if prefetch is enabled RawResultIterator launches an executor service for prefetching the data.
If compaction fails or the process is killed it can lead to thread leak due to executor service still in running state.

Fix
Close the executor service in task completion listener of compaction

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

