### PR TITLE
[CARBONDATA-2496] Changed to hadoop bloom implementation and added compress option to compress bloom on disk.

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMapFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMapFactory.java
@@ -18,6 +18,7 @@ package org.apache.carbondata.core.indexstore.blockletindex;
 
 import java.io.IOException;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.carbondata.core.cache.Cache;
 import org.apache.carbondata.core.cache.CacheProvider;
@@ -78,7 +79,7 @@ public class BlockletDataMapFactory extends CoarseGrainDataMapFactory
   private AbsoluteTableIdentifier identifier;
 
   // segmentId -> list of index file
-  private Map<String, Set<TableBlockIndexUniqueIdentifier>> segmentMap = new HashMap<>();
+  private Map<String, Set<TableBlockIndexUniqueIdentifier>> segmentMap = new ConcurrentHashMap<>();
 
   private Cache<TableBlockIndexUniqueIdentifier, BlockletDataMapIndexWrapper> cache;
 
@@ -279,7 +280,7 @@ public class BlockletDataMapFactory extends CoarseGrainDataMapFactory
   }
 
   @Override
-  public void clear() {
+  public synchronized void clear() {
     if (segmentMap.size() > 0) {
       for (String segmentId : segmentMap.keySet().toArray(new String[segmentMap.size()])) {
         clear(new Segment(segmentId, null, null));

--- a/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomCoarseGrainDataMapFactory.java
+++ b/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomCoarseGrainDataMapFactory.java
@@ -28,6 +28,7 @@ import org.apache.carbondata.common.annotations.InterfaceAudience;
 import org.apache.carbondata.common.exceptions.sql.MalformedDataMapCommandException;
 import org.apache.carbondata.common.logging.LogService;
 import org.apache.carbondata.common.logging.LogServiceFactory;
+import org.apache.carbondata.core.constants.CarbonV3DataFormatConstants;
 import org.apache.carbondata.core.datamap.DataMapDistributable;
 import org.apache.carbondata.core.datamap.DataMapLevel;
 import org.apache.carbondata.core.datamap.DataMapMeta;
@@ -68,7 +69,8 @@ public class BloomCoarseGrainDataMapFactory extends DataMapFactory<CoarseGrainDa
   /**
    * default size for bloom filter, cardinality of the column.
    */
-  private static final int DEFAULT_BLOOM_FILTER_SIZE = Short.MAX_VALUE;
+  private static final int DEFAULT_BLOOM_FILTER_SIZE =
+      CarbonV3DataFormatConstants.NUMBER_OF_ROWS_PER_BLOCKLET_COLUMN_PAGE_DEFAULT;
   /**
    * property for fpp(false-positive-probability) of bloom filter
    */
@@ -175,9 +177,8 @@ public class BloomCoarseGrainDataMapFactory extends DataMapFactory<CoarseGrainDa
   }
 
   /**
-   * validate bloom DataMap BLOOM_FPP
-   * 1. BLOOM_FPP property is optional, 0.00001 will be the default value.
-   * 2. BLOOM_FPP should be (0, 1)
+   * validate bloom DataMap COMPRESS_BLOOM
+   * Default value is true
    */
   private boolean validateAndGetBloomCompress(DataMapSchema dmSchema) {
     String bloomCompress = dmSchema.getProperties().get(COMPRESS_BLOOM);

--- a/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomDMModel.java
+++ b/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomDMModel.java
@@ -16,22 +16,29 @@
  */
 package org.apache.carbondata.datamap.bloom;
 
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
 import java.io.Serializable;
 
 import org.apache.carbondata.common.annotations.InterfaceAudience;
 
-import com.google.common.hash.BloomFilter;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.util.bloom.BloomFilter;
+import org.apache.hadoop.util.bloom.CarbonBloomFilter;
 
 /**
  * This class holds a bloom filter for one blocklet
  */
 @InterfaceAudience.Internal
-public class BloomDMModel implements Serializable {
-  private static final long serialVersionUID = 7281578747306832771L;
+public class BloomDMModel implements Writable {
   private int blockletNo;
-  private BloomFilter<byte[]> bloomFilter;
+  private CarbonBloomFilter bloomFilter;
 
-  public BloomDMModel(int blockletNo, BloomFilter<byte[]> bloomFilter) {
+  public BloomDMModel() {
+  }
+
+  public BloomDMModel(int blockletNo, CarbonBloomFilter bloomFilter) {
     this.blockletNo = blockletNo;
     this.bloomFilter = bloomFilter;
   }
@@ -40,15 +47,29 @@ public class BloomDMModel implements Serializable {
     return blockletNo;
   }
 
-  public BloomFilter<byte[]> getBloomFilter() {
+  public BloomFilter getBloomFilter() {
     return bloomFilter;
   }
 
-  @Override public String toString() {
+  @Override
+  public String toString() {
     final StringBuilder sb = new StringBuilder("BloomDMModel{");
     sb.append(", blockletNo=").append(blockletNo);
     sb.append(", bloomFilter=").append(bloomFilter);
     sb.append('}');
     return sb.toString();
+  }
+
+  @Override
+  public void write(DataOutput out) throws IOException {
+    out.writeInt(blockletNo);
+    bloomFilter.write(out);
+  }
+
+  @Override
+  public void readFields(DataInput in) throws IOException {
+    blockletNo = in.readInt();
+    bloomFilter = new CarbonBloomFilter();
+    bloomFilter.readFields(in);
   }
 }

--- a/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomDMModel.java
+++ b/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomDMModel.java
@@ -19,12 +19,10 @@ package org.apache.carbondata.datamap.bloom;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
-import java.io.Serializable;
 
 import org.apache.carbondata.common.annotations.InterfaceAudience;
 
 import org.apache.hadoop.io.Writable;
-import org.apache.hadoop.util.bloom.BloomFilter;
 import org.apache.hadoop.util.bloom.CarbonBloomFilter;
 
 /**
@@ -47,7 +45,7 @@ public class BloomDMModel implements Writable {
     return blockletNo;
   }
 
-  public BloomFilter getBloomFilter() {
+  public CarbonBloomFilter getBloomFilter() {
     return bloomFilter;
   }
 

--- a/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomDataMapBuilder.java
+++ b/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomDataMapBuilder.java
@@ -29,6 +29,8 @@ import org.apache.carbondata.core.metadata.datatype.DataTypes;
 import org.apache.carbondata.core.metadata.schema.table.column.CarbonColumn;
 import org.apache.carbondata.core.util.CarbonUtil;
 
+import org.apache.hadoop.util.bloom.Key;
+
 /**
  * Implementation for BloomFilter DataMap to rebuild the datamap for main table with existing data
  */
@@ -36,10 +38,10 @@ import org.apache.carbondata.core.util.CarbonUtil;
 public class BloomDataMapBuilder extends BloomDataMapWriter implements DataMapBuilder {
 
   BloomDataMapBuilder(String tablePath, String dataMapName, List<CarbonColumn> indexColumns,
-      Segment segment, String shardName, int bloomFilterSize, double bloomFilterFpp)
-      throws IOException {
-    super(tablePath, dataMapName, indexColumns, segment, shardName,
-        bloomFilterSize, bloomFilterFpp);
+      Segment segment, String shardName, int bloomFilterSize, double bloomFilterFpp,
+      boolean bloomCompress) throws IOException {
+    super(tablePath, dataMapName, indexColumns, segment, shardName, bloomFilterSize, bloomFilterFpp,
+        bloomCompress);
   }
 
   @Override
@@ -70,7 +72,7 @@ public class BloomDataMapBuilder extends BloomDataMapWriter implements DataMapBu
       } else {
         indexValue = CarbonUtil.getValueAsBytes(dataType, data);
       }
-      indexBloomFilters.get(i).put(indexValue);
+      indexBloomFilters.get(i).add(new Key(indexValue));
     }
   }
 

--- a/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomDataMapCache.java
+++ b/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomDataMapCache.java
@@ -19,7 +19,6 @@ package org.apache.carbondata.datamap.bloom;
 import java.io.DataInputStream;
 import java.io.EOFException;
 import java.io.IOException;
-import java.io.ObjectInputStream;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -133,15 +132,14 @@ public class BloomDataMapCache implements Serializable {
    */
   private List<BloomDMModel> loadBloomDataMapModel(CacheKey cacheKey) {
     DataInputStream dataInStream = null;
-    ObjectInputStream objectInStream = null;
     List<BloomDMModel> bloomDMModels = new ArrayList<BloomDMModel>();
     try {
       String indexFile = getIndexFileFromCacheKey(cacheKey);
       dataInStream = FileFactory.getDataInputStream(indexFile, FileFactory.getFileType(indexFile));
-      objectInStream = new ObjectInputStream(dataInStream);
       try {
-        BloomDMModel model = null;
-        while ((model = (BloomDMModel) objectInStream.readObject()) != null) {
+        while (dataInStream.available() > 0) {
+          BloomDMModel model = new BloomDMModel();
+          model.readFields(dataInStream);
           bloomDMModels.add(model);
         }
       } catch (EOFException e) {
@@ -150,12 +148,12 @@ public class BloomDataMapCache implements Serializable {
       }
       this.bloomDMCache.put(cacheKey, bloomDMModels);
       return bloomDMModels;
-    } catch (ClassNotFoundException | IOException e) {
+    } catch (IOException e) {
       clear(cacheKey);
       LOGGER.error(e, "Error occurs while reading bloom index");
       throw new RuntimeException("Error occurs while reading bloom index", e);
     } finally {
-      CarbonUtil.closeStreams(objectInStream, dataInStream);
+      CarbonUtil.closeStreams(dataInStream);
     }
   }
 

--- a/datamap/bloom/src/main/java/org/apache/hadoop/util/bloom/CarbonBloomFilter.java
+++ b/datamap/bloom/src/main/java/org/apache/hadoop/util/bloom/CarbonBloomFilter.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.util.bloom;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.BitSet;
+
+import org.roaringbitmap.RoaringBitmap;
+
+public class CarbonBloomFilter extends BloomFilter {
+
+  private RoaringBitmap bitmap;
+
+  private boolean compress;
+
+  public CarbonBloomFilter() {
+  }
+
+  public CarbonBloomFilter(int vectorSize, int nbHash, int hashType, boolean compress) {
+    super(vectorSize, nbHash, hashType);
+    this.compress = compress;
+  }
+
+  @Override
+  public boolean membershipTest(Key key) {
+    if (key == null) {
+      throw new NullPointerException("key cannot be null");
+    }
+
+    int[] h = hash.hash(key);
+    hash.clear();
+    if (compress) {
+      for (int i = 0; i < nbHash; i++) {
+        if (!bitmap.contains(h[i])) {
+          return false;
+        }
+      }
+    } else {
+      for (int i = 0; i < nbHash; i++) {
+        if (!bits.get(h[i])) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  @Override
+  public void write(DataOutput out) throws IOException {
+    out.writeInt(this.nbHash);
+    out.writeByte(this.hashType);
+    out.writeInt(this.vectorSize);
+    out.writeBoolean(compress);
+    if (!compress) {
+      byte[] bytes = bits.toByteArray();
+      out.writeInt(bytes.length);
+      out.write(bytes);
+    } else {
+      RoaringBitmap bitmap = new RoaringBitmap();
+      int length = bits.cardinality();
+      int nextSetBit = bits.nextSetBit(0);
+      for (int i = 0; i < length; ++i) {
+        bitmap.add(nextSetBit);
+        nextSetBit = bits.nextSetBit(nextSetBit + 1);
+      }
+      bitmap.serialize(out);
+    }
+  }
+
+  @Override
+  public void readFields(DataInput in) throws IOException {
+    this.nbHash = in.readInt();
+    this.hashType = in.readByte();
+    this.vectorSize = in.readInt();
+    this.compress = in.readBoolean();
+    if (!compress) {
+      int len = in.readInt();
+      byte[] bytes = new byte[len];
+      in.readFully(bytes);
+      this.bits = BitSet.valueOf(bytes);
+    } else {
+      this.bitmap = new RoaringBitmap();
+      bitmap.deserialize(in);
+    }
+    this.hash = new HashFunction(this.vectorSize, this.nbHash, this.hashType);
+  }
+}

--- a/datamap/bloom/src/main/java/org/apache/hadoop/util/bloom/CarbonBloomFilter.java
+++ b/datamap/bloom/src/main/java/org/apache/hadoop/util/bloom/CarbonBloomFilter.java
@@ -23,6 +23,10 @@ import java.util.BitSet;
 
 import org.roaringbitmap.RoaringBitmap;
 
+/**
+ * It is the extendable class to hadoop bloomfilter, it is extendable to implement compressed bloom
+ * and fast serialize and deserialize of bloom.
+ */
 public class CarbonBloomFilter extends BloomFilter {
 
   private RoaringBitmap bitmap;
@@ -46,6 +50,7 @@ public class CarbonBloomFilter extends BloomFilter {
     int[] h = hash.hash(key);
     hash.clear();
     if (compress) {
+      // If it is compressed check in roaring bitmap
       for (int i = 0; i < nbHash; i++) {
         if (!bitmap.contains(h[i])) {
           return false;


### PR DESCRIPTION
This PR removes the guava bloom and adds the hadoop bloom. And also added the compress bloom option to compress bloom on disk and in memory as well.
The user can use `bloom_compress` property to enable/disable compression. By default, it is enabled.
Please check the performance of bloom
Loaded 100 million data with bloom datamap on a column with a cardinality of 5 million with 'BLOOM_SIZE'='5000000', 'bloom_fpp'='0.001' .

Guava
-----------------------------
DataMap Size : 233.6 MB
Fisrt Read : 4.981 sec
Second Read: 0.541 sec

Hadoop
-----------------------------------
DataMap Size : 224.7 MB
Fisrt Read : 4.829 sec
Second Read: 0.555 sec

Haoop with compression
------------------------------------
DataMap Size : 98.8 MB
Fisrt Read : 4.984 sec
Second Read: 0.621 sec

As per the above readings compressed Hadoop implementation gives optimal performance in terms of space and read.Thats why compress is made as default.

Here RoaringBitMap is used internally for compressing the bloom so it s not only space efficient on disk and also efficient in memory.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 
 - [x] Any backward compatibility impacted?
 
 - [x] Document update required?

 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

