### PR TITLE
[CARBONDATA-2701] Refactor code to store minimal required info in Block and Blocklet Cache

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/block/SegmentPropertiesAndSchemaHolder.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/block/SegmentPropertiesAndSchemaHolder.java
@@ -1,0 +1,342 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.core.datastore.block;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.carbondata.common.logging.LogService;
+import org.apache.carbondata.common.logging.LogServiceFactory;
+import org.apache.carbondata.core.constants.CarbonCommonConstants;
+import org.apache.carbondata.core.indexstore.schema.CarbonRowSchema;
+import org.apache.carbondata.core.indexstore.schema.SchemaGenerator;
+import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
+import org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema;
+
+/**
+ * Singleton class which will help in creating the segment properties
+ */
+public class SegmentPropertiesAndSchemaHolder {
+
+  /**
+   * Logger
+   */
+  private static final LogService LOGGER =
+      LogServiceFactory.getLogService(SegmentPropertiesAndSchemaHolder.class.getName());
+  /**
+   * SegmentPropertiesAndSchemaHolder instance
+   */
+  private static final SegmentPropertiesAndSchemaHolder INSTANCE =
+      new SegmentPropertiesAndSchemaHolder();
+  /**
+   * object level lock
+   */
+  private static final Object lock = new Object();
+  /**
+   * counter for maintaining the index of segmentProperties
+   */
+  private static final AtomicInteger segmentPropertiesIndexCounter = new AtomicInteger(0);
+  /**
+   * holds segmentPropertiesWrapper to segment ID and segmentProperties Index wrapper mapping.
+   * Will be used while invaliding a segment and drop table
+   */
+  private Map<SegmentPropertiesWrapper, SegmentIdAndSegmentPropertiesIndexWrapper>
+      segmentPropWrapperToSegmentSetMap = new ConcurrentHashMap<>();
+  /**
+   * reverse mapping for segmentProperties index to segmentPropertiesWrapper
+   */
+  private static Map<Integer, SegmentPropertiesWrapper> indexToSegmentPropertiesWrapperMapping =
+      new ConcurrentHashMap<>();
+  /**
+   * Map to be used for table level locking while populating segmentProperties
+   */
+  private Map<String, Object> absoluteTableIdentifierByteMap = new ConcurrentHashMap<>();
+
+  /**
+   * private constructor for singleton instance
+   */
+  private SegmentPropertiesAndSchemaHolder() {
+
+  }
+
+  public static SegmentPropertiesAndSchemaHolder getInstance() {
+    return INSTANCE;
+  }
+
+  /**
+   * Method to add the segment properties and avoid construction of new segment properties until
+   * the schema is not modified
+   *
+   * @param tableIdentifier
+   * @param columnsInTable
+   * @param columnCardinality
+   * @param segmentId
+   */
+  public int addSegmentProperties(AbsoluteTableIdentifier tableIdentifier,
+      List<ColumnSchema> columnsInTable, int[] columnCardinality, String segmentId) {
+    SegmentPropertiesAndSchemaHolder.SegmentPropertiesWrapper segmentPropertiesWrapper =
+        new SegmentPropertiesAndSchemaHolder.SegmentPropertiesWrapper(tableIdentifier,
+            columnsInTable, columnCardinality);
+    SegmentIdAndSegmentPropertiesIndexWrapper segmentIdSetAndIndexWrapper =
+        this.segmentPropWrapperToSegmentSetMap.get(segmentPropertiesWrapper);
+    if (null == segmentIdSetAndIndexWrapper) {
+      synchronized (getOrCreateTableLock(tableIdentifier)) {
+        segmentIdSetAndIndexWrapper =
+            this.segmentPropWrapperToSegmentSetMap.get(segmentPropertiesWrapper);
+        if (null == segmentIdSetAndIndexWrapper) {
+          // create new segmentProperties
+          segmentPropertiesWrapper.initSegmentProperties();
+          int segmentPropertiesIndex = segmentPropertiesIndexCounter.incrementAndGet();
+          indexToSegmentPropertiesWrapperMapping
+              .put(segmentPropertiesIndex, segmentPropertiesWrapper);
+          LOGGER.info("Constructing new SegmentProperties for table: " + tableIdentifier
+              .getCarbonTableIdentifier().getTableUniqueName()
+              + ". Current size of segment properties" + " holder list is: "
+              + indexToSegmentPropertiesWrapperMapping.size());
+          // populate the SegmentIdAndSegmentPropertiesIndexWrapper to maintain the set of segments
+          // having same SegmentPropertiesWrapper instance this will used to decide during the
+          // tblSegmentsProperties map clean-up for the invalid segments
+          segmentIdSetAndIndexWrapper =
+              new SegmentIdAndSegmentPropertiesIndexWrapper(segmentId, segmentPropertiesIndex);
+          segmentPropWrapperToSegmentSetMap
+              .put(segmentPropertiesWrapper, segmentIdSetAndIndexWrapper);
+        }
+      }
+    } else {
+      synchronized (getOrCreateTableLock(tableIdentifier)) {
+        segmentIdSetAndIndexWrapper.addSegmentId(segmentId);
+      }
+    }
+    return segmentIdSetAndIndexWrapper.getSegmentPropertiesIndex();
+  }
+
+  /**
+   * Method to create table Level lock
+   *
+   * @param absoluteTableIdentifier
+   * @return
+   */
+  private Object getOrCreateTableLock(AbsoluteTableIdentifier absoluteTableIdentifier) {
+    Object tableLock = absoluteTableIdentifierByteMap
+        .get(absoluteTableIdentifier.getCarbonTableIdentifier().getTableUniqueName());
+    if (null == tableLock) {
+      synchronized (lock) {
+        tableLock = absoluteTableIdentifierByteMap
+            .get(absoluteTableIdentifier.getCarbonTableIdentifier().getTableUniqueName());
+        if (null == tableLock) {
+          tableLock = new Object();
+          absoluteTableIdentifierByteMap
+              .put(absoluteTableIdentifier.getCarbonTableIdentifier().getTableUniqueName(),
+                  tableLock);
+        }
+      }
+    }
+    return tableLock;
+  }
+
+  /**
+   * Method to get the segment properties from given index
+   *
+   * @param segmentPropertiesIndex
+   * @return
+   */
+  public SegmentProperties getSegmentProperties(int segmentPropertiesIndex) {
+    SegmentPropertiesWrapper segmentPropertiesWrapper =
+        getSegmentPropertiesWrapper(segmentPropertiesIndex);
+    if (null != segmentPropertiesWrapper) {
+      return segmentPropertiesWrapper.getSegmentProperties();
+    }
+    return null;
+  }
+
+  /**
+   * Method to get the segment properties from given index
+   *
+   * @param segmentPropertiesWrapperIndex
+   * @return
+   */
+  public SegmentPropertiesWrapper getSegmentPropertiesWrapper(int segmentPropertiesWrapperIndex) {
+    return indexToSegmentPropertiesWrapperMapping.get(segmentPropertiesWrapperIndex);
+  }
+
+  /**
+   * This method will remove the segment properties from the map on drop table
+   *
+   * @param absoluteTableIdentifier
+   */
+  public void invalidate(AbsoluteTableIdentifier absoluteTableIdentifier) {
+    List<SegmentPropertiesWrapper> segmentPropertiesWrappersToBeRemoved = new ArrayList<>();
+    // remove segmentProperties wrapper entries from the copyOnWriteArrayList
+    for (Map.Entry<SegmentPropertiesWrapper, SegmentIdAndSegmentPropertiesIndexWrapper> entry :
+          segmentPropWrapperToSegmentSetMap.entrySet()) {
+      SegmentPropertiesWrapper segmentPropertiesWrapper = entry.getKey();
+      if (segmentPropertiesWrapper.getTableIdentifier().getCarbonTableIdentifier()
+          .getTableUniqueName()
+          .equals(absoluteTableIdentifier.getCarbonTableIdentifier().getTableUniqueName())) {
+        SegmentIdAndSegmentPropertiesIndexWrapper value = entry.getValue();
+        // remove from the reverse mapping map
+        indexToSegmentPropertiesWrapperMapping.remove(value.getSegmentPropertiesIndex());
+        segmentPropertiesWrappersToBeRemoved.add(segmentPropertiesWrapper);
+      }
+    }
+    // remove all the segmentPropertiesWrapper entries from map
+    for (SegmentPropertiesWrapper segmentPropertiesWrapper : segmentPropertiesWrappersToBeRemoved) {
+      segmentPropWrapperToSegmentSetMap.remove(segmentPropertiesWrapper);
+    }
+    // remove the table lock
+    absoluteTableIdentifierByteMap
+        .remove(absoluteTableIdentifier.getCarbonTableIdentifier().getTableUniqueName());
+  }
+
+  /**
+   * Method to remove the given segment ID
+   *
+   * @param segmentId
+   * @param segmentPropertiesIndex
+   */
+  public void invalidate(String segmentId, int segmentPropertiesIndex) {
+    SegmentPropertiesWrapper segmentPropertiesWrapper =
+        indexToSegmentPropertiesWrapperMapping.get(segmentPropertiesIndex);
+    if (null != segmentPropertiesWrapper) {
+      SegmentIdAndSegmentPropertiesIndexWrapper segmentIdAndSegmentPropertiesIndexWrapper =
+          segmentPropWrapperToSegmentSetMap.get(segmentPropertiesWrapper);
+      synchronized (segmentPropertiesWrapper.getTableIdentifier().getCarbonTableIdentifier()
+          .getTableUniqueName()) {
+        segmentIdAndSegmentPropertiesIndexWrapper.removeSegmentId(segmentId);
+      }
+      // if after removal of given SegmentId, the segmentIdSet becomes empty that means this
+      // segmentPropertiesWrapper is not getting used at all. In that case this object can be
+      // removed from all the holders
+      if (segmentIdAndSegmentPropertiesIndexWrapper.segmentIdSet.isEmpty()) {
+        indexToSegmentPropertiesWrapperMapping.remove(segmentPropertiesIndex);
+        segmentPropWrapperToSegmentSetMap.remove(segmentPropertiesWrapper);
+      }
+    }
+  }
+
+  /**
+   * This class wraps tableIdentifier, columnsInTable and columnCardinality as a key to determine
+   * whether the SegmentProperties object can be reused.
+   */
+  public static class SegmentPropertiesWrapper {
+
+    private AbsoluteTableIdentifier tableIdentifier;
+    private List<ColumnSchema> columnsInTable;
+    private int[] columnCardinality;
+    private SegmentProperties segmentProperties;
+    private CarbonRowSchema[] taskSummarySchema;
+
+    public SegmentPropertiesWrapper(AbsoluteTableIdentifier tableIdentifier,
+        List<ColumnSchema> columnsInTable, int[] columnCardinality) {
+      this.tableIdentifier = tableIdentifier;
+      this.columnsInTable = columnsInTable;
+      this.columnCardinality = columnCardinality;
+    }
+
+    public void initSegmentProperties() {
+      segmentProperties = new SegmentProperties(columnsInTable, columnCardinality);
+    }
+
+    @Override public boolean equals(Object obj) {
+      if (!(obj instanceof SegmentPropertiesAndSchemaHolder.SegmentPropertiesWrapper)) {
+        return false;
+      }
+      SegmentPropertiesAndSchemaHolder.SegmentPropertiesWrapper other =
+          (SegmentPropertiesAndSchemaHolder.SegmentPropertiesWrapper) obj;
+      return tableIdentifier.equals(other.tableIdentifier) && columnsInTable
+          .equals(other.columnsInTable) && Arrays
+          .equals(columnCardinality, other.columnCardinality);
+    }
+
+    @Override public int hashCode() {
+      return tableIdentifier.hashCode() + columnsInTable.hashCode() + Arrays
+          .hashCode(columnCardinality);
+    }
+
+    public AbsoluteTableIdentifier getTableIdentifier() {
+      return tableIdentifier;
+    }
+
+    public SegmentProperties getSegmentProperties() {
+      return segmentProperties;
+    }
+
+    public List<ColumnSchema> getColumnsInTable() {
+      return columnsInTable;
+    }
+
+    public int[] getColumnCardinality() {
+      return columnCardinality;
+    }
+
+    public CarbonRowSchema[] getBlockSchema() {
+      return SchemaGenerator.createBlockSchema(segmentProperties);
+    }
+
+    public CarbonRowSchema[] getBlocketSchema() {
+      return SchemaGenerator.createBlockletSchema(segmentProperties);
+    }
+
+    public CarbonRowSchema[] getTaskSummarySchema() {
+      return taskSummarySchema;
+    }
+
+    public void setTaskSummarySchema(CarbonRowSchema[] taskSummarySchema) {
+      this.taskSummarySchema = taskSummarySchema;
+    }
+  }
+
+  /**
+   * holder for segmentId and segmentPropertiesIndex
+   */
+  public static class SegmentIdAndSegmentPropertiesIndexWrapper {
+
+    /**
+     * set holding all unique segment Id's using the same segmentProperties
+     */
+    private Set<String> segmentIdSet;
+    /**
+     * index which maps to segmentPropertiesWrpper Index from where segmentProperties
+     * can be retrieved
+     */
+    private int segmentPropertiesIndex;
+
+    public SegmentIdAndSegmentPropertiesIndexWrapper(String segmentId, int segmentPropertiesIndex) {
+      segmentIdSet = new HashSet<>(CarbonCommonConstants.DEFAULT_COLLECTION_SIZE);
+      addSegmentId(segmentId);
+      this.segmentPropertiesIndex = segmentPropertiesIndex;
+    }
+
+    public void addSegmentId(String segmentId) {
+      segmentIdSet.add(segmentId);
+    }
+
+    public void removeSegmentId(String segmentId) {
+      segmentIdSet.remove(segmentId);
+    }
+
+    public int getSegmentPropertiesIndex() {
+      return segmentPropertiesIndex;
+    }
+  }
+}

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/AbstractMemoryDMStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/AbstractMemoryDMStore.java
@@ -31,25 +31,16 @@ public abstract class AbstractMemoryDMStore implements Serializable {
 
   protected boolean isMemoryFreed;
 
-  protected CarbonRowSchema[] schema;
-
   protected final long taskId = ThreadLocalTaskInfo.getCarbonTaskInfo().getTaskId();
 
-  public AbstractMemoryDMStore(CarbonRowSchema[] schema) {
-    this.schema = schema;
-  }
+  public abstract void addIndexRow(CarbonRowSchema[] schema, DataMapRow indexRow)
+      throws MemoryException;
 
-  public abstract void addIndexRow(DataMapRow indexRow) throws MemoryException;
-
-  public abstract DataMapRow getDataMapRow(int index);
+  public abstract DataMapRow getDataMapRow(CarbonRowSchema[] schema, int index);
 
   public abstract void freeMemory();
 
   public abstract int getMemoryUsed();
-
-  public CarbonRowSchema[] getSchema() {
-    return schema;
-  }
 
   public abstract int getRowCount();
 
@@ -57,7 +48,8 @@ public abstract class AbstractMemoryDMStore implements Serializable {
     // do nothing in default implementation
   }
 
-  public UnsafeMemoryDMStore convertToUnsafeDMStore() throws MemoryException {
+  public UnsafeMemoryDMStore convertToUnsafeDMStore(CarbonRowSchema[] schema)
+      throws MemoryException {
     throw new UnsupportedOperationException("Operation not allowed");
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/Blocklet.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/Blocklet.java
@@ -34,9 +34,23 @@ public class Blocklet implements Writable,Serializable {
   /** id to identify the blocklet inside the block (it is a sequential number) */
   private String blockletId;
 
+  /**
+   * flag to specify whether to consider blocklet Id in equals and hashcode comparison. This is
+   * because when CACHE_LEVEL='BLOCK' which is default value, the blocklet ID returned by
+   * BlockDataMap pruning will always be -1 and other datamaps will give the the correct blocklet
+   * ID. Therefore if we compare -1 with correct blocklet ID the comparison will become wrong and
+   * always false will be returned resulting in incorrect result. Default value for flag is true.
+   */
+  private boolean compareBlockletIdForObjectMatching = true;
+
   public Blocklet(String filePath, String blockletId) {
     this.filePath = filePath;
     this.blockletId = blockletId;
+  }
+
+  public Blocklet(String filePath, String blockletId, boolean compareBlockletIdForObjectMatching) {
+    this(filePath, blockletId);
+    this.compareBlockletIdForObjectMatching = compareBlockletIdForObjectMatching;
   }
 
   // For serialization purpose
@@ -70,6 +84,9 @@ public class Blocklet implements Writable,Serializable {
     if (filePath != null ? !filePath.equals(blocklet.filePath) : blocklet.filePath != null) {
       return false;
     }
+    if (!compareBlockletIdForObjectMatching) {
+      return true;
+    }
     return blockletId != null ?
         blockletId.equals(blocklet.blockletId) :
         blocklet.blockletId == null;
@@ -77,7 +94,10 @@ public class Blocklet implements Writable,Serializable {
 
   @Override public int hashCode() {
     int result = filePath != null ? filePath.hashCode() : 0;
-    result = 31 * result + (blockletId != null ? blockletId.hashCode() : 0);
+    result = 31 * result;
+    if (compareBlockletIdForObjectMatching) {
+      result += blockletId != null ? blockletId.hashCode() : 0;
+    }
     return result;
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/ExtendedBlocklet.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/ExtendedBlocklet.java
@@ -37,6 +37,11 @@ public class ExtendedBlocklet extends Blocklet {
     super(filePath, blockletId);
   }
 
+  public ExtendedBlocklet(String filePath, String blockletId,
+      boolean compareBlockletIdForObjectMatching) {
+    super(filePath, blockletId, compareBlockletIdForObjectMatching);
+  }
+
   public BlockletDetailInfo getDetailInfo() {
     return detailInfo;
   }

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/UnsafeMemoryDMStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/UnsafeMemoryDMStore.java
@@ -47,8 +47,7 @@ public class UnsafeMemoryDMStore extends AbstractMemoryDMStore {
 
   private int rowCount;
 
-  public UnsafeMemoryDMStore(CarbonRowSchema[] schema) throws MemoryException {
-    super(schema);
+  public UnsafeMemoryDMStore() throws MemoryException {
     this.allocatedSize = capacity;
     this.memoryBlock = UnsafeMemoryManager.allocateMemoryWithRetry(taskId, allocatedSize);
     this.pointers = new int[1000];
@@ -87,7 +86,7 @@ public class UnsafeMemoryDMStore extends AbstractMemoryDMStore {
    * @param indexRow
    * @return
    */
-  public void addIndexRow(DataMapRow indexRow) throws MemoryException {
+  public void addIndexRow(CarbonRowSchema[] schema, DataMapRow indexRow) throws MemoryException {
     // First calculate the required memory to keep the row in unsafe
     int rowSize = indexRow.getTotalSizeInBytes();
     // Check whether allocated memory is sufficient or not.
@@ -176,7 +175,7 @@ public class UnsafeMemoryDMStore extends AbstractMemoryDMStore {
     }
   }
 
-  public DataMapRow getDataMapRow(int index) {
+  public DataMapRow getDataMapRow(CarbonRowSchema[] schema, int index) {
     assert (index < rowCount);
     return new UnsafeDataMapRow(schema, memoryBlock, pointers[index]);
   }

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMapFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMapFactory.java
@@ -99,7 +99,6 @@ public class BlockletDataMapFactory extends CoarseGrainDataMapFactory
   public static DataMap createDataMap(CarbonTable carbonTable) {
     boolean cacheLevelBlock =
         BlockletDataMapUtil.isCacheLevelBlock(carbonTable, CACHE_LEVEL_BLOCKLET);
-    cacheLevelBlock = false;
     if (cacheLevelBlock) {
       // case1: when CACHE_LEVEL = BLOCK
       return new BlockDataMap();
@@ -212,7 +211,9 @@ public class BlockletDataMapFactory extends CoarseGrainDataMapFactory
       BlockletDataMapIndexWrapper wrapper = cache.get(identifierWrapper);
       List<BlockDataMap> dataMaps = wrapper.getDataMaps();
       for (DataMap dataMap : dataMaps) {
-        if (((BlockDataMap) dataMap).getIndexFileName().startsWith(blocklet.getFilePath())) {
+        if (((BlockDataMap) dataMap)
+            .getTableTaskInfo(BlockletDataMapRowIndexes.SUMMARY_INDEX_FILE_NAME)
+            .startsWith(blocklet.getFilePath())) {
           return ((BlockDataMap) dataMap).getDetailedBlocklet(blocklet.getBlockletId());
         }
       }

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMapModel.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMapModel.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import org.apache.carbondata.core.datamap.dev.DataMapModel;
 import org.apache.carbondata.core.indexstore.BlockMetaInfo;
+import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
 
 /**
  * It is the model object to keep the information to build or initialize BlockletDataMap.
@@ -30,21 +31,25 @@ public class BlockletDataMapModel extends DataMapModel {
 
   private Map<String, BlockMetaInfo> blockMetaInfoMap;
 
+  private CarbonTable carbonTable;
+
   private String segmentId;
 
   private boolean addToUnsafe = true;
 
-  public BlockletDataMapModel(String filePath, byte[] fileData,
-      Map<String, BlockMetaInfo> blockMetaInfoMap, String segmentId) {
+  public BlockletDataMapModel(CarbonTable carbonTable, String filePath,
+      byte[] fileData, Map<String, BlockMetaInfo> blockMetaInfoMap, String segmentId) {
     super(filePath);
     this.fileData = fileData;
     this.blockMetaInfoMap = blockMetaInfoMap;
     this.segmentId = segmentId;
+    this.carbonTable = carbonTable;
   }
 
-  public BlockletDataMapModel(String filePath, byte[] fileData,
-      Map<String, BlockMetaInfo> blockMetaInfoMap, String segmentId, boolean addToUnsafe) {
-    this(filePath, fileData, blockMetaInfoMap, segmentId);
+  public BlockletDataMapModel(CarbonTable carbonTable, String filePath,
+      byte[] fileData, Map<String, BlockMetaInfo> blockMetaInfoMap, String segmentId,
+      boolean addToUnsafe) {
+    this(carbonTable, filePath, fileData, blockMetaInfoMap, segmentId);
     this.addToUnsafe = addToUnsafe;
   }
 
@@ -62,5 +67,9 @@ public class BlockletDataMapModel extends DataMapModel {
 
   public boolean isAddToUnsafe() {
     return addToUnsafe;
+  }
+
+  public CarbonTable getCarbonTable() {
+    return carbonTable;
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMapRowIndexes.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMapRowIndexes.java
@@ -52,14 +52,9 @@ public interface BlockletDataMapRowIndexes {
 
   int TASK_MAX_VALUES_INDEX = 1;
 
-  int SUMMARY_SCHEMA = 2;
+  int SUMMARY_INDEX_FILE_NAME = 2;
 
-  int SUMMARY_INDEX_PATH = 3;
+  int SUMMARY_SEGMENTID = 3;
 
-  int SUMMARY_INDEX_FILE_NAME = 4;
-
-  int SUMMARY_SEGMENTID = 5;
-
-  int SUMMARY_BLOCKLET_COUNT = 6;
-
+  int SUMMARY_INDEX_PATH = 4;
 }

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/row/DataMapRow.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/row/DataMapRow.java
@@ -26,7 +26,10 @@ import org.apache.carbondata.core.indexstore.schema.CarbonRowSchema;
  */
 public abstract class DataMapRow implements Serializable {
 
-  protected CarbonRowSchema[] schemas;
+  /**
+   * This is made transient as it is temporary and should not be serialized
+   */
+  protected transient CarbonRowSchema[] schemas;
 
   public DataMapRow(CarbonRowSchema[] schemas) {
     this.schemas = schemas;
@@ -100,5 +103,11 @@ public abstract class DataMapRow implements Serializable {
    */
   public DataMapRow convertToSafeRow() {
     return this;
+  }
+
+  public void setSchemas(CarbonRowSchema[] schemas) {
+    if (null == this.schemas) {
+      this.schemas = schemas;
+    }
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/schema/SchemaGenerator.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/schema/SchemaGenerator.java
@@ -100,23 +100,22 @@ public class SchemaGenerator {
    * @throws MemoryException
    */
   public static CarbonRowSchema[] createTaskSummarySchema(SegmentProperties segmentProperties,
-      byte[] schemaBinary, byte[] filePath, byte[] fileName, byte[] segmentId,
-      boolean storeBlockletCount) throws MemoryException {
+      boolean storeBlockletCount, boolean filePathToBeStored) throws MemoryException {
     List<CarbonRowSchema> taskMinMaxSchemas = new ArrayList<>();
     // get MinMax Schema
     getMinMaxSchema(segmentProperties, taskMinMaxSchemas);
-    // for storing column schema
-    taskMinMaxSchemas
-        .add(new CarbonRowSchema.FixedCarbonRowSchema(DataTypes.BYTE_ARRAY, schemaBinary.length));
-    // for storing file path
-    taskMinMaxSchemas
-        .add(new CarbonRowSchema.FixedCarbonRowSchema(DataTypes.BYTE_ARRAY, filePath.length));
     // for storing file name
     taskMinMaxSchemas
-        .add(new CarbonRowSchema.FixedCarbonRowSchema(DataTypes.BYTE_ARRAY, fileName.length));
+        .add(new CarbonRowSchema.VariableCarbonRowSchema(DataTypes.BYTE_ARRAY));
     // for storing segmentid
     taskMinMaxSchemas
-        .add(new CarbonRowSchema.FixedCarbonRowSchema(DataTypes.BYTE_ARRAY, segmentId.length));
+        .add(new CarbonRowSchema.VariableCarbonRowSchema(DataTypes.BYTE_ARRAY));
+    // store path only in case of partition table or non transactional table
+    if (filePathToBeStored) {
+      // for storing file path
+      taskMinMaxSchemas
+          .add(new CarbonRowSchema.VariableCarbonRowSchema(DataTypes.BYTE_ARRAY));
+    }
     // flag to check whether it is required to store blocklet count of each carbondata file as
     // binary in summary schema. This will be true when it is not a legacy store (>1.1 version)
     // and CACHE_LEVEL=BLOCK

--- a/core/src/main/java/org/apache/carbondata/core/scan/executor/impl/AbstractQueryExecutor.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/executor/impl/AbstractQueryExecutor.java
@@ -255,6 +255,8 @@ public abstract class AbstractQueryExecutor<E> implements QueryExecutor<E> {
       BlockletInfo blockletInfo, short blockletId) {
     TableBlockInfo info = blockInfo.copy();
     BlockletDetailInfo detailInfo = info.getDetailInfo();
+    // set column schema details
+    detailInfo.setColumnSchemas(fileFooter.getColumnInTable());
     detailInfo.setRowCount(blockletInfo.getNumberOfRows());
     byte[][] maxValues = blockletInfo.getBlockletIndex().getMinMaxIndex().getMaxValues();
     byte[][] minValues = blockletInfo.getBlockletIndex().getMinMaxIndex().getMinValues();

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/datasources/SparkCarbonFileFormat.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/datasources/SparkCarbonFileFormat.scala
@@ -260,7 +260,6 @@ class SparkCarbonFileFormat extends FileFormat
         val prunedBlocklets = dataMapExprWrapper.prune(segments, null)
 
         val detailInfo = prunedBlocklets.get(0).getDetailInfo
-        detailInfo.readColumnSchema(detailInfo.getColumnSchemaBinary)
         split.setDetailInfo(detailInfo)
 
         val carbonReader = if (readVector) {

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonFileMetastore.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonFileMetastore.scala
@@ -37,6 +37,7 @@ import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.core.cache.dictionary.ManageDictionaryAndBTree
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.datamap.DataMapStoreManager
+import org.apache.carbondata.core.datastore.block.SegmentPropertiesAndSchemaHolder
 import org.apache.carbondata.core.datastore.impl.FileFactory
 import org.apache.carbondata.core.fileoperations.FileWriteOperation
 import org.apache.carbondata.core.metadata.{AbsoluteTableIdentifier, CarbonMetadata, CarbonTableIdentifier}
@@ -491,6 +492,7 @@ class CarbonFileMetastore extends CarbonMetaStore {
       val tableIdentifier = TableIdentifier(tableName, Option(dbName))
       sparkSession.sessionState.catalog.refreshTable(tableIdentifier)
       DataMapStoreManager.getInstance().clearDataMaps(absoluteTableIdentifier)
+      SegmentPropertiesAndSchemaHolder.getInstance().invalidate(absoluteTableIdentifier)
     } else {
       if (!isTransactionalCarbonTable(absoluteTableIdentifier)) {
         removeTableFromMetadata(dbName, tableName)
@@ -499,6 +501,7 @@ class CarbonFileMetastore extends CarbonMetaStore {
         val tableIdentifier = TableIdentifier(tableName, Option(dbName))
         sparkSession.sessionState.catalog.refreshTable(tableIdentifier)
         DataMapStoreManager.getInstance().clearDataMaps(absoluteTableIdentifier)
+        SegmentPropertiesAndSchemaHolder.getInstance().invalidate(absoluteTableIdentifier)
       }
     }
   }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonHiveMetaStore.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonHiveMetaStore.scala
@@ -24,6 +24,7 @@ import org.apache.spark.sql.catalyst.TableIdentifier
 
 import org.apache.carbondata.core.cache.dictionary.ManageDictionaryAndBTree
 import org.apache.carbondata.core.datamap.DataMapStoreManager
+import org.apache.carbondata.core.datastore.block.SegmentPropertiesAndSchemaHolder
 import org.apache.carbondata.core.metadata.{schema, AbsoluteTableIdentifier, CarbonMetadata, CarbonTableIdentifier}
 import org.apache.carbondata.core.metadata.converter.ThriftWrapperSchemaConverterImpl
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable
@@ -84,6 +85,7 @@ class CarbonHiveMetaStore extends CarbonFileMetastore {
     val tableIdentifier = TableIdentifier(tableName, Option(dbName))
     sparkSession.sessionState.catalog.refreshTable(tableIdentifier)
     DataMapStoreManager.getInstance().clearDataMaps(absoluteTableIdentifier)
+    SegmentPropertiesAndSchemaHolder.getInstance().invalidate(absoluteTableIdentifier)
   }
 
   override def checkSchemasModifiedTimeAndReloadTable(tableIdentifier: TableIdentifier): Boolean = {


### PR DESCRIPTION
Things done as part of this PR
1. Refactored code to keep only minimal information in block and blocklet cache.
2. Introduced segment properties holder at JVM level to hold the segment properties. As it is heavy object, new segment properties object will be created only when schema or cardinality is changed for a table.
This PR depends on PR #2437 

 - [ ] Any interfaces changed?
 No
 - [ ] Any backward compatibility impacted?
 NA
 - [ ] Document update required?
No
 - [ ] Testing done
Yes       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA
