### PR TITLE
[CARBONDATA-2494] Fix lucene datasize and performance

### DIFF
--- a/datamap/lucene/src/main/java/org/apache/carbondata/datamap/lucene/LuceneDataMapBuilder.java
+++ b/datamap/lucene/src/main/java/org/apache/carbondata/datamap/lucene/LuceneDataMapBuilder.java
@@ -18,7 +18,10 @@
 package org.apache.carbondata.datamap.lucene;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.carbondata.common.logging.LogService;
 import org.apache.carbondata.common.logging.LogServiceFactory;
@@ -26,11 +29,13 @@ import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.datamap.Segment;
 import org.apache.carbondata.core.datamap.dev.DataMapBuilder;
 import org.apache.carbondata.core.datastore.impl.FileFactory;
-import org.apache.carbondata.core.metadata.datatype.DataType;
-import org.apache.carbondata.core.metadata.datatype.DataTypes;
 import org.apache.carbondata.core.metadata.schema.table.column.CarbonColumn;
 import org.apache.carbondata.core.util.CarbonProperties;
 import org.apache.carbondata.core.util.path.CarbonTablePath;
+
+import static org.apache.carbondata.datamap.lucene.LuceneDataMapWriter.addData;
+import static org.apache.carbondata.datamap.lucene.LuceneDataMapWriter.addToCache;
+import static org.apache.carbondata.datamap.lucene.LuceneDataMapWriter.flushCache;
 
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -38,20 +43,11 @@ import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.codecs.lucene50.Lucene50StoredFieldsFormat;
 import org.apache.lucene.codecs.lucene62.Lucene62Codec;
-import org.apache.lucene.document.Document;
-import org.apache.lucene.document.DoublePoint;
-import org.apache.lucene.document.Field;
-import org.apache.lucene.document.FloatPoint;
-import org.apache.lucene.document.IntPoint;
-import org.apache.lucene.document.IntRangeField;
-import org.apache.lucene.document.LongPoint;
-import org.apache.lucene.document.StoredField;
-import org.apache.lucene.document.TextField;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.store.Directory;
-import org.apache.lucene.store.RAMDirectory;
 import org.apache.solr.store.hdfs.HdfsDirectory;
