### PR TITLE
[CARBONDATA-2614] Fix the error when using FG in search mode and the prune result is none

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/scan/model/QueryModel.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/model/QueryModel.java
@@ -109,6 +109,11 @@ public class QueryModel {
    */
   private boolean requiredRowId;
 
+  /**
+   * whether it is FG with search mode
+   */
+  private boolean isFG;
+
   private QueryModel(CarbonTable carbonTable) {
     tableBlockInfos = new ArrayList<TableBlockInfo>();
     invalidSegmentIds = new ArrayList<>();
@@ -368,6 +373,14 @@ public class QueryModel {
 
   public void setRequiredRowId(boolean requiredRowId) {
     this.requiredRowId = requiredRowId;
+  }
+
+  public boolean isFG() {
+    return isFG;
+  }
+
+  public void setFG(boolean FG) {
+    isFG = FG;
   }
 
   @Override

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/CarbonRecordReader.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/CarbonRecordReader.java
@@ -80,7 +80,7 @@ public class CarbonRecordReader<T> extends AbstractRecordReader<T> {
     }
     // It should use the exists tableBlockInfos if tableBlockInfos of queryModel is not empty
     // otherwise the prune is no use before this method
-    if (queryModel.getTableBlockInfos().isEmpty()) {
+    if (!queryModel.isFG()) {
       List<TableBlockInfo> tableBlockInfoList = CarbonInputSplit.createBlocks(splitList);
       queryModel.setTableBlockInfos(tableBlockInfoList);
     }

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/detailquery/SearchModeTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/detailquery/SearchModeTestCase.scala
@@ -111,22 +111,26 @@ class SearchModeTestCase extends QueryTest with BeforeAndAfterAll {
   }
 
   test("test lucene datamap with search mode") {
+    sql("set carbon.search.enabled = true")
     sql("DROP DATAMAP IF EXISTS dm ON TABLE main")
     sql("CREATE DATAMAP dm ON TABLE main USING 'lucene' DMProperties('INDEX_COLUMNS'='id') ")
+    sql(s"SELECT * FROM main WHERE id='100000'").show()
     checkAnswer(sql("SELECT * FROM main WHERE TEXT_MATCH('id:100000')"),
       sql(s"SELECT * FROM main WHERE id='100000'"))
     sql("DROP DATAMAP if exists dm ON TABLE main")
   }
 
   test("test lucene datamap with search mode 2") {
+    sql("set carbon.search.enabled = true")
     sql("drop datamap if exists dm3 ON TABLE main")
     sql("CREATE DATAMAP dm3 ON TABLE main USING 'lucene' DMProperties('INDEX_COLUMNS'='city') ")
-    checkAnswer(sql("SELECT * FROM main WHERE TEXT_MATCH('city:city6')"),
-      sql("SELECT * FROM main WHERE city='city6'"))
+    checkAnswer(sql("SELECT * FROM main WHERE TEXT_MATCH('city:city5')"),
+      sql("SELECT * FROM main WHERE city='city5'"))
     sql("DROP DATAMAP if exists dm3 ON TABLE main")
   }
 
   test("test lucene datamap with search mode, two column") {
+    sql("set carbon.search.enabled = true")
     sql("drop datamap if exists dm3 ON TABLE main")
     sql("CREATE DATAMAP dm3 ON TABLE main USING 'lucene' DMProperties('INDEX_COLUMNS'='city , id') ")
     checkAnswer(sql("SELECT * FROM main WHERE TEXT_MATCH('city:city6')"),

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/detailquery/SearchModeTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/detailquery/SearchModeTestCase.scala
@@ -114,23 +114,20 @@ class SearchModeTestCase extends QueryTest with BeforeAndAfterAll {
     sql("set carbon.search.enabled = true")
     sql("DROP DATAMAP IF EXISTS dm ON TABLE main")
     sql("CREATE DATAMAP dm ON TABLE main USING 'lucene' DMProperties('INDEX_COLUMNS'='id') ")
-    sql(s"SELECT * FROM main WHERE id='100000'").show()
     checkAnswer(sql("SELECT * FROM main WHERE TEXT_MATCH('id:100000')"),
       sql(s"SELECT * FROM main WHERE id='100000'"))
     sql("DROP DATAMAP if exists dm ON TABLE main")
   }
 
   test("test lucene datamap with search mode 2") {
-    sql("set carbon.search.enabled = true")
     sql("drop datamap if exists dm3 ON TABLE main")
     sql("CREATE DATAMAP dm3 ON TABLE main USING 'lucene' DMProperties('INDEX_COLUMNS'='city') ")
-    checkAnswer(sql("SELECT * FROM main WHERE TEXT_MATCH('city:city5')"),
-      sql("SELECT * FROM main WHERE city='city5'"))
+    checkAnswer(sql("SELECT * FROM main WHERE TEXT_MATCH('city:city6')"),
+      sql("SELECT * FROM main WHERE city='city6'"))
     sql("DROP DATAMAP if exists dm3 ON TABLE main")
   }
 
   test("test lucene datamap with search mode, two column") {
-    sql("set carbon.search.enabled = true")
     sql("drop datamap if exists dm3 ON TABLE main")
     sql("CREATE DATAMAP dm3 ON TABLE main USING 'lucene' DMProperties('INDEX_COLUMNS'='city , id') ")
     checkAnswer(sql("SELECT * FROM main WHERE TEXT_MATCH('city:city6')"),

--- a/store/search/src/main/java/org/apache/carbondata/store/worker/SearchRequestHandler.java
+++ b/store/search/src/main/java/org/apache/carbondata/store/worker/SearchRequestHandler.java
@@ -201,6 +201,7 @@ public class SearchRequestHandler {
     LOG.info(String.format("[SearchId:%d] pruned using FG DataMap, pruned blocks: %d", queryId,
         blockToRead.size()));
     queryModel.setTableBlockInfos(blockToRead);
+    queryModel.setFG(true);
     return queryModel;
   }
 


### PR DESCRIPTION

 the prune result is none, and can not set datamapWritePath, which will not generate bitSegGroup in org.apache.carbondata.core.scan.filter.executer.RowLevelFilterExecuterImpl#applyFilter(org.apache.carbondata.core.scan.processor.RawBlockletColumnChunks, boolean), it mean the bitSetGroup is null. It will throw Fix the error when using FG in search mode and the prune result is none


 - [x] Any interfaces changed?
 No
 - [x] Any backward compatibility impacted?
 No
 - [x] Document update required?
No
 - [x] Testing done
     run the test case
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NO