### PR TITLE
[CARBONDATA-2408] Fix search mode master SaslException issue in the first time

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/carbondata/store/SparkCarbonStore.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/store/SparkCarbonStore.scala
@@ -110,6 +110,7 @@ class SparkCarbonStore extends MetaCachedCarbonStore {
   }
 
   def startSearchMode(): Unit = {
+    LOG.info("Starting search mode master")
     master = new Master(session.sparkContext.getConf)
     master.startService()
     startAllWorkers()

--- a/store/search/src/main/scala/org/apache/spark/rpc/Master.scala
+++ b/store/search/src/main/scala/org/apache/spark/rpc/Master.scala
@@ -123,7 +123,7 @@ class Master(sparkConf: SparkConf) {
         LOG.info("Search mode master started")
       }
     } else {
-      LOG.info("Search mode master has already existed before.")
+      LOG.info("Search mode master has already started")
     }
   }
 


### PR DESCRIPTION
Before register to master, the master maybe not finished the start service. Please check the jira.

Fix method:
   
    Waiting for search mode master thread finished and wait for request. And then start workers.


Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 No
 - [x] Any backward compatibility impacted?
 No
 - [x] Document update required?
No
 - [x] Testing done
    Add Thread.sleep(3000) into org.apache.spark.rpc.Master#startService
   And then test it with org.apache.carbondata.examples.SearchModeExample or org.apache.carbondata.spark.testsuite.detailquery.SearchModeTestCase,
or in cluster with beeline
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
No