+import org.roaringbitmap.RoaringBitmap;
 
 public class LuceneDataMapBuilder implements DataMapBuilder {
 
@@ -66,20 +62,28 @@ public class LuceneDataMapBuilder implements DataMapBuilder {
 
   private IndexWriter indexWriter = null;
 
-  private IndexWriter pageIndexWriter = null;
-
   private Analyzer analyzer = null;
 
-  LuceneDataMapBuilder(String tablePath, String dataMapName,
-      Segment segment, String shardName, List<CarbonColumn> indexColumns) {
-    this.dataMapPath = CarbonTablePath.getDataMapStorePathOnShardName(
-        tablePath, segment.getSegmentNo(), dataMapName, shardName);
+  private int writeCacheSize;
+
+  private Map<LuceneDataMapWriter.LuceneColumnKeys, Map<Integer, RoaringBitmap>> cache =
+      new HashMap<>();
+
+  private ByteBuffer intBuffer = ByteBuffer.allocate(4);
+
+  private boolean storeBlockletWise;
+
+  LuceneDataMapBuilder(String tablePath, String dataMapName, Segment segment, String shardName,
+      List<CarbonColumn> indexColumns, int writeCacheSize, boolean storeBlockletWise) {
+    this.dataMapPath = CarbonTablePath
+        .getDataMapStorePathOnShardName(tablePath, segment.getSegmentNo(), dataMapName, shardName);
     this.indexColumns = indexColumns;
     this.columnsCount = indexColumns.size();
+    this.writeCacheSize = writeCacheSize;
+    this.storeBlockletWise = storeBlockletWise;
   }
 
-  @Override
-  public void initialize() throws IOException {
+  @Override public void initialize() throws IOException {
     // get index path, put index data into segment's path
     Path indexPath = FileFactory.getPath(dataMapPath);
     FileSystem fs = FileFactory.getFileSystem(indexPath);
@@ -114,108 +118,36 @@ public class LuceneDataMapBuilder implements DataMapBuilder {
     indexWriter = new IndexWriter(indexDir, new IndexWriterConfig(analyzer));
   }
 
-  private IndexWriter createPageIndexWriter() throws IOException {
-    // save index data into ram, write into disk after one page finished
-    RAMDirectory ramDir = new RAMDirectory();
-    return new IndexWriter(ramDir, new IndexWriterConfig(analyzer));
-  }
-
-  private void addPageIndex(IndexWriter pageIndexWriter) throws IOException {
-
-    Directory directory = pageIndexWriter.getDirectory();
-
-    // close ram writer
-    pageIndexWriter.close();
-
-    // add ram index data into disk
-    indexWriter.addIndexes(directory);
-
-    // delete this ram data
-    directory.close();
-  }
-
-  @Override
-  public void addRow(int blockletId, int pageId, int rowId, Object[] values) throws IOException {
-    if (rowId == 0) {
-      if (pageIndexWriter != null) {
-        addPageIndex(pageIndexWriter);
-      }
-      pageIndexWriter = createPageIndexWriter();
-    }
-
-    // create a new document
-    Document doc = new Document();
-
-    // add blocklet Id
-    doc.add(new IntPoint(LuceneDataMapWriter.BLOCKLETID_NAME, (int) values[columnsCount]));
-    doc.add(new StoredField(LuceneDataMapWriter.BLOCKLETID_NAME, (int) values[columnsCount]));
-
-    // add page id
-    doc.add(new IntPoint(LuceneDataMapWriter.PAGEID_NAME, (int) values[columnsCount + 1]));
-    doc.add(new StoredField(LuceneDataMapWriter.PAGEID_NAME, (int) values[columnsCount + 1]));
-
-    // add row id
-    doc.add(new IntPoint(LuceneDataMapWriter.ROWID_NAME, rowId));
-    doc.add(new StoredField(LuceneDataMapWriter.ROWID_NAME, rowId));
+  @Override public void addRow(int blockletId, int pageId, int rowId, Object[] values)
+      throws IOException {
 
     // add other fields
+    LuceneDataMapWriter.LuceneColumnKeys columns =
+        new LuceneDataMapWriter.LuceneColumnKeys(columnsCount);
     for (int colIdx = 0; colIdx < columnsCount; colIdx++) {
-      CarbonColumn column = indexColumns.get(colIdx);
-      addField(doc, column.getColName(), column.getDataType(), values[colIdx]);
+      columns.getColValues()[colIdx] = values[colIdx];
     }
-
-    pageIndexWriter.addDocument(doc);
-  }
-
-  private boolean addField(Document doc, String fieldName, DataType type, Object value) {
-    if (type == DataTypes.STRING) {
-      doc.add(new TextField(fieldName, (String) value, Field.Store.NO));
-    } else if (type == DataTypes.BYTE) {
-      // byte type , use int range to deal with byte, lucene has no byte type
-      IntRangeField field =
-          new IntRangeField(fieldName, new int[] { Byte.MIN_VALUE }, new int[] { Byte.MAX_VALUE });
-      field.setIntValue((int) value);
-      doc.add(field);
-    } else if (type == DataTypes.SHORT) {
-      // short type , use int range to deal with short type, lucene has no short type
-      IntRangeField field = new IntRangeField(fieldName, new int[] { Short.MIN_VALUE },
-          new int[] { Short.MAX_VALUE });
-      field.setShortValue((short) value);
-      doc.add(field);
-    } else if (type == DataTypes.INT) {
-      // int type , use int point to deal with int type
-      doc.add(new IntPoint(fieldName, (int) value));
-    } else if (type == DataTypes.LONG) {
-      // long type , use long point to deal with long type
-      doc.add(new LongPoint(fieldName, (long) value));
-    } else if (type == DataTypes.FLOAT) {
-      doc.add(new FloatPoint(fieldName, (float) value));
-    } else if (type == DataTypes.DOUBLE) {
-      doc.add(new DoublePoint(fieldName, (double) value));
-    } else if (type == DataTypes.DATE) {
-      // TODO: how to get data value
-    } else if (type == DataTypes.TIMESTAMP) {
-      // TODO: how to get
-    } else if (type == DataTypes.BOOLEAN) {
-      IntRangeField field = new IntRangeField(fieldName, new int[] { 0 }, new int[] { 1 });
-      field.setIntValue((boolean) value ? 1 : 0);
-      doc.add(field);
+    if (writeCacheSize > 0) {
+      addToCache(columns, rowId, pageId, blockletId, cache, intBuffer, storeBlockletWise);
+      flushCacheIfCan();
     } else {
-      LOGGER.error("unsupport data type " + type);
-      throw new RuntimeException("unsupported data type " + type);
+      addData(columns, rowId, pageId, blockletId, intBuffer, indexWriter, indexColumns,
+          storeBlockletWise);
     }
-    return true;
+
   }
 
-  @Override
-  public void finish() throws IOException {
-    if (indexWriter != null && pageIndexWriter != null) {
-      addPageIndex(pageIndexWriter);
+  private void flushCacheIfCan() throws IOException {
+    if (cache.size() > writeCacheSize) {
+      flushCache(cache, indexColumns, indexWriter, storeBlockletWise);
     }
   }
 
-  @Override
-  public void close() throws IOException {
+  @Override public void finish() throws IOException {
+    flushCache(cache, indexColumns, indexWriter, storeBlockletWise);
+  }
+
+  @Override public void close() throws IOException {
     if (indexWriter != null) {
       indexWriter.close();
     }

--- a/datamap/lucene/src/main/java/org/apache/carbondata/datamap/lucene/LuceneDataMapBuilder.java
+++ b/datamap/lucene/src/main/java/org/apache/carbondata/datamap/lucene/LuceneDataMapBuilder.java
@@ -83,7 +83,8 @@ public class LuceneDataMapBuilder implements DataMapBuilder {
     this.storeBlockletWise = storeBlockletWise;
   }
 
-  @Override public void initialize() throws IOException {
+  @Override
+  public void initialize() throws IOException {
     // get index path, put index data into segment's path
     Path indexPath = FileFactory.getPath(dataMapPath);
     FileSystem fs = FileFactory.getFileSystem(indexPath);
@@ -118,7 +119,8 @@ public class LuceneDataMapBuilder implements DataMapBuilder {
     indexWriter = new IndexWriter(indexDir, new IndexWriterConfig(analyzer));
   }
 
-  @Override public void addRow(int blockletId, int pageId, int rowId, Object[] values)
+  @Override
+  public void addRow(int blockletId, int pageId, int rowId, Object[] values)
       throws IOException {
 
     // add other fields
@@ -129,7 +131,7 @@ public class LuceneDataMapBuilder implements DataMapBuilder {
     }
     if (writeCacheSize > 0) {
       addToCache(columns, rowId, pageId, blockletId, cache, intBuffer, storeBlockletWise);
-      flushCacheIfCan();
+      flushCacheIfPossible();
     } else {
       addData(columns, rowId, pageId, blockletId, intBuffer, indexWriter, indexColumns,
           storeBlockletWise);
@@ -137,17 +139,19 @@ public class LuceneDataMapBuilder implements DataMapBuilder {
 
   }
 
-  private void flushCacheIfCan() throws IOException {
-    if (cache.size() > writeCacheSize) {
+  private void flushCacheIfPossible() throws IOException {
+    if (cache.size() >= writeCacheSize) {
       flushCache(cache, indexColumns, indexWriter, storeBlockletWise);
     }
   }
 
-  @Override public void finish() throws IOException {
+  @Override
+  public void finish() throws IOException {
     flushCache(cache, indexColumns, indexWriter, storeBlockletWise);
   }
 
-  @Override public void close() throws IOException {
+  @Override
+  public void close() throws IOException {
     if (indexWriter != null) {
       indexWriter.close();
     }

--- a/datamap/lucene/src/main/java/org/apache/carbondata/datamap/lucene/LuceneDataMapFactoryBase.java
+++ b/datamap/lucene/src/main/java/org/apache/carbondata/datamap/lucene/LuceneDataMapFactoryBase.java
@@ -61,9 +61,29 @@ import org.apache.lucene.analysis.standard.StandardAnalyzer;
 @InterfaceAudience.Internal
 abstract class LuceneDataMapFactoryBase<T extends DataMap> extends DataMapFactory<T> {
 
+  /**
+   * Size of the cache to maintain in Lucene writer, if specified then it tries to aggregate the
+   * unique data till the cache limit and flush to Lucene.
+   * It is best suitable for low cardinality dimensions.
+   */
   static final String FLUSH_CACHE = "flush_cache";
 
+  /**
+   * By default it does not use any cache.
+   */
+  static final String FLUSH_CACHE_DEFAULT_SIZE = "-1";
+
+  /**
+   * when made as true then store the data in blocklet wise in lucene , it means new folder will be
+   * created for each blocklet thus it eliminates storing on blockletid in lucene.
+   * And also it makes lucene small chuns of data
+   */
   static final String SPLIT_BLOCKLET = "split_blocklet";
+
+  /**
+   * By default it is false
+   */
+  static final String SPLIT_BLOCKLET_DEFAULT = "false";
   /**
    * Logger
    */
@@ -127,7 +147,7 @@ abstract class LuceneDataMapFactoryBase<T extends DataMap> extends DataMapFactor
   public static int validateAndGetWriteCacheSize(DataMapSchema schema) {
     String cacheStr = schema.getProperties().get(FLUSH_CACHE);
     if (cacheStr == null) {
-      cacheStr = "-1";
+      cacheStr = FLUSH_CACHE_DEFAULT_SIZE;
     }
     int cacheSize;
     try {
@@ -141,7 +161,7 @@ abstract class LuceneDataMapFactoryBase<T extends DataMap> extends DataMapFactor
   public static boolean validateAndGetStoreBlockletWise(DataMapSchema schema) {
     String splitBlockletStr = schema.getProperties().get(SPLIT_BLOCKLET);
     if (splitBlockletStr == null) {
-      splitBlockletStr = "false";
+      splitBlockletStr = SPLIT_BLOCKLET_DEFAULT;
     }
     boolean splitBlockletWise;
     try {

--- a/datamap/lucene/src/main/java/org/apache/carbondata/datamap/lucene/LuceneDataMapFactoryBase.java
+++ b/datamap/lucene/src/main/java/org/apache/carbondata/datamap/lucene/LuceneDataMapFactoryBase.java
@@ -83,7 +83,7 @@ abstract class LuceneDataMapFactoryBase<T extends DataMap> extends DataMapFactor
   /**
    * By default it is false
    */
-  static final String SPLIT_BLOCKLET_DEFAULT = "false";
+  static final String SPLIT_BLOCKLET_DEFAULT = "true";
   /**
    * Logger
    */
@@ -167,7 +167,7 @@ abstract class LuceneDataMapFactoryBase<T extends DataMap> extends DataMapFactor
     try {
       splitBlockletWise = Boolean.parseBoolean(splitBlockletStr);
     } catch (NumberFormatException e) {
-      splitBlockletWise = false;
+      splitBlockletWise = true;
     }
     return splitBlockletWise;
   }
@@ -206,7 +206,7 @@ abstract class LuceneDataMapFactoryBase<T extends DataMap> extends DataMapFactor
   public DataMapWriter createWriter(Segment segment, String shardName) {
     LOGGER.info("lucene data write to " + shardName);
     return new LuceneDataMapWriter(getCarbonTable().getTablePath(), dataMapName,
-        dataMapMeta.getIndexedColumns(), segment, shardName, true, flushCacheSize,
+        dataMapMeta.getIndexedColumns(), segment, shardName, flushCacheSize,
         storeBlockletWise);
   }
 

--- a/datamap/lucene/src/main/java/org/apache/carbondata/datamap/lucene/LuceneDataMapWriter.java
+++ b/datamap/lucene/src/main/java/org/apache/carbondata/datamap/lucene/LuceneDataMapWriter.java
@@ -81,12 +81,6 @@ public class LuceneDataMapWriter extends DataMapWriter {
 
   private Analyzer analyzer = null;
 
-  private boolean isFineGrain = true;
-
-  public static final String BLOCKLETID_NAME = "blockletId";
-
-  private String indexShardName = null;
-
   public static final String PAGEID_NAME = "pageId";
 
   public static final String ROWID_NAME = "rowId";
@@ -100,10 +94,9 @@ public class LuceneDataMapWriter extends DataMapWriter {
   private boolean storeBlockletWise;
 
   LuceneDataMapWriter(String tablePath, String dataMapName, List<CarbonColumn> indexColumns,
-      Segment segment, String shardName, boolean isFineGrain, int flushSize,
+      Segment segment, String shardName, int flushSize,
       boolean storeBlockletWise) {
     super(tablePath, dataMapName, indexColumns, segment, shardName);
-    this.isFineGrain = isFineGrain;
     this.cacheSize = flushSize;
     this.storeBlockletWise = storeBlockletWise;
   }
@@ -234,7 +227,7 @@ public class LuceneDataMapWriter extends DataMapWriter {
     }
   }
 
-  private static boolean addField(Document doc, Object key, String fieldName, Field.Store store) {
+  private static void addField(Document doc, Object key, String fieldName, Field.Store store) {
     //get field name
     if (key instanceof Byte) {
       // byte type , use int range to deal with byte, lucene has no byte type
@@ -302,7 +295,6 @@ public class LuceneDataMapWriter extends DataMapWriter {
         doc.add(new StoredField(fieldName, value ? 1 : 0));
       }
     }
-    return true;
   }
 
   private Object getValue(ColumnPage page, int rowId) {

--- a/datamap/lucene/src/main/java/org/apache/carbondata/datamap/lucene/LuceneDataMapWriter.java
+++ b/datamap/lucene/src/main/java/org/apache/carbondata/datamap/lucene/LuceneDataMapWriter.java
@@ -66,7 +66,8 @@ import org.roaringbitmap.RoaringBitmap;
 /**
  * Implementation to write lucene index while loading
  */
-@InterfaceAudience.Internal public class LuceneDataMapWriter extends DataMapWriter {
+@InterfaceAudience.Internal
+public class LuceneDataMapWriter extends DataMapWriter {
   /**
    * logger
    */
@@ -208,7 +209,8 @@ import org.roaringbitmap.RoaringBitmap;
     // save index data into ram, write into disk after one page finished
     int columnsCount = pages.length;
     if (columnsCount <= 0) {
-      LOGGER.warn("empty data");
+      LOGGER.warn("No data in the page " + pageId + "with blockletid " + blockletId
+          + " to write lucene datamap");
       return;
     }
     for (int rowId = 0; rowId < pageSize; rowId++) {
@@ -228,7 +230,7 @@ import org.roaringbitmap.RoaringBitmap;
       }
     }
     if (cacheSize > 0) {
-      flushCacheIfCan();
+      flushCacheIfPossible();
     }
   }
 
@@ -395,7 +397,7 @@ import org.roaringbitmap.RoaringBitmap;
     indexWriter.addDocument(document);
   }
 
-  private void flushCacheIfCan() throws IOException {
+  private void flushCacheIfPossible() throws IOException {
     if (cache.size() > cacheSize) {
       flushCache(cache, getIndexColumns(), indexWriter, storeBlockletWise);
     }
@@ -446,6 +448,9 @@ import org.roaringbitmap.RoaringBitmap;
     }
   }
 
+  /**
+   * Keeps column values of a single row.
+   */
   public static class LuceneColumnKeys {
 
     private Object[] colValues;
@@ -458,14 +463,16 @@ import org.roaringbitmap.RoaringBitmap;
       return colValues;
     }
 
-    @Override public boolean equals(Object o) {
+    @Override
+    public boolean equals(Object o) {
       if (this == o) return true;
       if (o == null || getClass() != o.getClass()) return false;
       LuceneColumnKeys that = (LuceneColumnKeys) o;
       return Arrays.equals(colValues, that.colValues);
     }
 
-    @Override public int hashCode() {
+    @Override
+    public int hashCode() {
       return Arrays.hashCode(colValues);
     }
   }

--- a/datamap/lucene/src/main/java/org/apache/carbondata/datamap/lucene/LuceneFineGrainDataMapFactory.java
+++ b/datamap/lucene/src/main/java/org/apache/carbondata/datamap/lucene/LuceneFineGrainDataMapFactory.java
@@ -50,7 +50,7 @@ public class LuceneFineGrainDataMapFactory extends LuceneDataMapFactoryBase<Fine
    */
   @Override public List<FineGrainDataMap> getDataMaps(Segment segment) throws IOException {
     List<FineGrainDataMap> lstDataMap = new ArrayList<>();
-    FineGrainDataMap dataMap = new LuceneFineGrainDataMap(analyzer);
+    FineGrainDataMap dataMap = new LuceneFineGrainDataMap(analyzer, getDataMapSchema());
     try {
       dataMap.init(new DataMapModel(
           DataMapWriter.getDefaultDataMapPath(
@@ -70,7 +70,7 @@ public class LuceneFineGrainDataMapFactory extends LuceneDataMapFactoryBase<Fine
   public List<FineGrainDataMap> getDataMaps(DataMapDistributable distributable)
       throws IOException {
     List<FineGrainDataMap> lstDataMap = new ArrayList<>();
-    FineGrainDataMap dataMap = new LuceneFineGrainDataMap(analyzer);
+    FineGrainDataMap dataMap = new LuceneFineGrainDataMap(analyzer, getDataMapSchema());
     String indexPath = ((LuceneDataMapDistributable) distributable).getIndexPath();
     try {
       dataMap.init(new DataMapModel(indexPath));

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/datamap/lucene/LuceneFineGrainDataMapSuite.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/datamap/lucene/LuceneFineGrainDataMapSuite.scala
@@ -732,6 +732,50 @@ class LuceneFineGrainDataMapSuite extends QueryTest with BeforeAndAfterAll {
     sql("DROP TABLE table1")
   }
 
+  test("test lucene with flush_cache as true") {
+    sql("DROP TABLE IF EXISTS datamap_test_table")
+    sql(
+      """
+        | CREATE TABLE datamap_test_table(id INT, name STRING, city STRING, age INT)
+        | STORED BY 'carbondata'
+        | TBLPROPERTIES('SORT_COLUMNS'='city,name', 'SORT_SCOPE'='LOCAL_SORT')
+      """.stripMargin)
+    sql(
+      s"""
+         | CREATE DATAMAP dm_flush ON TABLE datamap_test_table
+         | USING 'lucene'
+         | DMProperties('INDEX_COLUMNS'='name , city', 'flush_cache'='true')
+      """.stripMargin)
+    sql(s"LOAD DATA LOCAL INPATH '$file2' INTO TABLE datamap_test_table OPTIONS('header'='false')")
+    checkAnswer(sql("SELECT * FROM datamap_test_table WHERE TEXT_MATCH('name:n99*')"),
+      sql("select * from datamap_test_table where name like 'n99%'"))
+    checkAnswer(sql("SELECT * FROM datamap_test_table WHERE TEXT_MATCH('name:n*9')"),
+      sql(s"select * from datamap_test_table where name like 'n%9'"))
+    sql("drop datamap if exists dm_flush on table datamap_test_table")
+  }
+
+  test("test lucene with split_blocklet as false ") {
+    sql("DROP TABLE IF EXISTS datamap_test_table")
+    sql(
+      """
+        | CREATE TABLE datamap_test_table(id INT, name STRING, city STRING, age INT)
+        | STORED BY 'carbondata'
+        | TBLPROPERTIES('SORT_COLUMNS'='city,name', 'SORT_SCOPE'='LOCAL_SORT')
+      """.stripMargin)
+    sql(
+      s"""
+         | CREATE DATAMAP dm_split_false ON TABLE datamap_test_table
+         | USING 'lucene'
+         | DMProperties('INDEX_COLUMNS'='name , city', 'split_blocklet'='false')
+      """.stripMargin)
+    sql(s"LOAD DATA LOCAL INPATH '$file2' INTO TABLE datamap_test_table OPTIONS('header'='false')")
+    checkAnswer(sql("SELECT * FROM datamap_test_table WHERE TEXT_MATCH('name:n99*')"),
+      sql("select * from datamap_test_table where name like 'n99%'"))
+    checkAnswer(sql("SELECT * FROM datamap_test_table WHERE TEXT_MATCH('name:n*9')"),
+      sql(s"select * from datamap_test_table where name like 'n%9'"))
+    sql("drop datamap if exists dm_split_false on table datamap_test_table")
+  }
+
   override protected def afterAll(): Unit = {
     LuceneFineGrainDataMapSuite.deleteFile(file2)
     sql("DROP TABLE IF EXISTS normal_test")


### PR DESCRIPTION
Improved lucene datamap size and performance by using the following parameters.
New DM properties 
`flush_cache`: size of the cache to maintain in Lucene writer, if specified then it tries to aggregate the unique data till the cache limit and flush to Lucene. It is best suitable for low cardinality dimensions.
`split_blocklet`: when made as true then store the data in blocklet wise in lucene , it means new folder will be created for each blocklet thus it eliminates storing on blockletid in lucene. And also it makes lucene small chunks of data.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

