### PR TITLE
[CARBONDATA-2715][LuceneDataMap] Fix bug in search mode with lucene datamap in windows

### DIFF
--- a/store/search/src/main/java/org/apache/carbondata/store/worker/SearchRequestHandler.java
+++ b/store/search/src/main/java/org/apache/carbondata/store/worker/SearchRequestHandler.java
@@ -191,7 +191,7 @@ public class SearchRequestHandler {
 
     HashMap<String, ExtendedBlocklet> pathToRead = new HashMap<>();
     for (ExtendedBlocklet prunedBlocklet : prunnedBlocklets) {
-      pathToRead.put(prunedBlocklet.getFilePath(), prunedBlocklet);
+      pathToRead.put(prunedBlocklet.getFilePath().replace('\\', '/'), prunedBlocklet);
     }
 
     List<TableBlockInfo> blocks = queryModel.getTableBlockInfos();


### PR DESCRIPTION
While comparing two pathes, the file separator is different in windows,
thus causing empty pruned blocklets. This PR will ignore the file
separator

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

