### PR TITLE
[CARBONDATA-2704] Index file size in describe formatted command is not updated correctly with the segment file

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/metadata/SegmentFileStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/SegmentFileStore.java
@@ -244,8 +244,8 @@ public class SegmentFileStore {
    * @return boolean which determines whether status update is done or not.
    * @throws IOException
    */
-  public static boolean updateSegmentFile(String tablePath, String segmentId, String segmentFile)
-      throws IOException {
+  public static boolean updateSegmentFile(String tablePath, String segmentId, String segmentFile,
+      SegmentFileStore segmentFileStore) throws IOException {
     boolean status = false;
     String tableStatusPath = CarbonTablePath.getTableStatusFilePath(tablePath);
     String metadataPath = CarbonTablePath.getMetadataPath(tablePath);
@@ -269,6 +269,9 @@ public class SegmentFileStore {
           // if the segments is in the list of marked for delete then update the status.
           if (segmentId.equals(detail.getLoadName())) {
             detail.setSegmentFile(segmentFile);
+            long carbonIndexSize =
+                CarbonUtil.getCarbonIndexSize(segmentFileStore, segmentFileStore.getLocationMap());
+            detail.setIndexSize(String.valueOf(carbonIndexSize));
             break;
           }
         }

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
@@ -2725,23 +2725,7 @@ public final class CarbonUtil {
       fileStore.readIndexFiles();
       Map<String, List<String>> indexFilesMap = fileStore.getIndexFilesMap();
       // get the size of carbonindex file
-      for (Map.Entry<String, SegmentFileStore.FolderDetails> entry : locationMap.entrySet()) {
-        SegmentFileStore.FolderDetails folderDetails = entry.getValue();
-        Set<String> carbonindexFiles = folderDetails.getFiles();
-        String mergeFileName = folderDetails.getMergeFileName();
-        if (null != mergeFileName) {
-          String mergeIndexPath =
-              fileStore.getTablePath() + entry.getKey() + CarbonCommonConstants.FILE_SEPARATOR
-                  + mergeFileName;
-          carbonIndexSize += FileFactory.getCarbonFile(mergeIndexPath).getSize();
-        }
-        for (String indexFile : carbonindexFiles) {
-          String indexPath =
-              fileStore.getTablePath() + entry.getKey() + CarbonCommonConstants.FILE_SEPARATOR
-                  + indexFile;
-          carbonIndexSize += FileFactory.getCarbonFile(indexPath).getSize();
-        }
-      }
+      carbonIndexSize = getCarbonIndexSize(fileStore, locationMap);
       for (Map.Entry<String, List<String>> entry : indexFilesMap.entrySet()) {
         // get the size of carbondata files
         for (String blockFile : entry.getValue()) {
@@ -2752,6 +2736,36 @@ public final class CarbonUtil {
     dataAndIndexSize.put(CarbonCommonConstants.CARBON_TOTAL_DATA_SIZE, carbonDataSize);
     dataAndIndexSize.put(CarbonCommonConstants.CARBON_TOTAL_INDEX_SIZE, carbonIndexSize);
     return dataAndIndexSize;
+  }
+
+  /**
+   * Calculate the index file size of a segment
+   *
+   * @param fileStore
+   * @param locationMap
+   * @return
+   */
+  public static long getCarbonIndexSize(SegmentFileStore fileStore,
+      Map<String, SegmentFileStore.FolderDetails> locationMap) {
+    long carbonIndexSize = 0L;
+    for (Map.Entry<String, SegmentFileStore.FolderDetails> entry : locationMap.entrySet()) {
+      SegmentFileStore.FolderDetails folderDetails = entry.getValue();
+      Set<String> carbonindexFiles = folderDetails.getFiles();
+      String mergeFileName = folderDetails.getMergeFileName();
+      if (null != mergeFileName) {
+        String mergeIndexPath =
+            fileStore.getTablePath() + entry.getKey() + CarbonCommonConstants.FILE_SEPARATOR
+                + mergeFileName;
+        carbonIndexSize += FileFactory.getCarbonFile(mergeIndexPath).getSize();
+      }
+      for (String indexFile : carbonindexFiles) {
+        String indexPath =
+            fileStore.getTablePath() + entry.getKey() + CarbonCommonConstants.FILE_SEPARATOR
+                + indexFile;
+        carbonIndexSize += FileFactory.getCarbonFile(indexPath).getSize();
+      }
+    }
+    return carbonIndexSize;
   }
 
   // Get the total size of carbon data and the total size of carbon index

--- a/core/src/main/java/org/apache/carbondata/core/writer/CarbonIndexFileMergeWriter.java
+++ b/core/src/main/java/org/apache/carbondata/core/writer/CarbonIndexFileMergeWriter.java
@@ -154,7 +154,7 @@ public class CarbonIndexFileMergeWriter {
     String path = CarbonTablePath.getSegmentFilesLocation(table.getTablePath())
         + CarbonCommonConstants.FILE_SEPARATOR + newSegmentFileName;
     SegmentFileStore.writeSegmentFile(sfs.getSegmentFile(), path);
-    SegmentFileStore.updateSegmentFile(table.getTablePath(), segmentId, newSegmentFileName);
+    SegmentFileStore.updateSegmentFile(table.getTablePath(), segmentId, newSegmentFileName, sfs);
 
     for (CarbonFile file : indexFiles) {
       file.delete();


### PR DESCRIPTION
**Problem:**
Describe formatted command is not showing correct index files size after index files merge.
**Solution:**
Segment file should be updated with the actual index files size of that segment after index files merge.

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [x] Testing done
        Manual Testing
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

