### PR TITLE
[CARBONDATA-2394] Setting segments in thread local space but was not getting reflected in the driver is fixed

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
@@ -90,10 +90,14 @@ class CarbonEnv {
         // update carbon session parameters , preserve thread parameters
         val currentThreadSesssionInfo = ThreadLocalSessionInfo.getCarbonSessionInfo
         carbonSessionInfo = new CarbonSessionInfo()
+        // We should not corrupt the information in carbonSessionInfo object which is at the
+        // session level. Instead create a new object and in that set the user specified values in
+        // thread/session params
+        val threadLevelCarbonSessionInfo = new CarbonSessionInfo()
         if (currentThreadSesssionInfo != null) {
-          carbonSessionInfo.setThreadParams(currentThreadSesssionInfo.getThreadParams)
+          threadLevelCarbonSessionInfo.setThreadParams(currentThreadSesssionInfo.getThreadParams)
         }
-        ThreadLocalSessionInfo.setCarbonSessionInfo(carbonSessionInfo)
+        ThreadLocalSessionInfo.setCarbonSessionInfo(threadLevelCarbonSessionInfo)
         val config = new CarbonSQLConf(sparkSession)
         if (sparkSession.conf.getOption(CarbonCommonConstants.ENABLE_UNSAFE_SORT).isEmpty) {
           config.addDefaultCarbonParams()


### PR DESCRIPTION
**Problem :** from multiple thread if we are setting any property to thread level. It is affecting other also.
**Analysis :** information in carbonSessionInfo object is being corrupted inside CarbonEnv. so if new thread may be impacted by prev one.
**Solution :** create a new object and in  set the user specified values in thread/session params to new object.

 - [x] Any interfaces changed? No
 
 - [x] Any backward compatibility impacted? No
 
 - [x] Document update required? No

 - [x] Testing done 
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.  NA

