### PR TITLE
[CARBONDATA-2472] Fixed:Refactor NonTransactional table code for Index file IO performance

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/indexstore/BlockletDataMapIndexStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/BlockletDataMapIndexStore.java
@@ -95,7 +95,8 @@ public class BlockletDataMapIndexStore
         } else {
           // if the identifier is a merge file then collect the index files and load the datamaps
           List<TableBlockIndexUniqueIdentifier> tableBlockIndexUniqueIdentifiers =
-              BlockletDataMapUtil.getIndexFileIdentifiersFromMergeFile(identifier, indexFileStore);
+              BlockletDataMapUtil.getIndexFileIdentifiersFromMergeFile(identifier, indexFileStore,
+                  identifier.getTableUniqueName());
           for (TableBlockIndexUniqueIdentifier blockIndexUniqueIdentifier :
               tableBlockIndexUniqueIdentifiers) {
             Map<String, BlockMetaInfo> blockMetaInfoMap = BlockletDataMapUtil

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/TableBlockIndexUniqueIdentifier.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/TableBlockIndexUniqueIdentifier.java
@@ -37,12 +37,16 @@ public class TableBlockIndexUniqueIdentifier implements Serializable {
 
   private String segmentId;
 
+  // contains a table uniqueName, this can be used to fetch table from MetaStore
+  private String tableUniqueName;
+
   public TableBlockIndexUniqueIdentifier(String indexFilePath, String indexFileName,
-      String mergeIndexFileName, String segmentId) {
+      String mergeIndexFileName, String segmentId, String tableUniqueName) {
     this.indexFilePath = indexFilePath;
     this.indexFileName = indexFileName;
     this.mergeIndexFileName = mergeIndexFileName;
     this.segmentId = segmentId;
+    this.tableUniqueName = tableUniqueName;
   }
 
   /**
@@ -68,6 +72,10 @@ public class TableBlockIndexUniqueIdentifier implements Serializable {
 
   public String getSegmentId() {
     return segmentId;
+  }
+
+  public String getTableUniqueName() {
+    return tableUniqueName;
   }
 
   @Override public boolean equals(Object o) {

--- a/core/src/test/java/org/apache/carbondata/core/indexstore/blockletindex/TestBlockletDataMapFactory.java
+++ b/core/src/test/java/org/apache/carbondata/core/indexstore/blockletindex/TestBlockletDataMapFactory.java
@@ -77,7 +77,8 @@ public class TestBlockletDataMapFactory {
         CacheProvider.getInstance().createCache(CacheType.DRIVER_BLOCKLET_DATAMAP));
     tableBlockIndexUniqueIdentifier =
         new TableBlockIndexUniqueIdentifier("/opt/store/default/carbon_table/Fact/Part0/Segment_0",
-            "0_batchno0-0-1521012756709.carbonindex", null, "0");
+            "0_batchno0-0-1521012756709.carbonindex", null, "0",
+            absoluteTableIdentifier.getCarbonTableIdentifier().getTableUniqueName());
     cache = CacheProvider.getInstance().createCache(CacheType.DRIVER_BLOCKLET_DATAMAP);
   }
 
@@ -108,11 +109,12 @@ public class TestBlockletDataMapFactory {
     dataMapDistributables.add(blockletDataMapDistributable1);
     new MockUp<BlockletDataMapFactory>() {
       @Mock Set<TableBlockIndexUniqueIdentifier> getTableBlockIndexUniqueIdentifiers(
-          Segment segment) {
+          Segment segment, String tableUniqueName) {
         TableBlockIndexUniqueIdentifier tableBlockIndexUniqueIdentifier1 =
             new TableBlockIndexUniqueIdentifier(
                 "/opt/store/default/carbon_table/Fact/Part0/Segment_0",
-                "0_batchno0-0-1521012756701.carbonindex", null, "0");
+                "0_batchno0-0-1521012756701.carbonindex", null, "0",
+                absoluteTableIdentifier.getCarbonTableIdentifier().getTableUniqueName());
         Set<TableBlockIndexUniqueIdentifier> tableBlockIndexUniqueIdentifiers = new HashSet<>(3);
         tableBlockIndexUniqueIdentifiers.add(tableBlockIndexUniqueIdentifier);
         tableBlockIndexUniqueIdentifiers.add(tableBlockIndexUniqueIdentifier1);

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestNonTransactionalCarbonTable.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestNonTransactionalCarbonTable.scala
@@ -971,7 +971,14 @@ class TestNonTransactionalCarbonTable extends QueryTest with BeforeAndAfterAll {
       sql("select * from sdkOutputTable").show(false)
     }
     assert(exception.getMessage()
-      .contains("All the files doesn't have same schema"))
+      .contains("Problem in loading segment blocks."))
+
+    val exception1 =
+      intercept[IOException] {
+        sql("select count(*) from sdkOutputTable").show(false)
+      }
+    assert(exception1.getMessage()
+      .contains("Problem in loading segment blocks."))
 
     sql("DROP TABLE sdkOutputTable")
     // drop table should not delete the files
@@ -1003,7 +1010,7 @@ class TestNonTransactionalCarbonTable extends QueryTest with BeforeAndAfterAll {
         sql("select * from sdkOutputTable").show(false)
       }
     assert(exception.getMessage()
-      .contains("All the files doesn't have same schema"))
+      .contains("Problem in loading segment blocks."))
 
 
     sql("DROP TABLE sdkOutputTable")


### PR DESCRIPTION
[CARBONDATA-2472] Fixed:Refactor NonTransactional table code for Index file IO performance

problem:  For NonTransactional table, for each query, 2 times IO happens (one time for actual blocklet load and one time for validation of schema) This results in more IO time.

Solution: At the time of blocklet load itself do the validation. So, IO will be only one time.

 - [ ] Any interfaces changed? NA
 
 - [ ] Any backward compatibility impacted? NA

 - [ ] Document update required? NA

 - [ ] Testing done
Already UT for this scenarios       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. NA

