### PR TITLE
[HOTFIX] Avoid adding status if there is no datamaps on table.

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datamap/status/DataMapStatusManager.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/status/DataMapStatusManager.java
@@ -53,11 +53,11 @@ public class DataMapStatusManager {
 
   public static void disableDataMap(String dataMapName) throws Exception {
     DataMapSchema dataMapSchema = getDataMapSchema(dataMapName);
-    List<DataMapSchema> list = new ArrayList<>();
     if (dataMapSchema != null) {
+      List<DataMapSchema> list = new ArrayList<>();
       list.add(dataMapSchema);
+      storageProvider.updateDataMapStatus(list, DataMapStatus.DISABLED);
     }
-    storageProvider.updateDataMapStatus(list, DataMapStatus.DISABLED);
   }
 
   public static void disableDataMapsOfTable(CarbonTable table) throws IOException {
@@ -68,11 +68,11 @@ public class DataMapStatusManager {
 
   public static void enableDataMap(String dataMapName) throws IOException, NoSuchDataMapException {
     DataMapSchema dataMapSchema = getDataMapSchema(dataMapName);
-    List<DataMapSchema> list = new ArrayList<>();
     if (dataMapSchema != null) {
+      List<DataMapSchema> list = new ArrayList<>();
       list.add(dataMapSchema);
+      storageProvider.updateDataMapStatus(list, DataMapStatus.ENABLED);
     }
-    storageProvider.updateDataMapStatus(list, DataMapStatus.ENABLED);
   }
 
   public static void enableDataMapsOfTable(CarbonTable table) throws IOException {
@@ -83,11 +83,11 @@ public class DataMapStatusManager {
 
   public static void dropDataMap(String dataMapName) throws IOException, NoSuchDataMapException {
     DataMapSchema dataMapSchema = getDataMapSchema(dataMapName);
-    List<DataMapSchema> list = new ArrayList<>();
     if (dataMapSchema != null) {
+      List<DataMapSchema> list = new ArrayList<>();
       list.add(dataMapSchema);
+      storageProvider.updateDataMapStatus(list, DataMapStatus.DROPPED);
     }
-    storageProvider.updateDataMapStatus(list, DataMapStatus.DROPPED);
   }
 
   private static DataMapSchema getDataMapSchema(String dataMapName)

--- a/core/src/main/java/org/apache/carbondata/core/datamap/status/DiskBasedDataMapStatusProvider.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/status/DiskBasedDataMapStatusProvider.java
@@ -98,6 +98,10 @@ public class DiskBasedDataMapStatusProvider implements DataMapStatusStorageProvi
   @Override
   public void updateDataMapStatus(List<DataMapSchema> dataMapSchemas, DataMapStatus dataMapStatus)
       throws IOException {
+    if (dataMapSchemas == null || dataMapSchemas.size() == 0) {
+      // There is nothing to update
+      return;
+    }
     ICarbonLock carbonTableStatusLock = getDataMapStatusLock();
     boolean locked = false;
     try {


### PR DESCRIPTION
Avoid adding datamap status to the status file if there is no datamap associated with the table while loading.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

