### PR TITLE
[HotFix] Getting carbon table identifier to datamap events

### DIFF
--- a/integration/spark-common/src/main/scala/org/apache/carbondata/events/DataMapEvents.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/events/DataMapEvents.scala
@@ -18,6 +18,7 @@
 package org.apache.carbondata.events
 
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.TableIdentifier
 
 import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier
 
@@ -26,14 +27,16 @@ import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier
  * example: bloom datamap, Lucene datamap
  */
 case class CreateDataMapPostExecutionEvent(sparkSession: SparkSession,
-    storePath: String) extends Event with CreateDataMapEventsInfo
+    storePath: String, tableIdentifier: TableIdentifier)
+  extends Event with CreateDataMapEventsInfo
 
 /**
  * For handling operation's before start of update index datmap status over table with index datamap
  * example: bloom datamap, Lucene datamap
  */
 case class UpdateDataMapPreExecutionEvent(sparkSession: SparkSession,
-    storePath: String) extends Event with CreateDataMapEventsInfo
+    storePath: String, tableIdentifier: TableIdentifier)
+  extends Event with CreateDataMapEventsInfo
 
 /**
  * For handling operation's after finish of  update index datmap status over table with index
@@ -41,7 +44,8 @@ case class UpdateDataMapPreExecutionEvent(sparkSession: SparkSession,
  * example: bloom datamap, Lucene datamap
  */
 case class UpdateDataMapPostExecutionEvent(sparkSession: SparkSession,
-    storePath: String) extends Event with CreateDataMapEventsInfo
+    storePath: String, tableIdentifier: TableIdentifier)
+  extends Event with CreateDataMapEventsInfo
 
 /**
  * For handling operation's before start of index build over table with index datamap
@@ -64,5 +68,6 @@ case class BuildDataMapPostExecutionEvent(sparkSession: SparkSession,
  * example: bloom datamap, Lucene datamap
  */
 case class CreateDataMapPreExecutionEvent(sparkSession: SparkSession,
-    storePath: String) extends Event with CreateDataMapEventsInfo
+    storePath: String, tableIdentifier: TableIdentifier)
+  extends Event with CreateDataMapEventsInfo
 

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/datamap/CarbonCreateDataMapCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/datamap/CarbonCreateDataMapCommand.scala
@@ -115,13 +115,15 @@ case class CarbonCreateDataMapCommand(
         val operationContext: OperationContext = new OperationContext()
         val systemFolderLocation: String = CarbonProperties.getInstance().getSystemFolderLocation
         val createDataMapPreExecutionEvent: CreateDataMapPreExecutionEvent =
-          new CreateDataMapPreExecutionEvent(sparkSession, systemFolderLocation)
+          new CreateDataMapPreExecutionEvent(sparkSession,
+            systemFolderLocation, tableIdentifier.get)
         OperationListenerBus.getInstance().fireEvent(createDataMapPreExecutionEvent,
           operationContext)
         dataMapProvider.initMeta(queryString.orNull)
         DataMapStatusManager.disableDataMap(dataMapName)
         val createDataMapPostExecutionEvent: CreateDataMapPostExecutionEvent =
-          new CreateDataMapPostExecutionEvent(sparkSession, systemFolderLocation)
+          new CreateDataMapPostExecutionEvent(sparkSession,
+            systemFolderLocation, tableIdentifier.get)
         OperationListenerBus.getInstance().fireEvent(createDataMapPostExecutionEvent,
           operationContext)
       case _ =>
@@ -145,12 +147,14 @@ case class CarbonCreateDataMapCommand(
           val operationContext: OperationContext = new OperationContext()
           val systemFolderLocation: String = CarbonProperties.getInstance().getSystemFolderLocation
           val updateDataMapPreExecutionEvent: UpdateDataMapPreExecutionEvent =
-            new UpdateDataMapPreExecutionEvent(sparkSession, systemFolderLocation)
+            new UpdateDataMapPreExecutionEvent(sparkSession,
+              systemFolderLocation, tableIdentifier.get)
           OperationListenerBus.getInstance().fireEvent(updateDataMapPreExecutionEvent,
             operationContext)
           DataMapStatusManager.enableDataMap(dataMapName)
           val updateDataMapPostExecutionEvent: UpdateDataMapPostExecutionEvent =
-            new UpdateDataMapPostExecutionEvent(sparkSession, systemFolderLocation)
+            new UpdateDataMapPostExecutionEvent(sparkSession,
+              systemFolderLocation, tableIdentifier.get)
           OperationListenerBus.getInstance().fireEvent(updateDataMapPostExecutionEvent,
             operationContext)
         }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/datamap/CarbonDataMapRebuildCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/datamap/CarbonDataMapRebuildCommand.scala
@@ -54,12 +54,16 @@ case class CarbonDataMapRebuildCommand(
     val operationContext: OperationContext = new OperationContext()
     val systemFolderLocation: String = CarbonProperties.getInstance().getSystemFolderLocation
     val updateDataMapPreExecutionEvent: UpdateDataMapPreExecutionEvent =
-      new UpdateDataMapPreExecutionEvent(sparkSession, systemFolderLocation)
+      new UpdateDataMapPreExecutionEvent(sparkSession,
+        systemFolderLocation,
+        new TableIdentifier(table.getTableName, Some(table.getDatabaseName)))
     OperationListenerBus.getInstance().fireEvent(updateDataMapPreExecutionEvent,
       operationContext)
     DataMapStatusManager.enableDataMap(dataMapName)
     val updateDataMapPostExecutionEvent: UpdateDataMapPostExecutionEvent =
-      new UpdateDataMapPostExecutionEvent(sparkSession, systemFolderLocation)
+      new UpdateDataMapPostExecutionEvent(sparkSession,
+        systemFolderLocation,
+        new TableIdentifier(table.getTableName, Some(table.getDatabaseName)))
     OperationListenerBus.getInstance().fireEvent(updateDataMapPostExecutionEvent,
       operationContext)
     Seq.empty

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/datamap/CarbonDropDataMapCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/datamap/CarbonDropDataMapCommand.scala
@@ -205,12 +205,12 @@ case class CarbonDropDataMapCommand(
         val operationContext: OperationContext = new OperationContext()
         val systemFolderLocation: String = CarbonProperties.getInstance().getSystemFolderLocation
         val updateDataMapPreExecutionEvent: UpdateDataMapPreExecutionEvent =
-          UpdateDataMapPreExecutionEvent(sparkSession, systemFolderLocation)
+          UpdateDataMapPreExecutionEvent(sparkSession, systemFolderLocation, null)
         OperationListenerBus.getInstance().fireEvent(updateDataMapPreExecutionEvent,
           operationContext)
         DataMapStatusManager.dropDataMap(dataMapSchema.getDataMapName)
         val updateDataMapPostExecutionEvent: UpdateDataMapPostExecutionEvent =
-          UpdateDataMapPostExecutionEvent(sparkSession, systemFolderLocation)
+          UpdateDataMapPostExecutionEvent(sparkSession, systemFolderLocation, null)
         OperationListenerBus.getInstance().fireEvent(updateDataMapPostExecutionEvent,
           operationContext)
         // if it is indexDataMap provider like lucene, then call cleanData, which will launch a job


### PR DESCRIPTION
Description : passing the table identifier to keep track of table in event in case preload and postload of datamap event.
Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed? NO
 
 - [ ] Any backward compatibility impacted? NO
 
 - [ ] Document update required? NO

 - [ ] Testing done NA
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

