### PR TITLE
[CARBONDATA-2658][DataLoad] Fix bugs in spilling in-memory pages

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonLoadOptionConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonLoadOptionConstants.java
@@ -144,12 +144,12 @@ public final class CarbonLoadOptionConstants {
    * If the sort memory is insufficient, spill inmemory pages to disk.
    * The total amount of pages is at most the specified percentage of total sort memory. Default
    * value 0 means that no pages will be spilled and the newly incoming pages will be spilled,
-   * whereas value 1 means that all pages will be spilled and newly incoming pages will be loaded
-   * into sort memory.
+   * whereas value 100 means that all pages will be spilled and newly incoming pages will be loaded
+   * into sort memory, valid value is from 0 to 100.
    */
   @CarbonProperty
   public static final String CARBON_LOAD_SORT_MEMORY_SPILL_PERCENTAGE
-      = "carbon.load.sortMemory.spill.percentage";
+      = "carbon.load.sortmemory.spill.percentage";
   public static final String CARBON_LOAD_SORT_MEMORY_SPILL_PERCENTAGE_DEFAULT = "0";
 
   /**

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/dataload/TestLoadDataWithUnsafeMemory.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/dataload/TestLoadDataWithUnsafeMemory.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.Row
 import org.apache.spark.sql.test.util.QueryTest
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Ignore}
 
-import org.apache.carbondata.core.constants.CarbonCommonConstants
+import org.apache.carbondata.core.constants.{CarbonCommonConstants, CarbonLoadOptionConstants}
 import org.apache.carbondata.core.util.CarbonProperties
 
 /**
@@ -44,6 +44,9 @@ class TestLoadDataWithUnsafeMemory extends QueryTest
   val originUnsafeSizeForChunk: String = CarbonProperties.getInstance()
     .getProperty(CarbonCommonConstants.OFFHEAP_SORT_CHUNK_SIZE_IN_MB,
       CarbonCommonConstants.OFFHEAP_SORT_CHUNK_SIZE_IN_MB_DEFAULT)
+  val originSpillPercentage: String = CarbonProperties.getInstance()
+    .getProperty(CarbonLoadOptionConstants.CARBON_LOAD_SORT_MEMORY_SPILL_PERCENTAGE,
+      CarbonLoadOptionConstants.CARBON_LOAD_SORT_MEMORY_SPILL_PERCENTAGE_DEFAULT)
   val targetTable = "table_unsafe_memory"
 
 
@@ -64,6 +67,8 @@ class TestLoadDataWithUnsafeMemory extends QueryTest
       .addProperty(CarbonCommonConstants.UNSAFE_WORKING_MEMORY_IN_MB, "512")
     CarbonProperties.getInstance()
       .addProperty(CarbonCommonConstants.OFFHEAP_SORT_CHUNK_SIZE_IN_MB, "512")
+    CarbonProperties.getInstance()
+      .addProperty(CarbonLoadOptionConstants.CARBON_LOAD_SORT_MEMORY_SPILL_PERCENTAGE, "-1")
   }
 
   override def afterAll(): Unit = {
@@ -75,6 +80,9 @@ class TestLoadDataWithUnsafeMemory extends QueryTest
       .addProperty(CarbonCommonConstants.UNSAFE_WORKING_MEMORY_IN_MB, originUnsafeMemForWorking)
     CarbonProperties.getInstance()
       .addProperty(CarbonCommonConstants.OFFHEAP_SORT_CHUNK_SIZE_IN_MB, originUnsafeSizeForChunk)
+    CarbonProperties.getInstance()
+      .addProperty(CarbonLoadOptionConstants.CARBON_LOAD_SORT_MEMORY_SPILL_PERCENTAGE,
+        originSpillPercentage)
   }
 
   private def testSimpleTable(): Unit = {

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/sort/unsafe/UnsafeSortDataRows.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/sort/unsafe/UnsafeSortDataRows.java
@@ -149,7 +149,6 @@ public class UnsafeSortDataRows {
     if (isMemoryAvailable) {
       UnsafeSortMemoryManager.INSTANCE.allocateDummyMemory(baseBlock.size());
     } else {
-      LOGGER.info("trigger in-memory merge and spill for table " + parameters.getTableName());
       // merge and spill in-memory pages to disk if memory is not enough
       unsafeInMemoryIntermediateFileMerger.tryTriggerInmemoryMerging(true);
     }


### PR DESCRIPTION
the parameter carbon.load.sortMemory.spill.percentage configured the value range 0-100,according to configuration merge and spill in-memory pages to disk

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 NA
 - [ ] Any backward compatibility impacted?
 NA
 - [ ] Document update required?
NA
 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       Test pass in environment
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA
