### PR TITLE
Update CarbonTableReader.java

### DIFF
--- a/integration/presto/src/main/java/org/apache/carbondata/presto/impl/CarbonTableReader.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/impl/CarbonTableReader.java
@@ -246,6 +246,7 @@ public class CarbonTableReader {
    * @return
    */
   private Set<String> updateTableList(String schemaName) {
+    updateCarbonFile();
     List<CarbonFile> schema =
         Stream.of(carbonFileList.listFiles()).filter(a -> schemaName.equals(a.getName()))
             .collect(Collectors.toList());


### PR DESCRIPTION
bug fix carbon not initalized  when show table from infomratino_schema

exception like this
java.lang.NullPointerException: undefined
	at
org.apache.carbondata.presto.impl.CarbonTableReader.updateTableList(CarbonTableReader.java:208)
	at
org.apache.carbondata.presto.impl.CarbonTableReader.getTableNames(CarbonTableReader.java:197)
	at
org.apache.carbondata.presto.CarbondataMetadata.listTables(CarbondataMetadata.java:73)
	at
com.facebook.presto.spi.connector.classloader.ClassLoaderSafeConnectorMetadata.listTables(ClassLoad
	
	SELECT table_name FROM information_schema.tables WHERE table_schema =
'tmp_sbu_vadmdb'