### PR TITLE
[CARBONDATA-2530][MV] Disable the MV datamaps after main table load.

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datamap/status/DataMapStatusManager.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/status/DataMapStatusManager.java
@@ -95,7 +95,9 @@ public class DataMapStatusManager {
         DataMapStoreManager.getInstance().getDataMapSchemasOfTable(table);
     List<DataMapSchema> dataMapToBeDisabled = new ArrayList<>(allDataMapSchemas.size());
     for (DataMapSchema dataMap : allDataMapSchemas) {
-      if (dataMap.isLazy()) {
+      // TODO all non datamaps like MV is now supports only lazy. Once the support is made the
+      // following check can be removed.
+      if (dataMap.isLazy() || !dataMap.isIndexDataMap()) {
         dataMapToBeDisabled.add(dataMap);
       }
     }

--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/DiskBasedDMSchemaStorageProvider.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/DiskBasedDMSchemaStorageProvider.java
@@ -39,6 +39,7 @@ import org.apache.carbondata.core.datastore.impl.FileFactory;
 import org.apache.carbondata.core.util.CarbonUtil;
 
 import com.google.gson.Gson;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.fs.permission.FsAction;
 import org.apache.hadoop.fs.permission.FsPermission;
 
@@ -109,7 +110,13 @@ public class DiskBasedDMSchemaStorageProvider implements DataMapSchemaStoragePro
     for (DataMapSchema dataMapSchema : this.dataMapSchemas) {
       List<RelationIdentifier> parentTables = dataMapSchema.getParentTables();
       for (RelationIdentifier identifier : parentTables) {
-        if (identifier.getTableId().equalsIgnoreCase(carbonTable.getTableId())) {
+        if (StringUtils.isNotEmpty(identifier.getTableId())) {
+          if (identifier.getTableId().equalsIgnoreCase(carbonTable.getTableId())) {
+            dataMapSchemas.add(dataMapSchema);
+            break;
+          }
+        } else if (identifier.getTableName().equalsIgnoreCase(carbonTable.getTableName()) &&
+            identifier.getDatabaseName().equalsIgnoreCase(carbonTable.getDatabaseName())) {
           dataMapSchemas.add(dataMapSchema);
           break;
         }

--- a/datamap/mv/core/src/main/scala/org/apache/carbondata/mv/rewrite/SummaryDatasetCatalog.scala
+++ b/datamap/mv/core/src/main/scala/org/apache/carbondata/mv/rewrite/SummaryDatasetCatalog.scala
@@ -235,7 +235,7 @@ private[mv] class SummaryDatasetCatalog(sparkSession: SparkSession)
       //  ****not sure what enabledDataSets is used for ****
       //  can enable/disable datamap move to other place ?
       //    val feasible = enabledDataSets.filter { x =>
-      val feasible = summaryDatasets.filter { x =>
+      val feasible = enabledDataSets.filter { x =>
         (x.signature, sig) match {
           case (Some(sig1), Some(sig2)) =>
             if (sig1.groupby && sig2.groupby && sig1.datasets.subsetOf(sig2.datasets)) {


### PR DESCRIPTION

This PR depends on https://github.com/apache/carbondata/pull/2453
Problem:
 MV datamaps are not disabled after the main table load is done. So the wrong data is displaying.
Solution:
Disable the MV datamaps after main table load success.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

