### PR TITLE
[HOTFIX] Fix JVM crash in search mode

### DIFF
--- a/store/search/src/main/java/org/apache/carbondata/store/worker/SearchRequestHandler.java
+++ b/store/search/src/main/java/org/apache/carbondata/store/worker/SearchRequestHandler.java
@@ -38,6 +38,8 @@ import org.apache.carbondata.core.readcommitter.LatestFilesReadCommittedScope;
 import org.apache.carbondata.core.scan.expression.Expression;
 import org.apache.carbondata.core.scan.model.QueryModel;
 import org.apache.carbondata.core.scan.model.QueryModelBuilder;
+import org.apache.carbondata.core.util.CarbonTaskInfo;
+import org.apache.carbondata.core.util.ThreadLocalTaskInfo;
 import org.apache.carbondata.hadoop.CarbonInputSplit;
 import org.apache.carbondata.hadoop.CarbonMultiBlockSplit;
 import org.apache.carbondata.hadoop.CarbonRecordReader;
@@ -76,12 +78,16 @@ public class SearchRequestHandler {
    */
   private List<CarbonRow> handleRequest(SearchRequest request)
       throws IOException, InterruptedException {
+    CarbonTaskInfo carbonTaskInfo = new CarbonTaskInfo();
+    carbonTaskInfo.setTaskId(System.nanoTime());
+    ThreadLocalTaskInfo.setCarbonTaskInfo(carbonTaskInfo);
     TableInfo tableInfo = request.tableInfo();
     CarbonTable table = CarbonTable.buildFromTableInfo(tableInfo);
     QueryModel queryModel = createQueryModel(table, request);
 
     // in search mode, plain reader is better since it requires less memory
     queryModel.setVectorReader(false);
+
     CarbonMultiBlockSplit mbSplit = request.split().value();
     long limit = request.limit();
     long rowCount = 0;


### PR DESCRIPTION
Problem : 
In search mode handler there is no task id set so memory manager try to clear the memory with old task id which is set during loading. So it crashes JVM.

Solution : 
Always use unique task id for each request so that memory manager can clear the leftover blocks . Set the taskid in SearchRequestHandler

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

