### PR TITLE
[CARBONDATA-2659] Support partition table by DataFrame API

### DIFF
--- a/examples/spark2/src/main/scala/org/apache/carbondata/examples/CarbonDataFrameExample.scala
+++ b/examples/spark2/src/main/scala/org/apache/carbondata/examples/CarbonDataFrameExample.scala
@@ -33,19 +33,20 @@ object CarbonDataFrameExample {
     // Writes Dataframe to CarbonData file:
     import spark.implicits._
     val df = spark.sparkContext.parallelize(1 to 100)
-      .map(x => ("a", "b", x))
+      .map(x => ("a" + x % 10, "b", x))
       .toDF("c1", "c2", "number")
 
     // Saves dataframe to carbondata file
     df.write
       .format("carbondata")
       .option("tableName", "carbon_df_table")
-      .option("compress", "true")
-      .option("tempCSV", "false")
+      .option("partitionColumns", "c1")  // a list of column names
       .mode(SaveMode.Overwrite)
       .save()
 
     spark.sql(""" SELECT * FROM carbon_df_table """).show()
+
+    spark.sql("SHOW PARTITIONS carbon_df_table").show()
 
     // Specify schema
     import org.apache.spark.sql.types.{StructType, StructField, StringType, IntegerType}

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/standardpartition/StandardPartitionTableQueryTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/standardpartition/StandardPartitionTableQueryTestCase.scala
@@ -73,6 +73,27 @@ class StandardPartitionTableQueryTestCase extends QueryTest with BeforeAndAfterA
 
   }
 
