### PR TITLE
[CARBONDATA-2601] Support column with varchar type in DDL as longstring

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -883,6 +883,7 @@ public final class CarbonCommonConstants {
   public static final String COLUMN_GROUPS = "column_groups";
   public static final String DICTIONARY_EXCLUDE = "dictionary_exclude";
   public static final String DICTIONARY_INCLUDE = "dictionary_include";
+  public static final String LONG_STRING_COLUMNS = "long_string_columns";
   /**
    * key for dictionary path
    */
@@ -1568,6 +1569,8 @@ public final class CarbonCommonConstants {
   // As Short data type is used for storing the length of a column during data processing hence
   // the maximum characters that can be supported should be less than Short max value
   public static final int MAX_CHARS_PER_COLUMN_DEFAULT = 32000;
+  // todo: use infinity first, will switch later
+  public static final int MAX_CHARS_PER_COLUMN_INFINITY = -1;
 
   /**
    * Enabling page level reader for compaction reduces the memory usage while compacting more

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/impl/FixedLengthDimensionColumnPage.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/impl/FixedLengthDimensionColumnPage.java
@@ -47,7 +47,7 @@ public class FixedLengthDimensionColumnPage extends AbstractDimensionColumnPage 
         dataChunk.length;
     dataChunkStore = DimensionChunkStoreFactory.INSTANCE
         .getDimensionChunkStore(columnValueSize, isExplicitSorted, numberOfRows, totalSize,
-            DimensionStoreType.FIXEDLENGTH);
+            DimensionStoreType.FIXED_LENGTH);
     dataChunkStore.putArray(invertedIndex, invertedIndexReverse, dataChunk);
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/impl/VariableLengthDimensionColumnPage.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/impl/VariableLengthDimensionColumnPage.java
@@ -32,7 +32,7 @@ public class VariableLengthDimensionColumnPage extends AbstractDimensionColumnPa
    * Constructor for this class
    */
   public VariableLengthDimensionColumnPage(byte[] dataChunks, int[] invertedIndex,
-      int[] invertedIndexReverse, int numberOfRows, boolean isTextEncoded) {
+      int[] invertedIndexReverse, int numberOfRows, boolean isVarcharEncoded) {
     boolean isExplicitSorted = isExplicitSorted(invertedIndex);
     long totalSize = null != invertedIndex ?
         (dataChunks.length + (2 * numberOfRows * CarbonCommonConstants.INT_SIZE_IN_BYTE) + (
@@ -40,7 +40,7 @@ public class VariableLengthDimensionColumnPage extends AbstractDimensionColumnPa
         (dataChunks.length + (numberOfRows * CarbonCommonConstants.INT_SIZE_IN_BYTE));
     dataChunkStore = DimensionChunkStoreFactory.INSTANCE
         .getDimensionChunkStore(0, isExplicitSorted, numberOfRows, totalSize,
-            isTextEncoded ?
+            isVarcharEncoded ?
                 DimensionStoreType.VARIABLE_INT_LENGTH :
                 DimensionStoreType.VARIABLE_SHORT_LENGTH);
     dataChunkStore.putArray(invertedIndex, invertedIndexReverse, dataChunks);

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/impl/VariableLengthDimensionColumnPage.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/impl/VariableLengthDimensionColumnPage.java
@@ -30,21 +30,19 @@ public class VariableLengthDimensionColumnPage extends AbstractDimensionColumnPa
 
   /**
    * Constructor for this class
-   * @param dataChunks
-   * @param invertedIndex
-   * @param invertedIndexReverse
-   * @param numberOfRows
    */
   public VariableLengthDimensionColumnPage(byte[] dataChunks, int[] invertedIndex,
-      int[] invertedIndexReverse, int numberOfRows) {
+      int[] invertedIndexReverse, int numberOfRows, boolean isTextEncoded) {
     boolean isExplicitSorted = isExplicitSorted(invertedIndex);
-    long totalSize = isExplicitSorted ?
+    long totalSize = null != invertedIndex ?
         (dataChunks.length + (2 * numberOfRows * CarbonCommonConstants.INT_SIZE_IN_BYTE) + (
             numberOfRows * CarbonCommonConstants.INT_SIZE_IN_BYTE)) :
         (dataChunks.length + (numberOfRows * CarbonCommonConstants.INT_SIZE_IN_BYTE));
     dataChunkStore = DimensionChunkStoreFactory.INSTANCE
         .getDimensionChunkStore(0, isExplicitSorted, numberOfRows, totalSize,
-            DimensionStoreType.VARIABLELENGTH);
+            isTextEncoded ?
+                DimensionStoreType.VARIABLE_INT_LENGTH :
+                DimensionStoreType.VARIABLE_SHORT_LENGTH);
     dataChunkStore.putArray(invertedIndex, invertedIndexReverse, dataChunks);
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/reader/dimension/v1/CompressedDimensionChunkFileBasedReaderV1.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/reader/dimension/v1/CompressedDimensionChunkFileBasedReaderV1.java
@@ -151,7 +151,7 @@ public class CompressedDimensionChunkFileBasedReaderV1 extends AbstractChunkRead
         .hasEncoding(dataChunk.getEncodingList(), Encoding.DICTIONARY)) {
       columnDataChunk =
           new VariableLengthDimensionColumnPage(dataPage, invertedIndexes, invertedIndexesReverse,
-              numberOfRows);
+              numberOfRows, false);
     } else {
       // to store fixed length column chunk values
       columnDataChunk =

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/reader/dimension/v2/CompressedDimensionChunkFileBasedReaderV2.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/reader/dimension/v2/CompressedDimensionChunkFileBasedReaderV2.java
@@ -175,7 +175,7 @@ public class CompressedDimensionChunkFileBasedReaderV2 extends AbstractChunkRead
     if (!hasEncoding(dimensionColumnChunk.encoders, Encoding.DICTIONARY)) {
       columnDataChunk =
           new VariableLengthDimensionColumnPage(dataPage, invertedIndexes, invertedIndexesReverse,
-              numberOfRows);
+              numberOfRows, false);
     } else {
       // to store fixed length column chunk values
       columnDataChunk =

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/reader/dimension/v3/CompressedDimensionChunkFileBasedReaderV3.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/reader/dimension/v3/CompressedDimensionChunkFileBasedReaderV3.java
@@ -274,7 +274,7 @@ public class CompressedDimensionChunkFileBasedReaderV3 extends AbstractChunkRead
       columnDataChunk =
           new VariableLengthDimensionColumnPage(dataPage, invertedIndexes, invertedIndexesReverse,
               pageMetadata.getNumberOfRowsInpage(),
-              hasEncoding(pageMetadata.encoders, Encoding.DIRECT_COMPRESS_TEXT));
+              hasEncoding(pageMetadata.encoders, Encoding.DIRECT_COMPRESS_VARCHAR));
     } else {
       // to store fixed length column chunk values
       columnDataChunk =

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/reader/dimension/v3/CompressedDimensionChunkFileBasedReaderV3.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/reader/dimension/v3/CompressedDimensionChunkFileBasedReaderV3.java
@@ -273,7 +273,8 @@ public class CompressedDimensionChunkFileBasedReaderV3 extends AbstractChunkRead
     if (!hasEncoding(pageMetadata.encoders, Encoding.DICTIONARY)) {
       columnDataChunk =
           new VariableLengthDimensionColumnPage(dataPage, invertedIndexes, invertedIndexesReverse,
-              pageMetadata.getNumberOfRowsInpage());
+              pageMetadata.getNumberOfRowsInpage(),
+              hasEncoding(pageMetadata.encoders, Encoding.DIRECT_COMPRESS_TEXT));
     } else {
       // to store fixed length column chunk values
       columnDataChunk =

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/DimensionChunkStoreFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/DimensionChunkStoreFactory.java
@@ -19,9 +19,11 @@ package org.apache.carbondata.core.datastore.chunk.store;
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.datastore.chunk.store.impl.safe.SafeFixedLengthDimensionDataChunkStore;
-import org.apache.carbondata.core.datastore.chunk.store.impl.safe.SafeVariableLengthDimensionDataChunkStore;
+import org.apache.carbondata.core.datastore.chunk.store.impl.safe.SafeVariableIntLengthDimensionDataChunkStore;
+import org.apache.carbondata.core.datastore.chunk.store.impl.safe.SafeVariableShortLengthDimensionDataChunkStore;
 import org.apache.carbondata.core.datastore.chunk.store.impl.unsafe.UnsafeFixedLengthDimensionDataChunkStore;
-import org.apache.carbondata.core.datastore.chunk.store.impl.unsafe.UnsafeVariableLengthDimensionDataChunkStore;
+import org.apache.carbondata.core.datastore.chunk.store.impl.unsafe.UnsafeVariableIntLengthDimensionDataChunkStore;
+import org.apache.carbondata.core.datastore.chunk.store.impl.unsafe.UnsafeVariableShortLengthDimensionDataChunkStore;
 import org.apache.carbondata.core.util.CarbonProperties;
 
 /**
@@ -63,19 +65,23 @@ public class DimensionChunkStoreFactory {
       boolean isInvertedIndex, int numberOfRows, long totalSize, DimensionStoreType storeType) {
 
     if (isUnsafe) {
-      if (storeType == DimensionStoreType.FIXEDLENGTH) {
+      if (storeType == DimensionStoreType.FIXED_LENGTH) {
         return new UnsafeFixedLengthDimensionDataChunkStore(totalSize, columnValueSize,
             isInvertedIndex, numberOfRows);
+      } else if (storeType == DimensionStoreType.VARIABLE_SHORT_LENGTH) {
+        return new UnsafeVariableShortLengthDimensionDataChunkStore(totalSize, isInvertedIndex,
+            numberOfRows);
       } else {
-        return new UnsafeVariableLengthDimensionDataChunkStore(totalSize, isInvertedIndex,
+        return new UnsafeVariableIntLengthDimensionDataChunkStore(totalSize, isInvertedIndex,
             numberOfRows);
       }
-
     } else {
-      if (storeType == DimensionStoreType.FIXEDLENGTH) {
+      if (storeType == DimensionStoreType.FIXED_LENGTH) {
         return new SafeFixedLengthDimensionDataChunkStore(isInvertedIndex, columnValueSize);
+      } else if (storeType == DimensionStoreType.VARIABLE_SHORT_LENGTH) {
+        return new SafeVariableShortLengthDimensionDataChunkStore(isInvertedIndex, numberOfRows);
       } else {
-        return new SafeVariableLengthDimensionDataChunkStore(isInvertedIndex, numberOfRows);
+        return new SafeVariableIntLengthDimensionDataChunkStore(isInvertedIndex, numberOfRows);
       }
     }
   }
@@ -84,6 +90,6 @@ public class DimensionChunkStoreFactory {
    * dimension store type enum
    */
   public enum DimensionStoreType {
-    FIXEDLENGTH, VARIABLELENGTH;
+    FIXED_LENGTH, VARIABLE_SHORT_LENGTH, VARIABLE_INT_LENGTH;
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/safe/SafeVariableIntLengthDimensionDataChunkStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/safe/SafeVariableIntLengthDimensionDataChunkStore.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.core.datastore.chunk.store.impl.safe;
+
+import java.nio.ByteBuffer;
+
+import org.apache.carbondata.core.constants.CarbonCommonConstants;
+
+/**
+ * Below class is responsible to store variable long length(>32000) dimension data chunk in
+ * memory. Memory occupied can be on heap or offheap using unsafe interface
+ */
+public class SafeVariableIntLengthDimensionDataChunkStore
+    extends SafeVariableLengthDimensionDataChunkStore {
+  public SafeVariableIntLengthDimensionDataChunkStore(boolean isInvertedIndex, int numberOfRows) {
+    super(isInvertedIndex, numberOfRows);
+  }
+
+  @Override
+  protected int getLengthSize() {
+    return CarbonCommonConstants.INT_SIZE_IN_BYTE;
+  }
+
+  @Override
+  protected int getLengthFromBuffer(ByteBuffer buffer) {
+    return buffer.getInt();
+  }
+}

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/safe/SafeVariableShortLengthDimensionDataChunkStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/safe/SafeVariableShortLengthDimensionDataChunkStore.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.core.datastore.chunk.store.impl.safe;
+
+import java.nio.ByteBuffer;
+
+import org.apache.carbondata.core.constants.CarbonCommonConstants;
+
+/**
+ * Below class is responsible to store variable long length(>32000) dimension data chunk in
+ * memory. Memory occupied can be on heap or offheap using unsafe interface
+ */
+public class SafeVariableShortLengthDimensionDataChunkStore
+    extends SafeVariableLengthDimensionDataChunkStore {
+  public SafeVariableShortLengthDimensionDataChunkStore(boolean isInvertedIndex, int numberOfRows) {
+    super(isInvertedIndex, numberOfRows);
+  }
+
+  @Override protected int getLengthSize() {
+    return CarbonCommonConstants.SHORT_SIZE_IN_BYTE;
+  }
+
+  @Override protected int getLengthFromBuffer(ByteBuffer buffer) {
+    return buffer.getShort();
+  }
+}

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/unsafe/UnsafeVariableIntLengthDimensionDataChunkStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/unsafe/UnsafeVariableIntLengthDimensionDataChunkStore.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.core.datastore.chunk.store.impl.unsafe;
+
+import java.nio.ByteBuffer;
+
+import org.apache.carbondata.core.constants.CarbonCommonConstants;
+
+/**
+ * Below class is responsible to store variable length dimension data chunk in
+ * memory Memory occupied can be on heap or offheap using unsafe interface
+ */
+public class UnsafeVariableIntLengthDimensionDataChunkStore
+    extends UnsafeVariableLengthDimensionDataChunkStore {
+  public UnsafeVariableIntLengthDimensionDataChunkStore(long totalSize, boolean isInvertedIdex,
+      int numberOfRows) {
+    super(totalSize, isInvertedIdex, numberOfRows);
+  }
+
+  @Override
+  protected int getLengthSize() {
+    return CarbonCommonConstants.INT_SIZE_IN_BYTE;
+  }
+
+  @Override
+  protected int getLengthFromBuffer(ByteBuffer byteBuffer) {
+    return byteBuffer.getInt();
+  }
+}

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/unsafe/UnsafeVariableShortLengthDimensionDataChunkStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/unsafe/UnsafeVariableShortLengthDimensionDataChunkStore.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.core.datastore.chunk.store.impl.unsafe;
+
+import java.nio.ByteBuffer;
+
+import org.apache.carbondata.core.constants.CarbonCommonConstants;
+
+/**
+ * Below class is responsible to store variable length dimension data chunk in
+ * memory Memory occupied can be on heap or offheap using unsafe interface
+ */
+public class UnsafeVariableShortLengthDimensionDataChunkStore
+    extends UnsafeVariableLengthDimensionDataChunkStore {
+  public UnsafeVariableShortLengthDimensionDataChunkStore(long totalSize, boolean isInvertedIdex,
+      int numberOfRows) {
+    super(totalSize, isInvertedIdex, numberOfRows);
+  }
+
+  @Override
+  protected int getLengthSize() {
+    return CarbonCommonConstants.SHORT_SIZE_IN_BYTE;
+  }
+
+  @Override
+  protected int getLengthFromBuffer(ByteBuffer byteBuffer) {
+    return byteBuffer.getShort();
+  }
+}

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/ColumnPage.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/ColumnPage.java
@@ -205,7 +205,7 @@ public abstract class ColumnPage {
         instance = new UnsafeDecimalColumnPage(columnSpec, dataType, pageSize);
       } else if (dataType == DataTypes.STRING
           || dataType == DataTypes.BYTE_ARRAY
-          || dataType == DataTypes.TEXT) {
+          || dataType == DataTypes.VARCHAR) {
         instance = new UnsafeVarLengthColumnPage(columnSpec, dataType, pageSize);
       } else {
         throw new RuntimeException("Unsupported data dataType: " + dataType);
@@ -229,7 +229,7 @@ public abstract class ColumnPage {
         instance = newDecimalPage(columnSpec, new byte[pageSize][]);
       } else if (dataType == DataTypes.STRING
           || dataType == DataTypes.BYTE_ARRAY
-          || dataType == DataTypes.TEXT) {
+          || dataType == DataTypes.VARCHAR) {
         instance = new SafeVarLengthColumnPage(columnSpec, dataType, pageSize);
       } else {
         throw new RuntimeException("Unsupported data dataType: " + dataType);
@@ -404,7 +404,7 @@ public abstract class ColumnPage {
       statsCollector.update((BigDecimal) value);
     } else if (dataType == DataTypes.STRING
         || dataType == DataTypes.BYTE_ARRAY
-        || dataType == DataTypes.TEXT) {
+        || dataType == DataTypes.VARCHAR) {
       putBytes(rowId, (byte[]) value);
       statsCollector.update((byte[]) value);
     } else {
@@ -439,7 +439,7 @@ public abstract class ColumnPage {
       return getDecimal(rowId);
     } else if (dataType == DataTypes.STRING
         || dataType == DataTypes.BYTE_ARRAY
-        || dataType == DataTypes.TEXT) {
+        || dataType == DataTypes.VARCHAR) {
       return getBytes(rowId);
     } else {
       throw new RuntimeException("unsupported data type: " + dataType);

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/ColumnPage.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/ColumnPage.java
@@ -203,7 +203,9 @@ public abstract class ColumnPage {
         instance = new UnsafeFixLengthColumnPage(columnSpec, dataType, pageSize);
       } else if (DataTypes.isDecimal(dataType)) {
         instance = new UnsafeDecimalColumnPage(columnSpec, dataType, pageSize);
-      } else if (dataType == DataTypes.STRING || dataType == DataTypes.BYTE_ARRAY) {
+      } else if (dataType == DataTypes.STRING
+          || dataType == DataTypes.BYTE_ARRAY
+          || dataType == DataTypes.TEXT) {
         instance = new UnsafeVarLengthColumnPage(columnSpec, dataType, pageSize);
       } else {
         throw new RuntimeException("Unsupported data dataType: " + dataType);
@@ -225,7 +227,9 @@ public abstract class ColumnPage {
         instance = newDoublePage(columnSpec, new double[pageSize]);
       } else if (DataTypes.isDecimal(dataType)) {
         instance = newDecimalPage(columnSpec, new byte[pageSize][]);
-      } else if (dataType == DataTypes.STRING || dataType == DataTypes.BYTE_ARRAY) {
+      } else if (dataType == DataTypes.STRING
+          || dataType == DataTypes.BYTE_ARRAY
+          || dataType == DataTypes.TEXT) {
         instance = new SafeVarLengthColumnPage(columnSpec, dataType, pageSize);
       } else {
         throw new RuntimeException("Unsupported data dataType: " + dataType);
@@ -398,7 +402,9 @@ public abstract class ColumnPage {
     } else if (DataTypes.isDecimal(dataType)) {
       putDecimal(rowId, (BigDecimal) value);
       statsCollector.update((BigDecimal) value);
-    } else if (dataType == DataTypes.STRING || dataType == DataTypes.BYTE_ARRAY) {
+    } else if (dataType == DataTypes.STRING
+        || dataType == DataTypes.BYTE_ARRAY
+        || dataType == DataTypes.TEXT) {
       putBytes(rowId, (byte[]) value);
       statsCollector.update((byte[]) value);
     } else {
@@ -431,7 +437,9 @@ public abstract class ColumnPage {
       return getDouble(rowId);
     } else if (DataTypes.isDecimal(dataType)) {
       return getDecimal(rowId);
-    } else if (dataType == DataTypes.STRING || dataType == DataTypes.BYTE_ARRAY) {
+    } else if (dataType == DataTypes.STRING
+        || dataType == DataTypes.BYTE_ARRAY
+        || dataType == DataTypes.TEXT) {
       return getBytes(rowId);
     } else {
       throw new RuntimeException("unsupported data type: " + dataType);

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/DefaultEncodingFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/DefaultEncodingFactory.java
@@ -103,6 +103,7 @@ public class DefaultEncodingFactory extends EncodingFactory {
         return new HighCardDictDimensionIndexCodec(
             dimensionSpec.isInSortColumns(),
             dimensionSpec.isInSortColumns() && dimensionSpec.isDoInvertedIndex(),
+            dimensionSpec.getSchemaDataType() == DataTypes.TEXT,
             compressor).createEncoder(null);
       default:
         throw new RuntimeException("unsupported dimension type: " +

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/DefaultEncodingFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/DefaultEncodingFactory.java
@@ -103,7 +103,7 @@ public class DefaultEncodingFactory extends EncodingFactory {
         return new HighCardDictDimensionIndexCodec(
             dimensionSpec.isInSortColumns(),
             dimensionSpec.isInSortColumns() && dimensionSpec.isDoInvertedIndex(),
-            dimensionSpec.getSchemaDataType() == DataTypes.TEXT,
+            dimensionSpec.getSchemaDataType() == DataTypes.VARCHAR,
             compressor).createEncoder(null);
       default:
         throw new RuntimeException("unsupported dimension type: " +

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/EncodingFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/EncodingFactory.java
@@ -47,7 +47,7 @@ import static org.apache.carbondata.format.Encoding.ADAPTIVE_FLOATING;
 import static org.apache.carbondata.format.Encoding.ADAPTIVE_INTEGRAL;
 import static org.apache.carbondata.format.Encoding.BOOL_BYTE;
 import static org.apache.carbondata.format.Encoding.DIRECT_COMPRESS;
-import static org.apache.carbondata.format.Encoding.DIRECT_COMPRESS_TEXT;
+import static org.apache.carbondata.format.Encoding.DIRECT_COMPRESS_VARCHAR;
 import static org.apache.carbondata.format.Encoding.RLE_INTEGRAL;
 
 /**
@@ -72,7 +72,7 @@ public abstract class EncodingFactory {
     byte[] encoderMeta = encoderMetas.get(0).array();
     ByteArrayInputStream stream = new ByteArrayInputStream(encoderMeta);
     DataInputStream in = new DataInputStream(stream);
-    if (encoding == DIRECT_COMPRESS || encoding == DIRECT_COMPRESS_TEXT) {
+    if (encoding == DIRECT_COMPRESS || encoding == DIRECT_COMPRESS_VARCHAR) {
       ColumnPageEncoderMeta metadata = new ColumnPageEncoderMeta();
       metadata.readFields(in);
       return new DirectCompressCodec(metadata.getStoreDataType()).createDecoder(metadata);

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/EncodingFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/EncodingFactory.java
@@ -47,6 +47,7 @@ import static org.apache.carbondata.format.Encoding.ADAPTIVE_FLOATING;
 import static org.apache.carbondata.format.Encoding.ADAPTIVE_INTEGRAL;
 import static org.apache.carbondata.format.Encoding.BOOL_BYTE;
 import static org.apache.carbondata.format.Encoding.DIRECT_COMPRESS;
+import static org.apache.carbondata.format.Encoding.DIRECT_COMPRESS_TEXT;
 import static org.apache.carbondata.format.Encoding.RLE_INTEGRAL;
 
 /**
@@ -71,7 +72,7 @@ public abstract class EncodingFactory {
     byte[] encoderMeta = encoderMetas.get(0).array();
     ByteArrayInputStream stream = new ByteArrayInputStream(encoderMeta);
     DataInputStream in = new DataInputStream(stream);
-    if (encoding == DIRECT_COMPRESS) {
+    if (encoding == DIRECT_COMPRESS || encoding == DIRECT_COMPRESS_TEXT) {
       ColumnPageEncoderMeta metadata = new ColumnPageEncoderMeta();
       metadata.readFields(in);
       return new DirectCompressCodec(metadata.getStoreDataType()).createDecoder(metadata);

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/compress/DirectCompressCodec.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/compress/DirectCompressCodec.java
@@ -64,7 +64,7 @@ public class DirectCompressCodec implements ColumnPageCodec {
     return new DirectDecompressor(meta);
   }
 
-  private static class DirectCompressor extends ColumnPageEncoder {
+  private class DirectCompressor extends ColumnPageEncoder {
 
     private Compressor compressor;
 
@@ -80,7 +80,8 @@ public class DirectCompressCodec implements ColumnPageCodec {
     @Override
     protected List<Encoding> getEncodingList() {
       List<Encoding> encodings = new ArrayList<>();
-      encodings.add(Encoding.DIRECT_COMPRESS);
+      encodings.add(
+          dataType == DataTypes.TEXT ? Encoding.DIRECT_COMPRESS_TEXT : Encoding.DIRECT_COMPRESS);
       return encodings;
     }
 

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/compress/DirectCompressCodec.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/compress/DirectCompressCodec.java
@@ -80,8 +80,9 @@ public class DirectCompressCodec implements ColumnPageCodec {
     @Override
     protected List<Encoding> getEncodingList() {
       List<Encoding> encodings = new ArrayList<>();
-      encodings.add(
-          dataType == DataTypes.TEXT ? Encoding.DIRECT_COMPRESS_TEXT : Encoding.DIRECT_COMPRESS);
+      encodings.add(dataType == DataTypes.VARCHAR ?
+          Encoding.DIRECT_COMPRESS_VARCHAR :
+          Encoding.DIRECT_COMPRESS);
       return encodings;
     }
 

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/dimension/legacy/HighCardDictDimensionIndexCodec.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/dimension/legacy/HighCardDictDimensionIndexCodec.java
@@ -32,14 +32,14 @@ import org.apache.carbondata.format.Encoding;
 
 public class HighCardDictDimensionIndexCodec extends IndexStorageCodec {
   /**
-   * whether this column is text data type(long string)
+   * whether this column is varchar data type(long string)
    */
-  private boolean isTextType;
+  private boolean isVarcharType;
 
   public HighCardDictDimensionIndexCodec(boolean isSort, boolean isInvertedIndex,
-      boolean isTextType, Compressor compressor) {
+      boolean isVarcharType, Compressor compressor) {
     super(isSort, isInvertedIndex, compressor);
-    this.isTextType = isTextType;
+    this.isVarcharType = isVarcharType;
   }
 
   @Override
@@ -68,8 +68,8 @@ public class HighCardDictDimensionIndexCodec extends IndexStorageCodec {
       @Override
       protected List<Encoding> getEncodingList() {
         List<Encoding> encodings = new ArrayList<>();
-        if (isTextType) {
-          encodings.add(Encoding.DIRECT_COMPRESS_TEXT);
+        if (isVarcharType) {
+          encodings.add(Encoding.DIRECT_COMPRESS_VARCHAR);
         } else if (indexStorage.getRowIdPageLengthInBytes() > 0) {
           encodings.add(Encoding.INVERTED_INDEX);
         }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/dimension/legacy/HighCardDictDimensionIndexCodec.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/dimension/legacy/HighCardDictDimensionIndexCodec.java
@@ -30,11 +30,16 @@ import org.apache.carbondata.core.datastore.page.encoding.ColumnPageEncoder;
 import org.apache.carbondata.core.util.ByteUtil;
 import org.apache.carbondata.format.Encoding;
 
-public class HighCardDictDimensionIndexCodec  extends IndexStorageCodec {
+public class HighCardDictDimensionIndexCodec extends IndexStorageCodec {
+  /**
+   * whether this column is text data type(long string)
+   */
+  private boolean isTextType;
 
   public HighCardDictDimensionIndexCodec(boolean isSort, boolean isInvertedIndex,
-      Compressor compressor) {
+      boolean isTextType, Compressor compressor) {
     super(isSort, isInvertedIndex, compressor);
+    this.isTextType = isTextType;
   }
 
   @Override
@@ -63,7 +68,9 @@ public class HighCardDictDimensionIndexCodec  extends IndexStorageCodec {
       @Override
       protected List<Encoding> getEncodingList() {
         List<Encoding> encodings = new ArrayList<>();
-        if (indexStorage.getRowIdPageLengthInBytes() > 0) {
+        if (isTextType) {
+          encodings.add(Encoding.DIRECT_COMPRESS_TEXT);
+        } else if (indexStorage.getRowIdPageLengthInBytes() > 0) {
           encodings.add(Encoding.INVERTED_INDEX);
         }
         return encodings;

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/statistics/LVLongStringStatsCollector.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/statistics/LVLongStringStatsCollector.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.core.datastore.page.statistics;
+
+/**
+ * This class is for the columns with text data type -- a string type which can hold more than 32000
+ * characters
+ */
+public class LVLongStringStatsCollector extends LVStringStatsCollector {
+
+  public static LVLongStringStatsCollector newInstance() {
+    return new LVLongStringStatsCollector();
+  }
+
+  private LVLongStringStatsCollector() {
+
+  }
+
+  @Override
+  protected byte[] getActualValue(byte[] value) {
+    byte[] actualValue;
+    assert (value.length >= 4);
+    if (value.length == 4) {
+      assert (value[0] == 0 && value[1] == 0);
+      actualValue = new byte[0];
+    } else {
+      // todo: what does this mean?
+      // int length = (value[0] << 8) + (value[1] & 0xff);
+      // assert (length > 0);
+      actualValue = new byte[value.length - 4];
+      System.arraycopy(value, 4, actualValue, 0, actualValue.length);
+    }
+    return actualValue;
+  }
+}

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/statistics/LVLongStringStatsCollector.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/statistics/LVLongStringStatsCollector.java
@@ -18,8 +18,8 @@
 package org.apache.carbondata.core.datastore.page.statistics;
 
 /**
- * This class is for the columns with text data type -- a string type which can hold more than 32000
- * characters
+ * This class is for the columns with varchar data type,
+ * a string type which can hold more than 32000 characters
  */
 public class LVLongStringStatsCollector extends LVStringStatsCollector {
 

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/statistics/LVShortStringStatsCollector.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/statistics/LVShortStringStatsCollector.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.core.datastore.page.statistics;
+
+/**
+ * This class is for the columns with string data type which hold less than 32000 characters
+ */
+public class LVShortStringStatsCollector extends LVStringStatsCollector {
+
+  public static LVShortStringStatsCollector newInstance() {
+    return new LVShortStringStatsCollector();
+  }
+
+  private LVShortStringStatsCollector() {
+
+  }
+
+  @Override
+  protected byte[] getActualValue(byte[] value) {
+    byte[] actualValue;
+    assert (value.length >= 2);
+    if (value.length == 2) {
+      assert (value[0] == 0 && value[1] == 0);
+      actualValue = new byte[0];
+    } else {
+      int length = (value[0] << 8) + (value[1] & 0xff);
+      assert (length > 0);
+      actualValue = new byte[value.length - 2];
+      System.arraycopy(value, 2, actualValue, 0, actualValue.length);
+    }
+    return actualValue;
+  }
+}

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/statistics/LVStringStatsCollector.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/statistics/LVStringStatsCollector.java
@@ -23,17 +23,9 @@ import org.apache.carbondata.core.metadata.datatype.DataType;
 import org.apache.carbondata.core.metadata.datatype.DataTypes;
 import org.apache.carbondata.core.util.ByteUtil;
 
-public class LVStringStatsCollector implements ColumnPageStatsCollector {
+public abstract class LVStringStatsCollector implements ColumnPageStatsCollector {
 
   private byte[] min, max;
-
-  public static LVStringStatsCollector newInstance() {
-    return new LVStringStatsCollector();
-  }
-
-  private LVStringStatsCollector() {
-
-  }
 
   @Override
   public void updateNull(int rowId) {
@@ -70,22 +62,13 @@ public class LVStringStatsCollector implements ColumnPageStatsCollector {
 
   }
 
+  protected abstract byte[] getActualValue(byte[] value);
+
   @Override
   public void update(byte[] value) {
     // input value is LV encoded
-    byte[] newValue = null;
-    assert (value.length >= 2);
-    if (value.length == 2) {
-      assert (value[0] == 0 && value[1] == 0);
-      newValue = new byte[0];
-    } else {
-      int length = (value[0] << 8) + (value[1] & 0xff);
-      assert (length > 0);
-      newValue = new byte[value.length - 2];
-      System.arraycopy(value, 2, newValue, 0, newValue.length);
-    }
-
-    if (null == min) {
+    byte[] newValue = getActualValue(value);
+    if (min == null) {
       min = newValue;
     }
 

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/UnsafeMemoryDMStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/UnsafeMemoryDMStore.java
@@ -144,7 +144,7 @@ public class UnsafeMemoryDMStore extends AbstractMemoryDMStore {
               "unsupported data type for unsafe storage: " + schema.getDataType());
         }
         break;
-      case VARIABLE:
+      case VARIABLE_SHORT:
         byte[] data = row.getByteArray(index);
         getUnsafe().putShort(memoryBlock.getBaseObject(),
             memoryBlock.getBaseOffset() + runningLength, (short) data.length);
@@ -152,6 +152,15 @@ public class UnsafeMemoryDMStore extends AbstractMemoryDMStore {
         getUnsafe().copyMemory(data, BYTE_ARRAY_OFFSET, memoryBlock.getBaseObject(),
             memoryBlock.getBaseOffset() + runningLength, data.length);
         runningLength += data.length;
+        break;
+      case VARIABLE_INT:
+        byte[] data2 = row.getByteArray(index);
+        getUnsafe().putInt(memoryBlock.getBaseObject(),
+            memoryBlock.getBaseOffset() + runningLength, data2.length);
+        runningLength += 4;
+        getUnsafe().copyMemory(data2, BYTE_ARRAY_OFFSET, memoryBlock.getBaseObject(),
+            memoryBlock.getBaseOffset() + runningLength, data2.length);
+        runningLength += data2.length;
         break;
       case STRUCT:
         CarbonRowSchema[] childSchemas =

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMap.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMap.java
@@ -607,12 +607,13 @@ public class BlockletDataMap extends CoarseGrainDataMap implements Serializable 
       CarbonRowSchema[] mapSchemas = new CarbonRowSchema[minMaxLen.length];
       for (int i = 0; i < minMaxLen.length; i++) {
         if (minMaxLen[i] <= 0) {
-          boolean isText = false;
+          boolean isVarchar = false;
           if (i < segmentProperties.getDimensions().size()
-              && segmentProperties.getDimensions().get(i).getDataType() == DataTypes.TEXT) {
-            isText = true;
+              && segmentProperties.getDimensions().get(i).getDataType() == DataTypes.VARCHAR) {
+            isVarchar = true;
           }
-          mapSchemas[i] = new CarbonRowSchema.VariableCarbonRowSchema(DataTypes.BYTE_ARRAY, isText);
+          mapSchemas[i] = new CarbonRowSchema.VariableCarbonRowSchema(DataTypes.BYTE_ARRAY,
+              isVarchar);
         } else {
           mapSchemas[i] =
               new CarbonRowSchema.FixedCarbonRowSchema(DataTypes.BYTE_ARRAY, minMaxLen[i]);

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMap.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMap.java
@@ -607,7 +607,12 @@ public class BlockletDataMap extends CoarseGrainDataMap implements Serializable 
       CarbonRowSchema[] mapSchemas = new CarbonRowSchema[minMaxLen.length];
       for (int i = 0; i < minMaxLen.length; i++) {
         if (minMaxLen[i] <= 0) {
-          mapSchemas[i] = new CarbonRowSchema.VariableCarbonRowSchema(DataTypes.BYTE_ARRAY);
+          boolean isText = false;
+          if (i < segmentProperties.getDimensions().size()
+              && segmentProperties.getDimensions().get(i).getDataType() == DataTypes.TEXT) {
+            isText = true;
+          }
+          mapSchemas[i] = new CarbonRowSchema.VariableCarbonRowSchema(DataTypes.BYTE_ARRAY, isText);
         } else {
           mapSchemas[i] =
               new CarbonRowSchema.FixedCarbonRowSchema(DataTypes.BYTE_ARRAY, minMaxLen[i]);

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/row/DataMapRow.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/row/DataMapRow.java
@@ -78,8 +78,10 @@ public abstract class DataMapRow implements Serializable {
     switch (schemas[ordinal].getSchemaType()) {
       case FIXED:
         return schemas[ordinal].getLength();
-      case VARIABLE:
+      case VARIABLE_SHORT:
         return getLengthInBytes(ordinal) + 2;
+      case VARIABLE_INT:
+        return getLengthInBytes(ordinal) + 4;
       case STRUCT:
         return getRow(ordinal).getTotalSizeInBytes();
       default:

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/schema/CarbonRowSchema.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/schema/CarbonRowSchema.java
@@ -90,9 +90,15 @@ public abstract class CarbonRowSchema implements Serializable {
   }
 
   public static class VariableCarbonRowSchema extends CarbonRowSchema {
+    private boolean isTextType = false;
 
     public VariableCarbonRowSchema(DataType dataType) {
       super(dataType);
+    }
+
+    public VariableCarbonRowSchema(DataType dataType, boolean isTextType) {
+      super(dataType);
+      this.isTextType = isTextType;
     }
 
     @Override public int getLength() {
@@ -100,7 +106,7 @@ public abstract class CarbonRowSchema implements Serializable {
     }
 
     @Override public DataMapSchemaType getSchemaType() {
-      return DataMapSchemaType.VARIABLE;
+      return isTextType ? DataMapSchemaType.VARIABLE_INT : DataMapSchemaType.VARIABLE_SHORT;
     }
   }
 
@@ -127,6 +133,6 @@ public abstract class CarbonRowSchema implements Serializable {
   }
 
   public enum DataMapSchemaType {
-    FIXED, VARIABLE, STRUCT
+    FIXED, VARIABLE_INT, VARIABLE_SHORT, STRUCT
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/schema/CarbonRowSchema.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/schema/CarbonRowSchema.java
@@ -90,15 +90,15 @@ public abstract class CarbonRowSchema implements Serializable {
   }
 
   public static class VariableCarbonRowSchema extends CarbonRowSchema {
-    private boolean isTextType = false;
+    private boolean isVarcharType = false;
 
     public VariableCarbonRowSchema(DataType dataType) {
       super(dataType);
     }
 
-    public VariableCarbonRowSchema(DataType dataType, boolean isTextType) {
+    public VariableCarbonRowSchema(DataType dataType, boolean isVarcharType) {
       super(dataType);
-      this.isTextType = isTextType;
+      this.isVarcharType = isVarcharType;
     }
 
     @Override public int getLength() {
@@ -106,7 +106,7 @@ public abstract class CarbonRowSchema implements Serializable {
     }
 
     @Override public DataMapSchemaType getSchemaType() {
-      return isTextType ? DataMapSchemaType.VARIABLE_INT : DataMapSchemaType.VARIABLE_SHORT;
+      return isVarcharType ? DataMapSchemaType.VARIABLE_INT : DataMapSchemaType.VARIABLE_SHORT;
     }
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/metadata/blocklet/BlockletInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/blocklet/BlockletInfo.java
@@ -205,7 +205,7 @@ public class BlockletInfo implements Serializable, Writable {
     output.writeLong(dimensionOffset);
     output.writeLong(measureOffsets);
     int dsize = dimensionChunkOffsets != null ? dimensionChunkOffsets.size() : 0;
-    output.writeShort(dsize);
+    output.writeInt(dsize);
     for (int i = 0; i < dsize; i++) {
       output.writeLong(dimensionChunkOffsets.get(i));
     }
@@ -268,7 +268,7 @@ public class BlockletInfo implements Serializable, Writable {
   @Override public void readFields(DataInput input) throws IOException {
     dimensionOffset = input.readLong();
     measureOffsets = input.readLong();
-    short dimensionChunkOffsetsSize = input.readShort();
+    int dimensionChunkOffsetsSize = input.readInt();
     dimensionChunkOffsets = new ArrayList<>(dimensionChunkOffsetsSize);
     for (int i = 0; i < dimensionChunkOffsetsSize; i++) {
       dimensionChunkOffsets.add(input.readLong());

--- a/core/src/main/java/org/apache/carbondata/core/metadata/converter/ThriftWrapperSchemaConverterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/converter/ThriftWrapperSchemaConverterImpl.java
@@ -111,6 +111,8 @@ public class ThriftWrapperSchemaConverterImpl implements SchemaConverter {
         return org.apache.carbondata.format.Encoding.RLE;
       case INVERTED_INDEX:
         return org.apache.carbondata.format.Encoding.INVERTED_INDEX;
+      case DIRECT_COMPRESS_TEXT:
+        return org.apache.carbondata.format.Encoding.DIRECT_COMPRESS_TEXT;
       case BIT_PACKED:
         return org.apache.carbondata.format.Encoding.BIT_PACKED;
       case DIRECT_DICTIONARY:
@@ -153,6 +155,8 @@ public class ThriftWrapperSchemaConverterImpl implements SchemaConverter {
       return org.apache.carbondata.format.DataType.ARRAY;
     } else if (DataTypes.isStructType(dataType)) {
       return org.apache.carbondata.format.DataType.STRUCT;
+    } else if (dataType.getId() == DataTypes.TEXT.getId()) {
+      return org.apache.carbondata.format.DataType.TEXT;
     } else {
       return org.apache.carbondata.format.DataType.STRING;
     }
@@ -446,6 +450,8 @@ public class ThriftWrapperSchemaConverterImpl implements SchemaConverter {
         return Encoding.RLE;
       case INVERTED_INDEX:
         return Encoding.INVERTED_INDEX;
+      case DIRECT_COMPRESS_TEXT:
+        return Encoding.DIRECT_COMPRESS_TEXT;
       case BIT_PACKED:
         return Encoding.BIT_PACKED;
       case DIRECT_DICTIONARY:
@@ -489,6 +495,8 @@ public class ThriftWrapperSchemaConverterImpl implements SchemaConverter {
         return DataTypes.createDefaultArrayType();
       case STRUCT:
         return DataTypes.createDefaultStructType();
+      case TEXT:
+        return DataTypes.TEXT;
       default:
         return DataTypes.STRING;
     }

--- a/core/src/main/java/org/apache/carbondata/core/metadata/converter/ThriftWrapperSchemaConverterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/converter/ThriftWrapperSchemaConverterImpl.java
@@ -111,8 +111,8 @@ public class ThriftWrapperSchemaConverterImpl implements SchemaConverter {
         return org.apache.carbondata.format.Encoding.RLE;
       case INVERTED_INDEX:
         return org.apache.carbondata.format.Encoding.INVERTED_INDEX;
-      case DIRECT_COMPRESS_TEXT:
-        return org.apache.carbondata.format.Encoding.DIRECT_COMPRESS_TEXT;
+      case DIRECT_COMPRESS_VARCHAR:
+        return org.apache.carbondata.format.Encoding.DIRECT_COMPRESS_VARCHAR;
       case BIT_PACKED:
         return org.apache.carbondata.format.Encoding.BIT_PACKED;
       case DIRECT_DICTIONARY:
@@ -155,8 +155,8 @@ public class ThriftWrapperSchemaConverterImpl implements SchemaConverter {
       return org.apache.carbondata.format.DataType.ARRAY;
     } else if (DataTypes.isStructType(dataType)) {
       return org.apache.carbondata.format.DataType.STRUCT;
-    } else if (dataType.getId() == DataTypes.TEXT.getId()) {
-      return org.apache.carbondata.format.DataType.TEXT;
+    } else if (dataType.getId() == DataTypes.VARCHAR.getId()) {
+      return org.apache.carbondata.format.DataType.VARCHAR;
     } else {
       return org.apache.carbondata.format.DataType.STRING;
     }
@@ -450,8 +450,8 @@ public class ThriftWrapperSchemaConverterImpl implements SchemaConverter {
         return Encoding.RLE;
       case INVERTED_INDEX:
         return Encoding.INVERTED_INDEX;
-      case DIRECT_COMPRESS_TEXT:
-        return Encoding.DIRECT_COMPRESS_TEXT;
+      case DIRECT_COMPRESS_VARCHAR:
+        return Encoding.DIRECT_COMPRESS_VARCHAR;
       case BIT_PACKED:
         return Encoding.BIT_PACKED;
       case DIRECT_DICTIONARY:
@@ -495,8 +495,8 @@ public class ThriftWrapperSchemaConverterImpl implements SchemaConverter {
         return DataTypes.createDefaultArrayType();
       case STRUCT:
         return DataTypes.createDefaultStructType();
-      case TEXT:
-        return DataTypes.TEXT;
+      case VARCHAR:
+        return DataTypes.VARCHAR;
       default:
         return DataTypes.STRING;
     }

--- a/core/src/main/java/org/apache/carbondata/core/metadata/datatype/DataType.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/datatype/DataType.java
@@ -69,7 +69,7 @@ public class DataType implements Serializable {
 
   public static final char DOUBLE_MEASURE_CHAR = 'n';
   public static final char STRING_CHAR = 's';
-  public static final char TEXT_CHAR = 'e';
+  public static final char VARCHAR_CHAR = 'v';
   public static final char TIMESTAMP_CHAR = 't';
   public static final char DATE_CHAR = 'x';
   public static final char BYTE_ARRAY_CHAR = 'y';
@@ -90,8 +90,8 @@ public class DataType implements Serializable {
       return BIG_DECIMAL_MEASURE_CHAR;
     } else if (dataType == DataTypes.STRING) {
       return STRING_CHAR;
-    } else if (dataType == DataTypes.TEXT) {
-      return TEXT_CHAR;
+    } else if (dataType == DataTypes.VARCHAR) {
+      return VARCHAR_CHAR;
     } else if (dataType == DataTypes.TIMESTAMP) {
       return TIMESTAMP_CHAR;
     } else if (dataType == DataTypes.DATE) {

--- a/core/src/main/java/org/apache/carbondata/core/metadata/datatype/DataType.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/datatype/DataType.java
@@ -69,6 +69,7 @@ public class DataType implements Serializable {
 
   public static final char DOUBLE_MEASURE_CHAR = 'n';
   public static final char STRING_CHAR = 's';
+  public static final char TEXT_CHAR = 'e';
   public static final char TIMESTAMP_CHAR = 't';
   public static final char DATE_CHAR = 'x';
   public static final char BYTE_ARRAY_CHAR = 'y';
@@ -89,6 +90,8 @@ public class DataType implements Serializable {
       return BIG_DECIMAL_MEASURE_CHAR;
     } else if (dataType == DataTypes.STRING) {
       return STRING_CHAR;
+    } else if (dataType == DataTypes.TEXT) {
+      return TEXT_CHAR;
     } else if (dataType == DataTypes.TIMESTAMP) {
       return TIMESTAMP_CHAR;
     } else if (dataType == DataTypes.DATE) {

--- a/core/src/main/java/org/apache/carbondata/core/metadata/datatype/DataTypes.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/datatype/DataTypes.java
@@ -47,7 +47,7 @@ public class DataTypes {
   // Only for internal use for backward compatability. It is only used for V1 version
   public static final DataType LEGACY_LONG = LegacyLongType.LEGACY_LONG;
 
-  public static final DataType TEXT = TextType.TEXT;
+  public static final DataType VARCHAR = VarcharType.VARCHAR;
 
   // these IDs are used within this package only
   static final int STRING_TYPE_ID = 0;
@@ -68,7 +68,7 @@ public class DataTypes {
   public static final int ARRAY_TYPE_ID = 11;
   public static final int STRUCT_TYPE_ID = 12;
   public static final int MAP_TYPE_ID = 13;
-  public static final int TEXT_TYPE_ID = 18;
+  public static final int VARCHAR_TYPE_ID = 18;
 
   /**
    * create a DataType instance from uniqueId of the DataType
@@ -110,8 +110,8 @@ public class DataTypes {
       return createDefaultMapType();
     } else if (id == BYTE_ARRAY.getId()) {
       return BYTE_ARRAY;
-    } else if (id == TEXT.getId()) {
-      return TEXT;
+    } else if (id == VARCHAR.getId()) {
+      return VARCHAR;
     } else {
       throw new RuntimeException("create DataType with invalid id: " + id);
     }

--- a/core/src/main/java/org/apache/carbondata/core/metadata/datatype/DataTypes.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/datatype/DataTypes.java
@@ -47,6 +47,8 @@ public class DataTypes {
   // Only for internal use for backward compatability. It is only used for V1 version
   public static final DataType LEGACY_LONG = LegacyLongType.LEGACY_LONG;
 
+  public static final DataType TEXT = TextType.TEXT;
+
   // these IDs are used within this package only
   static final int STRING_TYPE_ID = 0;
   static final int DATE_TYPE_ID = 1;
@@ -66,6 +68,7 @@ public class DataTypes {
   public static final int ARRAY_TYPE_ID = 11;
   public static final int STRUCT_TYPE_ID = 12;
   public static final int MAP_TYPE_ID = 13;
+  public static final int TEXT_TYPE_ID = 18;
 
   /**
    * create a DataType instance from uniqueId of the DataType
@@ -107,6 +110,8 @@ public class DataTypes {
       return createDefaultMapType();
     } else if (id == BYTE_ARRAY.getId()) {
       return BYTE_ARRAY;
+    } else if (id == TEXT.getId()) {
+      return TEXT;
     } else {
       throw new RuntimeException("create DataType with invalid id: " + id);
     }

--- a/core/src/main/java/org/apache/carbondata/core/metadata/datatype/TextType.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/datatype/TextType.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.core.metadata.datatype;
+
+/**
+ * This class is for internal use. It is used to support string that longer than 32000 characters
+ */
+public class TextType extends DataType {
+  static final DataType TEXT = new TextType(DataTypes.TEXT_TYPE_ID, 0, "TEXT", -1);
+
+  private TextType(int id, int precedenceOrder, String name, int sizeInBytes) {
+    super(id, precedenceOrder, name, sizeInBytes);
+  }
+
+  // this function is needed to ensure singleton pattern while supporting java serialization
+  private Object readResolve() {
+    return DataTypes.TEXT;
+  }
+}

--- a/core/src/main/java/org/apache/carbondata/core/metadata/datatype/VarcharType.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/datatype/VarcharType.java
@@ -20,15 +20,15 @@ package org.apache.carbondata.core.metadata.datatype;
 /**
  * This class is for internal use. It is used to support string that longer than 32000 characters
  */
-public class TextType extends DataType {
-  static final DataType TEXT = new TextType(DataTypes.TEXT_TYPE_ID, 0, "TEXT", -1);
+public class VarcharType extends DataType {
+  static final DataType VARCHAR = new VarcharType(DataTypes.VARCHAR_TYPE_ID, 0, "VARCHAR", -1);
 
-  private TextType(int id, int precedenceOrder, String name, int sizeInBytes) {
+  private VarcharType(int id, int precedenceOrder, String name, int sizeInBytes) {
     super(id, precedenceOrder, name, sizeInBytes);
   }
 
   // this function is needed to ensure singleton pattern while supporting java serialization
   private Object readResolve() {
-    return DataTypes.TEXT;
+    return DataTypes.VARCHAR;
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/metadata/encoder/Encoding.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/encoder/Encoding.java
@@ -31,7 +31,8 @@ public enum Encoding {
   DIRECT_COMPRESS,
   ADAPTIVE_INTEGRAL,
   ADAPTIVE_DELTA_INTEGRAL,
-  RLE_INTEGRAL;
+  RLE_INTEGRAL,
+  DIRECT_COMPRESS_TEXT;
 
   public static Encoding valueOf(int ordinal) {
     if (ordinal == DICTIONARY.ordinal()) {
@@ -56,6 +57,8 @@ public enum Encoding {
       return ADAPTIVE_DELTA_INTEGRAL;
     } else if (ordinal == RLE_INTEGRAL.ordinal()) {
       return RLE_INTEGRAL;
+    } else if (ordinal == DIRECT_COMPRESS_TEXT.ordinal()) {
+      return DIRECT_COMPRESS_TEXT;
     } else {
       throw new RuntimeException("create Encoding with invalid ordinal: " + ordinal);
     }

--- a/core/src/main/java/org/apache/carbondata/core/metadata/encoder/Encoding.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/encoder/Encoding.java
@@ -32,7 +32,7 @@ public enum Encoding {
   ADAPTIVE_INTEGRAL,
   ADAPTIVE_DELTA_INTEGRAL,
   RLE_INTEGRAL,
-  DIRECT_COMPRESS_TEXT;
+  DIRECT_COMPRESS_VARCHAR;
 
   public static Encoding valueOf(int ordinal) {
     if (ordinal == DICTIONARY.ordinal()) {
@@ -57,8 +57,8 @@ public enum Encoding {
       return ADAPTIVE_DELTA_INTEGRAL;
     } else if (ordinal == RLE_INTEGRAL.ordinal()) {
       return RLE_INTEGRAL;
-    } else if (ordinal == DIRECT_COMPRESS_TEXT.ordinal()) {
-      return DIRECT_COMPRESS_TEXT;
+    } else if (ordinal == DIRECT_COMPRESS_VARCHAR.ordinal()) {
+      return DIRECT_COMPRESS_VARCHAR;
     } else {
       throw new RuntimeException("create Encoding with invalid ordinal: " + ordinal);
     }

--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/TableSchemaBuilder.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/TableSchemaBuilder.java
@@ -203,6 +203,7 @@ public class TableSchemaBuilder {
         }
       }
     }
+    // todo: need more information such as long_string_columns
     return newColumn;
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/ExcludeFilterExecuterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/ExcludeFilterExecuterImpl.java
@@ -433,21 +433,11 @@ public class ExcludeFilterExecuterImpl implements FilterExecuter {
   @Override
   public void readColumnChunks(RawBlockletColumnChunks rawBlockletColumnChunks) throws IOException {
     if (isDimensionPresentInCurrentBlock) {
-      int chunkIndex = segmentProperties.getDimensionOrdinalToChunkMapping()
-          .get(dimColEvaluatorInfo.getColumnIndex());
-      if (null == rawBlockletColumnChunks.getDimensionRawColumnChunks()[chunkIndex]) {
-        rawBlockletColumnChunks.getDimensionRawColumnChunks()[chunkIndex] =
-            rawBlockletColumnChunks.getDataBlock().readDimensionChunk(
-                rawBlockletColumnChunks.getFileReader(), chunkIndex);
-      }
+      RawColumnChunkUtil.readDimensionRawColumnChunk(rawBlockletColumnChunks, dimColEvaluatorInfo,
+          segmentProperties);
     } else if (isMeasurePresentInCurrentBlock) {
-      int chunkIndex = segmentProperties.getMeasuresOrdinalToChunkMapping()
-          .get(msrColumnEvaluatorInfo.getColumnIndex());
-      if (null == rawBlockletColumnChunks.getMeasureRawColumnChunks()[chunkIndex]) {
-        rawBlockletColumnChunks.getMeasureRawColumnChunks()[chunkIndex] =
-            rawBlockletColumnChunks.getDataBlock().readMeasureChunk(
-                rawBlockletColumnChunks.getFileReader(), chunkIndex);
-      }
+      RawColumnChunkUtil.readMeasureRawColumnChunk(rawBlockletColumnChunks, msrColumnEvaluatorInfo,
+          segmentProperties);
     }
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/IncludeFilterExecuterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/IncludeFilterExecuterImpl.java
@@ -499,21 +499,11 @@ public class IncludeFilterExecuterImpl implements FilterExecuter {
   @Override
   public void readColumnChunks(RawBlockletColumnChunks rawBlockletColumnChunks) throws IOException {
     if (isDimensionPresentInCurrentBlock) {
-      int chunkIndex = segmentProperties.getDimensionOrdinalToChunkMapping()
-          .get(dimColumnEvaluatorInfo.getColumnIndex());
-      if (null == rawBlockletColumnChunks.getDimensionRawColumnChunks()[chunkIndex]) {
-        rawBlockletColumnChunks.getDimensionRawColumnChunks()[chunkIndex] =
-            rawBlockletColumnChunks.getDataBlock().readDimensionChunk(
-                rawBlockletColumnChunks.getFileReader(), chunkIndex);
-      }
+      RawColumnChunkUtil.readDimensionRawColumnChunk(rawBlockletColumnChunks,
+          dimColumnEvaluatorInfo, segmentProperties);
     } else if (isMeasurePresentInCurrentBlock) {
-      int chunkIndex = segmentProperties.getMeasuresOrdinalToChunkMapping()
-          .get(msrColumnEvaluatorInfo.getColumnIndex());
-      if (null == rawBlockletColumnChunks.getMeasureRawColumnChunks()[chunkIndex]) {
-        rawBlockletColumnChunks.getMeasureRawColumnChunks()[chunkIndex] =
-            rawBlockletColumnChunks.getDataBlock().readMeasureChunk(
-                rawBlockletColumnChunks.getFileReader(), chunkIndex);
-      }
+      RawColumnChunkUtil.readMeasureRawColumnChunk(rawBlockletColumnChunks,
+          msrColumnEvaluatorInfo, segmentProperties);
     }
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RangeValueFilterExecuterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RangeValueFilterExecuterImpl.java
@@ -670,13 +670,8 @@ public class RangeValueFilterExecuterImpl extends ValueBasedFilterExecuterImpl {
   @Override
   public void readColumnChunks(RawBlockletColumnChunks rawBlockletColumnChunks) throws IOException {
     if (isDimensionPresentInCurrentBlock) {
-      int chunkIndex = segmentProperties.getDimensionOrdinalToChunkMapping()
-          .get(dimColEvaluatorInfo.getColumnIndex());
-      if (null == rawBlockletColumnChunks.getDimensionRawColumnChunks()[chunkIndex]) {
-        rawBlockletColumnChunks.getDimensionRawColumnChunks()[chunkIndex] =
-            rawBlockletColumnChunks.getDataBlock().readDimensionChunk(
-                rawBlockletColumnChunks.getFileReader(), chunkIndex);
-      }
+      RawColumnChunkUtil.readDimensionRawColumnChunk(rawBlockletColumnChunks,
+          dimColEvaluatorInfo, segmentProperties);
     }
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RawColumnChunkUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RawColumnChunkUtil.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.core.scan.filter.executer;
+
+import java.io.IOException;
+
+import org.apache.carbondata.core.datastore.block.SegmentProperties;
+import org.apache.carbondata.core.datastore.chunk.impl.DimensionRawColumnChunk;
+import org.apache.carbondata.core.scan.filter.resolver.resolverinfo.DimColumnResolvedFilterInfo;
+import org.apache.carbondata.core.scan.filter.resolver.resolverinfo.MeasureColumnResolvedFilterInfo;
+import org.apache.carbondata.core.scan.processor.RawBlockletColumnChunks;
+
+/**
+ * This class is a util to read RawBlockletColumnChunks in order to eliminate duplicate code
+ */
+public class RawColumnChunkUtil {
+
+  public static void readDimensionRawColumnChunk(RawBlockletColumnChunks rawBlockletColumnChunks,
+      DimColumnResolvedFilterInfo dimColEvaluatorInfo,
+      SegmentProperties segmentProperties) throws IOException {
+    int chunkIndex = segmentProperties.getDimensionOrdinalToChunkMapping().get(
+        dimColEvaluatorInfo.getColumnIndex());
+    readDimensionRawColumnChunk(rawBlockletColumnChunks, dimColEvaluatorInfo, chunkIndex);
+  }
+
+  public static void readDimensionRawColumnChunk(RawBlockletColumnChunks rawBlockletColumnChunks,
+      DimColumnResolvedFilterInfo dimColEvaluatorInfo, int chunkIndex) throws IOException {
+    if (null == rawBlockletColumnChunks.getDimensionRawColumnChunks()[chunkIndex]) {
+      DimensionRawColumnChunk rawColumnChunk = rawBlockletColumnChunks.getDataBlock()
+          .readDimensionChunk(rawBlockletColumnChunks.getFileReader(), chunkIndex);
+      rawBlockletColumnChunks.getDimensionRawColumnChunks()[chunkIndex] = rawColumnChunk;
+    }
+  }
+
+  public static void readMeasureRawColumnChunk(RawBlockletColumnChunks rawBlockletColumnChunks,
+      MeasureColumnResolvedFilterInfo msrColEvaluatorInfo,
+      SegmentProperties segmentProperties) throws IOException {
+    int chunkIndex = segmentProperties.getMeasuresOrdinalToChunkMapping().get(
+        msrColEvaluatorInfo.getColumnIndex());
+    readMeasureRawColumnChunk(rawBlockletColumnChunks, chunkIndex);
+  }
+
+  public static void readMeasureRawColumnChunk(RawBlockletColumnChunks rawBlockletColumnChunks,
+      int chunkIndex) throws IOException {
+    if (null == rawBlockletColumnChunks.getMeasureRawColumnChunks()[chunkIndex]) {
+      rawBlockletColumnChunks.getMeasureRawColumnChunks()[chunkIndex] =
+          rawBlockletColumnChunks.getDataBlock()
+              .readMeasureChunk(rawBlockletColumnChunks.getFileReader(), chunkIndex);
+    }
+  }
+}

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RowLevelFilterExecuterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RowLevelFilterExecuterImpl.java
@@ -635,11 +635,9 @@ public class RowLevelFilterExecuterImpl implements FilterExecuter {
     for (int i = 0; i < dimColEvaluatorInfoList.size(); i++) {
       DimColumnResolvedFilterInfo dimColumnEvaluatorInfo = dimColEvaluatorInfoList.get(i);
       if (!dimColumnEvaluatorInfo.getDimension().getDataType().isComplexType()) {
-        if (null == rawBlockletColumnChunks.getDimensionRawColumnChunks()[dimensionChunkIndex[i]])
-        {
-          rawBlockletColumnChunks.getDimensionRawColumnChunks()[dimensionChunkIndex[i]] =
-              rawBlockletColumnChunks.getDataBlock().readDimensionChunk(
-                  rawBlockletColumnChunks.getFileReader(), dimensionChunkIndex[i]);
+        if (null == rawBlockletColumnChunks.getDimensionRawColumnChunks()[dimensionChunkIndex[i]]) {
+          RawColumnChunkUtil.readDimensionRawColumnChunk(rawBlockletColumnChunks,
+              dimColumnEvaluatorInfo, dimensionChunkIndex[i]);
         }
       } else {
         GenericQueryType complexType = complexDimensionInfoMap.get(dimensionChunkIndex[i]);
@@ -648,11 +646,7 @@ public class RowLevelFilterExecuterImpl implements FilterExecuter {
     }
 
     for (MeasureColumnResolvedFilterInfo msrColumnEvalutorInfo : msrColEvalutorInfoList) {
-      if (null == rawBlockletColumnChunks.getMeasureRawColumnChunks()[measureChunkIndex[0]]) {
-        rawBlockletColumnChunks.getMeasureRawColumnChunks()[measureChunkIndex[0]] =
-            rawBlockletColumnChunks.getDataBlock()
-              .readMeasureChunk(rawBlockletColumnChunks.getFileReader(), measureChunkIndex[0]);
-      }
+      RawColumnChunkUtil.readMeasureRawColumnChunk(rawBlockletColumnChunks, measureChunkIndex[0]);
     }
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RowLevelRangeGrtThanFiterExecuterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RowLevelRangeGrtThanFiterExecuterImpl.java
@@ -448,18 +448,11 @@ public class RowLevelRangeGrtThanFiterExecuterImpl extends RowLevelFilterExecute
         super.readColumnChunks(rawBlockletColumnChunks);
       }
       int chunkIndex = dimensionChunkIndex[0];
-      if (null == rawBlockletColumnChunks.getDimensionRawColumnChunks()[chunkIndex]) {
-        rawBlockletColumnChunks.getDimensionRawColumnChunks()[chunkIndex] =
-            rawBlockletColumnChunks.getDataBlock().readDimensionChunk(
-                rawBlockletColumnChunks.getFileReader(), chunkIndex);
-      }
+      RawColumnChunkUtil.readDimensionRawColumnChunk(rawBlockletColumnChunks,
+          dimColEvaluatorInfoList.get(0), chunkIndex);
     } else if (isMeasurePresentInCurrentBlock[0]) {
       int chunkIndex = measureChunkIndex[0];
-      if (null == rawBlockletColumnChunks.getMeasureRawColumnChunks()[chunkIndex]) {
-        rawBlockletColumnChunks.getMeasureRawColumnChunks()[chunkIndex] =
-            rawBlockletColumnChunks.getDataBlock().readMeasureChunk(
-                rawBlockletColumnChunks.getFileReader(), chunkIndex);
-      }
+      RawColumnChunkUtil.readMeasureRawColumnChunk(rawBlockletColumnChunks, chunkIndex);
     }
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RowLevelRangeGrtrThanEquaToFilterExecuterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RowLevelRangeGrtrThanEquaToFilterExecuterImpl.java
@@ -431,18 +431,11 @@ public class RowLevelRangeGrtrThanEquaToFilterExecuterImpl extends RowLevelFilte
         super.readColumnChunks(rawBlockletColumnChunks);
       }
       int chunkIndex = dimensionChunkIndex[0];
-      if (null == rawBlockletColumnChunks.getDimensionRawColumnChunks()[chunkIndex]) {
-        rawBlockletColumnChunks.getDimensionRawColumnChunks()[chunkIndex] =
-            rawBlockletColumnChunks.getDataBlock().readDimensionChunk(
-                rawBlockletColumnChunks.getFileReader(), chunkIndex);
-      }
+      RawColumnChunkUtil.readDimensionRawColumnChunk(rawBlockletColumnChunks,
+          dimColEvaluatorInfoList.get(0), chunkIndex);
     } else if (isMeasurePresentInCurrentBlock[0]) {
       int chunkIndex = measureChunkIndex[0];
-      if (null == rawBlockletColumnChunks.getMeasureRawColumnChunks()[chunkIndex]) {
-        rawBlockletColumnChunks.getMeasureRawColumnChunks()[chunkIndex] =
-            rawBlockletColumnChunks.getDataBlock().readMeasureChunk(
-                rawBlockletColumnChunks.getFileReader(), chunkIndex);
-      }
+      RawColumnChunkUtil.readMeasureRawColumnChunk(rawBlockletColumnChunks, chunkIndex);
     }
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RowLevelRangeLessThanEqualFilterExecuterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RowLevelRangeLessThanEqualFilterExecuterImpl.java
@@ -471,18 +471,11 @@ public class RowLevelRangeLessThanEqualFilterExecuterImpl extends RowLevelFilter
         super.readColumnChunks(rawBlockletColumnChunks);
       }
       int chunkIndex = dimensionChunkIndex[0];
-      if (null == rawBlockletColumnChunks.getDimensionRawColumnChunks()[chunkIndex]) {
-        rawBlockletColumnChunks.getDimensionRawColumnChunks()[chunkIndex] =
-            rawBlockletColumnChunks.getDataBlock().readDimensionChunk(
-                rawBlockletColumnChunks.getFileReader(), chunkIndex);
-      }
+      RawColumnChunkUtil.readDimensionRawColumnChunk(rawBlockletColumnChunks,
+          dimColEvaluatorInfoList.get(0), chunkIndex);
     } else if (isMeasurePresentInCurrentBlock[0]) {
       int chunkIndex = measureChunkIndex[0];
-      if (null == rawBlockletColumnChunks.getMeasureRawColumnChunks()[chunkIndex]) {
-        rawBlockletColumnChunks.getMeasureRawColumnChunks()[chunkIndex] =
-            rawBlockletColumnChunks.getDataBlock().readMeasureChunk(
-                rawBlockletColumnChunks.getFileReader(), chunkIndex);
-      }
+      RawColumnChunkUtil.readMeasureRawColumnChunk(rawBlockletColumnChunks, chunkIndex);
     }
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RowLevelRangeLessThanFilterExecuterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RowLevelRangeLessThanFilterExecuterImpl.java
@@ -484,18 +484,11 @@ public class RowLevelRangeLessThanFilterExecuterImpl extends RowLevelFilterExecu
         super.readColumnChunks(rawBlockletColumnChunks);
       }
       int chunkIndex = dimensionChunkIndex[0];
-      if (null == rawBlockletColumnChunks.getDimensionRawColumnChunks()[chunkIndex]) {
-        rawBlockletColumnChunks.getDimensionRawColumnChunks()[chunkIndex] =
-            rawBlockletColumnChunks.getDataBlock().readDimensionChunk(
-                rawBlockletColumnChunks.getFileReader(), chunkIndex);
-      }
+      RawColumnChunkUtil.readDimensionRawColumnChunk(rawBlockletColumnChunks,
+          dimColEvaluatorInfoList.get(0), chunkIndex);
     } else if (isMeasurePresentInCurrentBlock[0]) {
       int chunkIndex = measureChunkIndex[0];
-      if (null == rawBlockletColumnChunks.getMeasureRawColumnChunks()[chunkIndex]) {
-        rawBlockletColumnChunks.getMeasureRawColumnChunks()[chunkIndex] =
-            rawBlockletColumnChunks.getDataBlock().readMeasureChunk(
-                rawBlockletColumnChunks.getFileReader(), chunkIndex);
-      }
+      RawColumnChunkUtil.readMeasureRawColumnChunk(rawBlockletColumnChunks, chunkIndex);
     }
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/util/AbstractDataFileFooterConverter.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/AbstractDataFileFooterConverter.java
@@ -436,8 +436,8 @@ public abstract class AbstractDataFileFooterConverter {
         return DataTypes.createDefaultArrayType();
       case STRUCT:
         return DataTypes.createDefaultStructType();
-      case TEXT:
-        return DataTypes.TEXT;
+      case VARCHAR:
+        return DataTypes.VARCHAR;
       default:
         return DataTypes.STRING;
     }

--- a/core/src/main/java/org/apache/carbondata/core/util/AbstractDataFileFooterConverter.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/AbstractDataFileFooterConverter.java
@@ -436,6 +436,8 @@ public abstract class AbstractDataFileFooterConverter {
         return DataTypes.createDefaultArrayType();
       case STRUCT:
         return DataTypes.createDefaultStructType();
+      case TEXT:
+        return DataTypes.TEXT;
       default:
         return DataTypes.STRING;
     }

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
@@ -2307,8 +2307,8 @@ public final class CarbonUtil {
         return DataTypes.createDefaultArrayType();
       case STRUCT:
         return DataTypes.createDefaultStructType();
-      case TEXT:
-        return DataTypes.TEXT;
+      case VARCHAR:
+        return DataTypes.VARCHAR;
       default:
         return DataTypes.STRING;
     }
@@ -2469,7 +2469,7 @@ public final class CarbonUtil {
     } else if (dataType == DataTypes.STRING
         || dataType == DataTypes.TIMESTAMP
         || dataType == DataTypes.DATE
-        || dataType == DataTypes.TEXT) {
+        || dataType == DataTypes.VARCHAR) {
       return (byte[]) value;
     } else {
       throw new IllegalArgumentException("Invalid data type: " + dataType);

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
@@ -2307,6 +2307,8 @@ public final class CarbonUtil {
         return DataTypes.createDefaultArrayType();
       case STRUCT:
         return DataTypes.createDefaultStructType();
+      case TEXT:
+        return DataTypes.TEXT;
       default:
         return DataTypes.STRING;
     }
@@ -2464,8 +2466,10 @@ public final class CarbonUtil {
       return DataTypeUtil.bigDecimalToByte((BigDecimal) value);
     } else if (dataType == DataTypes.BYTE_ARRAY) {
       return (byte[]) value;
-    } else if (dataType == DataTypes.STRING || dataType == DataTypes.TIMESTAMP ||
-        dataType == DataTypes.DATE) {
+    } else if (dataType == DataTypes.STRING
+        || dataType == DataTypes.TIMESTAMP
+        || dataType == DataTypes.DATE
+        || dataType == DataTypes.TEXT) {
       return (byte[]) value;
     } else {
       throw new IllegalArgumentException("Invalid data type: " + dataType);

--- a/core/src/main/java/org/apache/carbondata/core/util/DataTypeUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/DataTypeUtil.java
@@ -854,8 +854,8 @@ public final class DataTypeUtil {
       return DataTypes.FLOAT;
     } else if (DataTypes.DOUBLE.getName().equalsIgnoreCase(name)) {
       return DataTypes.DOUBLE;
-    } else if (DataTypes.TEXT.getName().equalsIgnoreCase(name)) {
-      return DataTypes.TEXT;
+    } else if (DataTypes.VARCHAR.getName().equalsIgnoreCase(name)) {
+      return DataTypes.VARCHAR;
     } else if (DataTypes.NULL.getName().equalsIgnoreCase(name)) {
       return DataTypes.NULL;
     } else if (DataTypes.BYTE_ARRAY.getName().equalsIgnoreCase(name)) {
@@ -904,8 +904,8 @@ public final class DataTypeUtil {
       return DataTypes.FLOAT;
     } else if (DataTypes.DOUBLE.getName().equalsIgnoreCase(dataType.getName())) {
       return DataTypes.DOUBLE;
-    } else if (DataTypes.TEXT.getName().equalsIgnoreCase(dataType.getName())) {
-      return DataTypes.TEXT;
+    } else if (DataTypes.VARCHAR.getName().equalsIgnoreCase(dataType.getName())) {
+      return DataTypes.VARCHAR;
     } else if (DataTypes.NULL.getName().equalsIgnoreCase(dataType.getName())) {
       return DataTypes.NULL;
     } else if (DataTypes.BYTE_ARRAY.getName().equalsIgnoreCase(dataType.getName())) {

--- a/core/src/main/java/org/apache/carbondata/core/util/DataTypeUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/DataTypeUtil.java
@@ -854,6 +854,8 @@ public final class DataTypeUtil {
       return DataTypes.FLOAT;
     } else if (DataTypes.DOUBLE.getName().equalsIgnoreCase(name)) {
       return DataTypes.DOUBLE;
+    } else if (DataTypes.TEXT.getName().equalsIgnoreCase(name)) {
+      return DataTypes.TEXT;
     } else if (DataTypes.NULL.getName().equalsIgnoreCase(name)) {
       return DataTypes.NULL;
     } else if (DataTypes.BYTE_ARRAY.getName().equalsIgnoreCase(name)) {
@@ -902,6 +904,8 @@ public final class DataTypeUtil {
       return DataTypes.FLOAT;
     } else if (DataTypes.DOUBLE.getName().equalsIgnoreCase(dataType.getName())) {
       return DataTypes.DOUBLE;
+    } else if (DataTypes.TEXT.getName().equalsIgnoreCase(dataType.getName())) {
+      return DataTypes.TEXT;
     } else if (DataTypes.NULL.getName().equalsIgnoreCase(dataType.getName())) {
       return DataTypes.NULL;
     } else if (DataTypes.BYTE_ARRAY.getName().equalsIgnoreCase(dataType.getName())) {

--- a/core/src/test/java/org/apache/carbondata/core/metadata/converter/ThriftWrapperSchemaConverterImplTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/metadata/converter/ThriftWrapperSchemaConverterImplTest.java
@@ -1562,7 +1562,7 @@ public class ThriftWrapperSchemaConverterImplTest {
   }
 
   @Test public void testFromExternalToWrapperSchemaEvolutionEntry() {
-long time =1112745600000L;
+    long time =1112745600000L;
     ColumnSchema wrapperColumnSchema = new ColumnSchema();
     wrapperColumnSchema.setColumnUniqueId("1");
     wrapperColumnSchema.setColumnName("columnName");

--- a/format/src/main/thrift/schema.thrift
+++ b/format/src/main/thrift/schema.thrift
@@ -35,6 +35,7 @@ enum DataType {
 	BOOLEAN = 8,
 	ARRAY = 20,
 	STRUCT = 21,
+	TEXT = 22,
 }
 
 /**
@@ -56,6 +57,7 @@ enum Encoding{
 	ADAPTIVE_FLOATING = 11; // Identifies that a column is encoded using AdaptiveFloatingCodec
 	BOOL_BYTE = 12;   // Identifies that a column is encoded using BooleanPageCodec
 	ADAPTIVE_DELTA_FLOATING = 13; // Identifies that a column is encoded using AdaptiveDeltaFloatingCodec
+	DIRECT_COMPRESS_TEXT = 14;  // Identifies that a columm is encoded using DirectCompressTextCodec, it is used for long string columns
 }
 
 enum PartitionType{
@@ -173,6 +175,7 @@ struct TableSchema{
   4: optional map<string,string> tableProperties; // Table properties configured by the user
   5: optional BucketingInfo bucketingInfo; // Bucketing information
   6: optional PartitionInfo partitionInfo; // Partition information
+  7: optional list<string> long_string_columns // long string columns in the table
 }
 
 struct RelationIdentifier {

--- a/format/src/main/thrift/schema.thrift
+++ b/format/src/main/thrift/schema.thrift
@@ -35,7 +35,7 @@ enum DataType {
 	BOOLEAN = 8,
 	ARRAY = 20,
 	STRUCT = 21,
-	TEXT = 22,
+	VARCHAR = 22,
 }
 
 /**
@@ -57,7 +57,7 @@ enum Encoding{
 	ADAPTIVE_FLOATING = 11; // Identifies that a column is encoded using AdaptiveFloatingCodec
 	BOOL_BYTE = 12;   // Identifies that a column is encoded using BooleanPageCodec
 	ADAPTIVE_DELTA_FLOATING = 13; // Identifies that a column is encoded using AdaptiveDeltaFloatingCodec
-	DIRECT_COMPRESS_TEXT = 14;  // Identifies that a columm is encoded using DirectCompressTextCodec, it is used for long string columns
+	DIRECT_COMPRESS_VARCHAR = 14;  // Identifies that a columm is encoded using DirectCompressCodec, it is used for long string columns
 }
 
 enum PartitionType{

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/longstring/VarcharDataTypesBasicTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/longstring/VarcharDataTypesBasicTestCase.scala
@@ -66,12 +66,14 @@ class VarcharDataTypesBasicTestCase extends QueryTest with BeforeAndAfterEach wi
   }
 
   private def prepareTable(): Unit = {
+    // there are two long string columns: `description` is implicitly specified through `varchar` data type,
+    // while `note` is explicitly specified through property `long_string_columns`.
     sql(
       s"""
          | CREATE TABLE if not exists $longStringTable(
-         | id INT, name STRING, description STRING, address STRING, note STRING
+         | id INT, name STRING, description VARCHAR(33), address STRING, note STRING
          | ) STORED BY 'carbondata'
-         | TBLPROPERTIES('LONG_STRING_COLUMNS'='description, note', 'SORT_COLUMNS'='name')
+         | TBLPROPERTIES('SORT_COLUMNS'='name', 'long_string_columns'='note')
          |""".stripMargin)
     sql(
       s"""

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/longstring/VarcharDataTypesBasicTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/longstring/VarcharDataTypesBasicTestCase.scala
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.carbondata.spark.testsuite.texttype
+package org.apache.carbondata.spark.testsuite.longstring
 
 import java.io.{File, PrintWriter}
 
@@ -26,9 +26,9 @@ import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.util.CarbonProperties
 
-class TextDataTypesBasicTestCase extends QueryTest with BeforeAndAfterEach with BeforeAndAfterAll {
+class VarcharDataTypesBasicTestCase extends QueryTest with BeforeAndAfterEach with BeforeAndAfterAll {
   private val longStringTable = "long_string_table"
-  private val inputDir = s"$resourcesPath${File.separator}texttype${File.separator}"
+  private val inputDir = s"$resourcesPath${File.separator}varchartype${File.separator}"
   private val fileName = s"longStringData.csv"
   private val inputFile = s"$inputDir$fileName"
   private val lineNum = 1000

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/texttype/TextDataTypesBasicTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/texttype/TextDataTypesBasicTestCase.scala
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.spark.testsuite.texttype
+
+import java.io.{File, PrintWriter}
+
+import org.apache.commons.lang3.RandomStringUtils
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.test.util.QueryTest
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
+
+import org.apache.carbondata.core.constants.CarbonCommonConstants
+import org.apache.carbondata.core.util.CarbonProperties
+
+class TextDataTypesBasicTestCase extends QueryTest with BeforeAndAfterEach with BeforeAndAfterAll {
+  private val longStringTable = "long_string_table"
+  private val inputDir = s"$resourcesPath${File.separator}texttype${File.separator}"
+  private val fileName = s"longStringData.csv"
+  private val inputFile = s"$inputDir$fileName"
+  private val lineNum = 1000
+  private val head = 0
+  private val mid = lineNum / 2
+  private var tail = lineNum - 1
+  private var desc_line_head: String = _
+  private var desc_line_half: String = _
+  private var desc_line_tail: String = _
+  private var note_line_head: String = _
+  private var note_line_half: String = _
+  private var note_line_tail: String = _
+
+  override def beforeAll(): Unit = {
+    deleteFile(inputFile)
+    if (!new File(inputDir).exists()) {
+      new File(inputDir).mkdir()
+    }
+    createFile(inputFile, line = lineNum)
+  }
+
+  override def afterAll(): Unit = {
+    deleteFile(inputFile)
+    if (new File(inputDir).exists()) {
+      new File(inputDir).delete()
+    }
+  }
+
+  override def beforeEach(): Unit = {
+    sql(s"drop table if exists $longStringTable")
+  }
+
+  override def afterEach(): Unit = {
+    sql(s"drop table if exists $longStringTable")
+  }
+
+  private def prepareTable(): Unit = {
+    sql(
+      s"""
+         | CREATE TABLE if not exists $longStringTable(
+         | id INT, name STRING, description STRING, address STRING, note STRING
+         | ) STORED BY 'carbondata'
+         | TBLPROPERTIES('LONG_STRING_COLUMNS'='description, note', 'SORT_COLUMNS'='name')
+         |""".stripMargin)
+    sql(
+      s"""
+         | LOAD DATA LOCAL INPATH '$inputFile' INTO TABLE $longStringTable
+         | OPTIONS('header'='false')
+       """.stripMargin)
+  }
+
+  private def checkQuery(): Unit = {
+    // query without long_string_column
+    checkAnswer(sql(s"SELECT id, name, address FROM $longStringTable where id = $tail"),
+      Row(tail, s"name_$tail", s"address_$tail"))
+    // query return long_string_column in the middle position
+    checkAnswer(sql(s"SELECT id, name, description, address FROM $longStringTable where id = $head"),
+      Row(head, s"name_$head", desc_line_head, s"address_$head"))
+    // query return long_string_column at last position
+    checkAnswer(sql(s"SELECT id, name, address, description FROM $longStringTable where id = $mid"),
+      Row(mid, s"name_$mid", s"address_$mid", desc_line_half))
+    // query return 2 long_string_columns
+    checkAnswer(sql(s"SELECT id, name, note, address, description FROM $longStringTable where id = $mid"),
+      Row(mid, s"name_$mid", note_line_half, s"address_$mid", desc_line_half))
+    // query by simple string column
+    checkAnswer(sql(s"SELECT id, note, address, description FROM $longStringTable where name = 'name_$tail'"),
+      Row(tail, note_line_tail, s"address_$tail", desc_line_tail))
+    // query by long string column
+    checkAnswer(sql(s"SELECT id, name, address, description FROM $longStringTable where note = '$note_line_tail'"),
+      Row(tail, s"name_$tail", s"address_$tail", desc_line_tail))
+  }
+
+  test("Load and query with long string datatype: safe") {
+    CarbonProperties.getInstance().addProperty(CarbonCommonConstants.ENABLE_UNSAFE_SORT, "false")
+    CarbonProperties.getInstance().addProperty(CarbonCommonConstants.ENABLE_OFFHEAP_SORT, "false")
+
+    prepareTable()
+    checkQuery()
+
+    CarbonProperties.getInstance().addProperty(CarbonCommonConstants.ENABLE_UNSAFE_SORT,
+      CarbonCommonConstants.ENABLE_UNSAFE_SORT_DEFAULT)
+    CarbonProperties.getInstance().addProperty(CarbonCommonConstants.ENABLE_OFFHEAP_SORT,
+      CarbonCommonConstants.ENABLE_OFFHEAP_SORT_DEFAULT)
+  }
+
+  test("Load and query with long string datatype: unsafe") {
+    CarbonProperties.getInstance().addProperty(CarbonCommonConstants.ENABLE_UNSAFE_SORT, "true")
+    CarbonProperties.getInstance().addProperty(CarbonCommonConstants.ENABLE_OFFHEAP_SORT, "true")
+
+    prepareTable()
+    checkQuery()
+
+    CarbonProperties.getInstance().addProperty(CarbonCommonConstants.ENABLE_UNSAFE_SORT,
+      CarbonCommonConstants.ENABLE_UNSAFE_SORT_DEFAULT)
+    CarbonProperties.getInstance().addProperty(CarbonCommonConstants.ENABLE_OFFHEAP_SORT,
+      CarbonCommonConstants.ENABLE_OFFHEAP_SORT_DEFAULT)
+  }
+
+
+  private def createFile(filePath: String, line: Int = 10000, start: Int = 0): Unit = {
+    if (!new File(filePath).exists()) {
+      val write = new PrintWriter(new File(filePath))
+      for (i <- start until (start + line)) {
+        val description = RandomStringUtils.randomAlphabetic(Short.MaxValue + 1000)
+        val note = RandomStringUtils.randomAlphabetic(Short.MaxValue + 1000)
+        val line = s"$i,name_$i,$description,address_$i,$note"
+        if (head == i) {
+          desc_line_head = description
+          note_line_head = note
+        } else if (mid == i) {
+          desc_line_half = description
+          note_line_half = note
+        } else if (tail == i) {
+          desc_line_tail = description
+          note_line_tail = note
+        }
+        write.println(line)
+      }
+      write.close()
+    }
+  }
+
+  private def deleteFile(filePath: String): Unit = {
+    val file = new File(filePath)
+    if (file.exists()) {
+      file.delete()
+    }
+  }
+}

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/CarbonScalaUtil.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/CarbonScalaUtil.scala
@@ -115,7 +115,7 @@ object CarbonScalaUtil {
         case CarbonDataTypes.BOOLEAN => BooleanType
         case CarbonDataTypes.TIMESTAMP => TimestampType
         case CarbonDataTypes.DATE => DateType
-        case CarbonDataTypes.TEXT => StringType
+        case CarbonDataTypes.VARCHAR => StringType
       }
     }
   }

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/CarbonScalaUtil.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/CarbonScalaUtil.scala
@@ -115,6 +115,7 @@ object CarbonScalaUtil {
         case CarbonDataTypes.BOOLEAN => BooleanType
         case CarbonDataTypes.TIMESTAMP => TimestampType
         case CarbonDataTypes.DATE => DateType
+        case CarbonDataTypes.TEXT => StringType
       }
     }
   }

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/DataTypeConverterUtil.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/DataTypeConverterUtil.scala
@@ -126,7 +126,7 @@ object DataTypeConverterUtil {
       case "timestamp" => ThriftDataType.TIMESTAMP
       case "array" => ThriftDataType.ARRAY
       case "struct" => ThriftDataType.STRUCT
-      case "text" => ThriftDataType.TEXT
+      case "varchar" => ThriftDataType.VARCHAR
       case _ => ThriftDataType.STRING
     }
   }

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/DataTypeConverterUtil.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/DataTypeConverterUtil.scala
@@ -126,6 +126,7 @@ object DataTypeConverterUtil {
       case "timestamp" => ThriftDataType.TIMESTAMP
       case "array" => ThriftDataType.ARRAY
       case "struct" => ThriftDataType.STRUCT
+      case "text" => ThriftDataType.TEXT
       case _ => ThriftDataType.STRING
     }
   }

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
@@ -279,7 +279,7 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
     fields.zipWithIndex.foreach { case (field, index) =>
       field.schemaOrdinal = index
     }
-    val (dims, msrs, noDictionaryDims, sortKeyDims) = extractDimAndMsrFields(
+    val (dims, msrs, noDictionaryDims, sortKeyDims, textColumns) = extractDimAndMsrFields(
       fields, tableProperties)
 
     // column properties
@@ -310,6 +310,7 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
       reorderDimensions(dims.map(f => normalizeType(f)).map(f => addParent(f))),
       msrs.map(f => normalizeType(f)),
       Option(sortKeyDims),
+      Option(textColumns),
       Option(noDictionaryDims),
       Option(noInvertedIdxCols),
       groupCols,
@@ -547,12 +548,31 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
    * @return
    */
   protected def extractDimAndMsrFields(fields: Seq[Field],
-      tableProperties: Map[String, String]): (Seq[Field], Seq[Field], Seq[String], Seq[String]) = {
+      tableProperties: Map[String, String]):
+  (Seq[Field], Seq[Field], Seq[String], Seq[String], Seq[String]) = {
     var dimFields: LinkedHashSet[Field] = LinkedHashSet[Field]()
     var msrFields: Seq[Field] = Seq[Field]()
     var dictExcludeCols: Array[String] = Array[String]()
     var noDictionaryDims: Seq[String] = Seq[String]()
     var dictIncludeCols: Seq[String] = Seq[String]()
+    var textCols: Seq[String] = Seq[String]()
+
+    // All long_string cols should be there in create table cols and should be of string data type
+    if (tableProperties.get(CarbonCommonConstants.LONG_STRING_COLUMNS).isDefined) {
+      textCols =
+        tableProperties(CarbonCommonConstants.LONG_STRING_COLUMNS).split(",").map(_.trim)
+      textCols.foreach { textCol =>
+        val exists = fields.exists(f => f.column.equalsIgnoreCase(textCol) &&
+                                        DataTypes.STRING.getName.equalsIgnoreCase(f.dataType.get))
+        if (!exists) {
+          throw new MalformedCarbonCommandException(
+            s"""
+               |${CarbonCommonConstants.LONG_STRING_COLUMNS}: $textCol does not exist in table
+               | or its data type is not string. Please check create table statement.
+             """.stripMargin)
+        }
+      }
+    }
 
     // All columns in sortkey should be there in create table cols
     val sortKeyOption = tableProperties.get(CarbonCommonConstants.SORT_COLUMNS)
@@ -582,6 +602,10 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
           if (isDataTypeSupportedForSortColumn(dataType)) {
             val errormsg = s"sort_columns is unsupported for $dataType datatype column: " + column
             throw new MalformedCarbonCommandException(errormsg)
+          }
+          if (textCols.exists(x => x.equalsIgnoreCase(column))) {
+            throw new MalformedCarbonCommandException(
+              s"sort_columns is unsupported for long string datatype column $column")
           }
         }
       }
@@ -680,9 +704,11 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
 
     var sortKeyDims = sortKeyDimsTmp
     if (sortKeyOption.isEmpty) {
-      // if SORT_COLUMNS was not defined, add all dimension to SORT_COLUMNS.
+      // if SORT_COLUMNS was not defined,
+      // add all dimension(except long string columns) to SORT_COLUMNS.
       dimFields.foreach { field =>
-        if (!isComplexDimDictionaryExclude(field.dataType.get)) {
+        if (!isComplexDimDictionaryExclude(field.dataType.get) &&
+            !textCols.contains(field.column)) {
           sortKeyDims :+= field.column
         }
       }
@@ -693,7 +719,7 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
     } else {
       tableProperties.put(CarbonCommonConstants.SORT_COLUMNS, sortKeyDims.mkString(","))
     }
-    (dimFields.toSeq, msrFields, noDictionaryDims, sortKeyDims)
+    (dimFields.toSeq, msrFields, noDictionaryDims, sortKeyDims, textCols)
   }
 
   def isDefaultMeasure(dataType: Option[String]): Boolean = {

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonRelation.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonRelation.scala
@@ -201,7 +201,7 @@ case class CarbonRelation(
 object CarbonMetastoreTypes extends RegexParsers {
   protected lazy val primitiveType: Parser[DataType] =
     "string" ^^^ StringType |
-    "text" ^^^ StringType |
+    "varchar" ^^^ StringType |
     "float" ^^^ FloatType |
     "int" ^^^ IntegerType |
     "tinyint" ^^^ ShortType |

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonRelation.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonRelation.scala
@@ -201,6 +201,7 @@ case class CarbonRelation(
 object CarbonMetastoreTypes extends RegexParsers {
   protected lazy val primitiveType: Parser[DataType] =
     "string" ^^^ StringType |
+    "text" ^^^ StringType |
     "float" ^^^ FloatType |
     "int" ^^^ IntegerType |
     "tinyint" ^^^ ShortType |

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/converter/impl/NonDictionaryFieldConverterImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/converter/impl/NonDictionaryFieldConverterImpl.java
@@ -73,8 +73,10 @@ public class NonDictionaryFieldConverterImpl implements FieldConverter {
               .getBytesBasedOnDataTypeForNoDictionaryColumn(dimensionValue, dataType, dateFormat);
           if (dataType == DataTypes.STRING
               && value.length > CarbonCommonConstants.MAX_CHARS_PER_COLUMN_DEFAULT) {
-            throw new CarbonDataLoadingException("Dataload failed, String size cannot exceed "
-                + CarbonCommonConstants.MAX_CHARS_PER_COLUMN_DEFAULT + " bytes");
+            throw new CarbonDataLoadingException(String.format(
+                "Dataload failed, String size cannot exceed %d bytes,"
+                    + " please consider long string data type",
+                CarbonCommonConstants.MAX_CHARS_PER_COLUMN_DEFAULT));
           }
           row.update(value, index);
         } else {
@@ -82,8 +84,10 @@ public class NonDictionaryFieldConverterImpl implements FieldConverter {
               .getDataDataTypeForNoDictionaryColumn(dimensionValue, dataType, dateFormat);
           if (dataType == DataTypes.STRING
               && value.toString().length() > CarbonCommonConstants.MAX_CHARS_PER_COLUMN_DEFAULT) {
-            throw new CarbonDataLoadingException("Dataload failed, String size cannot exceed "
-                + CarbonCommonConstants.MAX_CHARS_PER_COLUMN_DEFAULT + " bytes");
+            throw new CarbonDataLoadingException(String.format(
+                "Dataload failed, String size cannot exceed %d bytes,"
+                    + " please consider long string data type",
+                CarbonCommonConstants.MAX_CHARS_PER_COLUMN_DEFAULT));
           }
           row.update(value, index);
         }

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/csvinput/CSVInputFormat.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/csvinput/CSVInputFormat.java
@@ -205,7 +205,9 @@ public class CSVInputFormat extends FileInputFormat<NullWritable, StringArrayWri
     parserSettings.setSkipEmptyLines(
         Boolean.valueOf(job.get(SKIP_EMPTY_LINE,
             CarbonCommonConstants.CARBON_SKIP_EMPTY_LINE_DEFAULT)));
-    parserSettings.setMaxCharsPerColumn(CarbonCommonConstants.MAX_CHARS_PER_COLUMN_DEFAULT);
+    // todo: will verify whether there is a performance degrade using -1 here
+    // parserSettings.setMaxCharsPerColumn(CarbonCommonConstants.MAX_CHARS_PER_COLUMN_DEFAULT);
+    parserSettings.setMaxCharsPerColumn(CarbonCommonConstants.MAX_CHARS_PER_COLUMN_INFINITY);
     String maxColumns = job.get(MAX_COLUMNS, "" + DEFAULT_MAX_NUMBER_OF_COLUMNS_FOR_PARSING);
     parserSettings.setMaxColumns(Integer.parseInt(maxColumns));
     parserSettings.getFormat().setQuote(job.get(QUOTE, QUOTE_DEFAULT).charAt(0));

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/row/IntermediateSortTempRow.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/row/IntermediateSortTempRow.java
@@ -54,12 +54,13 @@ public class IntermediateSortTempRow {
   /**
    * deserialize from bytes array to get the no sort fields
    * @param outDictNoSort stores the dict & no-sort fields
-   * @param outNoDictNoSort stores the no-dict & no-sort fields, including complex
+   * @param outNoDictNoSortAndTextDims stores the no-dict & no-sort fields,
+ *                                    including complex and text fields
    * @param outMeasures stores the measure fields
    * @param dataTypes data type for the measure
    */
-  public void unpackNoSortFromBytes(int[] outDictNoSort, byte[][] outNoDictNoSort,
-      Object[] outMeasures, DataType[] dataTypes) {
+  public void unpackNoSortFromBytes(int[] outDictNoSort, byte[][] outNoDictNoSortAndTextDims,
+      Object[] outMeasures, DataType[] dataTypes, int textDimCnt) {
     ByteBuffer rowBuffer = ByteBuffer.wrap(noSortDimsAndMeasures);
     // read dict_no_sort
     int dictNoSortCnt = outDictNoSort.length;
@@ -68,12 +69,20 @@ public class IntermediateSortTempRow {
     }
 
     // read no_dict_no_sort (including complex)
-    int noDictNoSortCnt = outNoDictNoSort.length;
+    int noDictNoSortCnt = outNoDictNoSortAndTextDims.length - textDimCnt;
     for (int i = 0; i < noDictNoSortCnt; i++) {
       short len = rowBuffer.getShort();
       byte[] bytes = new byte[len];
       rowBuffer.get(bytes);
-      outNoDictNoSort[i] = bytes;
+      outNoDictNoSortAndTextDims[i] = bytes;
+    }
+
+    // read text dims
+    for (int i = 0; i < textDimCnt; i++) {
+      int len = rowBuffer.getInt();
+      byte[] bytes = new byte[len];
+      rowBuffer.get(bytes);
+      outNoDictNoSortAndTextDims[i + noDictNoSortCnt] = bytes;
     }
 
     // read measure

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/row/IntermediateSortTempRow.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/row/IntermediateSortTempRow.java
@@ -54,13 +54,13 @@ public class IntermediateSortTempRow {
   /**
    * deserialize from bytes array to get the no sort fields
    * @param outDictNoSort stores the dict & no-sort fields
-   * @param outNoDictNoSortAndTextDims stores the no-dict & no-sort fields,
- *                                    including complex and text fields
+   * @param outNoDictNoSortAndVarcharDims stores the no-dict & no-sort fields,
+ *                                    including complex and varchar fields
    * @param outMeasures stores the measure fields
    * @param dataTypes data type for the measure
    */
-  public void unpackNoSortFromBytes(int[] outDictNoSort, byte[][] outNoDictNoSortAndTextDims,
-      Object[] outMeasures, DataType[] dataTypes, int textDimCnt) {
+  public void unpackNoSortFromBytes(int[] outDictNoSort, byte[][] outNoDictNoSortAndVarcharDims,
+      Object[] outMeasures, DataType[] dataTypes, int varcharDimCnt) {
     ByteBuffer rowBuffer = ByteBuffer.wrap(noSortDimsAndMeasures);
     // read dict_no_sort
     int dictNoSortCnt = outDictNoSort.length;
@@ -69,20 +69,20 @@ public class IntermediateSortTempRow {
     }
 
     // read no_dict_no_sort (including complex)
-    int noDictNoSortCnt = outNoDictNoSortAndTextDims.length - textDimCnt;
+    int noDictNoSortCnt = outNoDictNoSortAndVarcharDims.length - varcharDimCnt;
     for (int i = 0; i < noDictNoSortCnt; i++) {
       short len = rowBuffer.getShort();
       byte[] bytes = new byte[len];
       rowBuffer.get(bytes);
-      outNoDictNoSortAndTextDims[i] = bytes;
+      outNoDictNoSortAndVarcharDims[i] = bytes;
     }
 
-    // read text dims
-    for (int i = 0; i < textDimCnt; i++) {
+    // read varchar dims
+    for (int i = 0; i < varcharDimCnt; i++) {
       int len = rowBuffer.getInt();
       byte[] bytes = new byte[len];
       rowBuffer.get(bytes);
-      outNoDictNoSortAndTextDims[i + noDictNoSortCnt] = bytes;
+      outNoDictNoSortAndVarcharDims[i + noDictNoSortCnt] = bytes;
     }
 
     // read measure

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/sort/SortStepRowHandler.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/sort/SortStepRowHandler.java
@@ -46,7 +46,7 @@ public class SortStepRowHandler implements Serializable {
   private int dictNoSortDimCnt = 0;
   private int noDictSortDimCnt = 0;
   private int noDictNoSortDimCnt = 0;
-  private int textDimCnt = 0;
+  private int varcharDimCnt = 0;
   private int measureCnt;
 
   // indices for dict & sort dimension columns
@@ -57,7 +57,7 @@ public class SortStepRowHandler implements Serializable {
   private int[] noDictSortDimIdx;
   // indices for no-dict & no-sort dimension columns, including complex columns
   private int[] noDictNoSortDimIdx;
-  private int[] textDimIdx;
+  private int[] varcharDimIdx;
   // indices for measure columns
   private int[] measureIdx;
 
@@ -72,13 +72,13 @@ public class SortStepRowHandler implements Serializable {
     this.dictNoSortDimCnt = tableFieldStat.getDictNoSortDimCnt();
     this.noDictSortDimCnt = tableFieldStat.getNoDictSortDimCnt();
     this.noDictNoSortDimCnt = tableFieldStat.getNoDictNoSortDimCnt();
-    this.textDimCnt = tableFieldStat.getTextDimCnt();
+    this.varcharDimCnt = tableFieldStat.getVarcharDimCnt();
     this.measureCnt = tableFieldStat.getMeasureCnt();
     this.dictSortDimIdx = tableFieldStat.getDictSortDimIdx();
     this.dictNoSortDimIdx = tableFieldStat.getDictNoSortDimIdx();
     this.noDictSortDimIdx = tableFieldStat.getNoDictSortDimIdx();
     this.noDictNoSortDimIdx = tableFieldStat.getNoDictNoSortDimIdx();
-    this.textDimIdx = tableFieldStat.getTextDimIdx();
+    this.varcharDimIdx = tableFieldStat.getVarcharDimIdx();
     this.measureIdx = tableFieldStat.getMeasureIdx();
     this.dataTypes = tableFieldStat.getMeasureDataType();
   }
@@ -126,9 +126,9 @@ public class SortStepRowHandler implements Serializable {
       for (int idx = 0; idx < this.noDictNoSortDimCnt; idx++) {
         nonDictArray[idxAcc++] = (byte[]) row[this.noDictNoSortDimIdx[idx]];
       }
-      // convert text dims
-      for (int idx = 0; idx < this.textDimCnt; idx++) {
-        nonDictArray[idxAcc++] = (byte[]) row[this.textDimIdx[idx]];
+      // convert varchar dims
+      for (int idx = 0; idx < this.varcharDimCnt; idx++) {
+        nonDictArray[idxAcc++] = (byte[]) row[this.varcharDimIdx[idx]];
       }
 
       // convert measure data
@@ -154,15 +154,15 @@ public class SortStepRowHandler implements Serializable {
     int[] dictDims
         = new int[this.dictSortDimCnt + this.dictNoSortDimCnt];
     byte[][] noDictArray
-        = new byte[this.noDictSortDimCnt + this.noDictNoSortDimCnt + this.textDimCnt][];
+        = new byte[this.noDictSortDimCnt + this.noDictNoSortDimCnt + this.varcharDimCnt][];
 
     int[] dictNoSortDims = new int[this.dictNoSortDimCnt];
-    byte[][] noDictNoSortAndTextDims
-        = new byte[this.noDictNoSortDimCnt + this.textDimCnt][];
+    byte[][] noDictNoSortAndVarcharDims
+        = new byte[this.noDictNoSortDimCnt + this.varcharDimCnt][];
     Object[] measures = new Object[this.measureCnt];
 
-    sortTempRow.unpackNoSortFromBytes(dictNoSortDims, noDictNoSortAndTextDims, measures,
-        this.dataTypes, this.textDimCnt);
+    sortTempRow.unpackNoSortFromBytes(dictNoSortDims, noDictNoSortAndVarcharDims, measures,
+        this.dataTypes, this.varcharDimCnt);
 
     // dict dims
     System.arraycopy(sortTempRow.getDictSortDims(), 0 , dictDims,
@@ -173,8 +173,8 @@ public class SortStepRowHandler implements Serializable {
     // no dict dims, including complex
     System.arraycopy(sortTempRow.getNoDictSortDims(), 0,
         noDictArray, 0, this.noDictSortDimCnt);
-    System.arraycopy(noDictNoSortAndTextDims, 0, noDictArray,
-        this.noDictSortDimCnt, this.noDictNoSortDimCnt + this.textDimCnt);
+    System.arraycopy(noDictNoSortAndVarcharDims, 0, noDictArray,
+        this.noDictSortDimCnt, this.noDictNoSortDimCnt + this.varcharDimCnt);
 
     // measures are already here
 
@@ -438,9 +438,9 @@ public class SortStepRowHandler implements Serializable {
       rowBuffer.putShort((short) bytes.length);
       rowBuffer.put(bytes);
     }
-    // convert text dims
-    for (int idx = 0; idx < this.textDimCnt; idx++) {
-      byte[] bytes = (byte[]) row[this.textDimIdx[idx]];
+    // convert varchar dims
+    for (int idx = 0; idx < this.varcharDimCnt; idx++) {
+      byte[] bytes = (byte[]) row[this.varcharDimIdx[idx]];
       rowBuffer.putInt(bytes.length);
       rowBuffer.put(bytes);
     }

--- a/processing/src/main/java/org/apache/carbondata/processing/merger/CompactionResultSortProcessor.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/merger/CompactionResultSortProcessor.java
@@ -94,7 +94,7 @@ public class CompactionResultSortProcessor extends AbstractResultProcessor {
   /**
    * boolean mapping for long string dimension
    */
-  private boolean[] isTextDimMapping;
+  private boolean[] isVarcharDimMapping;
   /**
    * agg type defined for measures
    */
@@ -358,7 +358,7 @@ public class CompactionResultSortProcessor extends AbstractResultProcessor {
     measureCount = carbonTable.getMeasureByTableName(tableName).size();
     List<CarbonDimension> dimensions = carbonTable.getDimensionByTableName(tableName);
     noDictionaryColMapping = new boolean[dimensions.size()];
-    isTextDimMapping = new boolean[dimensions.size()];
+    isVarcharDimMapping = new boolean[dimensions.size()];
     int i = 0;
     int j = 0;
     for (CarbonDimension dimension : dimensions) {
@@ -367,8 +367,8 @@ public class CompactionResultSortProcessor extends AbstractResultProcessor {
         continue;
       }
       noDictionaryColMapping[i++] = true;
-      if (dimension.getColumnSchema().getDataType() == DataTypes.TEXT) {
-        isTextDimMapping[j++] = true;
+      if (dimension.getColumnSchema().getDataType() == DataTypes.VARCHAR) {
+        isVarcharDimMapping[j++] = true;
       }
       noDictionaryCount++;
     }
@@ -397,7 +397,7 @@ public class CompactionResultSortProcessor extends AbstractResultProcessor {
         .createSortParameters(carbonTable, carbonLoadModel.getDatabaseName(), tableName,
             dimensionColumnCount, segmentProperties.getComplexDimensions().size(), measureCount,
             noDictionaryCount, segmentId,
-            carbonLoadModel.getTaskNo(), noDictionaryColMapping, isTextDimMapping, true);
+            carbonLoadModel.getTaskNo(), noDictionaryColMapping, isVarcharDimMapping, true);
   }
 
   /**

--- a/processing/src/main/java/org/apache/carbondata/processing/merger/CompactionResultSortProcessor.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/merger/CompactionResultSortProcessor.java
@@ -92,6 +92,10 @@ public class CompactionResultSortProcessor extends AbstractResultProcessor {
    */
   private boolean[] noDictionaryColMapping;
   /**
+   * boolean mapping for long string dimension
+   */
+  private boolean[] isTextDimMapping;
+  /**
    * agg type defined for measures
    */
   private DataType[] dataTypes;
@@ -354,13 +358,18 @@ public class CompactionResultSortProcessor extends AbstractResultProcessor {
     measureCount = carbonTable.getMeasureByTableName(tableName).size();
     List<CarbonDimension> dimensions = carbonTable.getDimensionByTableName(tableName);
     noDictionaryColMapping = new boolean[dimensions.size()];
+    isTextDimMapping = new boolean[dimensions.size()];
     int i = 0;
+    int j = 0;
     for (CarbonDimension dimension : dimensions) {
       if (CarbonUtil.hasEncoding(dimension.getEncoder(), Encoding.DICTIONARY)) {
         i++;
         continue;
       }
       noDictionaryColMapping[i++] = true;
+      if (dimension.getColumnSchema().getDataType() == DataTypes.TEXT) {
+        isTextDimMapping[j++] = true;
+      }
       noDictionaryCount++;
     }
     dimensionColumnCount = dimensions.size();
@@ -388,7 +397,7 @@ public class CompactionResultSortProcessor extends AbstractResultProcessor {
         .createSortParameters(carbonTable, carbonLoadModel.getDatabaseName(), tableName,
             dimensionColumnCount, segmentProperties.getComplexDimensions().size(), measureCount,
             noDictionaryCount, segmentId,
-            carbonLoadModel.getTaskNo(), noDictionaryColMapping, true);
+            carbonLoadModel.getTaskNo(), noDictionaryColMapping, isTextDimMapping, true);
   }
 
   /**

--- a/processing/src/main/java/org/apache/carbondata/processing/sort/sortdata/SortParameters.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/sort/sortdata/SortParameters.java
@@ -111,7 +111,11 @@ public class SortParameters implements Serializable {
   private boolean[] noDictionaryDimnesionColumn;
 
   private boolean[] noDictionarySortColumn;
-
+  /**
+   * whether dimension is text data type.
+   * since all dimensions are string, we use an array of boolean instead of datatypes
+   */
+  private boolean[] isTextDimensionColumn;
   private int numberOfSortColumns;
 
   private int numberOfNoDictSortColumns;
@@ -143,6 +147,7 @@ public class SortParameters implements Serializable {
     parameters.segmentId = segmentId;
     parameters.taskNo = taskNo;
     parameters.noDictionaryDimnesionColumn = noDictionaryDimnesionColumn;
+    parameters.isTextDimensionColumn = isTextDimensionColumn;
     parameters.noDictionarySortColumn = noDictionarySortColumn;
     parameters.numberOfSortColumns = numberOfSortColumns;
     parameters.numberOfNoDictSortColumns = numberOfNoDictSortColumns;
@@ -312,6 +317,14 @@ public class SortParameters implements Serializable {
     this.noDictionaryDimnesionColumn = noDictionaryDimnesionColumn;
   }
 
+  public boolean[] getIsTextDimensionColumn() {
+    return isTextDimensionColumn;
+  }
+
+  public void setIsTextDimensionColumn(boolean[] isTextDimensionColumn) {
+    this.isTextDimensionColumn = isTextDimensionColumn;
+  }
+
   public int getNumberOfCores() {
     return numberOfCores;
   }
@@ -371,6 +384,8 @@ public class SortParameters implements Serializable {
         .getComplexNonDictionaryColumnCount());
     parameters.setNoDictionaryDimnesionColumn(
         CarbonDataProcessorUtil.getNoDictionaryMapping(configuration.getDataFields()));
+    parameters.setIsTextDimensionColumn(
+        CarbonDataProcessorUtil.getIsTextColumnMapping(configuration.getDataFields()));
     parameters.setBatchSortSizeinMb(CarbonDataProcessorUtil.getBatchSortSizeinMb(configuration));
 
     parameters.setNumberOfSortColumns(configuration.getNumberOfSortColumns());
@@ -461,7 +476,8 @@ public class SortParameters implements Serializable {
   public static SortParameters createSortParameters(CarbonTable carbonTable, String databaseName,
       String tableName, int dimColCount, int complexDimColCount, int measureColCount,
       int noDictionaryCount, String segmentId, String taskNo,
-      boolean[] noDictionaryColMaping, boolean isCompactionFlow) {
+      boolean[] noDictionaryColMaping, boolean[] isTextDimensionColumn,
+      boolean isCompactionFlow) {
     SortParameters parameters = new SortParameters();
     CarbonProperties carbonProperties = CarbonProperties.getInstance();
     parameters.setDatabaseName(databaseName);
@@ -476,6 +492,7 @@ public class SortParameters implements Serializable {
     parameters.setNumberOfNoDictSortColumns(carbonTable.getNumberOfNoDictSortColumns());
     parameters.setComplexDimColCount(complexDimColCount);
     parameters.setNoDictionaryDimnesionColumn(noDictionaryColMaping);
+    parameters.setIsTextDimensionColumn(isTextDimensionColumn);
     parameters.setObserver(new SortObserver());
     // get sort buffer size
     parameters.setSortBufferSize(Integer.parseInt(carbonProperties

--- a/processing/src/main/java/org/apache/carbondata/processing/sort/sortdata/SortParameters.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/sort/sortdata/SortParameters.java
@@ -112,10 +112,10 @@ public class SortParameters implements Serializable {
 
   private boolean[] noDictionarySortColumn;
   /**
-   * whether dimension is text data type.
+   * whether dimension is varchar data type.
    * since all dimensions are string, we use an array of boolean instead of datatypes
    */
-  private boolean[] isTextDimensionColumn;
+  private boolean[] isVarcharDimensionColumn;
   private int numberOfSortColumns;
 
   private int numberOfNoDictSortColumns;
@@ -147,7 +147,7 @@ public class SortParameters implements Serializable {
     parameters.segmentId = segmentId;
     parameters.taskNo = taskNo;
     parameters.noDictionaryDimnesionColumn = noDictionaryDimnesionColumn;
-    parameters.isTextDimensionColumn = isTextDimensionColumn;
+    parameters.isVarcharDimensionColumn = isVarcharDimensionColumn;
     parameters.noDictionarySortColumn = noDictionarySortColumn;
     parameters.numberOfSortColumns = numberOfSortColumns;
     parameters.numberOfNoDictSortColumns = numberOfNoDictSortColumns;
@@ -317,12 +317,12 @@ public class SortParameters implements Serializable {
     this.noDictionaryDimnesionColumn = noDictionaryDimnesionColumn;
   }
 
-  public boolean[] getIsTextDimensionColumn() {
-    return isTextDimensionColumn;
+  public boolean[] getIsVarcharDimensionColumn() {
+    return isVarcharDimensionColumn;
   }
 
-  public void setIsTextDimensionColumn(boolean[] isTextDimensionColumn) {
-    this.isTextDimensionColumn = isTextDimensionColumn;
+  public void setIsVarcharDimensionColumn(boolean[] isVarcharDimensionColumn) {
+    this.isVarcharDimensionColumn = isVarcharDimensionColumn;
   }
 
   public int getNumberOfCores() {
@@ -384,8 +384,8 @@ public class SortParameters implements Serializable {
         .getComplexNonDictionaryColumnCount());
     parameters.setNoDictionaryDimnesionColumn(
         CarbonDataProcessorUtil.getNoDictionaryMapping(configuration.getDataFields()));
-    parameters.setIsTextDimensionColumn(
-        CarbonDataProcessorUtil.getIsTextColumnMapping(configuration.getDataFields()));
+    parameters.setIsVarcharDimensionColumn(
+        CarbonDataProcessorUtil.getIsVarcharColumnMapping(configuration.getDataFields()));
     parameters.setBatchSortSizeinMb(CarbonDataProcessorUtil.getBatchSortSizeinMb(configuration));
 
     parameters.setNumberOfSortColumns(configuration.getNumberOfSortColumns());
@@ -476,7 +476,7 @@ public class SortParameters implements Serializable {
   public static SortParameters createSortParameters(CarbonTable carbonTable, String databaseName,
       String tableName, int dimColCount, int complexDimColCount, int measureColCount,
       int noDictionaryCount, String segmentId, String taskNo,
-      boolean[] noDictionaryColMaping, boolean[] isTextDimensionColumn,
+      boolean[] noDictionaryColMaping, boolean[] isVarcharDimensionColumn,
       boolean isCompactionFlow) {
     SortParameters parameters = new SortParameters();
     CarbonProperties carbonProperties = CarbonProperties.getInstance();
@@ -492,7 +492,7 @@ public class SortParameters implements Serializable {
     parameters.setNumberOfNoDictSortColumns(carbonTable.getNumberOfNoDictSortColumns());
     parameters.setComplexDimColCount(complexDimColCount);
     parameters.setNoDictionaryDimnesionColumn(noDictionaryColMaping);
-    parameters.setIsTextDimensionColumn(isTextDimensionColumn);
+    parameters.setIsVarcharDimensionColumn(isVarcharDimensionColumn);
     parameters.setObserver(new SortObserver());
     // get sort buffer size
     parameters.setSortBufferSize(Integer.parseInt(carbonProperties

--- a/processing/src/main/java/org/apache/carbondata/processing/sort/sortdata/TableFieldStat.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/sort/sortdata/TableFieldStat.java
@@ -33,13 +33,13 @@ public class TableFieldStat implements Serializable {
   private int dictSortDimCnt = 0;
   private int dictNoSortDimCnt = 0;
   private int noDictSortDimCnt = 0;
-  // for columns that are no_dict_dim and no_sort_dim and complex, except the text dims
+  // for columns that are no_dict_dim and no_sort_dim and complex, except the varchar dims
   private int noDictNoSortDimCnt = 0;
-  // for columns that are text data type
-  private int textDimCnt = 0;
+  // for columns that are varchar data type
+  private int varcharDimCnt = 0;
   // whether sort column is of dictionary type or not
   private boolean[] isSortColNoDictFlags;
-  private boolean[] isTextDimFlags;
+  private boolean[] isVarcharDimFlags;
   private int measureCnt;
   private DataType[] measureDataType;
 
@@ -51,8 +51,8 @@ public class TableFieldStat implements Serializable {
   private int[] noDictSortDimIdx;
   // indices for no-dict & no-sort dimension columns, including complex columns
   private int[] noDictNoSortDimIdx;
-  // indices for text dimension columns
-  private int[] textDimIdx;
+  // indices for varchar dimension columns
+  private int[] varcharDimIdx;
   // indices for measure columns
   private int[] measureIdx;
 
@@ -61,7 +61,7 @@ public class TableFieldStat implements Serializable {
     int complexDimCnt = sortParameters.getComplexDimColCount();
     int dictDimCnt = sortParameters.getDimColCount() - noDictDimCnt;
     this.isSortColNoDictFlags = sortParameters.getNoDictionarySortColumn();
-    this.isTextDimFlags = sortParameters.getIsTextDimensionColumn();
+    this.isVarcharDimFlags = sortParameters.getIsVarcharDimensionColumn();
     int sortColCnt = isSortColNoDictFlags.length;
     for (boolean flag : isSortColNoDictFlags) {
       if (flag) {
@@ -73,9 +73,9 @@ public class TableFieldStat implements Serializable {
     this.measureCnt = sortParameters.getMeasureColCount();
     this.measureDataType = sortParameters.getMeasureDataType();
 
-    for (boolean flag : isTextDimFlags) {
+    for (boolean flag : isVarcharDimFlags) {
       if (flag) {
-        textDimCnt++;
+        varcharDimCnt++;
       }
     }
 
@@ -84,21 +84,21 @@ public class TableFieldStat implements Serializable {
     this.dictNoSortDimIdx = new int[dictDimCnt - dictSortDimCnt];
     this.noDictSortDimIdx = new int[noDictSortDimCnt];
     this.noDictNoSortDimIdx = new int[noDictDimCnt + complexDimCnt - noDictSortDimCnt
-        - textDimCnt];
-    this.textDimIdx = new int[textDimCnt];
+        - varcharDimCnt];
+    this.varcharDimIdx = new int[varcharDimCnt];
     this.measureIdx = new int[measureCnt];
 
     int tmpNoDictSortCnt = 0;
     int tmpNoDictNoSortCnt = 0;
     int tmpDictSortCnt = 0;
     int tmpDictNoSortCnt = 0;
-    int tmpTextCnt = 0;
+    int tmpVarcharCnt = 0;
     boolean[] isDimNoDictFlags = sortParameters.getNoDictionaryDimnesionColumn();
 
     for (int i = 0; i < isDimNoDictFlags.length; i++) {
       if (isDimNoDictFlags[i]) {
-        if (isTextDimFlags[i]) {
-          textDimIdx[tmpTextCnt++] = i;
+        if (isVarcharDimFlags[i]) {
+          varcharDimIdx[tmpVarcharCnt++] = i;
         } else if (i < sortColCnt && isSortColNoDictFlags[i]) {
           noDictSortDimIdx[tmpNoDictSortCnt++] = i;
         } else {
@@ -144,16 +144,16 @@ public class TableFieldStat implements Serializable {
     return noDictNoSortDimCnt;
   }
 
-  public int getTextDimCnt() {
-    return textDimCnt;
+  public int getVarcharDimCnt() {
+    return varcharDimCnt;
   }
 
   public boolean[] getIsSortColNoDictFlags() {
     return isSortColNoDictFlags;
   }
 
-  public boolean[] getIsTextDimFlags() {
-    return isTextDimFlags;
+  public boolean[] getIsVarcharDimFlags() {
+    return isVarcharDimFlags;
   }
 
   public int getMeasureCnt() {
@@ -180,8 +180,8 @@ public class TableFieldStat implements Serializable {
     return noDictNoSortDimIdx;
   }
 
-  public int[] getTextDimIdx() {
-    return textDimIdx;
+  public int[] getVarcharDimIdx() {
+    return varcharDimIdx;
   }
 
   public int[] getMeasureIdx() {
@@ -196,12 +196,12 @@ public class TableFieldStat implements Serializable {
         && dictNoSortDimCnt == that.dictNoSortDimCnt
         && noDictSortDimCnt == that.noDictSortDimCnt
         && noDictNoSortDimCnt == that.noDictNoSortDimCnt
-        && textDimCnt == that.textDimCnt
+        && varcharDimCnt == that.varcharDimCnt
         && measureCnt == that.measureCnt;
   }
 
   @Override public int hashCode() {
     return Objects.hash(dictSortDimCnt, dictNoSortDimCnt, noDictSortDimCnt,
-        noDictNoSortDimCnt, textDimCnt, measureCnt);
+        noDictNoSortDimCnt, varcharDimCnt, measureCnt);
   }
 }

--- a/processing/src/main/java/org/apache/carbondata/processing/sort/sortdata/TableFieldStat.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/sort/sortdata/TableFieldStat.java
@@ -33,9 +33,13 @@ public class TableFieldStat implements Serializable {
   private int dictSortDimCnt = 0;
   private int dictNoSortDimCnt = 0;
   private int noDictSortDimCnt = 0;
+  // for columns that are no_dict_dim and no_sort_dim and complex, except the text dims
   private int noDictNoSortDimCnt = 0;
+  // for columns that are text data type
+  private int textDimCnt = 0;
   // whether sort column is of dictionary type or not
   private boolean[] isSortColNoDictFlags;
+  private boolean[] isTextDimFlags;
   private int measureCnt;
   private DataType[] measureDataType;
 
@@ -47,6 +51,8 @@ public class TableFieldStat implements Serializable {
   private int[] noDictSortDimIdx;
   // indices for no-dict & no-sort dimension columns, including complex columns
   private int[] noDictNoSortDimIdx;
+  // indices for text dimension columns
+  private int[] textDimIdx;
   // indices for measure columns
   private int[] measureIdx;
 
@@ -55,6 +61,7 @@ public class TableFieldStat implements Serializable {
     int complexDimCnt = sortParameters.getComplexDimColCount();
     int dictDimCnt = sortParameters.getDimColCount() - noDictDimCnt;
     this.isSortColNoDictFlags = sortParameters.getNoDictionarySortColumn();
+    this.isTextDimFlags = sortParameters.getIsTextDimensionColumn();
     int sortColCnt = isSortColNoDictFlags.length;
     for (boolean flag : isSortColNoDictFlags) {
       if (flag) {
@@ -66,22 +73,33 @@ public class TableFieldStat implements Serializable {
     this.measureCnt = sortParameters.getMeasureColCount();
     this.measureDataType = sortParameters.getMeasureDataType();
 
+    for (boolean flag : isTextDimFlags) {
+      if (flag) {
+        textDimCnt++;
+      }
+    }
+
     // be careful that the default value is 0
     this.dictSortDimIdx = new int[dictSortDimCnt];
     this.dictNoSortDimIdx = new int[dictDimCnt - dictSortDimCnt];
     this.noDictSortDimIdx = new int[noDictSortDimCnt];
-    this.noDictNoSortDimIdx = new int[noDictDimCnt + complexDimCnt - noDictSortDimCnt];
+    this.noDictNoSortDimIdx = new int[noDictDimCnt + complexDimCnt - noDictSortDimCnt
+        - textDimCnt];
+    this.textDimIdx = new int[textDimCnt];
     this.measureIdx = new int[measureCnt];
 
     int tmpNoDictSortCnt = 0;
     int tmpNoDictNoSortCnt = 0;
     int tmpDictSortCnt = 0;
     int tmpDictNoSortCnt = 0;
+    int tmpTextCnt = 0;
     boolean[] isDimNoDictFlags = sortParameters.getNoDictionaryDimnesionColumn();
 
     for (int i = 0; i < isDimNoDictFlags.length; i++) {
       if (isDimNoDictFlags[i]) {
-        if (i < sortColCnt && isSortColNoDictFlags[i]) {
+        if (isTextDimFlags[i]) {
+          textDimIdx[tmpTextCnt++] = i;
+        } else if (i < sortColCnt && isSortColNoDictFlags[i]) {
           noDictSortDimIdx[tmpNoDictSortCnt++] = i;
         } else {
           noDictNoSortDimIdx[tmpNoDictNoSortCnt++] = i;
@@ -126,8 +144,16 @@ public class TableFieldStat implements Serializable {
     return noDictNoSortDimCnt;
   }
 
+  public int getTextDimCnt() {
+    return textDimCnt;
+  }
+
   public boolean[] getIsSortColNoDictFlags() {
     return isSortColNoDictFlags;
+  }
+
+  public boolean[] getIsTextDimFlags() {
+    return isTextDimFlags;
   }
 
   public int getMeasureCnt() {
@@ -154,6 +180,10 @@ public class TableFieldStat implements Serializable {
     return noDictNoSortDimIdx;
   }
 
+  public int[] getTextDimIdx() {
+    return textDimIdx;
+  }
+
   public int[] getMeasureIdx() {
     return measureIdx;
   }
@@ -166,11 +196,12 @@ public class TableFieldStat implements Serializable {
         && dictNoSortDimCnt == that.dictNoSortDimCnt
         && noDictSortDimCnt == that.noDictSortDimCnt
         && noDictNoSortDimCnt == that.noDictNoSortDimCnt
+        && textDimCnt == that.textDimCnt
         && measureCnt == that.measureCnt;
   }
 
   @Override public int hashCode() {
     return Objects.hash(dictSortDimCnt, dictNoSortDimCnt, noDictSortDimCnt,
-        noDictNoSortDimCnt, measureCnt);
+        noDictNoSortDimCnt, textDimCnt, measureCnt);
   }
 }

--- a/processing/src/main/java/org/apache/carbondata/processing/store/TablePage.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/TablePage.java
@@ -100,8 +100,8 @@ public class TablePage {
     for (int i = 0; i < noDictDimensionPages.length; i++) {
       TableSpec.DimensionSpec spec = tableSpec.getDimensionSpec(i + numDictDimension);
       ColumnPage page;
-      if (DataTypes.TEXT == spec.getSchemaDataType()) {
-        page = ColumnPage.newPage(spec, DataTypes.TEXT, pageSize);
+      if (DataTypes.VARCHAR == spec.getSchemaDataType()) {
+        page = ColumnPage.newPage(spec, DataTypes.VARCHAR, pageSize);
         page.setStatsCollector(LVLongStringStatsCollector.newInstance());
       } else {
         // In previous implementation, other data types such as string, date and timestamp
@@ -164,7 +164,7 @@ public class TablePage {
       dictDimensionPages[i].putData(rowId, keys[i]);
     }
 
-    // 2. convert noDictionary columns and complex columns and text columns.
+    // 2. convert noDictionary columns and complex columns and varchar columns.
     int noDictionaryCount = noDictDimensionPages.length;
     int complexColumnCount = complexDimensionPages.length;
     if (noDictionaryCount > 0 || complexColumnCount > 0) {
@@ -172,7 +172,7 @@ public class TablePage {
       byte[][] noDictAndComplex = WriteStepRowUtil.getNoDictAndComplexDimension(row);
       for (int i = 0; i < noDictAndComplex.length; i++) {
         if (tableSpec.getDimensionSpec(dictDimensionPages.length + i).getSchemaDataType()
-            == DataTypes.TEXT) {
+            == DataTypes.VARCHAR) {
           byte[] valueWithLength = addIntLengthToByteArray(noDictAndComplex[i]);
           noDictDimensionPages[i].putData(rowId, valueWithLength);
         } else if (i < noDictionaryCount) {

--- a/processing/src/main/java/org/apache/carbondata/processing/util/CarbonDataProcessorUtil.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/util/CarbonDataProcessorUtil.java
@@ -224,10 +224,10 @@ public final class CarbonDataProcessorUtil {
   }
 
   /**
-   * Preparing the boolean [] to map whether the dimension is text data type or not.
+   * Preparing the boolean [] to map whether the dimension is varchar data type or not.
    */
-  public static boolean[] getIsTextColumnMapping(DataField[] fields) {
-    List<Boolean> isTextColumnMapping = new ArrayList<Boolean>();
+  public static boolean[] getIsVarcharColumnMapping(DataField[] fields) {
+    List<Boolean> isVarcharColumnMapping = new ArrayList<Boolean>();
     for (DataField field : fields) {
       // for complex type need to break the loop
       if (field.getColumn().isComplex()) {
@@ -235,12 +235,12 @@ public final class CarbonDataProcessorUtil {
       }
 
       if (field.getColumn().isDimension()) {
-        isTextColumnMapping.add(
-            field.getColumn().getColumnSchema().getDataType() == DataTypes.TEXT);
+        isVarcharColumnMapping.add(
+            field.getColumn().getColumnSchema().getDataType() == DataTypes.VARCHAR);
       }
     }
     return ArrayUtils.toPrimitive(
-        isTextColumnMapping.toArray(new Boolean[isTextColumnMapping.size()]));
+        isVarcharColumnMapping.toArray(new Boolean[isVarcharColumnMapping.size()]));
   }
 
   public static boolean[] getNoDictionaryMapping(CarbonColumn[] carbonColumns) {

--- a/processing/src/main/java/org/apache/carbondata/processing/util/CarbonDataProcessorUtil.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/util/CarbonDataProcessorUtil.java
@@ -223,6 +223,26 @@ public final class CarbonDataProcessorUtil {
         .toPrimitive(noDictionaryMapping.toArray(new Boolean[noDictionaryMapping.size()]));
   }
 
+  /**
+   * Preparing the boolean [] to map whether the dimension is text data type or not.
+   */
+  public static boolean[] getIsTextColumnMapping(DataField[] fields) {
+    List<Boolean> isTextColumnMapping = new ArrayList<Boolean>();
+    for (DataField field : fields) {
+      // for complex type need to break the loop
+      if (field.getColumn().isComplex()) {
+        break;
+      }
+
+      if (field.getColumn().isDimension()) {
+        isTextColumnMapping.add(
+            field.getColumn().getColumnSchema().getDataType() == DataTypes.TEXT);
+      }
+    }
+    return ArrayUtils.toPrimitive(
+        isTextColumnMapping.toArray(new Boolean[isTextColumnMapping.size()]));
+  }
+
   public static boolean[] getNoDictionaryMapping(CarbonColumn[] carbonColumns) {
     List<Boolean> noDictionaryMapping = new ArrayList<Boolean>();
     for (CarbonColumn column : carbonColumns) {


### PR DESCRIPTION
In DDL statement, column with varchar data type is implicitly considered long string column. User can also explicitly specify the column as string column in property 'long_string_columns'. Carbondata will consider both of them.

This PR follows #2252

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 `NO`
 - [x] Any backward compatibility impacted?
  `NO`
 - [x] Document update required?
 `Yes, will update it after the 32k feature is finished`
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
`Tests update`
        - How it is tested? Please attach test report.
`Tested in local`
        - Is it a performance related change? Please attach the performance test report.
`NO`
        - Any additional information to help reviewers in testing this change.
      `NA` 
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
`NA`

