### PR TITLE
[CARBONDATA-2655][BloomDataMap]  BloomFilter datamap support in operator

### DIFF
--- a/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomCoarseGrainDataMap.java
+++ b/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomCoarseGrainDataMap.java
@@ -180,6 +180,7 @@ public class BloomCoarseGrainDataMap extends CoarseGrainDataMap {
   private List<BloomQueryModel> createQueryModel(Expression expression)
       throws DictionaryGenerationException, UnsupportedEncodingException {
     List<BloomQueryModel> queryModels = new ArrayList<BloomQueryModel>();
+    // bloomdatamap only support equalTo and In operators now
     if (expression instanceof EqualToExpression) {
       Expression left = ((EqualToExpression) expression).getLeft();
       Expression right = ((EqualToExpression) expression).getRight();
@@ -200,6 +201,8 @@ public class BloomCoarseGrainDataMap extends CoarseGrainDataMap {
           queryModels.add(bloomQueryModel);
         }
         return queryModels;
+      } else {
+        LOGGER.warn("BloomFilter can only support the 'equal' filter like 'Col = PlainValue'");
       }
     } else if (expression instanceof InExpression) {
       Expression left = ((InExpression) expression).getLeft();
@@ -220,6 +223,9 @@ public class BloomCoarseGrainDataMap extends CoarseGrainDataMap {
               buildQueryModelForIn((ColumnExpression) right, (ListExpression) left);
           queryModels.addAll(models);
         }
+        return queryModels;
+      } else {
+        LOGGER.warn("BloomFilter can only support the 'in' filter like 'Col in (PlainValues)'");
       }
     }
 

--- a/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomCoarseGrainDataMapFactory.java
+++ b/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomCoarseGrainDataMapFactory.java
@@ -111,6 +111,7 @@ public class BloomCoarseGrainDataMapFactory extends DataMapFactory<CoarseGrainDa
     List<ExpressionType> optimizedOperations = new ArrayList<ExpressionType>();
     // todo: support more optimize operations
     optimizedOperations.add(ExpressionType.EQUALS);
+    optimizedOperations.add(ExpressionType.IN);
     this.dataMapMeta = new DataMapMeta(this.dataMapName, indexedColumns, optimizedOperations);
     LOGGER.info(String.format("DataMap %s works for %s with bloom size %d",
         this.dataMapName, this.dataMapMeta, this.bloomFilterSize));

--- a/integration/spark2/src/test/scala/org/apache/carbondata/datamap/bloom/BloomCoarseGrainDataMapSuite.scala
+++ b/integration/spark2/src/test/scala/org/apache/carbondata/datamap/bloom/BloomCoarseGrainDataMapSuite.scala
@@ -57,6 +57,9 @@ class BloomCoarseGrainDataMapSuite extends QueryTest with BeforeAndAfterAll with
   }
 
   private def checkQuery(dataMapName: String, shouldHit: Boolean = true) = {
+    /**
+     * queries that use equal operator
+     */
     checkAnswer(
       checkSqlHitDataMap(s"select * from $bloomDMSampleTable where id = 1", dataMapName, shouldHit),
       sql(s"select * from $normalTable where id = 1"))
@@ -85,6 +88,39 @@ class BloomCoarseGrainDataMapSuite extends QueryTest with BeforeAndAfterAll with
     checkAnswer(
       checkSqlHitDataMap(s"select * from $bloomDMSampleTable where city = 'city_999' and name='n1'", dataMapName, shouldHit),
       sql(s"select * from $normalTable where city = 'city_999' and name='n1'"))
+
+    /**
+     * queries that use in operator
+     */
+    checkAnswer(
+      checkSqlHitDataMap(s"select * from $bloomDMSampleTable where id in (1)", dataMapName, shouldHit),
+      sql(s"select * from $normalTable where id in (1)"))
+    checkAnswer(
+      checkSqlHitDataMap(s"select * from $bloomDMSampleTable where id in (999)", dataMapName, shouldHit),
+      sql(s"select * from $normalTable where id in (999)"))
+    checkAnswer(
+      checkSqlHitDataMap(s"select * from $bloomDMSampleTable where city in( 'city_1')", dataMapName, shouldHit),
+      sql(s"select * from $normalTable where city in( 'city_1')"))
+    checkAnswer(
+      checkSqlHitDataMap(s"select * from $bloomDMSampleTable where city in ('city_999')", dataMapName, shouldHit),
+      sql(s"select * from $normalTable where city in ('city_999')"))
+    // query with two index_columns
+    checkAnswer(
+      checkSqlHitDataMap(s"select * from $bloomDMSampleTable where id in (1) and city in ('city_1')", dataMapName, shouldHit),
+      sql(s"select * from $normalTable where id in (1) and city in ('city_1')"))
+    checkAnswer(
+      checkSqlHitDataMap(s"select * from $bloomDMSampleTable where id in (999) and city in ('city_999')", dataMapName, shouldHit),
+      sql(s"select * from $normalTable where id in (999) and city in ('city_999')"))
+    checkAnswer(
+      checkSqlHitDataMap(s"select * from $bloomDMSampleTable where city in ('city_1') and id in (0)", dataMapName, shouldHit),
+      sql(s"select * from $normalTable where city in ('city_1') and id in (0)"))
+    checkAnswer(
+      checkSqlHitDataMap(s"select * from $bloomDMSampleTable where city in ('city_999') and name in ('n999')", dataMapName, shouldHit),
+      sql(s"select * from $normalTable where city in ('city_999') and name in ('n999')"))
+    checkAnswer(
+      checkSqlHitDataMap(s"select * from $bloomDMSampleTable where city in ('city_999') and name in ('n1')", dataMapName, shouldHit),
+      sql(s"select * from $normalTable where city in ('city_999') and name in ('n1')"))
+
     checkAnswer(
       sql(s"select min(id), max(id), min(name), max(name), min(city), max(city)" +
           s" from $bloomDMSampleTable"),


### PR DESCRIPTION
Now queries with in expression on bloom index column can leverage the
BloomFilter datamap.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

