### PR TITLE
 [CARBONDATA-2456] Support handle request by shard in search mode

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -1670,6 +1670,19 @@ public final class CarbonCommonConstants {
   public static final String CARBON_SEARCH_QUERY_TIMEOUT_DEFAULT = "10s";
 
   /**
+   * It's prune mode of carbon search query
+   */
+  @CarbonProperty
+  @InterfaceStability.Unstable
+  public static final String CARBON_SEARCH_PRUNE_MODE = "carbon.search.prune.mode";
+
+  /**
+   * Default value is block mode
+   * Support prune by shard
+   */
+  public static final String CARBON_SEARCH_PRUNE_MODET_DEFAULT = "block";
+
+  /**
    * The size of thread pool used for reading files in Work for search mode. By default,
    * it is number of cores in Worker
    */

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/detailquery/SearchModeTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/detailquery/SearchModeTestCase.scala
@@ -23,6 +23,7 @@ import org.scalatest.BeforeAndAfterAll
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.util.CarbonProperties
+import org.apache.carbondata.datamap.lucene.LuceneFineGrainDataMapSuite
 import org.apache.carbondata.spark.util.DataGenerator
 
 /**
@@ -30,12 +31,14 @@ import org.apache.carbondata.spark.util.DataGenerator
  */
 
 class SearchModeTestCase extends QueryTest with BeforeAndAfterAll {
-
+  val file = resourcesPath + "/datamap_input.csv"
   val numRows = 500 * 1000
   override def beforeAll = {
     sqlContext.sparkContext.setLogLevel("INFO")
     sqlContext.sparkSession.asInstanceOf[CarbonSession].startSearchMode()
+    LuceneFineGrainDataMapSuite.createFile(file, 1000000)
     sql("DROP TABLE IF EXISTS main")
+    sql("DROP TABLE IF EXISTS shard_table")
 
     val df = DataGenerator.generateDataFrame(sqlContext.sparkSession, numRows)
     df.write
@@ -48,6 +51,8 @@ class SearchModeTestCase extends QueryTest with BeforeAndAfterAll {
 
   override def afterAll = {
     sql("DROP TABLE IF EXISTS main")
+    sql("DROP TABLE IF EXISTS shard_table")
+    LuceneFineGrainDataMapSuite.deleteFile(file)
     sqlContext.sparkSession.asInstanceOf[CarbonSession].stopSearchMode()
   }
 
@@ -149,4 +154,50 @@ class SearchModeTestCase extends QueryTest with BeforeAndAfterAll {
     checkSearchAnswer("select id from main where id = '3' limit 10")
     sqlContext.sparkSession.asInstanceOf[CarbonSession].stopSearchMode()
   }
+
+  test("test search mode with shard to search") {
+    sqlContext.sparkSession.asInstanceOf[CarbonSession].startSearchMode()
+    CarbonProperties.getInstance().addProperty(CarbonCommonConstants.CARBON_SEARCH_PRUNE_MODE, "shard")
+    sql("DROP TABLE IF EXISTS shard_table")
+    sql(
+      """
+        | CREATE TABLE shard_table(id INT, name STRING, city STRING, age INT)
+        | STORED BY 'carbondata'
+        | TBLPROPERTIES('SORT_COLUMNS'='city,name', 'SORT_SCOPE'='GLOBAL_SORT','TABLE_BLOCKSIZE'='1')
+      """.stripMargin)
+    sql(
+      s"""
+         | LOAD DATA LOCAL INPATH '$file'
+         | INTO TABLE shard_table
+         | OPTIONS('header'='false','GLOBAL_SORT_PARTITIONS'='2')
+       """.stripMargin)
+    sql(
+      s"""
+         | LOAD DATA LOCAL INPATH '$file'
+         | INTO TABLE shard_table
+         | OPTIONS('header'='false','GLOBAL_SORT_PARTITIONS'='2')
+       """.stripMargin)
+
+    val df1 = sql("SELECT * FROM shard_table WHERE name='n10'")
+    val df2 = sql("SELECT * FROM shard_table WHERE city='c0620666'")
+    val df3 = sql("SELECT COUNT(id) FROM shard_table WHERE age='62'")
+    val df4 = sql("SELECT COUNT(*) FROM shard_table WHERE age='62'")
+    val df5 = sql("SELECT * FROM shard_table WHERE id=620666")
+    val df6 = sql("SELECT * FROM shard_table WHERE id=825162")
+
+    sqlContext.sparkSession.asInstanceOf[CarbonSession].stopSearchMode()
+
+    checkAnswer(sql("SELECT * FROM shard_table WHERE name='n10'"), df1)
+    checkAnswer(sql("SELECT * FROM shard_table WHERE city='c0620666'"), df2)
+    checkAnswer(sql("SELECT COUNT(id) FROM shard_table WHERE age='62'"), df3)
+    checkAnswer(sql("SELECT COUNT(*) FROM shard_table WHERE age='62'"), df4)
+    checkAnswer(sql("SELECT * FROM shard_table WHERE id=620666"), df5)
+    checkAnswer(sql("SELECT * FROM shard_table WHERE id=825162"), df6)
+
+    sqlContext.sparkSession.asInstanceOf[CarbonSession].startSearchMode()
+
+    CarbonProperties.getInstance().addProperty(CarbonCommonConstants.CARBON_SEARCH_PRUNE_MODE,
+      CarbonCommonConstants.CARBON_SEARCH_PRUNE_MODET_DEFAULT)
+  }
+
 }

--- a/store/search/src/main/scala/org/apache/spark/rpc/Scheduler.scala
+++ b/store/search/src/main/scala/org/apache/spark/rpc/Scheduler.scala
@@ -81,7 +81,8 @@ private[rpc] class Scheduler {
     LOG.info(s"sending search request to worker ${worker.address}:${worker.port}")
 
     val list = new util.LinkedList[Future[T]]()
-    val mode = CarbonProperties.getInstance().getProperty(CarbonCommonConstants.CARBON_SEARCH_PRUNE_MODE,
+    val mode = CarbonProperties.getInstance()
+      .getProperty(CarbonCommonConstants.CARBON_SEARCH_PRUNE_MODE,
       CarbonCommonConstants.CARBON_SEARCH_PRUNE_MODET_DEFAULT)
     if (mode.equalsIgnoreCase("block")) {
       val future = worker.ref.ask(request)

--- a/store/search/src/main/scala/org/apache/spark/rpc/Scheduler.scala
+++ b/store/search/src/main/scala/org/apache/spark/rpc/Scheduler.scala
@@ -18,6 +18,8 @@
 package org.apache.spark.rpc
 
 import java.io.IOException
+import java.util
+import java.util.{ArrayList => JArrayList, List => JList}
 import java.util.concurrent.atomic.AtomicInteger
 
 import scala.collection.mutable
@@ -25,8 +27,16 @@ import scala.concurrent.Future
 import scala.reflect.ClassTag
 import scala.util.Random
 
+import org.apache.spark.SerializableWritable
+import org.apache.spark.search.SearchRequest
+
 import org.apache.carbondata.common.logging.LogServiceFactory
+import org.apache.carbondata.core.constants.CarbonCommonConstants
+import org.apache.carbondata.core.datastore.block.Distributable
 import org.apache.carbondata.core.util.CarbonProperties
+import org.apache.carbondata.core.util.path.CarbonTablePath
+import org.apache.carbondata.hadoop.{CarbonInputSplit, CarbonMultiBlockSplit}
+
 
 /**
  * [[org.apache.spark.rpc.Master]] uses Scheduler to pick a Worker to send request
@@ -44,7 +54,7 @@ private[rpc] class Scheduler {
    */
   def sendRequestAsync[T: ClassTag](
       splitAddress: String,
-      request: Any): (Schedulable, Future[T]) = {
+      request: Any): (Schedulable, JList[Future[T]]) = {
     require(splitAddress != null)
     if (workers.isEmpty) {
       throw new IOException("No worker is available")
@@ -69,9 +79,44 @@ private[rpc] class Scheduler {
         s"All workers are busy, number of workers: ${workers.size}, workload limit: $maxWorkload")
     }
     LOG.info(s"sending search request to worker ${worker.address}:${worker.port}")
-    val future = worker.ref.ask(request)
-    worker.workload.incrementAndGet()
-    (worker, future)
+
+    val list = new util.LinkedList[Future[T]]()
+    val mode = CarbonProperties.getInstance().getProperty(CarbonCommonConstants.CARBON_SEARCH_PRUNE_MODE,
+      CarbonCommonConstants.CARBON_SEARCH_PRUNE_MODET_DEFAULT)
+    if (mode.equalsIgnoreCase("block")) {
+      val future = worker.ref.ask(request)
+      worker.workload.incrementAndGet()
+      list.add(future)
+    } else if (mode.equalsIgnoreCase("shard")) {
+      val hashMap = new mutable.HashMap[String, JList[Distributable]]()
+      val blocks = request.asInstanceOf[SearchRequest].split.value.getAllSplits
+      for (i <- 0 until (blocks.size())) {
+        val shardName = CarbonTablePath
+          .getShardName(((blocks.get(i)).asInstanceOf[CarbonInputSplit].getBlockPath));
+        if (null == hashMap.get(shardName) || hashMap.get(shardName).isEmpty) {
+
+          val list = new JArrayList[Distributable]()
+          list.add(blocks.get(i))
+          hashMap.put(shardName, list)
+        } else {
+          hashMap.get(shardName).get.add(blocks.get(i))
+        }
+      }
+
+      hashMap.toArray.foreach { each =>
+        val splitByShard = new SerializableWritable[CarbonMultiBlockSplit](
+          new CarbonMultiBlockSplit(each._2, splitAddress))
+        val newRequest = request.asInstanceOf[SearchRequest].copy(split = splitByShard)
+        val future = worker.ref.ask(newRequest)
+        worker.workload.incrementAndGet()
+        list.add(future)
+      }
+
+    } else {
+      throw new RuntimeException("Prune mode of carbon search query doesn't support "
+        + mode + ", please choose block or shard")
+    }
+    (worker, list)
   }
 
   private def pickWorker[T: ClassTag](splitAddress: String) = {


### PR DESCRIPTION

 This PR support handle request by shard in search mode, which is different with handling the request by multiBlockSplit
 add property for it, we can change the mode by:
 CarbonProperties.getInstance().addProperty(CarbonCommonConstants.CARBON_SEARCH_PRUNE_MODE, "shard")

 CarbonProperties.getInstance().addProperty(CarbonCommonConstants.CARBON_SEARCH_PRUNE_MODE, "block")

 - [x] Any interfaces changed?
 No
 - [x] Any backward compatibility impacted?
 No
 - [x] Document update required?
No
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       add test case
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
No