### PR TITLE
[CARBONDATA-2675][32K] Support config long_string_columns when create datamap

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggCreateCommand.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggCreateCommand.scala
@@ -274,7 +274,8 @@ class TestPreAggCreateCommand extends QueryTest with BeforeAndAfterAll {
            | GROUP BY dob,name
        """.stripMargin)
     }
-    assert(e.getMessage.contains("Only 'path' and 'partitioning' dmproperties are allowed for this datamap"))
+    assert(e.getMessage.contains("Only 'path', 'partitioning' and 'long_string_columns' dmproperties "
+      + "are allowed for this datamap"))
     sql("DROP TABLE IF EXISTS maintabletime")
   }
 

--- a/integration/spark2/src/main/java/org/apache/carbondata/datamap/PreAggregateDataMapProvider.java
+++ b/integration/spark2/src/main/java/org/apache/carbondata/datamap/PreAggregateDataMapProvider.java
@@ -22,6 +22,7 @@ import java.util.Map;
 
 import org.apache.carbondata.common.annotations.InterfaceAudience;
 import org.apache.carbondata.common.exceptions.sql.MalformedDataMapCommandException;
+import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.datamap.DataMapCatalog;
 import org.apache.carbondata.core.datamap.DataMapProvider;
 import org.apache.carbondata.core.datamap.dev.DataMapFactory;
@@ -63,9 +64,11 @@ public class PreAggregateDataMapProvider extends DataMapProvider {
       properties.remove(DataMapProperty.DEFERRED_REBUILD);
       properties.remove(DataMapProperty.PATH);
       properties.remove(DataMapProperty.PARTITIONING);
+      properties.remove(CarbonCommonConstants.LONG_STRING_COLUMNS);
       if (properties.size() > 0) {
         throw new MalformedDataMapCommandException(
-                "Only 'path' and 'partitioning' dmproperties are allowed for this datamap");
+                "Only 'path', 'partitioning' and 'long_string_columns' dmproperties " +
+                "are allowed for this datamap");
       }
     }
   }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/preaaggregate/PreAggregateTableHelper.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/preaaggregate/PreAggregateTableHelper.scala
@@ -107,11 +107,13 @@ case class PreAggregateTableHelper(
       parentTable.getTableInfo.getFactTable.getTableProperties.asScala.getOrElse(
         CarbonCommonConstants.FLAT_FOLDER, CarbonCommonConstants.DEFAULT_FLAT_FOLDER))
 
-    // update column name with prefix for long_string_column
+    // Datamap table name and columns are automatically added prefix with parent table name
+    // in carbon. For convenient, users can type column names same as the ones in select statement
+    // when config dmproperties, and here we update column names with prefix.
     val longStringColumn = tableProperties.get(CarbonCommonConstants.LONG_STRING_COLUMNS)
     if (longStringColumn != None) {
       val fieldNames = fields.map(_.column)
-      val newLongStringColumn = longStringColumn.get.split(",").map(_.trim).map(colName => {
+      val newLongStringColumn = longStringColumn.get.split(",").map(_.trim).map{ colName =>
         val newColName = parentTable.getTableName.toLowerCase() + "_" + colName
         if (!fieldNames.contains(newColName)) {
           throw new MalformedDataMapCommandException(
@@ -119,7 +121,7 @@ case class PreAggregateTableHelper(
               + " does not in datamap")
         }
         newColName
-      })
+      }
       tableProperties.put(CarbonCommonConstants.LONG_STRING_COLUMNS,
         newLongStringColumn.mkString(","))
     }


### PR DESCRIPTION
Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 


Create datamap use select statement, but long string column is defined with StringType in the result dataframe if this column is selected. This PR allows to set long_string_columns property in dmproperties. 

FYI: SORT_COLUMNS/SORT_SCOPE/TABLE_BLOCKSIZE/FLAT_FOLDER  properties  are set automatically based on parent table currently.