### PR TITLE
[CARBONDATA-2540][CARBONDATA-2560][CARBONDATA-2568][MV] Add validations for unsupported MV queries 

### DIFF
--- a/datamap/mv/core/src/main/scala/org/apache/carbondata/mv/datamap/MVHelper.scala
+++ b/datamap/mv/core/src/main/scala/org/apache/carbondata/mv/datamap/MVHelper.scala
@@ -34,9 +34,11 @@ import org.apache.spark.sql.execution.datasources.LogicalRelation
 import org.apache.spark.sql.parser.CarbonSpark2SqlParser
 
 import org.apache.carbondata.core.datamap.DataMapStoreManager
+import org.apache.carbondata.core.metadata.schema.datamap.DataMapClassProvider
 import org.apache.carbondata.core.metadata.schema.table.{DataMapSchema, RelationIdentifier}
+import org.apache.carbondata.datamap.DataMapManager
 import org.apache.carbondata.mv.plans.modular.{GroupBy, Matchable, ModularPlan, Select}
-import org.apache.carbondata.mv.rewrite.{MVPlanWrapper, QueryRewrite}
+import org.apache.carbondata.mv.rewrite.{MVPlanWrapper, QueryRewrite, SummaryDatasetCatalog}
 import org.apache.carbondata.spark.util.CommonUtil
 
 /**
@@ -50,7 +52,9 @@ object MVHelper {
       ifNotExistsSet: Boolean = false): Unit = {
     val dmProperties = dataMapSchema.getProperties.asScala
     val updatedQuery = new CarbonSpark2SqlParser().addPreAggFunction(queryString)
-    val logicalPlan = sparkSession.sql(updatedQuery).drop("preAgg").queryExecution.analyzed
+    val query = sparkSession.sql(updatedQuery)
+    val logicalPlan = MVHelper.dropDummFuc(query.queryExecution.analyzed)
+    validateMVQuery(sparkSession, logicalPlan)
     val fullRebuild = isFullReload(logicalPlan)
     val fields = logicalPlan.output.map { attr =>
       val name = updateColumnName(attr)
@@ -116,6 +120,43 @@ object MVHelper {
     dataMapSchema.setParentTables(new util.ArrayList[RelationIdentifier](parentIdents.asJava))
     dataMapSchema.getProperties.put("full_refresh", fullRebuild.toString)
     DataMapStoreManager.getInstance().saveDataMapSchema(dataMapSchema)
+  }
+
+  private def validateMVQuery(sparkSession: SparkSession,
+      logicalPlan: LogicalPlan) {
+    val dataMapProvider = DataMapManager.get().getDataMapProvider(null,
+      new DataMapSchema("", DataMapClassProvider.MV.getShortName), sparkSession)
+    dataMapProvider
+    var catalog = DataMapStoreManager.getInstance().getDataMapCatalog(dataMapProvider,
+      DataMapClassProvider.MV.getShortName).asInstanceOf[SummaryDatasetCatalog]
+    if (catalog == null) {
+      catalog = new SummaryDatasetCatalog(sparkSession)
+    }
+    val modularPlan =
+      catalog.mvSession.sessionState.modularizer.modularize(
+        catalog.mvSession.sessionState.optimizer.execute(logicalPlan)).next().semiHarmonized
+
+    val isValid = modularPlan match {
+      case g: GroupBy =>
+        // Make sure all predicates are present in projections.
+        g.predicateList.forall{p =>
+          g.outputList.exists{
+            case a: Alias =>
+              a.semanticEquals(p) || a.child.semanticEquals(p)
+            case other => other.semanticEquals(p)
+          }
+        }
+      case _ => true
+    }
+    if (!isValid) {
+      throw new UnsupportedOperationException("Group by columns must be present in project columns")
+    }
+    if(catalog.isMVWithSameQueryPresent(logicalPlan)) {
+      throw new UnsupportedOperationException("MV with same query present")
+    }
+    if (!modularPlan.isSPJGH)  {
+      throw new UnsupportedOperationException("MV is not supported for this query")
+    }
   }
 
   def updateColumnName(attr: Attribute): String = {

--- a/datamap/mv/core/src/main/scala/org/apache/carbondata/mv/rewrite/SummaryDatasetCatalog.scala
+++ b/datamap/mv/core/src/main/scala/org/apache/carbondata/mv/rewrite/SummaryDatasetCatalog.scala
@@ -190,6 +190,13 @@ private[mv] class SummaryDatasetCatalog(sparkSession: SparkSession)
   }
 
   /**
+   * Check already with same query present in mv
+   */
+  private[mv] def isMVWithSameQueryPresent(query: LogicalPlan) : Boolean = {
+    lookupSummaryDataset(query).nonEmpty
+  }
+
+  /**
    * API for test only
    * Tries to remove the data set for the given [[DataFrame]] from the catalog if it's registered
    */


### PR DESCRIPTION
This PR depends on https://github.com/apache/carbondata/pull/2453
Problem: Validations are missing on the unsupported MV queries while creating MV datamap.
Solution: Added validation for the unsupported MV queries while creating datamap.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

