### PR TITLE
[CARBONDATA-2422] Search mode Master port should be dynamic

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -1659,7 +1659,9 @@ public final class CarbonCommonConstants {
   public static final String CARBON_SEARCH_MODE_SCAN_THREAD = "carbon.search.scan.thread";
 
   /**
-   * In search mode, Master will listen on this port for worker registration
+   * In search mode, Master will listen on this port for worker registration.
+   * If Master failed to start service with this port, it will try to increment the port number
+   * and try to bind again, until it is success
    */
   @CarbonProperty
   @InterfaceStability.Unstable

--- a/store/search/src/main/scala/org/apache/spark/rpc/Master.scala
+++ b/store/search/src/main/scala/org/apache/spark/rpc/Master.scala
@@ -66,8 +66,6 @@ class Master(sparkConf: SparkConf) {
 
   /** start service and listen on port passed in constructor */
   def startService(): Unit = {
-    var started: Boolean = false
-    var count: Int = 0
     if (rpcEnv == null) {
       new Thread(new Runnable {
         override def run(): Unit = {
@@ -99,20 +97,9 @@ class Master(sparkConf: SparkConf) {
           val registryEndpoint: RpcEndpoint = new Registry(rpcEnv, Master.this)
           rpcEnv.setupEndpoint("registry-service", registryEndpoint)
           LOG.info("registry-service started")
-          started = true
           rpcEnv.awaitTermination()
         }
       }).start()
-
-      // wait until registry-service is started
-      while (!started && count < 100) {
-        Thread.sleep(100)
-        count = count + 1
-      }
-      if (count == 100) {
-        LOG.error("Failed to start Master")
-        throw new RuntimeException("Failed to start Master, timed out")
-      }
     }
   }
 

--- a/store/search/src/main/scala/org/apache/spark/rpc/Master.scala
+++ b/store/search/src/main/scala/org/apache/spark/rpc/Master.scala
@@ -19,7 +19,7 @@ package org.apache.spark.rpc
 
 import java.io.IOException
 import java.net.{BindException, InetAddress}
-import java.util.{Objects, Random, UUID, List => JList, Map => JMap}
+import java.util.{List => JList, Map => JMap, Objects, Random, UUID}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
@@ -30,7 +30,6 @@ import scala.util.{Failure, Success, Try}
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.mapred.JobConf
 import org.apache.hadoop.mapreduce.Job
-import org.apache.spark.rpc.Worker.LOG
 import org.apache.spark.{SecurityManager, SerializableWritable, SparkConf}
 import org.apache.spark.rpc.netty.NettyRpcEnvFactory
 import org.apache.spark.search._


### PR DESCRIPTION
In SDV test, sometimes search mode testcase failed because Master port is occupied. This PR adds support for dynamic master port to avoid port binding failure

 - [X] Any interfaces changed?
 No
 - [X] Any backward compatibility impacted?
 No
 - [X] Document update required?
No
 - [X] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       No
 - [X] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA