### PR TITLE
[CARBONDATA-2534][MV] Fix substring expression not working in MV creation

### DIFF
--- a/datamap/mv/core/src/main/scala/org/apache/carbondata/mv/datamap/MVHelper.scala
+++ b/datamap/mv/core/src/main/scala/org/apache/carbondata/mv/datamap/MVHelper.scala
@@ -119,7 +119,12 @@ object MVHelper {
   }
 
   def updateColumnName(attr: Attribute): String = {
-    val name = attr.name.replace("(", "_").replace(")", "").replace(" ", "_").replace("=", "")
+    val name =
+      attr.name.replace("(", "_")
+        .replace(")", "")
+        .replace(" ", "_")
+        .replace("=", "")
+        .replace(",", "")
     attr.qualifier.map(qualifier => qualifier + "_" + name).getOrElse(name)
   }
 


### PR DESCRIPTION
This PR depends on https://github.com/apache/carbondata/pull/2453
Problem: The column generated when subquery expression column present is wrong while creating of MV table.
Solution: Corrected the column name by removing special characters.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

