### PR TITLE
[CARBONDATA-2714] Support merge index files for the segment

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -1394,9 +1394,6 @@ public final class CarbonCommonConstants {
   public static final String CARBON_SQLASTBUILDER_CLASSNAME =
       "spark.carbon.sqlastbuilder.classname";
 
-  public static final String CARBON_COMMON_LISTENER_REGISTER_CLASSNAME =
-      "spark.carbon.common.listener.register.classname";
-
   @CarbonProperty
   public static final String CARBON_LEASE_RECOVERY_RETRY_COUNT =
       "carbon.lease.recovery.retry.count";
@@ -1870,6 +1867,16 @@ public final class CarbonCommonConstants {
    * default value for cache level
    */
   public static final String CACHE_LEVEL_DEFAULT_VALUE = "BLOCK";
+
+  /**
+   * It is internal configuration and used only for test purpose.
+   * It will merge the carbon index files with in the segment to single segment.
+   */
+  @CarbonProperty
+  public static final String CARBON_MERGE_INDEX_IN_SEGMENT =
+      "carbon.merge.index.in.segment";
+
+  public static final String CARBON_MERGE_INDEX_IN_SEGMENT_DEFAULT = "true";
 
   private CarbonCommonConstants() {
   }

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/BlockletDataMapIndexStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/BlockletDataMapIndexStore.java
@@ -106,11 +106,13 @@ public class BlockletDataMapIndexStore
                 new TableBlockIndexUniqueIdentifierWrapper(blockIndexUniqueIdentifier,
                     identifierWrapper.getCarbonTable()), indexFileStore, filesRead,
                 carbonDataFileBlockMetaInfoMapping);
-            BlockDataMap blockletDataMap =
-                loadAndGetDataMap(blockIndexUniqueIdentifier, indexFileStore, blockMetaInfoMap,
-                    identifierWrapper.getCarbonTable(),
-                    identifierWrapper.isAddTableBlockToUnsafe());
-            dataMaps.add(blockletDataMap);
+            if (!blockMetaInfoMap.isEmpty()) {
+              BlockDataMap blockletDataMap =
+                  loadAndGetDataMap(blockIndexUniqueIdentifier, indexFileStore, blockMetaInfoMap,
+                      identifierWrapper.getCarbonTable(),
+                      identifierWrapper.isAddTableBlockToUnsafe());
+              dataMaps.add(blockletDataMap);
+            }
           }
           blockletDataMapIndexWrapper = new BlockletDataMapIndexWrapper(dataMaps);
         }

--- a/core/src/main/java/org/apache/carbondata/core/util/BlockletDataMapUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/BlockletDataMapUtil.java
@@ -112,7 +112,7 @@ public class BlockletDataMapUtil {
         CarbonTable.updateTableByTableInfo(carbonTable, carbonTable.getTableInfo());
       }
       String blockPath = footer.getBlockInfo().getTableBlockInfo().getFilePath();
-      if (null == blockMetaInfoMap.get(blockPath)) {
+      if (null == blockMetaInfoMap.get(blockPath) && FileFactory.isFileExist(blockPath)) {
         blockMetaInfoMap.put(blockPath, createBlockMetaInfo(fileNameToMetaInfoMapping, blockPath));
       }
     }

--- a/integration/spark-common-cluster-test/src/test/scala/org/apache/carbondata/cluster/sdv/generated/MergeIndexTestCase.scala
+++ b/integration/spark-common-cluster-test/src/test/scala/org/apache/carbondata/cluster/sdv/generated/MergeIndexTestCase.scala
@@ -23,11 +23,13 @@ import scala.collection.JavaConverters._
 import org.apache.spark.sql.common.util._
 import org.scalatest.BeforeAndAfterAll
 
+import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.datamap.Segment
 import org.apache.carbondata.core.datastore.filesystem.{CarbonFile, CarbonFileFilter}
 import org.apache.carbondata.core.datastore.impl.FileFactory
 import org.apache.carbondata.core.indexstore.blockletindex.SegmentIndexFileStore
 import org.apache.carbondata.core.metadata.{CarbonMetadata, SegmentFileStore}
+import org.apache.carbondata.core.util.CarbonProperties
 import org.apache.carbondata.core.writer.CarbonIndexFileMergeWriter
 import org.apache.carbondata.core.util.path.CarbonTablePath
 
@@ -39,30 +41,37 @@ class MergeIndexTestCase extends QueryTest with BeforeAndAfterAll {
 
 
   override protected def afterAll(): Unit = {
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.CARBON_MERGE_INDEX_IN_SEGMENT,
+        CarbonCommonConstants.CARBON_MERGE_INDEX_IN_SEGMENT_DEFAULT)
     sql("DROP TABLE IF EXISTS nonindexmerge")
     sql("DROP TABLE IF EXISTS indexmerge")
   }
 
   test("Verify correctness of index merge sdv") {
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.CARBON_MERGE_INDEX_IN_SEGMENT, "false")
     sql(s"""drop table if exists carbon_automation_nonmerge""").collect
 
     sql(s"""create table carbon_automation_nonmerge (imei string,deviceInformationId int,MAC string,deviceColor string,device_backColor string,modelId string,marketName string,AMSize string,ROMSize string,CUPAudit string,CPIClocked string,series string,productionDate timestamp,bomCode string,internalModels string, deliveryTime string, channelsId string, channelsName string , deliveryAreaId string, deliveryCountry string, deliveryProvince string, deliveryCity string,deliveryDistrict string, deliveryStreet string, oxSingleNumber string, ActiveCheckTime string, ActiveAreaId string, ActiveCountry string, ActiveProvince string, Activecity string, ActiveDistrict string, ActiveStreet string, ActiveOperatorId string, Active_releaseId string, Active_EMUIVersion string, Active_operaSysVersion string, Active_BacVerNumber string, Active_BacFlashVer string, Active_webUIVersion string, Active_webUITypeCarrVer string,Active_webTypeDataVerNumber string, Active_operatorsVersion string, Active_phonePADPartitionedVersions string, Latest_YEAR int, Latest_MONTH int, Latest_DAY int, Latest_HOUR string, Latest_areaId string, Latest_country string, Latest_province string, Latest_city string, Latest_district string, Latest_street string, Latest_releaseId string, Latest_EMUIVersion string, Latest_operaSysVersion string, Latest_BacVerNumber string, Latest_BacFlashVer string, Latest_webUIVersion string, Latest_webUITypeCarrVer string, Latest_webTypeDataVerNumber string, Latest_operatorsVersion string, Latest_phonePADPartitionedVersions string, Latest_operatorId string, gamePointDescription string,gamePointId double,contractNumber double) STORED BY 'org.apache.carbondata.format' TBLPROPERTIES ('DICTIONARY_INCLUDE'='deviceInformationId,Latest_YEAR,Latest_MONTH,Latest_DAY')""").collect
 
     sql(s"""LOAD DATA INPATH '$resourcesPath/Data/VmaLL100' INTO TABLE carbon_automation_nonmerge OPTIONS('DELIMITER'=',','QUOTECHAR'='"','FILEHEADER'='imei,deviceInformationId,MAC,deviceColor,device_backColor,modelId,marketName,AMSize,ROMSize,CUPAudit,CPIClocked,series,productionDate,bomCode,internalModels,deliveryTime,channelsId,channelsName,deliveryAreaId,deliveryCountry,deliveryProvince,deliveryCity,deliveryDistrict,deliveryStreet,oxSingleNumber,contractNumber,ActiveCheckTime,ActiveAreaId,ActiveCountry,ActiveProvince,Activecity,ActiveDistrict,ActiveStreet,ActiveOperatorId,Active_releaseId,Active_EMUIVersion,Active_operaSysVersion,Active_BacVerNumber,Active_BacFlashVer,Active_webUIVersion,Active_webUITypeCarrVer,Active_webTypeDataVerNumber,Active_operatorsVersion,Active_phonePADPartitionedVersions,Latest_YEAR,Latest_MONTH,Latest_DAY,Latest_HOUR,Latest_areaId,Latest_country,Latest_province,Latest_city,Latest_district,Latest_street,Latest_releaseId,Latest_EMUIVersion,Latest_operaSysVersion,Latest_BacVerNumber,Latest_BacFlashVer,Latest_webUIVersion,Latest_webUITypeCarrVer,Latest_webTypeDataVerNumber,Latest_operatorsVersion,Latest_phonePADPartitionedVersions,Latest_operatorId,gamePointId,gamePointDescription')""").collect
     assert(getIndexFileCount("default", "carbon_automation_nonmerge", "0") >= 1)
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.CARBON_MERGE_INDEX_IN_SEGMENT, "true")
     sql("DROP TABLE IF EXISTS carbon_automation_merge")
     sql(s"""create table carbon_automation_merge (imei string,deviceInformationId int,MAC string,deviceColor string,device_backColor string,modelId string,marketName string,AMSize string,ROMSize string,CUPAudit string,CPIClocked string,series string,productionDate timestamp,bomCode string,internalModels string, deliveryTime string, channelsId string, channelsName string , deliveryAreaId string, deliveryCountry string, deliveryProvince string, deliveryCity string,deliveryDistrict string, deliveryStreet string, oxSingleNumber string, ActiveCheckTime string, ActiveAreaId string, ActiveCountry string, ActiveProvince string, Activecity string, ActiveDistrict string, ActiveStreet string, ActiveOperatorId string, Active_releaseId string, Active_EMUIVersion string, Active_operaSysVersion string, Active_BacVerNumber string, Active_BacFlashVer string, Active_webUIVersion string, Active_webUITypeCarrVer string,Active_webTypeDataVerNumber string, Active_operatorsVersion string, Active_phonePADPartitionedVersions string, Latest_YEAR int, Latest_MONTH int, Latest_DAY int, Latest_HOUR string, Latest_areaId string, Latest_country string, Latest_province string, Latest_city string, Latest_district string, Latest_street string, Latest_releaseId string, Latest_EMUIVersion string, Latest_operaSysVersion string, Latest_BacVerNumber string, Latest_BacFlashVer string, Latest_webUIVersion string, Latest_webUITypeCarrVer string, Latest_webTypeDataVerNumber string, Latest_operatorsVersion string, Latest_phonePADPartitionedVersions string, Latest_operatorId string, gamePointDescription string,gamePointId double,contractNumber double) STORED BY 'org.apache.carbondata.format' TBLPROPERTIES ('DICTIONARY_INCLUDE'='deviceInformationId,Latest_YEAR,Latest_MONTH,Latest_DAY')""").collect
 
     sql(s"""LOAD DATA INPATH '$resourcesPath/Data/VmaLL100' INTO TABLE carbon_automation_merge OPTIONS('DELIMITER'=',','QUOTECHAR'='"','FILEHEADER'='imei,deviceInformationId,MAC,deviceColor,device_backColor,modelId,marketName,AMSize,ROMSize,CUPAudit,CPIClocked,series,productionDate,bomCode,internalModels,deliveryTime,channelsId,channelsName,deliveryAreaId,deliveryCountry,deliveryProvince,deliveryCity,deliveryDistrict,deliveryStreet,oxSingleNumber,contractNumber,ActiveCheckTime,ActiveAreaId,ActiveCountry,ActiveProvince,Activecity,ActiveDistrict,ActiveStreet,ActiveOperatorId,Active_releaseId,Active_EMUIVersion,Active_operaSysVersion,Active_BacVerNumber,Active_BacFlashVer,Active_webUIVersion,Active_webUITypeCarrVer,Active_webTypeDataVerNumber,Active_operatorsVersion,Active_phonePADPartitionedVersions,Latest_YEAR,Latest_MONTH,Latest_DAY,Latest_HOUR,Latest_areaId,Latest_country,Latest_province,Latest_city,Latest_district,Latest_street,Latest_releaseId,Latest_EMUIVersion,Latest_operaSysVersion,Latest_BacVerNumber,Latest_BacFlashVer,Latest_webUIVersion,Latest_webUITypeCarrVer,Latest_webTypeDataVerNumber,Latest_operatorsVersion,Latest_phonePADPartitionedVersions,Latest_operatorId,gamePointId,gamePointDescription')""").collect
 
-    val table = CarbonMetadata.getInstance().getCarbonTable("default","carbon_automation_merge")
-    new CarbonIndexFileMergeWriter(table).mergeCarbonIndexFilesOfSegment("0", table.getTablePath, false, String.valueOf(System.currentTimeMillis()))
     assert(getIndexFileCount("default", "carbon_automation_merge", "0") == 0)
     checkAnswer(sql("""Select count(*) from carbon_automation_nonmerge"""),
       sql("""Select count(*) from carbon_automation_merge"""))
   }
 
   test("Verify command of index merge  sdv") {
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.CARBON_MERGE_INDEX_IN_SEGMENT, "false")
     sql(s"""drop table if exists carbon_automation_nonmerge""").collect
 
     sql(s"""create table carbon_automation_nonmerge (imei string,deviceInformationId int,MAC string,deviceColor string,device_backColor string,modelId string,marketName string,AMSize string,ROMSize string,CUPAudit string,CPIClocked string,series string,productionDate timestamp,bomCode string,internalModels string, deliveryTime string, channelsId string, channelsName string , deliveryAreaId string, deliveryCountry string, deliveryProvince string, deliveryCity string,deliveryDistrict string, deliveryStreet string, oxSingleNumber string, ActiveCheckTime string, ActiveAreaId string, ActiveCountry string, ActiveProvince string, Activecity string, ActiveDistrict string, ActiveStreet string, ActiveOperatorId string, Active_releaseId string, Active_EMUIVersion string, Active_operaSysVersion string, Active_BacVerNumber string, Active_BacFlashVer string, Active_webUIVersion string, Active_webUITypeCarrVer string,Active_webTypeDataVerNumber string, Active_operatorsVersion string, Active_phonePADPartitionedVersions string, Latest_YEAR int, Latest_MONTH int, Latest_DAY int, Latest_HOUR string, Latest_areaId string, Latest_country string, Latest_province string, Latest_city string, Latest_district string, Latest_street string, Latest_releaseId string, Latest_EMUIVersion string, Latest_operaSysVersion string, Latest_BacVerNumber string, Latest_BacFlashVer string, Latest_webUIVersion string, Latest_webUITypeCarrVer string, Latest_webTypeDataVerNumber string, Latest_operatorsVersion string, Latest_phonePADPartitionedVersions string, Latest_operatorId string, gamePointDescription string,gamePointId double,contractNumber double) STORED BY 'org.apache.carbondata.format' TBLPROPERTIES ('DICTIONARY_INCLUDE'='deviceInformationId,Latest_YEAR,Latest_MONTH,Latest_DAY')""").collect
@@ -72,15 +81,16 @@ class MergeIndexTestCase extends QueryTest with BeforeAndAfterAll {
     val rows = sql("""Select count(*) from carbon_automation_nonmerge""").collect()
     assert(getIndexFileCount("default", "carbon_automation_nonmerge", "0") >= 1)
     assert(getIndexFileCount("default", "carbon_automation_nonmerge", "1") >= 1)
-    val table = CarbonMetadata.getInstance().getCarbonTable("default","carbon_automation_nonmerge")
-    new CarbonIndexFileMergeWriter(table).mergeCarbonIndexFilesOfSegment("0", table.getTablePath, false, String.valueOf(System.currentTimeMillis()))
-    new CarbonIndexFileMergeWriter(table).mergeCarbonIndexFilesOfSegment("1", table.getTablePath, false, String.valueOf(System.currentTimeMillis()))
+    sql("alter table carbon_automation_nonmerge compact 'SEGMENT_INDEX'")
     assert(getIndexFileCount("default", "carbon_automation_nonmerge", "0") == 0)
     assert(getIndexFileCount("default", "carbon_automation_nonmerge", "1") == 0)
     checkAnswer(sql("""Select count(*) from carbon_automation_nonmerge"""), rows)
   }
 
   test("Verify index index merge with compaction  sdv") {
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.CARBON_MERGE_INDEX_IN_SEGMENT, "false")
+
     sql(s"""drop table if exists carbon_automation_nonmerge""").collect
 
     sql(s"""create table carbon_automation_nonmerge (imei string,deviceInformationId int,MAC string,deviceColor string,device_backColor string,modelId string,marketName string,AMSize string,ROMSize string,CUPAudit string,CPIClocked string,series string,productionDate timestamp,bomCode string,internalModels string, deliveryTime string, channelsId string, channelsName string , deliveryAreaId string, deliveryCountry string, deliveryProvince string, deliveryCity string,deliveryDistrict string, deliveryStreet string, oxSingleNumber string, ActiveCheckTime string, ActiveAreaId string, ActiveCountry string, ActiveProvince string, Activecity string, ActiveDistrict string, ActiveStreet string, ActiveOperatorId string, Active_releaseId string, Active_EMUIVersion string, Active_operaSysVersion string, Active_BacVerNumber string, Active_BacFlashVer string, Active_webUIVersion string, Active_webUITypeCarrVer string,Active_webTypeDataVerNumber string, Active_operatorsVersion string, Active_phonePADPartitionedVersions string, Latest_YEAR int, Latest_MONTH int, Latest_DAY int, Latest_HOUR string, Latest_areaId string, Latest_country string, Latest_province string, Latest_city string, Latest_district string, Latest_street string, Latest_releaseId string, Latest_EMUIVersion string, Latest_operaSysVersion string, Latest_BacVerNumber string, Latest_BacFlashVer string, Latest_webUIVersion string, Latest_webUITypeCarrVer string, Latest_webTypeDataVerNumber string, Latest_operatorsVersion string, Latest_phonePADPartitionedVersions string, Latest_operatorId string, gamePointDescription string,gamePointId double,contractNumber double) STORED BY 'org.apache.carbondata.format' TBLPROPERTIES ('DICTIONARY_INCLUDE'='deviceInformationId,Latest_YEAR,Latest_MONTH,Latest_DAY')""").collect
@@ -93,9 +103,9 @@ class MergeIndexTestCase extends QueryTest with BeforeAndAfterAll {
     assert(getIndexFileCount("default", "carbon_automation_nonmerge", "0") >= 1)
     assert(getIndexFileCount("default", "carbon_automation_nonmerge", "1") >= 1)
     assert(getIndexFileCount("default", "carbon_automation_nonmerge", "2") >= 1)
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.CARBON_MERGE_INDEX_IN_SEGMENT, "true")
     sql("ALTER TABLE carbon_automation_nonmerge COMPACT 'minor'").collect()
-    val table = CarbonMetadata.getInstance().getCarbonTable("default","carbon_automation_nonmerge")
-    new CarbonIndexFileMergeWriter(table).mergeCarbonIndexFilesOfSegment("0.1", table.getTablePath, false, String.valueOf(System.currentTimeMillis()))
     assert(getIndexFileCount("default", "carbon_automation_nonmerge", "0.1") == 0)
     assert(getIndexFileCount("default", "carbon_automation_nonmerge", "0.1", true) >= 1)
     checkAnswer(sql("""Select count(*) from carbon_automation_nonmerge"""), rows)

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestGlobalSortDataLoad.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestGlobalSortDataLoad.scala
@@ -277,13 +277,13 @@ class TestGlobalSortDataLoad extends QueryTest with BeforeAndAfterEach with Befo
     val carbonTable = CarbonMetadata.getInstance().getCarbonTable("default", "carbon_globalsort")
     val segmentDir = CarbonTablePath.getSegmentPath(carbonTable.getTablePath, "0")
     if (FileFactory.isFileExist(segmentDir)) {
-      assertResult(Math.max(7, defaultParallelism) + 1)(new File(segmentDir).listFiles().length)
+      assertResult(Math.max(4, defaultParallelism) + 1)(new File(segmentDir).listFiles().length)
     } else {
       val segment = Segment.getSegment("0", carbonTable.getTablePath)
       val store = new SegmentFileStore(carbonTable.getTablePath, segment.getSegmentFileName)
       store.readIndexFiles()
       val size = store.getIndexFilesMap.asScala.map(f => f._2.size()).sum
-      assertResult(Math.max(7, defaultParallelism) + 1)(size + store.getIndexFilesMap.size())
+      assertResult(Math.max(4, defaultParallelism) + 1)(size + store.getIndexFilesMap.size())
     }
   }
 

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/standardpartition/StandardPartitionTableCleanTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/standardpartition/StandardPartitionTableCleanTestCase.scala
@@ -60,7 +60,7 @@ class StandardPartitionTableCleanTestCase extends QueryTest with BeforeAndAfterA
     val details = SegmentStatusManager.readLoadMetadata(CarbonTablePath.getMetadataPath(carbonTable.getTablePath))
     val segLoad = details.find(_.getLoadName.equals(segmentId)).get
     val seg = new SegmentFileStore(carbonTable.getTablePath, segLoad.getSegmentFile)
-    assert(seg.getIndexFiles.size == indexes)
+    assert(seg.getIndexOrMergeFiles.size == indexes)
   }
 
   test("clean up partition table for int partition column") {

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/standardpartition/StandardPartitionTableLoadingTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/standardpartition/StandardPartitionTableLoadingTestCase.scala
@@ -337,6 +337,8 @@ class StandardPartitionTableLoadingTestCase extends QueryTest with BeforeAndAfte
   }
 
   test("merge carbon index disable data loading for partition table for three partition column") {
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.CARBON_MERGE_INDEX_IN_SEGMENT, "false")
     sql(
       """
         | CREATE TABLE mergeindexpartitionthree (empno int, doj Timestamp,
@@ -354,6 +356,9 @@ class StandardPartitionTableLoadingTestCase extends QueryTest with BeforeAndAfte
     store.readIndexFiles()
     store.getIndexFiles
     assert(store.getIndexFiles.size() == 10)
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.CARBON_MERGE_INDEX_IN_SEGMENT,
+        CarbonCommonConstants.CARBON_MERGE_INDEX_IN_SEGMENT_DEFAULT)
   }
 
   test("load static partition table for one static partition column with load syntax issue") {

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/events/AlterTableEvents.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/events/AlterTableEvents.scala
@@ -204,6 +204,17 @@ case class AlterTableCompactionAbortEvent(sparkSession: SparkSession,
     alterTableModel: AlterTableModel) extends Event with AlterTableCompactionEventInfo
 
 /**
+ * Compaction Event for handling merge index in alter DDL
+ *
+ * @param sparkSession
+ * @param carbonTable
+ * @param alterTableModel
+ */
+case class AlterTableMergeIndexEvent(sparkSession: SparkSession,
+    carbonTable: CarbonTable,
+    alterTableModel: AlterTableModel) extends Event with AlterTableCompactionEventInfo
+
+/**
  * pre event for standard hive partition
  * @param sparkSession
  * @param carbonTable

--- a/integration/spark-common/src/main/scala/org/apache/spark/rdd/CarbonMergeFilesRDD.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/rdd/CarbonMergeFilesRDD.scala
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.rdd
+
+import org.apache.spark.{Partition, SparkContext, TaskContext}
+
+import org.apache.carbondata.core.metadata.schema.table.CarbonTable
+import org.apache.carbondata.core.util.path.CarbonTablePath
+import org.apache.carbondata.core.writer.CarbonIndexFileMergeWriter
+import org.apache.carbondata.processing.util.CarbonLoaderUtil
+import org.apache.carbondata.spark.rdd.CarbonRDD
+
+case class CarbonMergeFilePartition(rddId: Int, idx: Int, segmentId: String)
+  extends Partition {
+
+  override val index: Int = idx
+
+  override def hashCode(): Int = 41 * (41 + rddId) + idx
+}
+
+/**
+ * RDD to merge all carbonindex files of each segment to carbonindex file into the same segment.
+ * @param sc
+ * @param carbonTable
+ * @param segments segments to be merged
+ */
+class CarbonMergeFilesRDD(
+  sc: SparkContext,
+  carbonTable: CarbonTable,
+  segments: Seq[String],
+  segmentFileNameToSegmentIdMap: java.util.Map[String, String],
+  isHivePartitionedTable: Boolean,
+  readFileFooterFromCarbonDataFile: Boolean)
+  extends CarbonRDD[String](sc, Nil, sc.hadoopConfiguration) {
+
+  override def getPartitions: Array[Partition] = {
+    segments.zipWithIndex.map {s =>
+      CarbonMergeFilePartition(id, s._2, s._1)
+    }.toArray
+  }
+
+  override def internalCompute(theSplit: Partition, context: TaskContext): Iterator[String] = {
+    val tablePath = carbonTable.getTablePath
+    val iter = new Iterator[String] {
+      val split = theSplit.asInstanceOf[CarbonMergeFilePartition]
+      logInfo("Merging carbon index files of segment : " +
+              CarbonTablePath.getSegmentPath(tablePath, split.segmentId))
+
+      if (isHivePartitionedTable) {
+        CarbonLoaderUtil
+          .mergeIndexFilesinPartitionedSegment(carbonTable, split.segmentId,
+            segmentFileNameToSegmentIdMap.get(split.segmentId))
+      } else {
+        new CarbonIndexFileMergeWriter(carbonTable)
+          .mergeCarbonIndexFilesOfSegment(split.segmentId,
+            tablePath,
+            readFileFooterFromCarbonDataFile,
+            segmentFileNameToSegmentIdMap.get(split.segmentId))
+      }
+
+      var havePair = false
+      var finished = false
+
+      override def hasNext: Boolean = {
+        if (!finished && !havePair) {
+          finished = true
+          havePair = !finished
+        }
+        !finished
+      }
+
+      override def next(): String = {
+        if (!hasNext) {
+          throw new java.util.NoSuchElementException("End of stream")
+        }
+        havePair = false
+        ""
+      }
+
+    }
+    iter
+  }
+
+}
+

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/events/MergeIndexEventListener.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/events/MergeIndexEventListener.scala
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.events
+
+import java.util
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.SparkContext
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.util.CarbonException
+
+import org.apache.carbondata.common.logging.{LogService, LogServiceFactory}
+import org.apache.carbondata.core.constants.CarbonCommonConstants
+import org.apache.carbondata.core.datamap.Segment
+import org.apache.carbondata.core.locks.{CarbonLockFactory, LockUsage}
+import org.apache.carbondata.core.metadata.schema.table.CarbonTable
+import org.apache.carbondata.core.statusmanager.SegmentStatusManager
+import org.apache.carbondata.events.{AlterTableCompactionPostEvent, AlterTableMergeIndexEvent, Event, OperationContext, OperationEventListener}
+import org.apache.carbondata.processing.loading.events.LoadEvents.LoadTablePostExecutionEvent
+import org.apache.carbondata.processing.merger.CarbonDataMergerUtil
+import org.apache.carbondata.spark.util.CommonUtil
+
+class MergeIndexEventListener extends OperationEventListener with Logging {
+  val LOGGER: LogService = LogServiceFactory.getLogService(this.getClass.getCanonicalName)
+
+  override def onEvent(event: Event, operationContext: OperationContext): Unit = {
+    event match {
+      case preStatusUpdateEvent: LoadTablePostExecutionEvent =>
+        LOGGER.audit("Load post status event-listener called for merge index")
+        val loadTablePreStatusUpdateEvent = event.asInstanceOf[LoadTablePostExecutionEvent]
+        val carbonTableIdentifier = loadTablePreStatusUpdateEvent.getCarbonTableIdentifier
+        val loadModel = loadTablePreStatusUpdateEvent.getCarbonLoadModel
+        val carbonTable = loadModel.getCarbonDataLoadSchema.getCarbonTable
+        val compactedSegments = loadModel.getMergedSegmentIds
+        val sparkSession = SparkSession.getActiveSession.get
+        if(!carbonTable.isStreamingSink) {
+          if (null != compactedSegments && !compactedSegments.isEmpty) {
+            mergeIndexFilesForCompactedSegments(sparkSession.sparkContext,
+              carbonTable,
+              compactedSegments)
+          } else {
+            val segmentFileNameMap: java.util.Map[String, String] = new util.HashMap[String,
+              String]()
+
+            segmentFileNameMap
+              .put(loadModel.getSegmentId, String.valueOf(loadModel.getFactTimeStamp))
+            CommonUtil.mergeIndexFiles(sparkSession.sparkContext,
+              Seq(loadModel.getSegmentId),
+              segmentFileNameMap,
+              carbonTable.getTablePath,
+              carbonTable, false)
+          }
+        }
+      case alterTableCompactionPostEvent: AlterTableCompactionPostEvent =>
+        LOGGER.audit("Merge index for compaction called")
+        val alterTableCompactionPostEvent = event.asInstanceOf[AlterTableCompactionPostEvent]
+        val carbonTable = alterTableCompactionPostEvent.carbonTable
+        val mergedLoads = alterTableCompactionPostEvent.compactedLoads
+        val sparkContext = alterTableCompactionPostEvent.sparkSession.sparkContext
+        if(!carbonTable.isStreamingSink) {
+          mergeIndexFilesForCompactedSegments(sparkContext, carbonTable, mergedLoads)
+        }
+      case alterTableMergeIndexEvent: AlterTableMergeIndexEvent =>
+        val exceptionEvent = event.asInstanceOf[AlterTableMergeIndexEvent]
+        val alterTableModel = exceptionEvent.alterTableModel
+        val carbonMainTable = exceptionEvent.carbonTable
+        val compactionType = alterTableModel.compactionType
+        val sparkSession = exceptionEvent.sparkSession
+        if (!carbonMainTable.isStreamingSink) {
+          LOGGER.audit(s"Compaction request received for table " +
+                       s"${ carbonMainTable.getDatabaseName }.${ carbonMainTable.getTableName }")
+          LOGGER.info(s"Merge Index request received for table " +
+                      s"${ carbonMainTable.getDatabaseName }.${ carbonMainTable.getTableName }")
+          val lock = CarbonLockFactory.getCarbonLockObj(
+            carbonMainTable.getAbsoluteTableIdentifier,
+            LockUsage.COMPACTION_LOCK)
+
+          try {
+            if (lock.lockWithRetries()) {
+              LOGGER.info("Acquired the compaction lock for table" +
+                          s" ${ carbonMainTable.getDatabaseName }.${
+                            carbonMainTable
+                              .getTableName
+                          }")
+              val validSegments: mutable.Buffer[Segment] = CarbonDataMergerUtil.getValidSegmentList(
+                carbonMainTable.getAbsoluteTableIdentifier).asScala
+              val validSegmentIds: mutable.Buffer[String] = mutable.Buffer[String]()
+              validSegments.foreach { segment =>
+                validSegmentIds += segment.getSegmentNo
+              }
+              val loadFolderDetailsArray = SegmentStatusManager
+                .readLoadMetadata(carbonMainTable.getMetadataPath)
+              val segmentFileNameMap: java.util.Map[String, String] = new util.HashMap[String,
+                String]()
+              loadFolderDetailsArray.foreach(loadMetadataDetails => {
+                segmentFileNameMap
+                  .put(loadMetadataDetails.getLoadName, loadMetadataDetails.getSegmentFile)
+              })
+              CommonUtil.mergeIndexFiles(sparkSession.sparkContext,
+                validSegmentIds,
+                segmentFileNameMap,
+                carbonMainTable.getTablePath,
+                carbonMainTable,
+                true)
+              val requestMessage = "Compaction request completed for table "
+              s"${ carbonMainTable.getDatabaseName }.${ carbonMainTable.getTableName }"
+              LOGGER.audit(requestMessage)
+              LOGGER.info(requestMessage)
+            } else {
+              val lockMessage = "Not able to acquire the compaction lock for table " +
+                                s"${ carbonMainTable.getDatabaseName }.${
+                                  carbonMainTable
+                                    .getTableName
+                                }"
+
+              LOGGER.audit(lockMessage)
+              LOGGER.error(lockMessage)
+              CarbonException.analysisException(
+                "Table is already locked for compaction. Please try after some time.")
+            }
+          } finally {
+            lock.unlock()
+          }
+        }
+    }
+  }
+
+  def mergeIndexFilesForCompactedSegments(sparkContext: SparkContext,
+    carbonTable: CarbonTable,
+    mergedLoads: util.List[String]): Unit = {
+    // get only the valid segments of the table
+    val validSegments: mutable.Buffer[Segment] = CarbonDataMergerUtil.getValidSegmentList(
+      carbonTable.getAbsoluteTableIdentifier).asScala
+    val mergedSegmentIds = new util.ArrayList[String]()
+    mergedLoads.asScala.foreach(mergedLoad => {
+      val loadName = mergedLoad
+        .substring(mergedLoad.indexOf(CarbonCommonConstants.LOAD_FOLDER) +
+                   CarbonCommonConstants.LOAD_FOLDER.length)
+      mergedSegmentIds.add(loadName)
+    })
+    val loadFolderDetailsArray = SegmentStatusManager
+      .readLoadMetadata(carbonTable.getMetadataPath)
+    val segmentFileNameMap: java.util.Map[String, String] = new util.HashMap[String, String]()
+    loadFolderDetailsArray.foreach(loadMetadataDetails => {
+      segmentFileNameMap.put(loadMetadataDetails.getLoadName, loadMetadataDetails.getSegmentFile)
+    })
+    // filter out only the valid segments from the list of compacted segments
+    // Example: say compacted segments list contains 0.1, 3.1, 6.1, 0.2.
+    // In this list 0.1, 3.1 and 6.1 are compacted to 0.2 in the level 2 compaction.
+    // So, it is enough to do merge index only for 0.2 as it is the only valid segment in this list
+    val validMergedSegIds = validSegments
+      .filter { seg => mergedSegmentIds.contains(seg.getSegmentNo) }.map(_.getSegmentNo)
+    if (null != validMergedSegIds && !mergedSegmentIds.isEmpty) {
+      CommonUtil.mergeIndexFiles(sparkContext,
+          validMergedSegIds,
+          segmentFileNameMap,
+          carbonTable.getTablePath,
+          carbonTable,
+          false)
+    }
+  }
+}

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/test/Spark2TestQueryExecutor.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/test/Spark2TestQueryExecutor.scala
@@ -67,7 +67,6 @@ object Spark2TestQueryExecutor {
     .enableHiveSupport()
     .config("spark.sql.warehouse.dir", warehouse)
     .config("spark.sql.crossJoin.enabled", "true")
-    .config(CarbonCommonConstants.CARBON_COMMON_LISTENER_REGISTER_CLASSNAME, "")
     .getOrCreateCarbonSession(null, TestQueryExecutor.metastoredb)
   if (warehouse.startsWith("hdfs://")) {
     System.setProperty(CarbonCommonConstants.HDFS_TEMP_LOCATION, warehouse)

--- a/integration/spark2/src/test/scala/org/apache/carbondata/spark/testsuite/partition/TestAlterPartitionTable.scala
+++ b/integration/spark2/src/test/scala/org/apache/carbondata/spark/testsuite/partition/TestAlterPartitionTable.scala
@@ -859,22 +859,14 @@ class TestAlterPartitionTable extends QueryTest with BeforeAndAfterAll {
 
   def getDataFiles(carbonTable: CarbonTable, segmentId: String): Array[String] = {
     val segment = Segment.getSegment(segmentId, carbonTable.getTablePath)
-    if (segment.getSegmentFileName != null) {
-      val sfs = new SegmentFileStore(carbonTable.getTablePath, segment.getSegmentFileName)
-      sfs.readIndexFiles()
-      val indexFilesMap = sfs.getIndexFilesMap
-      val dataFiles = indexFilesMap.asScala.flatMap(_._2.asScala).map(f => new Path(f).getName)
-      dataFiles.toArray
-    } else {
-      val segmentDir = CarbonTablePath.getSegmentPath(carbonTable.getTablePath, segmentId)
-      val carbonFile = FileFactory.getCarbonFile(segmentDir, FileFactory.getFileType(segmentDir))
-      val dataFiles = carbonFile.listFiles(new CarbonFileFilter() {
-        override def accept(file: CarbonFile): Boolean = {
-          return file.getName.endsWith(".carbondata")
-        }
-      })
-      dataFiles.map(_.getName)
-    }
+    val segmentDir = CarbonTablePath.getSegmentPath(carbonTable.getTablePath, segmentId)
+    val carbonFile = FileFactory.getCarbonFile(segmentDir, FileFactory.getFileType(segmentDir))
+    val dataFiles = carbonFile.listFiles(new CarbonFileFilter() {
+      override def accept(file: CarbonFile): Boolean = {
+        return file.getName.endsWith(".carbondata")
+      }
+    })
+    dataFiles.map(_.getName)
   }
 
   /**

--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/TestStreamingTableWithRowParser.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/TestStreamingTableWithRowParser.scala
@@ -32,12 +32,9 @@ import org.apache.spark.sql.test.util.QueryTest
 import org.scalatest.BeforeAndAfterAll
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants
-import org.apache.carbondata.core.metadata.CarbonMetadata
-import org.apache.carbondata.core.metadata.schema.table.CarbonTable
 import org.apache.carbondata.core.statusmanager.{FileFormat, SegmentStatus}
 import org.apache.carbondata.core.util.CarbonProperties
 import org.apache.carbondata.core.util.path.CarbonTablePath
-import org.apache.carbondata.core.writer.CarbonIndexFileMergeWriter
 
 case class FileElement(school: Array[String], age: Integer)
 case class StreamData(id: Integer, name: String, city: String, salary: java.lang.Float,
@@ -409,53 +406,6 @@ class TestStreamingTableWithRowParser extends QueryTest with BeforeAndAfterAll {
         assertResult(FileFormat.COLUMNAR_V3.toString)(row.getString(5))
       }
     }
-
-  }
-  test("query on stream table with dictionary, sort_columns, with merge index applied") {
-    executeStreamingIngest(
-      tableName = "stream_table_with_mi",
-      batchNums = 2,
-      rowNumsEachBatch = 25,
-      intervalOfSource = 5,
-      intervalOfIngest = 5,
-      continueSeconds = 20,
-      generateBadRecords = true,
-      badRecordAction = "force",
-      autoHandoff = false
-    )
-    val carbonTable: CarbonTable = CarbonMetadata.getInstance
-      .getCarbonTable("streaming1", "stream_table_with_mi")
-    new CarbonIndexFileMergeWriter(carbonTable)
-      .mergeCarbonIndexFilesOfSegment("1", carbonTable.getTablePath, false, String.valueOf(System.currentTimeMillis()))
-    // non-filter
-    val result = sql("select * from streaming1.stream_table_with_mi order by id, name").collect()
-    assert(result != null)
-    assert(result.length == 55)
-    // check one row of streaming data
-    assert(result(1).isNullAt(0))
-    assert(result(1).getString(1) == "name_6")
-    // check one row of batch loading
-    assert(result(50).getInt(0) == 100000001)
-    assert(result(50).getString(1) == "batch_1")
-
-    // filter
-    checkAnswer(
-      sql("select * from stream_table_with_mi where id = 1"),
-      Seq(Row(1, "name_1", "city_1", 10000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Timestamp.valueOf("2010-01-01 10:01:01.0"))))
-
-    checkAnswer(
-      sql("select * from stream_table_with_mi where id > 49 and id < 100000002"),
-      Seq(Row(50, "name_50", "city_50", 500000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Timestamp.valueOf("2010-01-01 10:01:01.0")),
-        Row(100000001, "batch_1", "city_1", 0.1, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Timestamp.valueOf("2010-01-01 10:01:01.0"))))
-
-    checkAnswer(
-      sql("select * from stream_table_with_mi where id between 50 and 100000001"),
-      Seq(Row(50, "name_50", "city_50", 500000.0, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Timestamp.valueOf("2010-01-01 10:01:01.0")),
-        Row(100000001, "batch_1", "city_1", 0.1, BigDecimal.valueOf(0.01), 80.01, Date.valueOf("1990-01-01"), Timestamp.valueOf("2010-01-01 10:01:01.0"), Timestamp.valueOf("2010-01-01 10:01:01.0"))))
-
-    checkAnswer(
-      sql("select * from stream_table_with_mi where name in ('name_9','name_10', 'name_11', 'name_12') and id <> 10 and id not in (11, 12)"),
-      Seq(Row(9, "name_9", "city_9", 90000.0, BigDecimal.valueOf(0.04), 80.04, Date.valueOf("1990-01-04"), Timestamp.valueOf("2010-01-04 10:01:01.0"), Timestamp.valueOf("2010-01-04 10:01:01.0"))))
 
   }
 

--- a/integration/spark2/src/test/scala/org/apache/spark/sql/CarbonGetTableDetailComandTestCase.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/sql/CarbonGetTableDetailComandTestCase.scala
@@ -43,9 +43,9 @@ class CarbonGetTableDetailCommandTestCase extends QueryTest with BeforeAndAfterA
     assertResult(2)(result.length)
     assertResult("table_info1")(result(0).getString(0))
     // 2096 is the size of carbon table
-    assertResult(2098)(result(0).getLong(1))
+    assertResult(2147)(result(0).getLong(1))
     assertResult("table_info2")(result(1).getString(0))
-    assertResult(2098)(result(1).getLong(1))
+    assertResult(2147)(result(1).getLong(1))
   }
 
   override def afterAll: Unit = {

--- a/processing/src/main/java/org/apache/carbondata/processing/merger/CompactionType.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/merger/CompactionType.java
@@ -30,5 +30,6 @@ public enum CompactionType {
     STREAMING,
     CLOSE_STREAMING,
     CUSTOM,
+    SEGMENT_INDEX,
     NONE
 }


### PR DESCRIPTION
**Problem :**
The first-time query of carbon becomes very slow. It is because of reading many small carbonindex files and cache to the driver at the first time.
Many carbonindex files are created in below case
Loading data in large cluster
For example, if the cluster size is 100 nodes then for each load 100 index files are created per segment. So after 100 loads, the number of carbonindex files becomes 10000. .
It will be slower to read all the files from the driver since a lot of namenode calls and IO operations.
**Solution :**
Merge the carbonindex files in two levels.so that we can reduce the IO calls to namenode and improves the read performance.
Merge within a segment.
Merge the carbonindex files to single file immediately after load completes within the segment. It would be named as a .carbonindexmerge file. It is actually not a true data merging but a simple file merge. So that the current structure of carbonindex files does not change. While reading we just read one file instead of many carbonindex files within the segment.

This PR depends on [PR#2307](https://github.com/apache/carbondata/pull/2307)

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [x] Testing done
        UT and SDV added
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

