### PR TITLE
[CARBONDATA-2654][Datamap]  Optimize output for explaining querying with datamap

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datamap/dev/expr/AndDataMapExprWrapper.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/dev/expr/AndDataMapExprWrapper.java
@@ -25,7 +25,6 @@ import org.apache.carbondata.core.datamap.DataMapLevel;
 import org.apache.carbondata.core.datamap.Segment;
 import org.apache.carbondata.core.indexstore.ExtendedBlocklet;
 import org.apache.carbondata.core.indexstore.PartitionSpec;
-import org.apache.carbondata.core.metadata.schema.table.DataMapSchema;
 import org.apache.carbondata.core.scan.filter.resolver.FilterResolverIntf;
 
 /**
@@ -116,8 +115,13 @@ public class AndDataMapExprWrapper implements DataMapExprWrapper {
     return left.getDataMapLevel();
   }
 
-  @Override public DataMapSchema getDataMapSchema() {
-    return left.getDataMapSchema();
+  @Override
+  public DataMapExprWrapper getLeftDataMapWrapper() {
+    return left;
   }
 
+  @Override
+  public DataMapExprWrapper getRightDataMapWrapprt() {
+    return right;
+  }
 }

--- a/core/src/main/java/org/apache/carbondata/core/datamap/dev/expr/DataMapExprWrapper.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/dev/expr/DataMapExprWrapper.java
@@ -25,7 +25,6 @@ import org.apache.carbondata.core.datamap.DataMapLevel;
 import org.apache.carbondata.core.datamap.Segment;
 import org.apache.carbondata.core.indexstore.ExtendedBlocklet;
 import org.apache.carbondata.core.indexstore.PartitionSpec;
-import org.apache.carbondata.core.metadata.schema.table.DataMapSchema;
 import org.apache.carbondata.core.scan.filter.resolver.FilterResolverIntf;
 
 /**
@@ -90,8 +89,12 @@ public interface DataMapExprWrapper extends Serializable {
   DataMapLevel getDataMapLevel();
 
   /**
-   * Get the datamap schema
+   * get the left datamap wrapper
    */
-  DataMapSchema getDataMapSchema();
+  DataMapExprWrapper getLeftDataMapWrapper();
 
+  /**
+   * get the right datamap wrapper
+   */
+  DataMapExprWrapper getRightDataMapWrapprt();
 }

--- a/core/src/main/java/org/apache/carbondata/core/datamap/dev/expr/DataMapExprWrapperImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/dev/expr/DataMapExprWrapperImpl.java
@@ -97,8 +97,17 @@ public class DataMapExprWrapperImpl implements DataMapExprWrapper {
     return dataMap.getDataMapFactory().getDataMapLevel();
   }
 
-  @Override public DataMapSchema getDataMapSchema() {
+  public DataMapSchema getDataMapSchema() {
     return dataMap.getDataMapSchema();
   }
 
+  @Override
+  public DataMapExprWrapper getLeftDataMapWrapper() {
+    return null;
+  }
+
+  @Override
+  public DataMapExprWrapper getRightDataMapWrapprt() {
+    return null;
+  }
 }

