### PR TITLE
[CARBONDATA-2432][Build] Add bloomfilter datamap to carbondata assembly jar

### DIFF
--- a/integration/spark2/pom.xml
+++ b/integration/spark2/pom.xml
@@ -58,7 +58,6 @@
       <groupId>org.apache.carbondata</groupId>
       <artifactId>carbondata-bloom</artifactId>
       <version>${project.version}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>


### PR DESCRIPTION
Currently after build, the generated carbondata assembly jar does not contain bloomfilter datamap. This PR fix this.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 `NA`
 - [x] Any backward compatibility impacted?
  `NA`
 - [x] Document update required?
 `NA`
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
 `NA`
        - How it is tested? Please attach test report.
 `NA`
        - Is it a performance related change? Please attach the performance test report.
 `NA`
        - Any additional information to help reviewers in testing this change.
 `NA`
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
 `NA`

