### PR TITLE
[CARBONDATA-2610] Fix for datamap creation failed on table having loaded data with null value on string datatype

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/datamap/lucene/LuceneFineGrainDataMapSuite.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/datamap/lucene/LuceneFineGrainDataMapSuite.scala
@@ -815,6 +815,37 @@ class LuceneFineGrainDataMapSuite extends QueryTest with BeforeAndAfterAll {
       sql("select * from table_stop where text_match('suggestion:*is*')").collect().length == 1)
   }
 
+  test("test lucene data map on null values") {
+    sql("DROP TABLE IF EXISTS datamap_test4")
+    sql("DROP TABLE IF EXISTS datamap_copy")
+    sql(
+      """
+        | CREATE TABLE datamap_test4(id INT, name STRING, city STRING, age INT)
+        | STORED BY 'carbondata'
+        | TBLPROPERTIES('SORT_COLUMNS'='city,name', 'SORT_SCOPE'='LOCAL_SORT', 'autorefreshdatamap' = 'false')
+      """.stripMargin)
+    sql(
+      """
+        | CREATE TABLE datamap_copy(id INT, name STRING, city STRING, age INT)
+        | STORED BY 'carbondata'
+        | TBLPROPERTIES('SORT_COLUMNS'='city,name', 'SORT_SCOPE'='LOCAL_SORT', 'autorefreshdatamap' = 'false')
+      """.stripMargin)
+    sql("insert into datamap_test4 select 1,'name','city',20")
+    sql("insert into datamap_test4 select 2,'name1','city1',20")
+    sql("insert into datamap_test4 select 25,cast(null as string),'city2',NULL")
+    sql("insert into datamap_copy select * from datamap_test4")
+    sql(
+      s"""
+         | CREATE DATAMAP dm4 ON TABLE datamap_test4
+         | USING 'lucene'
+         | DMProperties('INDEX_COLUMNS'='name , city')
+      """.stripMargin)
+    checkAnswer(sql("SELECT * FROM datamap_test4 WHERE TEXT_MATCH('name:n*')"),
+      sql(s"select * from datamap_copy where name like '%n%'"))
+    sql("drop table datamap_test4")
+    sql("drop table datamap_copy")
+  }
+
   override protected def afterAll(): Unit = {
     LuceneFineGrainDataMapSuite.deleteFile(file2)
     sql("DROP TABLE IF EXISTS normal_test")

--- a/integration/spark2/src/main/scala/org/apache/carbondata/datamap/IndexDataMapRebuildRDD.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/datamap/IndexDataMapRebuildRDD.scala
@@ -126,7 +126,7 @@ class OriginalReadSupport(dataTypes: Array[DataType]) extends CarbonReadSupport[
 
   override def readRow(data: Array[Object]): Array[Object] = {
     dataTypes.zipWithIndex.foreach { case (dataType, i) =>
-      if (dataType == DataTypes.STRING) {
+      if (dataType == DataTypes.STRING && data(i) != null) {
         data(i) = data(i).toString
       }
     }


### PR DESCRIPTION
Problem: Datamap creation having null values already loaded in string datatype of table fails.
Solution: Check for null before converting data to the string.
Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed? No
 
 - [ ] Any backward compatibility impacted? No
 
 - [ ] Document update required? No

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required? Yes
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. NA

