### PR TITLE
 [CARBONDATA-2606][Complex DataType Enhancements]Fixed Projection Pushdown when Select filter contains Struct column

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonDatasourceHadoopRelation.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonDatasourceHadoopRelation.scala
@@ -69,6 +69,7 @@ case class CarbonDatasourceHadoopRelation(
   override def schema: StructType = tableSchema.getOrElse(carbonRelation.schema)
 
   def buildScan(requiredColumns: Array[String],
+      filterComplex: Seq[org.apache.spark.sql.catalyst.expressions.Expression],
       projects: Seq[NamedExpression],
       filters: Array[Filter],
       partitions: Seq[PartitionSpec]): RDD[InternalRow] = {
@@ -76,76 +77,84 @@ case class CarbonDatasourceHadoopRelation(
       CarbonFilters.createCarbonFilter(schema, filter)
     }.reduceOption(new AndExpression(_, _))
 
-    var parentColumn = new ListBuffer[String]
-    // In case of Struct or StructofStruct Complex type, get the project column for given
-    // parent/child field and pushdown the corresponding project column. In case of Array,
-    // ArrayofStruct or StructofArray, pushdown parent column
-    var reqColumns = projects.map {
-      case a@Alias(s: GetStructField, name) =>
-        var arrayTypeExists = false
-        var ifGetArrayItemExists = s
-        breakable({
-          while (ifGetArrayItemExists.containsChild != null) {
-            if (ifGetArrayItemExists.child.isInstanceOf[AttributeReference]) {
-              arrayTypeExists = s.childSchema.toString().contains("ArrayType")
-              break
-            } else {
-              if (ifGetArrayItemExists.child.isInstanceOf[GetArrayItem]) {
-                arrayTypeExists = true
-                break
-              }
-              else {
-                ifGetArrayItemExists = ifGetArrayItemExists.child.asInstanceOf[GetStructField]
-              }
-            }
-          }
-        })
-        if (!arrayTypeExists) {
-          parentColumn += s.toString().split("\\.")(0).replaceAll("#.*", "").toLowerCase
-          parentColumn = parentColumn.distinct
-          s.toString().replaceAll("#[0-9]*", "").toLowerCase
-        } else {
-          s.toString().split("\\.")(0).replaceAll("#.*", "").toLowerCase
-        }
-      case a@Alias(s: GetArrayItem, name) =>
-        s.toString().split("\\.")(0).replaceAll("#.*", "").toLowerCase
-      case attributeReference: AttributeReference =>
-        var columnName: String = attributeReference.name
-        requiredColumns.foreach(colName =>
-          if (colName.equalsIgnoreCase(attributeReference.name)) {
-            columnName = colName
-          })
-        columnName
-      case other =>
-        None
-    }
-
-    reqColumns = reqColumns.filter(col => !col.equals(None))
-    var output = new ListBuffer[String]
-
-    if (null != requiredColumns && requiredColumns.nonEmpty) {
-      requiredColumns.foreach(col => {
-
-        if (null != reqColumns && reqColumns.nonEmpty) {
-          reqColumns.foreach(reqCol => {
-            if (!reqCol.toString.equalsIgnoreCase(col) &&
-                !reqCol.toString.startsWith(col.toLowerCase + ".") &&
-                !parentColumn.contains(col.toLowerCase)) {
-              output += col
-            } else {
-              output += reqCol.toString
-            }
-          })
-        } else {
-          output += col
-        }
-        output = output.distinct
-      })
-    }
-
     val projection = new CarbonProjection
-    output.toArray.foreach(projection.addColumn)
 
+    // As Filter pushdown for Complex datatype is not supported, if filter is applied on complex
+    // column, then Projection pushdown on Complex Columns will not take effect. Hence, check if
+    // filter contains Struct Complex Column.
+    val complexFilterExists = filterComplex.map(col =>
+      col.map(_.isInstanceOf[GetStructField]))
+
+    if (!complexFilterExists.exists(f => f.contains(true))) {
+      var parentColumn = new ListBuffer[String]
+      // In case of Struct or StructofStruct Complex type, get the project column for given
+      // parent/child field and pushdown the corresponding project column. In case of Array,
+      // ArrayofStruct or StructofArray, pushdown parent column
+      var reqColumns = projects.map {
+        case a@Alias(s: GetStructField, name) =>
+          var arrayTypeExists = false
+          var ifGetArrayItemExists = s
+          breakable({
+            while (ifGetArrayItemExists.containsChild != null) {
+              if (ifGetArrayItemExists.child.isInstanceOf[AttributeReference]) {
+                arrayTypeExists = s.childSchema.toString().contains("ArrayType")
+                break
+              } else {
+                if (ifGetArrayItemExists.child.isInstanceOf[GetArrayItem]) {
+                  arrayTypeExists = true
+                  break
+                } else {
+                  ifGetArrayItemExists = ifGetArrayItemExists.child.asInstanceOf[GetStructField]
+                }
+              }
+            }
+          })
+          if (!arrayTypeExists) {
+            parentColumn += s.toString().split("\\.")(0).replaceAll("#.*", "").toLowerCase
+            parentColumn = parentColumn.distinct
+            s.toString().replaceAll("#[0-9]*", "").toLowerCase
+          } else {
+            s.toString().split("\\.")(0).replaceAll("#.*", "").toLowerCase
+          }
+        case a@Alias(s: GetArrayItem, name) =>
+          s.toString().split("\\.")(0).replaceAll("#.*", "").toLowerCase
+        case attributeReference: AttributeReference =>
+          var columnName: String = attributeReference.name
+          requiredColumns.foreach(colName =>
+            if (colName.equalsIgnoreCase(attributeReference.name)) {
+              columnName = colName
+            })
+          columnName
+        case other =>
+          None
+      }
+
+      reqColumns = reqColumns.filter(col => !col.equals(None))
+      var output = new ListBuffer[String]
+
+      if (null != requiredColumns && requiredColumns.nonEmpty) {
+        requiredColumns.foreach(col => {
+
+          if (null != reqColumns && reqColumns.nonEmpty) {
+            reqColumns.foreach(reqCol => {
+              if (!reqCol.toString.equalsIgnoreCase(col) &&
+                  !reqCol.toString.startsWith(col.toLowerCase + ".") &&
+                  !parentColumn.contains(col.toLowerCase)) {
+                output += col
+              } else {
+                output += reqCol.toString
+              }
+            })
+          } else {
+            output += col
+          }
+          output = output.distinct
+        })
+      }
+      output.toArray.foreach(projection.addColumn)
+    } else {
+      requiredColumns.foreach(projection.addColumn)
+    }
 
     CarbonSession.threadUnset(CarbonCommonConstants.SUPPORT_DIRECT_QUERY_ON_DATAMAP)
     val inputMetricsStats: CarbonInputMetrics = new CarbonInputMetrics

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/strategy/CarbonLateDecodeStrategy.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/strategy/CarbonLateDecodeStrategy.scala
@@ -64,7 +64,7 @@ private[sql] class CarbonLateDecodeStrategy extends SparkStrategy {
           projects,
           filters,
           (a, f, needDecoder, p) => toCatalystRDD(l, a, relation.buildScan(
-            a.map(_.name).toArray, projects, f, p), needDecoder)) :: Nil
+            a.map(_.name).toArray, filters, projects, f, p), needDecoder)) :: Nil
       case CarbonDictionaryCatalystDecoder(relations, profile, aliasMap, _, child) =>
         if ((profile.isInstanceOf[IncludeProfile] && profile.isEmpty) ||
             !CarbonDictionaryDecoder.


### PR DESCRIPTION
**Problem:**
         If Select filter contains Struct Column which is not in Projection list, then only null value is stored for struct column given in filter and select query result is null.
**Solution:** 
         Pushdown Parent column of corresponding struct type if any struct column is present in Filter list.
 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [x] Testing done
       Test Case Added
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

