### PR TITLE
[CARBONDATA-2644][DataLoad]ADD carbon.load.sortMemory.spill.percentage parameter  invalid value check

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonLoadOptionConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonLoadOptionConstants.java
@@ -149,7 +149,7 @@ public final class CarbonLoadOptionConstants {
    */
   @CarbonProperty
   public static final String CARBON_LOAD_SORT_MEMORY_SPILL_PERCENTAGE
-      = "carbon.load.sortMemory.spill.percentage";
+      = "carbon.load.sortmemory.spill.percentage";
   public static final String CARBON_LOAD_SORT_MEMORY_SPILL_PERCENTAGE_DEFAULT = "0";
 
   /**

--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonLoadOptionConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonLoadOptionConstants.java
@@ -144,8 +144,8 @@ public final class CarbonLoadOptionConstants {
    * If the sort memory is insufficient, spill inmemory pages to disk.
    * The total amount of pages is at most the specified percentage of total sort memory. Default
    * value 0 means that no pages will be spilled and the newly incoming pages will be spilled,
-   * whereas value 1 means that all pages will be spilled and newly incoming pages will be loaded
-   * into sort memory.
+   * whereas value 100 means that all pages will be spilled and newly incoming pages will be loaded
+   * into sort memory,Other percentage values range 0-100.
    */
   @CarbonProperty
   public static final String CARBON_LOAD_SORT_MEMORY_SPILL_PERCENTAGE

--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonLoadOptionConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonLoadOptionConstants.java
@@ -145,7 +145,7 @@ public final class CarbonLoadOptionConstants {
    * The total amount of pages is at most the specified percentage of total sort memory. Default
    * value 0 means that no pages will be spilled and the newly incoming pages will be spilled,
    * whereas value 100 means that all pages will be spilled and newly incoming pages will be loaded
-   * into sort memory, Other percentage values range 0-100.
+   * into sort memory, valid value is from 0 to 100.
    */
   @CarbonProperty
   public static final String CARBON_LOAD_SORT_MEMORY_SPILL_PERCENTAGE

--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonLoadOptionConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonLoadOptionConstants.java
@@ -145,7 +145,7 @@ public final class CarbonLoadOptionConstants {
    * The total amount of pages is at most the specified percentage of total sort memory. Default
    * value 0 means that no pages will be spilled and the newly incoming pages will be spilled,
    * whereas value 100 means that all pages will be spilled and newly incoming pages will be loaded
-   * into sort memory,Other percentage values range 0-100.
+   * into sort memory, Other percentage values range 0-100.
    */
   @CarbonProperty
   public static final String CARBON_LOAD_SORT_MEMORY_SPILL_PERCENTAGE

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/dataload/TestLoadDataWithUnsafeMemory.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/dataload/TestLoadDataWithUnsafeMemory.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.Row
 import org.apache.spark.sql.test.util.QueryTest
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Ignore}
 
-import org.apache.carbondata.core.constants.CarbonCommonConstants
+import org.apache.carbondata.core.constants.{CarbonCommonConstants, CarbonLoadOptionConstants}
 import org.apache.carbondata.core.util.CarbonProperties
 
 /**
@@ -44,6 +44,9 @@ class TestLoadDataWithUnsafeMemory extends QueryTest
   val originUnsafeSizeForChunk: String = CarbonProperties.getInstance()
     .getProperty(CarbonCommonConstants.OFFHEAP_SORT_CHUNK_SIZE_IN_MB,
       CarbonCommonConstants.OFFHEAP_SORT_CHUNK_SIZE_IN_MB_DEFAULT)
+  val originSpillPercentage: String = CarbonProperties.getInstance()
+    .getProperty(CarbonLoadOptionConstants.CARBON_LOAD_SORT_MEMORY_SPILL_PERCENTAGE,
+      CarbonLoadOptionConstants.CARBON_LOAD_SORT_MEMORY_SPILL_PERCENTAGE_DEFAULT)
   val targetTable = "table_unsafe_memory"
 
 
@@ -64,6 +67,8 @@ class TestLoadDataWithUnsafeMemory extends QueryTest
       .addProperty(CarbonCommonConstants.UNSAFE_WORKING_MEMORY_IN_MB, "512")
     CarbonProperties.getInstance()
       .addProperty(CarbonCommonConstants.OFFHEAP_SORT_CHUNK_SIZE_IN_MB, "512")
+    CarbonProperties.getInstance()
+      .addProperty(CarbonLoadOptionConstants.CARBON_LOAD_SORT_MEMORY_SPILL_PERCENTAGE, "-1")
   }
 
   override def afterAll(): Unit = {
@@ -75,6 +80,9 @@ class TestLoadDataWithUnsafeMemory extends QueryTest
       .addProperty(CarbonCommonConstants.UNSAFE_WORKING_MEMORY_IN_MB, originUnsafeMemForWorking)
     CarbonProperties.getInstance()
       .addProperty(CarbonCommonConstants.OFFHEAP_SORT_CHUNK_SIZE_IN_MB, originUnsafeSizeForChunk)
+    CarbonProperties.getInstance()
+      .addProperty(CarbonLoadOptionConstants.CARBON_LOAD_SORT_MEMORY_SPILL_PERCENTAGE,
+        originSpillPercentage)
   }
 
   private def testSimpleTable(): Unit = {

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/sort/unsafe/merger/UnsafeIntermediateMerger.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/sort/unsafe/merger/UnsafeIntermediateMerger.java
@@ -30,7 +30,6 @@ import java.util.concurrent.TimeUnit;
 import org.apache.carbondata.common.logging.LogService;
 import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
-import org.apache.carbondata.core.constants.CarbonLoadOptionConstants;
 import org.apache.carbondata.core.memory.UnsafeSortMemoryManager;
 import org.apache.carbondata.core.util.CarbonProperties;
 import org.apache.carbondata.core.util.CarbonThreadFactory;
@@ -82,21 +81,7 @@ public class UnsafeIntermediateMerger {
         SynchronizedList.decorate(new ArrayList<File>(CarbonCommonConstants.CONSTANT_SIZE_TEN));
     this.mergerTask = new ArrayList<>();
 
-    Integer spillPercentage;
-    try {
-      String spillPercentageStr = CarbonProperties.getInstance().getProperty(
-          CarbonLoadOptionConstants.CARBON_LOAD_SORT_MEMORY_SPILL_PERCENTAGE,
-          CarbonLoadOptionConstants.CARBON_LOAD_SORT_MEMORY_SPILL_PERCENTAGE_DEFAULT);
-      spillPercentage = Integer.valueOf(spillPercentageStr);
-      if (spillPercentage > 100 || spillPercentage < 0) {
-        spillPercentage = Integer.valueOf(
-            CarbonLoadOptionConstants.CARBON_LOAD_SORT_MEMORY_SPILL_PERCENTAGE_DEFAULT);
-      }
-    } catch (NumberFormatException e) {
-      spillPercentage = Integer.valueOf(
-          CarbonLoadOptionConstants.CARBON_LOAD_SORT_MEMORY_SPILL_PERCENTAGE_DEFAULT);
-    }
-
+    Integer spillPercentage = CarbonProperties.getInstance().getSortMemorySpillPercentage();
     this.spillSizeInSortMemory =
         UnsafeSortMemoryManager.INSTANCE.getUsableMemory() * spillPercentage / 100;
   }

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/sort/unsafe/merger/UnsafeIntermediateMerger.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/sort/unsafe/merger/UnsafeIntermediateMerger.java
@@ -88,6 +88,10 @@ public class UnsafeIntermediateMerger {
           CarbonLoadOptionConstants.CARBON_LOAD_SORT_MEMORY_SPILL_PERCENTAGE,
           CarbonLoadOptionConstants.CARBON_LOAD_SORT_MEMORY_SPILL_PERCENTAGE_DEFAULT);
       spillPercentage = Integer.valueOf(spillPercentageStr);
+      if (spillPercentage > 100 || spillPercentage < 0) {
+        spillPercentage = Integer.valueOf(
+            CarbonLoadOptionConstants.CARBON_LOAD_SORT_MEMORY_SPILL_PERCENTAGE_DEFAULT);
+      }
     } catch (NumberFormatException e) {
       spillPercentage = Integer.valueOf(
           CarbonLoadOptionConstants.CARBON_LOAD_SORT_MEMORY_SPILL_PERCENTAGE_DEFAULT);


### PR DESCRIPTION
Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 NA
 - [x] Any backward compatibility impacted?
 NO
 - [x] Document update required?
NO
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        Testing done UT 
        - How it is tested? Please attach test report.
        add example for it
        - Is it a performance related change? Please attach the performance test report.
          NA
        - Any additional information to help reviewers in testing this change.
        NA
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
       NO
