### PR TITLE
WIP:[CARBONDATA-2402] Optimize allocated buffer size while converting objects

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
@@ -2400,13 +2400,13 @@ public final class CarbonUtil {
       bytes[0] = (byte) value;
       return bytes;
     } else if (dataType == DataTypes.SHORT) {
-      b = ByteBuffer.allocate(8);
-      b.putLong((short) value);
+      b = ByteBuffer.allocate(2);
+      b.putShort((short) value);
       b.flip();
       return b.array();
     } else if (dataType == DataTypes.INT) {
-      b = ByteBuffer.allocate(8);
-      b.putLong((int) value);
+      b = ByteBuffer.allocate(4);
+      b.putInt((int) value);
       b.flip();
       return b.array();
     } else if (dataType == DataTypes.LONG) {

--- a/core/src/main/java/org/apache/carbondata/core/util/DataTypeUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/DataTypeUtil.java
@@ -130,9 +130,9 @@ public final class DataTypeUtil {
     if (dataType == DataTypes.BOOLEAN) {
       return BooleanConvert.byte2Boolean(bb.get());
     } else if (dataType == DataTypes.SHORT) {
-      return (short) bb.getLong();
+      return bb.getShort();
     } else if (dataType == DataTypes.INT) {
-      return (int) bb.getLong();
+      return bb.getInt();
     } else if (dataType == DataTypes.LONG) {
       return bb.getLong();
     } else if (DataTypes.isDecimal(dataType)) {
@@ -147,9 +147,9 @@ public final class DataTypeUtil {
     if (dataType == DataTypes.BOOLEAN) {
       return measurePage.getBoolean(index);
     } else if (dataType == DataTypes.SHORT) {
-      return (short) measurePage.getLong(index);
+      return measurePage.getShort(index);
     } else if (dataType == DataTypes.INT) {
-      return (int) measurePage.getLong(index);
+      return measurePage.getInt(index);
     } else if (dataType == DataTypes.LONG) {
       return measurePage.getLong(index);
     } else if (DataTypes.isDecimal(dataType)) {


### PR DESCRIPTION
Currently while converting objects to byte array, for value of int/short, reduce allocated buffer size from 8 bytes to 4/2 respectively.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 `NO`
 - [x] Any backward compatibility impacted?
 `Not sure`
 - [x] Document update required?
`NO`
 - [] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

