### PR TITLE
[CARBONDATA-2438][Assembly] Remove hadoop/spark/zookeeper related classes from assembly

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -89,7 +89,18 @@
           <artifactSet>
             <includes>
               <include>*:*</include>
+              <!--use the following line if we only want carbondata related classes-->
+              <!--<include>org.apache.carbondata:*</include>-->
             </includes>
+            <excludes>
+              <exclude>org.apache.hadoop:*</exclude>
+              <exclude>org.apache.spark:*</exclude>
+              <exclude>org.apache.zookeeper:*</exclude>
+              <exclude>org.apache.avro:*</exclude>
+              <exclude>com.google.guava:guava</exclude>
+              <exclude>org.xerial.snappy:snappy-java</exclude>
+              <!--add more items to be excluded from the assembly-->
+            </excludes>
           </artifactSet>
           <filters>
             <filter>


### PR DESCRIPTION
It remove hadoop/spark/zookeeper/snappy/guava related classes from assembly jar. It reduces the size of carbon-assembly jar from 75MB to 49MB.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 `NA`
 - [x] Any backward compatibility impacted?
  `NA`
 - [x] Document update required?
 `NA`
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
 `NA`
        - How it is tested? Please attach test report.
 `NA`
        - Is it a performance related change? Please attach the performance test report.
 `NA`
        - Any additional information to help reviewers in testing this change.
 `NA`
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
 `NA`
