### PR TITLE
[HOTFIX] Remove carbon-spark2 dependency in carbon-bloom

### DIFF
--- a/datamap/bloom/pom.xml
+++ b/datamap/bloom/pom.xml
@@ -20,7 +20,7 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.carbondata</groupId>
-      <artifactId>carbondata-spark2</artifactId>
+      <artifactId>carbondata-core</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/integration/spark2/pom.xml
+++ b/integration/spark2/pom.xml
@@ -55,6 +55,12 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.carbondata</groupId>
+      <artifactId>carbondata-bloom</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-hive-thriftserver_${scala.binary.version}</artifactId>
     </dependency>

--- a/integration/spark2/src/test/scala/org/apache/carbondata/datamap/bloom/BloomCoarseGrainDataMapSuite.scala
+++ b/integration/spark2/src/test/scala/org/apache/carbondata/datamap/bloom/BloomCoarseGrainDataMapSuite.scala
@@ -22,7 +22,6 @@ import java.util.UUID
 
 import scala.util.Random
 
-import org.apache.spark.sql.Row
 import org.apache.spark.sql.test.util.QueryTest
 import org.scalatest.BeforeAndAfterAll
 


### PR DESCRIPTION
carbon-bloom module should not depend on carbon-spark2 module.
Moved testcase to spark2 module and add carbon-bloom dependency in carbon-spark2 pom for test scope.

 - [X] Any interfaces changed?
 No
 - [X] Any backward compatibility impacted?
 No
 - [X] Document update required?
No
 - [X] Testing done
 NA
 - [X] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA
