### PR TITLE
[CARBONDATA-2585][CARBONDATA-2586][Local Dictionary]Added test cases for local dictionary support for alter table, set, unset and preaggregate

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/localdictionary/generator/ColumnLocalDictionaryGenerator.java
+++ b/core/src/main/java/org/apache/carbondata/core/localdictionary/generator/ColumnLocalDictionaryGenerator.java
@@ -39,7 +39,12 @@ public class ColumnLocalDictionaryGenerator implements LocalDictionaryGenerator 
     this.dictionaryHolder = new MapBasedDictionaryStore(newThreshold);
     ByteBuffer byteBuffer = ByteBuffer.allocate(
         lvLength + CarbonCommonConstants.MEMBER_DEFAULT_VAL_ARRAY.length);
-    byteBuffer.putShort((short)CarbonCommonConstants.MEMBER_DEFAULT_VAL_ARRAY.length);
+
+    if (lvLength == CarbonCommonConstants.SHORT_SIZE_IN_BYTE) {
+      byteBuffer.putShort((short) CarbonCommonConstants.MEMBER_DEFAULT_VAL_ARRAY.length);
+    } else {
+      byteBuffer.putInt(CarbonCommonConstants.MEMBER_DEFAULT_VAL_ARRAY.length);
+    }
     byteBuffer.put(CarbonCommonConstants.MEMBER_DEFAULT_VAL_ARRAY);
     // for handling null values
     try {

--- a/integration/spark-common-cluster-test/src/test/scala/org/apache/carbondata/cluster/sdv/generated/CreateTableWithLocalDictionaryTestCase.scala
+++ b/integration/spark-common-cluster-test/src/test/scala/org/apache/carbondata/cluster/sdv/generated/CreateTableWithLocalDictionaryTestCase.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.carbondata.cluster.sdv.generated
 
 import org.apache.spark.sql.test.util.QueryTest
@@ -76,8 +93,8 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
     }
     assert(exception.getMessage
       .contains(
-        "LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE column:  does not exist in table. Please check " +
-        "create table statement"))
+        "LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE column:  does not exist in table. Please " +
+        "check the DDL."))
   }
 
   test("test local dictionary custom configurations for local dict columns _004") {
@@ -93,9 +110,8 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
     }
     assert(exception1.getMessage
       .contains(
-        "LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE column: abc does not exist in table. Please check " +
-        "create table " +
-        "statement"))
+        "LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE column: abc does not exist in table. " +
+        "Please check the DDL."))
   }
 
   test("test local dictionary custom configurations for local dict columns _005") {
@@ -226,7 +242,6 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
     descLoc.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
       case Some(row) => assert(row.get(1).toString.contains("true"))
     }
-    sql("desc formatted local1").show(truncate = false)
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
       case Some(row) => assert(row.get(1).toString.contains("20000"))
     }
@@ -250,7 +265,6 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
     descLoc.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
       case Some(row) => assert(row.get(1).toString.contains("true"))
     }
-    sql("desc formatted local1").show(truncate = false)
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
       case Some(row) => assert(row.get(1).toString.contains("10000"))
     }
@@ -274,7 +288,6 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
     descLoc.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
       case Some(row) => assert(row.get(1).toString.contains("true"))
     }
-    sql("desc formatted local1").show(truncate = false)
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
       case Some(row) => assert(row.get(1).toString.contains("10000"))
     }
@@ -298,7 +311,6 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
     descLoc.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
       case Some(row) => assert(row.get(1).toString.contains("true"))
     }
-    sql("desc formatted local1").show(truncate = false)
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
       case Some(row) => assert(row.get(1).toString.contains("10000"))
     }
@@ -471,8 +483,8 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
     }
     assert(exception.getMessage
       .contains(
-        "LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE column:  does not exist in table. Please check " +
-        "create table statement"))
+        "LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE column:  does not exist in table. " +
+        "Please check the DDL."))
 
   }
 
@@ -489,9 +501,8 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
     }
     assert(exception1.getMessage
       .contains(
-        "LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE column: abc does not exist in table. Please check " +
-        "create table " +
-        "statement"))
+        "LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE column: abc does not exist in table. " +
+        "Please check the DDL."))
   }
 
   test("test local dictionary custom configurations when enabled for local dict columns _005") {
@@ -572,7 +583,7 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
     assert(exception.getMessage
       .contains(
         "LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE column:  does not exist in table. Please check " +
-        "create table statement"))
+        "the DDL."))
 
   }
 
@@ -589,9 +600,8 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
     }
     assert(exception1.getMessage
       .contains(
-        "LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE column: abc does not exist in table. Please check " +
-        "create table " +
-        "statement"))
+        "LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE column: abc does not exist in table. " +
+        "Please check the DDL."))
   }
 
   test("test local dictionary custom configurations when local_dictionary_exclude is configured _005") {
@@ -880,7 +890,6 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
     descLoc.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
       case Some(row) => assert(row.get(1).toString.contains("true"))
     }
-    sql("desc formatted local1").show(truncate = false)
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
       case Some(row) => assert(row.get(1).toString.contains("20000"))
     }
@@ -906,7 +915,6 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
     descLoc.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
       case Some(row) => assert(row.get(1).toString.contains("true"))
     }
-    sql("desc formatted local1").show(truncate = false)
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
       case Some(row) => assert(row.get(1).toString.contains("10000"))
     }
@@ -932,7 +940,6 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
     descLoc.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
       case Some(row) => assert(row.get(1).toString.contains("true"))
     }
-    sql("desc formatted local1").show(truncate = false)
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
       case Some(row) => assert(row.get(1).toString.contains("10000"))
     }
@@ -958,7 +965,6 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
     descLoc.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
       case Some(row) => assert(row.get(1).toString.contains("true"))
     }
-    sql("desc formatted local1").show(truncate = false)
     descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
       case Some(row) => assert(row.get(1).toString.contains("10000"))
     }
@@ -1645,7 +1651,7 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
     assert(exception.getMessage
       .contains(
         "LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE column:  does not exist in table. Please check " +
-        "create table statement"))
+        "the DDL."))
 
   }
 
