### PR TITLE
[HOTFIX] Implementing getMemorySize in BlockletDataMapIndexWrapper

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/indexstore/BlockletDataMapIndexWrapper.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/BlockletDataMapIndexWrapper.java
@@ -30,8 +30,16 @@ public class BlockletDataMapIndexWrapper implements Cacheable, Serializable {
 
   private List<BlockletDataMap> dataMaps;
 
+  // size of the wrapper. basically the total size of the datamaps this wrapper is holding
+  private long wrapperSize;
+
   public BlockletDataMapIndexWrapper(List<BlockletDataMap> dataMaps) {
     this.dataMaps = dataMaps;
+    this.wrapperSize = 0L;
+    // add the size of each and every datamap in this wrapper
+    for (BlockletDataMap dataMap : dataMaps) {
+      this.wrapperSize += dataMap.getMemorySize();
+    }
   }
 
   @Override public long getFileTimeStamp() {
@@ -43,7 +51,7 @@ public class BlockletDataMapIndexWrapper implements Cacheable, Serializable {
   }
 
   @Override public long getMemorySize() {
-    return 0;
+    return wrapperSize;
   }
 
   public List<BlockletDataMap> getDataMaps() {


### PR DESCRIPTION
Implementing getMemorySize in BlockletDataMapIndexWrapper and using it everywhere required.

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

