### PR TITLE
[CARBONDATA-2436][Query] Resolved Block pruning problem post the carbon schema restructure.

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMap.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMap.java
@@ -685,7 +685,11 @@ public class BlockletDataMap extends CoarseGrainDataMap implements Cacheable {
       }
     }
     // Prune with filters if the partitions are existed in this datamap
-    return prune(filterExp, segmentProperties);
+    // changed segmentProperties to this.segmentProperties to make sure the pruning with its own
+    // segmentProperties.
+    // Its a temporary fix. The Interface DataMap.prune(FilterResolverIntf filterExp,
+    // SegmentProperties segmentProperties, List<PartitionSpec> partitions) should be corrected
+    return prune(filterExp, this.segmentProperties);
   }
 
   private boolean isCorrectUUID(String[] fileDetails, PartitionSpec spec) {

--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/restructure/AlterTableValidationTestCase.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/restructure/AlterTableValidationTestCase.scala
@@ -43,7 +43,7 @@ class AlterTableValidationTestCase extends Spark2QueryTest with BeforeAndAfterAl
     sql("drop table if exists testalterwithboolean")
     sql("drop table if exists testalterwithbooleanwithoutdefaultvalue")
     sql("drop table if exists test")
-
+    sql("drop table if exists retructure_iud")
 
     // clean data folder
     CarbonProperties.getInstance()
@@ -690,7 +690,25 @@ test("test alter command for boolean data type with correct default measure valu
     testFilterWithDefaultValue(true)
     testFilterWithDefaultValue(false)
   }
-
+  test("Filter query on Restructure and updated table") {
+    sql(
+      """
+         CREATE TABLE retructure_iud(id int, name string, city string, age int)
+         STORED BY 'org.apache.carbondata.format'
+      """)
+    val testData = s"$resourcesPath/sample.csv"
+    sql(s"LOAD DATA LOCAL INPATH '$testData' into table retructure_iud")
+    sql("ALTER TABLE retructure_iud ADD COLUMNS (newField STRING) " +
+        "TBLPROPERTIES ('DEFAULT.VALUE.newField'='def', 'DICTIONARY_INCLUDE'='newField')").show()
+    sql("ALTER TABLE retructure_iud ADD COLUMNS (newField1 STRING) " +
+        "TBLPROPERTIES ('DEFAULT.VALUE.newField1'='def', 'DICTIONARY_EXCLUDE'='newField1')").show()
+    // update operation
+    sql("""update retructure_iud d  set (d.id) = (d.id + 1) where d.id > 2""").show()
+    checkAnswer(
+      sql("select count(*) from retructure_iud where id = 2 and newfield1='def'"),
+      Seq(Row(1))
+    )
+  }
   override def afterAll {
     sql("DROP TABLE IF EXISTS restructure")
     sql("drop table if exists table1")
@@ -707,5 +725,6 @@ test("test alter command for boolean data type with correct default measure valu
     sql("drop table if exists testalterwithboolean")
     sql("drop table if exists testalterwithbooleanwithoutdefaultvalue")
     sql("drop table if exists test")
+    sql("drop table if exists retructure_iud")
   }
 }


### PR DESCRIPTION
Currently DataMap is pruning with segmentproperties from the 0th block of BlockletDataMap is not 
correct. As post restructure if the table is updated then all the block will not have 
symmetric schema within the same segments.

Solution : It must be ensured the block could be pruned with the same schema.

Note: This is just a temporary fix only the main BlockletDataMap. The Segmentproperties is also
used for the MinMaxIndexDataMap also, the complete fix could be discussed at below mailing thread.     [Refactored SegmentPropertiesFetcher to resolve pruning problem post the carbon schema restructure](http://apache-carbondata-dev-mailing-list-archive.1130556.n5.nabble.com/Refactored-SegmentPropertiesFetcher-to-resolve-pruning-problem-post-the-carbon-schema-restructure-td48018.html
)
…

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [X] Any interfaces changed?
 NA
 - [X] Any backward compatibility impacted?
 NA
 - [X] Document update required?
NA
 - [X] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       Added test case to verify the restructured table update and filter query scenario
 - [X] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

