### PR TITLE
[CARBONDATA-2569] Change the strategy of Search mode throw exception and run sparkSQL

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSession.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSession.scala
@@ -101,8 +101,8 @@ class CarbonSession(@transient val sc: SparkContext,
           } catch {
             case e: Exception =>
               logError(String.format(
-                "Exception when executing search mode: %s, fallback to SparkSQL", e.getMessage))
-              new Dataset[Row](self, qe, RowEncoder(qe.analyzed.schema))
+                "Exception when executing search mode: %s", e.getMessage))
+              throw e;
           }
         } else {
           new Dataset[Row](self, qe, RowEncoder(qe.analyzed.schema))

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSession.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSession.scala
@@ -187,7 +187,8 @@ class CarbonSession(@transient val sc: SparkContext,
         runSearch(analyzed, columns, expr, logicalRelation, gl.maxRows, ll.maxRows)
       case _ =>
         LOG.info(String.format(
-          "Search service started, but don't support: %s, and running it with SparkSQL", sse.sqlText))
+          "Search service started, but don't support: %s, and running it with SparkSQL",
+          sse.sqlText))
         new Dataset[Row](self, qe, RowEncoder(qe.analyzed.schema))
     }
   }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSession.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSession.scala
@@ -170,20 +170,20 @@ class CarbonSession(@transient val sc: SparkContext,
    */
   private def trySearchMode(qe: QueryExecution, sse: SQLStart): DataFrame = {
     val analyzed = qe.analyzed
-    val LOG: LogService = LogServiceFactory.getLogService(classOf[CarbonSession].getName)
+    val LOG: LogService = LogServiceFactory.getLogService(this.getClass.getName)
     analyzed match {
       case _@Project(columns, _@Filter(expr, s: SubqueryAlias))
         if s.child.isInstanceOf[LogicalRelation] &&
            s.child.asInstanceOf[LogicalRelation].relation
              .isInstanceOf[CarbonDatasourceHadoopRelation] =>
-        LOG.info(s"Search service started and supports: ${sse.sqlText}")
+        LOG.info(s"Search service started and supports filter: ${sse.sqlText}")
         runSearch(analyzed, columns, expr, s.child.asInstanceOf[LogicalRelation])
       case gl@GlobalLimit(_, ll@LocalLimit(_, p@Project(columns, _@Filter(expr, s: SubqueryAlias))))
         if s.child.isInstanceOf[LogicalRelation] &&
            s.child.asInstanceOf[LogicalRelation].relation
              .isInstanceOf[CarbonDatasourceHadoopRelation] =>
         val logicalRelation = s.child.asInstanceOf[LogicalRelation]
-        LOG.info(s"Search service started and supports: ${sse.sqlText}")
+        LOG.info(s"Search service started and supports limit: ${sse.sqlText}")
         runSearch(analyzed, columns, expr, logicalRelation, gl.maxRows, ll.maxRows)
       case _ =>
         LOG.info(s"Search service started, but don't support: ${sse.sqlText}," +

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSession.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSession.scala
@@ -176,19 +176,18 @@ class CarbonSession(@transient val sc: SparkContext,
         if s.child.isInstanceOf[LogicalRelation] &&
            s.child.asInstanceOf[LogicalRelation].relation
              .isInstanceOf[CarbonDatasourceHadoopRelation] =>
-        LOG.info(String.format("Search service started and supports: %s", sse.sqlText))
+        LOG.info(s"Search service started and supports: ${sse.sqlText}")
         runSearch(analyzed, columns, expr, s.child.asInstanceOf[LogicalRelation])
       case gl@GlobalLimit(_, ll@LocalLimit(_, p@Project(columns, _@Filter(expr, s: SubqueryAlias))))
         if s.child.isInstanceOf[LogicalRelation] &&
            s.child.asInstanceOf[LogicalRelation].relation
              .isInstanceOf[CarbonDatasourceHadoopRelation] =>
         val logicalRelation = s.child.asInstanceOf[LogicalRelation]
-        LOG.info(String.format("Search service started and supports: %s", sse.sqlText))
+        LOG.info(s"Search service started and supports: ${sse.sqlText}")
         runSearch(analyzed, columns, expr, logicalRelation, gl.maxRows, ll.maxRows)
       case _ =>
-        LOG.info(String.format(
-          "Search service started, but don't support: %s, and running it with SparkSQL",
-          sse.sqlText))
+        LOG.info(s"Search service started, but don't support: ${sse.sqlText}," +
+          s" and will run it with SparkSQL")
         new Dataset[Row](self, qe, RowEncoder(qe.analyzed.schema))
     }
   }


### PR DESCRIPTION
 Search mode throw exception but test case pass, please check the jira.

This PR:
1. change the strategy of Search mode throw exception and run sparkSQL, remove the run the sparkSQL after search mode has exception
2. add some log for recording search service supports and don't supports sql
 - [X] Any interfaces changed?
 NO
 - [X] Any backward compatibility impacted?
 No
 - [X] Document update required?
No
 - [X] Testing done
 run test case searchModeTestCase
 - [X] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
No