### PR TITLE
[CARBONDATA-2625] Optimize the performance of CarbonReader read many files

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -1745,6 +1745,28 @@ public final class CarbonCommonConstants {
   public static final String CARBON_SEARCH_MODE_SCAN_THREAD = "carbon.search.scan.thread";
 
   /**
+   * The size of thread pool used for reading files in Work for CarbonReader. By default,
+   * it is number of cores in Worker
+   */
+  @CarbonProperty
+  @InterfaceStability.Unstable
+  public static final String CARBON_READER_THREAD = "carbon.reader.thread";
+
+  /**
+   * Whether it support CarbonReader, default value is false
+   */
+  @CarbonProperty
+  @InterfaceStability.Unstable
+  public static final String ENABLE_SDK_QUERY_EXECUTOR = "enable.sdk.query.executor";
+
+  /**
+   * Default value is false
+   */
+  @CarbonProperty
+  @InterfaceStability.Unstable
+  public static final String ENABLE_SDK_QUERY_EXECUTOR_DEFAULT = "false";
+
+  /**
    * In search mode, Master will listen on this port for worker registration.
    * If Master failed to start service with this port, it will try to increment the port number
    * and try to bind again, until it is success

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/BlockletDataMapIndexStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/BlockletDataMapIndexStore.java
@@ -18,6 +18,7 @@ package org.apache.carbondata.core.indexstore;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -49,6 +50,7 @@ public class BlockletDataMapIndexStore
    */
   protected CarbonLRUCache lruCache;
 
+  Map<String, Map<String, BlockMetaInfo>> segInfoCache;
   /**
    * map of block info to lock object map, while loading the btree this will be filled
    * and removed after loading the tree for that particular block info, this will be useful
@@ -81,8 +83,16 @@ public class BlockletDataMapIndexStore
         SegmentIndexFileStore indexFileStore = new SegmentIndexFileStore();
         Set<String> filesRead = new HashSet<>();
         String segmentFilePath = identifier.getIndexFilePath();
-        Map<String, BlockMetaInfo> carbonDataFileBlockMetaInfoMapping = BlockletDataMapUtil
-            .createCarbonDataFileBlockMetaInfoMapping(segmentFilePath);
+        if (segInfoCache == null) {
+          segInfoCache = new HashMap<String, Map<String, BlockMetaInfo>>();
+        }
+        Map<String, BlockMetaInfo> carbonDataFileBlockMetaInfoMapping =
+            segInfoCache.get(segmentFilePath);
+        if (carbonDataFileBlockMetaInfoMapping == null) {
+          carbonDataFileBlockMetaInfoMapping = BlockletDataMapUtil
+              .createCarbonDataFileBlockMetaInfoMapping(segmentFilePath);
+          segInfoCache.put(segmentFilePath, carbonDataFileBlockMetaInfoMapping);
+        }
         // if the identifier is not a merge file we can directly load the datamaps
         if (identifier.getMergeIndexFileName() == null) {
           Map<String, BlockMetaInfo> blockMetaInfoMap = BlockletDataMapUtil

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/SegmentPropertiesFetcher.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/SegmentPropertiesFetcher.java
@@ -18,8 +18,10 @@
 package org.apache.carbondata.core.indexstore;
 
 import java.io.IOException;
+import java.util.List;
 
 import org.apache.carbondata.core.datamap.Segment;
+import org.apache.carbondata.core.datamap.dev.cgdatamap.CoarseGrainDataMap;
 import org.apache.carbondata.core.datastore.block.SegmentProperties;
 
 /**
@@ -29,10 +31,14 @@ public interface SegmentPropertiesFetcher {
 
   /**
    * get the Segment properties based on the SegmentID.
-   * @param segmentId
+   * @param segment
    * @return
    * @throws IOException
    */
   SegmentProperties getSegmentProperties(Segment segment)
+      throws IOException;
+
+  SegmentProperties getSegmentProperties(Segment segment,
+       List<CoarseGrainDataMap> dataMaps)
       throws IOException;
 }

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMapFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMapFactory.java
@@ -317,13 +317,27 @@ public class BlockletDataMapFactory extends CoarseGrainDataMapFactory
     return dataMap.getSegmentProperties();
   }
 
+  @Override
+  public SegmentProperties getSegmentProperties(Segment segment,
+      List<CoarseGrainDataMap> dataMaps) throws IOException {
+    assert (dataMaps.size() > 0);
+    CoarseGrainDataMap coarseGrainDataMap = dataMaps.get(0);
+    assert (coarseGrainDataMap instanceof BlockletDataMap);
+    BlockletDataMap dataMap = (BlockletDataMap) coarseGrainDataMap;
+    return dataMap.getSegmentProperties();
+  }
+
   @Override public List<Blocklet> getAllBlocklets(Segment segment, List<PartitionSpec> partitions)
       throws IOException {
     List<Blocklet> blocklets = new ArrayList<>();
     List<CoarseGrainDataMap> dataMaps = getDataMaps(segment);
+    SegmentProperties segmentProperties = null;
+    if (dataMaps.size() > 0) {
+      getSegmentProperties(segment, dataMaps);
+    }
     for (CoarseGrainDataMap dataMap : dataMaps) {
       blocklets.addAll(
-          dataMap.prune(null, getSegmentProperties(segment), partitions));
+          dataMap.prune(null, segmentProperties, partitions));
     }
     return blocklets;
   }

--- a/core/src/main/java/org/apache/carbondata/core/scan/executor/QueryExecutorFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/executor/QueryExecutorFactory.java
@@ -40,7 +40,7 @@ public class QueryExecutorFactory {
         return new SearchModeDetailQueryExecutor();
       }
     } else {
-      String carbonReaderSupport = ThreadLocalSessionInfo.getCarbonSessionInfo().getSessionParams()
+      String carbonReaderSupport = CarbonProperties.getInstance()
           .getProperty(CarbonCommonConstants.ENABLE_SDK_QUERY_EXECUTOR,
               CarbonCommonConstants.ENABLE_SDK_QUERY_EXECUTOR_DEFAULT);
       if (carbonReaderSupport.equalsIgnoreCase("true")) {

--- a/core/src/main/java/org/apache/carbondata/core/scan/executor/QueryExecutorFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/executor/QueryExecutorFactory.java
@@ -24,7 +24,6 @@ import org.apache.carbondata.core.scan.executor.impl.SearchModeVectorDetailQuery
 import org.apache.carbondata.core.scan.executor.impl.VectorDetailQueryExecutor;
 import org.apache.carbondata.core.scan.model.QueryModel;
 import org.apache.carbondata.core.util.CarbonProperties;
-import org.apache.carbondata.core.util.ThreadLocalSessionInfo;
 
 /**
  * Factory class to get the query executor from RDD

--- a/core/src/main/java/org/apache/carbondata/core/scan/executor/QueryExecutorFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/executor/QueryExecutorFactory.java
@@ -16,12 +16,15 @@
  */
 package org.apache.carbondata.core.scan.executor;
 
+import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.scan.executor.impl.DetailQueryExecutor;
+import org.apache.carbondata.core.scan.executor.impl.SDKDetailQueryExecutor;
 import org.apache.carbondata.core.scan.executor.impl.SearchModeDetailQueryExecutor;
 import org.apache.carbondata.core.scan.executor.impl.SearchModeVectorDetailQueryExecutor;
 import org.apache.carbondata.core.scan.executor.impl.VectorDetailQueryExecutor;
 import org.apache.carbondata.core.scan.model.QueryModel;
 import org.apache.carbondata.core.util.CarbonProperties;
+import org.apache.carbondata.core.util.ThreadLocalSessionInfo;
 
 /**
  * Factory class to get the query executor from RDD
@@ -37,7 +40,12 @@ public class QueryExecutorFactory {
         return new SearchModeDetailQueryExecutor();
       }
     } else {
-      if (queryModel.isVectorReader()) {
+      String carbonReaderSupport = ThreadLocalSessionInfo.getCarbonSessionInfo().getSessionParams()
+          .getProperty(CarbonCommonConstants.ENABLE_SDK_QUERY_EXECUTOR,
+              CarbonCommonConstants.ENABLE_SDK_QUERY_EXECUTOR_DEFAULT);
+      if (carbonReaderSupport.equalsIgnoreCase("true")) {
+        return new SDKDetailQueryExecutor();
+      } else if (queryModel.isVectorReader()) {
         return new VectorDetailQueryExecutor();
       } else {
         return new DetailQueryExecutor();

--- a/core/src/main/java/org/apache/carbondata/core/scan/executor/impl/SDKDetailQueryExecutor.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/executor/impl/SDKDetailQueryExecutor.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.core.scan.executor.impl;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.apache.carbondata.common.CarbonIterator;
+import org.apache.carbondata.common.logging.LogService;
+import org.apache.carbondata.common.logging.LogServiceFactory;
+import org.apache.carbondata.core.constants.CarbonCommonConstants;
+import org.apache.carbondata.core.scan.executor.exception.QueryExecutionException;
+import org.apache.carbondata.core.scan.executor.infos.BlockExecutionInfo;
+import org.apache.carbondata.core.scan.model.QueryModel;
+import org.apache.carbondata.core.scan.result.iterator.SearchModeResultIterator;
+import org.apache.carbondata.core.util.CarbonProperties;
+
+/**
+ * It's for SDK carbon reader to execute the detail query
+ */
+public class SDKDetailQueryExecutor extends AbstractQueryExecutor<Object> {
+  private static final LogService LOGGER =
+          LogServiceFactory.getLogService(SDKDetailQueryExecutor.class.getName());
+  private static ExecutorService executorService = null;
+
+  public SDKDetailQueryExecutor() {
+    if (executorService == null) {
+      initThreadPool();
+    }
+  }
+
+  private static synchronized void initThreadPool() {
+    int defaultValue = Runtime.getRuntime().availableProcessors();
+    int nThread;
+    try {
+      nThread = Integer.parseInt(CarbonProperties.getInstance()
+          .getProperty(CarbonCommonConstants.CARBON_READER_THREAD,
+              String.valueOf(defaultValue)));
+    } catch (NumberFormatException e) {
+      nThread = defaultValue;
+      LOGGER.warn("The " + CarbonCommonConstants.CARBON_READER_THREAD
+          + " is invalid. Using the default value " + nThread);
+    }
+    if (nThread > 0) {
+      executorService = Executors.newFixedThreadPool(nThread);
+    } else {
+      executorService = Executors.newCachedThreadPool();
+    }
+  }
+
+  public static synchronized void shutdownThreadPool() {
+    if (executorService != null) {
+      executorService.shutdownNow();
+      executorService = null;
+    }
+  }
+
+  @Override
+  public CarbonIterator<Object> execute(QueryModel queryModel)
+      throws QueryExecutionException, IOException {
+    List<BlockExecutionInfo> blockExecutionInfoList = getBlockExecutionInfos(queryModel);
+
+    this.queryIterator = new SearchModeResultIterator(
+        blockExecutionInfoList,
+        queryModel,
+        executorService
+    );
+    return this.queryIterator;
+  }
+
+}

--- a/core/src/main/java/org/apache/carbondata/core/scan/model/QueryModel.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/model/QueryModel.java
@@ -325,6 +325,7 @@ public class QueryModel {
   public void setVectorReader(boolean vectorReader) {
     this.vectorReader = vectorReader;
   }
+
   public void setInvalidBlockForSegmentId(List<UpdateVO> invalidSegmentTimestampList) {
     for (UpdateVO anUpdateVO : invalidSegmentTimestampList) {
       this.invalidSegmentBlockIdMap.put(anUpdateVO.getSegmentId(), anUpdateVO);

--- a/examples/spark2/src/main/java/org/apache/carbondata/examples/sdk/CarbonReaderExample.java
+++ b/examples/spark2/src/main/java/org/apache/carbondata/examples/sdk/CarbonReaderExample.java
@@ -24,7 +24,9 @@ import java.sql.Timestamp;
 
 import org.apache.commons.io.FileUtils;
 
+import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.metadata.datatype.DataTypes;
+import org.apache.carbondata.core.util.CarbonProperties;
 import org.apache.carbondata.sdk.file.CarbonReader;
 import org.apache.carbondata.sdk.file.CarbonSchemaReader;
 import org.apache.carbondata.sdk.file.CarbonWriter;
@@ -134,6 +136,9 @@ public class CarbonReaderExample {
         } catch (Throwable e) {
             e.printStackTrace();
             System.out.println(e.getMessage());
+        } finally {
+            CarbonProperties.getInstance()
+                .addProperty(CarbonCommonConstants.ENABLE_SDK_QUERY_EXECUTOR, "false");
         }
     }
 }

--- a/examples/spark2/src/main/java/org/apache/carbondata/examples/sdk/SDKS3MultiFilesExample.java
+++ b/examples/spark2/src/main/java/org/apache/carbondata/examples/sdk/SDKS3MultiFilesExample.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.examples.sdk;
+
+import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import org.apache.carbondata.common.logging.LogService;
+import org.apache.carbondata.common.logging.LogServiceFactory;
+import org.apache.carbondata.core.metadata.datatype.DataTypes;
+import org.apache.carbondata.sdk.file.CarbonReader;
+import org.apache.carbondata.sdk.file.CarbonWriter;
+import org.apache.carbondata.sdk.file.Field;
+import org.apache.carbondata.sdk.file.Schema;
+
+
+/**
+ * Example for testing read many files on S3
+ */
+public class SDKS3MultiFilesExample {
+  public static void main(String[] args) throws Exception {
+    LogServiceFactory.getLogService().isInfoEnabled();
+    LogService logger = LogServiceFactory.getLogService(SDKS3MultiFilesExample.class.getName());
+    if (args == null || args.length < 3) {
+      logger.error("Usage: java SDKS3MultiFilesExample: <access-key> <secret-key>"
+          + "<s3-endpoint> [table-path-on-s3] [rows] [batch number]");
+      System.exit(0);
+    }
+
+    String path = "s3a://sdk/WriterOutput";
+    if (args.length > 3) {
+      path = args[3];
+    }
+
+    int num = 150;
+    if (args.length > 4) {
+      num = Integer.parseInt(args[4]);
+    }
+    int batch = 40;
+    if (args.length > 5) {
+      batch = Integer.parseInt(args[5]);
+    }
+
+    Field[] fields = new Field[9];
+    fields[0] = new Field("stringField", DataTypes.STRING);
+    fields[1] = new Field("shortField", DataTypes.SHORT);
+    fields[2] = new Field("intField", DataTypes.INT);
+    fields[3] = new Field("longField", DataTypes.LONG);
+    fields[4] = new Field("doubleField", DataTypes.DOUBLE);
+    fields[5] = new Field("boolField", DataTypes.BOOLEAN);
+    fields[6] = new Field("dateField", DataTypes.DATE);
+    fields[7] = new Field("timeField", DataTypes.TIMESTAMP);
+    fields[8] = new Field("decimalField", DataTypes.createDecimalType(8, 2));
+
+    long writeStartTime = System.currentTimeMillis();
+    CarbonWriter writer = CarbonWriter.builder()
+        .setAccessKey(args[0])
+        .setSecretKey(args[1])
+        .setEndPoint(args[2])
+        .outputPath(path)
+        .buildWriterForCSVInput(new Schema(fields));
+    long writeBuildTime = System.currentTimeMillis();
+    System.out.println("Finished build writer time: "
+        + (writeBuildTime - writeStartTime) / 1000.0 + " s");
+
+    int closeNum = 1;
+    for (int i = 0; i < num; i++) {
+      if (i > 0 && (i % batch) == 0) {
+        writer.close();
+        writer = null;
+        writer = CarbonWriter.builder()
+            .setAccessKey(args[0])
+            .setSecretKey(args[1])
+            .setEndPoint(args[2])
+            .outputPath(path)
+            .buildWriterForCSVInput(new Schema(fields));
+
+        System.out.println("Finished write the " + closeNum +
+            " batch, the number of each batch is " + batch);
+        closeNum++;
+      }
+      String[] row2 = new String[]{
+          "robot" + (i % 10),
+          String.valueOf(i % Short.MAX_VALUE),
+          String.valueOf(i),
+          String.valueOf(Long.MAX_VALUE - i),
+          String.valueOf((double) i / 2),
+          String.valueOf(true),
+          "2019-03-02",
+          "2019-02-12 03:03:34",
+          "12.345"
+      };
+      writer.write(row2);
+    }
+    System.out.println("Finished write the " + closeNum +
+        " batch, the number of each batch is " + batch);
+    writer.close();
+    System.out.println("Finished write data time: "
+        + (System.currentTimeMillis() - writeStartTime) / 1000.0 + " s");
+
+    // Read data
+    System.out.println("\nStart build reader: " +
+        new SimpleDateFormat("yyyyMMddHHmmssSSS").format(new Date()));
+    long startTime = System.currentTimeMillis();
+    CarbonReader reader = CarbonReader
+        .builder(path, "_temp")
+        .projection(new String[]{
+            "stringField"
+            , "shortField"
+            , "intField"
+            , "longField"
+            , "doubleField"
+            , "boolField"
+            , "dateField"
+            , "timeField"
+            , "decimalField"})
+        .build();
+    long buildTime = System.currentTimeMillis();
+    System.out.println("Finished build reader time: " + (buildTime - startTime) / 1000.0 + " s");
+    System.out.println("\nData:");
+    long day = 24L * 3600 * 1000;
+    int i = 0;
+    while (reader.hasNext()) {
+      Object[] row = (Object[]) reader.readNextRow();
+      if (i < 100) {
+        System.out.println(String.format("%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t",
+            i, row[0], row[1], row[2], row[3], row[4], row[5],
+            new Date((day * ((int) row[6]))), new Timestamp((long) row[7] / 1000), row[8]
+        ));
+
+        long rowTime = System.currentTimeMillis();
+        if (i == 0) {
+          System.out.println("Read first row time: "
+              + (rowTime - startTime) / 1000.0 + " s");
+        }
+      }
+      i++;
+    }
+    System.out.println("Finished read, the count of rows is:" + i);
+    long runTime = System.currentTimeMillis();
+    System.out.println("Read time:" + (runTime - startTime) / 1000.0 + " s");
+    reader.close();
+  }
+}

--- a/integration/spark-common-cluster-test/src/test/scala/org/apache/carbondata/cluster/sdv/generated/DataLoadingIUDTestCase.scala
+++ b/integration/spark-common-cluster-test/src/test/scala/org/apache/carbondata/cluster/sdv/generated/DataLoadingIUDTestCase.scala
@@ -75,6 +75,7 @@ class DataLoadingIUDTestCase extends QueryTest with BeforeAndAfterAll with Befor
   override def beforeEach(): Unit = {
     sql(s"""drop table if exists t_carbn01""").collect
     sql(s"""drop table if exists default.t_carbn01""").collect
+    CarbonProperties.getInstance.addProperty(CarbonCommonConstants.CARBON_READER_SUPPORT, "false")
   }
 
 

--- a/integration/spark-common-cluster-test/src/test/scala/org/apache/carbondata/cluster/sdv/generated/DataLoadingTestCase.scala
+++ b/integration/spark-common-cluster-test/src/test/scala/org/apache/carbondata/cluster/sdv/generated/DataLoadingTestCase.scala
@@ -1469,6 +1469,7 @@ class DataLoadingTestCase extends QueryTest with BeforeAndAfterAll {
   }
 
   override protected def beforeAll(): Unit = {
+    CarbonProperties.getInstance.addProperty(CarbonCommonConstants.CARBON_READER_SUPPORT, "false")
     sql(s"""drop table if exists uniqdata""").collect
-     }
+  }
 }

--- a/integration/spark-common-cluster-test/src/test/scala/org/apache/spark/sql/common/util/QueryTest.scala
+++ b/integration/spark-common-cluster-test/src/test/scala/org/apache/spark/sql/common/util/QueryTest.scala
@@ -45,6 +45,7 @@ class QueryTest extends PlanTest with Suite {
   Locale.setDefault(Locale.US)
   CarbonProperties.getInstance()
     .addProperty(CarbonCommonConstants.VALIDATE_DIRECT_QUERY_ON_DATAMAP, "false")
+    .addProperty(CarbonCommonConstants.CARBON_READER_SUPPORT, "false");
 
   /**
    * Runs the plan and makes sure the answer contains all of the keywords, or the

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/detailquery/SearchModeTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/detailquery/SearchModeTestCase.scala
@@ -49,6 +49,8 @@ class SearchModeTestCase extends QueryTest with BeforeAndAfterAll {
   override def afterAll = {
     sql("DROP TABLE IF EXISTS main")
     sqlContext.sparkSession.asInstanceOf[CarbonSession].stopSearchMode()
+    CarbonProperties.getInstance
+      .addProperty(CarbonCommonConstants.ENABLE_SDK_QUERY_EXECUTOR, "false")
   }
 
   private def sparkSql(sql: String): Seq[Row] = {

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/test/Spark2TestQueryExecutor.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/test/Spark2TestQueryExecutor.scala
@@ -70,8 +70,8 @@ object Spark2TestQueryExecutor {
     .getOrCreateCarbonSession(null, TestQueryExecutor.metastoredb)
   if (warehouse.startsWith("hdfs://")) {
     System.setProperty(CarbonCommonConstants.HDFS_TEMP_LOCATION, warehouse)
-    CarbonProperties.getInstance()
-      .addProperty(CarbonCommonConstants.LOCK_TYPE, CarbonCommonConstants.CARBON_LOCK_TYPE_HDFS)
+    CarbonProperties.getInstance().addProperty(CarbonCommonConstants.LOCK_TYPE,
+      CarbonCommonConstants.CARBON_LOCK_TYPE_HDFS)
     ResourceRegisterAndCopier.
       copyResourcesifNotExists(hdfsUrl, s"$integrationPath/spark-common-test/src/test/resources",
         s"$integrationPath//spark-common-cluster-test/src/test/resources/testdatafileslist.txt")

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/test/Spark2TestQueryExecutor.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/test/Spark2TestQueryExecutor.scala
@@ -45,7 +45,6 @@ object Spark2TestQueryExecutor {
   CarbonProperties.getInstance()
     .addProperty(CarbonCommonConstants.CARBON_BAD_RECORDS_ACTION, "FORCE")
 
-
   import org.apache.spark.sql.CarbonSession._
 
   val conf = new SparkConf()
@@ -71,8 +70,8 @@ object Spark2TestQueryExecutor {
     .getOrCreateCarbonSession(null, TestQueryExecutor.metastoredb)
   if (warehouse.startsWith("hdfs://")) {
     System.setProperty(CarbonCommonConstants.HDFS_TEMP_LOCATION, warehouse)
-    CarbonProperties.getInstance().addProperty(CarbonCommonConstants.LOCK_TYPE,
-      CarbonCommonConstants.CARBON_LOCK_TYPE_HDFS)
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.LOCK_TYPE, CarbonCommonConstants.CARBON_LOCK_TYPE_HDFS)
     ResourceRegisterAndCopier.
       copyResourcesifNotExists(hdfsUrl, s"$integrationPath/spark-common-test/src/test/resources",
         s"$integrationPath//spark-common-cluster-test/src/test/resources/testdatafileslist.txt")

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonReader.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonReader.java
@@ -24,6 +24,9 @@ import java.util.List;
 
 import org.apache.carbondata.common.annotations.InterfaceAudience;
 import org.apache.carbondata.common.annotations.InterfaceStability;
+import org.apache.carbondata.core.constants.CarbonCommonConstants;
+import org.apache.carbondata.core.scan.executor.impl.SDKDetailQueryExecutor;
+import org.apache.carbondata.core.util.CarbonProperties;
 import org.apache.carbondata.core.util.CarbonTaskInfo;
 import org.apache.carbondata.core.util.ThreadLocalTaskInfo;
 
@@ -121,6 +124,9 @@ public class CarbonReader<T> {
    */
   public void close() throws IOException {
     validateReader();
+    SDKDetailQueryExecutor.shutdownThreadPool();
+    CarbonProperties.getInstance()
+        .addProperty(CarbonCommonConstants.ENABLE_SDK_QUERY_EXECUTOR, "false");
     this.currentReader.close();
     this.initialise = false;
   }

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonReaderBuilder.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonReaderBuilder.java
@@ -24,10 +24,13 @@ import java.util.Objects;
 
 import org.apache.carbondata.common.annotations.InterfaceAudience;
 import org.apache.carbondata.common.annotations.InterfaceStability;
+import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.datamap.DataMapStoreManager;
 import org.apache.carbondata.core.datastore.impl.FileFactory;
+import org.apache.carbondata.core.exception.InvalidConfigurationException;
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
 import org.apache.carbondata.core.scan.expression.Expression;
+import org.apache.carbondata.core.util.ThreadLocalSessionInfo;
 import org.apache.carbondata.hadoop.api.CarbonFileInputFormat;
 
 import org.apache.hadoop.conf.Configuration;
@@ -175,7 +178,8 @@ public class CarbonReaderBuilder {
    * @throws IOException
    * @throws InterruptedException
    */
-  public <T> CarbonReader<T> build() throws IOException, InterruptedException {
+  public <T> CarbonReader<T> build() throws IOException, InterruptedException,
+      InvalidConfigurationException {
     // DB name is not applicable for SDK reader as, table will be never registered.
     CarbonTable table;
     if (isTransactionalTable) {
@@ -207,6 +211,8 @@ public class CarbonReaderBuilder {
           format.getSplits(new JobContextImpl(job.getConfiguration(), new JobID()));
 
       List<RecordReader<Void, T>> readers = new ArrayList<>(splits.size());
+      ThreadLocalSessionInfo.getCarbonSessionInfo().getSessionParams()
+          .addProperty(CarbonCommonConstants.ENABLE_SDK_QUERY_EXECUTOR, "true");
       for (InputSplit split : splits) {
         TaskAttemptContextImpl attempt =
             new TaskAttemptContextImpl(job.getConfiguration(), new TaskAttemptID());

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonReaderBuilder.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonReaderBuilder.java
@@ -27,10 +27,9 @@ import org.apache.carbondata.common.annotations.InterfaceStability;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.datamap.DataMapStoreManager;
 import org.apache.carbondata.core.datastore.impl.FileFactory;
-import org.apache.carbondata.core.exception.InvalidConfigurationException;
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
 import org.apache.carbondata.core.scan.expression.Expression;
-import org.apache.carbondata.core.util.ThreadLocalSessionInfo;
+import org.apache.carbondata.core.util.CarbonProperties;
 import org.apache.carbondata.hadoop.api.CarbonFileInputFormat;
 
 import org.apache.hadoop.conf.Configuration;
@@ -178,8 +177,7 @@ public class CarbonReaderBuilder {
    * @throws IOException
    * @throws InterruptedException
    */
-  public <T> CarbonReader<T> build() throws IOException, InterruptedException,
-      InvalidConfigurationException {
+  public <T> CarbonReader<T> build() throws IOException, InterruptedException {
     // DB name is not applicable for SDK reader as, table will be never registered.
     CarbonTable table;
     if (isTransactionalTable) {
@@ -211,7 +209,7 @@ public class CarbonReaderBuilder {
           format.getSplits(new JobContextImpl(job.getConfiguration(), new JobID()));
 
       List<RecordReader<Void, T>> readers = new ArrayList<>(splits.size());
-      ThreadLocalSessionInfo.getCarbonSessionInfo().getSessionParams()
+      CarbonProperties.getInstance()
           .addProperty(CarbonCommonConstants.ENABLE_SDK_QUERY_EXECUTOR, "true");
       for (InputSplit split : splits) {
         TaskAttemptContextImpl attempt =

--- a/store/sdk/src/test/java/org/apache/carbondata/sdk/file/CarbonReaderTest.java
+++ b/store/sdk/src/test/java/org/apache/carbondata/sdk/file/CarbonReaderTest.java
@@ -56,6 +56,9 @@ public class CarbonReaderTest extends TestCase {
       FileUtils.deleteDirectory(new File(path));
     } catch (IOException e) {
       e.printStackTrace();
+    } finally {
+      CarbonProperties.getInstance()
+          .addProperty(CarbonCommonConstants.ENABLE_SDK_QUERY_EXECUTOR, "false");
     }
   }
 


### PR DESCRIPTION
About the issue:  it's timeout and no result in 8 minutes  when read more than 10 million data with 140 files,  Even though increase 200000 rows for each carbon Writer and it can reduce the index files and data files when the number of rows is 13000000, but when there are more than  1 billion or more, the number of files still still many.  I check the code and find read more 140 files can be optimize:

In the cache.getAll, the IO is more than 140  if there are 140 carbon files,  in fact, the IO are more than 70 * 140 times, it's slow and can be optimized

Secondly, there are some duplicate operate in getDataMaps and can be optimized 

Thirdly, SDK need much time to create multiple carbonRecorderReader, it need more than 8 minutes  by testing 150 files and 15million rows data when create more than 16 carbonReorederReader if the machine has 8 cores .   It can be optimized

By optimizing the three points,including cache.getAll, getDatamaps and create carbonRecordReader,  now SDK can work for reading 150 files and 15million rows data in 8 minutes,  it need about 340 seconds by testing.

One case: 150 files , each file has 200000 rows, total rows is 15000000
Finished write data time: 449.102 s
Finished build reader time:192.596 s
Read first row time: 192.597 s, including build reader
Read time:341.556 s,  including build reader

Another case: 15 files , each file has 2000000 rows, total rows is 15000000
Finished write data time: 286.907 s
Finished build reader time: 134.665 s
Read first row time: 134.666 s,  including build reader
Finished read, the count of rows is:15000000
Read time:156.427 s,  including build reader

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 Yes, add new one for optimizing performance
 - [x] Any backward compatibility impacted?
 NA
 - [x] Document update required?
NO
 - [x] Testing done
    add example for it
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NO
