### PR TITLE
[CARBONDATA-2442] and [CARBONDATA-2469] Fixed: multiple issues in sdk writer and external table

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/column/ColumnSchema.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/column/ColumnSchema.java
@@ -343,6 +343,36 @@ public class ColumnSchema implements Serializable, Writable {
   }
 
   /**
+   * method to compare columnSchema,
+   * other parameters along with just column name and column data type
+   * @param obj
+   * @return
+   */
+  public boolean equalsWithStrictCheck(Object obj) {
+    if (!this.equals(obj)) {
+      return false;
+    }
+    ColumnSchema other = (ColumnSchema) obj;
+    if (!columnUniqueId.equals(other.columnUniqueId) ||
+        (isDimensionColumn != other.isDimensionColumn) ||
+        (scale != other.scale) ||
+        (precision != other.precision) ||
+        (isSortColumn != other.isSortColumn)) {
+      return false;
+    }
+    if (encodingList.size() != other.encodingList.size()) {
+      return false;
+    }
+    for (int i = 0; i < encodingList.size(); i++) {
+      if (encodingList.get(i).compareTo(other.encodingList.get(i)) != 0) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  /**
    * @return the dataType
    */
   public DataType getDataType() {

--- a/core/src/main/java/org/apache/carbondata/core/readcommitter/LatestFilesReadCommittedScope.java
+++ b/core/src/main/java/org/apache/carbondata/core/readcommitter/LatestFilesReadCommittedScope.java
@@ -125,7 +125,7 @@ public class LatestFilesReadCommittedScope implements ReadCommittedScope {
     if (file == null) {
       // For nonTransactional table, files can be removed at any point of time.
       // So cannot assume files will be present
-      throw new IOException("No files are present in the table location");
+      throw new IOException("No files are present in the table location :"+ carbonFilePath);
     }
     Map<String, List<String>> indexFileStore = new HashMap<>();
     if (file.isDirectory()) {

--- a/core/src/main/java/org/apache/carbondata/core/readcommitter/LatestFilesReadCommittedScope.java
+++ b/core/src/main/java/org/apache/carbondata/core/readcommitter/LatestFilesReadCommittedScope.java
@@ -122,6 +122,11 @@ public class LatestFilesReadCommittedScope implements ReadCommittedScope {
   @Override public void takeCarbonIndexFileSnapShot() throws IOException {
     // Read the current file Path get the list of indexes from the path.
     CarbonFile file = FileFactory.getCarbonFile(carbonFilePath);
+    if (file == null) {
+      // For nonTransactional table, files can be removed at any point of time.
+      // So cannot assume files will be present
+      throw new IOException("No files are present in the table location");
+    }
     Map<String, List<String>> indexFileStore = new HashMap<>();
     if (file.isDirectory()) {
       CarbonFile[] carbonIndexFiles = SegmentIndexFileStore.getCarbonIndexFiles(carbonFilePath);

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableInputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableInputFormat.java
@@ -36,11 +36,14 @@ import org.apache.carbondata.core.datastore.impl.FileFactory;
 import org.apache.carbondata.core.indexstore.ExtendedBlocklet;
 import org.apache.carbondata.core.indexstore.PartitionSpec;
 import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
+import org.apache.carbondata.core.metadata.converter.SchemaConverter;
+import org.apache.carbondata.core.metadata.converter.ThriftWrapperSchemaConverterImpl;
 import org.apache.carbondata.core.metadata.schema.PartitionInfo;
 import org.apache.carbondata.core.metadata.schema.SchemaReader;
 import org.apache.carbondata.core.metadata.schema.partition.PartitionType;
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
 import org.apache.carbondata.core.metadata.schema.table.TableInfo;
+import org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema;
 import org.apache.carbondata.core.mutate.CarbonUpdateUtil;
 import org.apache.carbondata.core.mutate.SegmentUpdateDetails;
 import org.apache.carbondata.core.mutate.UpdateVO;
@@ -149,6 +152,35 @@ public class CarbonTableInputFormat<T> extends CarbonInputFormat<T> {
     SegmentStatusManager segmentStatusManager = new SegmentStatusManager(identifier);
     SegmentStatusManager.ValidAndInvalidSegmentsInfo segments = segmentStatusManager
         .getValidAndInvalidSegments(loadMetadataDetails, this.readCommittedScope);
+
+    // For NonTransactional table, compare the schema of all index files with inferred schema.
+    // If there is a mismatch throw exception. As all files must be of same schema.
+    if (!carbonTable.getTableInfo().isTransactionalTable()) {
+      SchemaConverter schemaConverter = new ThriftWrapperSchemaConverterImpl();
+      for (Segment segment : segments.getValidSegments()) {
+        Map<String, String> indexFiles = segment.getCommittedIndexFile();
+        for (Map.Entry<String, String> indexFileEntry : indexFiles.entrySet()) {
+          Path indexFile = new Path(indexFileEntry.getKey());
+          org.apache.carbondata.format.TableInfo tableInfo = CarbonUtil.inferSchemaFromIndexFile(
+              indexFile.toString(), carbonTable.getTableName());
+          TableInfo wrapperTableInfo = schemaConverter.fromExternalToWrapperTableInfo(
+              tableInfo, identifier.getDatabaseName(),
+              identifier.getTableName(),
+              identifier.getTablePath());
+          List<ColumnSchema> indexFileColumnList =
+              wrapperTableInfo.getFactTable().getListOfColumns();
+          List<ColumnSchema> tableColumnList =
+              carbonTable.getTableInfo().getFactTable().getListOfColumns();
+          if (!compareColumnSchemaList(indexFileColumnList, tableColumnList)) {
+            LOG.error("Schema of " + indexFile.getName()
+                + " doesn't match with the table's schema");
+            throw new IOException("All the files doesn't have same schema. "
+                + "Unsupported operation on nonTransactional table. Check logs.");
+          }
+        }
+      }
+    }
+
     // to check whether only streaming segments access is enabled or not,
     // if access streaming segment is true then data will be read from streaming segments
     boolean accessStreamingSegments = getAccessStreamingSegments(job.getConfiguration());
@@ -260,6 +292,17 @@ public class CarbonTableInputFormat<T> extends CarbonInputFormat<T> {
       splits.addAll(splitsOfStreaming);
     }
     return splits;
+  }
+
+  private boolean compareColumnSchemaList(List<ColumnSchema> indexFileColumnList,
+      List<ColumnSchema> tableColumnList) {
+    if (indexFileColumnList.size() != tableColumnList.size()) {
+      return false;
+    }
+    for (int i = 0; i < tableColumnList.size(); i++) {
+      return indexFileColumnList.get(i).equalsWithStrictCheck(tableColumnList.get(i));
+    }
+    return false;
   }
 
   /**

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestCreateExternalTable.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestCreateExternalTable.scala
@@ -53,6 +53,8 @@ class TestCreateExternalTable extends QueryTest with BeforeAndAfterAll {
        """.stripMargin)
     checkAnswer(sql("SELECT count(*) from source"), sql("SELECT count(*) from origin"))
 
+    checkExistence(sql("describe formatted source"), true, storeLocation+"/origin")
+
     val carbonTable = CarbonEnv.getCarbonTable(None, "source")(sqlContext.sparkSession)
     assert(carbonTable.isExternalTable)
     

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestNonTransactionalCarbonTable.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestNonTransactionalCarbonTable.scala
@@ -19,7 +19,6 @@ package org.apache.carbondata.spark.testsuite.createTable
 
 import java.sql.Timestamp
 import java.io.{File, FileFilter, IOException}
-import java.io.{File, FileFilter}
 import java.util
 
 import org.apache.commons.io.FileUtils
@@ -33,8 +32,7 @@ import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.datastore.filesystem.CarbonFile
 import org.apache.carbondata.core.datastore.impl.FileFactory
 import org.apache.carbondata.core.util.CarbonUtil
-import org.apache.carbondata.sdk.file.{CarbonWriter, CarbonWriterBuilder, Field, Schema}
-import org.apache.carbondata.sdk.file.{AvroCarbonWriter, CarbonWriter, Field, Schema}
+import org.apache.carbondata.sdk.file.AvroCarbonWriter
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 
@@ -42,7 +40,7 @@ import org.apache.avro
 import org.apache.commons.lang.CharEncoding
 import tech.allegro.schema.json2avro.converter.JsonAvroConverter
 
-import org.apache.carbondata.core.metadata.datatype.{DataTypes, StructField}
+import org.apache.carbondata.core.metadata.datatype.DataTypes
 import org.apache.carbondata.sdk.file.{CarbonWriter, CarbonWriterBuilder, Field, Schema}
 
 
@@ -240,6 +238,8 @@ class TestNonTransactionalCarbonTable extends QueryTest with BeforeAndAfterAll {
          |'$writerPath' """.stripMargin)
 
     checkExistence(sql("describe formatted sdkOutputTable"), true, "age,name")
+
+    checkExistence(sql("describe formatted sdkOutputTable"), true, writerPath)
 
     sql("DROP TABLE sdkOutputTable")
     // drop table should not delete the files

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonDescribeFormattedCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonDescribeFormattedCommand.scala
@@ -86,10 +86,10 @@ private[sql] case class CarbonDescribeFormattedCommand(
     results ++= Seq(("Database Name", relation.carbonTable.getDatabaseName, "")
     )
     results ++= Seq(("Table Name", relation.carbonTable.getTableName, ""))
-    if (carbonTable.isTransactionalTable) {
+    if (!carbonTable.isExternalTable) {
       results ++= Seq(("CARBON Store Path ", CarbonProperties.getStorePath, ""))
     } else {
-      // for NonTransactional table should show files path.
+      // for external table should show files path.
       results ++= Seq(("CARBON Store Path ", carbonTable.getTablePath, ""))
     }
 


### PR DESCRIPTION
[CARBONDATA-2442] Reading two sdk writer output with differnt schema should prompt exception

**problem** : when two sdk writer output with differnt schema is placed in
same folder for reading, output is not as expected. It has many null
output.

**root cause:** when multiple carbondata and indexx files is placed in same
folder. table schema is inferred by first file.
comparing table schema with all other index file schema validation is
not present

**solution:** compare table schema with all other index file schema, if
there is a mismatch throw exception


[CARBONDATA-2469] External Table must show its location instead of default store location 
 solution: For external tables, show the carbon table path instead of default store location in describe formatted

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed? NA
 
 - [ ] Any backward compatibility impacted? NA
 
 - [ ] Document update required? NA

 - [ ] Testing done
   added the test case in  TestNonTransactionalCarbonTable.scala
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.  NA

