### PR TITLE
[CARBONDATA-2524] Support create carbonReader with default projection

### DIFF
--- a/docs/sdk-guide.md
+++ b/docs/sdk-guide.md
@@ -493,7 +493,7 @@ Find example code at [CarbonReaderExample](https://github.com/apache/carbondata/
 
 ```
   /**
-   * Projected all Columns for carbon reader
+   * Project all Columns for carbon reader
    *
    * @return CarbonReaderBuilder object
    * @throws IOException

--- a/docs/sdk-guide.md
+++ b/docs/sdk-guide.md
@@ -493,6 +493,16 @@ Find example code at [CarbonReaderExample](https://github.com/apache/carbondata/
 
 ```
   /**
+   * Projected all Columns for carbon reader
+   *
+   * @return CarbonReaderBuilder object
+   * @throws IOException
+   */
+  public CarbonReaderBuilder projectAllColumns();
+```
+
+```
+  /**
    * Configure the transactional status of table
    * If set to false, then reads the carbondata and carbonindex files from a flat folder structure.
    * If set to true, then reads the carbondata and carbonindex files from segment folder structure.

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonReaderBuilder.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonReaderBuilder.java
@@ -50,8 +50,12 @@ public class CarbonReaderBuilder {
   private Expression filterExpression;
   private String tableName;
   private boolean isTransactionalTable = true;
-  // it will be true if use the projectAllColumns method
-  private boolean isProjectAllColumns = false;
+
+  /**
+   * It will be true if use the projectAllColumns method，
+   * it will be false if use the projection method
+   */
+  private boolean isProjectAllColumns = true;
 
   /**
    * Construct a CarbonReaderBuilder with table path and table name
@@ -73,6 +77,7 @@ public class CarbonReaderBuilder {
   public CarbonReaderBuilder projection(String[] projectionColumnNames) {
     Objects.requireNonNull(projectionColumnNames);
     this.projectionColumns = projectionColumnNames;
+    isProjectAllColumns = false;
     return this;
   }
 

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonReaderBuilder.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonReaderBuilder.java
@@ -50,6 +50,8 @@ public class CarbonReaderBuilder {
   private Expression filterExpression;
   private String tableName;
   private boolean isTransactionalTable = true;
+  // it will be true if use the projectAllColumns method
+  private boolean isProjectAllColumns = false;
 
   /**
    * Construct a CarbonReaderBuilder with table path and table name
@@ -112,6 +114,7 @@ public class CarbonReaderBuilder {
       projectionColumns[i] = columnName;
       i++;
     }
+    isProjectAllColumns = true;
     return this;
   }
 
@@ -213,7 +216,7 @@ public class CarbonReaderBuilder {
     if (filterExpression != null) {
       format.setFilterPredicates(job.getConfiguration(), filterExpression);
     }
-    if (projectionColumns == null) {
+    if (isProjectAllColumns) {
       projectAllColumns();
     }
     format.setColumnProjection(job.getConfiguration(), new CarbonProjection(projectionColumns));

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonReaderBuilder.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonReaderBuilder.java
@@ -92,7 +92,7 @@ public class CarbonReaderBuilder {
   }
 
   /**
-   * Projected all Columns for carbon reader
+   * Project all Columns for carbon reader
    *
    * @return CarbonReaderBuilder object
    * @throws IOException

--- a/store/sdk/src/test/java/org/apache/carbondata/sdk/file/CarbonReaderTest.java
+++ b/store/sdk/src/test/java/org/apache/carbondata/sdk/file/CarbonReaderTest.java
@@ -409,4 +409,76 @@ public class CarbonReaderTest extends TestCase {
         badRecordLoc);
   }
 
+  @Test
+  public void testReadFilesWithProjectAllColumns() throws IOException, InterruptedException {
+    String path = "./testWriteFiles";
+    FileUtils.deleteDirectory(new File(path));
+
+    Field[] fields = new Field[2];
+    fields[0] = new Field("name", DataTypes.STRING);
+    fields[1] = new Field("age", DataTypes.INT);
+
+    TestUtil.writeFilesAndVerify(new Schema(fields), path, true);
+
+    CarbonReader reader = CarbonReader
+        .builder(path, "_temp")
+        .projectAllColumns()
+        .build();
+
+    // expected output after sorting
+    String[] name = new String[100];
+    int[] age = new int[100];
+    for (int i = 0; i < 100; i++) {
+      name[i] = "robot" + (i / 10);
+      age[i] = (i % 10) * 10 + i / 10;
+    }
+
+    int i = 0;
+    while (reader.hasNext()) {
+      Object[] row = (Object[]) reader.readNextRow();
+      // Default sort column is applied for dimensions. So, need  to validate accordingly
+      Assert.assertEquals(name[i], row[0]);
+      Assert.assertEquals(age[i], row[1]);
+      i++;
+    }
+    Assert.assertEquals(i, 100);
+
+    reader.close();
+    FileUtils.deleteDirectory(new File(path));
+  }
+
+  @Test
+  public void testReadFilesWithDefaultProjection() throws IOException, InterruptedException {
+    String path = "./testWriteFiles";
+    FileUtils.deleteDirectory(new File(path));
+
+    Field[] fields = new Field[2];
+    fields[0] = new Field("name", DataTypes.STRING);
+    fields[1] = new Field("age", DataTypes.INT);
+
+    TestUtil.writeFilesAndVerify(new Schema(fields), path, true);
+
+    CarbonReader reader = CarbonReader
+        .builder(path, "_temp")
+        .build();
+
+    // expected output after sorting
+    String[] name = new String[100];
+    int[] age = new int[100];
+    for (int i = 0; i < 100; i++) {
+      name[i] = "robot" + (i / 10);
+      age[i] = (i % 10) * 10 + i / 10;
+    }
+    // Default sort column is applied for dimensions. So, need  to validate accordingly
+
+    int i = 0;
+    while (reader.hasNext()) {
+      Object[] row = (Object[]) reader.readNextRow();
+      // Default sort column is applied for dimensions. So, need  to validate accordingly
+      Assert.assertEquals(name[i], row[0]);
+      Assert.assertEquals(age[i], row[1]);
+      i++;
+    }
+    Assert.assertEquals(i, 100);
+  }
 }

--- a/store/sdk/src/test/java/org/apache/carbondata/sdk/file/CarbonReaderTest.java
+++ b/store/sdk/src/test/java/org/apache/carbondata/sdk/file/CarbonReaderTest.java
@@ -448,7 +448,7 @@ public class CarbonReaderTest extends TestCase {
   }
 
   @Test
-  public void testReadFilesWithDefaultProjection() throws IOException, InterruptedException {
+  public void testReadFilesWithNullProjection() throws IOException, InterruptedException {
     String path = "./testWriteFiles";
     FileUtils.deleteDirectory(new File(path));
 
@@ -460,6 +460,7 @@ public class CarbonReaderTest extends TestCase {
 
     CarbonReader reader = CarbonReader
         .builder(path, "_temp")
+        .projection(new String[]{})
         .build();
 
     // expected output after sorting
@@ -471,14 +472,9 @@ public class CarbonReaderTest extends TestCase {
     }
     // Default sort column is applied for dimensions. So, need  to validate accordingly
 
-    int i = 0;
     while (reader.hasNext()) {
       Object[] row = (Object[]) reader.readNextRow();
-      // Default sort column is applied for dimensions. So, need  to validate accordingly
-      Assert.assertEquals(name[i], row[0]);
-      Assert.assertEquals(age[i], row[1]);
-      i++;
+      assert(row.length==0);
     }
-    Assert.assertEquals(i, 100);
   }
 }

--- a/store/sdk/src/test/java/org/apache/carbondata/sdk/file/CarbonReaderTest.java
+++ b/store/sdk/src/test/java/org/apache/carbondata/sdk/file/CarbonReaderTest.java
@@ -448,6 +448,39 @@ public class CarbonReaderTest extends TestCase {
   }
 
   @Test
+  public void testReadFilesWithDefaultProjection() throws IOException, InterruptedException {
+    String path = "./testWriteFiles";
+    FileUtils.deleteDirectory(new File(path));
+
+    Field[] fields = new Field[2];
+    fields[0] = new Field("name", DataTypes.STRING);
+    fields[1] = new Field("age", DataTypes.INT);
+
+    TestUtil.writeFilesAndVerify(new Schema(fields), path, true);
+
+    CarbonReader reader = CarbonReader
+        .builder(path, "_temp")
+        .build();
+
+    // expected output after sorting
+    String[] name = new String[100];
+    int[] age = new int[100];
+    for (int i = 0; i < 100; i++) {
+      name[i] = "robot" + (i / 10);
+      age[i] = (i % 10) * 10 + i / 10;
+    }
+
+    int i = 0;
+    while (reader.hasNext()) {
+      Object[] row = (Object[]) reader.readNextRow();
+      Assert.assertEquals(name[i], row[0]);
+      Assert.assertEquals(age[i], row[1]);
+      i++;
+    }
+    Assert.assertEquals(i, 100);
+  }
+
+  @Test
   public void testReadFilesWithNullProjection() throws IOException, InterruptedException {
     String path = "./testWriteFiles";
     FileUtils.deleteDirectory(new File(path));


### PR DESCRIPTION
1.Support  create carbonReader with default projection, like:
`  CarbonReader reader = CarbonReader.builder(path, "_temp").build();
`
2.Add projectAllColumns method, like:
`  CarbonReader reader = CarbonReader.builder(path, "_temp")
        . projectAllColumns().build();
`
Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 NA
 - [x] Any backward compatibility impacted?
 NO
 - [x] Document update required?
NA
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       Yes, add some test case.
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
No