### PR TITLE
[CARBONDATA-2479] Multiple issue fixes in SDK writer and external table flow

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/readcommitter/LatestFilesReadCommittedScope.java
+++ b/core/src/main/java/org/apache/carbondata/core/readcommitter/LatestFilesReadCommittedScope.java
@@ -138,7 +138,7 @@ public class LatestFilesReadCommittedScope implements ReadCommittedScope {
   @Override public void takeCarbonIndexFileSnapShot() throws IOException {
     // Read the current file Path get the list of indexes from the path.
     CarbonFile file = FileFactory.getCarbonFile(carbonFilePath);
-    if (file == null) {
+    if (file.listFiles().length == 0) {
       // For nonTransactional table, files can be removed at any point of time.
       // So cannot assume files will be present
       throw new IOException("No files are present in the table location :" + carbonFilePath);

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonDescribeFormattedCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonDescribeFormattedCommand.scala
@@ -86,12 +86,7 @@ private[sql] case class CarbonDescribeFormattedCommand(
     results ++= Seq(("Database Name", relation.carbonTable.getDatabaseName, "")
     )
     results ++= Seq(("Table Name", relation.carbonTable.getTableName, ""))
-    if (!carbonTable.isExternalTable) {
-      results ++= Seq(("CARBON Store Path ", CarbonProperties.getStorePath, ""))
-    } else {
-      // for external table should show files path.
-      results ++= Seq(("CARBON Store Path ", carbonTable.getTablePath, ""))
-    }
+    results ++= Seq(("CARBON Store Path ", carbonTable.getTablePath, ""))
 
     val tblProps = carbonTable.getTableInfo.getFactTable.getTableProperties
 

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/AvroCarbonWriter.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/AvroCarbonWriter.java
@@ -97,8 +97,9 @@ public class AvroCarbonWriter extends CarbonWriter {
         out = fieldValue;
         break;
       case FLOAT:
-        Float f = (Float) fieldValue;
-        out = f.doubleValue();
+        // direct conversion will change precision. So parse from string.
+        // also carbon internally needs float as double
+        out = Double.parseDouble(fieldValue.toString());
         break;
       case RECORD:
         List<Schema.Field> fields = avroField.schema().getFields();
@@ -121,7 +122,8 @@ public class AvroCarbonWriter extends CarbonWriter {
           arrayChildObjects = new Object[size];
           for (int i = 0; i < size; i++) {
             Object childObject = avroFieldToObject(
-                new Schema.Field(avroField.name(), avroField.schema().getElementType(), null, true),
+                new Schema.Field(avroField.name(), avroField.schema().getElementType(),
+                    avroField.doc(), avroField.defaultVal()),
                 ((GenericData.Array) fieldValue).get(i));
             if (childObject != null) {
               arrayChildObjects[i] = childObject;
@@ -132,8 +134,8 @@ public class AvroCarbonWriter extends CarbonWriter {
           arrayChildObjects = new Object[size];
           for (int i = 0; i < size; i++) {
             Object childObject = avroFieldToObject(
-                new Schema.Field(avroField.name(), avroField.schema().getElementType(), null, true),
-                ((ArrayList) fieldValue).get(i));
+                new Schema.Field(avroField.name(), avroField.schema().getElementType(),
+                    avroField.doc(), avroField.defaultVal()), ((ArrayList) fieldValue).get(i));
             if (childObject != null) {
               arrayChildObjects[i] = childObject;
             }

--- a/store/sdk/src/test/java/org/apache/carbondata/sdk/file/CarbonReaderTest.java
+++ b/store/sdk/src/test/java/org/apache/carbondata/sdk/file/CarbonReaderTest.java
@@ -162,7 +162,7 @@ public class CarbonReaderTest {
       i++;
     }
     Assert.assertEquals(i, 100);
-
+    reader.close();
     FileUtils.deleteDirectory(new File(path));
   }
 }


### PR DESCRIPTION
[CARBONDATA-2479] Multiple issues:
    fixed external table path display
    fixed default value for array in AVRO
    fixed NPE when delete folder before the second select query
    fixed: avro float value precision change issue


Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?NA
 
 - [ ] Any backward compatibility impacted?NA
 
 - [ ] Document update required?NA

 - [ ] Testing done
yes updated the UT

 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. NA

