### PR TITLE
[CARBONDATA-2542][MV] Fix the mv query from table with different database 

### DIFF
--- a/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/MVCreateTestCase.scala
+++ b/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/MVCreateTestCase.scala
@@ -750,6 +750,28 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     sql("drop table if exists test1")
   }
 
+  test("jira carbondata-2542") {
+    sql("""drop database if exists xy cascade""")
+    sql("""create database if not exists xy""")
+    sql(
+      """
+        | CREATE TABLE xy.fact_tablexy (empname String, designation String, doj Timestamp,
+        |  workgroupcategory int, workgroupcategoryname String, deptno int, deptname String,
+        |  projectcode int, projectjoindate Timestamp, projectenddate Timestamp,attendance int,
+        |  utilization int,salary int)
+        | STORED BY 'org.apache.carbondata.format'
+      """.stripMargin)
+    sql("drop datamap if exists MV_exp")
+    sql("create datamap MV_exp using 'mv' as select doj,sum(salary) from xy.fact_tablexy group by doj")
+    sql("rebuild datamap MV_exp")
+    val frame = sql(
+      "select doj,sum(salary) from xy.fact_tablexy group by doj")
+    val analyzed = frame.queryExecution.analyzed
+    assert(verifyMVDataMap(analyzed, "MV_exp"))
+    sql("drop datamap if exists MV_exp")
+    sql("""drop database if exists xy cascade""")
+  }
+
   def verifyMVDataMap(logicalPlan: LogicalPlan, dataMapName: String): Boolean = {
     val tables = logicalPlan collect {
       case l: LogicalRelation => l.catalogTable.get

--- a/datamap/mv/plan/src/main/scala/org/apache/carbondata/mv/plans/util/Printers.scala
+++ b/datamap/mv/plan/src/main/scala/org/apache/carbondata/mv/plans/util/Printers.scala
@@ -180,7 +180,7 @@ trait Printers {
     }
 
     def printTable(name: Seq[String]): Unit = {
-      print("%s".format(name.last))
+      print("%s".format(name.mkString(".")))
     }
 
     trait ExprSeq extends Seq[SortOrder]


### PR DESCRIPTION
This PR depends on https://github.com/apache/carbondata/pull/2453
Problem: database name is not added to the table name while generating mv query.
Solution: Add the database name to the table name while creating mv query.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

