### PR TITLE
[CARBONDATA-2694][32k] Show longstring table property in descformatted

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/longstring/VarcharDataTypesBasicTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/longstring/VarcharDataTypesBasicTestCase.scala
@@ -287,6 +287,18 @@ class VarcharDataTypesBasicTestCase extends QueryTest with BeforeAndAfterEach wi
     checkQuery()
   }
 
+  test("desc table shows long_string_columns property") {
+    sql(
+      s"""
+         | CREATE TABLE if not exists $longStringTable(
+         | id INT, name STRING, description STRING, address STRING, note STRING
+         | ) STORED BY 'carbondata'
+         | TBLPROPERTIES('LONG_STRING_COLUMNS'='address, note', 'dictionary_include'='name', 'sort_columns'='id')
+         |""".
+        stripMargin)
+    checkExistence(sql(s"desc formatted $longStringTable"), true, "long_string_columns", "address", "note")
+  }
+
   // will create 2 long string columns
   private def createFile(filePath: String, line: Int = 10000, start: Int = 0,
       varcharLen: Int = Short.MaxValue + 1000): Content = {

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/longstring/VarcharDataTypesBasicTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/longstring/VarcharDataTypesBasicTestCase.scala
@@ -296,7 +296,7 @@ class VarcharDataTypesBasicTestCase extends QueryTest with BeforeAndAfterEach wi
          | TBLPROPERTIES('LONG_STRING_COLUMNS'='address, note', 'dictionary_include'='name', 'sort_columns'='id')
          |""".
         stripMargin)
-    checkExistence(sql(s"desc formatted $longStringTable"), true, "long_string_columns", "address", "note")
+    checkExistence(sql(s"desc formatted $longStringTable"), true, "long_string_columns".toUpperCase, "address", "note")
   }
 
   // will create 2 long string columns

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonDescribeFormattedCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonDescribeFormattedCommand.scala
@@ -114,6 +114,13 @@ private[sql] case class CarbonDescribeFormattedCommand(
       CarbonCommonConstants.CACHE_LEVEL_DEFAULT_VALUE), ""))
     val isStreaming = tblProps.asScala.getOrElse("streaming", "false")
     results ++= Seq(("Streaming", isStreaming, ""))
+
+    // longstring related info
+    if (tblProps.containsKey(CarbonCommonConstants.LONG_STRING_COLUMNS)) {
+      results ++= Seq((CarbonCommonConstants.LONG_STRING_COLUMNS,
+        tblProps.get(CarbonCommonConstants.LONG_STRING_COLUMNS), ""))
+    }
+
     var isLocalDictEnabled = tblProps.asScala
       .getOrElse(CarbonCommonConstants.LOCAL_DICTIONARY_ENABLE,
         CarbonCommonConstants.LOCAL_DICTIONARY_ENABLE_DEFAULT)

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonDescribeFormattedCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonDescribeFormattedCommand.scala
@@ -117,7 +117,7 @@ private[sql] case class CarbonDescribeFormattedCommand(
 
     // longstring related info
     if (tblProps.containsKey(CarbonCommonConstants.LONG_STRING_COLUMNS)) {
-      results ++= Seq((CarbonCommonConstants.LONG_STRING_COLUMNS,
+      results ++= Seq((CarbonCommonConstants.LONG_STRING_COLUMNS.toUpperCase,
         tblProps.get(CarbonCommonConstants.LONG_STRING_COLUMNS), ""))
     }
 


### PR DESCRIPTION
add longstring table property in the output of desc formantted command

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 `NO`
 - [x] Any backward compatibility impacted?
  `NO`
 - [x] Document update required?
 `NO`
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
`Added test`
        - How it is tested? Please attach test report.
`Tested in local machine`
        - Is it a performance related change? Please attach the performance test report.
`NO`
        - Any additional information to help reviewers in testing this change.
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

