### PR TITLE
[CARBONDATA-2626] Fix bugs in sequence of column page

### DIFF
--- a/processing/src/main/java/org/apache/carbondata/processing/store/TablePage.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/TablePage.java
@@ -94,10 +94,12 @@ public class TablePage {
     noDictDimensionPages = new ColumnPage[model.getNoDictionaryCount()];
     int tmpNumDictDimIdx = 0;
     int tmpNumNoDictDimIdx = 0;
-    for (int i = 0; i < tableSpec.getNumDimensions(); i++) {
+    for (int i = 0; i < dictDimensionPages.length + noDictDimensionPages.length; i++) {
       TableSpec.DimensionSpec spec = tableSpec.getDimensionSpec(i);
+      ColumnType columnType = tableSpec.getDimensionSpec(i).getColumnType();
       ColumnPage page;
-      if (ColumnType.GLOBAL_DICTIONARY == tableSpec.getDimensionSpec(i).getColumnType()) {
+      if (ColumnType.GLOBAL_DICTIONARY == columnType
+          || ColumnType.DIRECT_DICTIONARY == columnType) {
         page = ColumnPage.newPage(spec, DataTypes.BYTE_ARRAY, pageSize);
         page.setStatsCollector(KeyPageStatsCollector.newInstance(DataTypes.BYTE_ARRAY));
         dictDimensionPages[tmpNumDictDimIdx++] = page;

--- a/processing/src/main/java/org/apache/carbondata/processing/store/TablePage.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/TablePage.java
@@ -89,28 +89,32 @@ public class TablePage {
     this.pageSize = pageSize;
     int numDictDimension = model.getMDKeyGenerator().getDimCount();
     TableSpec tableSpec = model.getTableSpec();
+
     dictDimensionPages = new ColumnPage[numDictDimension];
-    for (int i = 0; i < dictDimensionPages.length; i++) {
-      TableSpec.DimensionSpec spec = tableSpec.getDimensionSpec(i);
-      ColumnPage page = ColumnPage.newPage(spec, DataTypes.BYTE_ARRAY, pageSize);
-      page.setStatsCollector(KeyPageStatsCollector.newInstance(DataTypes.BYTE_ARRAY));
-      dictDimensionPages[i] = page;
-    }
     noDictDimensionPages = new ColumnPage[model.getNoDictionaryCount()];
-    for (int i = 0; i < noDictDimensionPages.length; i++) {
-      TableSpec.DimensionSpec spec = tableSpec.getDimensionSpec(i + numDictDimension);
+    int tmpNumDictDimIdx = 0;
+    int tmpNumNoDictDimIdx = 0;
+    for (int i = 0; i < tableSpec.getNumDimensions(); i++) {
+      TableSpec.DimensionSpec spec = tableSpec.getDimensionSpec(i);
       ColumnPage page;
-      if (DataTypes.VARCHAR == spec.getSchemaDataType()) {
-        page = ColumnPage.newPage(spec, DataTypes.VARCHAR, pageSize);
-        page.setStatsCollector(LVLongStringStatsCollector.newInstance());
+      if (ColumnType.GLOBAL_DICTIONARY == tableSpec.getDimensionSpec(i).getColumnType()) {
+        page = ColumnPage.newPage(spec, DataTypes.BYTE_ARRAY, pageSize);
+        page.setStatsCollector(KeyPageStatsCollector.newInstance(DataTypes.BYTE_ARRAY));
+        dictDimensionPages[tmpNumDictDimIdx++] = page;
       } else {
-        // In previous implementation, other data types such as string, date and timestamp
-        // will be encoded using string page
-        page = ColumnPage.newPage(spec, DataTypes.STRING, pageSize);
-        page.setStatsCollector(LVShortStringStatsCollector.newInstance());
+        if (DataTypes.VARCHAR == spec.getSchemaDataType()) {
+          page = ColumnPage.newPage(spec, DataTypes.VARCHAR, pageSize);
+          page.setStatsCollector(LVLongStringStatsCollector.newInstance());
+        } else {
+          // In previous implementation, other data types such as string, date and timestamp
+          // will be encoded using string page
+          page = ColumnPage.newPage(spec, DataTypes.STRING, pageSize);
+          page.setStatsCollector(LVShortStringStatsCollector.newInstance());
+        }
+        noDictDimensionPages[tmpNumNoDictDimIdx++] = page;
       }
-      noDictDimensionPages[i] = page;
     }
+
     complexDimensionPages = new ComplexColumnPage[model.getComplexColumnCount()];
     for (int i = 0; i < complexDimensionPages.length; i++) {
       // here we still do not the depth of the complex column, it will be initialized when


### PR DESCRIPTION
In tableSpec, the sort column dimensions are in the left of those
dictionary dimensions.

Create table and load data to it. The table schema is:

```
sql(
 s"""
 | CREATE TABLE $bloomDMSampleTable(id INT, name STRING, city STRING, age INT,
 | s1 STRING, s2 STRING, s3 STRING, s4 STRING, s5 STRING, s6 STRING, s7 STRING, s8 STRING)
 | STORED BY 'carbondata' TBLPROPERTIES('table_blocksize'='128', 'dictionary_include'='id', 'sort_columns'='name')
 | """.stripMargin)
```

 In tablespec, the first dimension spec is 'name' which is sort_columns but not dictionary. But Carbondata now treat it as dictionary page. (See TablePage Line94)
 
Tested before and after this implementation on the following scenarios, the dataload and query is fine:

1. Create & load data with master code, query with this bug-fix code
2. Create & load data with this bug-fix code, query with master code

each scenario with test cases:

1. dictionary: id, sort_columns: name
2. dictionary: id, sort_columns: id
3. dictionary: id, sort_columns: id,name
4. dictionary: id, sort_columns: name,id


Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

