### PR TITLE
[CARBONDATA-2722] [CARBONDATA-2721] JsonWriter issue fixes

### DIFF
--- a/integration/spark-common-test/src/test/resources/jsonFiles/data/PrimitiveTypeWithNull.json
+++ b/integration/spark-common-test/src/test/resources/jsonFiles/data/PrimitiveTypeWithNull.json
@@ -1,0 +1,4 @@
+{
+	"stringField": null,
+	"intField": 26
+}

--- a/integration/spark-common-test/src/test/resources/jsonFiles/data/StructOfAllTypes.json
+++ b/integration/spark-common-test/src/test/resources/jsonFiles/data/StructOfAllTypes.json
@@ -5,7 +5,7 @@
 		"longField": 12345678,
 		"doubleField": 123400.78,
 		"boolField": true,
-		"FloorNum": [ 1, 2],
+		"FloorNum": [1,2,3,4,5,6],
 		"FloorString": [ "abc", "def"],
 		"FloorLong": [ 1234567, 2345678],
 		"FloorDouble": [ 1.0, 2.0, 33.33],

--- a/integration/spark-common-test/src/test/resources/jsonFiles/data/allPrimitiveType.json
+++ b/integration/spark-common-test/src/test/resources/jsonFiles/data/allPrimitiveType.json
@@ -1,5 +1,5 @@
 {
-	"stringField": "ajantha",
+	"stringField": "ajantha\"bhat\"",
 	"intField": 26,
 	"shortField": 26,
 	"longField": 1234567,

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/parser/impl/JsonRowParser.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/parser/impl/JsonRowParser.java
@@ -97,7 +97,7 @@ public class JsonRowParser implements RowParser {
       int size = carbonDimension.getNumberOfChild();
       Map<String, Object> jsonMap =
           (Map<String, Object>) jsonNodeMap.get(extractChildColumnName(column));
-      if ((jsonMap == null) || (jsonMap.size() == 0)) {
+      if (jsonMap == null) {
         return null;
       }
       Object[] structChildObjects = new Object[size];
@@ -141,10 +141,6 @@ public class JsonRowParser implements RowParser {
       return new ArrayObject(arrayChildObjects);
     } else if (DataTypes.isStructType(type)) {
       Map<String, Object> childFieldsMap = (Map<String, Object>) childObject;
-      if (childFieldsMap.size() == 0) {
-        // handling empty struct
-        return null;
-      }
       int size = column.getNumberOfChild();
       Object[] structChildObjects = new Object[size];
       for (int i = 0; i < size; i++) {

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/parser/impl/JsonRowParser.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/parser/impl/JsonRowParser.java
@@ -56,6 +56,9 @@ public class JsonRowParser implements RowParser {
       Map<String, Object> jsonNodeMap =
           objectMapper.readValue(jsonString, new TypeReference<Map<String, Object>>() {
           });
+      if (jsonNodeMap == null) {
+        return null;
+      }
       return jsonToCarbonRecord(jsonNodeMap, dataFields);
     } catch (IOException e) {
       throw new IOException("Failed to parse Json String: " + e.getMessage());
@@ -66,9 +69,7 @@ public class JsonRowParser implements RowParser {
     List<Object> fields = new ArrayList<>();
     for (DataField dataField : dataFields) {
       Object field = jsonToCarbonObject(jsonNodeMap, dataField.getColumn());
-      if (field != null) {
-        fields.add(field);
-      }
+      fields.add(field);
     }
     // use this array object to form carbonRow
     return fields.toArray();
@@ -78,12 +79,16 @@ public class JsonRowParser implements RowParser {
     DataType type = column.getDataType();
     if (DataTypes.isArrayType(type)) {
       CarbonDimension carbonDimension = (CarbonDimension) column;
-      int size = carbonDimension.getNumberOfChild();
       ArrayList array = (ArrayList) jsonNodeMap.get(extractChildColumnName(column));
+      if ((array == null) || (array.size() == 0)) {
+        return null;
+      }
       // stored as array in carbonObject
-      Object[] arrayChildObjects = new Object[size];
-      for (int i = 0; i < size; i++) {
-        CarbonDimension childCol = carbonDimension.getListOfChildDimensions().get(i);
+      Object[] arrayChildObjects = new Object[array.size()];
+      for (int i = 0; i < array.size(); i++) {
+        // array column will have only one child, hence get(0).
+        // But data can have n elements, hence the loop.
+        CarbonDimension childCol = carbonDimension.getListOfChildDimensions().get(0);
         arrayChildObjects[i] = jsonChildElementToCarbonChildElement(array.get(i), childCol);
       }
       return new ArrayObject(arrayChildObjects);
@@ -92,47 +97,61 @@ public class JsonRowParser implements RowParser {
       int size = carbonDimension.getNumberOfChild();
       Map<String, Object> jsonMap =
           (Map<String, Object>) jsonNodeMap.get(extractChildColumnName(column));
+      if ((jsonMap == null) || (jsonMap.size() == 0)) {
+        return null;
+      }
       Object[] structChildObjects = new Object[size];
       for (int i = 0; i < size; i++) {
         CarbonDimension childCol = carbonDimension.getListOfChildDimensions().get(i);
         Object childObject =
             jsonChildElementToCarbonChildElement(jsonMap.get(extractChildColumnName(childCol)),
                 childCol);
-        if (childObject != null) {
-          structChildObjects[i] = childObject;
-        }
+        structChildObjects[i] = childObject;
       }
       return new StructObject(structChildObjects);
     } else {
       // primitive type
+      if (jsonNodeMap.get(extractChildColumnName(column)) == null) {
+        return null;
+      }
       return jsonNodeMap.get(extractChildColumnName(column)).toString();
     }
   }
 
   private Object jsonChildElementToCarbonChildElement(Object childObject,
       CarbonDimension column) {
+    if (childObject == null) {
+      return null;
+    }
     DataType type = column.getDataType();
     if (DataTypes.isArrayType(type)) {
-      int size = column.getNumberOfChild();
       ArrayList array = (ArrayList) childObject;
+      if (array.size() == 0) {
+        // handling empty array
+        return null;
+      }
       // stored as array in carbonObject
-      Object[] arrayChildObjects = new Object[size];
-      for (int i = 0; i < size; i++) {
-        CarbonDimension childCol = column.getListOfChildDimensions().get(i);
+      Object[] arrayChildObjects = new Object[array.size()];
+      for (int i = 0; i < array.size(); i++) {
+        // array column will have only one child, hence get(0).
+        // But data can have n elements, hence the loop.
+        CarbonDimension childCol = column.getListOfChildDimensions().get(0);
         arrayChildObjects[i] = jsonChildElementToCarbonChildElement(array.get(i), childCol);
       }
       return new ArrayObject(arrayChildObjects);
     } else if (DataTypes.isStructType(type)) {
       Map<String, Object> childFieldsMap = (Map<String, Object>) childObject;
+      if (childFieldsMap.size() == 0) {
+        // handling empty struct
+        return null;
+      }
       int size = column.getNumberOfChild();
       Object[] structChildObjects = new Object[size];
       for (int i = 0; i < size; i++) {
         CarbonDimension childCol = column.getListOfChildDimensions().get(i);
         Object child = jsonChildElementToCarbonChildElement(
             childFieldsMap.get(extractChildColumnName(childCol)), childCol);
-        if (child != null) {
-          structChildObjects[i] = child;
-        }
+        structChildObjects[i] = child;
       }
       return new StructObject(structChildObjects);
     } else {
@@ -140,6 +159,7 @@ public class JsonRowParser implements RowParser {
       return childObject.toString();
     }
   }
+
   private static String extractChildColumnName(CarbonColumn column) {
     String columnName = column.getColName();
     if (columnName.contains(".")) {
@@ -153,5 +173,4 @@ public class JsonRowParser implements RowParser {
     }
     return columnName;
   }
-
 }


### PR DESCRIPTION
[CARBONDATA-2722][SDK] [JsonWriter] NPE when schema and data are not of same length or Data is null.

problem: Null data is not handled in the json object to carbon row conversion.

solution: add a null check when object is fetched from json map.

[CARBONDATA-2721][SDK] [JsonWriter] Json writer is writing only first element of an array and discarding the rest of the elements.

problem: converting json object to carbon row array object is based on array children count , instead of array element count. 
Hence as array will always have one children. only one element is filled.

solution: use array element count instead of array children count.Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?NA
 
 - [ ] Any backward compatibility impacted?NA
 
 - [ ] Document update required?NA

 - [ ] Testing done
updated the UT       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

