### PR TITLE
[CARBONDATA-2676]Support local Dictionary for SDK Writer

### DIFF
--- a/docs/sdk-guide.md
+++ b/docs/sdk-guide.md
@@ -253,6 +253,23 @@ public CarbonWriterBuilder withBlockletSize(int blockletSize);
 
 ```
 /**
+   * @param enableLocalDictionary enable local dictionary  , default is false
+   * @return updated CarbonWriterBuilder
+   */
+public CarbonWriterBuilder enableLocalDictionary(boolean enableLocalDictionary);
+```
+
+```
+/**
+   * @param localDictionaryThreshold is localDictionaryThreshold,default is 1000
+   * @return updated CarbonWriterBuilder
+   */
+public CarbonWriterBuilder localDictionaryThreshold(int localDictionaryThreshold) ;
+```
+
+
+```
+/**
 * sets the list of columns that needs to be in sorted order
 * @param sortColumns is a string array of columns that needs to be sorted.
 *                    If it is null or by default all dimensions are selected for sorting

--- a/docs/sdk-guide.md
+++ b/docs/sdk-guide.md
@@ -261,7 +261,7 @@ public CarbonWriterBuilder enableLocalDictionary(boolean enableLocalDictionary);
 
 ```
 /**
-   * @param localDictionaryThreshold is localDictionaryThreshold,default is 1000
+   * @param localDictionaryThreshold is localDictionaryThreshold,default is 10000
    * @return updated CarbonWriterBuilder
    */
 public CarbonWriterBuilder localDictionaryThreshold(int localDictionaryThreshold) ;

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestNonTransactionalCarbonTable.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestNonTransactionalCarbonTable.scala
@@ -1053,7 +1053,7 @@ class TestNonTransactionalCarbonTable extends QueryTest with BeforeAndAfterAll {
       json: String) = {
     // conversion to GenericData.Record
     val nn = new avro.Schema.Parser().parse(mySchema)
-    val record = avroUtil.jsonToAvro(json, mySchema)
+    val record = testUtil.jsonToAvro(json, mySchema)
     try {
       val writer = CarbonWriter.builder
         .outputPath(writerPath).isTransactionalTable(false)
@@ -2027,7 +2027,7 @@ class TestNonTransactionalCarbonTable extends QueryTest with BeforeAndAfterAll {
       """{"id": 101,"course_details": { "course_struct_course_time":"2014-01-05"  }}""".stripMargin
 
     val nn = new org.apache.avro.Schema.Parser().parse(schema1)
-    val record = avroUtil.jsonToAvro(json1, schema1)
+    val record = testUtil.jsonToAvro(json1, schema1)
 
     assert(intercept[RuntimeException] {
       val writer = CarbonWriter.builder.sortBy(Array("name", "id"))
@@ -2068,7 +2068,7 @@ class TestNonTransactionalCarbonTable extends QueryTest with BeforeAndAfterAll {
       """{"id": null,"course_details": { "course_struct_course_time":"2014-01-05"  }}""".stripMargin
 
     val nn = new org.apache.avro.Schema.Parser().parse(schema1)
-    val record = avroUtil.jsonToAvro(json1, schema1)
+    val record = testUtil.jsonToAvro(json1, schema1)
 
     val writer = CarbonWriter.builder
       .outputPath(writerPath).isTransactionalTable(false).buildWriterForAvroInput(nn)
@@ -2106,7 +2106,7 @@ class TestNonTransactionalCarbonTable extends QueryTest with BeforeAndAfterAll {
     val json1 =
       """{"id": 101,"course_details": { "course_struct_course_time":"2014-01-05 00:00:00"  }}""".stripMargin
     val nn = new org.apache.avro.Schema.Parser().parse(schema1)
-    val record = avroUtil.jsonToAvro(json1, schema1)
+    val record = testUtil.jsonToAvro(json1, schema1)
 
     val writer = CarbonWriter.builder.sortBy(Array("id"))
       .outputPath(writerPath).isTransactionalTable(false).buildWriterForAvroInput(nn)
@@ -2150,7 +2150,7 @@ class TestNonTransactionalCarbonTable extends QueryTest with BeforeAndAfterAll {
       """{"id": 101, "entries": [ {"id":1234}, {"id":3212}  ]}""".stripMargin
 
     val nn = new org.apache.avro.Schema.Parser().parse(schema)
-    val record = avroUtil.jsonToAvro(json1, schema)
+    val record = testUtil.jsonToAvro(json1, schema)
 
     val writer = CarbonWriter.builder
       .outputPath(writerPath).isTransactionalTable(false).buildWriterForAvroInput(nn)
@@ -2190,7 +2190,7 @@ class TestNonTransactionalCarbonTable extends QueryTest with BeforeAndAfterAll {
     val json1 =
       """{"id": 101, "course_details": { "course_struct_course_time":10}}""".stripMargin
     val nn = new org.apache.avro.Schema.Parser().parse(schema1)
-    val record = avroUtil.jsonToAvro(json1, schema1)
+    val record = testUtil.jsonToAvro(json1, schema1)
 
     val writer = CarbonWriter.builder
       .outputPath(writerPath).isTransactionalTable(false).buildWriterForAvroInput(nn)
@@ -2236,7 +2236,7 @@ class TestNonTransactionalCarbonTable extends QueryTest with BeforeAndAfterAll {
       """{"id": 172800000,"course_details": { "course_struct_course_time":172800000}}""".stripMargin
 
     val nn = new org.apache.avro.Schema.Parser().parse(schema1)
-    val record = avroUtil.jsonToAvro(json1, schema1)
+    val record = testUtil.jsonToAvro(json1, schema1)
 
     val writer = CarbonWriter.builder
       .outputPath(writerPath).isTransactionalTable(false).buildWriterForAvroInput(nn)
@@ -2282,7 +2282,7 @@ class TestNonTransactionalCarbonTable extends QueryTest with BeforeAndAfterAll {
       """{"id": 172800000000,"course_details": { "course_struct_course_time":172800000000}}""".stripMargin
 
     val nn = new org.apache.avro.Schema.Parser().parse(schema1)
-    val record = avroUtil.jsonToAvro(json1, schema1)
+    val record = testUtil.jsonToAvro(json1, schema1)
 
 
     val writer = CarbonWriter.builder
@@ -2303,7 +2303,7 @@ class TestNonTransactionalCarbonTable extends QueryTest with BeforeAndAfterAll {
       .uniqueIdentifier(System.currentTimeMillis).taskNo(System.nanoTime).outputPath(writerPath)
     generateCarbonData(builder)
     assert(FileFactory.getCarbonFile(writerPath).exists())
-    assert(avroUtil.checkForLocalDictionary(avroUtil.getDimRawChunk(0,writerPath)))
+    assert(testUtil.checkForLocalDictionary(testUtil.getDimRawChunk(0,writerPath)))
     sql("DROP TABLE IF EXISTS sdkTable")
     sql(
       s"""CREATE EXTERNAL TABLE sdkTable STORED BY 'carbondata' LOCATION
@@ -2329,7 +2329,7 @@ class TestNonTransactionalCarbonTable extends QueryTest with BeforeAndAfterAll {
       .uniqueIdentifier(System.currentTimeMillis).taskNo(System.nanoTime).outputPath(writerPath)
     generateCarbonData(builder)
     assert(FileFactory.getCarbonFile(writerPath).exists())
-    assert(avroUtil.checkForLocalDictionary(avroUtil.getDimRawChunk(0,writerPath)))
+    assert(testUtil.checkForLocalDictionary(testUtil.getDimRawChunk(0,writerPath)))
     sql("DROP TABLE IF EXISTS sdkTable")
     sql(
       s"""CREATE EXTERNAL TABLE sdkTable STORED BY 'carbondata' LOCATION
@@ -2355,7 +2355,7 @@ class TestNonTransactionalCarbonTable extends QueryTest with BeforeAndAfterAll {
       .uniqueIdentifier(System.currentTimeMillis).taskNo(System.nanoTime).outputPath(writerPath)
     generateCarbonData(builder)
     assert(FileFactory.getCarbonFile(writerPath).exists())
-    assert(!avroUtil.checkForLocalDictionary(avroUtil.getDimRawChunk(0,writerPath)))
+    assert(!testUtil.checkForLocalDictionary(testUtil.getDimRawChunk(0,writerPath)))
     sql("DROP TABLE IF EXISTS sdkTable")
     sql(
       s"""CREATE EXTERNAL TABLE sdkTable STORED BY 'carbondata' LOCATION
@@ -2381,7 +2381,7 @@ class TestNonTransactionalCarbonTable extends QueryTest with BeforeAndAfterAll {
       .uniqueIdentifier(System.currentTimeMillis).taskNo(System.nanoTime).outputPath(writerPath)
     generateCarbonData(builder)
     assert(FileFactory.getCarbonFile(writerPath).exists())
-    assert(avroUtil.checkForLocalDictionary(avroUtil.getDimRawChunk(0,writerPath)))
+    assert(testUtil.checkForLocalDictionary(testUtil.getDimRawChunk(0,writerPath)))
     sql("DROP TABLE IF EXISTS sdkTable")
     sql(
       s"""CREATE EXTERNAL TABLE sdkTable STORED BY 'carbondata' LOCATION
@@ -2389,7 +2389,7 @@ class TestNonTransactionalCarbonTable extends QueryTest with BeforeAndAfterAll {
     FileUtils.deleteDirectory(new File(writerPath))
     sql("insert into sdkTable select 's1','s2',23 ")
     assert(FileFactory.getCarbonFile(writerPath).exists())
-    assert(avroUtil.checkForLocalDictionary(avroUtil.getDimRawChunk(0,writerPath)))
+    assert(testUtil.checkForLocalDictionary(testUtil.getDimRawChunk(0,writerPath)))
     val descLoc = sql("describe formatted sdkTable").collect
     descLoc.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
       case Some(row) => assert(row.get(1).toString.contains("true"))
@@ -2424,7 +2424,7 @@ class TestNonTransactionalCarbonTable extends QueryTest with BeforeAndAfterAll {
 }
 
 
-object avroUtil{
+object testUtil{
 
   def jsonToAvro(json: String, avroSchema: String): GenericRecord = {
     var input: InputStream = null

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestNonTransactionalCarbonTableWithComplexType.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestNonTransactionalCarbonTableWithComplexType.scala
@@ -62,7 +62,7 @@ class TestNonTransactionalCarbonTableWithComplexType extends QueryTest with Befo
   private def WriteFilesWithAvroWriter(rows: Int, mySchema: String, json: String, isLocalDictionary: Boolean): Unit = {
     // conversion to GenericData.Record
     val nn = new avro.Schema.Parser().parse(mySchema)
-    val record = avroUtil.jsonToAvro(json, mySchema)
+    val record = testUtil.jsonToAvro(json, mySchema)
     try {
       val writer = if (isLocalDictionary) {
         CarbonWriter.builder
@@ -214,7 +214,7 @@ class TestNonTransactionalCarbonTableWithComplexType extends QueryTest with Befo
       s"""CREATE EXTERNAL TABLE localComplex STORED BY 'carbondata' LOCATION
          |'$writerPath' """.stripMargin)
     assert(FileFactory.getCarbonFile(writerPath).exists())
-    assert(avroUtil.checkForLocalDictionary(avroUtil.getDimRawChunk(0,writerPath)))
+    assert(testUtil.checkForLocalDictionary(testUtil.getDimRawChunk(0,writerPath)))
     sql("describe formatted localComplex").show(30, false)
     val descLoc = sql("describe formatted localComplex").collect
     descLoc.find(_.get(0).toString.contains("Local Dictionary Enabled")) match {
@@ -272,7 +272,7 @@ class TestNonTransactionalCarbonTableWithComplexType extends QueryTest with Befo
         |}
       """.stripMargin
     val pschema= org.apache.avro.Schema.parse(mySchema)
-    val records = avroUtil.jsonToAvro(jsonvalue, mySchema)
+    val records = testUtil.jsonToAvro(jsonvalue, mySchema)
     val writer=CarbonWriter.builder().outputPath(writerPath).buildWriterForAvroInput(pschema)
     writer.write(records)
     writer.close()

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonWriterBuilder.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonWriterBuilder.java
@@ -67,6 +67,8 @@ public class CarbonWriterBuilder {
   private long UUID;
   private Map<String, String> options;
   private String taskNo;
+  private int localDictionaryThreshold;
+  private boolean isLocalDictionaryEnabled;
 
   /**
    * Sets the output path of the writer builder
@@ -285,6 +287,29 @@ public class CarbonWriterBuilder {
   }
 
   /**
+   * @param localDictionaryThreshold is localDictionaryThreshold,default is 1000
+   * @return updated CarbonWriterBuilder
+   */
+  public CarbonWriterBuilder localDictionaryThreshold(int localDictionaryThreshold) {
+    if (localDictionaryThreshold <= 0) {
+      throw new IllegalArgumentException(
+          "Local Dictionary Threshold should be between greater than 0");
+    }
+    this.localDictionaryThreshold = localDictionaryThreshold;
+    return this;
+  }
+
+  /**
+   * @param enableLocalDictionary enable local dictionary  , default is false
+   * @return updated CarbonWriterBuilder
+   */
+  public CarbonWriterBuilder enableLocalDictionary(boolean enableLocalDictionary) {
+    this.isLocalDictionaryEnabled = enableLocalDictionary;
+    return this;
+  }
+
+
+  /**
    * To set the blocklet size of CarbonData file
    * @param blockletSize is blocklet size in MB
    * default value is 64 MB
@@ -393,7 +418,8 @@ public class CarbonWriterBuilder {
     if (blockletSize > 0) {
       tableSchemaBuilder = tableSchemaBuilder.blockletSize(blockletSize);
     }
-
+    tableSchemaBuilder.enableLocalDictionary(isLocalDictionaryEnabled);
+    tableSchemaBuilder.localDictionaryThreshold(localDictionaryThreshold);
     List<String> sortColumnsList = new ArrayList<>();
     if (sortColumns == null) {
       // If sort columns are not specified, default set all dimensions to sort column.

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonWriterBuilder.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonWriterBuilder.java
@@ -287,7 +287,7 @@ public class CarbonWriterBuilder {
   }
 
   /**
-   * @param localDictionaryThreshold is localDictionaryThreshold,default is 1000
+   * @param localDictionaryThreshold is localDictionaryThreshold,default is 10000
    * @return updated CarbonWriterBuilder
    */
   public CarbonWriterBuilder localDictionaryThreshold(int localDictionaryThreshold) {


### PR DESCRIPTION
Currently local dictionary is supported for managed table which is created using sql .
We it should be supported for SDK Writer also.
This PR contains 
a. Interface to supply dictionary threshold & Boolean  to enable dictionary.
b. DataLoading flow 

**Yet to support** 
a. Query Flow of Local dictionary (it will be done when normal table start supports for same)
b. External Table loading and Query .


Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 Existing Interface is not changed added new method
 - [ ] Any backward compatibility impacted?
 NA
 - [ ] Document update required?
NO
 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
Added UT
        - How it is tested? Please attach test report.
UT is added
        - Is it a performance related change? Please attach the performance test report.
   NO        
- Any additional information to help reviewers in testing this change.
       NO
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NO