--- a/core/src/main/java/org/apache/carbondata/core/datamap/dev/expr/DataMapWrapperSchema.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/dev/expr/DataMapWrapperSchema.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.core.datamap.dev.expr;
+
+import org.apache.carbondata.core.metadata.schema.table.DataMapSchema;
+
+/**
+ * schema for datamap wrapper
+ */
+public class DataMapWrapperSchema {
+  enum WrapperType {
+    PRIMITIVE,
+    AND,
+    OR
+  }
+
+  private WrapperType wrapperType;
+  private DataMapWrapperSchema left;
+  private DataMapWrapperSchema right;
+  private DataMapSchema schema;
+
+  private DataMapWrapperSchema(WrapperType wrapperType, DataMapWrapperSchema left,
+      DataMapWrapperSchema right) {
+    this.wrapperType = wrapperType;
+    this.left = left;
+    this.right = right;
+  }
+
+  private DataMapWrapperSchema(DataMapSchema schema) {
+    this.wrapperType = WrapperType.PRIMITIVE;
+    this.schema = schema;
+  }
+
+  public static DataMapWrapperSchema fromDataMapWrapper(DataMapExprWrapper dataMapExprWrapper) {
+    if (dataMapExprWrapper instanceof DataMapExprWrapperImpl) {
+      return new DataMapWrapperSchema(
+          ((DataMapExprWrapperImpl) dataMapExprWrapper).getDataMapSchema());
+    } else if (dataMapExprWrapper instanceof AndDataMapExprWrapper) {
+      return new DataMapWrapperSchema(WrapperType.AND,
+          fromDataMapWrapper(dataMapExprWrapper.getLeftDataMapWrapper()),
+          fromDataMapWrapper(dataMapExprWrapper.getRightDataMapWrapprt()));
+    } else {
+      return new DataMapWrapperSchema(WrapperType.OR,
+          fromDataMapWrapper(dataMapExprWrapper.getLeftDataMapWrapper()),
+          fromDataMapWrapper(dataMapExprWrapper.getRightDataMapWrapprt()));
+    }
+  }
+
+  public String getDataMapWrapperName() {
+    if (WrapperType.PRIMITIVE == wrapperType) {
+      return schema.getDataMapName();
+    } else {
+      return String.format("%s(%s, %s)",
+          wrapperType, left.getDataMapWrapperName(), right.getDataMapWrapperName());
+    }
+  }
+
+  public String getDataMapWrapperProvider() {
+    if (WrapperType.PRIMITIVE == wrapperType) {
+      return schema.getProviderName();
+    } else {
+      return String.format("%s(%s, %s)",
+          wrapperType, left.getDataMapWrapperProvider(), right.getDataMapWrapperProvider());
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "DatamapWrapperSchema: Name->" + getDataMapWrapperName()
+        + ", Provider->" + getDataMapWrapperProvider();
+  }
+}

--- a/core/src/main/java/org/apache/carbondata/core/datamap/dev/expr/DataMapWrapperSimpleInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/dev/expr/DataMapWrapperSimpleInfo.java
@@ -20,9 +20,12 @@ package org.apache.carbondata.core.datamap.dev.expr;
 import org.apache.carbondata.core.metadata.schema.table.DataMapSchema;
 
 /**
- * schema for datamap wrapper
+ * schema for datamap wrapper.
+ * Currently a DataMapWrapper contains more than one datamap, this class is used to describe its
+ * schema. For example a AndDataMapExprWrapper contains BloomFilter in its left and Lucene in
+ * its right, then its schema would be AND(BloomFilter, Lucene)
  */
-public class DataMapWrapperSchema {
+public class DataMapWrapperSimpleInfo {
   enum WrapperType {
     PRIMITIVE,
     AND,
@@ -30,32 +33,32 @@ public class DataMapWrapperSchema {
   }
 
   private WrapperType wrapperType;
-  private DataMapWrapperSchema left;
-  private DataMapWrapperSchema right;
+  private DataMapWrapperSimpleInfo left;
+  private DataMapWrapperSimpleInfo right;
   private DataMapSchema schema;
 
-  private DataMapWrapperSchema(WrapperType wrapperType, DataMapWrapperSchema left,
-      DataMapWrapperSchema right) {
+  private DataMapWrapperSimpleInfo(WrapperType wrapperType, DataMapWrapperSimpleInfo left,
+      DataMapWrapperSimpleInfo right) {
     this.wrapperType = wrapperType;
     this.left = left;
     this.right = right;
   }
 
-  private DataMapWrapperSchema(DataMapSchema schema) {
+  private DataMapWrapperSimpleInfo(DataMapSchema schema) {
     this.wrapperType = WrapperType.PRIMITIVE;
     this.schema = schema;
   }
 
-  public static DataMapWrapperSchema fromDataMapWrapper(DataMapExprWrapper dataMapExprWrapper) {
+  public static DataMapWrapperSimpleInfo fromDataMapWrapper(DataMapExprWrapper dataMapExprWrapper) {
     if (dataMapExprWrapper instanceof DataMapExprWrapperImpl) {
-      return new DataMapWrapperSchema(
+      return new DataMapWrapperSimpleInfo(
           ((DataMapExprWrapperImpl) dataMapExprWrapper).getDataMapSchema());
     } else if (dataMapExprWrapper instanceof AndDataMapExprWrapper) {
-      return new DataMapWrapperSchema(WrapperType.AND,
+      return new DataMapWrapperSimpleInfo(WrapperType.AND,
           fromDataMapWrapper(dataMapExprWrapper.getLeftDataMapWrapper()),
           fromDataMapWrapper(dataMapExprWrapper.getRightDataMapWrapprt()));
     } else {
-      return new DataMapWrapperSchema(WrapperType.OR,
+      return new DataMapWrapperSimpleInfo(WrapperType.OR,
           fromDataMapWrapper(dataMapExprWrapper.getLeftDataMapWrapper()),
           fromDataMapWrapper(dataMapExprWrapper.getRightDataMapWrapprt()));
     }

--- a/core/src/main/java/org/apache/carbondata/core/datamap/dev/expr/OrDataMapExprWrapper.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/dev/expr/OrDataMapExprWrapper.java
@@ -27,7 +27,6 @@ import org.apache.carbondata.core.datamap.DataMapLevel;
 import org.apache.carbondata.core.datamap.Segment;
 import org.apache.carbondata.core.indexstore.ExtendedBlocklet;
 import org.apache.carbondata.core.indexstore.PartitionSpec;
-import org.apache.carbondata.core.metadata.schema.table.DataMapSchema;
 import org.apache.carbondata.core.scan.filter.resolver.FilterResolverIntf;
 
 /**
@@ -109,7 +108,13 @@ public class OrDataMapExprWrapper implements DataMapExprWrapper {
     return left.getDataMapLevel();
   }
 
-  @Override public DataMapSchema getDataMapSchema() {
-    return left.getDataMapSchema();
+  @Override
+  public DataMapExprWrapper getLeftDataMapWrapper() {
+    return left;
+  }
+
+  @Override
+  public DataMapExprWrapper getRightDataMapWrapprt() {
+    return right;
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/profiler/ExplainCollector.java
+++ b/core/src/main/java/org/apache/carbondata/core/profiler/ExplainCollector.java
@@ -26,7 +26,7 @@ import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.carbondata.common.annotations.InterfaceAudience;
-import org.apache.carbondata.core.datamap.dev.expr.DataMapWrapperSchema;
+import org.apache.carbondata.core.datamap.dev.expr.DataMapWrapperSimpleInfo;
 
 /**
  * An information collector used for EXPLAIN command, to print out
@@ -94,27 +94,27 @@ public class ExplainCollector {
     }
   }
 
-  public static void recordDefaultDataMapPruning(DataMapWrapperSchema dataMapWrapperSchema,
+  public static void recordDefaultDataMapPruning(DataMapWrapperSimpleInfo dataMapWrapperSimpleInfo,
       int numBlocklets) {
     if (enabled()) {
       TablePruningInfo scan = getCurrentTablePruningInfo();
-      scan.setNumBlockletsAfterDefaultPruning(dataMapWrapperSchema, numBlocklets);
+      scan.setNumBlockletsAfterDefaultPruning(dataMapWrapperSimpleInfo, numBlocklets);
     }
   }
 
-  public static void recordCGDataMapPruning(DataMapWrapperSchema dataMapWrapperSchema,
+  public static void recordCGDataMapPruning(DataMapWrapperSimpleInfo dataMapWrapperSimpleInfo,
       int numBlocklets) {
     if (enabled()) {
       TablePruningInfo scan = getCurrentTablePruningInfo();
-      scan.setNumBlockletsAfterCGPruning(dataMapWrapperSchema, numBlocklets);
+      scan.setNumBlockletsAfterCGPruning(dataMapWrapperSimpleInfo, numBlocklets);
     }
   }
 
-  public static void recordFGDataMapPruning(DataMapWrapperSchema dataMapWrapperSchema,
+  public static void recordFGDataMapPruning(DataMapWrapperSimpleInfo dataMapWrapperSimpleInfo,
       int numBlocklets) {
     if (enabled()) {
       TablePruningInfo scan = getCurrentTablePruningInfo();
-      scan.setNumBlockletsAfterFGPruning(dataMapWrapperSchema, numBlocklets);
+      scan.setNumBlockletsAfterFGPruning(dataMapWrapperSimpleInfo, numBlocklets);
     }
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/profiler/ExplainCollector.java
+++ b/core/src/main/java/org/apache/carbondata/core/profiler/ExplainCollector.java
@@ -26,7 +26,7 @@ import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.carbondata.common.annotations.InterfaceAudience;
-import org.apache.carbondata.core.metadata.schema.table.DataMapSchema;
+import org.apache.carbondata.core.datamap.dev.expr.DataMapWrapperSchema;
 
 /**
  * An information collector used for EXPLAIN command, to print out
@@ -94,24 +94,27 @@ public class ExplainCollector {
     }
   }
 
-  public static void recordDefaultDataMapPruning(DataMapSchema dataMapSchema, int numBlocklets) {
+  public static void recordDefaultDataMapPruning(DataMapWrapperSchema dataMapWrapperSchema,
+      int numBlocklets) {
     if (enabled()) {
       TablePruningInfo scan = getCurrentTablePruningInfo();
-      scan.setNumBlockletsAfterDefaultPruning(dataMapSchema, numBlocklets);
+      scan.setNumBlockletsAfterDefaultPruning(dataMapWrapperSchema, numBlocklets);
     }
   }
 
-  public static void recordCGDataMapPruning(DataMapSchema dataMapSchema, int numBlocklets) {
+  public static void recordCGDataMapPruning(DataMapWrapperSchema dataMapWrapperSchema,
+      int numBlocklets) {
     if (enabled()) {
       TablePruningInfo scan = getCurrentTablePruningInfo();
-      scan.setNumBlockletsAfterCGPruning(dataMapSchema, numBlocklets);
+      scan.setNumBlockletsAfterCGPruning(dataMapWrapperSchema, numBlocklets);
     }
   }
 
-  public static void recordFGDataMapPruning(DataMapSchema dataMapSchema, int numBlocklets) {
+  public static void recordFGDataMapPruning(DataMapWrapperSchema dataMapWrapperSchema,
+      int numBlocklets) {
     if (enabled()) {
       TablePruningInfo scan = getCurrentTablePruningInfo();
-      scan.setNumBlockletsAfterFGPruning(dataMapSchema, numBlocklets);
+      scan.setNumBlockletsAfterFGPruning(dataMapWrapperSchema, numBlocklets);
     }
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/profiler/TablePruningInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/profiler/TablePruningInfo.java
@@ -18,7 +18,7 @@
 package org.apache.carbondata.core.profiler;
 
 import org.apache.carbondata.common.annotations.InterfaceAudience;
-import org.apache.carbondata.core.metadata.schema.table.DataMapSchema;
+import org.apache.carbondata.core.datamap.dev.expr.DataMapWrapperSchema;
 
 /**
  * Used for EXPLAIN command
@@ -29,13 +29,13 @@ public class TablePruningInfo {
   private int totalBlocklets;
   private String filterStatement;
 
-  private DataMapSchema defaultDataMap;
+  private DataMapWrapperSchema defaultDataMap;
   private int numBlockletsAfterDefaultPruning;
 
-  private DataMapSchema cgDataMap;
+  private DataMapWrapperSchema cgDataMap;
   private int numBlockletsAfterCGPruning;
 
-  private DataMapSchema fgDataMap;
+  private DataMapWrapperSchema fgDataMap;
   private int numBlockletsAfterFGPruning;
 
   void addTotalBlocklets(int numBlocklets) {
@@ -46,18 +46,19 @@ public class TablePruningInfo {
     this.filterStatement = filterStatement;
   }
 
-  void setNumBlockletsAfterDefaultPruning(DataMapSchema dataMapSchema, int numBlocklets) {
-    this.defaultDataMap = dataMapSchema;
+  void setNumBlockletsAfterDefaultPruning(DataMapWrapperSchema dataMapWrapperSchema,
+      int numBlocklets) {
+    this.defaultDataMap = dataMapWrapperSchema;
     this.numBlockletsAfterDefaultPruning = numBlocklets;
   }
 
-  void setNumBlockletsAfterCGPruning(DataMapSchema dataMapSchema, int numBlocklets) {
-    this.cgDataMap = dataMapSchema;
+  void setNumBlockletsAfterCGPruning(DataMapWrapperSchema dataMapWrapperSchema, int numBlocklets) {
+    this.cgDataMap = dataMapWrapperSchema;
     this.numBlockletsAfterCGPruning = numBlocklets;
   }
 
-  void setNumBlockletsAfterFGPruning(DataMapSchema dataMapSchema, int numBlocklets) {
-    this.fgDataMap = dataMapSchema;
+  void setNumBlockletsAfterFGPruning(DataMapWrapperSchema dataMapWrapperSchema, int numBlocklets) {
+    this.fgDataMap = dataMapWrapperSchema;
     this.numBlockletsAfterFGPruning = numBlocklets;
   }
 
@@ -77,8 +78,8 @@ public class TablePruningInfo {
       int skipBlocklets = numBlockletsAfterDefaultPruning - numBlockletsAfterCGPruning;
       builder
           .append(" - pruned by CG DataMap").append("\n")
-          .append("    - name: ").append(cgDataMap.getDataMapName()).append("\n")
-          .append("    - provider: ").append(cgDataMap.getProviderName()).append("\n")
+          .append("    - name: ").append(cgDataMap.getDataMapWrapperName()).append("\n")
+          .append("    - provider: ").append(cgDataMap.getDataMapWrapperProvider()).append("\n")
           .append("    - skipped blocklets: ").append(skipBlocklets).append("\n");
     }
     if (fgDataMap != null) {
@@ -90,8 +91,8 @@ public class TablePruningInfo {
       }
       builder
           .append(" - pruned by FG DataMap").append("\n")
-          .append("    - name: ").append(fgDataMap.getDataMapName()).append("\n")
-          .append("    - provider: ").append(fgDataMap.getProviderName()).append("\n")
+          .append("    - name: ").append(fgDataMap.getDataMapWrapperName()).append("\n")
+          .append("    - provider: ").append(fgDataMap.getDataMapWrapperProvider()).append("\n")
           .append("    - skipped blocklets: ").append(skipBlocklets).append("\n");
     }
     return builder.toString();

--- a/core/src/main/java/org/apache/carbondata/core/profiler/TablePruningInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/profiler/TablePruningInfo.java
@@ -18,7 +18,7 @@
 package org.apache.carbondata.core.profiler;
 
 import org.apache.carbondata.common.annotations.InterfaceAudience;
-import org.apache.carbondata.core.datamap.dev.expr.DataMapWrapperSchema;
+import org.apache.carbondata.core.datamap.dev.expr.DataMapWrapperSimpleInfo;
 
 /**
  * Used for EXPLAIN command
@@ -29,13 +29,13 @@ public class TablePruningInfo {
   private int totalBlocklets;
   private String filterStatement;
 
-  private DataMapWrapperSchema defaultDataMap;
+  private DataMapWrapperSimpleInfo defaultDataMap;
   private int numBlockletsAfterDefaultPruning;
 
-  private DataMapWrapperSchema cgDataMap;
+  private DataMapWrapperSimpleInfo cgDataMap;
   private int numBlockletsAfterCGPruning;
 
-  private DataMapWrapperSchema fgDataMap;
+  private DataMapWrapperSimpleInfo fgDataMap;
   private int numBlockletsAfterFGPruning;
 
   void addTotalBlocklets(int numBlocklets) {
@@ -46,19 +46,21 @@ public class TablePruningInfo {
     this.filterStatement = filterStatement;
   }
 
-  void setNumBlockletsAfterDefaultPruning(DataMapWrapperSchema dataMapWrapperSchema,
+  void setNumBlockletsAfterDefaultPruning(DataMapWrapperSimpleInfo dataMapWrapperSimpleInfo,
       int numBlocklets) {
-    this.defaultDataMap = dataMapWrapperSchema;
+    this.defaultDataMap = dataMapWrapperSimpleInfo;
     this.numBlockletsAfterDefaultPruning = numBlocklets;
   }
 
-  void setNumBlockletsAfterCGPruning(DataMapWrapperSchema dataMapWrapperSchema, int numBlocklets) {
-    this.cgDataMap = dataMapWrapperSchema;
+  void setNumBlockletsAfterCGPruning(DataMapWrapperSimpleInfo dataMapWrapperSimpleInfo,
+      int numBlocklets) {
+    this.cgDataMap = dataMapWrapperSimpleInfo;
     this.numBlockletsAfterCGPruning = numBlocklets;
   }
 
-  void setNumBlockletsAfterFGPruning(DataMapWrapperSchema dataMapWrapperSchema, int numBlocklets) {
-    this.fgDataMap = dataMapWrapperSchema;
+  void setNumBlockletsAfterFGPruning(DataMapWrapperSimpleInfo dataMapWrapperSimpleInfo,
+      int numBlocklets) {
+    this.fgDataMap = dataMapWrapperSimpleInfo;
     this.numBlockletsAfterFGPruning = numBlocklets;
   }
 

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonInputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonInputFormat.java
@@ -467,7 +467,6 @@ m filterExpression
       ExplainCollector.recordCGDataMapPruning(
           DataMapWrapperSimpleInfo.fromDataMapWrapper(cgDataMapExprWrapper),
           prunedBlocklets.size());
-          cgDataMapExprWrapper.getDataMapSchema(), prunedBlocklets.size());
     }
 
     if (prunedBlocklets.size() == 0) {
@@ -485,7 +484,8 @@ m filterExpression
         // 'prunedBlocklets', so the intersection should keep the elements in 'fgPrunedBlocklets'
         prunedBlocklets = (List) CollectionUtils.intersection(fgPrunedBlocklets,
             prunedBlocklets);
-        ExplainCollector.recordFGDataMapPruning(DataMapWrapperSimpleInfo.fromDataMapWrapper(),
+        ExplainCollector.recordFGDataMapPruning(
+            DataMapWrapperSimpleInfo.fromDataMapWrapper(fgDataMapExprWrapper),
             prunedBlocklets.size());
       }
     }

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonInputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonInputFormat.java
@@ -33,7 +33,7 @@ import org.apache.carbondata.core.datamap.DataMapJob;
 import org.apache.carbondata.core.datamap.DataMapUtil;
 import org.apache.carbondata.core.datamap.Segment;
 import org.apache.carbondata.core.datamap.dev.expr.DataMapExprWrapper;
-import org.apache.carbondata.core.datamap.dev.expr.DataMapWrapperSchema;
+import org.apache.carbondata.core.datamap.dev.expr.DataMapWrapperSimpleInfo;
 import org.apache.carbondata.core.exception.InvalidConfigurationException;
 import org.apache.carbondata.core.indexstore.ExtendedBlocklet;
 import org.apache.carbondata.core.indexstore.PartitionSpec;
@@ -434,12 +434,13 @@ m filterExpression
     DataMapJob dataMapJob = DataMapUtil.getDataMapJob(job.getConfiguration());
     List<PartitionSpec> partitionsToPrune = getPartitionsToPrune(job.getConfiguration());
     // First prune using default datamap on driver side.
-    DataMapExprWrapper dataMapExprWrapper = DataMapChooser.getDefaultDataMap(
-        getOrCreateCarbonTable(job.getConfiguration()), resolver);
-    List<ExtendedBlocklet> prunedBlocklets = dataMapExprWrapper.prune(segmentIds,
-        partitionsToPrune);
-    ExplainCollector.recordDefaultDataMapPruning(dataMapExprWrapper.getDataMapSchema(),
-        prunedBlocklets.size());
+    DataMapExprWrapper dataMapExprWrapper = DataMapChooser
+        .getDefaultDataMap(getOrCreateCarbonTable(job.getConfiguration()), resolver);
+    List<ExtendedBlocklet> prunedBlocklets =
+        dataMapExprWrapper.prune(segmentIds, partitionsToPrune);
+
+    ExplainCollector.recordDefaultDataMapPruning(
+        DataMapWrapperSimpleInfo.fromDataMapWrapper(dataMapExprWrapper), prunedBlocklets.size());
     if (prunedBlocklets.size() == 0) {
       return prunedBlocklets;
     }
@@ -464,6 +465,8 @@ m filterExpression
       prunedBlocklets = (List) CollectionUtils.intersection(
           cgPrunedBlocklets, prunedBlocklets);
       ExplainCollector.recordCGDataMapPruning(
+          DataMapWrapperSimpleInfo.fromDataMapWrapper(cgDataMapExprWrapper),
+          prunedBlocklets.size());
           cgDataMapExprWrapper.getDataMapSchema(), prunedBlocklets.size());
     }
 
@@ -482,7 +485,7 @@ m filterExpression
         // 'prunedBlocklets', so the intersection should keep the elements in 'fgPrunedBlocklets'
         prunedBlocklets = (List) CollectionUtils.intersection(fgPrunedBlocklets,
             prunedBlocklets);
-        ExplainCollector.recordFGDataMapPruning(fgDataMapExprWrapper.getDataMapSchema(),
+        ExplainCollector.recordFGDataMapPruning(DataMapWrapperSimpleInfo.fromDataMapWrapper(),
             prunedBlocklets.size());
       }
     }

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonInputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonInputFormat.java
@@ -33,6 +33,7 @@ import org.apache.carbondata.core.datamap.DataMapJob;
 import org.apache.carbondata.core.datamap.DataMapUtil;
 import org.apache.carbondata.core.datamap.Segment;
 import org.apache.carbondata.core.datamap.dev.expr.DataMapExprWrapper;
+import org.apache.carbondata.core.datamap.dev.expr.DataMapWrapperSchema;
 import org.apache.carbondata.core.exception.InvalidConfigurationException;
 import org.apache.carbondata.core.indexstore.ExtendedBlocklet;
 import org.apache.carbondata.core.indexstore.PartitionSpec;

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datamap/CGDataMapTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datamap/CGDataMapTestCase.scala
@@ -425,10 +425,7 @@ class CGDataMapTestCase extends QueryTest with BeforeAndAfterAll {
     val df1 = sql(s"EXPLAIN EXTENDED SELECT * FROM $tableName WHERE name='n502670' AND city='c2670'").collect()
     assert(df1(0).getString(0).contains("CG DataMap"))
     assert(df1(0).getString(0).contains(dataMapName1))
-    val e11 = intercept[Exception] {
-      assert(df1(0).getString(0).contains(dataMapName2))
-    }
-    assert(e11.getMessage.contains("did not contain \"" + dataMapName2))
+    assert(df1(0).getString(0).contains(dataMapName2))
 
     // make datamap1 invisible
     sql(s"SET ${CarbonCommonConstants.CARBON_DATAMAP_VISIBLE}default.$tableName.$dataMapName1 = false")

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datamap/FGDataMapTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datamap/FGDataMapTestCase.scala
@@ -516,10 +516,7 @@ class FGDataMapTestCase extends QueryTest with BeforeAndAfterAll {
     val df1 = sql(s"EXPLAIN EXTENDED SELECT * FROM $tableName WHERE name='n502670' AND city='c2670'").collect()
     assert(df1(0).getString(0).contains("FG DataMap"))
     assert(df1(0).getString(0).contains(dataMapName1))
-    val e11 = intercept[Exception] {
-      assert(df1(0).getString(0).contains(dataMapName2))
-    }
-    assert(e11.getMessage.contains("did not contain \"" + dataMapName2))
+    assert(df1(0).getString(0).contains(dataMapName2))
 
     // make datamap1 invisible
     sql(s"SET ${CarbonCommonConstants.CARBON_DATAMAP_VISIBLE}default.$tableName.$dataMapName1 = false")
@@ -548,15 +545,12 @@ class FGDataMapTestCase extends QueryTest with BeforeAndAfterAll {
 
     // make datamap1,datamap2 visible
     sql(s"SET ${CarbonCommonConstants.CARBON_DATAMAP_VISIBLE}default.$tableName.$dataMapName1 = true")
-    sql(s"SET ${CarbonCommonConstants.CARBON_DATAMAP_VISIBLE}default.$tableName.$dataMapName1 = true")
+    sql(s"SET ${CarbonCommonConstants.CARBON_DATAMAP_VISIBLE}default.$tableName.$dataMapName2 = true")
     checkAnswer(sql(s"SELECT * FROM $tableName WHERE name='n502670' AND city='c2670'"),
       sql("SELECT * FROM normal_test WHERE name='n502670' AND city='c2670'"))
     val df4 = sql(s"EXPLAIN EXTENDED SELECT * FROM $tableName WHERE name='n502670' AND city='c2670'").collect()
     assert(df4(0).getString(0).contains(dataMapName1))
-    val e41 = intercept[Exception] {
-      assert(df3(0).getString(0).contains(dataMapName2))
-    }
-    assert(e41.getMessage.contains("did not contain \"" + dataMapName2))
+    assert(df4(0).getString(0).contains(dataMapName2))
   }
 
   override protected def afterAll(): Unit = {


### PR DESCRIPTION
Currently if we have multiple datamaps and the query hits all the
datamaps, carbondata explain command will only show the first datamap
and all the datamaps are not shown. In this commit, we show all the
datamaps that are hitted in this query.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 `Yes, only internal interfaces have been changed`
 - [x] Any backward compatibility impacted?
 `NO`
 - [x] Document update required?
 `NO`
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
`Tests added and updated`
        - How it is tested? Please attach test report.
`Tested in local machine`
        - Is it a performance related change? Please attach the performance test report.
`No`
        - Any additional information to help reviewers in testing this change.
       `NA`
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
`NA`

