### PR TITLE
[CARBONDATA-2476][DataMap] Fix bug in bloom datamap cache

### DIFF
--- a/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomDataMapCache.java
+++ b/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomDataMapCache.java
@@ -151,10 +151,10 @@ public class BloomDataMapCache implements Serializable {
       this.bloomDMCache.put(cacheKey, bloomDMModels);
       return bloomDMModels;
     } catch (ClassNotFoundException | IOException e) {
+      clear(cacheKey);
       LOGGER.error(e, "Error occurs while reading bloom index");
       throw new RuntimeException("Error occurs while reading bloom index", e);
     } finally {
-      clear();
       CarbonUtil.closeStreams(objectInStream, dataInStream);
     }
   }
@@ -191,10 +191,10 @@ public class BloomDataMapCache implements Serializable {
   /**
    * clear this cache
    */
-  private void clear() {
+  private void clear(CacheKey cacheKey) {
     LOGGER.info(String.format("Current meta cache statistic: %s", getCacheStatus()));
-    LOGGER.info("Trigger invalid all the cache for bloom datamap");
-    this.bloomDMCache.invalidateAll();
+    LOGGER.info("Trigger invalid cache for bloom datamap, key is " + cacheKey);
+    this.bloomDMCache.invalidate(cacheKey);
   }
 
   public static class CacheKey {


### PR DESCRIPTION
Since the cache is used by all bloomfilter datamaps, the cache will be evicted only for specified keys only if loading the specified cache is failed.
Previous bug will cause all the cache be evicted after it is loaded.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 `NO`
 - [x] Any backward compatibility impacted?
  `NO`
 - [x] Document update required?
 `NO`
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
`NO`
        - How it is tested? Please attach test report.
`Tested in local`
        - Is it a performance related change? Please attach the performance test report.
`After this PR, performance is as we expected`
        - Any additional information to help reviewers in testing this change.
       `NO`
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
`NO`