@@ -1668,9 +1674,8 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
     }
     assert(exception1.getMessage
       .contains(
-        "LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE column: abc does not exist in table. Please check " +
-        "create table " +
-        "statement"))
+        "LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE column: abc does not exist in table. " +
+        "Please check the DDL."))
   }
 
   test("test CTAS statements for local dictionary custom configurations when enabled for local dict columns _005") {
@@ -1779,7 +1784,7 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
     assert(exception.getMessage
       .contains(
         "LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE column:  does not exist in table. Please check " +
-        "create table statement"))
+        "the DDL."))
   }
 
   test("test CTAS statements for local dictionary custom configurations when local_dictionary_exclude is configured _004") {
@@ -1801,9 +1806,8 @@ class CreateTableWithLocalDictionaryTestCase extends QueryTest with BeforeAndAft
     }
     assert(exception1.getMessage
       .contains(
-        "LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE column: abc does not exist in table. Please check " +
-        "create table " +
-        "statement"))
+        "LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE column: abc does not exist in table. " +
+        "Please check the DDL."))
   }
 
   test("test CTAS statements for local dictionary custom configurations when local_dictionary_exclude is configured _005") {

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/localdictionary/LocalDictionarySupportAlterTableTest.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/localdictionary/LocalDictionarySupportAlterTableTest.scala
@@ -1,0 +1,1127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.spark.testsuite.localdictionary
+
+import org.apache.spark.sql.test.util.QueryTest
+import org.scalatest.BeforeAndAfterAll
+
+import org.apache.carbondata.common.exceptions.sql.MalformedCarbonCommandException
+
+class LocalDictionarySupportAlterTableTest extends QueryTest with BeforeAndAfterAll{
+
+  override protected def beforeAll(): Unit = {
+    sql("DROP TABLE IF EXISTS LOCAL1")
+  }
+
+  test("test alter table add column") {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int)
+        | STORED BY 'org.apache.carbondata.format' tblproperties('local_dictionary_enable'='true',
+        | 'local_dictionary_threshold'='20000','local_dictionary_include'='city','no_inverted_index'='name')
+      """.stripMargin)
+    sql("alter table local1 add columns (alt string) tblproperties('local_dictionary_include'='alt')")
+    val descLoc = sql("describe formatted local1").collect
+    descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
+      case Some(row) => assert(row.get(1).toString.contains("20000"))
+    }
+    descLoc.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
+      case Some(row) => assert(row.get(1).toString.contains("true"))
+    }
+    descLoc.find(_.get(0).toString.contains("Local Dictionary Include")) match {
+      case Some(row) => assert(row.get(1).toString.contains("city,alt"))
+    }
+  }
+
+  test("test alter table add column default configs for local dictionary") {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int)
+        | STORED BY 'org.apache.carbondata.format' tblproperties('local_dictionary_enable'='true',
+        | 'local_dictionary_threshold'='20000','no_inverted_index'='name')
+      """.stripMargin)
+    sql("alter table local1 add columns (alt string)")
+    val descLoc = sql("describe formatted local1").collect
+    descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
+      case Some(row) => assert(row.get(1).toString.contains("20000"))
+    }
+    descLoc.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
+      case Some(row) => assert(row.get(1).toString.contains("true"))
+    }
+    descLoc.find(_.get(0).toString.contains("Local Dictionary Include")) match {
+      case Some(row) => assert(row.get(1).toString.contains("name,city,alt"))
+    }
+  }
+
+  test("test alter table add column where same column is in dictionary include and local dictionary include") {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int)
+        | STORED BY 'org.apache.carbondata.format' tblproperties('local_dictionary_enable'='true',
+        | 'local_dictionary_threshold'='20000','local_dictionary_include'='city','no_inverted_index'='name')
+      """.stripMargin)
+    val exception = intercept[MalformedCarbonCommandException] {
+      sql(
+        "alter table local1 add columns (alt string) tblproperties('local_dictionary_include'='alt','dictionary_include'='alt')")
+    }
+    assert(exception.getMessage
+      .contains(
+        "LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE column: alt specified in Dictionary " +
+        "include. Local Dictionary will not be generated for Dictionary include columns. " +
+        "Please check the DDL."))
+  }
+
+  test("test alter table add column where duplicate columns present in local dictionary include") {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int)
+        | STORED BY 'org.apache.carbondata.format' tblproperties('local_dictionary_enable'='true',
+        | 'local_dictionary_threshold'='20000','local_dictionary_include'='city','no_inverted_index'='name')
+      """.stripMargin)
+    val exception = intercept[MalformedCarbonCommandException] {
+      sql(
+        "alter table local1 add columns (alt string) tblproperties('local_dictionary_include'='alt,alt')")
+    }
+    assert(exception.getMessage
+      .contains(
+        "LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE contains Duplicate Columns: alt. " +
+        "Please check the DDL."))
+  }
+
+  test("test alter table add column where duplicate columns present in local dictionary include/exclude") {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int)
+        | STORED BY 'org.apache.carbondata.format' tblproperties('local_dictionary_enable'='true',
+        | 'local_dictionary_threshold'='20000','local_dictionary_include'='city',
+        | 'no_inverted_index'='name')
+      """.stripMargin)
+    val exception1 = intercept[MalformedCarbonCommandException] {
+      sql(
+        "alter table local1 add columns (alt string) tblproperties" +
+        "('local_dictionary_include'='abc')")
+    }
+    assert(exception1.getMessage
+      .contains(
+        "LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE column: abc does not exist in table. " +
+        "Please check the DDL."))
+    val exception2 = intercept[MalformedCarbonCommandException] {
+      sql(
+        "alter table local1 add columns (alt string) tblproperties" +
+        "('local_dictionary_exclude'='abc')")
+    }
+    assert(exception2.getMessage
+      .contains(
+        "LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE column: abc does not exist in table. " +
+        "Please check the DDL."))
+  }
+
+  test("test alter table add column for datatype validation") {
+    sql("drop table if exists local1")
+    sql(
+      """ | CREATE TABLE local1(id int, name string, city string, age int)
+        | STORED BY 'org.apache.carbondata.format' tblproperties('local_dictionary_enable'='true',
+        | 'local_dictionary_include'='city', 'no_inverted_index'='name')
+      """.stripMargin)
+    val exception = intercept[MalformedCarbonCommandException] {
+      sql(
+        "alter table local1 add columns (alt string,abc int) tblproperties" +
+        "('local_dictionary_include'='abc')")
+    }
+    assert(exception.getMessage
+      .contains(
+        "LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE column: abc is not a String/complex " +
+        "datatype column. LOCAL_DICTIONARY_COLUMN should be no dictionary string/complex datatype" +
+        " column.Please check the DDL."))
+  }
+
+  test("test alter table add column where duplicate columns are present in local dictionary include and exclude") {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int)
+        | STORED BY 'org.apache.carbondata.format' tblproperties('local_dictionary_enable'='true',
+        | 'local_dictionary_include'='city', 'no_inverted_index'='name')
+      """.stripMargin)
+    val exception = intercept[MalformedCarbonCommandException] {
+      sql(
+        "alter table local1 add columns (alt string,abc string) tblproperties" +
+        "('local_dictionary_include'='abc','local_dictionary_exclude'='alt,abc')")
+    }
+    assert(exception.getMessage
+      .contains(
+        "Column ambiguity as duplicate column(s):abc is present in LOCAL_DICTIONARY_INCLUDE " +
+        "and LOCAL_DICTIONARY_EXCLUDE. Duplicate columns are not allowed."))
+  }
+
+  test("test alter table add column unsupported table property") {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int)
+        | STORED BY 'org.apache.carbondata.format' tblproperties('local_dictionary_enable'='true',
+        | 'local_dictionary_include'='city', 'no_inverted_index'='name')
+      """.stripMargin)
+    val exception = intercept[MalformedCarbonCommandException] {
+      sql(
+        "alter table local1 add columns (alt string,abc string) tblproperties" +
+        "('local_dictionary_enable'='abc')")
+    }
+    assert(exception.getMessage
+      .contains(
+        "Unsupported Table property in add column: local_dictionary_enable"))
+    val exception1 = intercept[MalformedCarbonCommandException] {
+      sql(
+        "alter table local1 add columns (alt string,abc string) tblproperties" +
+        "('local_dictionary_threshold'='10000')")
+    }
+    assert(exception1.getMessage
+      .contains(
+        "Unsupported Table property in add column: local_dictionary_threshold"))
+  }
+
+  test("test alter table add column when main table is disabled for local dictionary") {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int)
+        | STORED BY 'org.apache.carbondata.format' tblproperties('local_dictionary_enable'='false',
+        | 'local_dictionary_include'='city', 'no_inverted_index'='name')
+      """.stripMargin)
+    sql(
+      "alter table local1 add columns (alt string,abc string) tblproperties" +
+      "('local_dictionary_include'='abc')")
+    val descLoc = sql("describe formatted local1").collect
+    descLoc.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
+      case Some(row) => assert(row.get(1).toString.contains("false"))
+    }
+
+    checkExistence(sql("DESC FORMATTED local1"), false,
+      "Local Dictionary Include")
+  }
+
+  test("test local dictionary threshold for boundary values") {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int)
+        | STORED BY 'org.apache.carbondata.format' tblproperties('local_dictionary_threshold'='300000')
+      """.stripMargin)
+    val descLoc = sql("describe formatted local1").collect
+    descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
+      case Some(row) => assert(row.get(1).toString.contains("10000"))
+    }
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int)
+        | STORED BY 'org.apache.carbondata.format' tblproperties('local_dictionary_threshold'='500')
+      """.stripMargin)
+    val descLoc1 = sql("describe formatted local1").collect
+    descLoc1.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
+      case Some(row) => assert(row.get(1).toString.contains("10000"))
+    }
+  }
+
+  test("test alter table add column for local dictionary include and exclude configs") {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int)
+        | STORED BY 'org.apache.carbondata.format' tblproperties('local_dictionary_enable'='true',
+        | 'local_dictionary_include'='city', 'no_inverted_index'='name')
+      """.stripMargin)
+    sql(
+      "alter table local1 add columns (alt string,abc string) tblproperties" +
+      "('local_dictionary_include'='abc','local_dictionary_exclude'='alt')")
+    val descLoc = sql("describe formatted local1").collect
+    descLoc.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
+      case Some(row) => assert(row.get(1).toString.contains("true"))
+    }
+    descLoc.find(_.get(0).toString.contains("Local Dictionary Include")) match {
+      case Some(row) => assert(row.get(1).toString.contains("city,abc"))
+    }
+    descLoc.find(_.get(0).toString.contains("Local Dictionary Exclude")) match {
+      case Some(row) => assert(row.get(1).toString.contains("alt"))
+    }
+  }
+
+  test("test local dictionary foer varchar datatype columns") {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int)
+        | STORED BY 'org.apache.carbondata.format' tblproperties('local_dictionary_include'='city',
+        | 'LONG_STRING_COLUMNS'='city')
+      """.stripMargin)
+    val descLoc = sql("describe formatted local1").collect
+    descLoc.find(_.get(0).toString.contains("Local Dictionary Include")) match {
+      case Some(row) => assert(row.get(1).toString.contains("city"))
+    }
+    descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
+      case Some(row) => assert(row.get(1).toString.contains("10000"))
+    }
+  }
+
+  test("test local dictionary describe formatted only with default configs") {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int)
+        | STORED BY 'carbondata'
+      """.stripMargin)
+
+    val descLoc = sql("describe formatted local1").collect
+    descLoc.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
+      case Some(row) => assert(row.get(1).toString.contains("true"))
+    }
+    descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
+      case Some(row) => assert(row.get(1).toString.contains("10000"))
+    }
+    descLoc.find(_.get(0).toString.contains("Local Dictionary Include")) match {
+      case Some(row) => assert(row.get(1).toString.contains("name,city"))
+    }
+  }
+
+  test("test local dictionary for invalid threshold") {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int)
+        | STORED BY 'carbondata' tblproperties('local_dictionary_threshold'='300000')
+      """.stripMargin)
+
+    val descLoc = sql("describe formatted local1").collect
+    descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
+      case Some(row) => assert(row.get(1).toString.contains("10000"))
+    }
+  }
+
+  test("test alter set for local dictionary enable to disable") {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int)
+        | STORED BY 'carbondata' tblproperties('local_dictionary_threshold'='300000')
+      """.stripMargin)
+
+    val descLoc1 = sql("describe formatted local1").collect
+    descLoc1.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
+      case Some(row) => assert(row.get(1).toString.contains("true"))
+    }
+    descLoc1.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
+      case Some(row) => assert(row.get(1).toString.contains("10000"))
+    }
+    sql("alter table local1 set tblproperties('local_dictionary_enable'='false')")
+    val descLoc2 = sql("describe formatted local1").collect
+    descLoc2.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
+      case Some(row) => assert(row.get(1).toString.contains("false"))
+    }
+    checkExistence(sql("DESC FORMATTED local1"), false,
+      "Local Dictionary Threshold")
+  }
+
+  test("test alter set for local dictionary _001") {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int)
+        | STORED BY 'carbondata'
+      """.stripMargin)
+
+    val descLoc1 = sql("describe formatted local1").collect
+    descLoc1.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
+      case Some(row) => assert(row.get(1).toString.contains("true"))
+    }
+    sql("alter table local1 set tblproperties('local_dictionary_threshold'='30000')")
+    val descLoc2 = sql("describe formatted local1").collect
+    descLoc2.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
+      case Some(row) => assert(row.get(1).toString.contains("true"))
+    }
+    descLoc2.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
+      case Some(row) => assert(row.get(1).toString.contains("30000"))
+    }
+  }
+
+
+  test("test alter set for local dictionary _002") {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int)
+        | STORED BY 'carbondata'
+      """.stripMargin)
+
+    val descLoc1 = sql("describe formatted local1").collect
+    descLoc1.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
+      case Some(row) => assert(row.get(1).toString.contains("true"))
+    }
+    sql("alter table local1 set tblproperties('local_dictionary_include'='name')")
+    val descLoc2 = sql("describe formatted local1").collect
+    descLoc2.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
+      case Some(row) => assert(row.get(1).toString.contains("true"))
+    }
+    descLoc2.find(_.get(0).toString.contains("Local Dictionary Include")) match {
+      case Some(row) => assert(row.get(1).toString.contains("name") && !row.get(1).toString.contains("city"))
+    }
+  }
+
+  test("test alter set for local dictionary _003") {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int)
+        | STORED BY 'carbondata'
+      """.stripMargin)
+
+    val descLoc1 = sql("describe formatted local1").collect
+    descLoc1.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
+      case Some(row) => assert(row.get(1).toString.contains("true"))
+    }
+    sql("alter table local1 set tblproperties('local_dictionary_exclude'='name')")
+    val descLoc2 = sql("describe formatted local1").collect
+    descLoc2.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
+      case Some(row) => assert(row.get(1).toString.contains("true"))
+    }
+    descLoc2.find(_.get(0).toString.contains("Local Dictionary Include")) match {
+      case Some(row) => assert(row.get(1).toString.contains("city"))
+    }
+    descLoc2.find(_.get(0).toString.contains("Local Dictionary Exclude")) match {
+      case Some(row) => assert(row.get(1).toString.contains("name"))
+    }
+  }
+
+  test("test alter set for local dictionary _004") {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int)
+        | STORED BY 'carbondata' tblproperties('local_dictionary_include'='name')
+      """.stripMargin)
+
+    val descLoc1 = sql("describe formatted local1").collect
+    descLoc1.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
+      case Some(row) => assert(row.get(1).toString.contains("true"))
+    }
+    sql("alter table local1 set tblproperties('local_dictionary_include'='city')")
+
+    val descLoc2 = sql("describe formatted local1").collect
+    descLoc2.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
+      case Some(row) => assert(row.get(1).toString.contains("true"))
+    }
+    descLoc2.find(_.get(0).toString.contains("Local Dictionary Include")) match {
+      case Some(row) => assert(row.get(1).toString.contains("city"))
+    }
+  }
+
+  test("test alter set for local dictionary _005") {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int)
+        | STORED BY 'carbondata' tblproperties('local_dictionary_include'='name')
+      """.stripMargin)
+
+    val descLoc1 = sql("describe formatted local1").collect
+    descLoc1.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
+      case Some(row) => assert(row.get(1).toString.contains("true"))
+    }
+    sql("alter table local1 set tblproperties('local_dictionary_include'='name,city')")
+
+    val descLoc2 = sql("describe formatted local1").collect
+    descLoc2.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
+      case Some(row) => assert(row.get(1).toString.contains("true"))
+    }
+    descLoc2.find(_.get(0).toString.contains("Local Dictionary Include")) match {
+      case Some(row) => assert(row.get(1).toString.contains("name,city"))
+    }
+  }
+
+  test("test alter set for local dictionary _006") {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int)
+        | STORED BY 'carbondata' tblproperties('local_dictionary_include'='name')
+      """.stripMargin)
+
+    val descLoc1 = sql("describe formatted local1").collect
+    descLoc1.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
+      case Some(row) => assert(row.get(1).toString.contains("true"))
+    }
+    sql("alter table local1 set tblproperties('local_dictionary_exclude'='city')")
+
+    val descLoc2 = sql("describe formatted local1").collect
+    descLoc2.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
+      case Some(row) => assert(row.get(1).toString.contains("true"))
+    }
+    descLoc2.find(_.get(0).toString.contains("Local Dictionary Include")) match {
+      case Some(row) => assert(row.get(1).toString.contains("name"))
+    }
+    descLoc2.find(_.get(0).toString.contains("Local Dictionary Exclude")) match {
+      case Some(row) => assert(row.get(1).toString.contains("city"))
+    }
+  }
+
+  test("test alter set for local dictionary _007") {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int)
+        | STORED BY 'carbondata' tblproperties('local_dictionary_include'='name')
+      """.stripMargin)
+
+    val descLoc1 = sql("describe formatted local1").collect
+    descLoc1.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
+      case Some(row) => assert(row.get(1).toString.contains("true"))
+    }
+    val exception1 = intercept[Exception] {
+      sql("alter table local1 set tblproperties('local_dictionary_include'='city, ')")
+    }
+    assert(exception1.getMessage
+      .contains(
+        "LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE column:  does not exist in table. " +
+        "Please check the DDL."))
+  }
+
+  test("test alter set for local dictionary _008") {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int)
+        | STORED BY 'carbondata' tblproperties('local_dictionary_include'='name')
+      """.stripMargin)
+
+    val descLoc1 = sql("describe formatted local1").collect
+    descLoc1.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
+      case Some(row) => assert(row.get(1).toString.contains("true"))
+    }
+    val exception1 = intercept[Exception] {
+      sql("alter table local1 set tblproperties('local_dictionary_exclude'='name')")
+    }
+    assert(exception1.getMessage.contains("Column ambiguity as duplicate column(s):name is present in LOCAL_DICTIONARY_INCLUDE and LOCAL_DICTIONARY_EXCLUDE. Duplicate columns are not allowed."))
+  }
+
+  test("test alter set for local dictionary _009") {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int)
+        | STORED BY 'carbondata' tblproperties('local_dictionary_include'='name')
+      """.stripMargin)
+
+    val descLoc1 = sql("describe formatted local1").collect
+    descLoc1.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
+      case Some(row) => assert(row.get(1).toString.contains("true"))
+    }
+    val exception1 = intercept[Exception] {
+      sql("alter table local1 set tblproperties('local_dictionary_exclude'='id')")
+    }
+    assert(exception1.getMessage.contains("LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE column: id is not a String/complex datatype column. LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE should be no dictionary string/complex datatype column."))
+  }
+
+  test("test alter set for local dictionary _010") {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int)
+        | STORED BY 'carbondata' tblproperties('dictionary_include'='name')
+      """.stripMargin)
+
+    val descLoc1 = sql("describe formatted local1").collect
+    descLoc1.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
+      case Some(row) => assert(row.get(1).toString.contains("true"))
+    }
+    val exception1 = intercept[Exception] {
+      sql("alter table local1 set tblproperties('local_dictionary_include'='name')")
+    }
+    assert(exception1.getMessage.contains("LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE column: name specified in Dictionary include. Local Dictionary will not be generated for Dictionary include columns. Please check the DDL."))
+  }
+
+  test("test alter set for local dictionary _011") {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int)
+        | STORED BY 'carbondata' tblproperties('local_dictionary_exclude'='name')
+      """.stripMargin)
+
+    val descLoc1 = sql("describe formatted local1").collect
+    descLoc1.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
+      case Some(row) => assert(row.get(1).toString.contains("true"))
+    }
+    sql("alter table local1 set tblproperties('local_dictionary_exclude'='city')")
+    val descLoc2 = sql("describe formatted local1").collect
+    descLoc2.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
+      case Some(row) => assert(row.get(1).toString.contains("true"))
+    }
+    descLoc2.find(_.get(0).toString.contains("Local Dictionary Include")) match {
+      case Some(row) => assert(row.get(1).toString.contains("name"))
+    }
+    descLoc2.find(_.get(0).toString.contains("Local Dictionary Exclude")) match {
+      case Some(row) => assert(row.get(1).toString.contains("city"))
+    }
+  }
+
+  test("test alter set for local dictionary _012") {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int)
+        | STORED BY 'carbondata' tblproperties('local_dictionary_exclude'='name')
+      """.stripMargin)
+
+    val descLoc1 = sql("describe formatted local1").collect
+    descLoc1.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
+      case Some(row) => assert(row.get(1).toString.contains("true"))
+    }
+    val exception1 = intercept[Exception] {
+      sql("alter table local1 set tblproperties('local_dictionary_exclude'='city, ')")
+    }
+    assert(exception1.getMessage.contains("LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE column:  does not exist in table. Please check the DDL."))
+  }
+
+  test("test alter set for local dictionary _013") {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int)
+        | STORED BY 'carbondata' tblproperties('dictionary_include'='name')
+      """.stripMargin)
+
+    val descLoc1 = sql("describe formatted local1").collect
+    descLoc1.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
+      case Some(row) => assert(row.get(1).toString.contains("true"))
+    }
+    val exception1 = intercept[Exception] {
+      sql("alter table local1 set tblproperties('local_dictionary_exclude'='name')")
+    }
+    assert(exception1.getMessage.contains("LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE column: name specified in Dictionary include. Local Dictionary will not be generated for Dictionary include columns. Please check the DDL."))
+  }
+
+  test("test alter set for local dictionary _014") {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int)
+        | STORED BY 'carbondata' tblproperties('local_dictionary_include'='name')
+      """.stripMargin)
+
+    val descLoc1 = sql("describe formatted local1").collect
+    descLoc1.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
+      case Some(row) => assert(row.get(1).toString.contains("true"))
+    }
+    val exception1 = intercept[Exception] {
+      sql("alter table local1 set tblproperties('local_dictionary_exclude'='name')")
+    }
+    assert(exception1.getMessage.contains("Column ambiguity as duplicate column(s):name is present in LOCAL_DICTIONARY_INCLUDE and LOCAL_DICTIONARY_EXCLUDE. Duplicate columns are not allowed."))
+  }
+
+  test("test alter set for local dictionary _015") {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int)
+        | STORED BY 'carbondata' tblproperties('local_dictionary_include'='name')
+      """.stripMargin)
+
+    val descLoc1 = sql("describe formatted local1").collect
+    descLoc1.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
+      case Some(row) => assert(row.get(1).toString.contains("true"))
+    }
+    sql("alter table local1 set tblproperties('local_dictionary_enable'='false')")
+    val descLoc2 = sql("describe formatted local1").collect
+    descLoc2.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
+      case Some(row) => assert(row.get(1).toString.contains("false"))
+    }
+  }
+
+  test("test alter set for local dictionary _016") {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int)
+        | STORED BY 'carbondata' tblproperties('local_dictionary_enable'='false')
+      """.stripMargin)
+
+    sql("alter table local1 set tblproperties('local_dictionary_include'='name')")
+    val descLoc2 = sql("describe formatted local1").collect
+    descLoc2.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
+      case Some(row) => assert(row.get(1).toString.contains("false"))
+    }
+  }
+
+  test("test alter set for local dictionary _017") {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int)
+        | STORED BY 'carbondata' tblproperties('local_dictionary_include'='name','local_dictionary_exclude'='city')
+      """.stripMargin)
+
+    val exception1 = intercept[Exception] {
+      sql("alter table local1 set tblproperties('local_dictionary_exclude'='name')")
+    }
+    assert(exception1.getMessage.contains("Column ambiguity as duplicate column(s):name is present in LOCAL_DICTIONARY_INCLUDE and LOCAL_DICTIONARY_EXCLUDE. Duplicate columns are not allowed."))
+  }
+
+  test("test alter unset for local dictionary") {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int)
+        | STORED BY 'carbondata' tblproperties('local_dictionary_include'='name','local_dictionary_exclude'='city')
+      """.stripMargin)
+
+    sql("alter table local1 unset tblproperties('local_dictionary_exclude')")
+    val descLoc2 = sql("describe formatted local1").collect
+    descLoc2.find(_.get(0).toString.contains("Local Dictionary Include")) match {
+      case Some(row) => assert(row.get(1).toString.contains("name"))
+    }
+  }
+
+  test("test alter set for local dictionary disable to enable") {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int)
+        | STORED BY 'carbondata' tblproperties('local_dictionary_enable'='false','local_dictionary_threshold'='300000')
+      """.stripMargin)
+
+    val descLoc1 = sql("describe formatted local1").collect
+    descLoc1.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
+      case Some(row) => assert(row.get(1).toString.contains("false"))
+    }
+    checkExistence(sql("DESC FORMATTED local1"), false,
+      "Local Dictionary Threshold")
+    sql("alter table local1 set tblproperties('local_dictionary_enable'='true','local_dictionary_threshold'='30000')")
+    val descLoc2 = sql("describe formatted local1").collect
+    descLoc2.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
+      case Some(row) => assert(row.get(1).toString.contains("true"))
+    }
+    descLoc2.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
+      case Some(row) => assert(row.get(1).toString.contains("30000"))
+    }
+  }
+
+  test("test alter set same column for local dictionary exclude and include") {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int)
+        | STORED BY 'carbondata' tblproperties('local_dictionary_exclude'='city')
+      """.stripMargin)
+    intercept[Exception] {
+      sql(
+        "alter table local1 set tblproperties('local_dictionary_include'='name'," +
+        "'local_dictionary_exclude'='name')")
+    }
+  }
+
+  test("test alter set for valid and invalid complex type as include/exclude") {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int,st struct<s_id:int,
+        | s_name:string,s_city:array<string>>, dcity array<string>)
+        | STORED BY 'org.apache.carbondata.format'
+        | tblproperties('local_dictionary_exclude'='name','local_dictionary_include'='city,dcity',
+        | 'local_dictionary_enable'='true')
+      """.
+        stripMargin)
+    val descFormatted1 = sql("describe formatted local1").collect
+    descFormatted1.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
+      case Some(row) => assert(row.get(1).toString.contains("true"))
+    }
+    descFormatted1.find(_.get(0).toString.contains("Local Dictionary Include")) match {
+      case Some(row) => assert(
+        row.get(1).toString.contains("city,dcity") && !row.get(1).toString.contains("name"))
+    }
+    intercept[Exception] {
+      sql("alter table local1 set tblproperties('local_dictionary_exclude'='dcity')")
+    }
+    sql("alter table local1 set tblproperties('local_dictionary_exclude'='st')")
+    val descFormatted2 = sql("describe formatted local1").collect
+    descFormatted2.find(_.get(0).toString.contains("Local Dictionary Exclude")) match {
+      case Some(row) => assert(row.get(1).toString.contains("st"))
+    }
+    descFormatted2.find(_.get(0).toString.contains("Local Dictionary Include")) match {
+      case Some(row) => assert(row.get(1).toString.contains("city,dcity"))
+    }
+    sql("alter table local1 set tblproperties('local_dictionary_exclude'='st'," +
+        "'local_dictionary_include'='dcity')")
+    val descFormatted3 = sql("describe formatted local1").collect
+    descFormatted3.find(_.get(0).toString.contains("Local Dictionary Exclude")) match {
+      case Some(row) => assert(row.get(1).toString.contains("st"))
+    }
+    descFormatted3.find(_.get(0).toString.contains("Local Dictionary Include")) match {
+      case Some(row) => assert(row.get(1).toString.contains("dcity"))
+    }
+  }
+
+  test("test alter set for invalid complex type as include/exclude") {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int,st struct<s_id:int,
+        | s_name:int,s_city:array<int>>, dcity array<int>)
+        | STORED BY 'org.apache.carbondata.format'
+        | tblproperties('local_dictionary_exclude'='name',
+        | 'local_dictionary_enable'='true')
+      """.
+        stripMargin)
+    intercept[Exception] {
+      sql("alter table local1 set tblproperties('local_dictionary_exclude'='dcity')")
+    }
+    intercept[Exception] {
+      sql("alter table local1 set tblproperties('local_dictionary_include'='st')")
+    }
+  }
+
+  test("test alter unset for local dictionary disable") {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int,add string)
+        | STORED BY 'carbondata' tblproperties('local_dictionary_enable'='false')
+      """.stripMargin)
+
+    val descLoc1 = sql("describe formatted local1").collect
+    descLoc1.find(_.get(0).toString.contains("Local Dictionary Enable")) match {
+      case Some(row) => assert(row.get(1).toString.contains("false"))
+    }
+    sql("alter table local1 unset tblproperties('local_dictionary_enable')")
+    val descLoc2 = sql("describe formatted local1").collect
+    descLoc2.find(_.get(0).toString.contains("Local Dictionary Enable")) match {
+      case Some(row) => assert(row.get(1).toString.contains("true"))
+    }
+  }
+
+  test("test alter unset for local dictionary enable local dict include") {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int,add string)
+        | STORED BY 'carbondata' tblproperties('local_dictionary_include'='city')
+      """.stripMargin)
+
+    val descLoc1 = sql("describe formatted local1").collect
+    descLoc1.find(_.get(0).toString.contains("Local Dictionary Include")) match {
+      case Some(row) => assert(row.get(1).toString.contains("city"))
+    }
+    sql("alter table local1 unset tblproperties('local_dictionary_include')")
+    val descLoc2 = sql("describe formatted local1").collect
+    descLoc2.find(_.get(0).toString.contains("Local Dictionary Include")) match {
+      case Some(row) => assert(row.get(1).toString.contains("name,city"))
+    }
+  }
+
+  test("test alter unset for local dictionary enable local dict exclude") {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int,add string)
+        | STORED BY 'carbondata' tblproperties('local_dictionary_include'='city',
+        | 'local_dictionary_exclude'='name')
+      """.stripMargin)
+
+    val descLoc1 = sql("describe formatted local1").collect
+    descLoc1.find(_.get(0).toString.contains("Local Dictionary Include")) match {
+      case Some(row) => assert(row.get(1).toString.contains("city"))
+    }
+    sql("alter table local1 unset tblproperties('local_dictionary_exclude')")
+    val descLoc2 = sql("describe formatted local1").collect
+    descLoc2.find(_.get(0).toString.contains("Local Dictionary Include")) match {
+      case Some(row) => assert(row.get(1).toString.contains("city"))
+    }
+  }
+
+  test("test alter unset for valid/invalid complex type as include/exclude") {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int,st struct<s_id:int,
+        | s_name:string,s_city:array<int>>, dcity array<string>)
+        | STORED BY 'org.apache.carbondata.format'
+        | tblproperties('local_dictionary_exclude'='st','local_dictionary_include'='city',
+        | 'local_dictionary_enable'='true')
+      """.
+        stripMargin)
+    val descLoc1 = sql("describe formatted local1").collect
+    descLoc1.find(_.get(0).toString.contains("Local Dictionary Include")) match {
+      case Some(row) => assert(row.get(1).toString.contains("city"))
+    }
+    descLoc1.find(_.get(0).toString.contains("Local Dictionary Exclude")) match {
+      case Some(row) => assert(
+        row.get(1).toString.contains("st.s_name") && !row.get(1).toString.contains("st.s_id"))
+    }
+    sql("alter table local1 unset tblproperties('local_dictionary_exclude')")
+    sql("alter table local1 unset tblproperties('local_dictionary_include')")
+    val descLoc2 = sql("describe formatted local1").collect
+    descLoc2.find(_.get(0).toString.contains("Local Dictionary Include")) match {
+      case Some(row) => assert(row.get(1).toString.contains("name,city,st.s_name,dcity.val"))
+    }
+  }
+
+  test("test alter table drop column for local dictionary include") {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name struct<n:int,m:string>, city string, age int)
+        | STORED BY 'org.apache.carbondata.format' tblproperties('local_dictionary_enable'='true',
+        | 'local_dictionary_threshold'='20000','no_inverted_index'='name',
+        | 'local_dictionary_include'='name,city')
+      """.stripMargin)
+    sql("alter table local1 drop columns (city)")
+    val descLoc = sql("describe formatted local1").collect
+    descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
+      case Some(row) => assert(row.get(1).toString.contains("20000"))
+    }
+    descLoc.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
+      case Some(row) => assert(row.get(1).toString.contains("true"))
+    }
+    descLoc.find(_.get(0).toString.contains("Local Dictionary Include")) match {
+      case Some(row) => assert(row.get(1).toString.contains("name") && !row.get(1).toString.contains("city"))
+    }
+  }
+
+  test("test alter table drop column for local dictionary exclude") {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int)
+        | STORED BY 'org.apache.carbondata.format' tblproperties('local_dictionary_enable'='true',
+        | 'local_dictionary_threshold'='20000','no_inverted_index'='name',
+        | 'local_dictionary_exclude'='name,city')
+      """.stripMargin)
+    sql("alter table local1 drop columns (name)")
+    val descLoc = sql("describe formatted local1").collect
+    descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
+      case Some(row) => assert(row.get(1).toString.contains("20000"))
+    }
+    descLoc.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
+      case Some(row) => assert(row.get(1).toString.contains("true"))
+    }
+    descLoc.find(_.get(0).toString.contains("Local Dictionary Exclude")) match {
+      case Some(row) => assert(row.get(1).toString.contains("city") && !row.get(1).toString.contains("name"))
+    }
+  }
+
+  test("test alter set case sensitivity") {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int)
+        | STORED BY 'org.apache.carbondata.format' tblproperties('local_dictionary_enable'='true',
+        | 'local_dictionary_threshold'='20000','no_inverted_index'='name',
+        | 'local_dictionary_include'='city')
+      """.stripMargin)
+    intercept[Exception] {
+      sql("alter table local1 set tblproperties('local_dictionary_include'='city, CiTy')")
+    }
+    intercept[Exception] {
+      sql("alter table local1 set tblproperties('local_dictionary_include'='naMe , NaMe')")
+    }
+  }
+
+  test("test alter add and drop columns") {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int)
+        | STORED BY 'org.apache.carbondata.format' tblproperties('local_dictionary_enable'='true',
+        | 'local_dictionary_threshold'='20000','no_inverted_index'='name')
+      """.stripMargin)
+    sql("alter table local1 add columns(add1 string,add2 string) tblproperties('local_dictionary_exclude'='add1')")
+    sql("alter table local1 drop columns (add1)")
+    sql("alter table local1 add columns(add1 string) tblproperties('local_dictionary_include'='add1')")
+    val descLoc = sql("describe formatted local1").collect
+    descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
+      case Some(row) => assert(row.get(1).toString.contains("20000"))
+    }
+    descLoc.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
+      case Some(row) => assert(row.get(1).toString.contains("true"))
+    }
+    descLoc.find(_.get(0).toString.contains("Local Dictionary Include")) match {
+      case Some(row) => assert(row.get(1).toString.contains("name,city,add2,add1"))
+    }
+  }
+
+  test("test alter add columns and set properties") {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int)
+        | STORED BY 'org.apache.carbondata.format' tblproperties('local_dictionary_enable'='true',
+        | 'local_dictionary_threshold'='20000','no_inverted_index'='name')
+      """.stripMargin)
+    sql("alter table local1 add columns(add1 string) tblproperties('local_dictionary_include'='add1')")
+    sql("alter table local1 set tblproperties('local_dictionary_include'='name')")
+    val descLoc = sql("describe formatted local1").collect
+    descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
+      case Some(row) => assert(row.get(1).toString.contains("20000"))
+    }
+    descLoc.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
+      case Some(row) => assert(row.get(1).toString.contains("true"))
+    }
+    descLoc.find(_.get(0).toString.contains("Local Dictionary Include")) match {
+      case Some(row) => assert(row.get(1).toString.contains("name") && !row.get(1).toString.contains("city,add2,add1"))
+    }
+  }
+
+  test("test alter add columns and set properties _002") {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int)
+        | STORED BY 'org.apache.carbondata.format' tblproperties('local_dictionary_enable'='true',
+        | 'local_dictionary_threshold'='20000','no_inverted_index'='name')
+      """.stripMargin)
+    sql("alter table local1 add columns(add1 string) tblproperties('local_dictionary_include'='add1')")
+    sql("alter table local1 set tblproperties('local_dictionary_enable'='false')")
+    val descLoc = sql("describe formatted local1").collect
+    descLoc.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
+      case Some(row) => assert(row.get(1).toString.contains("false"))
+    }
+  }
+
+  test("test alter set on complex columns __001") {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int,st struct<s_id:int,
+        | s_name:string,s_city:array<string>>, dcity array<string>)
+        | STORED BY 'org.apache.carbondata.format'
+        | tblproperties('local_dictionary_enable'='true')
+      """.
+        stripMargin)
+    sql("alter table local1 unset tblproperties('local_dictionary_exclude')")
+    sql("alter table local1 set tblproperties('local_dictionary_include'='st')")
+
+    val descFormatted1 = sql("describe formatted local1").collect
+    descFormatted1.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
+      case Some(row) => assert(row.get(1).toString.contains("true"))
+    }
+    descFormatted1.find(_.get(0).toString.contains("Local Dictionary Include")) match {
+      case Some(row) => assert(
+        row.get(1).toString.contains("st.s_name,st.s_city.val") &&
+        !row.get(1).toString.contains("dcity"))
+    }
+    sql("alter table local1 unset tblproperties('local_dictionary_include')")
+    sql("alter table local1 set tblproperties('local_dictionary_exclude'='st')")
+    val descFormatted2 = sql("describe formatted local1").collect
+    descFormatted2.find(_.get(0).toString.contains("Local Dictionary Exclude")) match {
+      case Some(row) => assert(row.get(1).toString.contains("st"))
+    }
+    descFormatted2.find(_.get(0).toString.contains("Local Dictionary Include")) match {
+      case Some(row) => assert(row.get(1).toString.contains("city,dcity"))
+    }
+    sql("alter table local1 set tblproperties('local_dictionary_exclude'='st'," +
+        "'local_dictionary_include'='dcity')")
+    val descFormatted3 = sql("describe formatted local1").collect
+    descFormatted3.find(_.get(0).toString.contains("Local Dictionary Exclude")) match {
+      case Some(row) => assert(row.get(1).toString.contains("st"))
+    }
+    descFormatted3.find(_.get(0).toString.contains("Local Dictionary Include")) match {
+      case Some(row) => assert(row.get(1).toString.contains("dcity"))
+    }
+  }
+
+  test("test alter set on complex columns __002") {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int,st struct<s_id:int,
+        | s_name:string,s_city:array<string>>, dcity array<string>)
+        | STORED BY 'org.apache.carbondata.format'
+        | tblproperties('local_dictionary_include'='st','local_dictionary_enable'='true')
+      """.
+        stripMargin)
+    sql("alter table local1 set tblproperties('local_dictionary_include'='dcity')")
+
+    val descFormatted1 = sql("describe formatted local1").collect
+    descFormatted1.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
+      case Some(row) => assert(row.get(1).toString.contains("true"))
+    }
+    descFormatted1.find(_.get(0).toString.contains("Local Dictionary Include")) match {
+      case Some(row) => assert(
+        row.get(1).toString.contains("dcity.val") &&
+        !row.get(1).toString.contains("st"))
+    }
+  }
+
+  test("test alter set on complex columns __003") {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int,st struct<s_id:int,
+        | s_city:array<string>,s_name:string>, dcity array<string>)
+        | STORED BY 'org.apache.carbondata.format'
+        | tblproperties('local_dictionary_include'='st','local_dictionary_enable'='true')
+      """.
+        stripMargin)
+    sql("alter table local1 unset tblproperties('local_dictionary_include')")
+    sql("alter table local1 set tblproperties('local_dictionary_exclude'='st')")
+    val descFormatted1 = sql("describe formatted local1").collect
+    descFormatted1.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
+      case Some(row) => assert(row.get(1).toString.contains("true"))
+    }
+    descFormatted1.find(_.get(0).toString.contains("Local Dictionary Include")) match {
+      case Some(row) => assert(
+        row.get(1).toString.contains("name,city,dcity.val") &&
+        !row.get(1).toString.contains("st"))
+    }
+    descFormatted1.find(_.get(0).toString.contains("Local Dictionary Exclude")) match {
+      case Some(row) => assert(
+        row.get(1).toString.contains("st.s_city.val,st.s_name"))
+    }
+  }
+
+  test("test alter set on complex columns __004") {
+    sql("drop table if exists local1")
+    sql(
+      """
+        | CREATE TABLE local1(id int, name string, city string, age int,st struct<s_id:int,
+        | s_city:array<string>,s_name:string>, dcity array<string>)
+        | STORED BY 'org.apache.carbondata.format'
+        | tblproperties('local_dictionary_include'='st,city,name','local_dictionary_exclude'='dcity','local_dictionary_enable'='true')
+      """.
+        stripMargin)
+    sql("alter table local1 unset tblproperties('local_dictionary_exclude')")
+    sql("alter table local1 set tblproperties('local_dictionary_include'='dcity')")
+    val descFormatted1 = sql("describe formatted local1").collect
+    descFormatted1.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
+      case Some(row) => assert(row.get(1).toString.contains("true"))
+    }
+    descFormatted1.find(_.get(0).toString.contains("Local Dictionary Include")) match {
+      case Some(row) => assert(
+        row.get(1).toString.contains("dcity.val"))
+    }
+  }
+
+
+  override protected def afterAll(): Unit = {
+    sql("DROP TABLE IF EXISTS LOCAL1")
+  }
+
+}

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/localdictionary/LocalDictionarySupportCreateTableTest.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/localdictionary/LocalDictionarySupportCreateTableTest.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.carbondata.spark.testsuite.localdictionary
 
 import org.apache.spark.sql.test.util.QueryTest
