### PR TITLE
[CARBONDATA-2503] Data write fails if empty value is provided for sort columns in sdk is fixed

### DIFF
--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonWriterBuilder.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonWriterBuilder.java
@@ -383,7 +383,7 @@ public class CarbonWriterBuilder {
     }
 
     List<String> sortColumnsList = new ArrayList<>();
-    if (sortColumns == null) {
+    if (sortColumns == null || sortColumns.length == 0) {
       // If sort columns are not specified, default set all dimensions to sort column.
       // When dimensions are default set to sort column,
       // Inverted index will be supported by default for sort columns.


### PR DESCRIPTION
**Issue  =>** SortColumn with empty value was giving exception.
**Sol :** sort-columns existence is checked in schema fields . for empty sort-column name it will not find any column in schema. so check the empty value of sortColumns list.

 - [x] Any interfaces changed? No
 
 - [x] Any backward compatibility impacted? No
 
 - [x] Document update required? No

 - [x] Testing done ==> UT added
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. NA

