### PR TITLE
[CARBONDATA-2464]Fixed OOM issue in case of Complex type

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/util/ByteUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/ByteUtil.java
@@ -517,8 +517,8 @@ public final class ByteUtil {
   }
 
   public static int toInt(byte[] bytes, int offset) {
-    return (((int)bytes[offset]) << 24) + (((int)bytes[offset + 1]) << 16) +
-        (((int)bytes[offset + 2]) << 8) + bytes[offset + 3];
+    return (((int)bytes[offset] & 0xff) << 24) + (((int)bytes[offset + 1] & 0xff) << 16) +
+        (((int)bytes[offset + 2] & 0xff) << 8) + ((int)bytes[offset + 3] & 0xff);
   }
 
   public static void setInt(byte[] data, int offset, int value) {

--- a/core/src/test/java/org/apache/carbondata/core/util/ByteUtilTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/util/ByteUtilTest.java
@@ -113,6 +113,12 @@ public class ByteUtilTest extends TestCase {
         prepareBuffers();
         assertFalse(UnsafeComparer.INSTANCE.compareTo(buff1, buff2) < 0);
     }
+    @Test
+    public void testIntConversion() {
+        byte[] data = new byte[4];
+        ByteUtil.setInt(data, 0, 968);
+        assertEquals(ByteUtil.toInt(data, 0), 968);
+    }
 
     @Test
     public void testEqualToCase() {


### PR DESCRIPTION
**Problem**: Query with Complex type is failing with OOM

**Root Cause**: Complex type child column(No-dictionary) values are written in LV format, while reading the data it will read length then based on length it is reading the data. Converting byte array to int is giving wrong length value, because of this it's trying to create big memory chunk and as memory is not available in Unsafe it is failing with OOM.

**Code issue**: While converting byte array to int it is not masking the the byte values and because of this is giving wrong integer value.

**Solution**: Mask each byte and then left shift the bits
 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Added UT
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

