### PR TITLE
[CARBONDATA-2463] concurrent insert requires separtate temp path which is differentiated with seg_id only

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonLoadDataCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonLoadDataCommand.scala
@@ -272,6 +272,8 @@ case class CarbonLoadDataCommand(
           if (!FileFactory.isFileExist(metadataDirectoryPath, fileType)) {
             FileFactory.mkdirs(metadataDirectoryPath, fileType)
           }
+        } else {
+          carbonLoadModel.setSegmentId(System.currentTimeMillis().toString)
         }
         val partitionStatus = SegmentStatus.SUCCESS
         val columnar = sparkSession.conf.get("carbon.is.columnar.storage", "true").toBoolean

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonWriterBuilder.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonWriterBuilder.java
@@ -109,8 +109,8 @@ public class CarbonWriterBuilder {
    * by default it is system time in nano seconds.
    * @return updated CarbonWriterBuilder
    */
-  public CarbonWriterBuilder taskNo(String taskNo) {
-    this.taskNo = taskNo;
+  public CarbonWriterBuilder taskNo(long taskNo) {
+    this.taskNo = String.valueOf(taskNo);
     return this;
   }
 

--- a/store/sdk/src/test/java/org/apache/carbondata/sdk/file/CSVCarbonWriterTest.java
+++ b/store/sdk/src/test/java/org/apache/carbondata/sdk/file/CSVCarbonWriterTest.java
@@ -257,7 +257,7 @@ public class CSVCarbonWriterTest {
     try {
       CarbonWriterBuilder builder = CarbonWriter.builder()
           .withSchema(new Schema(fields))
-          .isTransactionalTable(true).taskNo("5")
+          .isTransactionalTable(true).taskNo(5)
           .outputPath(path);
 
       CarbonWriter writer = builder.buildWriterForCSVInput();

--- a/store/sdk/src/test/java/org/apache/carbondata/sdk/file/CSVNonTransactionalCarbonWriterTest.java
+++ b/store/sdk/src/test/java/org/apache/carbondata/sdk/file/CSVNonTransactionalCarbonWriterTest.java
@@ -96,7 +96,7 @@ public class CSVNonTransactionalCarbonWriterTest {
           .withSchema(schema)
           .isTransactionalTable(false)
           .uniqueIdentifier(System.currentTimeMillis())
-          .taskNo(Long.toString(System.nanoTime()))
+          .taskNo(System.nanoTime())
           .outputPath(path);
       if (sortColumns != null) {
         builder = builder.sortBy(sortColumns);
@@ -160,7 +160,7 @@ public class CSVNonTransactionalCarbonWriterTest {
           .withSchema(new Schema(fields))
           .uniqueIdentifier(System.currentTimeMillis())
           .isTransactionalTable(false)
-          .taskNo(Long.toString(System.nanoTime()))
+          .taskNo(System.nanoTime())
           .outputPath(path);
 
       CarbonWriter writer = builder.buildWriterForCSVInput();


### PR DESCRIPTION
**issue :**  for non-transaction table we are not setting any segment-id in loadmodel . temp location contains `databasenaem_tablename_segId_taskid` . during concurrent insert  in same table, temp folder has to be created at separate location . only segment_id value will change during two concurrent insert.

**solution:** insert flow for external table is same as carbon table., and we are not storing segment info to anywhere. so dummy unique segment-id can be assigned to loadmodel for nontransactional table.

 - [x] Any interfaces changed? No
 
 - [x] Any backward compatibility impacted? No
 
 - [x] Document update required? NO

 - [x] Testing done ==> UT added       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. NA

