### PR TITLE
[CARBONDATA-2647] [CARBONDATA-2648] Fix cache level display in describe formatted command

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/alterTable/TestAlterTableWithColumnMetCacheAndCacheLevelProperty.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/alterTable/TestAlterTableWithColumnMetCacheAndCacheLevelProperty.scala
@@ -160,6 +160,25 @@ class TestAlterTableWithColumnMetCacheAndCacheLevelProperty extends QueryTest wi
     checkExistence(descResult, true, "CACHE_LEVEL")
   }
 
+  test("validate column_meta_cache and cache_level on child dataMap- ALTER_CACHE_LEVEL_07") {
+    intercept [Exception] {
+      sql("CREATE DATAMAP agg1 ON TABLE alter_column_meta_cache USING 'preaggregate' DMPROPERTIES('column_meta_cache'='c2') AS SELECT c2,sum(c3) FROM alter_column_meta_cache GROUP BY c2")
+    }
+
+    intercept [Exception] {
+      sql("CREATE DATAMAP agg1 ON TABLE alter_column_meta_cache USING 'preaggregate' DMPROPERTIES('cache_level'='blocklet') AS SELECT c2,sum(c3) FROM alter_column_meta_cache GROUP BY c2")
+    }
+
+    // create datamap
+    sql("CREATE DATAMAP agg1 ON TABLE alter_column_meta_cache USING 'preaggregate' AS SELECT c2,sum(c3) FROM alter_column_meta_cache GROUP BY c2")
+    intercept [Exception] {
+      sql("Alter table alter_column_meta_cache_agg1 SET TBLPROPERTIES('column_meta_cache'='c2')")
+    }
+    intercept [Exception] {
+      sql("Alter table alter_column_meta_cache_agg1 SET TBLPROPERTIES('cache_level'='BLOCKLET')")
+    }
+  }
+
   override def afterAll: Unit = {
     // drop table
     dropTable

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/CommonUtil.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/CommonUtil.scala
@@ -976,9 +976,7 @@ object CommonUtil {
         }
         // check if the column exists in the table
         if (!tableColumns.contains(col.toLowerCase)) {
-          val errorMessage = s"Column $col does not exists in the table ${
-            databaseName
-          }.${ tableIdentifier.table }"
+          val errorMessage = s"Column $col does not exists in the table ${ tableIdentifier.table }"
           throw new MalformedCarbonCommandException(errorMessage)
         }
       })

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
@@ -384,8 +384,9 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
     if (tableProperties.get(CarbonCommonConstants.COLUMN_META_CACHE).isDefined) {
       // validate the column_meta_cache option
       val tableColumns = dims.map(x => x.name.get) ++ msrs.map(x => x.name.get)
-      CommonUtil.validateColumnMetaCacheFields(tableName,
+      CommonUtil.validateColumnMetaCacheFields(
         dbName.getOrElse(CarbonCommonConstants.DATABASE_DEFAULT_NAME),
+        tableName,
         tableColumns,
         tableProperties.get(CarbonCommonConstants.COLUMN_META_CACHE).get,
         tableProperties)

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonDescribeFormattedCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonDescribeFormattedCommand.scala
@@ -109,7 +109,8 @@ private[sql] case class CarbonDescribeFormattedCommand(
       .LOAD_SORT_SCOPE_DEFAULT), tblProps.asScala.getOrElse("sort_scope", CarbonCommonConstants
       .LOAD_SORT_SCOPE_DEFAULT)))
     // add Cache Level property
-    results ++= Seq(("CACHE_LEVEL", tblProps.getOrDefault("CACHE_LEVEL", "BLOCK"), ""))
+    results ++= Seq(("CACHE_LEVEL", tblProps.asScala.getOrElse(CarbonCommonConstants.CACHE_LEVEL,
+      CarbonCommonConstants.CACHE_LEVEL_DEFAULT_VALUE), ""))
     val isStreaming = tblProps.asScala.getOrElse("streaming", "false")
     results ++= Seq(("Streaming", isStreaming, ""))
     val isLocalDictEnabled = tblProps.asScala


### PR DESCRIPTION
Things done as part of this PR
1. Correct CACHE_LEVEL display in describe formatted command. It was always displays BLOCK even though val was configured BLOCKLET.
2. Correct the method arguments to pass dbName first and then tableName.
3. Added test case for blocking column_meta_cache and cache_level on child dataMaps.

 - [ ] Any interfaces changed?
 No
 - [ ] Any backward compatibility impacted?
 No
 - [ ] Document update required?
No
 - [ ] Testing done
UT added       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA
