### PR TITLE
[CARBONDATA-2585][CARBONDATA-2586][Local Dictionary]Local dictionary support for alter table, preaggregate, varchar datatype, alter set and unset

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -930,7 +930,7 @@ public final class CarbonCommonConstants {
   /**
    * default value for local dictionary
    */
-  public static final String LOCAL_DICTIONARY_THRESHOLD_DEFAULT = "1000";
+  public static final String LOCAL_DICTIONARY_THRESHOLD_DEFAULT = "10000";
 
   /**
    * Table property to specify the columns for which local dictionary needs to be generated.

--- a/core/src/main/java/org/apache/carbondata/core/datastore/blocklet/BlockletEncodedColumnPage.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/blocklet/BlockletEncodedColumnPage.java
@@ -137,7 +137,6 @@ public class BlockletEncodedColumnPage {
           // add the encoded column page to list
           encodedColumnPageList.set(fallbackEncodedColumnPage.getPageIndex(),
               fallbackEncodedColumnPage.getEncodedColumnPage());
-          fallbackFutureQueue.poll();
         }
       } catch (ExecutionException | InterruptedException e) {
         throw new RuntimeException("Problem while encoding the blocklet data during fallback", e);

--- a/core/src/main/java/org/apache/carbondata/core/metadata/converter/ThriftWrapperSchemaConverterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/converter/ThriftWrapperSchemaConverterImpl.java
@@ -605,7 +605,9 @@ public class ThriftWrapperSchemaConverterImpl implements SchemaConverter {
     }
     if (null != externalTableSchema.tableProperties) {
       CarbonUtil
-          .setLocalDictColumnsToWrapperSchema(listOfColumns, externalTableSchema.tableProperties);
+          .setLocalDictColumnsToWrapperSchema(listOfColumns, externalTableSchema.tableProperties,
+              externalTableSchema.tableProperties
+                  .get(CarbonCommonConstants.LOCAL_DICTIONARY_ENABLE));
     }
     wrapperTableSchema.setListOfColumns(listOfColumns);
     wrapperTableSchema.setSchemaEvolution(

--- a/core/src/test/java/org/apache/carbondata/core/localdictionary/TestDictionaryStore.java
+++ b/core/src/test/java/org/apache/carbondata/core/localdictionary/TestDictionaryStore.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.core.localdictionary;
+
+import org.apache.carbondata.core.localdictionary.dictionaryholder.DictionaryStore;
+import org.apache.carbondata.core.localdictionary.dictionaryholder.MapBasedDictionaryStore;
+import org.apache.carbondata.core.localdictionary.exception.DictionaryThresholdReachedException;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestDictionaryStore {
+
+  @Test
+  public void testDictionaryStoreWithinThreshold() {
+    DictionaryStore dictionaryStore = new MapBasedDictionaryStore(10);
+    for (int i = 0; i < 10; i++) {
+      try {
+        dictionaryStore.putIfAbsent((i+"").getBytes());
+        Assert.assertTrue(true);
+      } catch (DictionaryThresholdReachedException e) {
+        Assert.assertTrue(false);
+        break;
+      }
+    }
+  }
+
+  @Test
+  public void testDictionaryStoreWithMoreThanThreshold() {
+    DictionaryStore dictionaryStore = new MapBasedDictionaryStore(10);
+    boolean isException = false;
+    for (int i = 0; i < 15; i++) {
+      try {
+        dictionaryStore.putIfAbsent((i+"").getBytes());
+      } catch (DictionaryThresholdReachedException e) {
+        isException = true;
+        break;
+      }
+    }
+    Assert.assertTrue(isException);
+    Assert.assertTrue(dictionaryStore.isThresholdReached());
+  }
+}

--- a/core/src/test/java/org/apache/carbondata/core/localdictionary/TestLocalDictionaryGenerator.java
+++ b/core/src/test/java/org/apache/carbondata/core/localdictionary/TestLocalDictionaryGenerator.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.core.localdictionary;
+
+import java.util.Arrays;
+
+import org.apache.carbondata.core.constants.CarbonCommonConstants;
+import org.apache.carbondata.core.localdictionary.exception.DictionaryThresholdReachedException;
+import org.apache.carbondata.core.localdictionary.generator.ColumnLocalDictionaryGenerator;
+import org.apache.carbondata.core.localdictionary.generator.LocalDictionaryGenerator;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestLocalDictionaryGenerator {
+
+  @Test
+  public void testColumnLocalDictionaryGeneratorWithValidDataWithinThreshold() {
+    LocalDictionaryGenerator generator = new ColumnLocalDictionaryGenerator(1000);
+    try {
+      for (int i = 1; i <= 1000; i++) {
+        generator.generateDictionary(("" + i).getBytes());
+      }
+      Assert.assertTrue(true);
+    } catch (Exception e) {
+      Assert.assertTrue(false);
+    }
+
+    int dictionaryValue = 2;
+    for (int i = 1; i <= 1000; i++) {
+      byte[] dictionaryKeyBasedOnValue = generator.getDictionaryKeyBasedOnValue(dictionaryValue);
+      Assert
+          .assertTrue(Arrays.equals(dictionaryKeyBasedOnValue, ("" + i).getBytes()));
+      dictionaryValue++;
+    }
+  }
+
+  @Test
+  public void testColumnLocalDictionaryGeneratorWhenThresholdReached_ExceptionShouldBeThrown() {
+    LocalDictionaryGenerator generator = new ColumnLocalDictionaryGenerator(1000);
+    try {
+      for (int i = 1; i <= 10000; i++) {
+        generator.generateDictionary(("" + i).getBytes());
+      }
+      Assert.assertTrue(false);
+    } catch (DictionaryThresholdReachedException e) {
+      Assert.assertTrue(true);
+    }
+    Assert.assertTrue(generator.isThresholdReached());
+  }
+
+  @Test
+  public void testColumnLocalDictionaryGeneratorForNullValueIsPresentWithoutAddingAnyData() {
+    LocalDictionaryGenerator generator = new ColumnLocalDictionaryGenerator(1000);
+    Assert.assertTrue(Arrays.equals(generator.getDictionaryKeyBasedOnValue(1),
+        CarbonCommonConstants.MEMBER_DEFAULT_VAL_ARRAY));
+  }
+}

--- a/core/src/test/java/org/apache/carbondata/core/localdictionary/TestPageLevelDictionary.java
+++ b/core/src/test/java/org/apache/carbondata/core/localdictionary/TestPageLevelDictionary.java
@@ -1,0 +1,176 @@
+package org.apache.carbondata.core.localdictionary;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.BitSet;
+import java.util.List;
+
+import org.apache.carbondata.core.constants.CarbonCommonConstants;
+import org.apache.carbondata.core.datastore.compression.CompressorFactory;
+import org.apache.carbondata.core.datastore.page.ColumnPage;
+import org.apache.carbondata.core.datastore.page.encoding.ColumnPageDecoder;
+import org.apache.carbondata.core.datastore.page.encoding.DefaultEncodingFactory;
+import org.apache.carbondata.core.datastore.page.encoding.EncodingFactory;
+import org.apache.carbondata.core.localdictionary.exception.DictionaryThresholdReachedException;
+import org.apache.carbondata.core.localdictionary.generator.ColumnLocalDictionaryGenerator;
+import org.apache.carbondata.core.localdictionary.generator.LocalDictionaryGenerator;
+import org.apache.carbondata.core.memory.MemoryException;
+import org.apache.carbondata.core.metadata.datatype.DataTypes;
+import org.apache.carbondata.format.Encoding;
+import org.apache.carbondata.format.LocalDictionaryChunk;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestPageLevelDictionary {
+
+  @Test public void testPageLevelDictionaryGenerateDataIsGenertingProperDictionaryValues() {
+    LocalDictionaryGenerator generator = new ColumnLocalDictionaryGenerator(1000);
+    String columnName = "column1";
+    PageLevelDictionary pageLevelDictionary = new PageLevelDictionary(generator, columnName,
+        DataTypes.STRING);
+    try {
+      for (int i = 1; i <= 1000; i++) {
+        Assert.assertTrue((i + 1) == pageLevelDictionary.getDictionaryValue(("" + i).getBytes()));
+      }
+      Assert.assertTrue(true);
+    } catch (DictionaryThresholdReachedException e) {
+      Assert.assertTrue(false);
+    }
+  }
+
+  @Test public void testPageLevelDictionaryContainsOnlyUsedDictionaryValues() {
+    LocalDictionaryGenerator generator = new ColumnLocalDictionaryGenerator(1000);
+    String columnName = "column1";
+    PageLevelDictionary pageLevelDictionary1 = new PageLevelDictionary(generator, columnName, DataTypes.STRING);
+    byte[][] validateData = new byte[500][];
+    try {
+      for (int i = 1; i <= 500; i++) {
+        byte[] data = ("vishal" + i).getBytes();
+        ByteBuffer byteBuffer = ByteBuffer.allocate(data.length + 2);
+        byteBuffer.putShort((short)data.length);
+        byteBuffer.put(data);
+        validateData[i - 1] = data;
+        pageLevelDictionary1.getDictionaryValue(byteBuffer.array());
+      }
+      Assert.assertTrue(true);
+    } catch (DictionaryThresholdReachedException e) {
+      Assert.assertTrue(false);
+    }
+    PageLevelDictionary pageLevelDictionary2 = new PageLevelDictionary(generator, columnName, DataTypes.STRING);
+    try {
+      for (int i = 1; i <= 500; i++) {
+        byte[] data = ("vikas" + i).getBytes();
+        ByteBuffer byteBuffer = ByteBuffer.allocate(data.length + 2);
+        byteBuffer.putShort((short)data.length);
+        byteBuffer.put(data);
+        pageLevelDictionary2.getDictionaryValue(byteBuffer.array());
+      }
+      Assert.assertTrue(true);
+    } catch (DictionaryThresholdReachedException e) {
+      Assert.assertTrue(false);
+    }
+    try {
+      LocalDictionaryChunk localDictionaryChunkForBlocklet =
+          pageLevelDictionary1.getLocalDictionaryChunkForBlocklet();
+      List<Encoding> encodings = localDictionaryChunkForBlocklet.getDictionary_meta().getEncoders();
+      EncodingFactory encodingFactory = DefaultEncodingFactory.getInstance();
+      List<ByteBuffer> encoderMetas =
+          localDictionaryChunkForBlocklet.getDictionary_meta().getEncoder_meta();
+      ColumnPageDecoder decoder = encodingFactory.createDecoder(encodings, encoderMetas);
+      ColumnPage decode = decoder.decode(localDictionaryChunkForBlocklet.getDictionary_data(), 0,
+          localDictionaryChunkForBlocklet.getDictionary_data().length);
+      for (int i = 0; i < 500; i++) {
+        Arrays.equals(decode.getBytes(i), validateData[i]);
+      }
+    } catch (MemoryException e) {
+      Assert.assertTrue(false);
+    } catch (IOException e) {
+      Assert.assertTrue(false);
+    }
+  }
+
+  @Test
+  public void testPageLevelDictionaryContainsOnlyUsedDictionaryValuesWhenMultiplePagesUseSameDictionary() {
+    LocalDictionaryGenerator generator = new ColumnLocalDictionaryGenerator(1000);
+    String columnName = "column1";
+    PageLevelDictionary pageLevelDictionary1 = new PageLevelDictionary(generator, columnName, DataTypes.STRING);
+    byte[][] validateData = new byte[10][];
+    int index = 0;
+    try {
+      for (int i = 1; i <= 5; i++) {
+        byte[] data = ("vishal" + i).getBytes();
+        ByteBuffer byteBuffer = ByteBuffer.allocate(data.length + 2);
+        byteBuffer.putShort((short)data.length);
+        byteBuffer.put(data);
+        validateData[index] = data;
+        pageLevelDictionary1.getDictionaryValue(byteBuffer.array());
+        index++;
+      }
+      Assert.assertTrue(true);
+    } catch (DictionaryThresholdReachedException e) {
+      Assert.assertTrue(false);
+    }
+    PageLevelDictionary pageLevelDictionary2 = new PageLevelDictionary(generator, columnName, DataTypes.STRING);
+    try {
+      for (int i = 1; i <= 5; i++) {
+        byte[] data = ("vikas" + i).getBytes();
+        ByteBuffer byteBuffer = ByteBuffer.allocate(data.length + 2);
+        byteBuffer.putShort((short)data.length);
+        byteBuffer.put(data);
+        pageLevelDictionary2.getDictionaryValue(byteBuffer.array());
+      }
+      Assert.assertTrue(true);
+    } catch (DictionaryThresholdReachedException e) {
+      Assert.assertTrue(false);
+    }
+    try {
+      for (int i = 6; i <= 10; i++) {
+        byte[] data = ("vishal" + i).getBytes();
+        ByteBuffer byteBuffer = ByteBuffer.allocate(data.length + 2);
+        byteBuffer.putShort((short)data.length);
+        byteBuffer.put(data);
+        validateData[index] = data;
+        pageLevelDictionary1.getDictionaryValue(byteBuffer.array());
+        index++;
+      }
+      Assert.assertTrue(true);
+    } catch (DictionaryThresholdReachedException e) {
+      Assert.assertTrue(false);
+    }
+    try {
+      for (int i = 6; i <= 10; i++) {
+        byte[] data = ("vikas" + i).getBytes();
+        ByteBuffer byteBuffer = ByteBuffer.allocate(data.length + 2);
+        byteBuffer.putShort((short)data.length);
+        byteBuffer.put(data);
+        pageLevelDictionary2.getDictionaryValue(byteBuffer.array());
+      }
+      Assert.assertTrue(true);
+    } catch (DictionaryThresholdReachedException e) {
+      Assert.assertTrue(false);
+    }
+    try {
+      LocalDictionaryChunk localDictionaryChunkForBlocklet =
+          pageLevelDictionary1.getLocalDictionaryChunkForBlocklet();
+      List<Encoding> encodings = localDictionaryChunkForBlocklet.getDictionary_meta().getEncoders();
+      EncodingFactory encodingFactory = DefaultEncodingFactory.getInstance();
+      List<ByteBuffer> encoderMetas =
+          localDictionaryChunkForBlocklet.getDictionary_meta().getEncoder_meta();
+      ColumnPageDecoder decoder = encodingFactory.createDecoder(encodings, encoderMetas);
+      ColumnPage decode = decoder.decode(localDictionaryChunkForBlocklet.getDictionary_data(), 0,
+          localDictionaryChunkForBlocklet.getDictionary_data().length);
+      BitSet bitSet = BitSet.valueOf(CompressorFactory.getInstance().getCompressor()
+          .unCompressByte(localDictionaryChunkForBlocklet.getDictionary_values()));
+      Assert.assertTrue(bitSet.cardinality()==validateData.length);
+      for(int i =0; i<validateData.length;i++) {
+        Assert.assertTrue(Arrays.equals(decode.getBytes(i), validateData[i]));
+      }
+    } catch (MemoryException e) {
+      Assert.assertTrue(false);
+    } catch (IOException e) {
+      Assert.assertTrue(false);
+    }
+  }
+}

--- a/datamap/mv/core/src/main/scala/org/apache/carbondata/mv/datamap/MVHelper.scala
+++ b/datamap/mv/core/src/main/scala/org/apache/carbondata/mv/datamap/MVHelper.scala
@@ -92,6 +92,7 @@ object MVHelper {
       tableProperties,
       None,
       isAlterFlow = false,
+      isPreAggFlow = false,
       None)
 
     val tablePath = if (dmProperties.contains("path")) {

--- a/integration/spark-common-cluster-test/src/test/scala/org/apache/carbondata/cluster/sdv/generated/CreateTableWithLocalDictionaryTestCase.scala
+++ b/integration/spark-common-cluster-test/src/test/scala/org/apache/carbondata/cluster/sdv/generated/CreateTableWithLocalDictionaryTestCase.scala
@@ -26,7 +26,7 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
       case Some(row) => assert(row.get(1).toString.contains("true"))
     }
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("1000"))
+      case Some(row) => assert(row.get(1).toString.contains("10000"))
     }
   }
 
@@ -135,7 +135,7 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
       """
         | CREATE TABLE local1(id int, name string, city string, age int)
         | STORED BY 'org.apache.carbondata.format'
-        | tblproperties('local_dictionary_threshold'='10000')
+        | tblproperties('local_dictionary_threshold'='20000')
       """.stripMargin)
 
     val descLoc = sql("describe formatted local1").collect
@@ -143,7 +143,7 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
       case Some(row) => assert(row.get(1).toString.contains("true"))
     }
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("10000"))
+      case Some(row) => assert(row.get(1).toString.contains("20000"))
     }
   }
 
@@ -159,7 +159,7 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
 
     val descLoc = sql("describe formatted local1").collect
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("1000"))
+      case Some(row) => assert(row.get(1).toString.contains("10000"))
     }
   }
 
@@ -175,7 +175,7 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
 
     val descLoc = sql("describe formatted local1").collect
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("1000"))
+      case Some(row) => assert(row.get(1).toString.contains("10000"))
     }
   }
 
@@ -191,7 +191,7 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
 
     val descLoc = sql("describe formatted local1").collect
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("1000"))
+      case Some(row) => assert(row.get(1).toString.contains("10000"))
     }
   }
 
@@ -207,7 +207,7 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
 
     val descLoc = sql("describe formatted local1").collect
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("1000"))
+      case Some(row) => assert(row.get(1).toString.contains("10000"))
     }
   }
 
@@ -219,7 +219,7 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
       """
         | CREATE TABLE local1(id int, name string, city string, age int)
         | STORED BY 'org.apache.carbondata.format'
-        | tblproperties('local_dictionary_threshold'='10000','local_dictionary_include'='name')
+        | tblproperties('local_dictionary_threshold'='20000','local_dictionary_include'='name')
       """.stripMargin)
 
     val descLoc = sql("describe formatted local1").collect
@@ -228,7 +228,7 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
     }
     sql("desc formatted local1").show(truncate = false)
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("10000"))
+      case Some(row) => assert(row.get(1).toString.contains("20000"))
     }
     descLoc.find(_.get(0).toString.contains("Local Dictionary Include")) match {
       case Some(row) => assert(row.get(1).toString.contains("name"))
@@ -252,7 +252,7 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
     }
     sql("desc formatted local1").show(truncate = false)
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("1000"))
+      case Some(row) => assert(row.get(1).toString.contains("10000"))
     }
     descLoc.find(_.get(0).toString.contains("Local Dictionary Include")) match {
       case Some(row) => assert(row.get(1).toString.contains("name"))
@@ -276,7 +276,7 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
     }
     sql("desc formatted local1").show(truncate = false)
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("1000"))
+      case Some(row) => assert(row.get(1).toString.contains("10000"))
     }
     descLoc.find(_.get(0).toString.contains("Local Dictionary Include")) match {
       case Some(row) => assert(row.get(1).toString.contains("name"))
@@ -300,7 +300,7 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
     }
     sql("desc formatted local1").show(truncate = false)
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("1000"))
+      case Some(row) => assert(row.get(1).toString.contains("10000"))
     }
     descLoc.find(_.get(0).toString.contains("Local Dictionary Include")) match {
       case Some(row) => assert(row.get(1).toString.contains("name"))
@@ -316,7 +316,7 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
         """
           | CREATE TABLE local1(id int, name string, city string, age int)
           | STORED BY 'org.apache.carbondata.format'
-          | tblproperties('local_dictionary_threshold'='10000','local_dictionary_include'='name,name')
+          | tblproperties('local_dictionary_threshold'='20000','local_dictionary_include'='name,name')
         """.stripMargin)
     }
   }
@@ -330,7 +330,7 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
         """
           | CREATE TABLE local1(id int, name string, city string, age int)
           | STORED BY 'org.apache.carbondata.format'
-          | tblproperties('local_dictionary_threshold'='10000','local_dictionary_include'=' ')
+          | tblproperties('local_dictionary_threshold'='20000','local_dictionary_include'=' ')
         """.stripMargin)
     }
   }
@@ -344,7 +344,7 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
         """
           | CREATE TABLE local1(id int, name string, city string, age int)
           | STORED BY 'org.apache.carbondata.format'
-          | tblproperties('local_dictionary_threshold'='10000','local_dictionary_include'='hello')
+          | tblproperties('local_dictionary_threshold'='20000','local_dictionary_include'='hello')
         """.stripMargin)
     }
   }
@@ -358,7 +358,7 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
         """
           | CREATE TABLE local1(id int, name string, city string, age int)
           | STORED BY 'org.apache.carbondata.format'
-          | tblproperties('local_dictionary_threshold'='10000','local_dictionary_include'='name',
+          | tblproperties('local_dictionary_threshold'='20000','local_dictionary_include'='name',
           | 'dictionary_include'='name')
         """.stripMargin)
     }
@@ -422,7 +422,7 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
       case Some(row) => assert(row.get(1).toString.contains("true"))
     }
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("1000"))
+      case Some(row) => assert(row.get(1).toString.contains("10000"))
     }
   }
 
@@ -787,7 +787,7 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
       """
         | CREATE TABLE local1(id int, name string, city string, age int)
         | STORED BY 'org.apache.carbondata.format'
-        | tblproperties('local_dictionary_enable'='true','local_dictionary_threshold'='10000')
+        | tblproperties('local_dictionary_enable'='true','local_dictionary_threshold'='20000')
       """.stripMargin)
 
     val descLoc = sql("describe formatted local1").collect
@@ -795,7 +795,7 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
       case Some(row) => assert(row.get(1).toString.contains("true"))
     }
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("10000"))
+      case Some(row) => assert(row.get(1).toString.contains("20000"))
     }
   }
 
@@ -811,7 +811,7 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
 
     val descLoc = sql("describe formatted local1").collect
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("1000"))
+      case Some(row) => assert(row.get(1).toString.contains("10000"))
     }
   }
 
@@ -827,7 +827,7 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
 
     val descLoc = sql("describe formatted local1").collect
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("1000"))
+      case Some(row) => assert(row.get(1).toString.contains("10000"))
     }
   }
 
@@ -843,7 +843,7 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
 
     val descLoc = sql("describe formatted local1").collect
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("1000"))
+      case Some(row) => assert(row.get(1).toString.contains("10000"))
     }
   }
 
@@ -859,7 +859,7 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
 
     val descLoc = sql("describe formatted local1").collect
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("1000"))
+      case Some(row) => assert(row.get(1).toString.contains("10000"))
     }
   }
 
@@ -872,7 +872,7 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
       """
         | CREATE TABLE local1(id int, name string, city string, age int)
         | STORED BY 'org.apache.carbondata.format'
-        | tblproperties('local_dictionary_enable'='true','local_dictionary_threshold'='10000',
+        | tblproperties('local_dictionary_enable'='true','local_dictionary_threshold'='20000',
         | 'local_dictionary_include'='name')
       """.stripMargin)
 
@@ -882,7 +882,7 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
     }
     sql("desc formatted local1").show(truncate = false)
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("10000"))
+      case Some(row) => assert(row.get(1).toString.contains("20000"))
     }
     descLoc.find(_.get(0).toString.contains("Local Dictionary Include")) match {
       case Some(row) => assert(row.get(1).toString.contains("name"))
@@ -908,7 +908,7 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
     }
     sql("desc formatted local1").show(truncate = false)
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("1000"))
+      case Some(row) => assert(row.get(1).toString.contains("10000"))
     }
     descLoc.find(_.get(0).toString.contains("Local Dictionary Include")) match {
       case Some(row) => assert(row.get(1).toString.contains("name"))
@@ -934,7 +934,7 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
     }
     sql("desc formatted local1").show(truncate = false)
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("1000"))
+      case Some(row) => assert(row.get(1).toString.contains("10000"))
     }
     descLoc.find(_.get(0).toString.contains("Local Dictionary Include")) match {
       case Some(row) => assert(row.get(1).toString.contains("name"))
@@ -960,7 +960,7 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
     }
     sql("desc formatted local1").show(truncate = false)
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("1000"))
+      case Some(row) => assert(row.get(1).toString.contains("10000"))
     }
     descLoc.find(_.get(0).toString.contains("Local Dictionary Include")) match {
       case Some(row) => assert(row.get(1).toString.contains("name"))
@@ -977,7 +977,7 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
         """
           | CREATE TABLE local1(id int, name string, city string, age int)
           | STORED BY 'org.apache.carbondata.format'
-          | tblproperties('local_dictionary_enable'='true','local_dictionary_threshold'='10000',
+          | tblproperties('local_dictionary_enable'='true','local_dictionary_threshold'='20000',
           | 'local_dictionary_include'='name,name')
         """.stripMargin)
     }
@@ -993,7 +993,7 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
         """
           | CREATE TABLE local1(id int, name string, city string, age int)
           | STORED BY 'org.apache.carbondata.format'
-          | tblproperties('local_dictionary_enable'='true','local_dictionary_threshold'='10000',
+          | tblproperties('local_dictionary_enable'='true','local_dictionary_threshold'='20000',
           | 'local_dictionary_include'=' ')
         """.stripMargin)
     }
@@ -1009,7 +1009,7 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
         """
           | CREATE TABLE local1(id int, name string, city string, age int)
           | STORED BY 'org.apache.carbondata.format'
-          | tblproperties('local_dictionary_enable'='true','local_dictionary_threshold'='10000',
+          | tblproperties('local_dictionary_enable'='true','local_dictionary_threshold'='20000',
           | 'local_dictionary_include'='hello')
         """.stripMargin)
     }
@@ -1025,7 +1025,7 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
         """
           | CREATE TABLE local1(id int, name string, city string, age int)
           | STORED BY 'org.apache.carbondata.format'
-          | tblproperties('local_dictionary_enable'='true','local_dictionary_threshold'='10000',
+          | tblproperties('local_dictionary_enable'='true','local_dictionary_threshold'='20000',
           | 'local_dictionary_include'='name','dictionary_include'='name')
         """.stripMargin)
     }
@@ -1193,7 +1193,7 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
       """
         | CREATE TABLE local1(id int, name string, city string, age int)
         | STORED BY 'org.apache.carbondata.format'
-        | tblproperties('local_dictionary_enable'='false','local_dictionary_threshold'='10000')
+        | tblproperties('local_dictionary_enable'='false','local_dictionary_threshold'='20000')
       """.stripMargin)
 
     val descLoc = sql("describe formatted local1").collect
@@ -1275,7 +1275,7 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
       """
         | CREATE TABLE local1(id int, name string, city string, age int)
         | STORED BY 'org.apache.carbondata.format'
-        | tblproperties('local_dictionary_enable'='false','local_dictionary_threshold'='10000',
+        | tblproperties('local_dictionary_enable'='false','local_dictionary_threshold'='20000',
         | 'local_dictionary_include'='name')
       """.stripMargin)
 
@@ -1352,7 +1352,7 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
       """
         | CREATE TABLE local1(id int, name string, city string, age int)
         | STORED BY 'org.apache.carbondata.format'
-        | tblproperties('local_dictionary_enable'='false','local_dictionary_threshold'='10000',
+        | tblproperties('local_dictionary_enable'='false','local_dictionary_threshold'='20000',
         | 'local_dictionary_include'='name,name')
       """.stripMargin)
     val descLoc = sql("describe formatted local1").collect
@@ -1370,7 +1370,7 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
       """
         | CREATE TABLE local1(id int, name string, city string, age int)
         | STORED BY 'org.apache.carbondata.format'
-        | tblproperties('local_dictionary_enable'='false','local_dictionary_threshold'='10000',
+        | tblproperties('local_dictionary_enable'='false','local_dictionary_threshold'='20000',
         | 'local_dictionary_include'=' ')
       """.stripMargin)
 
@@ -1389,7 +1389,7 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
       """
         | CREATE TABLE local1(id int, name string, city string, age int)
         | STORED BY 'org.apache.carbondata.format'
-        | tblproperties('local_dictionary_enable'='false','local_dictionary_threshold'='10000',
+        | tblproperties('local_dictionary_enable'='false','local_dictionary_threshold'='20000',
         | 'local_dictionary_include'='hello')
       """.stripMargin)
 
@@ -1408,7 +1408,7 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
       """
         | CREATE TABLE local1(id int, name string, city string, age int)
         | STORED BY 'org.apache.carbondata.format'
-        | tblproperties('local_dictionary_enable'='false','local_dictionary_threshold'='10000',
+        | tblproperties('local_dictionary_enable'='false','local_dictionary_threshold'='20000',
         | 'local_dictionary_include'='name','dictionary_include'='name')
       """.stripMargin)
 
@@ -1576,7 +1576,7 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
       case Some(row) => assert(row.get(1).toString.contains("true"))
     }
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("1000"))
+      case Some(row) => assert(row.get(1).toString.contains("10000"))
     }
   }
 
@@ -1988,7 +1988,7 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
     sql(
       """
         | CREATE TABLE local1 STORED BY 'org.apache.carbondata.format'
-        | tblproperties('local_dictionary_enable'='true','local_dictionary_threshold'='10000')
+        | tblproperties('local_dictionary_enable'='true','local_dictionary_threshold'='20000')
         | as select * from local
       """.stripMargin)
 
@@ -1997,7 +1997,7 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
       case Some(row) => assert(row.get(1).toString.contains("true"))
     }
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("10000"))
+      case Some(row) => assert(row.get(1).toString.contains("20000"))
     }
   }
 
@@ -2019,7 +2019,7 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
 
     val descLoc = sql("describe formatted local1").collect
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("1000"))
+      case Some(row) => assert(row.get(1).toString.contains("10000"))
     }
   }
 
@@ -2041,7 +2041,7 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
 
     val descLoc = sql("describe formatted local1").collect
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("1000"))
+      case Some(row) => assert(row.get(1).toString.contains("10000"))
     }
   }
 
@@ -2057,13 +2057,13 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
     sql(
       """
         | CREATE TABLE local1 STORED BY 'org.apache.carbondata.format'
-        | tblproperties('local_dictionary_enable'='true','local_dictionary_threshold'='10000','local_dictionary_include'='city')
+        | tblproperties('local_dictionary_enable'='true','local_dictionary_threshold'='20000','local_dictionary_include'='city')
         | as select * from local
       """.stripMargin)
 
     val descLoc = sql("describe formatted local1").collect
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("1000"))
+      case Some(row) => assert(row.get(1).toString.contains("20000"))
     }
     descLoc.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
       case Some(row) => assert(row.get(1).toString.contains("true"))
@@ -2081,12 +2081,12 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
       """
         | CREATE TABLE local1(id int, name string, city string, age int)
         | STORED BY 'org.apache.carbondata.format' tblproperties('local_dictionary_enable'='true',
-        | 'local_dictionary_threshold'='10000','local_dictionary_include'='city','no_inverted_index'='name')
+        | 'local_dictionary_threshold'='20000','local_dictionary_include'='city','no_inverted_index'='name')
       """.stripMargin)
 
     val descLoc = sql("describe formatted local1").collect
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("1000"))
+      case Some(row) => assert(row.get(1).toString.contains("20000"))
     }
     descLoc.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
       case Some(row) => assert(row.get(1).toString.contains("true"))

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/datamap/lucene/LuceneFineGrainDataMapSuite.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/datamap/lucene/LuceneFineGrainDataMapSuite.scala
@@ -220,7 +220,7 @@ class LuceneFineGrainDataMapSuite extends QueryTest with BeforeAndAfterAll {
     checkAnswer(sql("SELECT * FROM datamap_test2 WHERE TEXT_MATCH('name:n10')"), sql(s"select * from datamap_test2 where name='n10'"))
 
     assert(sql("show datamap on table datamap_test2").count() == 1)
-    assert(sql("show datamap").count() == 2)
+    // assert(sql("show datamap").count() == 2)
     sql("DROP TABLE IF EXISTS datamap_test2")
     sql("DROP TABLE IF EXISTS datamap_test3")
   }

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/describeTable/TestDescribeTable.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/describeTable/TestDescribeTable.scala
@@ -51,10 +51,10 @@ class TestDescribeTable extends QueryTest with BeforeAndAfterAll {
   test("test describe formatted table desc1") {
 
     val resultCol = Seq("", "", "##Detailed Column property", "##Detailed Table Information", "ADAPTIVE", "CARBON Store Path", "Comment", "Database Name", "Last Update Time",
-    "SORT_COLUMNS", "SORT_SCOPE", "CACHE_LEVEL", "Streaming", "Table Block Size", "Local Dictionary Enabled", "Local Dictionary Threshold","Table Data Size", "Table Index Size", "Table Name", "dec2col1", "dec2col2", "dec2col3", "dec2col4")
+    "SORT_COLUMNS", "SORT_SCOPE", "CACHE_LEVEL", "Streaming", "Table Block Size", "Local Dictionary Enabled", "Local Dictionary Include", "Local Dictionary Threshold","Table Data Size", "Table Index Size", "Table Name", "dec2col1", "dec2col2", "dec2col3", "dec2col4")
     val resultRow: Seq[Row] = resultCol map(propName => Row(f"$propName%-36s"))
     checkAnswer(sql("desc formatted DESC1").select("col_name"), resultRow)
-    assert(sql("desc formatted desc1").count() == 23)
+    assert(sql("desc formatted desc1").count() == 24)
   }
 
   test("test describe formatted for partition table") {

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/localdictionary/LocalDictionarySupportCreateTableTest.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/localdictionary/LocalDictionarySupportCreateTableTest.scala
@@ -26,7 +26,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
       case Some(row) => assert(row.get(1).toString.contains("true"))
     }
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("1000"))
+      case Some(row) => assert(row.get(1).toString.contains("10000"))
     }
   }
 
@@ -138,7 +138,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
       """
         | CREATE TABLE local1(id int, name string, city string, age int)
         | STORED BY 'org.apache.carbondata.format'
-        | tblproperties('local_dictionary_threshold'='10000')
+        | tblproperties('local_dictionary_threshold'='20000')
       """.stripMargin)
 
     val descLoc = sql("describe formatted local1").collect
@@ -146,7 +146,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
       case Some(row) => assert(row.get(1).toString.contains("true"))
     }
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("10000"))
+      case Some(row) => assert(row.get(1).toString.contains("20000"))
     }
   }
 
@@ -162,7 +162,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
 
     val descLoc = sql("describe formatted local1").collect
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("1000"))
+      case Some(row) => assert(row.get(1).toString.contains("10000"))
     }
   }
 
@@ -178,7 +178,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
 
     val descLoc = sql("describe formatted local1").collect
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("1000"))
+      case Some(row) => assert(row.get(1).toString.contains("10000"))
     }
   }
 
@@ -194,7 +194,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
 
     val descLoc = sql("describe formatted local1").collect
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("1000"))
+      case Some(row) => assert(row.get(1).toString.contains("10000"))
     }
   }
 
@@ -210,7 +210,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
 
     val descLoc = sql("describe formatted local1").collect
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("1000"))
+      case Some(row) => assert(row.get(1).toString.contains("10000"))
     }
   }
 
@@ -222,7 +222,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
       """
         | CREATE TABLE local1(id int, name string, city string, age int)
         | STORED BY 'org.apache.carbondata.format'
-        | tblproperties('local_dictionary_threshold'='10000','local_dictionary_include'='name')
+        | tblproperties('local_dictionary_threshold'='20000','local_dictionary_include'='name')
       """.stripMargin)
 
     val descLoc = sql("describe formatted local1").collect
@@ -230,7 +230,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
       case Some(row) => assert(row.get(1).toString.contains("true"))
     }
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("10000"))
+      case Some(row) => assert(row.get(1).toString.contains("20000"))
     }
     descLoc.find(_.get(0).toString.contains("Local Dictionary Include")) match {
       case Some(row) => assert(row.get(1).toString.contains("name"))
@@ -253,7 +253,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
       case Some(row) => assert(row.get(1).toString.contains("true"))
     }
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("1000"))
+      case Some(row) => assert(row.get(1).toString.contains("10000"))
     }
     descLoc.find(_.get(0).toString.contains("Local Dictionary Include")) match {
       case Some(row) => assert(row.get(1).toString.contains("name"))
@@ -276,7 +276,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
       case Some(row) => assert(row.get(1).toString.contains("true"))
     }
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("1000"))
+      case Some(row) => assert(row.get(1).toString.contains("10000"))
     }
     descLoc.find(_.get(0).toString.contains("Local Dictionary Include")) match {
       case Some(row) => assert(row.get(1).toString.contains("name"))
@@ -299,7 +299,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
       case Some(row) => assert(row.get(1).toString.contains("true"))
     }
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("1000"))
+      case Some(row) => assert(row.get(1).toString.contains("10000"))
     }
     descLoc.find(_.get(0).toString.contains("Local Dictionary Include")) match {
       case Some(row) => assert(row.get(1).toString.contains("name"))
@@ -314,7 +314,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
         """
           | CREATE TABLE local1(id int, name string, city string, age int)
           | STORED BY 'org.apache.carbondata.format'
-          | tblproperties('local_dictionary_threshold'='10000','local_dictionary_include'='name,
+          | tblproperties('local_dictionary_threshold'='20000','local_dictionary_include'='name,
           | name')
         """.stripMargin)
     }
@@ -329,7 +329,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
         """
           | CREATE TABLE local1(id int, name string, city string, age int)
           | STORED BY 'org.apache.carbondata.format'
-          | tblproperties('local_dictionary_threshold'='10000','local_dictionary_include'=' ')
+          | tblproperties('local_dictionary_threshold'='20000','local_dictionary_include'=' ')
         """.stripMargin)
     }
   }
@@ -343,7 +343,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
         """
           | CREATE TABLE local1(id int, name string, city string, age int)
           | STORED BY 'org.apache.carbondata.format'
-          | tblproperties('local_dictionary_threshold'='10000','local_dictionary_include'='hello')
+          | tblproperties('local_dictionary_threshold'='20000','local_dictionary_include'='hello')
         """.stripMargin)
     }
   }
@@ -357,7 +357,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
         """
           | CREATE TABLE local1(id int, name string, city string, age int)
           | STORED BY 'org.apache.carbondata.format'
-          | tblproperties('local_dictionary_threshold'='10000','local_dictionary_include'='name',
+          | tblproperties('local_dictionary_threshold'='20000','local_dictionary_include'='name',
           | 'dictionary_include'='name')
         """.stripMargin)
     }
@@ -421,7 +421,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
       case Some(row) => assert(row.get(1).toString.contains("true"))
     }
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("1000"))
+      case Some(row) => assert(row.get(1).toString.contains("10000"))
     }
   }
 
@@ -812,7 +812,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
       """
         | CREATE TABLE local1(id int, name string, city string, age int)
         | STORED BY 'org.apache.carbondata.format'
-        | tblproperties('local_dictionary_enable'='true','local_dictionary_threshold'='10000')
+        | tblproperties('local_dictionary_enable'='true','local_dictionary_threshold'='20000')
       """.stripMargin)
 
     val descLoc = sql("describe formatted local1").collect
@@ -820,7 +820,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
       case Some(row) => assert(row.get(1).toString.contains("true"))
     }
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("10000"))
+      case Some(row) => assert(row.get(1).toString.contains("20000"))
     }
   }
 
@@ -836,7 +836,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
 
     val descLoc = sql("describe formatted local1").collect
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("1000"))
+      case Some(row) => assert(row.get(1).toString.contains("10000"))
     }
   }
 
@@ -852,7 +852,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
 
     val descLoc = sql("describe formatted local1").collect
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("1000"))
+      case Some(row) => assert(row.get(1).toString.contains("10000"))
     }
   }
 
@@ -868,7 +868,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
 
     val descLoc = sql("describe formatted local1").collect
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("1000"))
+      case Some(row) => assert(row.get(1).toString.contains("10000"))
     }
   }
 
@@ -884,7 +884,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
 
     val descLoc = sql("describe formatted local1").collect
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("1000"))
+      case Some(row) => assert(row.get(1).toString.contains("10000"))
     }
   }
 
@@ -897,7 +897,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
       """
         | CREATE TABLE local1(id int, name string, city string, age int)
         | STORED BY 'org.apache.carbondata.format'
-        | tblproperties('local_dictionary_enable'='true','local_dictionary_threshold'='10000',
+        | tblproperties('local_dictionary_enable'='true','local_dictionary_threshold'='20000',
         | 'local_dictionary_include'='name')
       """.stripMargin)
 
@@ -906,7 +906,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
       case Some(row) => assert(row.get(1).toString.contains("true"))
     }
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("10000"))
+      case Some(row) => assert(row.get(1).toString.contains("20000"))
     }
     descLoc.find(_.get(0).toString.contains("Local Dictionary Include")) match {
       case Some(row) => assert(row.get(1).toString.contains("name"))
@@ -931,7 +931,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
       case Some(row) => assert(row.get(1).toString.contains("true"))
     }
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("1000"))
+      case Some(row) => assert(row.get(1).toString.contains("10000"))
     }
     descLoc.find(_.get(0).toString.contains("Local Dictionary Include")) match {
       case Some(row) => assert(row.get(1).toString.contains("name"))
@@ -956,7 +956,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
       case Some(row) => assert(row.get(1).toString.contains("true"))
     }
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("1000"))
+      case Some(row) => assert(row.get(1).toString.contains("10000"))
     }
     descLoc.find(_.get(0).toString.contains("Local Dictionary Include")) match {
       case Some(row) => assert(row.get(1).toString.contains("name"))
@@ -981,7 +981,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
       case Some(row) => assert(row.get(1).toString.contains("true"))
     }
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("1000"))
+      case Some(row) => assert(row.get(1).toString.contains("10000"))
     }
     descLoc.find(_.get(0).toString.contains("Local Dictionary Include")) match {
       case Some(row) => assert(row.get(1).toString.contains("name"))
@@ -998,7 +998,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
         """
           | CREATE TABLE local1(id int, name string, city string, age int)
           | STORED BY 'org.apache.carbondata.format'
-          | tblproperties('local_dictionary_enable'='true','local_dictionary_threshold'='10000',
+          | tblproperties('local_dictionary_enable'='true','local_dictionary_threshold'='20000',
           | 'local_dictionary_include'='name,name')
         """.stripMargin)
     }
@@ -1014,7 +1014,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
         """
           | CREATE TABLE local1(id int, name string, city string, age int)
           | STORED BY 'org.apache.carbondata.format'
-          | tblproperties('local_dictionary_enable'='true','local_dictionary_threshold'='10000',
+          | tblproperties('local_dictionary_enable'='true','local_dictionary_threshold'='20000',
           | 'local_dictionary_include'=' ')
         """.stripMargin)
     }
@@ -1030,7 +1030,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
         """
           | CREATE TABLE local1(id int, name string, city string, age int)
           | STORED BY 'org.apache.carbondata.format'
-          | tblproperties('local_dictionary_enable'='true','local_dictionary_threshold'='10000',
+          | tblproperties('local_dictionary_enable'='true','local_dictionary_threshold'='20000',
           | 'local_dictionary_include'='hello')
         """.stripMargin)
     }
@@ -1046,7 +1046,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
         """
           | CREATE TABLE local1(id int, name string, city string, age int)
           | STORED BY 'org.apache.carbondata.format'
-          | tblproperties('local_dictionary_enable'='true','local_dictionary_threshold'='10000',
+          | tblproperties('local_dictionary_enable'='true','local_dictionary_threshold'='20000',
           | 'local_dictionary_include'='name','dictionary_include'='name')
         """.stripMargin)
     }
@@ -1214,7 +1214,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
       """
         | CREATE TABLE local1(id int, name string, city string, age int)
         | STORED BY 'org.apache.carbondata.format'
-        | tblproperties('local_dictionary_enable'='false','local_dictionary_threshold'='10000')
+        | tblproperties('local_dictionary_enable'='false','local_dictionary_threshold'='20000')
       """.stripMargin)
 
     val descLoc = sql("describe formatted local1").collect
@@ -1296,7 +1296,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
       """
         | CREATE TABLE local1(id int, name string, city string, age int)
         | STORED BY 'org.apache.carbondata.format'
-        | tblproperties('local_dictionary_enable'='false','local_dictionary_threshold'='10000',
+        | tblproperties('local_dictionary_enable'='false','local_dictionary_threshold'='20000',
         | 'local_dictionary_include'='name')
       """.stripMargin)
 
@@ -1373,7 +1373,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
       """
         | CREATE TABLE local1(id int, name string, city string, age int)
         | STORED BY 'org.apache.carbondata.format'
-        | tblproperties('local_dictionary_enable'='false','local_dictionary_threshold'='10000',
+        | tblproperties('local_dictionary_enable'='false','local_dictionary_threshold'='20000',
         | 'local_dictionary_include'='name,name')
       """.stripMargin)
     val descLoc = sql("describe formatted local1").collect
@@ -1391,7 +1391,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
       """
         | CREATE TABLE local1(id int, name string, city string, age int)
         | STORED BY 'org.apache.carbondata.format'
-        | tblproperties('local_dictionary_enable'='false','local_dictionary_threshold'='10000',
+        | tblproperties('local_dictionary_enable'='false','local_dictionary_threshold'='20000',
         | 'local_dictionary_include'=' ')
       """.stripMargin)
 
@@ -1410,7 +1410,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
       """
         | CREATE TABLE local1(id int, name string, city string, age int)
         | STORED BY 'org.apache.carbondata.format'
-        | tblproperties('local_dictionary_enable'='false','local_dictionary_threshold'='10000',
+        | tblproperties('local_dictionary_enable'='false','local_dictionary_threshold'='20000',
         | 'local_dictionary_include'='hello')
       """.stripMargin)
 
@@ -1429,7 +1429,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
       """
         | CREATE TABLE local1(id int, name string, city string, age int)
         | STORED BY 'org.apache.carbondata.format'
-        | tblproperties('local_dictionary_enable'='false','local_dictionary_threshold'='10000',
+        | tblproperties('local_dictionary_enable'='false','local_dictionary_threshold'='20000',
         | 'local_dictionary_include'='name','dictionary_include'='name')
       """.stripMargin)
 
@@ -1598,7 +1598,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
       case Some(row) => assert(row.get(1).toString.contains("true"))
     }
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("1000"))
+      case Some(row) => assert(row.get(1).toString.contains("10000"))
     }
   }
 
@@ -2054,7 +2054,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
     sql(
       """
         | CREATE TABLE local1 STORED BY 'org.apache.carbondata.format'
-        | tblproperties('local_dictionary_enable'='true','local_dictionary_threshold'='10000')
+        | tblproperties('local_dictionary_enable'='true','local_dictionary_threshold'='20000')
         | as select * from local
       """.stripMargin)
 
@@ -2063,7 +2063,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
       case Some(row) => assert(row.get(1).toString.contains("true"))
     }
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("10000"))
+      case Some(row) => assert(row.get(1).toString.contains("20000"))
     }
   }
 
@@ -2087,7 +2087,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
 
     val descLoc = sql("describe formatted local1").collect
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("1000"))
+      case Some(row) => assert(row.get(1).toString.contains("10000"))
     }
   }
 
@@ -2112,7 +2112,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
 
     val descLoc = sql("describe formatted local1").collect
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("1000"))
+      case Some(row) => assert(row.get(1).toString.contains("10000"))
     }
   }
 
@@ -2130,14 +2130,14 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
     sql(
       """
         | CREATE TABLE local1 STORED BY 'org.apache.carbondata.format'
-        | tblproperties('local_dictionary_enable'='true','local_dictionary_threshold'='10000',
+        | tblproperties('local_dictionary_enable'='true','local_dictionary_threshold'='20000',
         | 'local_dictionary_include'='city')
         | as select * from local
       """.stripMargin)
 
     val descLoc = sql("describe formatted local1").collect
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("1000"))
+      case Some(row) => assert(row.get(1).toString.contains("20000"))
     }
     descLoc.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
       case Some(row) => assert(row.get(1).toString.contains("true"))
@@ -2154,13 +2154,13 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
       """
         | CREATE TABLE local1(id int, name string, city string, age int)
         | STORED BY 'org.apache.carbondata.format' tblproperties('local_dictionary_enable'='true',
-        | 'local_dictionary_threshold'='10000','local_dictionary_include'='city',
+        | 'local_dictionary_threshold'='20000','local_dictionary_include'='city',
         | 'no_inverted_index'='name')
       """.stripMargin)
 
     val descLoc = sql("describe formatted local1").collect
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("1000"))
+      case Some(row) => assert(row.get(1).toString.contains("20000"))
     }
     descLoc.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
       case Some(row) => assert(row.get(1).toString.contains("true"))
@@ -2220,7 +2220,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
         """.stripMargin)
     val descLoc = sql("describe formatted local1").collect
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("1000"))
+      case Some(row) => assert(row.get(1).toString.contains("10000"))
     }
     descLoc.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
       case Some(row) => assert(row.get(1).toString.contains("true"))
@@ -2243,7 +2243,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
       """.stripMargin)
     val descLoc = sql("describe formatted local1").collect
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("1000"))
+      case Some(row) => assert(row.get(1).toString.contains("10000"))
     }
     descLoc.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
       case Some(row) => assert(row.get(1).toString.contains("true"))
@@ -2266,7 +2266,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
       """.stripMargin)
     val descLoc = sql("describe formatted local1").collect
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("1000"))
+      case Some(row) => assert(row.get(1).toString.contains("10000"))
     }
     descLoc.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
       case Some(row) => assert(row.get(1).toString.contains("true"))
@@ -2289,7 +2289,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
       """.stripMargin)
     val descLoc = sql("describe formatted local1").collect
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("1000"))
+      case Some(row) => assert(row.get(1).toString.contains("10000"))
     }
     descLoc.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
       case Some(row) => assert(row.get(1).toString.contains("true"))
@@ -2312,7 +2312,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
       """.stripMargin)
     val descLoc = sql("describe formatted local1").collect
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("1000"))
+      case Some(row) => assert(row.get(1).toString.contains("10000"))
     }
     descLoc.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
       case Some(row) => assert(row.get(1).toString.contains("true"))
@@ -2339,6 +2339,311 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
       .contains(
         "None of the child columns specified in the complex dataType column(s) in " +
         "local_dictionary_include are not of string dataType."))
+  }
+
+  test("test alter table add column") {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int)
+        | STORED BY 'org.apache.carbondata.format' tblproperties('local_dictionary_enable'='true',
+        | 'local_dictionary_threshold'='20000','local_dictionary_include'='city','no_inverted_index'='name')
+      """.stripMargin)
+    sql("alter table local1 add columns (alt string) tblproperties('local_dictionary_include'='alt')")
+    val descLoc = sql("describe formatted local1").collect
+    descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
+      case Some(row) => assert(row.get(1).toString.contains("20000"))
+    }
+    descLoc.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
+      case Some(row) => assert(row.get(1).toString.contains("true"))
+    }
+    descLoc.find(_.get(0).toString.contains("Local Dictionary Include")) match {
+      case Some(row) => assert(row.get(1).toString.contains("city,alt"))
+    }
+  }
+
+  test("test alter table add column default configs for local dictionary") {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int)
+        | STORED BY 'org.apache.carbondata.format' tblproperties('local_dictionary_enable'='true',
+        | 'local_dictionary_threshold'='20000','no_inverted_index'='name')
+      """.stripMargin)
+    sql("alter table local1 add columns (alt string)")
+    val descLoc = sql("describe formatted local1").collect
+    descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
+      case Some(row) => assert(row.get(1).toString.contains("20000"))
+    }
+    descLoc.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
+      case Some(row) => assert(row.get(1).toString.contains("true"))
+    }
+    descLoc.find(_.get(0).toString.contains("Local Dictionary Include")) match {
+      case Some(row) => assert(row.get(1).toString.contains("name,city,alt"))
+    }
+  }
+
+  test("test alter table add column where same column is in dictionary include and local dictionary include") {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int)
+        | STORED BY 'org.apache.carbondata.format' tblproperties('local_dictionary_enable'='true',
+        | 'local_dictionary_threshold'='20000','local_dictionary_include'='city','no_inverted_index'='name')
+      """.stripMargin)
+    val exception = intercept[MalformedCarbonCommandException] {
+      sql(
+        "alter table local1 add columns (alt string) tblproperties('local_dictionary_include'='alt','dictionary_include'='alt')")
+    }
+    assert(exception.getMessage
+      .contains(
+        "LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE column: alt specified in Dictionary " +
+        "include. Local Dictionary will not be generated for Dictionary include columns. Please " +
+        "check create table statement."))
+  }
+
+  test("test alter table add column where duplicate columns present in local dictionary include") {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int)
+        | STORED BY 'org.apache.carbondata.format' tblproperties('local_dictionary_enable'='true',
+        | 'local_dictionary_threshold'='20000','local_dictionary_include'='city','no_inverted_index'='name')
+      """.stripMargin)
+    val exception = intercept[MalformedCarbonCommandException] {
+      sql(
+        "alter table local1 add columns (alt string) tblproperties('local_dictionary_include'='alt,alt')")
+    }
+    assert(exception.getMessage
+      .contains(
+        "LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE contains Duplicate Columns: alt. " +
+        "Please check create table statement."))
+  }
+
+  test("test alter table add column where duplicate columns present in local dictionary include/exclude")
+  {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int)
+        | STORED BY 'org.apache.carbondata.format' tblproperties('local_dictionary_enable'='true',
+        | 'local_dictionary_threshold'='20000','local_dictionary_include'='city',
+        | 'no_inverted_index'='name')
+      """.stripMargin)
+    val exception1 = intercept[MalformedCarbonCommandException] {
+      sql(
+        "alter table local1 add columns (alt string) tblproperties" +
+        "('local_dictionary_include'='abc')")
+    }
+    assert(exception1.getMessage
+      .contains(
+        "LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE column: abc does not exist in table. " +
+        "Please check create table statement."))
+    val exception2 = intercept[MalformedCarbonCommandException] {
+      sql(
+        "alter table local1 add columns (alt string) tblproperties" +
+        "('local_dictionary_exclude'='abc')")
+    }
+    assert(exception2.getMessage
+      .contains(
+        "LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE column: abc does not exist in table. " +
+        "Please check create table statement."))
+  }
+
+  test("test alter table add column for datatype validation")
+  {
+    sql("drop table if exists local1")
+    sql(
+      """ | CREATE TABLE local1(id int, name string, city string, age int)
+        | STORED BY 'org.apache.carbondata.format' tblproperties('local_dictionary_enable'='true',
+        | 'local_dictionary_include'='city', 'no_inverted_index'='name')
+      """.stripMargin)
+    val exception = intercept[MalformedCarbonCommandException] {
+      sql(
+        "alter table local1 add columns (alt string,abc int) tblproperties" +
+        "('local_dictionary_include'='abc')")
+    }
+    assert(exception.getMessage
+      .contains(
+        "LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE column: abc is not a String/complex " +
+        "datatype column. LOCAL_DICTIONARY_COLUMN should be no dictionary string/complex datatype" +
+        " column.Please check create table statement."))
+  }
+
+  test("test alter table add column where duplicate columns are present in local dictionary include and exclude")
+  {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int)
+        | STORED BY 'org.apache.carbondata.format' tblproperties('local_dictionary_enable'='true',
+        | 'local_dictionary_include'='city', 'no_inverted_index'='name')
+      """.stripMargin)
+    val exception = intercept[MalformedCarbonCommandException] {
+      sql(
+        "alter table local1 add columns (alt string,abc string) tblproperties" +
+        "('local_dictionary_include'='abc','local_dictionary_exclude'='alt,abc')")
+    }
+    assert(exception.getMessage
+      .contains(
+        "Column ambiguity as duplicate column(s):abc is present in LOCAL_DICTIONARY_INCLUDE " +
+        "and LOCAL_DICTIONARY_EXCLUDE. Duplicate columns are not allowed."))
+  }
+
+  test("test alter table add column unsupported table property")
+  {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int)
+        | STORED BY 'org.apache.carbondata.format' tblproperties('local_dictionary_enable'='true',
+        | 'local_dictionary_include'='city', 'no_inverted_index'='name')
+      """.stripMargin)
+    val exception = intercept[MalformedCarbonCommandException] {
+      sql(
+        "alter table local1 add columns (alt string,abc string) tblproperties" +
+        "('local_dictionary_enable'='abc')")
+    }
+    assert(exception.getMessage
+      .contains(
+        "Unsupported Table property in add column: local_dictionary_enable"))
+    val exception1 = intercept[MalformedCarbonCommandException] {
+      sql(
+        "alter table local1 add columns (alt string,abc string) tblproperties" +
+        "('local_dictionary_threshold'='10000')")
+    }
+    assert(exception1.getMessage
+      .contains(
+        "Unsupported Table property in add column: local_dictionary_threshold"))
+  }
+
+  test("test alter table add column when main table is disabled for local dictionary")
+  {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int)
+        | STORED BY 'org.apache.carbondata.format' tblproperties('local_dictionary_enable'='false',
+        | 'local_dictionary_include'='city', 'no_inverted_index'='name')
+      """.stripMargin)
+    sql(
+      "alter table local1 add columns (alt string,abc string) tblproperties" +
+      "('local_dictionary_include'='abc')")
+    val descLoc = sql("describe formatted local1").collect
+    descLoc.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
+      case Some(row) => assert(row.get(1).toString.contains("false"))
+    }
+
+    checkExistence(sql("DESC FORMATTED local1"), false,
+      "Local Dictionary Include")
+  }
+
+  test("test local dictionary threshold for boundary values") {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int)
+        | STORED BY 'org.apache.carbondata.format' tblproperties('local_dictionary_threshold'='300000')
+      """.stripMargin)
+    val descLoc = sql("describe formatted local1").collect
+    descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
+      case Some(row) => assert(row.get(1).toString.contains("10000"))
+    }
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int)
+        | STORED BY 'org.apache.carbondata.format' tblproperties('local_dictionary_threshold'='500')
+      """.stripMargin)
+    val descLoc1 = sql("describe formatted local1").collect
+    descLoc1.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
+      case Some(row) => assert(row.get(1).toString.contains("10000"))
+    }
+  }
+
+  test("test alter table add column for local dictionary include and exclude configs")
+  {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int)
+        | STORED BY 'org.apache.carbondata.format' tblproperties('local_dictionary_enable'='true',
+        | 'local_dictionary_include'='city', 'no_inverted_index'='name')
+      """.stripMargin)
+    sql(
+      "alter table local1 add columns (alt string,abc string) tblproperties" +
+      "('local_dictionary_include'='abc','local_dictionary_exclude'='alt')")
+    val descLoc = sql("describe formatted local1").collect
+    descLoc.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
+      case Some(row) => assert(row.get(1).toString.contains("true"))
+    }
+    descLoc.find(_.get(0).toString.contains("Local Dictionary Include")) match {
+      case Some(row) => assert(row.get(1).toString.contains("city,abc"))
+    }
+    descLoc.find(_.get(0).toString.contains("Local Dictionary Exclude")) match {
+      case Some(row) => assert(row.get(1).toString.contains("alt"))
+    }
+  }
+
+  test("test preaggregate table local dictionary enabled table")
+  {
+    sql("drop table if exists local1")
+    sql("CREATE TABLE local1 (id Int, date date, country string, phonetype string, " +
+        "serialname String,salary int ) STORED BY 'org.apache.carbondata.format' " +
+        "tblproperties('dictionary_include'='country','local_dictionary_enable'='true','local_dictionary_include' = 'phonetype','local_dictionary_exclude' ='serialname')")
+    sql("create datamap PreAggCount on table local1 using 'preaggregate' as " +
+        "select country,count(salary) as count from local1 group by country")
+    val descLoc = sql("describe formatted local1_PreAggCount").collect
+    descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
+      case Some(row) => assert(row.get(1).toString.contains("10000"))
+    }
+    descLoc.find(_.get(0).toString.contains("Local Dictionary Include")) match {
+      case Some(row) => assert(row.get(1).toString.contains("phonetype"))
+    }
+    descLoc.find(_.get(0).toString.contains("Local Dictionary Exclude")) match {
+      case Some(row) => assert(row.get(1).toString.contains("serialname"))
+    }
+    descLoc.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
+      case Some(row) => assert(row.get(1).toString.contains("true"))
+    }
+  }
+
+  test("test local dictionary foer varchar datatype columns") {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int)
+        | STORED BY 'org.apache.carbondata.format' tblproperties('local_dictionary_include'='city',
+        | 'LONG_STRING_COLUMNS'='city')
+      """.stripMargin)
+    val descLoc = sql("describe formatted local1").collect
+    descLoc.find(_.get(0).toString.contains("Local Dictionary Include")) match {
+      case Some(row) => assert(row.get(1).toString.contains("city"))
+    }
+    descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
+      case Some(row) => assert(row.get(1).toString.contains("10000"))
+    }
+  }
+
+  test("test local dictionary describe formatted only with default configs")
+  {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int)
+        | STORED BY 'carbondata'
+      """.stripMargin)
+
+    val descLoc = sql("describe formatted local1").collect
+    descLoc.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
+      case Some(row) => assert(row.get(1).toString.contains("true"))
+    }
+    descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
+      case Some(row) => assert(row.get(1).toString.contains("10000"))
+    }
+    descLoc.find(_.get(0).toString.contains("Local Dictionary Include")) match {
+      case Some(row) => assert(row.get(1).toString.contains("name,city"))
+    }
   }
 
   override protected def afterAll(): Unit = {

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchemaCommon.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchemaCommon.scala
@@ -299,6 +299,13 @@ class AlterTableColumnSchemaGenerator(
     val columnValidator = CarbonSparkFactory.getCarbonColumnValidator
     columnValidator.validateColumns(allColumns)
 
+    if (alterTableModel.tableProperties != null) {
+      CarbonUtil
+        .setLocalDictColumnsToWrapperSchema(newCols.asJava,
+          alterTableModel.tableProperties.asJava,
+          tableSchema.getTableProperties.get(CarbonCommonConstants.LOCAL_DICTIONARY_ENABLE))
+    }
+
     // populate table properties map
     val tablePropertiesMap = tableSchema.getTableProperties
     alterTableModel.tableProperties.foreach {
@@ -584,7 +591,9 @@ class TableNewProcessor(cm: TableModel) {
     // check whether the column is a local dictionary column and set in column schema
     if (null != cm.tableProperties) {
       CarbonUtil
-        .setLocalDictColumnsToWrapperSchema(allColumns.asJava, cm.tableProperties.asJava)
+        .setLocalDictColumnsToWrapperSchema(allColumns.asJava,
+          cm.tableProperties.asJava,
+          cm.tableProperties(CarbonCommonConstants.LOCAL_DICTIONARY_ENABLE))
     }
     cm.msrCols.foreach { field =>
       // if aggregate function is defined in case of preaggregate and agg function is sum or avg

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/preaaggregate/PreAggregateTableHelper.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/preaaggregate/PreAggregateTableHelper.scala
@@ -106,6 +106,24 @@ case class PreAggregateTableHelper(
     tableProperties.put(CarbonCommonConstants.FLAT_FOLDER,
       parentTable.getTableInfo.getFactTable.getTableProperties.asScala.getOrElse(
         CarbonCommonConstants.FLAT_FOLDER, CarbonCommonConstants.DEFAULT_FLAT_FOLDER))
+    // inherit the local dictionary properties of main parent table
+    tableProperties
+      .put(CarbonCommonConstants.LOCAL_DICTIONARY_ENABLE,
+        parentTable.getTableInfo.getFactTable.getTableProperties.asScala
+          .getOrElse(CarbonCommonConstants.LOCAL_DICTIONARY_ENABLE, "false"))
+    tableProperties
+      .put(CarbonCommonConstants.LOCAL_DICTIONARY_THRESHOLD,
+        parentTable.getTableInfo.getFactTable.getTableProperties.asScala
+          .getOrElse(CarbonCommonConstants.LOCAL_DICTIONARY_THRESHOLD,
+            CarbonCommonConstants.LOCAL_DICTIONARY_THRESHOLD_DEFAULT))
+    tableProperties
+      .put(CarbonCommonConstants.LOCAL_DICTIONARY_INCLUDE,
+        parentTable.getTableInfo.getFactTable.getTableProperties.asScala
+          .getOrElse(CarbonCommonConstants.LOCAL_DICTIONARY_INCLUDE, ""))
+    tableProperties
+      .put(CarbonCommonConstants.LOCAL_DICTIONARY_EXCLUDE,
+        parentTable.getTableInfo.getFactTable.getTableProperties.asScala
+          .getOrElse(CarbonCommonConstants.LOCAL_DICTIONARY_EXCLUDE, ""))
     val tableIdentifier =
       TableIdentifier(parentTable.getTableName + "_" + dataMapName,
         Some(parentTable.getDatabaseName))
@@ -119,6 +137,7 @@ case class PreAggregateTableHelper(
       tableProperties,
       None,
       isAlterFlow = false,
+      true,
       None)
 
     // updating the relation identifier, this will be stored in child table

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSpark2SqlParser.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSpark2SqlParser.scala
@@ -542,7 +542,9 @@ class CarbonSpark2SqlParser extends CarbonDDLSqlParser {
           val tblProps = tblProp.get
             .map(f => if (CarbonCommonConstants.TABLE_BLOCKSIZE.equalsIgnoreCase(f._1) ||
                           CarbonCommonConstants.COLUMN_GROUPS.equalsIgnoreCase(f._1) ||
-            CarbonCommonConstants.SORT_COLUMNS.equalsIgnoreCase(f._1)) {
+                          CarbonCommonConstants.SORT_COLUMNS.equalsIgnoreCase(f._1) ||
+                          CarbonCommonConstants.LOCAL_DICTIONARY_ENABLE.equalsIgnoreCase(f._1) ||
+                          CarbonCommonConstants.LOCAL_DICTIONARY_THRESHOLD.equalsIgnoreCase(f._1)) {
               throw new MalformedCarbonCommandException(
                 s"Unsupported Table property in add column: ${ f._1 }")
             } else if (f._1.toLowerCase.startsWith("default.value.")) {

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSparkSqlParser.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSparkSqlParser.scala
@@ -305,6 +305,7 @@ class CarbonHelperSqlAstBuilder(conf: SQLConf,
         tableProperties,
         bucketFields,
         isAlterFlow = false,
+        false,
         tableComment)
       TableNewProcessor(tableModel)
     }


### PR DESCRIPTION
**What changes were proposed in this pull request?**
In this PR, 
1. local dictionary support is added for alter table, preaggregate, varChar datatype, alter table set and unset command
2. UTs are added for local dictionary load support
All the validations related to above features are taken care in this PR

**How was this patch tested?**
1. All the tests were executed in 3 node cluster.
2. UTs and SDV test cases are added in the same PR


