### PR TITLE
[CARBONDATA-2509][CARBONDATA-2510][CARBONDATA-2511][32K]  Add validate for long string columns

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/longstring/VarcharDataTypesBasicTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/longstring/VarcharDataTypesBasicTestCase.scala
@@ -74,6 +74,63 @@ class VarcharDataTypesBasicTestCase extends QueryTest with BeforeAndAfterEach wi
     sql(s"drop table if exists $longStringTable")
   }
 
+  test("long string columns cannot be dictionary include") {
+    val exceptionCaught = intercept[Exception] {
+      sql(
+        s"""
+           | CREATE TABLE if not exists $longStringTable(
+           | id INT, name STRING, description STRING, address STRING, note STRING
+           | ) STORED BY 'carbondata'
+           | TBLPROPERTIES('LONG_STRING_COLUMNS'='address, note', 'dictionary_include'='address')
+           |""".
+          stripMargin)
+    }
+    assert(exceptionCaught.getMessage.contains("DICTIONARY_INCLUDE is unsupported for long string datatype column: address"))
+  }
+
+  test("long string columns cannot be dictionay exclude") {
+    val exceptionCaught = intercept[Exception] {
+      sql(
+        s"""
+           | CREATE TABLE if not exists $longStringTable(
+           | id INT, name STRING, description STRING, address STRING, note STRING
+           | ) STORED BY 'carbondata'
+           | TBLPROPERTIES('LONG_STRING_COLUMNS'='address, note', 'dictionary_exclude'='address')
+           |""".
+          stripMargin)
+    }
+    assert(exceptionCaught.getMessage.contains("DICTIONARY_EXCLUDE is unsupported for long string datatype column: address"))
+  }
+
+  test("long string columns cannot be sort_columns") {
+    val exceptionCaught = intercept[Exception] {
+      sql(
+        s"""
+           | CREATE TABLE if not exists $longStringTable(
+           | id INT, name STRING, description STRING, address STRING, note STRING
+           | ) STORED BY 'carbondata'
+           | TBLPROPERTIES('LONG_STRING_COLUMNS'='name, note', 'SORT_COLUMNS'='name, address')
+           |""".
+          stripMargin)
+    }
+    assert(exceptionCaught.getMessage.contains("sort_columns is unsupported for long string datatype column: name"))
+  }
+
+  test("long string columns can only be string columns") {
+    val exceptionCaught = intercept[Exception] {
+      sql(
+        s"""
+           | CREATE TABLE if not exists $longStringTable(
+           | id INT, name STRING, description STRING, address STRING, note STRING
+           | ) STORED BY 'carbondata'
+           | TBLPROPERTIES('LONG_STRING_COLUMNS'='id, note')
+           |""".
+          stripMargin)
+    }
+    assert(exceptionCaught.getMessage.contains("long_string_columns: id"))
+    assert(exceptionCaught.getMessage.contains("its data type is not string"))
+  }
+
   private def prepareTable(): Unit = {
     sql(
       s"""

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
@@ -749,7 +749,7 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
           }
           if (varcharCols.exists(x => x.equalsIgnoreCase(column))) {
             throw new MalformedCarbonCommandException(
-              s"sort_columns is unsupported for long string datatype column $column")
+              s"sort_columns is unsupported for long string datatype column: $column")
           }
         }
       }
@@ -788,6 +788,10 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
               val errorMsg = "DICTIONARY_EXCLUDE is unsupported for " + dataType.toLowerCase() +
                              " data type column: " + dictExcludeCol
               throw new MalformedCarbonCommandException(errorMsg)
+            } else if (varcharCols.contains(dictExcludeCol)) {
+              throw new MalformedCarbonCommandException(
+                "DICTIONARY_EXCLUDE is unsupported for long string datatype column: " +
+                dictExcludeCol)
             }
           }
         }
@@ -801,6 +805,11 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
           val errormsg = "DICTIONARY_INCLUDE column: " + distIncludeCol.trim +
                          " does not exist in table. Please check create table statement."
           throw new MalformedCarbonCommandException(errormsg)
+        }
+        if (varcharCols.exists(x => x.equalsIgnoreCase(distIncludeCol.trim))) {
+          throw new MalformedCarbonCommandException(
+            "DICTIONARY_INCLUDE is unsupported for long string datatype column: " +
+            distIncludeCol.trim)
         }
       }
     }

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
@@ -788,7 +788,7 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
               val errorMsg = "DICTIONARY_EXCLUDE is unsupported for " + dataType.toLowerCase() +
                              " data type column: " + dictExcludeCol
               throw new MalformedCarbonCommandException(errorMsg)
-            } else if (varcharCols.contains(dictExcludeCol)) {
+            } else if (varcharCols.exists(x => x.equalsIgnoreCase(dictExcludeCol))) {
               throw new MalformedCarbonCommandException(
                 "DICTIONARY_EXCLUDE is unsupported for long string datatype column: " +
                 dictExcludeCol)


### PR DESCRIPTION
1. long string columns cannot be sort_columns
2. long string columns cannot be dictionary include
3. long string columns cannot be dictionary exclude
4. long string columns can only be string columns

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 `NO`
 - [x] Any backward compatibility impacted?
  `NO`
 - [x] Document update required?
 `NO`
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
`Added tests`
        - How it is tested? Please attach test report.
`Tested in local`
        - Is it a performance related change? Please attach the performance test report.
`NO`
        - Any additional information to help reviewers in testing this change.
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

