### PR TITLE
[CARBONDATA-2592][Integration] Getting NoSuchMethod error due to aws sdk multple version jar conflicts

### DIFF
--- a/integration/spark2/pom.xml
+++ b/integration/spark2/pom.xml
@@ -103,25 +103,6 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk</artifactId>
-      <version>1.7.4</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-core</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-annotations</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-databind</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>net.java.dev.jets3t</groupId>
       <artifactId>jets3t</artifactId>
       <version>0.9.0</version>


### PR DESCRIPTION
```
## What changes were proposed in this pull request?
Currently in Carbon Spark2 project multiple dependency for the aws-sdk jar has been defined,this will create issue when we build carbon-assembly jars with
latest versions of hadoop/spark project. As part of hadoop-aws project, already aws-sdk 1.10.6 version jar will be fetched, since in the carbon-spark2 pom.xml
there is an explicit dependency defined/hardcoded for aws-sdk 1.7.4(old version)  this can lead to conflicts while loading the class files. because of this problem
when we run any carbon examples passing carbon-assembly jars as the argument using spark-submit  none of the testcases will work.
As a solution we can remove this dependency(aws-sdk 1.7.4) as already hadoop-aws dependency defined in the pom.xml of carbon-spark2 project
will fetch the latest aws-sdk jars.

## How was this patch tested?
After updating the pom, manually projects has been build and the use-case mentioned above  is manually tested.```


