### PR TITLE
[CARBONDATA-2529] Fixed S3 Issue for Hadoop 2.8.3

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/HDFSCarbonFile.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/HDFSCarbonFile.java
@@ -120,7 +120,8 @@ public class HDFSCarbonFile extends AbstractDFSCarbonFile {
         ((DistributedFileSystem) fs).rename(fileStatus.getPath(), new Path(changetoName),
             org.apache.hadoop.fs.Options.Rename.OVERWRITE);
         return true;
-      } else if (fileStatus.getPath().toString().startsWith("s3n")) {
+      } else if (fileStatus.getPath().toString().startsWith("s3n")
+          || fileStatus.getPath().toString().startsWith("s3a")) {
         fs.delete(new Path(changetoName), true);
         return fs.rename(fileStatus.getPath(), new Path(changetoName));
       } else {


### PR DESCRIPTION
This issue fixes the issue while loading the data with S3 as backend.

 - [ N] Any interfaces changed?
 
 - [N ] Any backward compatibility impacted?
 
 - [ N] Document update required?

 - [Y ] Testing done


