### PR TITLE
[CARBONDATA-2439][Pom] upgrade guava version for bloom datamap

### DIFF
--- a/datamap/bloom/pom.xml
+++ b/datamap/bloom/pom.xml
@@ -22,6 +22,20 @@
       <groupId>org.apache.carbondata</groupId>
       <artifactId>carbondata-core</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <!--ignore guava 11.0.2 introduced by hadoop-->
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <!--note: guava 14.0.1 is omitted during assembly.
+    The compile scope here is for building and running test-->
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>14.0.1</version>
     </dependency>
     <dependency>
       <groupId>org.scalatest</groupId>


### PR DESCRIPTION
upgrade guava version from 11.0.2(provided by hadoop) to 14.0.1(provided by spark)

The dependency scope in carbon-bloom is `compile`, because `provide` scope will cause Class/MethodNotFound failure during tests. But never mind, we remove the guava dependency in carbon-assembly.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 `NA`
 - [x] Any backward compatibility impacted?
 `NA` 
 - [x] Document update required?
 `NA`
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
 `NA`
        - How it is tested? Please attach test report.
 `NA`
        - Is it a performance related change? Please attach the performance test report.
 `NA`
        - Any additional information to help reviewers in testing this change.
 `NA`
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
 `NA`
