### PR TITLE
[HOTFIX][Search] Carbon should throw exception for TEXT_MATCH UDF

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RowLevelFilterExecuterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RowLevelFilterExecuterImpl.java
@@ -193,7 +193,13 @@ public class RowLevelFilterExecuterImpl implements FilterExecuter {
   public BitSetGroup applyFilter(RawBlockletColumnChunks rawBlockletColumnChunks,
       boolean useBitsetPipeLine) throws FilterUnsupportedException, IOException {
     if (exp instanceof MatchExpression) {
-      return rawBlockletColumnChunks.getBitSetGroup();
+      BitSetGroup bitSetGroup = rawBlockletColumnChunks.getBitSetGroup();
+      if (bitSetGroup == null) {
+        // It means there are no datamap created on this table
+        throw new FilterUnsupportedException(
+            exp.getFilterExpressionType().name() + " is not supported on this table");
+      }
+      return bitSetGroup;
     }
     readColumnChunks(rawBlockletColumnChunks);
     // CHECKSTYLE:ON

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RowLevelFilterExecuterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RowLevelFilterExecuterImpl.java
@@ -196,8 +196,8 @@ public class RowLevelFilterExecuterImpl implements FilterExecuter {
       BitSetGroup bitSetGroup = rawBlockletColumnChunks.getBitSetGroup();
       if (bitSetGroup == null) {
         // It means there are no datamap created on this table
-        throw new FilterUnsupportedException(
-            exp.getFilterExpressionType().name() + " is not supported on this table");
+        throw new FilterUnsupportedException(String.format("%s is not supported on table %s",
+            exp.getFilterExpressionType().name(), tableIdentifier.getTableName()));
       }
       return bitSetGroup;
     }

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/datamap/lucene/LuceneFineGrainDataMapSuite.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/datamap/lucene/LuceneFineGrainDataMapSuite.scala
@@ -423,7 +423,7 @@ class LuceneFineGrainDataMapSuite extends QueryTest with BeforeAndAfterAll {
     sql("DROP TABLE IF EXISTS datamap_test_table")
     sql(
       """
-        | CREATE TABLE datamap_test_table(id INT, name STRING, city STRING, age INT)
+        | CREATE TABLE datamap_test_table(id INT, name STRING, city STRING, age INT)LuceneFineGrainDataMapSuite
         | STORED BY 'carbondata'
         | TBLPROPERTIES('SORT_COLUMNS'='city,name', 'SORT_SCOPE'='GLOBAL_SORT')
       """.stripMargin)
@@ -710,7 +710,7 @@ class LuceneFineGrainDataMapSuite extends QueryTest with BeforeAndAfterAll {
     val msg = intercept[SparkException] {
       sql("select * from table1 where TEXT_MATCH('name:n*')").show()
     }
-    assert(msg.getMessage.contains("TEXT_MATCH is not supported on this table"))
+    assert(msg.getCause.getMessage.contains("TEXT_MATCH is not supported on table"))
     sql("DROP TABLE table1")
   }
 

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/datamap/lucene/LuceneFineGrainDataMapSuite.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/datamap/lucene/LuceneFineGrainDataMapSuite.scala
@@ -423,7 +423,7 @@ class LuceneFineGrainDataMapSuite extends QueryTest with BeforeAndAfterAll {
     sql("DROP TABLE IF EXISTS datamap_test_table")
     sql(
       """
-        | CREATE TABLE datamap_test_table(id INT, name STRING, city STRING, age INT)LuceneFineGrainDataMapSuite
+        | CREATE TABLE datamap_test_table(id INT, name STRING, city STRING, age INT)
         | STORED BY 'carbondata'
         | TBLPROPERTIES('SORT_COLUMNS'='city,name', 'SORT_SCOPE'='GLOBAL_SORT')
       """.stripMargin)

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
@@ -451,7 +451,7 @@ class CarbonScanRDD[T: ClassTag](
             reader.close()
           } catch {
             case e: Exception =>
-              LOGGER.error(e)
+              LogServiceFactory.getLogService(this.getClass.getCanonicalName).error(e)
           }
           reader = null
         }


### PR DESCRIPTION
Carbon should throw exception for TEXT_MATCH UDF on a table that does not have a lucene datamap 

 - [X] Any interfaces changed?
 No
 - [X] Any backward compatibility impacted?
 No
 - [X] Document update required?
No
 - [X] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
 Test added      
 - [X] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA