### PR TITLE
[CARBONDATA-2499][Test] Validate the visible/invisible status of datamap

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datamap/CGDataMapTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datamap/CGDataMapTestCase.scala
@@ -393,87 +393,70 @@ class CGDataMapTestCase extends QueryTest with BeforeAndAfterAll {
     sql(s"DROP TABLE IF EXISTS $tableName")
     sql(
       s"""
-        | CREATE TABLE $tableName(id INT, name STRING, city STRING, age INT)
-        | STORED BY 'org.apache.carbondata.format'
-        | TBLPROPERTIES('SORT_COLUMNS'='city,name', 'SORT_SCOPE'='LOCAL_SORT')
+         | CREATE TABLE $tableName(id INT, name STRING, city STRING, age INT)
+         | STORED BY 'org.apache.carbondata.format'
+         | TBLPROPERTIES('SORT_COLUMNS'='city,name', 'SORT_SCOPE'='LOCAL_SORT')
       """.stripMargin)
-    // register datamap writer
-    sql(s"create datamap $dataMapName1 on table $tableName using '${classOf[CGDataMapFactory].getName}' DMPROPERTIES('index_columns'='name')")
-    sql(s"create datamap $dataMapName2 on table $tableName using '${classOf[CGDataMapFactory].getName}' DMPROPERTIES('index_columns'='city')")
-    sql(s"LOAD DATA LOCAL INPATH '$file2' INTO TABLE $tableName OPTIONS('header'='false')")
-
-    // make datamap1 invisible
-    sql(s"set ${CarbonCommonConstants.CARBON_DATAMAP_VISIBLE}default.$tableName.$dataMapName1 = false")
-    checkAnswer(sql(s"select * from $tableName where name='n502670' and city='c2670'"),
-      sql("select * from normal_test where name='n502670' and city='c2670'"))
-
-    // also make datamap2 invisible
-    sql(s"set ${CarbonCommonConstants.CARBON_DATAMAP_VISIBLE}default.$tableName.$dataMapName2 = false")
-    checkAnswer(sql(s"select * from $tableName where name='n502670' and city='c2670'"),
-      sql("select * from normal_test where name='n502670' and city='c2670'"))
-
-    // make datamap1,datamap2 visible
-    sql(s"set ${CarbonCommonConstants.CARBON_DATAMAP_VISIBLE}default.$tableName.$dataMapName1 = true")
-    sql(s"set ${CarbonCommonConstants.CARBON_DATAMAP_VISIBLE}default.$tableName.$dataMapName1 = true")
-    checkAnswer(sql(s"select * from $tableName where name='n502670' and city='c2670'"),
-      sql("select * from normal_test where name='n502670' and city='c2670'"))
-  }
-
-  test("test cg datamap and validate the visible and invisible status of datamap ") {
-    val tableName = "datamap_test2"
-    val dataMapName1 = "ggdatamap1";
-    sql(s"DROP TABLE IF EXISTS $tableName")
-    sql(
-      s"""
-        | CREATE TABLE $tableName(id INT, name STRING, city STRING, age INT)
-        | STORED BY 'org.apache.carbondata.format'
-        | TBLPROPERTIES('SORT_COLUMNS'='city,name', 'SORT_SCOPE'='LOCAL_SORT')
-      """.stripMargin)
-    val table = CarbonMetadata.getInstance().getCarbonTable("default_datamap_test")
     // register datamap writer
     sql(
       s"""
-         | CREATE DATAMAP ggdatamap1 ON TABLE $tableName
+         | CREATE DATAMAP $dataMapName1
+         | ON TABLE $tableName
          | USING '${classOf[CGDataMapFactory].getName}'
          | DMPROPERTIES('index_columns'='name')
-       """.stripMargin)
+      """.stripMargin)
     sql(
       s"""
-         | CREATE DATAMAP ggdatamap2 ON TABLE $tableName
+         | CREATE DATAMAP $dataMapName2
+         | ON TABLE $tableName
          | USING '${classOf[CGDataMapFactory].getName}'
          | DMPROPERTIES('index_columns'='city')
        """.stripMargin)
     sql(s"LOAD DATA LOCAL INPATH '$file2' INTO TABLE $tableName OPTIONS('header'='false')")
+    val df1 = sql(s"EXPLAIN EXTENDED SELECT * FROM $tableName WHERE name='n502670' AND city='c2670'").collect()
+    assert(df1(0).getString(0).contains("CG DataMap"))
+    assert(df1(0).getString(0).contains(dataMapName1))
+    val e11 = intercept[Exception] {
+      assert(df1(0).getString(0).contains(dataMapName2))
+    }
+    assert(e11.getMessage.contains("did not contain \"" + dataMapName2))
 
-    val df1 = sql(s"EXPLAIN EXTENDED SELECT * FROM $tableName WHERE name='n502670'").collect()
-    assertResult(
-      s"""== CarbonData Profiler ==
-        |Table Scan on $tableName
-        | - total blocklets: 1
-        | - filter: (name <> null and name = n502670)
-        | - pruned by Main DataMap
-        |    - skipped blocklets: 0
-        | - pruned by CG DataMap
-        |    - name: ggdatamap1
-        |    - provider: org.apache.carbondata.spark.testsuite.datamap.CGDataMapFactory
-        |    - skipped blocklets: 0
-        |""".stripMargin)(df1(0).getString(0))
-
-    sql(s"set ${CarbonCommonConstants.CARBON_DATAMAP_VISIBLE}default.$tableName.$dataMapName1 = false")
-
-    val df2 = sql(s"EXPLAIN EXTENDED SELECT * FROM $tableName WHERE name='n502670'").collect()
-    assertResult(
-      s"""== CarbonData Profiler ==
-        |Table Scan on $tableName
-        | - total blocklets: 1
-        | - filter: (name <> null and name = n502670)
-        | - pruned by Main DataMap
-        |    - skipped blocklets: 0
-        |""".stripMargin)(df2(0).getString(0))
-
+    // make datamap1 invisible
+    sql(s"SET ${CarbonCommonConstants.CARBON_DATAMAP_VISIBLE}default.$tableName.$dataMapName1 = false")
+    val df2 = sql(s"EXPLAIN EXTENDED SELECT * FROM $tableName WHERE name='n502670' AND city='c2670'").collect()
+    val e = intercept[Exception] {
+      assert(df2(0).getString(0).contains(dataMapName1))
+    }
+    assert(e.getMessage.contains("did not contain \"" + dataMapName1))
+    assert(df2(0).getString(0).contains(dataMapName2))
     checkAnswer(sql(s"SELECT * FROM $tableName WHERE name='n502670' AND city='c2670'"),
-      sql(s"SELECT * FROM $tableName WHERE name='n502670' AND city='c2670'"))
-    sql(s"DROP TABLE IF EXISTS $tableName")
+      sql("SELECT * FROM normal_test WHERE name='n502670' AND city='c2670'"))
+
+    // also make datamap2 invisible
+    sql(s"SET ${CarbonCommonConstants.CARBON_DATAMAP_VISIBLE}default.$tableName.$dataMapName2 = false")
+    checkAnswer(sql(s"SELECT * FROM $tableName WHERE name='n502670' AND city='c2670'"),
+      sql("SELECT * FROM normal_test WHERE name='n502670' AND city='c2670'"))
+    val df3 = sql(s"EXPLAIN EXTENDED SELECT * FROM $tableName WHERE name='n502670' AND city='c2670'").collect()
+    val e31 = intercept[Exception] {
+      assert(df3(0).getString(0).contains(dataMapName1))
+    }
+    assert(e31.getMessage.contains("did not contain \"" + dataMapName1))
+    val e32 = intercept[Exception] {
+      assert(df3(0).getString(0).contains(dataMapName2))
+    }
+    assert(e32.getMessage.contains("did not contain \"" + dataMapName2))
+
+    // make datamap1,datamap2 visible
+    sql(s"SET ${CarbonCommonConstants.CARBON_DATAMAP_VISIBLE}default.$tableName.$dataMapName1 = true")
+    sql(s"SET ${CarbonCommonConstants.CARBON_DATAMAP_VISIBLE}default.$tableName.$dataMapName1 = true")
+    checkAnswer(sql(s"SELECT * FROM $tableName WHERE name='n502670' AND city='c2670'"),
+      sql("SELECT * FROM normal_test WHERE name='n502670' AND city='c2670'"))
+    val df4 = sql(s"EXPLAIN EXTENDED SELECT * FROM $tableName WHERE name='n502670' AND city='c2670'").collect()
+    assert(df4(0).getString(0).contains(dataMapName1))
+    val e41 = intercept[Exception] {
+      assert(df3(0).getString(0).contains(dataMapName2))
+    }
+    assert(e41.getMessage.contains("did not contain \"" + dataMapName2))
   }
 
   test("test datamap storage in system folder") {

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datamap/CGDataMapTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datamap/CGDataMapTestCase.scala
@@ -22,7 +22,6 @@ import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 
 import com.sun.xml.internal.messaging.saaj.util.ByteOutputStream
-import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.test.util.QueryTest
 import org.scalatest.BeforeAndAfterAll
 
@@ -474,6 +473,7 @@ class CGDataMapTestCase extends QueryTest with BeforeAndAfterAll {
 
     checkAnswer(sql(s"SELECT * FROM $tableName WHERE name='n502670' AND city='c2670'"),
       sql(s"SELECT * FROM $tableName WHERE name='n502670' AND city='c2670'"))
+    sql(s"DROP TABLE IF EXISTS $tableName")
   }
 
   test("test datamap storage in system folder") {

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datamap/FGDataMapTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datamap/FGDataMapTestCase.scala
@@ -480,7 +480,7 @@ class FGDataMapTestCase extends QueryTest with BeforeAndAfterAll {
   }
 
   test("test invisible datamap during query") {
-    val tableName = "datamap_test"
+    val tableName = "datamap_testFG"
     val dataMapName1 = "datamap1"
     val dataMapName2 = "datamap2"
     sql(s"DROP TABLE IF EXISTS $tableName")
@@ -556,5 +556,6 @@ class FGDataMapTestCase extends QueryTest with BeforeAndAfterAll {
     CompactionSupportGlobalSortBigFileTest.deleteFile(file2)
     sql("DROP TABLE IF EXISTS normal_test")
     sql("DROP TABLE IF EXISTS datamap_test")
+    sql("DROP TABLE IF EXISTS datamap_testFG")
   }
 }

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datamap/FGDataMapTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datamap/FGDataMapTestCase.scala
@@ -481,6 +481,61 @@ class FGDataMapTestCase extends QueryTest with BeforeAndAfterAll {
       sql("select * from normal_test where name='n502670' and city='c2670'"))
   }
 
+  test("test fg datamap and validate the visible and invisible status of datamap ") {
+    sql("DROP TABLE IF EXISTS datamap_test")
+    sql(
+      """
+        | CREATE TABLE datamap_test(id INT, name STRING, city STRING, age INT)
+        | STORED BY 'org.apache.carbondata.format'
+        | TBLPROPERTIES('SORT_COLUMNS'='city,name', 'SORT_SCOPE'='LOCAL_SORT')
+      """.stripMargin)
+    val table = CarbonMetadata.getInstance().getCarbonTable("default_datamap_test")
+    // register datamap writer
+    sql(
+      s"""
+         | CREATE DATAMAP ggdatamap1 ON TABLE datamap_test
+         | USING '${classOf[FGDataMapFactory].getName}'
+         | DMPROPERTIES('index_columns'='name')
+       """.stripMargin)
+    sql(
+      s"""
+         | CREATE DATAMAP ggdatamap2 ON TABLE datamap_test
+         | USING '${classOf[FGDataMapFactory].getName}'
+         | DMPROPERTIES('index_columns'='city')
+       """.stripMargin)
+    sql(s"LOAD DATA LOCAL INPATH '$file2' INTO TABLE datamap_test OPTIONS('header'='false')")
+
+    val tableName = "datamap_test";
+    val dataMapName1 = "ggdatamap1";
+    val df1 = sql("EXPLAIN EXTENDED SELECT * FROM datamap_test WHERE name='n502670'").collect()
+    assertResult(
+      """== CarbonData Profiler ==
+        |Table Scan on datamap_test
+        | - total blocklets: 1
+        | - filter: (name <> null and name = n502670)
+        | - pruned by Main DataMap
+        |    - skipped blocklets: 0
+        | - pruned by FG DataMap
+        |    - name: ggdatamap1
+        |    - provider: org.apache.carbondata.spark.testsuite.datamap.FGDataMapFactory
+        |    - skipped blocklets: 0
+        |""".stripMargin)(df1(0).getString(0))
+
+    sql(s"set ${CarbonCommonConstants.CARBON_DATAMAP_VISIBLE}default.$tableName.$dataMapName1 = false")
+    val df2 = sql("EXPLAIN EXTENDED SELECT * FROM datamap_test WHERE name='n502670'").collect()
+    assertResult(
+      """== CarbonData Profiler ==
+        |Table Scan on datamap_test
+        | - total blocklets: 1
+        | - filter: (name <> null and name = n502670)
+        | - pruned by Main DataMap
+        |    - skipped blocklets: 0
+        |""".stripMargin)(df2(0).getString(0))
+
+    checkAnswer(sql("SELECT * FROM datamap_test WHERE name='n502670' AND city='c2670'"),
+      sql("SELECT * FROM normal_test WHERE name='n502670' AND city='c2670'"))
+  }
+
   override protected def afterAll(): Unit = {
     CompactionSupportGlobalSortBigFileTest.deleteFile(file2)
     sql("DROP TABLE IF EXISTS normal_test")

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datamap/FGDataMapTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datamap/FGDataMapTestCase.scala
@@ -22,12 +22,10 @@ import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 
 import com.sun.xml.internal.messaging.saaj.util.ByteOutputStream
+import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.spark.sql.test.util.QueryTest
 import org.scalatest.BeforeAndAfterAll
 
-import org.apache.carbondata.core.datamap.{DataMapDistributable, DataMapMeta}
-import org.apache.carbondata.core.datamap.Segment
-import org.apache.carbondata.core.datamap.dev.{DataMapModel, DataMapBuilder, DataMapWriter}
 import org.apache.carbondata.core.datamap.{DataMapDistributable, DataMapMeta, Segment}
 import org.apache.carbondata.core.datamap.dev.{DataMapModel, DataMapBuilder, DataMapWriter}
 import org.apache.carbondata.core.datamap.dev.fgdatamap.{FineGrainBlocklet, FineGrainDataMap, FineGrainDataMapFactory}
@@ -534,6 +532,7 @@ class FGDataMapTestCase extends QueryTest with BeforeAndAfterAll {
 
     checkAnswer(sql("SELECT * FROM datamap_test WHERE name='n502670' AND city='c2670'"),
       sql("SELECT * FROM normal_test WHERE name='n502670' AND city='c2670'"))
+    sql("DROP TABLE IF EXISTS datamap_test")
   }
 
   override protected def afterAll(): Unit = {

--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/DataLoadFailAllTypeSortTest.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/DataLoadFailAllTypeSortTest.scala
@@ -17,8 +17,6 @@
 
 package org.apache.spark.carbondata
 
-import java.io.File
-
 import org.apache.spark.sql.common.util.Spark2QueryTest
 import org.apache.spark.sql.hive.HiveContext
 import org.scalatest.BeforeAndAfterAll
@@ -28,8 +26,6 @@ import org.apache.carbondata.core.util.CarbonProperties
 
 /**
  * Test Class for detailed query on timestamp datatypes
- *
- *
  */
 class DataLoadFailAllTypeSortTest extends Spark2QueryTest with BeforeAndAfterAll {
   var hiveContext: HiveContext = _


### PR DESCRIPTION

This jira https://issues.apache.org/jira/browse/CARBONDATA-2380 not check the visible/invisible status of datamap.  There will not thro exception when the related code changed and affect visible/invisible status of datamap.  So we should add some test case for this function.

When I develop https://github.com/apache/carbondata/pull/2290, carbon don't throw exception when I change the org.apache.carbondata.core.datamap.DataMapStoreManager#getAllVisibleDataMap
Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 No
 - [x] Any backward compatibility impacted?
 No
 - [x] Document update required?
No
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       add some test cases
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
No