+  test("create partition table by dataframe") {
+    sql("select * from originTable")
+      .write
+      .format("carbondata")
+      .option("tableName", "partitionxxx")
+      .option("partitionColumns", "empno")
+      .save("Overwrite")
+
+    val frame = sql(
+      "select empno, empname, designation, doj, workgroupcategory, workgroupcategoryname, deptno," +
+      " deptname, projectcode, projectjoindate, projectenddate, attendance, utilization, salary " +
+      "from partitionxxx where empno=11 order by empno")
+    verifyPartitionInfo(frame, Seq("empno=11"))
+
+    checkAnswer(frame,
+      sql("select  empno, empname, designation, doj, workgroupcategory, workgroupcategoryname, deptno, " +
+          "deptname, projectcode, projectjoindate, projectenddate, attendance, utilization, salary " +
+          "from originTable where empno=11 order by empno"))
+    sql("drop table if exists partitionxxx")
+  }
+
   test("querying on partition table for string partition column") {
     sql(
       """

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/CarbonOption.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/CarbonOption.scala
@@ -23,38 +23,49 @@ package org.apache.carbondata.spark
  */
 class CarbonOption(options: Map[String, String]) {
 
-  def dbName: Option[String] = options.get("dbName")
+  lazy val dbName: Option[String] = options.get("dbName")
 
-  def tableName: String = options.getOrElse("tableName", "default_table")
+  lazy val tableName: String = options.getOrElse("tableName", "default_table")
 
-  def tablePath: Option[String] = options.get("tablePath")
+  lazy val tablePath: Option[String] = options.get("tablePath")
 
-  def partitionCount: String = options.getOrElse("partitionCount", "1")
+  lazy val partitionCount: String = options.getOrElse("partitionCount", "1")
 
-  def tempCSV: Boolean = options.getOrElse("tempCSV", "false").toBoolean
+  lazy val partitionClass: String = {
+    options.getOrElse("partitionClass",
+      "org.apache.carbondata.processing.partition.impl.SampleDataPartitionerImpl")
+  }
 
-  def compress: Boolean = options.getOrElse("compress", "false").toBoolean
+  lazy val compress: Boolean = options.getOrElse("compress", "false").toBoolean
 
-  def singlePass: Boolean = options.getOrElse("single_pass", "false").toBoolean
+  lazy val partitionColumns: Option[Seq[String]] = {
+    if (options.contains("partitionColumns")) {
+      Option(options("partitionColumns").split(",").map(_.trim))
+    } else {
+      None
+    }
+  }
 
-  def sortColumns: Option[String] = options.get("sort_columns")
+  lazy val singlePass: Boolean = options.getOrElse("single_pass", "false").toBoolean
 
-  def dictionaryInclude: Option[String] = options.get("dictionary_include")
+  lazy val sortColumns: Option[String] = options.get("sort_columns")
 
-  def dictionaryExclude: Option[String] = options.get("dictionary_exclude")
+  lazy val dictionaryInclude: Option[String] = options.get("dictionary_include")
 
-  def longStringColumns: Option[String] = options.get("long_string_columns")
+  lazy val dictionaryExclude: Option[String] = options.get("dictionary_exclude")
 
-  def tableBlockSize: Option[String] = options.get("table_blocksize")
+  lazy val longStringColumns: Option[String] = options.get("long_string_columns")
 
-  def bucketNumber: Int = options.getOrElse("bucketnumber", "0").toInt
+  lazy val tableBlockSize: Option[String] = options.get("table_blocksize")
 
-  def bucketColumns: String = options.getOrElse("bucketcolumns", "")
+  lazy val bucketNumber: Int = options.getOrElse("bucketnumber", "0").toInt
 
-  def isBucketingEnabled: Boolean = options.contains("bucketcolumns") &&
+  lazy val bucketColumns: String = options.getOrElse("bucketcolumns", "")
+
+  lazy val isBucketingEnabled: Boolean = options.contains("bucketcolumns") &&
                                     options.contains("bucketnumber")
 
-  def isStreaming: Boolean = {
+  lazy val isStreaming: Boolean = {
     var stream = options.getOrElse("streaming", "false")
     if (stream.equalsIgnoreCase("sink") || stream.equalsIgnoreCase("source")) {
       stream = "true"
@@ -62,7 +73,7 @@ class CarbonOption(options: Map[String, String]) {
     stream.toBoolean
   }
 
-  def overwriteEnabled: Boolean =
+  lazy val overwriteEnabled: Boolean =
     options.getOrElse("overwrite", "false").toBoolean
 
   def toMap: Map[String, String] = options

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonDataFrameWriter.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonDataFrameWriter.scala
@@ -105,7 +105,10 @@ class CarbonDataFrameWriter(sqlContext: SQLContext, val dataFrame: DataFrame) {
     }
 
     val schemaWithoutPartition = if (options.partitionColumns.isDefined) {
-      val fields = schema.filterNot(field => options.partitionColumns.get.contains(field.name))
+      val partitionCols = options.partitionColumns.get
+      val fields = schema.filterNot {
+        field => partitionCols.exists(_.equalsIgnoreCase(field.name))
+      }
       StructType(fields)
     } else {
       schema

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonDataFrameWriter.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonDataFrameWriter.scala
@@ -21,6 +21,7 @@ import org.apache.spark.sql.execution.command.management.CarbonLoadDataCommand
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.util.CarbonException
 
+import org.apache.carbondata.common.exceptions.sql.MalformedCarbonCommandException
 import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.core.metadata.datatype.{DataTypes => CarbonType}
 import org.apache.carbondata.spark.CarbonOption
@@ -78,10 +79,6 @@ class CarbonDataFrameWriter(sqlContext: SQLContext, val dataFrame: DataFrame) {
   }
 
   private def makeCreateTableString(schema: StructType, options: CarbonOption): String = {
-    val carbonSchema = schema.map { field =>
-      s"${ field.name } ${ convertToCarbonType(field.dataType) }"
-    }
-
     val property = Map(
       "SORT_COLUMNS" -> options.sortColumns,
       "DICTIONARY_INCLUDE" -> options.dictionaryInclude,
@@ -92,11 +89,38 @@ class CarbonDataFrameWriter(sqlContext: SQLContext, val dataFrame: DataFrame) {
     ).filter(_._2.isDefined)
       .map(property => s"'${property._1}' = '${property._2.get}'").mkString(",")
 
+    val partition: Seq[String] = if (options.partitionColumns.isDefined) {
+      if (options.partitionColumns.get.toSet.size != options.partitionColumns.get.length) {
+        throw new MalformedCarbonCommandException(s"repeated partition column")
+      }
+      options.partitionColumns.get.map { column =>
+        val field = schema.fields.find(_.name.equalsIgnoreCase(column))
+        if (field.isEmpty) {
+          throw new MalformedCarbonCommandException(s"invalid partition column: $column")
+        }
+        s"$column ${field.get.dataType.typeName}"
+      }
+    } else {
+      Seq()
+    }
+
+    val schemaWithoutPartition = if (options.partitionColumns.isDefined) {
+      val fields = schema.filterNot(field => options.partitionColumns.get.contains(field.name))
+      StructType(fields)
+    } else {
+      schema
+    }
+
+    val carbonSchema = schemaWithoutPartition.map { field =>
+      s"${ field.name } ${ convertToCarbonType(field.dataType) }"
+    }
+
     val dbName = CarbonEnv.getDatabaseName(options.dbName)(sqlContext.sparkSession)
 
     s"""
        | CREATE TABLE IF NOT EXISTS $dbName.${options.tableName}
        | (${ carbonSchema.mkString(", ") })
+       | ${ if (partition.nonEmpty) s"PARTITIONED BY (${partition.mkString(", ")})" else ""}
        | STORED BY 'carbondata'
        | ${ if (options.tablePath.nonEmpty) s"LOCATION '${options.tablePath.get}'" else ""}
        |  ${ if (property.nonEmpty) "TBLPROPERTIES (" + property + ")" else "" }


### PR DESCRIPTION
Currently only partition table is only supported by SQL, it should be supported by Spark DataFrame API also.
This PR added an option to specify the partition columns when writing a DataFrame to carbon table
For example:
```
    df.write
      .format("carbondata")
      .option("tableName", "carbon_df_table")
      .option("partitionColumns", "c1, c2")  // a list of column names
      .mode(SaveMode.Overwrite)
      .save()
```

 - [X] Any interfaces changed?
 Added an option for DataFrame.write

 - [X] Any backward compatibility impacted?
 No
 - [X] Document update required?

 - [X] Testing done
 Added one test case

 - [X] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA
