### PR TITLE
[CARBONDATA-2457] Add converter to get Carbon SDK Schema from Avro schema directly.

### DIFF
--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/AvroCarbonWriter.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/AvroCarbonWriter.java
@@ -142,13 +142,15 @@ public class AvroCarbonWriter extends CarbonWriter {
     Field[] carbonField = new Field[avroSchema.getFields().size()];
     int i = 0;
     for (Schema.Field avroField : avroSchema.getFields()) {
-      carbonField[i] = prepareFields(avroField.name(), avroField.schema());
+      carbonField[i] = prepareFields(avroField);
       i++;
     }
     return new org.apache.carbondata.sdk.file.Schema(carbonField);
   }
 
-  private static Field prepareFields(String FieldName, Schema childSchema) {
+  private static Field prepareFields(Schema.Field avroField) {
+    String FieldName = avroField.name();
+    Schema childSchema = avroField.schema();
     Schema.Type type = childSchema.getType();
     switch (type) {
       case BOOLEAN:

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/AvroCarbonWriter.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/AvroCarbonWriter.java
@@ -24,6 +24,9 @@ import java.util.Random;
 import java.util.UUID;
 
 import org.apache.carbondata.common.annotations.InterfaceAudience;
+import org.apache.carbondata.core.metadata.datatype.DataType;
+import org.apache.carbondata.core.metadata.datatype.DataTypes;
+import org.apache.carbondata.core.metadata.datatype.StructField;
 import org.apache.carbondata.hadoop.api.CarbonTableOutputFormat;
 import org.apache.carbondata.hadoop.internal.ObjectArrayWritable;
 import org.apache.carbondata.processing.loading.complexobjects.ArrayObject;
@@ -46,7 +49,7 @@ import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl;
  * Writer Implementation to write Avro Record to carbondata file.
  */
 @InterfaceAudience.Internal
-class AvroCarbonWriter extends CarbonWriter {
+public class AvroCarbonWriter extends CarbonWriter {
 
   private RecordWriter<NullWritable, ObjectArrayWritable> recordWriter;
   private TaskAttemptContext context;
@@ -118,9 +121,129 @@ class AvroCarbonWriter extends CarbonWriter {
         break;
 
       default:
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException(
+            "carbon not support " + type.toString() + " avro type yet");
     }
     return out;
+  }
+
+  /**
+   * converts avro schema to carbon schema required by carbonWriter
+   *
+   * @param avroSchemaString json formatted avro schema as string
+   * @return carbon sdk schema
+   */
+  public static org.apache.carbondata.sdk.file.Schema getCarbonSchemaFromAvroSchema(
+      String avroSchemaString) {
+    if (avroSchemaString == null) {
+      throw new UnsupportedOperationException("avro schema string cannot be null");
+    }
+    Schema avroSchema = new Schema.Parser().parse(avroSchemaString);
+    Field[] carbonField = new Field[avroSchema.getFields().size()];
+    int i = 0;
+    for (Schema.Field avroField : avroSchema.getFields()) {
+      carbonField[i] = prepareFields(avroField.name(), avroField.schema());
+      i++;
+    }
+    return new org.apache.carbondata.sdk.file.Schema(carbonField);
+  }
+
+  private static Field prepareFields(String FieldName, Schema childSchema) {
+    Schema.Type type = childSchema.getType();
+    switch (type) {
+      case BOOLEAN:
+        return new Field(FieldName, DataTypes.BOOLEAN);
+      case INT:
+        return new Field(FieldName, DataTypes.INT);
+      case LONG:
+        return new Field(FieldName, DataTypes.LONG);
+      case DOUBLE:
+        return new Field(FieldName, DataTypes.DOUBLE);
+      case STRING:
+        return new Field(FieldName, DataTypes.STRING);
+      case FLOAT:
+        return new Field(FieldName, DataTypes.DOUBLE);
+      case RECORD:
+        // recursively get the sub fields
+        ArrayList<StructField> structSubFields = new ArrayList<>();
+        for (Schema.Field avroSubField : childSchema.getFields()) {
+          structSubFields.add(prepareSubFields(avroSubField.name(), avroSubField.schema()));
+        }
+        return new Field(FieldName, "struct", structSubFields);
+      case ARRAY:
+        // recursively get the sub fields
+        ArrayList<StructField> arraySubField = new ArrayList<>();
+        // array will have only one sub field.
+        arraySubField.add(prepareSubFields("val", childSchema.getElementType()));
+        return new Field(FieldName, "array", arraySubField);
+      default:
+        throw new UnsupportedOperationException(
+            "carbon not support " + type.toString() + " avro type yet");
+    }
+  }
+
+  private static StructField prepareSubFields(String FieldName, Schema childSchema) {
+    Schema.Type type = childSchema.getType();
+    switch (type) {
+      case BOOLEAN:
+        return new StructField(FieldName, DataTypes.BOOLEAN);
+      case INT:
+        return new StructField(FieldName, DataTypes.INT);
+      case LONG:
+        return new StructField(FieldName, DataTypes.LONG);
+      case DOUBLE:
+        return new StructField(FieldName, DataTypes.DOUBLE);
+      case STRING:
+        return new StructField(FieldName, DataTypes.STRING);
+      case FLOAT:
+        return new StructField(FieldName, DataTypes.FLOAT);
+      case RECORD:
+        // recursively get the sub fields
+        ArrayList<StructField> structSubFields = new ArrayList<>();
+        for (Schema.Field avroSubField : childSchema.getFields()) {
+          structSubFields.add(prepareSubFields(avroSubField.name(), avroSubField.schema()));
+        }
+        return (new StructField(FieldName, DataTypes.createStructType(structSubFields)));
+      case ARRAY:
+        // recursively get the sub fields
+        // array will have only one sub field.
+        return (new StructField(FieldName, DataTypes.createArrayType(
+            getMappingDataTypeForArrayRecord(childSchema.getElementType()))));
+      default:
+        throw new UnsupportedOperationException(
+            "carbon not support " + type.toString() + " avro type yet");
+    }
+  }
+
+  private static DataType getMappingDataTypeForArrayRecord(Schema childSchema) {
+    switch (childSchema.getType()) {
+      case BOOLEAN:
+        return DataTypes.BOOLEAN;
+      case INT:
+        return DataTypes.INT;
+      case LONG:
+        return DataTypes.LONG;
+      case DOUBLE:
+        return DataTypes.DOUBLE;
+      case STRING:
+        return DataTypes.STRING;
+      case FLOAT:
+        return DataTypes.FLOAT;
+      case RECORD:
+        // recursively get the sub fields
+        ArrayList<StructField> structSubFields = new ArrayList<>();
+        for (Schema.Field avroSubField : childSchema.getFields()) {
+          structSubFields.add(prepareSubFields(avroSubField.name(), avroSubField.schema()));
+        }
+        return DataTypes.createStructType(structSubFields);
+      case ARRAY:
+        // array will have only one sub field.
+        return DataTypes.createArrayType(
+            getMappingDataTypeForArrayRecord(childSchema.getElementType()));
+      default:
+        throw new UnsupportedOperationException(
+            "carbon not support " + childSchema.getType().toString() + " avro type yet");
+    }
   }
 
   /**

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/AvroCarbonWriter.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/AvroCarbonWriter.java
@@ -198,7 +198,7 @@ public class AvroCarbonWriter extends CarbonWriter {
       case STRING:
         return new StructField(FieldName, DataTypes.STRING);
       case FLOAT:
-        return new StructField(FieldName, DataTypes.FLOAT);
+        return new StructField(FieldName, DataTypes.DOUBLE);
       case RECORD:
         // recursively get the sub fields
         ArrayList<StructField> structSubFields = new ArrayList<>();
@@ -230,7 +230,7 @@ public class AvroCarbonWriter extends CarbonWriter {
       case STRING:
         return DataTypes.STRING;
       case FLOAT:
-        return DataTypes.FLOAT;
+        return DataTypes.DOUBLE;
       case RECORD:
         // recursively get the sub fields
         ArrayList<StructField> structSubFields = new ArrayList<>();

--- a/store/sdk/src/test/java/org/apache/carbondata/sdk/file/AvroCarbonWriterTest.java
+++ b/store/sdk/src/test/java/org/apache/carbondata/sdk/file/AvroCarbonWriterTest.java
@@ -21,30 +21,20 @@ import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
-import java.util.ArrayList;
-import java.util.List;
 
 import org.apache.carbondata.common.exceptions.sql.InvalidLoadOptionException;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
-import org.apache.carbondata.core.metadata.datatype.ArrayType;
-import org.apache.carbondata.core.metadata.datatype.DataTypes;
-import org.apache.carbondata.core.metadata.datatype.StructField;
-import org.apache.carbondata.core.metadata.datatype.StructType;
 import org.apache.carbondata.core.util.path.CarbonTablePath;
 
 import org.apache.avro.generic.GenericData;
-import org.apache.avro.generic.GenericRecord;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.CharEncoding;
-import org.apache.hadoop.conf.Configuration;
 import org.junit.Assert;
 import org.junit.Test;
 
-import scala.Array;
 import tech.allegro.schema.json2avro.converter.JsonAvroConverter;
 import org.apache.avro.Schema;
 
-import static org.apache.hadoop.yarn.webapp.hamlet.HamletSpec.InputType.file;
 
 public class AvroCarbonWriterTest {
   private String path = "./AvroCarbonWriterSuiteWriteFiles";
@@ -70,13 +60,9 @@ public class AvroCarbonWriterTest {
     GenericData.Record record = converter.convertToGenericDataRecord(
         json.getBytes(CharEncoding.UTF_8), new Schema.Parser().parse(avroSchema));
 
-    Field[] fields = new Field[2];
-    fields[0] = new Field("name", DataTypes.STRING);
-    fields[1] = new Field("age", DataTypes.STRING);
-
     try {
       CarbonWriter writer = CarbonWriter.builder()
-          .withSchema(new org.apache.carbondata.sdk.file.Schema(fields))
+          .withSchema(AvroCarbonWriter.getCarbonSchemaFromAvroSchema(avroSchema))
           .outputPath(path)
           .isTransactionalTable(true)
           .buildWriterForAvroInput();
@@ -145,19 +131,9 @@ public class AvroCarbonWriterTest {
     GenericData.Record record = converter.convertToGenericDataRecord(
         json.getBytes(CharEncoding.UTF_8), new Schema.Parser().parse(avroSchema));
 
-    Field[] fields = new Field[6];
-    // fields[0] = new Field("mynull", DataTypes.NULL);
-    fields[0] = new Field("myboolean", DataTypes.BOOLEAN);
-    fields[1] = new Field("myint", DataTypes.INT);
-    fields[2] = new Field("mylong", DataTypes.LONG);
-    fields[3] = new Field("myfloat", DataTypes.DOUBLE);
-    fields[4] = new Field("mydouble", DataTypes.DOUBLE);
-    fields[5] = new Field("mystring", DataTypes.STRING);
-
-
     try {
       CarbonWriter writer = CarbonWriter.builder()
-          .withSchema(new org.apache.carbondata.sdk.file.Schema(fields))
+          .withSchema(AvroCarbonWriter.getCarbonSchemaFromAvroSchema(avroSchema))
           .outputPath(path)
           .isTransactionalTable(true)
           .buildWriterForAvroInput();
@@ -250,18 +226,9 @@ public class AvroCarbonWriterTest {
     GenericData.Record record = converter.convertToGenericDataRecord(
         json.getBytes(CharEncoding.UTF_8), nn);
 
-    Field[] fields = new Field[3];
-    fields[0] = new Field("name", DataTypes.STRING);
-    fields[1] = new Field("name1", DataTypes.STRING);
-    // fields[1] = new Field("age", DataTypes.INT);
-    List fld = new ArrayList<StructField>();
-    fld.add(new StructField("street", DataTypes.STRING));
-    fld.add(new StructField("city", DataTypes.STRING));
-    fields[2] = new Field("address", "struct", fld);
-
     try {
       CarbonWriter writer = CarbonWriter.builder()
-          .withSchema(new org.apache.carbondata.sdk.file.Schema(fields))
+          .withSchema(AvroCarbonWriter.getCarbonSchemaFromAvroSchema(mySchema))
           .outputPath(path)
           .isTransactionalTable(true)
           .buildWriterForAvroInput();
@@ -323,18 +290,9 @@ public class AvroCarbonWriterTest {
     GenericData.Record record = converter.convertToGenericDataRecord(
         json.getBytes(CharEncoding.UTF_8), nn);
 
-    Field[] fields = new Field[3];
-    fields[0] = new Field("name", DataTypes.STRING);
-    fields[1] = new Field("name1", DataTypes.STRING);
-    // fields[1] = new Field("age", DataTypes.INT);
-    List fld = new ArrayList<StructField>();
-    fld.add(new StructField("street", DataTypes.STRING));
-    fld.add(new StructField("city", DataTypes.STRING));
-    fields[2] = new Field("address", "struct", fld);
-
     try {
       CarbonWriter writer = CarbonWriter.builder()
-          .withSchema(new org.apache.carbondata.sdk.file.Schema(fields))
+          .withSchema(AvroCarbonWriter.getCarbonSchemaFromAvroSchema(mySchema))
           .outputPath(path)
           .isTransactionalTable(true)
           .buildWriterForAvroInput();
@@ -365,17 +323,6 @@ public class AvroCarbonWriterTest {
 
   private void WriteAvroComplexData(String mySchema, String json, String[] sortColumns)
       throws UnsupportedEncodingException, IOException, InvalidLoadOptionException {
-    Field[] fields = new Field[4];
-    fields[0] = new Field("name", DataTypes.STRING);
-    fields[1] = new Field("name1", DataTypes.STRING);
-    // fields[1] = new Field("age", DataTypes.INT);
-    List fld = new ArrayList<StructField>();
-    fld.add(new StructField("street", DataTypes.STRING));
-    fld.add(new StructField("city", DataTypes.STRING));
-    fields[2] = new Field("address", "struct", fld);
-    List fld1 = new ArrayList<StructField>();
-    fld1.add(new StructField("eachDoorNum", DataTypes.INT));
-    fields[3] = new Field("doorNum","array",fld1);
 
     // conversion to GenericData.Record
     Schema nn = new Schema.Parser().parse(mySchema);
@@ -385,7 +332,7 @@ public class AvroCarbonWriterTest {
 
     try {
       CarbonWriter writer = CarbonWriter.builder()
-          .withSchema(new org.apache.carbondata.sdk.file.Schema(fields))
+          .withSchema(AvroCarbonWriter.getCarbonSchemaFromAvroSchema(mySchema))
           .outputPath(path)
           .isTransactionalTable(true).sortBy(sortColumns)
           .buildWriterForAvroInput();


### PR DESCRIPTION
[CARBONDATA-2457] Add converter to get Carbon SDK Schema from Avro schema directly.

In the current implementation, SDK users have to manually create carbon schema of fields from avro schema. 
This is time-consuming and error-prone. Also, user should not be worried about this logic.
So, abstract the carbon schema creation from avro schema by exposing a method to user.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed? Added new interface, not modified existing
 
 - [ ] Any backward compatibility impacted? NA
 
 - [ ] Document update required? will be handled in separate PR

 - [ ] Testing done
       yes, updated the test case in TestNonTransactionalCarbonTable.scala
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. NA

