### PR TITLE
[CARBONDATA-2419] sortColumns Order we are getting wrong as we set for external table is fixed

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/TableSchemaBuilder.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/TableSchemaBuilder.java
@@ -103,7 +103,11 @@ public class TableSchemaBuilder {
     return schema;
   }
 
-  public TableSchemaBuilder addColumn(StructField field, boolean isSortColumn) {
+  public void setSortColumns(List<ColumnSchema> sortColumns) {
+    this.sortColumns = sortColumns;
+  }
+
+  public ColumnSchema addColumn(StructField field, boolean isSortColumn) {
     Objects.requireNonNull(field);
     checkRepeatColumnName(field);
     ColumnSchema newColumn = new ColumnSchema();
@@ -138,10 +142,7 @@ public class TableSchemaBuilder {
       newColumn.setPrecision(decimalType.getPrecision());
       newColumn.setScale(decimalType.getScale());
     }
-    if (isSortColumn) {
-      sortColumns.add(newColumn);
-      newColumn.setSortColumn(true);
-    } else {
+    if (!isSortColumn) {
       otherColumns.add(newColumn);
     }
     if (newColumn.isDimensionColumn()) {
@@ -156,7 +157,7 @@ public class TableSchemaBuilder {
         }
       }
     }
-    return this;
+    return newColumn;
   }
 
   /**

--- a/core/src/test/java/org/apache/carbondata/core/metadata/schema/table/TableSchemaBuilderSuite.java
+++ b/core/src/test/java/org/apache/carbondata/core/metadata/schema/table/TableSchemaBuilderSuite.java
@@ -17,6 +17,7 @@
 
 package org.apache.carbondata.core.metadata.schema.table;
 
+import java.util.Arrays;
 import java.util.List;
 
 import org.apache.carbondata.core.metadata.datatype.DataTypes;
@@ -37,7 +38,8 @@ public class TableSchemaBuilderSuite {
   @Test
   public void testBuilder() {
     TableSchemaBuilder builder = TableSchema.builder();
-    builder.addColumn(new StructField("a", DataTypes.INT), true);
+    ColumnSchema columnSchema = builder.addColumn(new StructField("a", DataTypes.INT), true);
+    builder.setSortColumns(Arrays.asList(columnSchema));
     builder.addColumn(new StructField("b", DataTypes.DOUBLE), false);
     TableSchema schema = builder.build();
     Assert.assertEquals(2, schema.getListOfColumns().size());
@@ -49,7 +51,8 @@ public class TableSchemaBuilderSuite {
   @Test(expected = IllegalArgumentException.class)
   public void testRepeatedColumn() {
     TableSchemaBuilder builder = TableSchema.builder();
-    builder.addColumn(new StructField("a", DataTypes.INT), true);
+    ColumnSchema columnSchema = builder.addColumn(new StructField("a", DataTypes.INT), true);
+    builder.setSortColumns(Arrays.asList(columnSchema));
     builder.addColumn(new StructField("a", DataTypes.DOUBLE), false);
     TableSchema schema = builder.build();
   }


### PR DESCRIPTION

**Problem** : sortColumns propert was being added during addition of column in builder.
**Solution** : sortColumns property is set explicitly instead of during addition of column in builder.

 - [x] Any interfaces changed? No
 
 - [x] Any backward compatibility impacted? No
 
 - [x] Document update required? NO

 - [x] Testing done => UT added
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. NA

