### PR TITLE
[CARBONDATA-2313] fixed multiple issues in SDK writer and external table with NonTransactional table data

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/TableSchemaBuilder.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/TableSchemaBuilder.java
@@ -139,6 +139,10 @@ public class TableSchemaBuilder {
     } else {
       otherColumns.add(newColumn);
     }
+
+    if (newColumn.isDimensionColumn()) {
+      newColumn.setUseInvertedIndex(true);
+    }
     return this;
   }
 

--- a/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -471,7 +471,10 @@ object CarbonDataRDDFactory {
       // update the load entry in table status file for changing the status to marked for delete
       CarbonLoaderUtil.updateTableStatusForFailure(carbonLoadModel, uniqueTableStatusId)
       LOGGER.info("********starting clean up**********")
-      CarbonLoaderUtil.deleteSegment(carbonLoadModel, carbonLoadModel.getSegmentId.toInt)
+      if (carbonLoadModel.isCarbonTransactionalTable) {
+        // delete segment is applicable for transactional table
+        CarbonLoaderUtil.deleteSegment(carbonLoadModel, carbonLoadModel.getSegmentId.toInt)
+      }
       LOGGER.info("********clean up done**********")
       LOGGER.audit(s"Data load is failed for " +
                    s"${ carbonLoadModel.getDatabaseName }.${ carbonLoadModel.getTableName }")
@@ -486,7 +489,10 @@ object CarbonDataRDDFactory {
         // update the load entry in table status file for changing the status to marked for delete
         CarbonLoaderUtil.updateTableStatusForFailure(carbonLoadModel, uniqueTableStatusId)
         LOGGER.info("********starting clean up**********")
-        CarbonLoaderUtil.deleteSegment(carbonLoadModel, carbonLoadModel.getSegmentId.toInt)
+        if (carbonLoadModel.isCarbonTransactionalTable) {
+          // delete segment is applicable for transactional table
+          CarbonLoaderUtil.deleteSegment(carbonLoadModel, carbonLoadModel.getSegmentId.toInt)
+        }
         LOGGER.info("********clean up done**********")
         LOGGER.audit(s"Data load is failed for " +
                      s"${ carbonLoadModel.getDatabaseName }.${ carbonLoadModel.getTableName }")
@@ -539,7 +545,10 @@ object CarbonDataRDDFactory {
       if (!done || !commitComplete) {
         CarbonLoaderUtil.updateTableStatusForFailure(carbonLoadModel, uniqueTableStatusId)
         LOGGER.info("********starting clean up**********")
-        CarbonLoaderUtil.deleteSegment(carbonLoadModel, carbonLoadModel.getSegmentId.toInt)
+        if (carbonLoadModel.isCarbonTransactionalTable) {
+          // delete segment is applicable for transactional table
+          CarbonLoaderUtil.deleteSegment(carbonLoadModel, carbonLoadModel.getSegmentId.toInt)
+        }
         LOGGER.info("********clean up done**********")
         LOGGER.audit("Data load is failed for " +
                      s"${ carbonLoadModel.getDatabaseName }.${ carbonLoadModel.getTableName }")

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonDescribeFormattedCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonDescribeFormattedCommand.scala
@@ -81,12 +81,17 @@ private[sql] case class CarbonDescribeFormattedCommand(
     } else {
       colProps.toString()
     }
+    val carbonTable = relation.carbonTable
     results ++= Seq(("", "", ""), ("##Detailed Table Information", "", ""))
     results ++= Seq(("Database Name", relation.carbonTable.getDatabaseName, "")
     )
     results ++= Seq(("Table Name", relation.carbonTable.getTableName, ""))
-    results ++= Seq(("CARBON Store Path ", CarbonProperties.getStorePath, ""))
-    val carbonTable = relation.carbonTable
+    if (carbonTable.isTransactionalTable) {
+      results ++= Seq(("CARBON Store Path ", CarbonProperties.getStorePath, ""))
+    } else {
+      // for NonTransactional table should show files path.
+      results ++= Seq(("CARBON Store Path ", carbonTable.getTablePath, ""))
+    }
 
     val tblProps = carbonTable.getTableInfo.getFactTable.getTableProperties
 

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/BadRecordsLoggerProvider.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/BadRecordsLoggerProvider.java
@@ -71,13 +71,21 @@ public class BadRecordsLoggerProvider {
     }
     CarbonTableIdentifier identifier =
         configuration.getTableIdentifier().getCarbonTableIdentifier();
+    String storeLocation = "";
+    if (configuration.isCarbonTransactionalTable()) {
+      storeLocation =
+          identifier.getDatabaseName() + CarbonCommonConstants.FILE_SEPARATOR + identifier
+              .getTableName() + CarbonCommonConstants.FILE_SEPARATOR + configuration.getSegmentId()
+              + CarbonCommonConstants.FILE_SEPARATOR + configuration.getTaskNo();
+    } else {
+      storeLocation =
+          "SdkWriterBadRecords" + CarbonCommonConstants.FILE_SEPARATOR + configuration.getTaskNo();
+    }
+
     return new BadRecordsLogger(identifier.getBadRecordLoggerKey(),
         identifier.getTableName() + '_' + System.currentTimeMillis(),
-        getBadLogStoreLocation(configuration,
-            identifier.getDatabaseName() + CarbonCommonConstants.FILE_SEPARATOR + identifier
-                .getTableName() + CarbonCommonConstants.FILE_SEPARATOR + configuration
-                .getSegmentId() + CarbonCommonConstants.FILE_SEPARATOR + configuration.getTaskNo()),
-        badRecordsLogRedirect, badRecordsLoggerEnable, badRecordConvertNullDisable, isDataLoadFail);
+        getBadLogStoreLocation(configuration, storeLocation), badRecordsLogRedirect,
+        badRecordsLoggerEnable, badRecordConvertNullDisable, isDataLoadFail);
   }
 
   public static String getBadLogStoreLocation(CarbonDataLoadConfiguration configuration,

--- a/processing/src/main/java/org/apache/carbondata/processing/util/CarbonBadRecordUtil.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/util/CarbonBadRecordUtil.java
@@ -49,9 +49,17 @@ public class CarbonBadRecordUtil {
     // rename the bad record in progress to normal
     CarbonTableIdentifier identifier =
         configuration.getTableIdentifier().getCarbonTableIdentifier();
-    renameBadRecordsFromInProgressToNormal(configuration,
-        identifier.getDatabaseName() + File.separator + identifier.getTableName() + File.separator
-            + configuration.getSegmentId() + File.separator + configuration.getTaskNo());
+    String storeLocation = "";
+    if (configuration.isCarbonTransactionalTable()) {
+      storeLocation =
+          identifier.getDatabaseName() + CarbonCommonConstants.FILE_SEPARATOR + identifier
+              .getTableName() + CarbonCommonConstants.FILE_SEPARATOR + configuration.getSegmentId()
+              + CarbonCommonConstants.FILE_SEPARATOR + configuration.getTaskNo();
+    } else {
+      storeLocation =
+          "SdkWriterBadRecords" + CarbonCommonConstants.FILE_SEPARATOR + configuration.getTaskNo();
+    }
+    renameBadRecordsFromInProgressToNormal(configuration, storeLocation);
   }
 
   /**

--- a/processing/src/main/java/org/apache/carbondata/processing/util/CarbonLoaderUtil.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/util/CarbonLoaderUtil.java
@@ -465,9 +465,6 @@ public final class CarbonLoaderUtil {
     CarbonLoaderUtil
         .populateNewLoadMetaEntry(newLoadMetaEntry, status, model.getFactTimeStamp(), false);
 
-    if (!model.isCarbonTransactionalTable() && insertOverwrite) {
-      CarbonLoaderUtil.deleteNonTransactionalTableForInsertOverwrite(model);
-    }
     boolean entryAdded = CarbonLoaderUtil
         .recordNewLoadMetadata(newLoadMetaEntry, model, true, insertOverwrite, uuid);
     if (!entryAdded) {

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/AvroCarbonWriter.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/AvroCarbonWriter.java
@@ -85,6 +85,7 @@ class AvroCarbonWriter extends CarbonWriter {
       case LONG:
       case DOUBLE:
       case STRING:
+      case FLOAT:
         out.append(fieldValue.toString());
         break;
       default:

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonWriterBuilder.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonWriterBuilder.java
@@ -66,7 +66,7 @@ public class CarbonWriterBuilder {
   /**
    * prepares the builder with the schema provided
    * @param schema is instance of Schema
-   *        This method must be called when building CarbonWriterBuilder
+   * This method must be called when building CarbonWriterBuilder
    * @return updated CarbonWriterBuilder
    */
   public CarbonWriterBuilder withSchema(Schema schema) {
@@ -78,7 +78,7 @@ public class CarbonWriterBuilder {
   /**
    * Sets the output path of the writer builder
    * @param path is the absolute path where output files are written
-   *             This method must be called when building CarbonWriterBuilder
+   * This method must be called when building CarbonWriterBuilder
    * @return updated CarbonWriterBuilder
    */
   public CarbonWriterBuilder outputPath(String path) {
@@ -90,8 +90,8 @@ public class CarbonWriterBuilder {
   /**
    * sets the list of columns that needs to be in sorted order
    * @param sortColumns is a string array of columns that needs to be sorted.
-   *                    If it is null or by default all dimensions are selected for sorting
-   *                    If it is empty array, no columns are sorted
+   * If it is null or by default all dimensions are selected for sorting
+   * If it is empty array, no columns are sorted
    * @return updated CarbonWriterBuilder
    */
   public CarbonWriterBuilder sortBy(String[] sortColumns) {
@@ -103,7 +103,7 @@ public class CarbonWriterBuilder {
    * sets the taskNo for the writer. SDKs concurrently running
    * will set taskNo in order to avoid conflicts in file's name during write.
    * @param taskNo is the TaskNo user wants to specify.
-   *               by default it is system time in nano seconds.
+   * by default it is system time in nano seconds.
    * @return updated CarbonWriterBuilder
    */
   public CarbonWriterBuilder taskNo(String taskNo) {
@@ -116,7 +116,7 @@ public class CarbonWriterBuilder {
   /**
    * If set, create a schema file in metadata folder.
    * @param persist is a boolean value, If set to true, creates a schema file in metadata folder.
-   *                By default set to false. will not create metadata folder
+   * By default set to false. will not create metadata folder
    * @return updated CarbonWriterBuilder
    */
   public CarbonWriterBuilder persistSchemaFile(boolean persist) {
@@ -127,11 +127,11 @@ public class CarbonWriterBuilder {
   /**
    * If set false, writes the carbondata and carbonindex files in a flat folder structure
    * @param isTransactionalTable is a boolelan value
-   *             if set to false, then writes the carbondata and carbonindex files
-   *                                                            in a flat folder structure.
-   *             if set to true, then writes the carbondata and carbonindex files
-   *                                                            in segment folder structure..
-   *             By default set to false.
+   * if set to false, then writes the carbondata and carbonindex files
+   * in a flat folder structure.
+   * if set to true, then writes the carbondata and carbonindex files
+   * in segment folder structure..
+   * By default set to false.
    * @return updated CarbonWriterBuilder
    */
   public CarbonWriterBuilder isTransactionalTable(boolean isTransactionalTable) {
@@ -210,7 +210,7 @@ public class CarbonWriterBuilder {
   /**
    * to set the timestamp in the carbondata and carbonindex index files
    * @param UUID is a timestamp to be used in the carbondata and carbonindex index files.
-   *             By default set to zero.
+   * By default set to zero.
    * @return updated CarbonWriterBuilder
    */
   public CarbonWriterBuilder uniqueIdentifier(long UUID) {
@@ -222,28 +222,28 @@ public class CarbonWriterBuilder {
   /**
    * To support the load options for sdk writer
    * @param options key,value pair of load options.
-   *                supported keys values are
-   *                a. bad_records_logger_enable -- true (write into separate logs), false
-   *                b. bad_records_action -- FAIL, FORCE, IGNORE, REDIRECT
-   *                c. bad_record_path -- path
-   *                d. dateformat -- same as JAVA SimpleDateFormat
-   *                e. timestampformat -- same as JAVA SimpleDateFormat
-   *                f. complex_delimiter_level_1 -- value to Split the complexTypeData
-   *                g. complex_delimiter_level_2 -- value to Split the nested complexTypeData
-   *                h. quotechar
-   *                i. escapechar
+   * supported keys values are
+   * a. bad_records_logger_enable -- true (write into separate logs), false
+   * b. bad_records_action -- FAIL, FORCE, IGNORE, REDIRECT
+   * c. bad_record_path -- path
+   * d. dateformat -- same as JAVA SimpleDateFormat
+   * e. timestampformat -- same as JAVA SimpleDateFormat
+   * f. complex_delimiter_level_1 -- value to Split the complexTypeData
+   * g. complex_delimiter_level_2 -- value to Split the nested complexTypeData
+   * h. quotechar
+   * i. escapechar
    *
-   *                Default values are as follows.
+   * Default values are as follows.
    *
-   *                a. bad_records_logger_enable -- "false"
-   *                b. bad_records_action -- "FAIL"
-   *                c. bad_record_path -- ""
-   *                d. dateformat -- "" , uses from carbon.properties file
-   *                e. timestampformat -- "", uses from carbon.properties file
-   *                f. complex_delimiter_level_1 -- "$"
-   *                g. complex_delimiter_level_2 -- ":"
-   *                h. quotechar -- "\""
-   *                i. escapechar -- "\\"
+   * a. bad_records_logger_enable -- "false"
+   * b. bad_records_action -- "FAIL"
+   * c. bad_record_path -- ""
+   * d. dateformat -- "" , uses from carbon.properties file
+   * e. timestampformat -- "", uses from carbon.properties file
+   * f. complex_delimiter_level_1 -- "$"
+   * g. complex_delimiter_level_2 -- ":"
+   * h. quotechar -- "\""
+   * i. escapechar -- "\\"
    *
    * @return updated CarbonWriterBuilder
    */
@@ -280,7 +280,7 @@ public class CarbonWriterBuilder {
   /**
    * To set the carbondata file size in MB between 1MB-2048MB
    * @param blockSize is size in MB between 1MB to 2048 MB
-   *                  default value is 1024 MB
+   * default value is 1024 MB
    * @return updated CarbonWriterBuilder
    */
   public CarbonWriterBuilder withBlockSize(int blockSize) {
@@ -294,7 +294,7 @@ public class CarbonWriterBuilder {
   /**
    * To set the blocklet size of carbondata file
    * @param blockletSize is blocklet size in MB
-   *                     default value is 64 MB
+   * default value is 64 MB
    * @return updated CarbonWriterBuilder
    */
   public CarbonWriterBuilder withBlockletSize(int blockletSize) {

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonWriterBuilder.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonWriterBuilder.java
@@ -47,7 +47,7 @@ import org.apache.carbondata.processing.loading.model.CarbonLoadModelBuilder;
 import org.apache.hadoop.fs.s3a.Constants;
 
 /**
- * Biulder for {@link CarbonWriter}
+ * Builder for {@link CarbonWriter}
  */
 @InterfaceAudience.User
 @InterfaceStability.Unstable
@@ -66,6 +66,7 @@ public class CarbonWriterBuilder {
   /**
    * prepares the builder with the schema provided
    * @param schema is instance of Schema
+   *        This method must be called when building CarbonWriterBuilder
    * @return updated CarbonWriterBuilder
    */
   public CarbonWriterBuilder withSchema(Schema schema) {
@@ -77,6 +78,7 @@ public class CarbonWriterBuilder {
   /**
    * Sets the output path of the writer builder
    * @param path is the absolute path where output files are written
+   *             This method must be called when building CarbonWriterBuilder
    * @return updated CarbonWriterBuilder
    */
   public CarbonWriterBuilder outputPath(String path) {
@@ -88,7 +90,7 @@ public class CarbonWriterBuilder {
   /**
    * sets the list of columns that needs to be in sorted order
    * @param sortColumns is a string array of columns that needs to be sorted.
-   *                    If it is null, all dimensions are selected for sorting
+   *                    If it is null or by default all dimensions are selected for sorting
    *                    If it is empty array, no columns are sorted
    * @return updated CarbonWriterBuilder
    */
@@ -99,8 +101,9 @@ public class CarbonWriterBuilder {
 
   /**
    * sets the taskNo for the writer. SDKs concurrently running
-   * will set taskNo in order to avoid conflits in file write.
-   * @param taskNo is the TaskNo user wants to specify. Mostly it system time.
+   * will set taskNo in order to avoid conflicts in file's name during write.
+   * @param taskNo is the TaskNo user wants to specify.
+   *               by default it is system time in nano seconds.
    * @return updated CarbonWriterBuilder
    */
   public CarbonWriterBuilder taskNo(String taskNo) {
@@ -112,7 +115,8 @@ public class CarbonWriterBuilder {
 
   /**
    * If set, create a schema file in metadata folder.
-   * @param persist is a boolean value, If set, create a schema file in metadata folder
+   * @param persist is a boolean value, If set to true, creates a schema file in metadata folder.
+   *                By default set to false. will not create metadata folder
    * @return updated CarbonWriterBuilder
    */
   public CarbonWriterBuilder persistSchemaFile(boolean persist) {
@@ -122,8 +126,12 @@ public class CarbonWriterBuilder {
 
   /**
    * If set false, writes the carbondata and carbonindex files in a flat folder structure
-   * @param isTransactionalTable is a boolelan value if set to false then writes
-   *                     the carbondata and carbonindex files in a flat folder structure
+   * @param isTransactionalTable is a boolelan value
+   *             if set to false, then writes the carbondata and carbonindex files
+   *                                                            in a flat folder structure.
+   *             if set to true, then writes the carbondata and carbonindex files
+   *                                                            in segment folder structure..
+   *             By default set to false.
    * @return updated CarbonWriterBuilder
    */
   public CarbonWriterBuilder isTransactionalTable(boolean isTransactionalTable) {
@@ -201,7 +209,8 @@ public class CarbonWriterBuilder {
 
   /**
    * to set the timestamp in the carbondata and carbonindex index files
-   * @param UUID is a timestamp to be used in the carbondata and carbonindex index files
+   * @param UUID is a timestamp to be used in the carbondata and carbonindex index files.
+   *             By default set to zero.
    * @return updated CarbonWriterBuilder
    */
   public CarbonWriterBuilder uniqueIdentifier(long UUID) {
@@ -223,6 +232,18 @@ public class CarbonWriterBuilder {
    *                g. complex_delimiter_level_2 -- value to Split the nested complexTypeData
    *                h. quotechar
    *                i. escapechar
+   *
+   *                Default values are as follows.
+   *
+   *                a. bad_records_logger_enable -- "false"
+   *                b. bad_records_action -- "FAIL"
+   *                c. bad_record_path -- ""
+   *                d. dateformat -- "" , uses from carbon.properties file
+   *                e. timestampformat -- "", uses from carbon.properties file
+   *                f. complex_delimiter_level_1 -- "$"
+   *                g. complex_delimiter_level_2 -- ":"
+   *                h. quotechar -- "\""
+   *                i. escapechar -- "\\"
    *
    * @return updated CarbonWriterBuilder
    */
@@ -259,6 +280,7 @@ public class CarbonWriterBuilder {
   /**
    * To set the carbondata file size in MB between 1MB-2048MB
    * @param blockSize is size in MB between 1MB to 2048 MB
+   *                  default value is 1024 MB
    * @return updated CarbonWriterBuilder
    */
   public CarbonWriterBuilder withBlockSize(int blockSize) {
@@ -272,6 +294,7 @@ public class CarbonWriterBuilder {
   /**
    * To set the blocklet size of carbondata file
    * @param blockletSize is blocklet size in MB
+   *                     default value is 64 MB
    * @return updated CarbonWriterBuilder
    */
   public CarbonWriterBuilder withBlockletSize(int blockletSize) {
@@ -284,6 +307,9 @@ public class CarbonWriterBuilder {
 
   /**
    * Build a {@link CarbonWriter}, which accepts row in CSV format
+   * @return CSVCarbonWriter
+   * @throws IOException
+   * @throws InvalidLoadOptionException
    */
   public CarbonWriter buildWriterForCSVInput() throws IOException, InvalidLoadOptionException {
     Objects.requireNonNull(schema, "schema should not be null");
@@ -294,8 +320,9 @@ public class CarbonWriterBuilder {
 
   /**
    * Build a {@link CarbonWriter}, which accepts Avro object
-   * @return
+   * @return AvroCarbonWriter
    * @throws IOException
+   * @throws InvalidLoadOptionException
    */
   public CarbonWriter buildWriterForAvroInput() throws IOException, InvalidLoadOptionException {
     Objects.requireNonNull(schema, "schema should not be null");

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/Field.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/Field.java
@@ -32,6 +32,11 @@ public class Field {
   private String name;
   private DataType type;
 
+  /**
+   * Field Constructor
+   * @param name name of the field
+   * @param type datatype of field, specified in strings.
+   */
   public Field(String name, String type) {
     this.name = name;
     if (type.equalsIgnoreCase("string")) {
@@ -59,6 +64,11 @@ public class Field {
     }
   }
 
+  /**
+   * Field constructor
+   * @param name name of the field
+   * @param type datatype of the field of class DataType
+   */
   public Field(String name, DataType type) {
     this.name = name;
     this.type = type;

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/Schema.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/Schema.java
@@ -36,6 +36,10 @@ public class Schema {
 
   private Field[] fields;
 
+  /**
+   * construct a schema with fields
+   * @param fields
+   */
   public Schema(Field[] fields) {
     this.fields = fields;
   }
@@ -46,6 +50,8 @@ public class Schema {
    *   {"name":"string"},
    *   {"age":"int"}
    * ]
+   * @param json specified as string
+   * @return Schema
    */
   public static Schema parseJson(String json) {
     GsonBuilder gsonBuilder = new GsonBuilder();


### PR DESCRIPTION
[CARBONDATA-2313] fixed multiple issues in SDK writer and external table with NonTransactional table data

*Header update for sdk interface api.
*bad record path issue in sdk writer, should not be "null/null/null/taskno" changed to "sdkBadRecords/taskno".
*Non transactional table, Number format exception was coming instead of bad record exception when load fails due to bad record.
*Non transactional table, insert overwrite failure case old files must not be deleted.
*Non transactional table, describe formatted path should be files path.
*SDK, default all dimensions munst be inverted index encoding.
*SDK, avro not supporting float datatype.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?No
 
 - [ ] Any backward compatibility impacted?No
 
 - [ ] Document update required?NA

 - [ ] Testing done
        updated UT test cases. 
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.  NA

