### PR TITLE
[CARBONDATA-2687][BloomDataMap][Doc] Update document for bloomfilter datamap

### DIFF
--- a/docs/datamap/bloomfilter-datamap-guide.md
+++ b/docs/datamap/bloomfilter-datamap-guide.md
@@ -87,8 +87,6 @@ inside each segment folders.
 
 
 ## Querying Data
-A system level configuration `carbon.query.datamap.bloom.cache.size` can used to enhance query performance with BloomFilter datamap by providing a cache for the bloomfilter index files.
-The default value is `512` and its unit is `MB`. Internally the cache will be expired after it's idle for 2 hours.
 
 User can verify whether a query can leverage BloomFilter datamap by executing `EXPLAIN` command,
 which will show the transformed logical plan, and thus user can check whether the BloomFilter datamap can skip blocklets during the scan.


### PR DESCRIPTION
In previous PR, cache behaviour for bloomfilter datamap has been changed: changed from guava-cache to carbon-cache. This PR update the document for bloomfilter datamap and remove the description for cache.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

