### PR TITLE
[CARBONDATA-2704] Index file size in describe formatted command is not updated correctly with the segment file

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/metadata/SegmentFileStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/SegmentFileStore.java
@@ -281,7 +281,7 @@ public class SegmentFileStore {
    * @throws IOException
    */
   public static boolean updateSegmentFile(String tablePath, String segmentId, String segmentFile,
-      String tableId) throws IOException {
+      String tableId, SegmentFileStore segmentFileStore) throws IOException {
     boolean status = false;
     String tableStatusPath = CarbonTablePath.getTableStatusFilePath(tablePath);
     if (!FileFactory.isFileExist(tableStatusPath)) {
@@ -308,6 +308,8 @@ public class SegmentFileStore {
           // if the segments is in the list of marked for delete then update the status.
           if (segmentId.equals(detail.getLoadName())) {
             detail.setSegmentFile(segmentFile);
+            detail.setIndexSize(String.valueOf(CarbonUtil
+                .getCarbonIndexSize(segmentFileStore, segmentFileStore.getLocationMap())));
             break;
           }
         }

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
@@ -2731,23 +2731,7 @@ public final class CarbonUtil {
       fileStore.readIndexFiles();
       Map<String, List<String>> indexFilesMap = fileStore.getIndexFilesMap();
       // get the size of carbonindex file
-      for (Map.Entry<String, SegmentFileStore.FolderDetails> entry : locationMap.entrySet()) {
-        SegmentFileStore.FolderDetails folderDetails = entry.getValue();
-        Set<String> carbonindexFiles = folderDetails.getFiles();
-        String mergeFileName = folderDetails.getMergeFileName();
-        if (null != mergeFileName) {
-          String mergeIndexPath =
-              fileStore.getTablePath() + entry.getKey() + CarbonCommonConstants.FILE_SEPARATOR
-                  + mergeFileName;
-          carbonIndexSize += FileFactory.getCarbonFile(mergeIndexPath).getSize();
-        }
-        for (String indexFile : carbonindexFiles) {
-          String indexPath =
-              fileStore.getTablePath() + entry.getKey() + CarbonCommonConstants.FILE_SEPARATOR
-                  + indexFile;
-          carbonIndexSize += FileFactory.getCarbonFile(indexPath).getSize();
-        }
-      }
+      carbonIndexSize = getCarbonIndexSize(fileStore, locationMap);
       for (Map.Entry<String, List<String>> entry : indexFilesMap.entrySet()) {
         // get the size of carbondata files
         for (String blockFile : entry.getValue()) {
@@ -2758,6 +2742,36 @@ public final class CarbonUtil {
     dataAndIndexSize.put(CarbonCommonConstants.CARBON_TOTAL_DATA_SIZE, carbonDataSize);
     dataAndIndexSize.put(CarbonCommonConstants.CARBON_TOTAL_INDEX_SIZE, carbonIndexSize);
     return dataAndIndexSize;
+  }
+
+  /**
+   * Calcuate the index files size of the segment
+   *
+   * @param fileStore
+   * @param locationMap
+   * @return
+   */
+  public static long getCarbonIndexSize(SegmentFileStore fileStore,
+      Map<String, SegmentFileStore.FolderDetails> locationMap) {
+    long carbonIndexSize = 0L;
+    for (Map.Entry<String, SegmentFileStore.FolderDetails> entry : locationMap.entrySet()) {
+      SegmentFileStore.FolderDetails folderDetails = entry.getValue();
+      Set<String> carbonindexFiles = folderDetails.getFiles();
+      String mergeFileName = folderDetails.getMergeFileName();
+      if (null != mergeFileName) {
+        String mergeIndexPath =
+            fileStore.getTablePath() + entry.getKey() + CarbonCommonConstants.FILE_SEPARATOR
+                + mergeFileName;
+        carbonIndexSize += FileFactory.getCarbonFile(mergeIndexPath).getSize();
+      }
+      for (String indexFile : carbonindexFiles) {
+        String indexPath =
+            fileStore.getTablePath() + entry.getKey() + CarbonCommonConstants.FILE_SEPARATOR
+                + indexFile;
+        carbonIndexSize += FileFactory.getCarbonFile(indexPath).getSize();
+      }
+    }
+    return carbonIndexSize;
   }
 
   // Get the total size of carbon data and the total size of carbon index

--- a/core/src/main/java/org/apache/carbondata/core/writer/CarbonIndexFileMergeWriter.java
+++ b/core/src/main/java/org/apache/carbondata/core/writer/CarbonIndexFileMergeWriter.java
@@ -114,11 +114,11 @@ public class CarbonIndexFileMergeWriter {
   private String writeMergeIndexFileBasedOnSegmentFile(
       String segmentId,
       List<String> indexFileNamesTobeAdded,
-      SegmentFileStore sfs, CarbonFile[] indexFiles) throws IOException {
+      SegmentFileStore segmentFileStore, CarbonFile[] indexFiles) throws IOException {
     SegmentIndexFileStore fileStore = new SegmentIndexFileStore();
     fileStore
-        .readAllIIndexOfSegment(sfs.getSegmentFile(), sfs.getTablePath(), SegmentStatus.SUCCESS,
-            true);
+        .readAllIIndexOfSegment(segmentFileStore.getSegmentFile(), segmentFileStore.getTablePath(),
+            SegmentStatus.SUCCESS, true);
     Map<String, byte[]> indexMap = fileStore.getCarbonIndexMapWithFullPath();
     Map<String, Map<String, byte[]>> indexLocationMap = new HashMap<>();
     for (Map.Entry<String, byte[]> entry: indexMap.entrySet()) {
@@ -133,11 +133,12 @@ public class CarbonIndexFileMergeWriter {
     for (Map.Entry<String, Map<String, byte[]>> entry : indexLocationMap.entrySet()) {
       String mergeIndexFile =
           writeMergeIndexFile(indexFileNamesTobeAdded, entry.getKey(), entry.getValue(), segmentId);
-      for (Map.Entry<String, SegmentFileStore.FolderDetails> segentry : sfs.getLocationMap()
-          .entrySet()) {
+      for (Map.Entry<String, SegmentFileStore.FolderDetails> segentry : segmentFileStore
+          .getLocationMap().entrySet()) {
         String location = segentry.getKey();
         if (segentry.getValue().isRelative()) {
-          location = sfs.getTablePath() + CarbonCommonConstants.FILE_SEPARATOR + location;
+          location =
+              segmentFileStore.getTablePath() + CarbonCommonConstants.FILE_SEPARATOR + location;
         }
         if (new Path(entry.getKey()).equals(new Path(location))) {
           segentry.getValue().setMergeFileName(mergeIndexFile);
@@ -153,9 +154,9 @@ public class CarbonIndexFileMergeWriter {
             + CarbonTablePath.SEGMENT_EXT;
     String path = CarbonTablePath.getSegmentFilesLocation(table.getTablePath())
         + CarbonCommonConstants.FILE_SEPARATOR + newSegmentFileName;
-    SegmentFileStore.writeSegmentFile(sfs.getSegmentFile(), path);
+    SegmentFileStore.writeSegmentFile(segmentFileStore.getSegmentFile(), path);
     SegmentFileStore.updateSegmentFile(table.getTablePath(), segmentId, newSegmentFileName,
-        table.getCarbonTableIdentifier().getTableId());
+        table.getCarbonTableIdentifier().getTableId(), segmentFileStore);
 
     for (CarbonFile file : indexFiles) {
       file.delete();

--- a/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -520,7 +520,9 @@ object CarbonDataRDDFactory {
         carbonTable.getTablePath,
         carbonLoadModel.getSegmentId,
         segmentFileName,
-        carbonTable.getCarbonTableIdentifier.getTableId)
+        carbonTable.getCarbonTableIdentifier.getTableId,
+        new SegmentFileStore(carbonTable.getTablePath, segmentFileName))
+
       operationContext.setProperty(carbonTable.getTableUniqueName + "_Segment",
         carbonLoadModel.getSegmentId)
       val loadTablePreStatusUpdateEvent: LoadTablePreStatusUpdateEvent =


### PR DESCRIPTION
**Problem:**
Describe formatted command is not showing correct index files size after index files merge.
**Solution:**
Segment file should be updated with the actual index files size of that segment after index files merge.

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [x] Testing done
        UT added
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

