### PR TITLE
[CARBONDATA-2578] fixed memory leak inside CarbonReader and handled failure case for creation of multi reader for non-transactional table 

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestNonTransactionalCarbonTable.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestNonTransactionalCarbonTable.scala
@@ -368,8 +368,9 @@ class TestNonTransactionalCarbonTable extends QueryTest with BeforeAndAfterAll {
          |'carbondata' LOCATION
          |'$writerPath' """.stripMargin)
 
-    checkExistence(sql("describe formatted sdkOutputTable"), true, "age")
-
+    checkExistence(sql("describe formatted sdkOutputTable"), true, "SORT_COLUMNS                        age")
+    checkExistence(sql("describe formatted sdkOutputTable"), false, "SORT_COLUMNS                        name,age")
+    checkExistence(sql("describe formatted sdkOutputTable"), false, "SORT_COLUMNS                        age,name")
     buildTestDataSingleFile()
     assert(new File(writerPath).exists())
     sql("DROP TABLE IF EXISTS sdkOutputTable")
@@ -402,7 +403,7 @@ class TestNonTransactionalCarbonTable extends QueryTest with BeforeAndAfterAll {
     intercept[RuntimeException] {
       buildTestDataWithSortColumns(List(""))
     }
-    
+
     assert(!(new File(writerPath).exists()))
     cleanTestData()
   }

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonReader.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonReader.java
@@ -74,6 +74,8 @@ public class CarbonReader<T> {
         return false;
       } else {
         index++;
+        // current reader is closed
+        currentReader.close();
         currentReader = readers.get(index);
         return currentReader.nextKeyValue();
       }

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonWriterBuilder.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonWriterBuilder.java
@@ -484,11 +484,6 @@ public class CarbonWriterBuilder {
           if (isSortColumn > -1) {
             columnSchema.setSortColumn(true);
             sortColumnsSchemaList[isSortColumn] = columnSchema;
-          } else if (!sortColumnsList.isEmpty() && columnSchema.isDimensionColumn()
-              && columnSchema.getNumberOfChild() < 1) {
-            columnSchema.setSortColumn(true);
-            sortColumnsSchemaList[i] = columnSchema;
-            i++;
           }
         }
       }


### PR DESCRIPTION
**Issue :** 
1. CarbonIterator inside CarbonRecordReader was keeping reference of RowBatch and it is not being closed inside CarbonRecordReader.
2. sort_column with measure was considering all the dimension column along with given column.
3. if creation of one CarbonReader for non transactional table is failed then we are not able to create another CarbonReader.

**Solution :** 
1. close() called inside hasNext() to clear the previous iterator before iterating over the next CarbonReader..
2. if sortcolumn is not empty and sortcolumnsList contains the fields check is added to finally in sortcolumn props.
3. Clear the datamap in catch block, if creation of CarbonReader is failed.

 - [x] Any interfaces changed? No
 
 - [x] Any backward compatibility impacted? No
 
 - [x] Document update required? No

 - [x] Testing done Yes
Test Step : 
1. After closing the carbonReader object took heapDump
2. Observed count of RowBatch object is zero now.

 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.  NA

