### PR TITLE
[HOTFIX] Fix lucene match limit code

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/scan/expression/MatchExpression.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/expression/MatchExpression.java
@@ -29,15 +29,20 @@ import org.apache.carbondata.core.scan.filter.intf.RowIntf;
 @InterfaceAudience.Internal
 public class MatchExpression extends Expression {
   private String queryString;
-  public static String maxDoc;
+  private int maxDoc;
 
-  public MatchExpression(String queryString, String maxDoc) {
+  public MatchExpression(String queryString) {
     this.queryString = queryString;
-    setMaxDoc(maxDoc);
+    this.maxDoc = -1;
   }
 
-  private void setMaxDoc(String maxDoc) {
-    MatchExpression.maxDoc = maxDoc;
+  public MatchExpression(String queryString, int maxDoc) {
+    this.queryString = queryString;
+    this.maxDoc = maxDoc;
+  }
+
+  public int getMaxDoc() {
+    return maxDoc;
   }
 
   @Override

--- a/datamap/lucene/src/main/java/org/apache/carbondata/datamap/lucene/LuceneFineGrainDataMap.java
+++ b/datamap/lucene/src/main/java/org/apache/carbondata/datamap/lucene/LuceneFineGrainDataMap.java
@@ -153,8 +153,19 @@ public class LuceneFineGrainDataMap extends FineGrainDataMap {
    * Return Maximum records
    * @return
    */
-  private int getMaxDoc() {
-    return Integer.parseInt(MatchExpression.maxDoc);
+  private int getMaxDoc(Expression expression) {
+    if (expression.getFilterExpressionType() == ExpressionType.TEXT_MATCH) {
+      int maxDoc = ((MatchExpression) expression).getMaxDoc();
+      if (maxDoc < 0) {
+        maxDoc = Integer.MAX_VALUE;
+      }
+      return maxDoc;
+    }
+
+    for (Expression child : expression.getChildren()) {
+      return getMaxDoc(child);
+    }
+    return Integer.MAX_VALUE;
   }
 
   /**
@@ -172,7 +183,7 @@ public class LuceneFineGrainDataMap extends FineGrainDataMap {
     String strQuery = getQueryString(filterExp.getFilterExpression());
     int maxDocs;
     try {
-      maxDocs = getMaxDoc();
+      maxDocs = getMaxDoc(filterExp.getFilterExpression());
     } catch (NumberFormatException e) {
       maxDocs = Integer.MAX_VALUE;
     }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/optimizer/CarbonFilters.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/optimizer/CarbonFilters.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.optimizer
 import java.util
 
 import scala.collection.JavaConverters._
+import scala.util.Try
 
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.expressions._
@@ -30,7 +31,6 @@ import org.apache.spark.sql.CarbonEndsWith
 import org.apache.spark.sql.CarbonExpressions.{MatchCast => Cast}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.hive.CarbonSessionCatalog
-import org.apache.spark.sql.sources.Filter
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.datamap.Segment
@@ -141,9 +141,9 @@ object CarbonFilters {
         case FalseExpr() =>
           Some(new FalseExpression(null))
         case TextMatch(queryString) =>
-          Some(new MatchExpression(queryString, null))
+          Some(new MatchExpression(queryString))
         case TextMatchLimit(queryString, maxDoc) =>
-          Some(new MatchExpression(queryString, maxDoc))
+          Some(new MatchExpression(queryString, Try(maxDoc.toInt).getOrElse(Integer.MAX_VALUE)))
         case _ => None
       }
     }


### PR DESCRIPTION
Problem
Currently, Lucene match limit is set as Static in `MatchExpression` it cannot work in concurrent scenarios.
Solution:
Change to object variable and get the match max limit from expression.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

