### PR TITLE
 [CARBONDATA-2493] DataType.equals() failes for complex types 

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/metadata/datatype/ArrayType.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/datatype/ArrayType.java
@@ -39,10 +39,14 @@ public class ArrayType extends DataType {
     if (obj == null) {
       return false;
     }
-    if (!(obj instanceof ArrayType)) {
+    if (getClass() != obj.getClass()) {
       return false;
     }
-    if (!this.getName().equalsIgnoreCase(((ArrayType) obj).getName())) {
+    ArrayType other = (ArrayType) obj;
+    if (!this.getName().equalsIgnoreCase(other.getName())) {
+      return false;
+    }
+    if (!this.getElementType().equals(other.getElementType())) {
       return false;
     }
     return true;
@@ -53,10 +57,12 @@ public class ArrayType extends DataType {
     final int prime = 31;
     int result = 1;
     result = prime * result + getName().hashCode();
+    result = prime * result + getElementType().hashCode();
     return result;
   }
 
   public DataType getElementType() {
     return elementType;
   }
+
 }

--- a/core/src/main/java/org/apache/carbondata/core/metadata/datatype/DataType.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/datatype/DataType.java
@@ -115,4 +115,28 @@ public class DataType implements Serializable {
     }
   }
 
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + getName().hashCode();
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null) {
+      return false;
+    }
+    if (getClass() != obj.getClass()) {
+      return false;
+    }
+    if (!this.getName().equalsIgnoreCase(((DataType) obj).getName())) {
+      return false;
+    }
+    return true;
+  }
 }

--- a/core/src/main/java/org/apache/carbondata/core/metadata/datatype/DecimalType.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/datatype/DecimalType.java
@@ -37,16 +37,17 @@ public class DecimalType extends DataType {
     if (obj == null) {
       return false;
     }
-    if (!(obj instanceof DecimalType)) {
+    if (getClass() != obj.getClass()) {
       return false;
     }
-    if (!this.getName().equalsIgnoreCase(((DecimalType) obj).getName())) {
+    DecimalType other = (DecimalType)obj;
+    if (!this.getName().equalsIgnoreCase(other.getName())) {
       return false;
     }
-    if (this.precision != ((DecimalType) obj).precision) {
+    if (this.precision != other.precision) {
       return false;
     }
-    if (this.scale != ((DecimalType) obj).scale) {
+    if (this.scale != other.scale) {
       return false;
     }
     return true;
@@ -57,6 +58,8 @@ public class DecimalType extends DataType {
     final int prime = 31;
     int result = 1;
     result = prime * result + getName().hashCode();
+    result = prime * result + getPrecision();
+    result = prime * result + getScale();
     return result;
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/metadata/datatype/MapType.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/datatype/MapType.java
@@ -32,4 +32,38 @@ public class MapType extends DataType {
   public boolean isComplexType() {
     return true;
   }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null) {
+      return false;
+    }
+    if (getClass() != obj.getClass()) {
+      return false;
+    }
+    MapType other = (MapType) obj;
+    if (!this.getName().equalsIgnoreCase(other.getName())) {
+      return false;
+    }
+    if (!this.keyType.equals(other.keyType)) {
+      return false;
+    }
+    if (!this.valueType.equals(other.valueType)) {
+      return false;
+    }
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + getName().hashCode();
+    result = prime * result + keyType.hashCode();
+    result = prime * result + valueType.hashCode();
+    return result;
+  }
 }

--- a/core/src/main/java/org/apache/carbondata/core/metadata/datatype/StructField.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/datatype/StructField.java
@@ -54,4 +54,44 @@ public class StructField implements Serializable {
   public List<StructField> getChildren() {
     return children;
   }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + fieldName.hashCode();
+    result = prime * result + dataType.hashCode();
+    result = prime * result + ((children == null) ? 0 : children.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null) {
+      return false;
+    }
+    if (getClass() != obj.getClass()) {
+      return false;
+    }
+    StructField other = (StructField) obj;
+    if (!this.fieldName.equalsIgnoreCase(other.fieldName)) {
+      return false;
+    }
+    if (!this.dataType.equals(other.dataType)) {
+      return false;
+    }
+    if (children == null) {
+      if (other.children != null) {
+        return false;
+      }
+    } else if (other.children == null) {
+      return false;
+    } else if (!children.equals(other.children)) {
+      return false;
+    }
+    return true;
+  }
 }

--- a/core/src/main/java/org/apache/carbondata/core/metadata/datatype/StructType.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/datatype/StructType.java
@@ -41,10 +41,14 @@ public class StructType extends DataType {
     if (obj == null) {
       return false;
     }
-    if (!(obj instanceof StructType)) {
+    if (getClass() != obj.getClass()) {
       return false;
     }
-    if (!this.getName().equalsIgnoreCase(((StructType) obj).getName())) {
+    StructType other = (StructType) obj;
+    if (!this.getName().equalsIgnoreCase(other.getName())) {
+      return false;
+    }
+    if (!this.getFields().equals(other.getFields())) {
       return false;
     }
     return true;
@@ -55,6 +59,7 @@ public class StructType extends DataType {
     final int prime = 31;
     int result = 1;
     result = prime * result + getName().hashCode();
+    result = prime * result + getFields().hashCode();
     return result;
   }
 


### PR DESCRIPTION
problem : 
[CARBONDATA-2493] DataType.equals() failes for complex types

root cause : Complex types equals method was not implemented. Just the object's equals was used

Solution: Add a equals method for all the complex type

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?NO
 
 - [ ] Any backward compatibility impacted?NA
 
 - [ ] Document update required?NA

 - [ ] Testing done
Same test cases with complex type are ran
     
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

