### PR TITLE
[CARBONDATA-2653][BloomDataMap] Fix bugs in incorrect blocklet number in bloomfilter

### DIFF
--- a/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomDataMapBuilder.java
+++ b/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomDataMapBuilder.java
@@ -42,6 +42,7 @@ public class BloomDataMapBuilder extends BloomDataMapWriter implements DataMapBu
       boolean bloomCompress) throws IOException {
     super(tablePath, dataMapName, indexColumns, segment, shardName, bloomFilterSize, bloomFilterFpp,
         bloomCompress);
+    this.isWriteFromBuilder = true;
   }
 
   @Override

--- a/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomDataMapBuilder.java
+++ b/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomDataMapBuilder.java
@@ -42,7 +42,6 @@ public class BloomDataMapBuilder extends BloomDataMapWriter implements DataMapBu
       boolean bloomCompress) throws IOException {
     super(tablePath, dataMapName, indexColumns, segment, shardName, bloomFilterSize, bloomFilterFpp,
         bloomCompress);
-    this.isWriteFromBuilder = true;
   }
 
   @Override
@@ -79,7 +78,13 @@ public class BloomDataMapBuilder extends BloomDataMapWriter implements DataMapBu
 
   @Override
   public void finish() throws IOException {
-    super.finish();
+    if (!isWritingFinished()) {
+      if (indexBloomFilters.size() > 0) {
+        writeBloomDataMapFile();
+      }
+      releaseResouce();
+      setWritingFinished(true);
+    }
   }
 
   @Override

--- a/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomDataMapWriter.java
+++ b/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomDataMapWriter.java
@@ -55,6 +55,8 @@ public class BloomDataMapWriter extends DataMapWriter {
   private List<String> currentDMFiles;
   private List<DataOutputStream> currentDataOutStreams;
   protected List<CarbonBloomFilter> indexBloomFilters;
+  // whether the bloom index is written from rebuild
+  protected boolean isWriteFromBuilder = false;
 
   BloomDataMapWriter(String tablePath, String dataMapName, List<CarbonColumn> indexColumns,
       Segment segment, String shardName, int bloomFilterSize, double bloomFilterFpp,
@@ -190,8 +192,6 @@ public class BloomDataMapWriter extends DataMapWriter {
       }
       throw new RuntimeException(e);
     } finally {
-      // finished writing the index for this blocklet
-      setWritingFinished(true);
       resetBloomFilters();
     }
   }
@@ -199,7 +199,7 @@ public class BloomDataMapWriter extends DataMapWriter {
   @Override
   public void finish() throws IOException {
     if (!isWritingFinished()) {
-      if (indexBloomFilters.size() > 0) {
+      if (isWriteFromBuilder && indexBloomFilters.size() > 0) {
         writeBloomDataMapFile();
       }
       releaseResouce();

--- a/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomDataMapWriter.java
+++ b/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomDataMapWriter.java
@@ -55,8 +55,6 @@ public class BloomDataMapWriter extends DataMapWriter {
   private List<String> currentDMFiles;
   private List<DataOutputStream> currentDataOutStreams;
   protected List<CarbonBloomFilter> indexBloomFilters;
-  // whether the bloom index is written from rebuild
-  protected boolean isWriteFromBuilder = false;
 
   BloomDataMapWriter(String tablePath, String dataMapName, List<CarbonColumn> indexColumns,
       Segment segment, String shardName, int bloomFilterSize, double bloomFilterFpp,
@@ -199,9 +197,6 @@ public class BloomDataMapWriter extends DataMapWriter {
   @Override
   public void finish() throws IOException {
     if (!isWritingFinished()) {
-      if (isWriteFromBuilder && indexBloomFilters.size() > 0) {
-        writeBloomDataMapFile();
-      }
       releaseResouce();
       setWritingFinished(true);
     }

--- a/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomDataMapWriter.java
+++ b/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomDataMapWriter.java
@@ -197,9 +197,6 @@ public class BloomDataMapWriter extends DataMapWriter {
   @Override
   public void finish() throws IOException {
     if (!isWritingFinished()) {
-      if (indexBloomFilters.size() > 0) {
-        writeBloomDataMapFile();
-      }
       releaseResouce();
       setWritingFinished(true);
     }

--- a/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomDataMapWriter.java
+++ b/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomDataMapWriter.java
@@ -190,6 +190,8 @@ public class BloomDataMapWriter extends DataMapWriter {
       }
       throw new RuntimeException(e);
     } finally {
+      // finished writing the index for this blocklet
+      setWritingFinished(true);
       resetBloomFilters();
     }
   }
@@ -197,6 +199,9 @@ public class BloomDataMapWriter extends DataMapWriter {
   @Override
   public void finish() throws IOException {
     if (!isWritingFinished()) {
+      if (indexBloomFilters.size() > 0) {
+        writeBloomDataMapFile();
+      }
       releaseResouce();
       setWritingFinished(true);
     }


### PR DESCRIPTION
In non-deferred reuibuild scenario, the last bloomfilter index file has already been written onBlockletEnd, no need to write again, otherwise an extra blocklet number will be
generated in the bloom index file.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 `NO`
 - [x] Any backward compatibility impacted?
  `NO`
 - [x] Document update required?
 `NO`
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
`NO`
        - How it is tested? Please attach test report.
`Tested in local machine`
        - Is it a performance related change? Please attach the performance test report.
`NO`
        - Any additional information to help reviewers in testing this change.
       `NA`
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
`NA`
