### PR TITLE
[CARBONDATA-2635][BloomDataMap] Support different provider based index datamaps on same column

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datamap/DataMapProvider.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/DataMapProvider.java
@@ -67,7 +67,7 @@ public abstract class DataMapProvider {
     return mainTable;
   }
 
-  protected final DataMapSchema getDataMapSchema() {
+  public final DataMapSchema getDataMapSchema() {
     return dataMapSchema;
   }
 

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/datamap/lucene/LuceneFineGrainDataMapSuite.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/datamap/lucene/LuceneFineGrainDataMapSuite.scala
@@ -225,32 +225,6 @@ class LuceneFineGrainDataMapSuite extends QueryTest with BeforeAndAfterAll {
     sql("DROP TABLE IF EXISTS datamap_test3")
   }
 
-  test("test lucene fine grain data map for create datamap with Duplicate Columns") {
-    sql("DROP TABLE IF EXISTS datamap_test_table")
-    sql(
-      """
-        | CREATE TABLE datamap_test_table(id INT, name STRING, city STRING, age INT)
-        | STORED BY 'carbondata'
-        | TBLPROPERTIES('SORT_COLUMNS'='city,name', 'SORT_SCOPE'='LOCAL_SORT')
-      """.stripMargin)
-    val exception_duplicate_column: Exception = intercept[MalformedDataMapCommandException] {
-      sql(
-        s"""
-           | CREATE DATAMAP dm ON TABLE datamap_test_table
-           | USING 'lucene'
-           | DMProperties('INDEX_COLUMNS'='name')
-      """.stripMargin)
-      sql(
-        s"""
-           | CREATE DATAMAP dm1 ON TABLE datamap_test_table
-           | USING 'lucene'
-           | DMProperties('INDEX_COLUMNS'='name')
-      """.stripMargin)
-    }
-    assertResult("column 'name' already has datamap created")(exception_duplicate_column.getMessage)
-    sql("drop datamap if exists dm on table datamap_test_table")
-  }
-
   test("test lucene fine grain data map with wildcard matching ") {
     sql("DROP TABLE IF EXISTS datamap_test_table")
     sql(

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datamap/TestDataMapCommand.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datamap/TestDataMapCommand.scala
@@ -287,6 +287,57 @@ class TestDataMapCommand extends QueryTest with BeforeAndAfterAll {
     sql("drop table main")
   }
 
+  test("test create datamap: unable to create same index datamap for one column") {
+    sql("DROP TABLE IF EXISTS datamap_test_table")
+    sql(
+      """
+        | CREATE TABLE datamap_test_table(id INT, name STRING, city STRING, age INT)
+        | STORED BY 'carbondata'
+        | TBLPROPERTIES('SORT_COLUMNS'='city,name', 'SORT_SCOPE'='LOCAL_SORT')
+      """.stripMargin)
+    val exception_duplicate_column: Exception = intercept[MalformedDataMapCommandException] {
+      sql(
+        s"""
+           | CREATE DATAMAP dm ON TABLE datamap_test_table
+           | USING 'lucene'
+           | DMProperties('INDEX_COLUMNS'='name')
+      """.stripMargin)
+      sql(
+        s"""
+           | CREATE DATAMAP dm1 ON TABLE datamap_test_table
+           | USING 'lucene'
+           | DMProperties('INDEX_COLUMNS'='name')
+      """.stripMargin)
+    }
+    assertResult("column 'name' already has lucene index datamap created")(exception_duplicate_column.getMessage)
+    sql("drop table if exists datamap_test_table")
+  }
+
+  test("test create datamap: able to create different index datamap for one column") {
+    sql("DROP TABLE IF EXISTS datamap_test_table")
+    sql(
+      """
+        | CREATE TABLE datamap_test_table(id INT, name STRING, city STRING, age INT)
+        | STORED BY 'carbondata'
+        | TBLPROPERTIES('SORT_COLUMNS'='city,name', 'SORT_SCOPE'='LOCAL_SORT')
+      """.stripMargin)
+    sql(
+      s"""
+         | CREATE DATAMAP dm ON TABLE datamap_test_table
+         | USING 'lucene'
+         | DMProperties('INDEX_COLUMNS'='name')
+      """.stripMargin)
+    sql(
+      s"""
+         | CREATE DATAMAP dm1 ON TABLE datamap_test_table
+         | USING 'bloomfilter'
+         | DMProperties('INDEX_COLUMNS'='name')
+      """.stripMargin)
+    sql("show datamap on table datamap_test_table").show(false)
+    checkExistence(sql("show datamap on table datamap_test_table"), true, "dm", "dm1", "lucene", "bloomfilter")
+    sql("drop table if exists datamap_test_table")
+  }
+
   override def afterAll {
     sql("DROP TABLE IF EXISTS maintable")
     sql("drop table if exists uniqdata")


### PR DESCRIPTION
User can create different provider based index datamaps on one column,
for example user can create bloomfilter datamap and lucene datamap on
one column, but not able to create two bloomfilter datamap on one
column.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

