### PR TITLE
[CARBONDATA-2512][32k] Support writing longstring through SDK

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/TableSchemaBuilder.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/TableSchemaBuilder.java
@@ -138,6 +138,7 @@ public class TableSchemaBuilder {
     newColumn.setDataType(field.getDataType());
     if (isSortColumn ||
         field.getDataType() == DataTypes.STRING ||
+        field.getDataType() == DataTypes.VARCHAR ||
         field.getDataType() == DataTypes.DATE ||
         field.getDataType() == DataTypes.TIMESTAMP ||
         field.getDataType().isComplexType() ||

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonWriterBuilder.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonWriterBuilder.java
@@ -469,9 +469,10 @@ public class CarbonWriterBuilder {
         if (isSortColumn > -1) {
           // unsupported types for ("array", "struct", "double", "float", "decimal")
           if (field.getDataType() == DataTypes.DOUBLE || field.getDataType() == DataTypes.FLOAT
-              || DataTypes.isDecimal(field.getDataType()) || field.getDataType().isComplexType()) {
+              || DataTypes.isDecimal(field.getDataType()) || field.getDataType().isComplexType()
+              || field.getDataType() == DataTypes.VARCHAR) {
             throw new RuntimeException(
-                " sort columns not supported for " + "array, struct, double, float, decimal ");
+                " sort columns not supported for array, struct, double, float, decimal, varchar");
           }
         }
         if (field.getChildren() != null && field.getChildren().size() > 0) {

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/Field.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/Field.java
@@ -54,6 +54,8 @@ public class Field {
     this.name = name;
     if (type.equalsIgnoreCase("string")) {
       this.type = DataTypes.STRING;
+    } else if (type.equalsIgnoreCase("varchar")) {
+      this.type = DataTypes.VARCHAR;
     } else if (type.equalsIgnoreCase("date")) {
       this.type = DataTypes.DATE;
     } else if (type.equalsIgnoreCase("timestamp")) {
@@ -87,6 +89,8 @@ public class Field {
     this.children = fields;
     if (type.equalsIgnoreCase("string")) {
       this.type = DataTypes.STRING;
+    } else if (type.equalsIgnoreCase("varchar")) {
+      this.type = DataTypes.VARCHAR;
     } else if (type.equalsIgnoreCase("date")) {
       this.type = DataTypes.DATE;
     } else if (type.equalsIgnoreCase("timestamp")) {


### PR DESCRIPTION
Support writing longstring through SDK.
User can specify the datatype as 'varchar' for longstring columns.
Please note that, the 'varchar' column cannot be sort_columns.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 `NO`
 - [x] Any backward compatibility impacted?
  `NO`
 - [x] Document update required?
 `NO`
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
`Added test`
        - How it is tested? Please attach test report.
`Tested in local machine`
        - Is it a performance related change? Please attach the performance test report.
`No`
        - Any additional information to help reviewers in testing this change.
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
`NA`