@@ -77,8 +94,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
     assert(exception.getMessage
       .contains(
         "LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE column:  does not exist in table. " +
-        "Please check " +
-        "create table statement"))
+        "Please check the DDL."))
   }
 
   test("test local dictionary custom configurations for local dict columns _004") {
@@ -95,9 +111,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
     assert(exception1.getMessage
       .contains(
         "LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE column: abc does not exist in table. " +
-        "Please check " +
-        "create table " +
-        "statement"))
+        "Please check the DDL."))
   }
 
   test("test local dictionary custom configurations for local dict columns _005") {
@@ -471,8 +485,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
     assert(exception.getMessage
       .contains(
         "LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE column:  does not exist in table. " +
-        "Please check " +
-        "create table statement"))
+        "Please check the DDL."))
 
   }
 
@@ -490,9 +503,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
     assert(exception1.getMessage
       .contains(
         "LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE column: abc does not exist in table. " +
-        "Please check " +
-        "create table " +
-        "statement"))
+        "Please check the DDL."))
   }
 
   test("test local dictionary custom configurations when enabled for local dict columns _005") {
@@ -563,7 +574,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
     assert(exception.getMessage
       .contains(
         "LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE contains Duplicate Columns: name. " +
-        "Please check create table statement."))
+        "Please check the DDL."))
   }
 
   test(
@@ -582,8 +593,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
     assert(exception.getMessage
       .contains(
         "LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE column:  does not exist in table. " +
-        "Please check " +
-        "create table statement"))
+        "Please check the DDL."))
 
   }
 
@@ -603,9 +613,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
     assert(exception1.getMessage
       .contains(
         "LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE column: abc does not exist in table. " +
-        "Please check " +
-        "create table " +
-        "statement"))
+        "Please check the DDL."))
   }
 
   test(
@@ -1675,8 +1683,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
     assert(exception.getMessage
       .contains(
         "LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE column:  does not exist in table. " +
-        "Please check " +
-        "create table statement"))
+        "Please check the DDL."))
 
   }
 
@@ -1703,9 +1710,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
     assert(exception1.getMessage
       .contains(
         "LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE column: abc does not exist in table. " +
-        "Please check " +
-        "create table " +
-        "statement"))
+        "Please check the DDL."))
   }
 
   test(
@@ -1829,8 +1834,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
     assert(exception.getMessage
       .contains(
         "LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE column:  does not exist in table. " +
-        "Please check " +
-        "create table statement"))
+        "Please check the DDL."))
   }
 
   test(
@@ -1856,9 +1860,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
     assert(exception1.getMessage
       .contains(
         "LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE column: abc does not exist in table. " +
-        "Please check " +
-        "create table " +
-        "statement"))
+        "Please check the DDL."))
   }
 
   test(
@@ -2339,311 +2341,6 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
       .contains(
         "None of the child columns specified in the complex dataType column(s) in " +
         "local_dictionary_include are not of string dataType."))
-  }
-
-  test("test alter table add column") {
-    sql("drop table if exists local1")
-    sql(
-      """
-        | CREATE TABLE local1(id int, name string, city string, age int)
-        | STORED BY 'org.apache.carbondata.format' tblproperties('local_dictionary_enable'='true',
-        | 'local_dictionary_threshold'='20000','local_dictionary_include'='city','no_inverted_index'='name')
-      """.stripMargin)
-    sql("alter table local1 add columns (alt string) tblproperties('local_dictionary_include'='alt')")
-    val descLoc = sql("describe formatted local1").collect
-    descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("20000"))
-    }
-    descLoc.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
-      case Some(row) => assert(row.get(1).toString.contains("true"))
-    }
-    descLoc.find(_.get(0).toString.contains("Local Dictionary Include")) match {
-      case Some(row) => assert(row.get(1).toString.contains("city,alt"))
-    }
-  }
-
-  test("test alter table add column default configs for local dictionary") {
-    sql("drop table if exists local1")
-    sql(
-      """
-        | CREATE TABLE local1(id int, name string, city string, age int)
-        | STORED BY 'org.apache.carbondata.format' tblproperties('local_dictionary_enable'='true',
-        | 'local_dictionary_threshold'='20000','no_inverted_index'='name')
-      """.stripMargin)
-    sql("alter table local1 add columns (alt string)")
-    val descLoc = sql("describe formatted local1").collect
-    descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("20000"))
-    }
-    descLoc.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
-      case Some(row) => assert(row.get(1).toString.contains("true"))
-    }
-    descLoc.find(_.get(0).toString.contains("Local Dictionary Include")) match {
-      case Some(row) => assert(row.get(1).toString.contains("name,city,alt"))
-    }
-  }
-
-  test("test alter table add column where same column is in dictionary include and local dictionary include") {
-    sql("drop table if exists local1")
-    sql(
-      """
-        | CREATE TABLE local1(id int, name string, city string, age int)
-        | STORED BY 'org.apache.carbondata.format' tblproperties('local_dictionary_enable'='true',
-        | 'local_dictionary_threshold'='20000','local_dictionary_include'='city','no_inverted_index'='name')
-      """.stripMargin)
-    val exception = intercept[MalformedCarbonCommandException] {
-      sql(
-        "alter table local1 add columns (alt string) tblproperties('local_dictionary_include'='alt','dictionary_include'='alt')")
-    }
-    assert(exception.getMessage
-      .contains(
-        "LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE column: alt specified in Dictionary " +
-        "include. Local Dictionary will not be generated for Dictionary include columns. Please " +
-        "check create table statement."))
-  }
-
-  test("test alter table add column where duplicate columns present in local dictionary include") {
-    sql("drop table if exists local1")
-    sql(
-      """
-        | CREATE TABLE local1(id int, name string, city string, age int)
-        | STORED BY 'org.apache.carbondata.format' tblproperties('local_dictionary_enable'='true',
-        | 'local_dictionary_threshold'='20000','local_dictionary_include'='city','no_inverted_index'='name')
-      """.stripMargin)
-    val exception = intercept[MalformedCarbonCommandException] {
-      sql(
-        "alter table local1 add columns (alt string) tblproperties('local_dictionary_include'='alt,alt')")
-    }
-    assert(exception.getMessage
-      .contains(
-        "LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE contains Duplicate Columns: alt. " +
-        "Please check create table statement."))
-  }
-
-  test("test alter table add column where duplicate columns present in local dictionary include/exclude")
-  {
-    sql("drop table if exists local1")
-    sql(
-      """
-        | CREATE TABLE local1(id int, name string, city string, age int)
-        | STORED BY 'org.apache.carbondata.format' tblproperties('local_dictionary_enable'='true',
-        | 'local_dictionary_threshold'='20000','local_dictionary_include'='city',
-        | 'no_inverted_index'='name')
-      """.stripMargin)
-    val exception1 = intercept[MalformedCarbonCommandException] {
-      sql(
-        "alter table local1 add columns (alt string) tblproperties" +
-        "('local_dictionary_include'='abc')")
-    }
-    assert(exception1.getMessage
-      .contains(
-        "LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE column: abc does not exist in table. " +
-        "Please check create table statement."))
-    val exception2 = intercept[MalformedCarbonCommandException] {
-      sql(
-        "alter table local1 add columns (alt string) tblproperties" +
-        "('local_dictionary_exclude'='abc')")
-    }
-    assert(exception2.getMessage
-      .contains(
-        "LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE column: abc does not exist in table. " +
-        "Please check create table statement."))
-  }
-
-  test("test alter table add column for datatype validation")
-  {
-    sql("drop table if exists local1")
-    sql(
-      """ | CREATE TABLE local1(id int, name string, city string, age int)
-        | STORED BY 'org.apache.carbondata.format' tblproperties('local_dictionary_enable'='true',
-        | 'local_dictionary_include'='city', 'no_inverted_index'='name')
-      """.stripMargin)
-    val exception = intercept[MalformedCarbonCommandException] {
-      sql(
-        "alter table local1 add columns (alt string,abc int) tblproperties" +
-        "('local_dictionary_include'='abc')")
-    }
-    assert(exception.getMessage
-      .contains(
-        "LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE column: abc is not a String/complex " +
-        "datatype column. LOCAL_DICTIONARY_COLUMN should be no dictionary string/complex datatype" +
-        " column.Please check create table statement."))
-  }
-
-  test("test alter table add column where duplicate columns are present in local dictionary include and exclude")
-  {
-    sql("drop table if exists local1")
-    sql(
-      """
-        | CREATE TABLE local1(id int, name string, city string, age int)
-        | STORED BY 'org.apache.carbondata.format' tblproperties('local_dictionary_enable'='true',
-        | 'local_dictionary_include'='city', 'no_inverted_index'='name')
-      """.stripMargin)
-    val exception = intercept[MalformedCarbonCommandException] {
-      sql(
-        "alter table local1 add columns (alt string,abc string) tblproperties" +
-        "('local_dictionary_include'='abc','local_dictionary_exclude'='alt,abc')")
-    }
-    assert(exception.getMessage
-      .contains(
-        "Column ambiguity as duplicate column(s):abc is present in LOCAL_DICTIONARY_INCLUDE " +
-        "and LOCAL_DICTIONARY_EXCLUDE. Duplicate columns are not allowed."))
-  }
-
-  test("test alter table add column unsupported table property")
-  {
-    sql("drop table if exists local1")
-    sql(
-      """
-        | CREATE TABLE local1(id int, name string, city string, age int)
-        | STORED BY 'org.apache.carbondata.format' tblproperties('local_dictionary_enable'='true',
-        | 'local_dictionary_include'='city', 'no_inverted_index'='name')
-      """.stripMargin)
-    val exception = intercept[MalformedCarbonCommandException] {
-      sql(
-        "alter table local1 add columns (alt string,abc string) tblproperties" +
-        "('local_dictionary_enable'='abc')")
-    }
-    assert(exception.getMessage
-      .contains(
-        "Unsupported Table property in add column: local_dictionary_enable"))
-    val exception1 = intercept[MalformedCarbonCommandException] {
-      sql(
-        "alter table local1 add columns (alt string,abc string) tblproperties" +
-        "('local_dictionary_threshold'='10000')")
-    }
-    assert(exception1.getMessage
-      .contains(
-        "Unsupported Table property in add column: local_dictionary_threshold"))
-  }
-
-  test("test alter table add column when main table is disabled for local dictionary")
-  {
-    sql("drop table if exists local1")
-    sql(
-      """
-        | CREATE TABLE local1(id int, name string, city string, age int)
-        | STORED BY 'org.apache.carbondata.format' tblproperties('local_dictionary_enable'='false',
-        | 'local_dictionary_include'='city', 'no_inverted_index'='name')
-      """.stripMargin)
-    sql(
-      "alter table local1 add columns (alt string,abc string) tblproperties" +
-      "('local_dictionary_include'='abc')")
-    val descLoc = sql("describe formatted local1").collect
-    descLoc.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
-      case Some(row) => assert(row.get(1).toString.contains("false"))
-    }
-
-    checkExistence(sql("DESC FORMATTED local1"), false,
-      "Local Dictionary Include")
-  }
-
-  test("test local dictionary threshold for boundary values") {
-    sql("drop table if exists local1")
-    sql(
-      """
-        | CREATE TABLE local1(id int, name string, city string, age int)
-        | STORED BY 'org.apache.carbondata.format' tblproperties('local_dictionary_threshold'='300000')
-      """.stripMargin)
-    val descLoc = sql("describe formatted local1").collect
-    descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("10000"))
-    }
-    sql("drop table if exists local1")
-    sql(
-      """
-        | CREATE TABLE local1(id int, name string, city string, age int)
-        | STORED BY 'org.apache.carbondata.format' tblproperties('local_dictionary_threshold'='500')
-      """.stripMargin)
-    val descLoc1 = sql("describe formatted local1").collect
-    descLoc1.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("10000"))
-    }
-  }
-
-  test("test alter table add column for local dictionary include and exclude configs")
-  {
-    sql("drop table if exists local1")
-    sql(
-      """
-        | CREATE TABLE local1(id int, name string, city string, age int)
-        | STORED BY 'org.apache.carbondata.format' tblproperties('local_dictionary_enable'='true',
-        | 'local_dictionary_include'='city', 'no_inverted_index'='name')
-      """.stripMargin)
-    sql(
-      "alter table local1 add columns (alt string,abc string) tblproperties" +
-      "('local_dictionary_include'='abc','local_dictionary_exclude'='alt')")
-    val descLoc = sql("describe formatted local1").collect
-    descLoc.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
-      case Some(row) => assert(row.get(1).toString.contains("true"))
-    }
-    descLoc.find(_.get(0).toString.contains("Local Dictionary Include")) match {
-      case Some(row) => assert(row.get(1).toString.contains("city,abc"))
-    }
-    descLoc.find(_.get(0).toString.contains("Local Dictionary Exclude")) match {
-      case Some(row) => assert(row.get(1).toString.contains("alt"))
-    }
-  }
-
-  test("test preaggregate table local dictionary enabled table")
-  {
-    sql("drop table if exists local1")
-    sql("CREATE TABLE local1 (id Int, date date, country string, phonetype string, " +
-        "serialname String,salary int ) STORED BY 'org.apache.carbondata.format' " +
-        "tblproperties('dictionary_include'='country','local_dictionary_enable'='true','local_dictionary_include' = 'phonetype','local_dictionary_exclude' ='serialname')")
-    sql("create datamap PreAggCount on table local1 using 'preaggregate' as " +
-        "select country,count(salary) as count from local1 group by country")
-    val descLoc = sql("describe formatted local1_PreAggCount").collect
-    descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("10000"))
-    }
-    descLoc.find(_.get(0).toString.contains("Local Dictionary Include")) match {
-      case Some(row) => assert(row.get(1).toString.contains("phonetype"))
-    }
-    descLoc.find(_.get(0).toString.contains("Local Dictionary Exclude")) match {
-      case Some(row) => assert(row.get(1).toString.contains("serialname"))
-    }
-    descLoc.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
-      case Some(row) => assert(row.get(1).toString.contains("true"))
-    }
-  }
-
-  test("test local dictionary foer varchar datatype columns") {
-    sql("drop table if exists local1")
-    sql(
-      """
-        | CREATE TABLE local1(id int, name string, city string, age int)
-        | STORED BY 'org.apache.carbondata.format' tblproperties('local_dictionary_include'='city',
-        | 'LONG_STRING_COLUMNS'='city')
-      """.stripMargin)
-    val descLoc = sql("describe formatted local1").collect
-    descLoc.find(_.get(0).toString.contains("Local Dictionary Include")) match {
-      case Some(row) => assert(row.get(1).toString.contains("city"))
-    }
-    descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("10000"))
-    }
-  }
-
-  test("test local dictionary describe formatted only with default configs")
-  {
-    sql("drop table if exists local1")
-    sql(
-      """
-        | CREATE TABLE local1(id int, name string, city string, age int)
-        | STORED BY 'carbondata'
-      """.stripMargin)
-
-    val descLoc = sql("describe formatted local1").collect
-    descLoc.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
-      case Some(row) => assert(row.get(1).toString.contains("true"))
-    }
-    descLoc.find(_.get(0).toString.contains("Local Dictionary Threshold")) match {
-      case Some(row) => assert(row.get(1).toString.contains("10000"))
-    }
-    descLoc.find(_.get(0).toString.contains("Local Dictionary Include")) match {
-      case Some(row) => assert(row.get(1).toString.contains("name,city"))
-    }
   }
 
   override protected def afterAll(): Unit = {

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/CarbonScalaUtil.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/CarbonScalaUtil.scala
@@ -636,7 +636,7 @@ object CarbonScalaUtil {
       val errMsg =
         "LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE contains Duplicate Columns: " +
         duplicateColumns.mkString(",") +
-        ". Please check create table statement."
+        ". Please check the DDL."
       throw new MalformedCarbonCommandException(errMsg)
     }
 
@@ -652,8 +652,7 @@ object CarbonScalaUtil {
           val errormsg = "LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE column: " +
                          commonColumn.mkString(",") +
                          " specified in Dictionary include. Local Dictionary will not be " +
-                         "generated for Dictionary include columns. Please check create table " +
-                         "statement."
+                         "generated for Dictionary include columns. Please check the DDL."
           throw new MalformedCarbonCommandException(errormsg)
         }
       }

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
@@ -452,7 +452,7 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
     localDictColumns.foreach { distCol =>
       if (!fields.exists(x => x.column.equalsIgnoreCase(distCol.trim))) {
         val errormsg = "LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE column: " + distCol.trim +
-                       " does not exist in table. Please check create table statement."
+                       " does not exist in table. Please check the DDL."
         throw new MalformedCarbonCommandException(errormsg)
       }
     }
@@ -467,8 +467,7 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
         val errormsg = "LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE column: " +
                        dictColm.trim +
                        " is not a String/complex datatype column. LOCAL_DICTIONARY_COLUMN should " +
-                       "be no dictionary string/complex datatype column.Please check create table" +
-                       " statement."
+                       "be no dictionary string/complex datatype column.Please check the DDL."
         throw new MalformedCarbonCommandException(errormsg)
       }
     }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/schema/CarbonAlterTableDropColumnCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/schema/CarbonAlterTableDropColumnCommand.scala
@@ -75,6 +75,16 @@ private[sql] case class CarbonAlterTableDropColumnCommand(
                                                   s"$partitionColumns")
         }
       }
+
+      // Check if column to be dropped is of complex dataType
+      alterTableDropColumnModel.columns.foreach { column =>
+        if (carbonTable.getColumnByName(alterTableDropColumnModel.tableName, column).getDataType
+          .isComplexType) {
+          val errMsg = "Complex column cannot be dropped"
+          throw new MalformedCarbonCommandException(errMsg)
+        }
+      }
+
       val tableColumns = carbonTable.getCreateOrderColumn(tableName).asScala
       var dictionaryColumns = Seq[org.apache.carbondata.core.metadata.schema.table.column
       .ColumnSchema]()

--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/restructure/vectorreader/DropColumnTestCases.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/restructure/vectorreader/DropColumnTestCases.scala
@@ -112,6 +112,15 @@ class DropColumnTestCases extends Spark2QueryTest with BeforeAndAfterAll {
     sql("drop table if exists preaggMain_preagg1")
   }
 
+  test("test dropping of complex column should throw exception") {
+    sql("drop table if exists maintbl")
+    sql("create table maintbl (a string, b string, c struct<si:int>) stored by 'carbondata'")
+    assert(intercept[ProcessMetaDataException] {
+      sql("alter table maintbl drop columns(b,c)").show
+    }.getMessage.contains("Complex column cannot be dropped"))
+    sql("drop table if exists maintbl")
+  }
+
   override def afterAll {
     sql("DROP TABLE IF EXISTS dropcolumntest")
     sql("DROP TABLE IF EXISTS hivetable")


### PR DESCRIPTION
Dependent on #2401

**What changes were proposed in this pull request?**

In this PR,
Added test cases for local dictionary support for alter table, set, unset and pre-aggregate
All the validations related to above features are taken care in this PR

**How was this patch tested?**
Test case were executed on a 3 node cluster and the same were automated and added as SDV test cases