### PR TITLE
[CARBONDATA-2618][32K] Split to multiple pages if varchar column page exceeds 2GB/snappy limits

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/compression/SnappyCompressor.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/compression/SnappyCompressor.java
@@ -31,6 +31,9 @@ public class SnappyCompressor implements Compressor {
   private static final LogService LOGGER =
       LogServiceFactory.getLogService(SnappyCompressor.class.getName());
 
+  // snappy estimate max compressed length as 32 + source_len + source_len/6
+  public static final int MAX_BYTE_TO_COMPRESS = (int)((Integer.MAX_VALUE - 32) / 7.0 * 6);
+
   private final SnappyNative snappyNative;
 
   public SnappyCompressor() {

--- a/processing/src/main/java/org/apache/carbondata/processing/store/CarbonFactDataHandlerModel.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/CarbonFactDataHandlerModel.java
@@ -34,7 +34,9 @@ import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
 import org.apache.carbondata.core.metadata.CarbonMetadata;
 import org.apache.carbondata.core.metadata.CarbonTableIdentifier;
 import org.apache.carbondata.core.metadata.datatype.DataType;
+import org.apache.carbondata.core.metadata.datatype.DataTypes;
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
+import org.apache.carbondata.core.metadata.schema.table.column.CarbonColumn;
 import org.apache.carbondata.core.metadata.schema.table.column.CarbonMeasure;
 import org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema;
 import org.apache.carbondata.core.util.CarbonProperties;
@@ -43,6 +45,7 @@ import org.apache.carbondata.core.util.path.CarbonTablePath;
 import org.apache.carbondata.processing.datamap.DataMapWriterListener;
 import org.apache.carbondata.processing.datatypes.GenericDataType;
 import org.apache.carbondata.processing.loading.CarbonDataLoadConfiguration;
+import org.apache.carbondata.processing.loading.DataField;
 import org.apache.carbondata.processing.loading.constants.DataLoadProcessorConstants;
 import org.apache.carbondata.processing.loading.model.CarbonLoadModel;
 import org.apache.carbondata.processing.loading.sort.SortScopeOptions;
@@ -172,6 +175,8 @@ public class CarbonFactDataHandlerModel {
 
   private int numberOfCores;
 
+  private List<Integer> varcharDimIdxInNoDict;
+
   /**
    * Create the model using @{@link CarbonDataLoadConfiguration}
    */
@@ -214,6 +219,19 @@ public class CarbonFactDataHandlerModel {
     for (int i = 0; i < simpleDimsCount; i++) {
       simpleDimsLen[i] = dimLens[i];
     }
+
+    // for dynamic page size in write step if varchar columns exist
+    List<Integer> varcharDimIdxInNoDict = new ArrayList<>();
+    int dictDimCount = configuration.getDimensionCount() - configuration.getNoDictionaryCount();
+    for (DataField dataField : configuration.getDataFields()) {
+      CarbonColumn column = dataField.getColumn();
+      if (!column.isComplex() && !dataField.hasDictionaryEncoding() &&
+              column.getDataType() == DataTypes.VARCHAR) {
+        // ordinal is set in CarbonTable.fillDimensionsAndMeasuresForTables()
+        varcharDimIdxInNoDict.add(column.getOrdinal() - dictDimCount);
+      }
+    }
+
     //To Set MDKey Index of each primitive type in complex type
     int surrIndex = simpleDimsCount;
     Iterator<Map.Entry<String, GenericDataType>> complexMap =
@@ -280,6 +298,7 @@ public class CarbonFactDataHandlerModel {
     carbonFactDataHandlerModel.dataMapWriterlistener = listener;
     carbonFactDataHandlerModel.writingCoresCount = configuration.getWritingCoresCount();
     setNumberOfCores(carbonFactDataHandlerModel);
+    carbonFactDataHandlerModel.setVarcharDimIdxInNoDict(varcharDimIdxInNoDict);
     return carbonFactDataHandlerModel;
   }
 
@@ -654,5 +673,14 @@ public class CarbonFactDataHandlerModel {
   public int getNumberOfCores() {
     return numberOfCores;
   }
+
+  public void setVarcharDimIdxInNoDict(List<Integer> varcharDimIdxInNoDict) {
+    this.varcharDimIdxInNoDict = varcharDimIdxInNoDict;
+  }
+
+  public List<Integer> getVarcharDimIdxInNoDict() {
+    return varcharDimIdxInNoDict;
+  }
+
 }
 


### PR DESCRIPTION
Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.

        Testcase in VarcharDataTypesBasicTestCase is ignored because  it will need at least 4GB memory to run successfully.  


       LocalTest is passed for cases:
        - unsafe column page with 4GB unsafe working memory
        - disable using unsafe column page

 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 


A varchar column page uses SafeVarLengthColumnPage/UnsafeVarLengthColumnPage to store data
and encoded using HighCardDictDimensionIndexCodec which will call getByteArrayPage() from
column page and flatten into byte[] for compression.
Limited by the index of array, we can only put number of Integer.MAX_VALUE bytes in a page.

Another limitation is from Compressor. Currently we use snappy as default compressor,
and it will call MaxCompressedLength method to estimate the result size for preparing output.
For safety, the estimate result is oversize: `32 + source_len + source_len/6`.
So the maximum bytes to compress by snappy is (2GB-32)*6/7≈1.71GB.

Size of a row does not exceed 2MB since UnsafeSortDataRows uses 2MB byte[] as rowBuffer.
Such that we can stop adding more row here if any long string column reach this limit.
