### PR TITLE
[CARBONDATA-2406][dataload]-Dictionary Server and Dictionary Client MD5 Validation failed with hive.server2.enable.doAs = true

### DIFF
--- a/integration/spark-common/src/main/java/org/apache/carbondata/spark/dictionary/server/SecureDictionaryServer.java
+++ b/integration/spark-common/src/main/java/org/apache/carbondata/spark/dictionary/server/SecureDictionaryServer.java
@@ -16,6 +16,9 @@
  */
 package org.apache.carbondata.spark.dictionary.server;
 
+import java.io.IOException;
+import java.security.PrivilegedExceptionAction;
+
 import org.apache.carbondata.common.logging.LogService;
 import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
@@ -29,6 +32,7 @@ import org.apache.carbondata.core.util.CarbonProperties;
 import com.google.common.collect.Lists;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.spark.SecurityManager;
 import org.apache.spark.SparkConf;
 import org.apache.spark.network.TransportContext;
@@ -63,7 +67,18 @@ public class SecureDictionaryServer extends AbstractDictionaryServer implements 
     this.conf = conf;
     this.host = host;
     this.port = port;
-    startServer();
+    try {
+      UserGroupInformation.getLoginUser().doAs(new PrivilegedExceptionAction<Void>() {
+        @Override public Void run() throws Exception {
+          startServer();
+          return null;
+        }
+      });
+    } catch (IOException io) {
+      LOGGER.error(io, "Failed to start Dictionary Server in secure mode");
+    } catch (InterruptedException ie) {
+      LOGGER.error(ie, "Failed to start Dictionary Server in secure mode");
+    }
   }
 
   public static synchronized DictionaryServer getInstance(SparkConf conf, String host, int port,
@@ -186,8 +201,19 @@ public class SecureDictionaryServer extends AbstractDictionaryServer implements 
   @Override
   public void shutdown() throws Exception {
     LOGGER.info("Shutting down dictionary server");
-    worker.shutdownGracefully();
-    boss.shutdownGracefully();
+    try {
+      UserGroupInformation.getLoginUser().doAs(new PrivilegedExceptionAction<Void>() {
+        @Override public Void run() throws Exception {
+          worker.shutdownGracefully();
+          boss.shutdownGracefully();
+          return null;
+        }
+      });
+    } catch (IOException io) {
+      LOGGER.error(io, "Failed to stop Dictionary Server in secure mode");
+    } catch (InterruptedException ie) {
+      LOGGER.error(ie, "Failed to stop Dictionary Server in secure mode");
+    }
   }
 
   public void initializeDictionaryGenerator(CarbonTable carbonTable) throws Exception {


### PR DESCRIPTION
With conf hive.server2.enable.doAs = true, the dictionary server is started with the user who submit the load request. But the dictionary client run as the user who started the executor process. Due to this dictionary client can not successfully communicate with the dictionary server.

 - [X] Any interfaces changed?
 None
 - [X] Any backward compatibility impacted?
 None
 - [X] Document update required?
None
 - [X] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       No test case added.
 - [X] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA
