### PR TITLE
[CARBONDATA-2513][32K] Support write long string from dataframe

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/longstring/VarcharDataTypesBasicTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/longstring/VarcharDataTypesBasicTestCase.scala
@@ -20,8 +20,9 @@ package org.apache.carbondata.spark.testsuite.longstring
 import java.io.{File, PrintWriter}
 
 import org.apache.commons.lang3.RandomStringUtils
-import org.apache.spark.sql.Row
+import org.apache.spark.sql.{DataFrame, Row, SaveMode}
 import org.apache.spark.sql.test.util.QueryTest
+import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants
@@ -36,6 +37,7 @@ class VarcharDataTypesBasicTestCase extends QueryTest with BeforeAndAfterEach wi
   private val inputFile_2g_column_page = s"$inputDir$fileName_2g_column_page"
   private val lineNum = 1000
   private var content: Content = _
+  private var longStringDF: DataFrame = _
   private var originMemorySize = CarbonProperties.getInstance().getProperty(
     CarbonCommonConstants.UNSAFE_WORKING_MEMORY_IN_MB,
     CarbonCommonConstants.UNSAFE_WORKING_MEMORY_IN_MB_DEFAULT)
@@ -198,6 +200,34 @@ class VarcharDataTypesBasicTestCase extends QueryTest with BeforeAndAfterEach wi
        """.stripMargin)
     }
     // since after exception wrapper, we cannot get the root cause directly
+  }
+
+  private def prepareDF(): Unit = {
+    val schema = StructType(
+      StructField("id", IntegerType, nullable = true) ::
+      StructField("name", StringType, nullable = true) ::
+      StructField("description", StringType, nullable = true) ::
+      StructField("address", StringType, nullable = true) ::
+      StructField("note", StringType, nullable = true) :: Nil
+    )
+    longStringDF = sqlContext.sparkSession.read
+      .schema(schema)
+      .csv(inputFile)
+  }
+
+  test("write from dataframe with long string datatype") {
+    prepareDF()
+    // write spark dataframe to carbondata with `long_string_columns` property
+    longStringDF.write
+      .format("carbondata")
+      .option("tableName", longStringTable)
+      .option("single_pass", "false")
+      .option("sort_columns", "name")
+      .option("long_string_columns", "description, note")
+      .mode(SaveMode.Overwrite)
+      .save()
+
+    checkQuery()
   }
 
   // will create 2 long string columns

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/CarbonOption.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/CarbonOption.scala
@@ -48,6 +48,8 @@ class CarbonOption(options: Map[String, String]) {
 
   def dictionaryExclude: Option[String] = options.get("dictionary_exclude")
 
+  def longStringColumns: Option[String] = options.get("long_string_columns")
+
   def tableBlockSize: Option[String] = options.get("table_blocksize")
 
   def bucketNumber: Int = options.getOrElse("bucketnumber", "0").toInt

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/CarbonScalaUtil.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/CarbonScalaUtil.scala
@@ -126,9 +126,10 @@ object CarbonScalaUtil {
       delimiterLevel2: String,
       timeStampFormat: SimpleDateFormat,
       dateFormat: SimpleDateFormat,
+      isVarcharType: Boolean = false,
       level: Int = 1): String = {
     FieldConverter.objectToString(value, serializationNullFormat, delimiterLevel1,
-      delimiterLevel2, timeStampFormat, dateFormat, level)
+      delimiterLevel2, timeStampFormat, dateFormat, isVarcharType = isVarcharType, level)
   }
 
   /**

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonDataFrameWriter.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonDataFrameWriter.scala
@@ -86,6 +86,7 @@ class CarbonDataFrameWriter(sqlContext: SQLContext, val dataFrame: DataFrame) {
       "SORT_COLUMNS" -> options.sortColumns,
       "DICTIONARY_INCLUDE" -> options.dictionaryInclude,
       "DICTIONARY_EXCLUDE" -> options.dictionaryExclude,
+      "LONG_STRING_COLUMNS" -> options.longStringColumns,
       "TABLE_BLOCKSIZE" -> options.tableBlockSize,
       "STREAMING" -> Option(options.isStreaming.toString)
     ).filter(_._2.isDefined)

--- a/streaming/src/main/scala/org/apache/carbondata/streaming/parser/FieldConverter.scala
+++ b/streaming/src/main/scala/org/apache/carbondata/streaming/parser/FieldConverter.scala
@@ -32,6 +32,7 @@ object FieldConverter {
    * @param delimiterLevel2 level 2 delimiter for complex type
    * @param timeStampFormat timestamp format
    * @param dateFormat date format
+   * @param isVarcharType whether it is varchar type. A varchar type has no string length limit
    * @param level level for recursive call
    */
   def objectToString(
@@ -41,12 +42,14 @@ object FieldConverter {
       delimiterLevel2: String,
       timeStampFormat: SimpleDateFormat,
       dateFormat: SimpleDateFormat,
+      isVarcharType: Boolean = false,
       level: Int = 1): String = {
     if (value == null) {
       serializationNullFormat
     } else {
       value match {
-        case s: String => if (s.length > CarbonCommonConstants.MAX_CHARS_PER_COLUMN_DEFAULT) {
+        case s: String => if (!isVarcharType &&
+                              s.length > CarbonCommonConstants.MAX_CHARS_PER_COLUMN_DEFAULT) {
           throw new Exception("Dataload failed, String length cannot exceed " +
                               CarbonCommonConstants.MAX_CHARS_PER_COLUMN_DEFAULT + " characters")
         } else {
@@ -71,7 +74,8 @@ object FieldConverter {
           val builder = new StringBuilder()
           s.foreach { x =>
             builder.append(objectToString(x, serializationNullFormat, delimiterLevel1,
-              delimiterLevel2, timeStampFormat, dateFormat, level + 1)).append(delimiter)
+              delimiterLevel2, timeStampFormat, dateFormat, isVarcharType, level + 1))
+              .append(delimiter)
           }
           builder.substring(0, builder.length - delimiter.length())
         case m: scala.collection.Map[Any, Any] =>
@@ -85,7 +89,8 @@ object FieldConverter {
           val builder = new StringBuilder()
           for (i <- 0 until r.length) {
             builder.append(objectToString(r(i), serializationNullFormat, delimiterLevel1,
-              delimiterLevel2, timeStampFormat, dateFormat, level + 1)).append(delimiter)
+              delimiterLevel2, timeStampFormat, dateFormat, isVarcharType, level + 1))
+              .append(delimiter)
           }
           builder.substring(0, builder.length - delimiter.length())
         case other => other.toString


### PR DESCRIPTION
Support write long string from dataframe

Sample for usage:
```
longStringDF.write
  .format("carbondata")
  .option("tableName", longStringTable)
  .option("single_pass", "false")
  .option("sort_columns", "name")
  .option("long_string_columns", "description, note")
  .mode(SaveMode.Overwrite)
  .save()
```

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 `NO`
 - [x] Any backward compatibility impacted?
  `NO`
 - [x] Document update required?
 `NO`
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
`Tests added`
        - How it is tested? Please attach test report.
`Tested in local machine`
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

