### PR TITLE
[CARBONDATA-2684]Code Generator Error is thrown when Select filter contains more than one count of distinct of ComplexColumn with group by Clause

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/complexType/TestComplexDataType.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/complexType/TestComplexDataType.scala
@@ -636,4 +636,24 @@ class TestComplexDataType extends QueryTest with BeforeAndAfterAll {
     sql("select b.c[0],a[0][0] from test").show(false)
   }
 
+  test("test structofarray with count(distinct)") {
+    sql("DROP TABLE IF EXISTS test")
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, "yyyy/MM/dd")
+    sql(
+      "create table test(cus_id string, struct_of_array struct<id:int,date:timestamp," +
+      "sno:array<int>,sal:array<double>,state:array<string>,date1:array<timestamp>>) stored by " +
+      "'carbondata'")
+    sql("insert into test values('cus_01','1$2017/01/01$1:2$2.0:3.0$ab:ac$2018/01/01')")
+    sql("select *from test").show(false)
+    sql(
+      "select struct_of_array.state[0],count(distinct struct_of_array.id) as count_int,count" +
+      "(distinct struct_of_array.state[0]) as count_string from test group by struct_of_array" +
+      ".state[0]")
+      .show(false)
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT,
+        CarbonCommonConstants.CARBON_TIMESTAMP_DEFAULT_FORMAT)
+  }
+
 }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/optimizer/CarbonLateDecodeRule.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/optimizer/CarbonLateDecodeRule.scala
@@ -90,7 +90,12 @@ class CarbonLateDecodeRule extends Rule[LogicalPlan] with PredicateHelper {
         LOGGER.info("skip CarbonOptimizer for scalar/predicate sub query")
         return false
       }
-      true
+      if(relations.exists(_.dictionaryMap.dictionaryMap.exists(_._2))) {
+        true
+      } else {
+        false
+      }
+
     } else {
       LOGGER.info("skip CarbonOptimizer")
       false


### PR DESCRIPTION

This PR fixes Code Generator Error thrown when Select filter contains more than one count of distinct of ComplexColumn with group by Clause

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [x] Testing done
      Testcase added
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

