### PR TITLE
[CARBONDATA-2455]Fix _System Folder creation and lucene AND,OR,NOT Filter fix

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/DiskBasedDMSchemaStorageProvider.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/DiskBasedDMSchemaStorageProvider.java
@@ -55,7 +55,7 @@ public class DiskBasedDMSchemaStorageProvider implements DataMapSchemaStoragePro
   private Set<DataMapSchema> dataMapSchemas = new HashSet<>();
 
   public DiskBasedDMSchemaStorageProvider(String storePath) {
-    this.storePath = storePath;
+    this.storePath = CarbonUtil.checkAndAppendHDFSUrl(storePath);
     this.mdtFilePath = storePath + CarbonCommonConstants.FILE_SEPARATOR + "datamap.mdtfile";
   }
 

--- a/datamap/lucene/src/main/java/org/apache/carbondata/datamap/lucene/LuceneDataMapWriter.java
+++ b/datamap/lucene/src/main/java/org/apache/carbondata/datamap/lucene/LuceneDataMapWriter.java
@@ -274,7 +274,6 @@ public class LuceneDataMapWriter extends DataMapWriter {
       }
     } else if (type == DataTypes.STRING) {
       byte[] value = (byte[]) data;
-      // TODO: how to get string value
       String strValue = null;
       try {
         strValue = new String(value, 2, value.length - 2, "UTF-8");

--- a/datamap/lucene/src/main/java/org/apache/carbondata/datamap/lucene/LuceneFineGrainDataMap.java
+++ b/datamap/lucene/src/main/java/org/apache/carbondata/datamap/lucene/LuceneFineGrainDataMap.java
@@ -205,8 +205,7 @@ public class LuceneFineGrainDataMap extends FineGrainDataMap {
     queryParser.setAllowLeadingWildcard(true);
     Query query;
     try {
-      // always send lowercase string to lucene as it is case sensitive
-      query = queryParser.parse(strQuery.toLowerCase());
+      query = queryParser.parse(strQuery);
     } catch (ParseException e) {
       String errorMessage = String.format(
           "failed to filter block with query %s, detail is %s", strQuery, e.getMessage());

--- a/integration/spark-common-cluster-test/src/test/scala/org/apache/carbondata/cluster/sdv/generated/LuceneTestCase.scala
+++ b/integration/spark-common-cluster-test/src/test/scala/org/apache/carbondata/cluster/sdv/generated/LuceneTestCase.scala
@@ -110,14 +110,13 @@ class LuceneTestCase extends QueryTest with BeforeAndAfterAll {
     checkAnswer(sql("SELECT * FROM datamap_main WHERE TEXT_MATCH('country:ch*')"),
       sql("select * from datamap_main where country like 'ch%'"))
     checkAnswer(sql(
-      "SELECT * FROM datamap_main WHERE TEXT_MATCH('country:ch*') AND TEXT_MATCH('name:aa*')"),
+      "SELECT * FROM datamap_main WHERE TEXT_MATCH('country:ch* AND name:aa*')"),
       sql("select * from datamap_main where country like 'ch%' and name like 'aa%'"))
     checkAnswer(sql(
-      "SELECT * FROM datamap_main WHERE TEXT_MATCH('country:u* or name:aa*')"),
+      "SELECT * FROM datamap_main WHERE TEXT_MATCH('country:u* OR name:aa*')"),
       sql("select * from datamap_main where country like 'u%'or name like 'aa%'"))
     checkAnswer(sql(
-      "SELECT * FROM datamap_main WHERE TEXT_MATCH('country:u*') OR TEXT_MATCH('name:aaa1*') AND " +
-      "TEXT_MATCH('name:aaa2*')"),
+      "SELECT * FROM datamap_main WHERE TEXT_MATCH('country:u* OR (name:aaa1* AND name:aaa2*)')"),
       sql(
         "select * from datamap_main where country like 'u%' OR name like 'aaa1%' AND name like " +
         "'aaa2%'"))

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/datamap/lucene/LuceneFineGrainDataMapSuite.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/datamap/lucene/LuceneFineGrainDataMapSuite.scala
@@ -290,7 +290,7 @@ class LuceneFineGrainDataMapSuite extends QueryTest with BeforeAndAfterAll {
       """.stripMargin)
     sql(s"LOAD DATA LOCAL INPATH '$file2' INTO TABLE datamap_test_table OPTIONS('header'='false')")
     checkAnswer(sql(
-      "SELECT * FROM datamap_test_table WHERE TEXT_MATCH('name:n0*') AND TEXT_MATCH(' city:c0*')"),
+      "SELECT * FROM datamap_test_table WHERE TEXT_MATCH('name:n0* AND city:c0*')"),
       sql("select * from datamap_test_table where name like 'n0%' and city like 'c0%'"))
     sql("drop datamap if exists dm on table datamap_test_table")
   }
@@ -311,7 +311,7 @@ class LuceneFineGrainDataMapSuite extends QueryTest with BeforeAndAfterAll {
       """.stripMargin)
     sql(s"LOAD DATA LOCAL INPATH '$file2' INTO TABLE datamap_test_table OPTIONS('header'='false')")
     checkAnswer(sql(
-      "SELECT * FROM datamap_test_table WHERE TEXT_MATCH('name:n1*') or TEXT_MATCH('city:c01*')"),
+      "SELECT * FROM datamap_test_table WHERE TEXT_MATCH('name:n1* OR city:c01*')"),
       sql("select * from datamap_test_table where name like 'n1%' or city like 'c01%'"))
     sql("drop datamap if exists dm on table datamap_test_table")
   }
@@ -332,8 +332,7 @@ class LuceneFineGrainDataMapSuite extends QueryTest with BeforeAndAfterAll {
       """.stripMargin)
     sql(s"LOAD DATA LOCAL INPATH '$file2' INTO TABLE datamap_test_table OPTIONS('header'='false')")
     checkAnswer(sql(
-      "SELECT * FROM datamap_test_table WHERE TEXT_MATCH('name:n1*') OR TEXT_MATCH ('city:c01*') " +
-      "AND TEXT_MATCH('city:C02*')"),
+      "SELECT * FROM datamap_test_table WHERE TEXT_MATCH('name:n1* OR (city:c01* AND city:c02*)')"),
       sql(
         "select * from datamap_test_table where name like 'n1%' OR city like 'c01%' and city like" +
         " 'c02%'"))
@@ -488,7 +487,7 @@ class LuceneFineGrainDataMapSuite extends QueryTest with BeforeAndAfterAll {
       sql("select *from datamap_test_table where name like'n1%' AND not name like 'n2%'"))
     //check NOT filter with TEXTMATCH wildcard-search using AND on different columns
     checkAnswer(sql(
-      "select *from datamap_test_table where TEXT_MATCH('name:n1*')AND TEXT_MATCH('city:c01* NOT " +
+      "select *from datamap_test_table where TEXT_MATCH('name:n1* AND city:c01* NOT " +
       "c02*')"),
       sql("select *from datamap_test_table where name like'n1%' AND not city='c02%'"))
     sql("drop datamap if exists dm on table datamap_test_table")
@@ -716,7 +715,7 @@ class LuceneFineGrainDataMapSuite extends QueryTest with BeforeAndAfterAll {
       sql(s"SELECT * FROM datamap_test5 WHERE city='c020'"))
     sql("DROP TABLE IF EXISTS datamap_test5")
   }
-
+  
   test("test text_match on normal table") {
     sql("DROP TABLE IF EXISTS table1")
     sql(


### PR DESCRIPTION
1.Lucene AND,OR,NOT Filter fix
   Lucene uses Standard Analyzer which takes only lower case letters to query. But AND,OR,NOT filters 
   should be in Upper Case. Hence user should use lower case letters to query and filters should be in
   should be in uppercase
2.Fix  _System folder creation for datamap when carbon.storeLocation is not provided
 
 - [x] Any interfaces changed?
         NA
 - [x] Any backward compatibility impacted?
         NA
 - [x] Document update required?
        YES
 - [x] Testing done
        Yes. Testcases added
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
        NA
