### PR TITLE
[CARBONDATA-2629] Support  SDK carbon reader read data from HDFS and S3 with filter function

### DIFF
--- a/examples/spark2/src/main/java/org/apache/carbondata/examples/sdk/SDKS3Example.java
+++ b/examples/spark2/src/main/java/org/apache/carbondata/examples/sdk/SDKS3Example.java
@@ -20,6 +20,9 @@ package org.apache.carbondata.examples.sdk;
 import org.apache.carbondata.common.logging.LogService;
 import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.metadata.datatype.DataTypes;
+import org.apache.carbondata.core.scan.expression.ColumnExpression;
+import org.apache.carbondata.core.scan.expression.LiteralExpression;
+import org.apache.carbondata.core.scan.expression.conditional.EqualToExpression;
 import org.apache.carbondata.sdk.file.*;
 
 /**
@@ -60,13 +63,19 @@ public class SDKS3Example {
         }
         writer.close();
         // Read data
+
+        EqualToExpression equalToExpression = new EqualToExpression(
+            new ColumnExpression("name", DataTypes.STRING),
+            new LiteralExpression("robot1", DataTypes.STRING));
+
         CarbonReader reader = CarbonReader
-                .builder(path, "_temp")
-                .projection(new String[]{"name", "age"})
-                .setAccessKey(args[0])
-                .setSecretKey(args[1])
-                .setEndPoint(args[2])
-                .build();
+            .builder(path, "_temp")
+            .projection(new String[]{"name", "age"})
+            .filter(equalToExpression)
+            .setAccessKey(args[0])
+            .setSecretKey(args[1])
+            .setEndPoint(args[2])
+            .build();
 
         System.out.println("\nData:");
         int i = 0;


### PR DESCRIPTION
Now SDK carbon reader only support read data from local with filter function, it will throw exception when read data from HDFS and S3 with filter function 
This PR support it:
  Support SDK carbon reader read data from HDFS and S3 with filter function 


 - [x] Any interfaces changed?
 NO
 - [x] Any backward compatibility impacted?
 No
 - [x] Document update required?
No
 - [x] Testing done
   add test case in example
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
No