### PR TITLE
[CARBONDATA-2411] infinite loop when sdk writer throws Exception

### DIFF
--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/AvroCarbonWriter.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/AvroCarbonWriter.java
@@ -99,14 +99,15 @@ class AvroCarbonWriter extends CarbonWriter {
    */
   @Override
   public void write(Object object) throws IOException {
-    GenericData.Record record = (GenericData.Record) object;
-
-    // convert Avro record to CSV String[]
-    String[] csvRecord = avroToCsv(record);
-    writable.set(csvRecord);
     try {
+      GenericData.Record record = (GenericData.Record) object;
+
+      // convert Avro record to CSV String[]
+      String[] csvRecord = avroToCsv(record);
+      writable.set(csvRecord);
       recordWriter.write(NullWritable.get(), writable);
-    } catch (InterruptedException e) {
+    } catch (Exception e) {
+      close();
       throw new IOException(e);
     }
   }

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CSVCarbonWriter.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CSVCarbonWriter.java
@@ -65,10 +65,11 @@ class CSVCarbonWriter extends CarbonWriter {
    */
   @Override
   public void write(Object object) throws IOException {
-    writable.set((String[]) object);
     try {
+      writable.set((String[]) object);
       recordWriter.write(NullWritable.get(), writable);
-    } catch (InterruptedException e) {
+    } catch (Exception e) {
+      close();
       throw new IOException(e);
     }
   }

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonWriterBuilder.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonWriterBuilder.java
@@ -334,11 +334,15 @@ public class CarbonWriterBuilder {
       // If sort columns are not specified, default set all dimensions to sort column.
       // When dimensions are default set to sort column,
       // Inverted index will be supported by default for sort columns.
+      //Null check for field to handle hole in field[] ex.
+      //  user passed size 4 but supplied only 2 fileds
       for (Field field : schema.getFields()) {
-        if (field.getDataType() == DataTypes.STRING ||
-            field.getDataType() == DataTypes.DATE ||
-            field.getDataType() == DataTypes.TIMESTAMP) {
-          sortColumnsList.add(field.getFieldName());
+        if (null != field) {
+          if (field.getDataType() == DataTypes.STRING ||
+              field.getDataType() == DataTypes.DATE ||
+              field.getDataType() == DataTypes.TIMESTAMP) {
+            sortColumnsList.add(field.getFieldName());
+          }
         }
       }
       sortColumns = new String[sortColumnsList.size()];
@@ -347,9 +351,11 @@ public class CarbonWriterBuilder {
       sortColumnsList = Arrays.asList(sortColumns);
     }
     for (Field field : schema.getFields()) {
-      tableSchemaBuilder.addColumn(
-          new StructField(field.getFieldName(), field.getDataType()),
-          sortColumnsList.contains(field.getFieldName()));
+      if (null != field) {
+        tableSchemaBuilder.addColumn(
+            new StructField(field.getFieldName(), field.getDataType()),
+            sortColumnsList.contains(field.getFieldName()));
+      }
     }
     String tableName;
     String dbName;

--- a/store/sdk/src/test/java/org/apache/carbondata/sdk/file/CSVCarbonWriterTest.java
+++ b/store/sdk/src/test/java/org/apache/carbondata/sdk/file/CSVCarbonWriterTest.java
@@ -205,4 +205,45 @@ public class CSVCarbonWriterTest {
     FileUtils.deleteDirectory(new File(path));
   }
 
+
+  @Test(expected = IOException.class)
+  public void testWhenWriterthrowsError() throws IOException{
+    CarbonWriter carbonWriter = null;
+    String path = "./testWriteFiles";
+
+    FileUtils.deleteDirectory(new File(path));
+    Field[] fields = new Field[2];
+    fields[0] = new Field("name", DataTypes.STRING);
+    fields[1] = new Field("age", DataTypes.INT);
+    try {
+      carbonWriter = CarbonWriter.builder().isTransactionalTable(false).
+          outputPath(path).withSchema(new Schema(fields)).buildWriterForCSVInput();
+    } catch (InvalidLoadOptionException e) {
+      e.printStackTrace();
+      Assert.assertTrue(false);
+    }
+    carbonWriter.write("babu,1");
+    carbonWriter.close();
+
+  }
+  @Test
+  public void testWrongSchemaFieldsValidation() throws IOException{
+    CarbonWriter carbonWriter = null;
+    String path = "./testWriteFiles";
+
+    FileUtils.deleteDirectory(new File(path));
+    Field[] fields = new Field[3]; // supply 3 size fields but actual Field array value given is 2
+    fields[0] = new Field("name", DataTypes.STRING);
+    fields[1] = new Field("age", DataTypes.INT);
+    try {
+      carbonWriter = CarbonWriter.builder().isTransactionalTable(false).
+          outputPath(path).withSchema(new Schema(fields)).buildWriterForCSVInput();
+    } catch (InvalidLoadOptionException e) {
+      e.printStackTrace();
+      Assert.assertTrue(false);
+    }
+    carbonWriter.write(new String[]{"babu","1"});
+    carbonWriter.close();
+
+  }
 }


### PR DESCRIPTION
Issue & root Cause :- Exception is not handled  when Object is cast to String[]   in writer method of CarbonWriter  so no Exception thrown to caller and data-loading threads is not interrupted which is leading complete sdk application to infinite  loop ( Or data loading max timeout 2 Day). 
 
Solution :- Throw Exception to caller and one Exception call writer close method .

 - [ ] Any interfaces changed?
 NO
 - [ ] Any backward compatibility impacted?
 NO
 - [ ] Document update required?
NO
 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
     Testcase Addded  
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA
