### PR TITLE
[CARBONDATA-2550][CARBONDATA-2576][MV] Fix limit and average function issue in MV query

### DIFF
--- a/datamap/mv/core/src/main/scala/org/apache/carbondata/mv/datamap/MVHelper.scala
+++ b/datamap/mv/core/src/main/scala/org/apache/carbondata/mv/datamap/MVHelper.scala
@@ -439,7 +439,7 @@ object MVHelper {
   private def updateFlagSpec(keepAlias: Boolean,
       select: Select,
       relation: Select,
-      aliasMap: Map[AttributeKey, NamedExpression]) = {
+      aliasMap: Map[AttributeKey, NamedExpression]): Seq[Seq[Any]] = {
     val updatedFlagSpec = select.flagSpec.map { f =>
       f.map {
         case list: ArrayBuffer[SortOrder] =>


### PR DESCRIPTION
This PR depends on https://github.com/apache/carbondata/pull/2453
Problem: Limit is not working on mv queries and the average is also not working.
Solution: Correct the limit queries and average queries through making as full refresh query.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

