### PR TITLE
[CARBONDATA-2693][BloomDataMap]Fix bug for alter rename is renaming the existing table on which bloomfilter datamp exists

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/CarbonTable.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/CarbonTable.java
@@ -60,6 +60,7 @@ import org.apache.carbondata.core.util.CarbonUtil;
 import org.apache.carbondata.core.util.DataTypeUtil;
 import org.apache.carbondata.core.util.path.CarbonTablePath;
 
+import static org.apache.carbondata.core.metadata.schema.datamap.DataMapClassProvider.MV;
 import static org.apache.carbondata.core.util.CarbonUtil.thriftColumnSchemaToWrapperColumnSchema;
 
 /**
@@ -472,6 +473,13 @@ public class CarbonTable implements Serializable {
    */
   public String getTableName() {
     return tableInfo.getFactTable().getTableName();
+  }
+
+  /**
+   * @return the tabelId
+   */
+  public String getTableId() {
+    return tableInfo.getFactTable().getTableId();
   }
 
   /**
@@ -1206,5 +1214,21 @@ public class CarbonTable implements Serializable {
       }
     }
     return cachedColsList;
+  }
+
+  /**
+   * Return true if MV datamap present in the specified table
+   * @param carbonTable
+   * @return timeseries data map present
+   */
+  public static boolean hasMVDataMap(CarbonTable carbonTable) throws IOException {
+    List<DataMapSchema> dataMapSchemaList = DataMapStoreManager.getInstance()
+        .getDataMapSchemasOfTable(carbonTable);
+    for (DataMapSchema dataMapSchema : dataMapSchemaList) {
+      if (dataMapSchema.getProviderName().equalsIgnoreCase(MV.toString())) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/DiskBasedDMSchemaStorageProvider.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/DiskBasedDMSchemaStorageProvider.java
@@ -108,8 +108,7 @@ public class DiskBasedDMSchemaStorageProvider implements DataMapSchemaStoragePro
     for (DataMapSchema dataMapSchema : this.dataMapSchemas) {
       List<RelationIdentifier> parentTables = dataMapSchema.getParentTables();
       for (RelationIdentifier identifier : parentTables) {
-        if (identifier.getTableName().equalsIgnoreCase(carbonTable.getTableName()) &&
-            identifier.getDatabaseName().equalsIgnoreCase(carbonTable.getDatabaseName())) {
+        if (identifier.getTableId().equalsIgnoreCase(carbonTable.getTableId())) {
           dataMapSchemas.add(dataMapSchema);
           break;
         }

--- a/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomCoarseGrainDataMapFactory.java
+++ b/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomCoarseGrainDataMapFactory.java
@@ -366,7 +366,26 @@ public class BloomCoarseGrainDataMapFactory extends DataMapFactory<CoarseGrainDa
   }
 
   @Override public boolean willBecomeStale(TableOperation operation) {
-    return false;
+    switch (operation) {
+      case ALTER_RENAME:
+        return false;
+      case ALTER_DROP:
+        return true;
+      case ALTER_ADD_COLUMN:
+        return true;
+      case ALTER_CHANGE_DATATYPE:
+        return true;
+      case STREAMING:
+        return true;
+      case DELETE:
+        return true;
+      case UPDATE:
+        return true;
+      case PARTITION:
+        return true;
+      default:
+        return false;
+    }
   }
 
   @Override

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestRenameTableWithDataMap.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestRenameTableWithDataMap.scala
@@ -1,0 +1,192 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.spark.testsuite.createTable
+
+import org.apache.spark.sql.test.util.QueryTest
+import org.scalatest.BeforeAndAfterAll
+
+/**
+ * test functionality for alter table with datamap
+ */
+class TestRenameTableWithDataMap extends QueryTest with BeforeAndAfterAll {
+
+  val smallFile = s"$resourcesPath/sample.csv"
+
+  override def beforeAll {
+    sql("DROP TABLE IF EXISTS carbon_table")
+    sql("DROP TABLE IF EXISTS carbon_tb")
+    sql("DROP TABLE IF EXISTS fact_table1")
+  }
+
+  test("Creating a bloomfilter datamap,then table rename") {
+    sql(
+      s"""
+         | CREATE TABLE carbon_table(
+         | id INT, name String, city String, age INT
+         | )
+         | STORED BY 'carbondata'
+       """.stripMargin)
+
+    sql(
+      s"""
+         | CREATE DATAMAP dm_carbon_table_name ON TABLE carbon_table
+         | USING 'bloomfilter'
+         | DMProperties('INDEX_COLUMNS'='name,city', 'BLOOM_SIZE'='640000')
+      """.stripMargin)
+
+    (1 to 2).foreach { i =>
+
+      sql(
+        s"""
+           | insert into carbon_table select 5,'bb','beijing',21
+           | """.stripMargin)
+
+      sql(
+        s"""
+           | insert into carbon_table select 6,'cc','shanghai','29'
+           | """.stripMargin)
+      sql(
+        s"""
+           | LOAD DATA LOCAL INPATH '$smallFile' INTO TABLE carbon_table
+           | OPTIONS('header'='false')
+         """.stripMargin)
+    }
+
+    sql(
+      s"""
+         | show datamap on table carbon_table
+       """.stripMargin).show(false)
+
+    sql(
+      s"""
+         | select * from carbon_table where name='eason'
+       """.stripMargin).show(false)
+
+    sql(
+      s"""
+         | explain select * from carbon_table where name='eason'
+       """.stripMargin).show(false)
+
+    sql(
+      s"""
+         | alter TABLE carbon_table rename to carbon_tb
+       """.stripMargin)
+
+    sql(
+      s"""
+         | show datamap on table carbon_tb
+       """.stripMargin).show(false)
+
+    sql(
+      s"""
+         | select * from carbon_tb where name='eason'
+       """.stripMargin).show(false)
+
+    sql(
+      s"""
+         | explain select * from carbon_tb where name='eason'
+       """.stripMargin).show(false)
+  }
+
+  test("Creating a preaggregate datamap,then table rename") {
+    sql(
+      """
+        | CREATE TABLE fact_table1 (empname String, designation String, doj Timestamp,
+        |  workgroupcategory int, workgroupcategoryname String, deptno int, deptname String,
+        |  projectcode int, projectjoindate Timestamp, projectenddate Timestamp,attendance int,
+        |  utilization int,salary int)
+        | STORED BY 'org.apache.carbondata.format'
+      """.stripMargin)
+    sql(s"""LOAD DATA local inpath '$resourcesPath/data_big.csv' INTO TABLE fact_table1 OPTIONS('DELIMITER'= ',', 'QUOTECHAR'= '"')""")
+    sql(s"""LOAD DATA local inpath '$resourcesPath/data_big.csv' INTO TABLE fact_table1 OPTIONS('DELIMITER'= ',', 'QUOTECHAR'= '"')""")
+
+    sql(
+      s"""
+         | CREATE DATAMAP dm_agg_age ON TABLE fact_table1
+         | USING 'preaggregate'
+         | AS
+         |  select deptno,deptname,sum(salary) from fact_table1
+         |  group by deptno,deptname
+            """.stripMargin)
+
+    sql(
+      s"""
+         | show datamap on table fact_table1
+       """.stripMargin).show(false)
+    sql(
+      s"""
+         | select deptno,deptname,sum(salary) from fact_table1
+         | group by deptno,deptname
+       """.stripMargin).show(false)
+
+    sql(
+      s"""
+         | explain select deptno,deptname,sum(salary) from fact_table1
+         | group by deptno,deptname
+       """.stripMargin).show(false)
+
+    val exception_tb_rename: Exception = intercept[Exception] {
+      sql(
+        s"""
+           | alter TABLE fact_table1 rename to fact_tb
+       """.stripMargin)
+    }
+    assert(exception_tb_rename.getMessage
+      .contains("Rename operation is not supported for table"
+                + " with pre-aggregate tables"))
+  }
+
+  /*
+   * mv datamap does not support running here, now must run in mv project.
+  test("Creating a mv datamap,then table rename") {
+    sql(
+      """
+        | CREATE TABLE fact_table2 (empname String, designation String, doj Timestamp,
+        |  workgroupcategory int, workgroupcategoryname String, deptno int, deptname String,
+        |  projectcode int, projectjoindate Timestamp, projectenddate Timestamp,attendance int,
+        |  utilization int,salary int)
+        | STORED BY 'org.apache.carbondata.format'
+      """.stripMargin)
+    sql(s"""LOAD DATA local inpath '$resourcesPath/data_big.csv' INTO TABLE fact_table2 OPTIONS('DELIMITER'= ',', 'QUOTECHAR'= '"')""")
+    sql(s"""LOAD DATA local inpath '$resourcesPath/data_big.csv' INTO TABLE fact_table2 OPTIONS('DELIMITER'= ',', 'QUOTECHAR'= '"')""")
+
+    sql("drop datamap if exists datamap1")
+    sql("create datamap datamap1 using 'mv' as select empname, designation from fact_table2")
+    sql(s"rebuild datamap datamap1")
+
+    sql(
+      s"""
+         | show datamap on table fact_table2
+       """.stripMargin).show(false)
+
+    val exception_tb_rename: Exception = intercept[Exception] {
+      sql(
+        s"""
+           | alter TABLE fact_table2 rename to fact_tb2
+       """.stripMargin)
+    }
+    assert(exception_tb_rename.getMessage
+      .contains("alter rename is not supported for mv datamap"))
+  } */
+
+  override def afterAll: Unit = {
+    sql("DROP TABLE IF EXISTS carbon_table")
+    sql("DROP TABLE IF EXISTS carbon_tb")
+    sql("DROP TABLE IF EXISTS fact_table1")
+  }
+}

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/preaaggregate/PreAggregateListeners.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/preaaggregate/PreAggregateListeners.scala
@@ -802,11 +802,6 @@ object RenameTablePreListener extends OperationEventListener {
       throw new UnsupportedOperationException(
         "Rename operation is not supported for table with pre-aggregate tables")
     }
-    val indexSchemas = DataMapStoreManager.getInstance().getDataMapSchemasOfTable(carbonTable)
-    if (!indexSchemas.isEmpty) {
-      throw new UnsupportedOperationException(
-        "Rename operation is not supported for table with datamaps")
-    }
   }
 }
 


### PR DESCRIPTION
Fix bug for alter rename is renaming the existing table on which bloom filter datamap exists

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 NA
 - [x] Any backward compatibility impacted?
 NA
 - [x] Document update required?
NA
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
      add a test case ,test pass in environment
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA
