### PR TITLE
Added Performance Optimization for Presto by using MultiBlockSplit

### DIFF
--- a/integration/presto/README.md
+++ b/integration/presto/README.md
@@ -77,6 +77,9 @@ Please follow the below steps to query carbondata in presto
   carbondata-store={schema-store-path}
   enable.unsafe.in.query.processing=false
   carbon.unsafe.working.memory.in.mb={value}
+  enable.unsafe.columnpage=false
+  enable.unsafe.sort=false
+
   ```
   Replace the schema-store-path with the absolute path of the parent directory of the schema.
   For example, if you have a schema named 'default' stored in hdfs://namenode:9000/test/carbondata/,
@@ -112,7 +115,11 @@ Please follow the below steps to query carbondata in presto
 ####  Unsafe Properties    
   enable.unsafe.in.query.processing property by default is true in CarbonData system, the carbon.unsafe.working.memory.in.mb 
   property defines the limit for Unsafe Memory usage in Mega Bytes, the default value is 512 MB.
-  If your tables are big you can increase the unsafe memory, or disable unsafe via setting enable.unsafe.in.query.processing=false.
+  Currently Presto does not support Unsafe Memory so we have to disable the unsafe feature by setting below properties to false.
+
+  enable.unsafe.in.query.processing=false.
+  enable.unsafe.columnpage=false
+  enable.unsafe.sort=false
 
   If you updated the jar balls or configuration files, make sure you have dispatched them
    to all the presto nodes and restarted the presto servers on the nodes. The updates will not take effect before restarting.

--- a/integration/presto/pom.xml
+++ b/integration/presto/pom.xml
@@ -463,12 +463,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
-      <version>3.0.2</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>org.glassfish.hk2</groupId>
       <artifactId>hk2-api</artifactId>
       <version>2.5.0-b42</version>
@@ -552,13 +546,7 @@
     <testSourceDirectory>src/test/scala</testSourceDirectory>
     <resources>
       <resource>
-        <directory>src/resources</directory>
-      </resource>
-      <resource>
-        <directory>.</directory>
-        <includes>
-          <include>CARBON_SPARK_INTERFACELogResource.properties</include>
-        </includes>
+        <directory>src/main/resources</directory>
       </resource>
     </resources>
     <plugins>

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/CarbonVectorBatch.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/CarbonVectorBatch.java
@@ -25,7 +25,7 @@ import org.apache.carbondata.core.scan.result.vector.impl.CarbonColumnVectorImpl
 
 public class CarbonVectorBatch {
 
-  private static final int DEFAULT_BATCH_SIZE = 1024;
+  private static final int DEFAULT_BATCH_SIZE =  4 * 1024;
 
   private final StructField[] schema;
   private final int capacity;

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/CarbondataMetadata.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/CarbondataMetadata.java
@@ -17,32 +17,51 @@
 
 package org.apache.carbondata.presto;
 
-import org.apache.carbondata.core.constants.CarbonCommonConstants;
-import org.apache.carbondata.core.datastore.impl.FileFactory;
-import org.apache.carbondata.core.metadata.datatype.DataTypes;
-import org.apache.carbondata.core.metadata.schema.table.column.CarbonColumn;
-import org.apache.carbondata.presto.impl.CarbonTableConfig;
-import org.apache.carbondata.presto.impl.CarbonTableReader;
-import com.facebook.presto.spi.*;
-import com.facebook.presto.spi.connector.ConnectorMetadata;
-import com.facebook.presto.spi.type.*;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
+import javax.inject.Inject;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
 import org.apache.carbondata.core.metadata.datatype.DataType;
+import org.apache.carbondata.core.metadata.datatype.DataTypes;
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
+import org.apache.carbondata.core.metadata.schema.table.column.CarbonColumn;
 import org.apache.carbondata.core.metadata.schema.table.column.CarbonDimension;
 import org.apache.carbondata.core.metadata.schema.table.column.CarbonMeasure;
 import org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema;
+import org.apache.carbondata.presto.impl.CarbonTableReader;
 
-import javax.inject.Inject;
-import java.util.*;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ColumnMetadata;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorTableHandle;
+import com.facebook.presto.spi.ConnectorTableLayout;
+import com.facebook.presto.spi.ConnectorTableLayoutHandle;
+import com.facebook.presto.spi.ConnectorTableLayoutResult;
+import com.facebook.presto.spi.ConnectorTableMetadata;
+import com.facebook.presto.spi.Constraint;
+import com.facebook.presto.spi.SchemaNotFoundException;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.SchemaTablePrefix;
+import com.facebook.presto.spi.connector.ConnectorMetadata;
+import com.facebook.presto.spi.type.BigintType;
+import com.facebook.presto.spi.type.BooleanType;
+import com.facebook.presto.spi.type.DateType;
+import com.facebook.presto.spi.type.DecimalType;
+import com.facebook.presto.spi.type.DoubleType;
+import com.facebook.presto.spi.type.IntegerType;
+import com.facebook.presto.spi.type.SmallintType;
+import com.facebook.presto.spi.type.TimestampType;
+import com.facebook.presto.spi.type.Type;
+import com.facebook.presto.spi.type.VarcharType;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
-import static org.apache.carbondata.presto.Types.checkType;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
-import static org.apache.hadoop.fs.s3a.Constants.ACCESS_KEY;
-import static org.apache.hadoop.fs.s3a.Constants.ENDPOINT;
-import static org.apache.hadoop.fs.s3a.Constants.SECRET_KEY;
+import static org.apache.carbondata.presto.Types.checkType;
 
 public class CarbondataMetadata implements ConnectorMetadata {
   private final String connectorId;
@@ -119,8 +138,13 @@ public class CarbondataMetadata implements ConnectorMetadata {
     List<CarbonColumn> carbonColumns = carbonTable.getCreateOrderColumn(schemaTableName.getTableName());
     for (CarbonColumn col : carbonColumns) {
       //show columns command will return these data
-      Type columnType = carbonDataType2SpiMapper(col.getColumnSchema());
-      ColumnMetadata columnMeta = new ColumnMetadata(col.getColumnSchema().getColumnName(), columnType);
+      ColumnSchema columnSchema = col.getColumnSchema();
+      Type columnType = carbonDataType2SpiMapper(columnSchema);
+      String extraValues =
+          columnSchema.getEncodingList().stream().map(encoding -> encoding.toString() + " ")
+              .reduce("", String::concat);
+      ColumnMetadata columnMeta =
+          new ColumnMetadata(columnSchema.getColumnName(), columnType, "", extraValues, false);
       columnsMetaList.add(columnMeta);
     }
 
@@ -152,22 +176,22 @@ public class CarbondataMetadata implements ConnectorMetadata {
 
       Type spiType = carbonDataType2SpiMapper(cs);
       columnHandles.put(cs.getColumnName(),
-          new CarbondataColumnHandle(connectorId, cs.getColumnName(), spiType, column.getSchemaOrdinal(),
-              column.getKeyOrdinal(), column.getColumnGroupOrdinal(), false, cs.getColumnGroupId(),
-              cs.getColumnUniqueId(), cs.isUseInvertedIndex(), cs.getPrecision(), cs.getScale()));
+          new CarbondataColumnHandle(connectorId, cs.getColumnName(), spiType,
+              column.getSchemaOrdinal(), column.getKeyOrdinal(), column.getColumnGroupOrdinal(),
+              false, cs.getColumnGroupId(), cs.getColumnUniqueId(), cs.isUseInvertedIndex(),
+              cs.getPrecision(), cs.getScale()));
     }
 
     for (CarbonMeasure measure : cb.getMeasureByTableName(tableName)) {
       ColumnSchema cs = measure.getColumnSchema();
-
       Type spiType = carbonDataType2SpiMapper(cs);
       columnHandles.put(cs.getColumnName(),
-          new CarbondataColumnHandle(connectorId, cs.getColumnName(), spiType, cs.getSchemaOrdinal(),
-              measure.getOrdinal(), cs.getColumnGroupId(), true, cs.getColumnGroupId(),
-              cs.getColumnUniqueId(), cs.isUseInvertedIndex(), cs.getPrecision(), cs.getScale()));
+          new CarbondataColumnHandle(connectorId, cs.getColumnName(), spiType,
+              cs.getSchemaOrdinal(), measure.getOrdinal(), cs.getColumnGroupId(), true,
+              cs.getColumnGroupId(), cs.getColumnUniqueId(), cs.isUseInvertedIndex(),
+              cs.getPrecision(), cs.getScale()));
     }
 
-    //should i cache it?
     columnHandleMap = columnHandles.build();
 
     return columnHandleMap;
@@ -183,12 +207,7 @@ public class CarbondataMetadata implements ConnectorMetadata {
 
   @Override
   public ConnectorTableHandle getTableHandle(ConnectorSession session, SchemaTableName tableName) {
-    //check tablename is valid
-    //schema is exist
-    //tables is exist
-
-    //CarbondataTable  get from jar
-    return new CarbondataTableHandle(connectorId, tableName);
+      return new CarbondataTableHandle(connectorId, tableName);
   }
 
   @Override public List<ConnectorTableLayoutResult> getTableLayouts(ConnectorSession session,
@@ -196,7 +215,7 @@ public class CarbondataMetadata implements ConnectorMetadata {
       Optional<Set<ColumnHandle>> desiredColumns) {
     CarbondataTableHandle handle = checkType(table, CarbondataTableHandle.class, "table");
     ConnectorTableLayout layout = new ConnectorTableLayout(
-        new CarbondataTableLayoutHandle(handle, constraint.getSummary()/*, constraint.getPredicateMap(),constraint.getFilterTuples()*/));
+        new CarbondataTableLayoutHandle(handle, constraint.getSummary()));
     return ImmutableList.of(new ConnectorTableLayoutResult(layout, constraint.getSummary()));
   }
 

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/CarbondataPageSourceProvider.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/CarbondataPageSourceProvider.java
@@ -18,7 +18,6 @@
 package org.apache.carbondata.presto;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.carbondata.common.CarbonIterator;
@@ -31,10 +30,12 @@ import org.apache.carbondata.core.scan.executor.exception.QueryExecutionExceptio
 import org.apache.carbondata.core.scan.expression.Expression;
 import org.apache.carbondata.core.scan.model.QueryModel;
 import org.apache.carbondata.core.scan.result.iterator.AbstractDetailQueryResultIterator;
+import org.apache.carbondata.core.util.CarbonTimeStatisticsFactory;
 import org.apache.carbondata.hadoop.CarbonInputSplit;
+import org.apache.carbondata.hadoop.CarbonMultiBlockSplit;
 import org.apache.carbondata.hadoop.CarbonProjection;
 import org.apache.carbondata.hadoop.api.CarbonTableInputFormat;
-import org.apache.carbondata.presto.impl.CarbonLocalInputSplit;
+import org.apache.carbondata.presto.impl.CarbonLocalMultiBlockSplit;
 import org.apache.carbondata.presto.impl.CarbonTableCacheModel;
 import org.apache.carbondata.presto.impl.CarbonTableReader;
 
@@ -64,17 +65,18 @@ public class CarbondataPageSourceProvider implements ConnectorPageSourceProvider
 
   private String connectorId;
   private CarbonTableReader carbonTableReader;
+  private String queryId ;
 
   @Inject public CarbondataPageSourceProvider(CarbondataConnectorId connectorId,
       CarbonTableReader carbonTableReader) {
     this.connectorId = requireNonNull(connectorId, "connectorId is null").toString();
     this.carbonTableReader = requireNonNull(carbonTableReader, "carbonTableReader is null");
-
   }
 
   @Override
   public ConnectorPageSource createPageSource(ConnectorTransactionHandle transactionHandle,
       ConnectorSession session, ConnectorSplit split, List<ColumnHandle> columns) {
+    this.queryId = ((CarbondataSplit)split).getQueryId();
     CarbonDictionaryDecodeReadSupport readSupport = new CarbonDictionaryDecodeReadSupport();
     PrestoCarbonVectorizedRecordReader carbonRecordReader = createReader(split, columns, readSupport);
     return new CarbondataPageSource(readSupport, carbonRecordReader, columns );
@@ -100,8 +102,10 @@ public class CarbondataPageSourceProvider implements ConnectorPageSourceProvider
     try {
       CarbonIterator iterator = queryExecutor.execute(queryModel);
       readSupport.initialize(queryModel.getProjectionColumns(), queryModel.getTable());
-      return new PrestoCarbonVectorizedRecordReader(queryExecutor, queryModel,
+      PrestoCarbonVectorizedRecordReader reader = new PrestoCarbonVectorizedRecordReader(queryExecutor, queryModel,
           (AbstractDetailQueryResultIterator) iterator);
+      reader.setTaskId(carbondataSplit.getIndex());
+      return reader;
     } catch (IOException e) {
       throw new RuntimeException("Unable to get the Query Model ", e);
     } catch (QueryExecutionException e) {
@@ -129,22 +133,27 @@ public class CarbondataPageSourceProvider implements ConnectorPageSourceProvider
       String carbonTablePath = carbonTable.getAbsoluteTableIdentifier().getTablePath();
 
       conf.set(CarbonTableInputFormat.INPUT_DIR, carbonTablePath);
+      conf.set("query.id", queryId);
       JobConf jobConf = new JobConf(conf);
       CarbonTableInputFormat carbonTableInputFormat = createInputFormat(jobConf, carbonTable,
           PrestoFilterUtil.parseFilterExpression(carbondataSplit.getConstraints()),
           carbonProjection);
       TaskAttemptContextImpl hadoopAttemptContext =
           new TaskAttemptContextImpl(jobConf, new TaskAttemptID("", 1, TaskType.MAP, 0, 0));
-      CarbonInputSplit carbonInputSplit =
-          CarbonLocalInputSplit.convertSplit(carbondataSplit.getLocalInputSplit());
+      CarbonMultiBlockSplit carbonInputSplit =
+          CarbonLocalMultiBlockSplit.convertSplit(carbondataSplit.getLocalInputSplit());
       QueryModel queryModel =
           carbonTableInputFormat.createQueryModel(carbonInputSplit, hadoopAttemptContext);
+      queryModel.setQueryId(queryId);
       queryModel.setVectorReader(true);
+      queryModel.setStatisticsRecorder(
+          CarbonTimeStatisticsFactory.createExecutorRecorder(queryModel.getQueryId()));
 
-      List<CarbonInputSplit> splitList = new ArrayList<>(1);
-      splitList.add(carbonInputSplit);
-      List<TableBlockInfo> tableBlockInfoList = CarbonInputSplit.createBlocks(splitList);
+      List<TableBlockInfo> tableBlockInfoList =
+          CarbonInputSplit.createBlocks(carbonInputSplit.getAllSplits());
       queryModel.setTableBlockInfos(tableBlockInfoList);
+
+
 
       return queryModel;
     } catch (IOException e) {

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/CarbondataSplit.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/CarbondataSplit.java
@@ -18,6 +18,8 @@
 package org.apache.carbondata.presto;
 
 import org.apache.carbondata.presto.impl.CarbonLocalInputSplit;
+import org.apache.carbondata.presto.impl.CarbonLocalMultiBlockSplit;
+
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
@@ -36,21 +38,27 @@ public class CarbondataSplit implements ConnectorSplit {
   private final String connectorId;
   private final SchemaTableName schemaTableName;
   private final TupleDomain<ColumnHandle> constraints;
-  private final CarbonLocalInputSplit localInputSplit;
+  private final CarbonLocalMultiBlockSplit localInputSplit;
   private final List<CarbondataColumnConstraint> rebuildConstraints;
   private final ImmutableList<HostAddress> addresses;
+  private final String queryId;
+  private final long index;
 
   @JsonCreator public CarbondataSplit(@JsonProperty("connectorId") String connectorId,
       @JsonProperty("schemaTableName") SchemaTableName schemaTableName,
       @JsonProperty("constraints") TupleDomain<ColumnHandle> constraints,
-      @JsonProperty("localInputSplit") CarbonLocalInputSplit localInputSplit,
-      @JsonProperty("rebuildConstraints") List<CarbondataColumnConstraint> rebuildConstraints) {
+      @JsonProperty("localInputSplit") CarbonLocalMultiBlockSplit localInputSplit,
+      @JsonProperty("rebuildConstraints") List<CarbondataColumnConstraint> rebuildConstraints,
+      @JsonProperty("queryId") String queryId,
+      @JsonProperty("index") long index) {
     this.connectorId = requireNonNull(connectorId, "connectorId is null");
     this.schemaTableName = requireNonNull(schemaTableName, "schemaTable is null");
     this.constraints = requireNonNull(constraints, "constraints is null");
     this.localInputSplit = requireNonNull(localInputSplit, "localInputSplit is null");
     this.rebuildConstraints = requireNonNull(rebuildConstraints, "rebuildConstraints is null");
     this.addresses = ImmutableList.of();
+    this.queryId = queryId;
+    this.index = index;
   }
 
   @JsonProperty public String getConnectorId() {
@@ -65,7 +73,7 @@ public class CarbondataSplit implements ConnectorSplit {
     return constraints;
   }
 
-  @JsonProperty public CarbonLocalInputSplit getLocalInputSplit() {
+  @JsonProperty public CarbonLocalMultiBlockSplit getLocalInputSplit() {
     return localInputSplit;
   }
 
@@ -83,6 +91,14 @@ public class CarbondataSplit implements ConnectorSplit {
 
   @Override public Object getInfo() {
     return this;
+  }
+
+  @JsonProperty public String getQueryId() {
+    return queryId;
+  }
+
+  @JsonProperty public long getIndex() {
+    return index;
   }
 }
 

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/CarbondataSplitManager.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/CarbondataSplitManager.java
@@ -22,7 +22,11 @@ import java.util.List;
 import java.util.Optional;
 
 import org.apache.carbondata.core.scan.expression.Expression;
-import org.apache.carbondata.presto.impl.CarbonLocalInputSplit;
+import org.apache.carbondata.core.stats.QueryStatistic;
+import org.apache.carbondata.core.stats.QueryStatisticsConstants;
+import org.apache.carbondata.core.stats.QueryStatisticsRecorder;
+import org.apache.carbondata.core.util.CarbonTimeStatisticsFactory;
+import org.apache.carbondata.presto.impl.CarbonLocalMultiBlockSplit;
 import org.apache.carbondata.presto.impl.CarbonTableCacheModel;
 import org.apache.carbondata.presto.impl.CarbonTableReader;
 
@@ -62,7 +66,16 @@ public class CarbondataSplitManager implements ConnectorSplitManager {
     CarbondataTableHandle tableHandle = layoutHandle.getTable();
     SchemaTableName key = tableHandle.getSchemaTableName();
 
-    // Packaging presto-TupleDomain into CarbondataColumnConstraint, to decouple from presto-spi Module
+    String queryId = System.nanoTime() + "";
+    QueryStatistic statistic = new QueryStatistic();
+    QueryStatisticsRecorder statisticRecorder = CarbonTimeStatisticsFactory.createDriverRecorder();
+    statistic.addStatistics(QueryStatisticsConstants.BLOCK_ALLOCATION, System.currentTimeMillis());
+    statisticRecorder.recordStatisticsForDriver(statistic, queryId);
+    statistic = new QueryStatistic();
+
+    carbonTableReader.setQueryId(queryId);
+    // Packaging presto-TupleDomain into CarbondataColumnConstraint,
+    // to decouple from presto-spi Module
     List<CarbondataColumnConstraint> rebuildConstraints =
         getColumnConstraints(layoutHandle.getConstraint());
 
@@ -70,14 +83,23 @@ public class CarbondataSplitManager implements ConnectorSplitManager {
     if (null != cache) {
       Expression filters = PrestoFilterUtil.parseFilterExpression(layoutHandle.getConstraint());
       try {
-        List<CarbonLocalInputSplit> splits = carbonTableReader.getInputSplits2(cache, filters,
-                layoutHandle.getConstraint());
+        List<CarbonLocalMultiBlockSplit> splits =
+            carbonTableReader.getInputSplits2(cache, filters, layoutHandle.getConstraint());
 
         ImmutableList.Builder<ConnectorSplit> cSplits = ImmutableList.builder();
-        for (CarbonLocalInputSplit split : splits) {
+        long index = 0;
+        for (CarbonLocalMultiBlockSplit split : splits) {
+          index++;
           cSplits.add(new CarbondataSplit(connectorId, tableHandle.getSchemaTableName(),
-              layoutHandle.getConstraint(), split, rebuildConstraints));
+              layoutHandle.getConstraint(), split, rebuildConstraints, queryId, index));
         }
+
+        statisticRecorder.logStatisticsAsTableDriver();
+
+        statistic.addStatistics(QueryStatisticsConstants.BLOCK_IDENTIFICATION,
+            System.currentTimeMillis());
+        statisticRecorder.recordStatisticsForDriver(statistic, queryId);
+        statisticRecorder.logStatisticsAsTableDriver();
         return new FixedSplitSource(cSplits.build());
       } catch (Exception ex) {
         throw new RuntimeException(ex.getMessage(), ex);

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/impl/CarbonLocalInputSplit.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/impl/CarbonLocalInputSplit.java
@@ -42,6 +42,7 @@ public class CarbonLocalInputSplit {
   private List<String> locations;// locations are the locations for different replicas.
   private short version;
   private String[] deleteDeltaFiles;
+  private String blockletId;
 
 
   private String detailInfo;
@@ -87,6 +88,10 @@ public class CarbonLocalInputSplit {
     return detailInfo;
   }
 
+  @JsonProperty public String getBlockletId() {
+    return blockletId;
+  }
+
   public void setDetailInfo(BlockletDetailInfo blockletDetailInfo) {
     Gson gson = new Gson();
     detailInfo = gson.toJson(blockletDetailInfo);
@@ -100,6 +105,7 @@ public class CarbonLocalInputSplit {
                                  @JsonProperty("tableBlockInfo") TableBlockInfo tableBlockInfo*/,
       @JsonProperty("version") short version,
       @JsonProperty("deleteDeltaFiles") String[] deleteDeltaFiles,
+      @JsonProperty("blockletId") String blockletId,
       @JsonProperty("detailInfo") String detailInfo
   ) {
     this.path = path;
@@ -111,22 +117,23 @@ public class CarbonLocalInputSplit {
     //this.tableBlockInfo = tableBlockInfo;
     this.version = version;
     this.deleteDeltaFiles = deleteDeltaFiles;
+    this.blockletId = blockletId;
     this.detailInfo = detailInfo;
 
   }
 
   public static CarbonInputSplit convertSplit(CarbonLocalInputSplit carbonLocalInputSplit) {
-    CarbonInputSplit inputSplit = new CarbonInputSplit(carbonLocalInputSplit.getSegmentId(), "0",
-        new Path(carbonLocalInputSplit.getPath()), carbonLocalInputSplit.getStart(),
-        carbonLocalInputSplit.getLength(), carbonLocalInputSplit.getLocations()
-        .toArray(new String[carbonLocalInputSplit.getLocations().size()]),
+    CarbonInputSplit inputSplit = new CarbonInputSplit(carbonLocalInputSplit.getSegmentId(),
+        carbonLocalInputSplit.getBlockletId(), new Path(carbonLocalInputSplit.getPath()),
+        carbonLocalInputSplit.getStart(), carbonLocalInputSplit.getLength(),
+        carbonLocalInputSplit.getLocations()
+            .toArray(new String[carbonLocalInputSplit.getLocations().size()]),
         carbonLocalInputSplit.getNumberOfBlocklets(),
         ColumnarFormatVersion.valueOf(carbonLocalInputSplit.getVersion()),
         carbonLocalInputSplit.getDeleteDeltaFiles());
     Gson gson = new Gson();
     BlockletDetailInfo blockletDetailInfo =
         gson.fromJson(carbonLocalInputSplit.detailInfo, BlockletDetailInfo.class);
-
     if (null == blockletDetailInfo) {
       throw new RuntimeException("Could not read blocklet details");
     }
@@ -138,4 +145,6 @@ public class CarbonLocalInputSplit {
     inputSplit.setDetailInfo(blockletDetailInfo);
     return inputSplit;
   }
+
+
 }

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/impl/CarbonLocalMultiBlockSplit.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/impl/CarbonLocalMultiBlockSplit.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.presto.impl;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.carbondata.core.statusmanager.FileFormat;
+import org.apache.carbondata.hadoop.CarbonInputSplit;
+import org.apache.carbondata.hadoop.CarbonMultiBlockSplit;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * CarbonLocalInputSplit represents a block, it contains a set of blocklet.
+ */
+public class CarbonLocalMultiBlockSplit {
+
+  private static final long serialVersionUID = 3520344046772190207L;
+
+  /*
+  * Splits (HDFS Blocks) for task to scan.
+  */
+  private List<CarbonLocalInputSplit> splitList;
+
+  /*
+   * The locations of all wrapped splits
+   */
+  private String[] locations;
+
+  private FileFormat fileFormat = FileFormat.COLUMNAR_V3;
+
+  private long length;
+
+  @JsonProperty public long getLength() {
+    return length;
+  }
+
+  @JsonProperty public String[] getLocations() {
+    return locations;
+  }
+
+  @JsonProperty public List<CarbonLocalInputSplit> getSplitList() {
+    return splitList;
+  }
+
+  @JsonProperty public FileFormat getFileFormat() {
+    return fileFormat;
+  }
+
+  @JsonCreator public CarbonLocalMultiBlockSplit(
+      @JsonProperty("splitList") List<CarbonLocalInputSplit> splitList,
+      @JsonProperty("locations") String[] locations) {
+    this.splitList = splitList;
+    this.locations = locations;
+  }
+
+  public static CarbonMultiBlockSplit convertSplit(
+      CarbonLocalMultiBlockSplit carbonLocalMultiBlockSplit) {
+    List<CarbonInputSplit> carbonInputSplitList =
+        carbonLocalMultiBlockSplit.getSplitList().stream().map(CarbonLocalInputSplit::convertSplit)
+            .collect(Collectors.toList());
+
+    CarbonMultiBlockSplit carbonMultiBlockSplit =
+        new CarbonMultiBlockSplit(carbonInputSplitList, carbonLocalMultiBlockSplit.getLocations());
+
+    return carbonMultiBlockSplit;
+  }
+
+}

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/impl/CarbonTableConfig.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/impl/CarbonTableConfig.java
@@ -17,9 +17,9 @@
 
 package org.apache.carbondata.presto.impl;
 
-import javax.validation.constraints.NotNull;
-
 import io.airlift.configuration.Config;
+
+import javax.validation.constraints.NotNull;
 
 /**
  * Configuration read from etc/catalog/carbondata.properties
@@ -32,6 +32,10 @@ public class CarbonTableConfig {
   private String storePath;
   private String unsafeMemoryInMb;
   private String enableUnsafeInQueryExecution;
+  private String enableUnsafeColumnPage;
+  private String enableUnsafeSort;
+  private String enableQueryStatistics;
+  private String batchSize;
   private String s3A_acesssKey;
   private String s3A_secretKey;
   private String s3_acesssKey;
@@ -85,6 +89,38 @@ public class CarbonTableConfig {
   @Config("enable.unsafe.in.query.processing")
   public CarbonTableConfig setEnableUnsafeInQueryExecution(String enableUnsafeInQueryExecution) {
     this.enableUnsafeInQueryExecution = enableUnsafeInQueryExecution;
+    return this;
+  }
+
+  public String getEnableUnsafeColumnPage() { return enableUnsafeColumnPage; }
+
+  @Config("enable.unsafe.columnpage")
+  public CarbonTableConfig setEnableUnsafeColumnPage(String enableUnsafeColumnPage) {
+    this.enableUnsafeColumnPage = enableUnsafeColumnPage;
+    return this;
+  }
+
+  public String getEnableUnsafeSort() { return enableUnsafeSort; }
+
+  @Config("enable.unsafe.sort")
+  public CarbonTableConfig setEnableUnsafeSort(String enableUnsafeSort) {
+    this.enableUnsafeSort = enableUnsafeSort;
+    return this;
+  }
+
+  public String getEnableQueryStatistics() { return enableQueryStatistics; }
+
+  @Config("enable.query.statistics")
+  public CarbonTableConfig setEnableQueryStatistics(String enableQueryStatistics) {
+    this.enableQueryStatistics = enableQueryStatistics;
+    return this;
+  }
+
+  public String getBatchSize() { return batchSize; }
+
+  @Config("query.vector.batchSize")
+  public CarbonTableConfig setBatchSize(String batchSize) {
+    this.batchSize = batchSize;
     return this;
   }
 

--- a/integration/presto/src/main/resources/log4j.properties
+++ b/integration/presto/src/main/resources/log4j.properties
@@ -1,0 +1,11 @@
+# Root logger option
+log4j.rootLogger=INFO,stdout
+
+
+# Redirect log messages to console
+log4j.appender.debug=org.apache.log4j.RollingFileAppender
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
+


### PR DESCRIPTION
This PR deals with the changes in performance of Presto Integration layer, the major changes are
- Introducing CarbonMultiBlockSplit to reduce the Network Latency
- Added Query Statistics support in Presto
- Optimized DecimalStreamReader
- Added log4j.properties to get the logs output on console
- Optimized pom.xml to remove unnecessary stuff and duplicate dependencies

 - [X ] Any interfaces changed?
 
 - [ X] Any backward compatibility impacted?
 
 - [ X] Document update required?

 - [ Y] Testing done
     We have run the Queries on local environment and there is an improvement in the performance
       
 - [ N] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

