### PR TITLE
[CARBONDATA-2723][DataMap] Fix bugs in recreate datamap on table

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datamap/DataMapMeta.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/DataMapMeta.java
@@ -74,6 +74,6 @@ public class DataMapMeta {
   @Override
   public String toString() {
     return "DataMapMeta{" + "dataMapName='" + dataMapName + '\'' + ", indexedColumns="
-        + indexedColumns + ", optimizedOperation=" + optimizedOperation + '}';
+        + getIndexedColumnNames() + ", optimizedOperation=" + optimizedOperation + '}';
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/datamap/DataMapMeta.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/DataMapMeta.java
@@ -26,6 +26,7 @@ import org.apache.carbondata.core.scan.filter.intf.ExpressionType;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.Transformer;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Metadata of the datamap, set by DataMap developer
@@ -71,9 +72,13 @@ public class DataMapMeta {
     return optimizedOperation;
   }
 
-  @Override
-  public String toString() {
-    return "DataMapMeta{" + "dataMapName='" + dataMapName + '\'' + ", indexedColumns="
-        + getIndexedColumnNames() + ", optimizedOperation=" + optimizedOperation + '}';
+  @Override public String toString() {
+    return new StringBuilder("DataMapMeta{")
+        .append("dataMapName='").append(dataMapName).append('\'')
+        .append(", indexedColumns=[")
+        .append(StringUtils.join(getIndexedColumnNames(), ", ")).append("]\'")
+        .append(", optimizedOperation=").append(optimizedOperation)
+        .append('}')
+        .toString();
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/datamap/DataMapStoreManager.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/DataMapStoreManager.java
@@ -431,6 +431,7 @@ public final class DataMapStoreManager {
         }
       }
     }
+    allDataMaps.remove(tableUniqName);
   }
 
   /**
@@ -460,6 +461,7 @@ public final class DataMapStoreManager {
         }
         i++;
       }
+      allDataMaps.put(tableUniqueName, tableIndices);
     }
   }
 

--- a/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/AbstractBloomDataMapWriter.java
+++ b/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/AbstractBloomDataMapWriter.java
@@ -116,7 +116,6 @@ public abstract class AbstractBloomDataMapWriter extends DataMapWriter {
 
   protected void resetBloomFilters() {
     indexBloomFilters.clear();
-    List<CarbonColumn> indexColumns = getIndexColumns();
     int[] stats = calculateBloomStats();
     for (int i = 0; i < indexColumns.size(); i++) {
       indexBloomFilters
@@ -225,7 +224,6 @@ public abstract class AbstractBloomDataMapWriter extends DataMapWriter {
         throw new IOException("Failed to create directory " + dataMapPath);
       }
     }
-    List<CarbonColumn> indexColumns = getIndexColumns();
     for (int indexColId = 0; indexColId < indexColumns.size(); indexColId++) {
       String dmFile = BloomCoarseGrainDataMap.getBloomIndexFile(dataMapPath,
           indexColumns.get(indexColId).getColName());
@@ -245,7 +243,6 @@ public abstract class AbstractBloomDataMapWriter extends DataMapWriter {
   }
 
   protected void writeBloomDataMapFile() {
-    List<CarbonColumn> indexColumns = getIndexColumns();
     try {
       for (int indexColId = 0; indexColId < indexColumns.size(); indexColId++) {
         CarbonBloomFilter bloomFilter = indexBloomFilters.get(indexColId);
@@ -274,7 +271,6 @@ public abstract class AbstractBloomDataMapWriter extends DataMapWriter {
   }
 
   protected void releaseResouce() {
-    List<CarbonColumn> indexColumns = getIndexColumns();
     for (int indexColId = 0; indexColId < indexColumns.size(); indexColId++) {
       CarbonUtil.closeStreams(
           currentDataOutStreams.get(indexColId));

--- a/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomDataMapBuilder.java
+++ b/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomDataMapBuilder.java
@@ -52,7 +52,6 @@ public class BloomDataMapBuilder extends AbstractBloomDataMapWriter implements D
       currentBlockletId = blockletId;
     }
     // for each indexed column, add the data to bloom filter
-    List<CarbonColumn> indexColumns = getIndexColumns();
     for (int i = 0; i < indexColumns.size(); i++) {
       Object data = values[i];
       addValue2BloomIndex(i, data);

--- a/processing/src/main/java/org/apache/carbondata/processing/datamap/DataMapWriterListener.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/datamap/DataMapWriterListener.java
@@ -54,6 +54,9 @@ public class DataMapWriterListener {
    */
   public void registerAllWriter(CarbonTable carbonTable, String segmentId,
       String taskNo, SegmentProperties segmentProperties) {
+    // clear cache in executor side
+    DataMapStoreManager.getInstance()
+        .clearDataMaps(carbonTable.getCarbonTableIdentifier().getTableUniqueName());
     List<TableDataMap> tableIndices;
     try {
       tableIndices = DataMapStoreManager.getInstance().getAllDataMap(carbonTable);

--- a/processing/src/main/java/org/apache/carbondata/processing/store/writer/AbstractFactDataWriter.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/writer/AbstractFactDataWriter.java
@@ -422,6 +422,7 @@ public abstract class AbstractFactDataWriter implements CarbonFactDataWriter {
       for (int i = 0; i < executorServiceSubmitList.size(); i++) {
         executorServiceSubmitList.get(i).get();
       }
+      listener = null;
     } catch (InterruptedException | ExecutionException | IOException e) {
       throw new CarbonDataWriterException(e);
     }


### PR DESCRIPTION
While we drop datamap/table, the executor side cache for datamap is
stale. So if we recreate the datamap with different index columns, when
we are doing data loading, the cache should be cleaned, otherwise the
DataMapWriterListener will not take effect for the new datamap.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

