### PR TITLE
[CARBONDATA-2606] [Complex DataType Enhancements]Fix for ComplexDataType Projection PushDown

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/scan/model/QueryModelBuilder.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/model/QueryModelBuilder.java
@@ -82,13 +82,15 @@ public class QueryModelBuilder {
       }
     }
     projection = optimizeProjectionForComplexColumns(projection, projectionColumns, factTableName);
+    List<String> projectionDimensionAndMeasures = new ArrayList<>();
     this.projection = projection;
     for (ProjectionDimension projectionDimension : projection.getDimensions()) {
-      LOGGER.info("Project Columns: " + projectionDimension.getColumnName());
+      projectionDimensionAndMeasures.add(projectionDimension.getColumnName());
     }
     for (ProjectionMeasure projectionMeasure : projection.getMeasures()) {
-      LOGGER.info("Project Columns: " + projectionMeasure.getColumnName());
+      projectionDimensionAndMeasures.add(projectionMeasure.getColumnName());
     }
+    LOGGER.info("Projection Columns: " + projectionDimensionAndMeasures);
     return this;
   }
 


### PR DESCRIPTION
Problem1: Fix for ComplexDataType Projection PushDown when Table Schema contains ColumnName in UpperCase
Solution: Change ColumnName to Lowercase
Problem2: If Struct contains Array, pushdown only parent column
Solution: Check for ArrayType or GetArrayItem in the Complex Column, if any ArrayType is found, then pushdown parent column 

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
      
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

