### PR TITLE
[CARBONDATA-2621][BloomDataMap] Lock problem in index datamap

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
@@ -34,6 +34,7 @@ import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.constants.CarbonLoadOptionConstants;
 import org.apache.carbondata.core.constants.CarbonV3DataFormatConstants;
+import org.apache.carbondata.core.datastore.impl.FileFactory;
 import org.apache.carbondata.core.metadata.ColumnarFormatVersion;
 import static org.apache.carbondata.core.constants.CarbonCommonConstants.BLOCKLET_SIZE;
 import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_CUSTOM_BLOCK_DISTRIBUTION;
@@ -1531,6 +1532,8 @@ public final class CarbonProperties {
     if (systemLocation == null) {
       systemLocation = getStorePath();
     }
+    systemLocation = CarbonUtil.checkAndAppendFileSystemURIScheme(systemLocation);
+    systemLocation = FileFactory.getUpdatedFilePath(systemLocation);
     return systemLocation + CarbonCommonConstants.FILE_SEPARATOR + "_system";
   }
 

--- a/core/src/test/java/org/apache/carbondata/core/metadata/schema/table/DiskBasedDMSchemaStoraheProviderSuite.java
+++ b/core/src/test/java/org/apache/carbondata/core/metadata/schema/table/DiskBasedDMSchemaStoraheProviderSuite.java
@@ -37,7 +37,7 @@ public class DiskBasedDMSchemaStoraheProviderSuite {
 
   @BeforeClass public static void setUp() throws IOException {
     String path =
-        new File(DiskBasedDMSchemaStorageProvider.class.getResource("/").getPath() + "../")
+        new File(DiskBasedDMSchemaStoraheProviderSuite.class.getResource("/").getPath() + "../")
             .getCanonicalPath().replaceAll("\\\\", "/");
 
     CarbonProperties.getInstance()

--- a/hadoop/src/test/java/org/apache/carbondata/hadoop/ft/CarbonTableInputFormatTest.java
+++ b/hadoop/src/test/java/org/apache/carbondata/hadoop/ft/CarbonTableInputFormatTest.java
@@ -40,6 +40,7 @@ import org.apache.carbondata.core.util.path.CarbonTablePath;
 import org.apache.carbondata.hadoop.CarbonProjection;
 import org.apache.carbondata.hadoop.api.CarbonTableInputFormat;
 import org.apache.carbondata.hadoop.testutil.StoreCreator;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.IntWritable;
@@ -58,6 +59,8 @@ public class CarbonTableInputFormatTest {
   static {
     CarbonProperties.getInstance().
         addProperty(CarbonCommonConstants.CARBON_BADRECORDS_LOC, "/tmp/carbon/badrecords");
+    CarbonProperties.getInstance()
+        .addProperty(CarbonCommonConstants.CARBON_SYSTEM_FOLDER_LOCATION, "/tmp/carbon/");
     try {
       StoreCreator.createCarbonStore();
     } catch (Exception e) {

--- a/hadoop/src/test/java/org/apache/carbondata/hadoop/ft/CarbonTableOutputFormatTest.java
+++ b/hadoop/src/test/java/org/apache/carbondata/hadoop/ft/CarbonTableOutputFormatTest.java
@@ -51,6 +51,8 @@ public class CarbonTableOutputFormatTest {
   static {
     CarbonProperties.getInstance().
         addProperty(CarbonCommonConstants.CARBON_BADRECORDS_LOC, "/tmp/carbon/badrecords");
+    CarbonProperties.getInstance()
+        .addProperty(CarbonCommonConstants.CARBON_SYSTEM_FOLDER_LOCATION, "/tmp/carbon/");
     try {
       carbonLoadModel = StoreCreator.createTableAndLoadModel();
     } catch (Exception e) {

--- a/integration/presto/src/test/scala/org/apache/carbondata/presto/integrationtest/PrestoAllDataTypeTest.scala
+++ b/integration/presto/src/test/scala/org/apache/carbondata/presto/integrationtest/PrestoAllDataTypeTest.scala
@@ -24,8 +24,10 @@ import org.apache.hadoop.fs.permission.{FsAction, FsPermission}
 import org.scalatest.{BeforeAndAfterAll, FunSuiteLike}
 
 import org.apache.carbondata.common.logging.LogServiceFactory
+import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.datastore.impl.FileFactory
 import org.apache.carbondata.core.datastore.impl.FileFactory.FileType
+import org.apache.carbondata.core.util.CarbonProperties
 import org.apache.carbondata.presto.server.PrestoServer
 
 
@@ -37,6 +39,7 @@ class PrestoAllDataTypeTest extends FunSuiteLike with BeforeAndAfterAll {
   private val rootPath = new File(this.getClass.getResource("/").getPath
                                   + "../../../..").getCanonicalPath
   private val storePath = s"$rootPath/integration/presto/target/store"
+  private val systemPath = s"$rootPath/integration/presto/target/system"
 
 
   // Table schema:
@@ -68,6 +71,8 @@ class PrestoAllDataTypeTest extends FunSuiteLike with BeforeAndAfterAll {
 
   override def beforeAll: Unit = {
     import org.apache.carbondata.presto.util.CarbonDataStoreCreator
+    CarbonProperties.getInstance().addProperty(CarbonCommonConstants.CARBON_SYSTEM_FOLDER_LOCATION,
+      systemPath)
     CarbonDataStoreCreator
       .createCarbonStore(storePath,
         s"$rootPath/integration/presto/src/test/resources/alldatatype.csv")

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/datamap/lucene/LuceneFineGrainDataMapSuite.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/datamap/lucene/LuceneFineGrainDataMapSuite.scala
@@ -41,8 +41,6 @@ class LuceneFineGrainDataMapSuite extends QueryTest with BeforeAndAfterAll {
     LuceneFineGrainDataMapSuite.createFile(file2)
     sql("create database if not exists lucene")
     CarbonProperties.getInstance()
-      .addProperty(CarbonCommonConstants.CARBON_SYSTEM_FOLDER_LOCATION,
-        CarbonEnv.getDatabaseLocation("lucene", sqlContext.sparkSession))
       .addProperty(CarbonCommonConstants.USE_DISTRIBUTED_DATAMAP, "true")
     sql("use lucene")
     sql("DROP TABLE IF EXISTS normal_test")

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/datamap/lucene/LuceneFineGrainDataMapWithSearchModeSuite.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/datamap/lucene/LuceneFineGrainDataMapWithSearchModeSuite.scala
@@ -45,9 +45,6 @@ class LuceneFineGrainDataMapWithSearchModeSuite extends QueryTest with BeforeAnd
       .addProperty(CarbonCommonConstants.CARBON_SEARCH_QUERY_TIMEOUT, "100s")
     LuceneFineGrainDataMapSuite.createFile(file2, n)
     sql("create database if not exists lucene")
-    CarbonProperties.getInstance()
-      .addProperty(CarbonCommonConstants.CARBON_SYSTEM_FOLDER_LOCATION,
-        CarbonEnv.getDatabaseLocation("lucene", sqlContext.sparkSession))
     sql("use lucene")
     sql("DROP TABLE IF EXISTS datamap_test")
     sql(
@@ -305,9 +302,6 @@ class LuceneFineGrainDataMapWithSearchModeSuite extends QueryTest with BeforeAnd
     sql("DROP TABLE IF EXISTS datamap_test")
     sql("DROP TABLE IF EXISTS datamap_test5")
     sql("use default")
-    CarbonProperties.getInstance()
-      .addProperty(CarbonCommonConstants.CARBON_SYSTEM_FOLDER_LOCATION,
-        CarbonProperties.getStorePath)
     sqlContext.sparkSession.asInstanceOf[CarbonSession].stopSearchMode()
   }
 

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/test/TestQueryExecutor.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/test/TestQueryExecutor.scala
@@ -128,6 +128,11 @@ object TestQueryExecutor {
       } else {
         s"$target/bad_store"
       }
+  val systemFolderPath = if (hdfsUrl.startsWith("hdfs://")) {
+    s"$hdfsUrl/systemfolder" + System.nanoTime()
+  } else {
+    s"$target/systemfolder"
+  }
     createDirectory(badStoreLocation)
 
   val hiveresultpath = if (hdfsUrl.startsWith("hdfs://")) {
@@ -175,6 +180,7 @@ object TestQueryExecutor {
       (CarbonCommonConstants.DICTIONARY_SERVER_PORT_DEFAULT.toInt + Random.nextInt(100)) + "")
     .addProperty(CarbonCommonConstants.CARBON_MAX_DRIVER_LRU_CACHE_SIZE, "1024")
     .addProperty(CarbonCommonConstants.CARBON_MAX_EXECUTOR_LRU_CACHE_SIZE, "1024")
+    .addProperty(CarbonCommonConstants.CARBON_SYSTEM_FOLDER_LOCATION, systemFolderPath)
 
   private def lookupQueryExecutor: Class[_] = {
     ServiceLoader.load(classOf[TestQueryExecutorRegister], Utils.getContextOrSparkClassLoader)

--- a/store/sdk/src/test/java/org/apache/carbondata/sdk/file/AvroCarbonWriterTest.java
+++ b/store/sdk/src/test/java/org/apache/carbondata/sdk/file/AvroCarbonWriterTest.java
@@ -27,6 +27,8 @@ import java.util.Map;
 import org.apache.carbondata.common.exceptions.sql.InvalidLoadOptionException;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.metadata.datatype.DataTypes;
+import org.apache.carbondata.core.metadata.schema.table.DiskBasedDMSchemaStorageProvider;
+import org.apache.carbondata.core.util.CarbonProperties;
 import org.apache.carbondata.core.util.path.CarbonTablePath;
 
 import org.apache.avro.generic.GenericData;
@@ -44,6 +46,15 @@ public class AvroCarbonWriterTest {
 
   @Before
   public void cleanFile() {
+    String path = null;
+    try {
+      path = new File(AvroCarbonWriterTest.class.getResource("/").getPath() + "../")
+          .getCanonicalPath().replaceAll("\\\\", "/");
+    } catch (IOException e) {
+      assert (false);
+    }
+    CarbonProperties.getInstance()
+        .addProperty(CarbonCommonConstants.CARBON_SYSTEM_FOLDER_LOCATION, path);
     assert (TestUtil.cleanMdtFile());
   }
 

--- a/store/sdk/src/test/java/org/apache/carbondata/sdk/file/CSVCarbonWriterTest.java
+++ b/store/sdk/src/test/java/org/apache/carbondata/sdk/file/CSVCarbonWriterTest.java
@@ -24,6 +24,8 @@ import java.io.IOException;
 import org.apache.carbondata.common.exceptions.sql.InvalidLoadOptionException;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.metadata.datatype.DataTypes;
+import org.apache.carbondata.core.metadata.schema.table.DiskBasedDMSchemaStorageProvider;
+import org.apache.carbondata.core.util.CarbonProperties;
 import org.apache.carbondata.core.util.path.CarbonTablePath;
 
 import org.apache.commons.io.FileUtils;
@@ -39,6 +41,15 @@ public class CSVCarbonWriterTest {
 
   @Before
   public void cleanFile() {
+    String path = null;
+    try {
+      path = new File(CSVCarbonWriterTest.class.getResource("/").getPath() + "../")
+          .getCanonicalPath().replaceAll("\\\\", "/");
+    } catch (IOException e) {
+      assert (false);
+    }
+    CarbonProperties.getInstance()
+        .addProperty(CarbonCommonConstants.CARBON_SYSTEM_FOLDER_LOCATION, path);
     assert (TestUtil.cleanMdtFile());
   }
 

--- a/store/sdk/src/test/java/org/apache/carbondata/sdk/file/CSVNonTransactionalCarbonWriterTest.java
+++ b/store/sdk/src/test/java/org/apache/carbondata/sdk/file/CSVNonTransactionalCarbonWriterTest.java
@@ -24,6 +24,8 @@ import java.io.IOException;
 import org.apache.carbondata.common.exceptions.sql.InvalidLoadOptionException;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.metadata.datatype.DataTypes;
+import org.apache.carbondata.core.metadata.schema.table.DiskBasedDMSchemaStorageProvider;
+import org.apache.carbondata.core.util.CarbonProperties;
 import org.apache.carbondata.core.util.path.CarbonTablePath;
 
 import org.apache.commons.io.FileUtils;
@@ -38,6 +40,15 @@ import org.junit.Test;
 public class CSVNonTransactionalCarbonWriterTest {
   @Before
   public void cleanFile() {
+    String path = null;
+    try {
+      path = new File(CSVNonTransactionalCarbonWriterTest.class.getResource("/").getPath() + "../")
+          .getCanonicalPath().replaceAll("\\\\", "/");
+    } catch (IOException e) {
+      assert (false);
+    }
+    CarbonProperties.getInstance()
+        .addProperty(CarbonCommonConstants.CARBON_SYSTEM_FOLDER_LOCATION, path);
     assert (TestUtil.cleanMdtFile());
   }
 

--- a/store/sdk/src/test/java/org/apache/carbondata/sdk/file/CarbonReaderTest.java
+++ b/store/sdk/src/test/java/org/apache/carbondata/sdk/file/CarbonReaderTest.java
@@ -28,6 +28,7 @@ import org.apache.carbondata.common.logging.LogService;
 import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.metadata.datatype.DataTypes;
+import org.apache.carbondata.core.metadata.schema.table.DiskBasedDMSchemaStorageProvider;
 import org.apache.carbondata.core.scan.expression.ColumnExpression;
 import org.apache.carbondata.core.scan.expression.LiteralExpression;
 import org.apache.carbondata.core.scan.expression.conditional.*;
@@ -937,6 +938,15 @@ public class CarbonReaderTest extends TestCase {
   @Override
   public void setUp() {
     carbonProperties = CarbonProperties.getInstance();
+    String path = null;
+    try {
+      path = new File(CarbonReaderTest.class.getResource("/").getPath() + "../")
+          .getCanonicalPath().replaceAll("\\\\", "/");
+    } catch (IOException e) {
+      assert (false);
+    }
+    CarbonProperties.getInstance()
+        .addProperty(CarbonCommonConstants.CARBON_SYSTEM_FOLDER_LOCATION, path);
   }
 
   private static final LogService LOGGER =

--- a/store/sdk/src/test/java/org/apache/carbondata/store/LocalCarbonStoreTest.java
+++ b/store/sdk/src/test/java/org/apache/carbondata/store/LocalCarbonStoreTest.java
@@ -21,8 +21,10 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Iterator;
 
+import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.datastore.row.CarbonRow;
 import org.apache.carbondata.core.metadata.datatype.DataTypes;
+import org.apache.carbondata.core.util.CarbonProperties;
 import org.apache.carbondata.sdk.file.Field;
 import org.apache.carbondata.sdk.file.Schema;
 import org.apache.carbondata.sdk.file.TestUtil;
@@ -35,6 +37,15 @@ import org.junit.Test;
 public class LocalCarbonStoreTest {
   @Before
   public void cleanFile() {
+    String path = null;
+    try {
+      path = new File(LocalCarbonStoreTest.class.getResource("/").getPath() + "../")
+          .getCanonicalPath().replaceAll("\\\\", "/");
+    } catch (IOException e) {
+      assert (false);
+    }
+    CarbonProperties.getInstance()
+        .addProperty(CarbonCommonConstants.CARBON_SYSTEM_FOLDER_LOCATION, path);
     assert (TestUtil.cleanMdtFile());
   }
 


### PR DESCRIPTION
**Problem**
The locking for the index Datamap is not correct.
The HDFS lock is not working properly, because the lock is getting created the 
the local filesystem instead of HDFS. 
**Solution**
Corrected the system folder path.
 - [X] Any interfaces changed?
 None
 - [X] Any backward compatibility impacted?
 None
 - [X] Document update required?
None
 - [X] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       Corrected the test case.
 - [X] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA

