### PR TITLE
[CARBONDATA-2467] sdk writer log shouldnot print null

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/metadata/datatype/ArrayType.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/datatype/ArrayType.java
@@ -34,4 +34,17 @@ public class ArrayType extends DataType {
   public DataType getElementType() {
     return elementType;
   }
+
+  @Override public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof ArrayType)) return false;
+
+    ArrayType arrayType = (ArrayType) o;
+
+    return elementType.equals(arrayType.elementType);
+  }
+
+  @Override public int hashCode() {
+    return elementType.hashCode();
+  }
 }

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonWriterBuilder.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonWriterBuilder.java
@@ -414,8 +414,8 @@ public class CarbonWriterBuilder {
       tableName = "_tempTable";
       dbName = "_tempDB";
     } else {
-      dbName = null;
-      tableName = null;
+      dbName = "";
+      tableName = "_tempTable_" + String.valueOf(UUID);
     }
     TableSchema schema = tableSchemaBuilder.build();
     schema.setTableName(tableName);


### PR DESCRIPTION
**issue :**

1. Logger prints the threadname along with log. In case of sdk writer we are assigning null for dbname and table name and table name is used to assign the thread name in CarbonTableOutputFormat and DataWriterProcessStepImpl. which leads to add null in many logs.
2. Comparision of two array type was being wrong.

**Solution :**  
1. assign temp value with current time in millisec to tablename  instead of null.
2. `ArrayType` class donot contains `equls` method. Hence it goes to `Object.equals()` which will perform  `==` operation to compare both the object which is wrong . so add `equals` method to `ArrayType` class .


 - [x] Any interfaces changed? NO
 
 - [x] Any backward compatibility impacted? NO
 
 - [x] Document update required? No

 - [x] Testing done UT and sdv success report is sufficient
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.  NA

