### PR TITLE
[CARBONDATA-2735]Fixed Performance issue for complex array data type when number of elements in array is more

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/ColumnPage.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/ColumnPage.java
@@ -49,7 +49,7 @@ import static org.apache.carbondata.core.metadata.datatype.DataTypes.SHORT_INT;
 public abstract class ColumnPage {
 
   // number of row in this page
-  protected final int pageSize;
+  protected int pageSize;
 
   // data type of the page storage
   protected final DataType dataType;
@@ -830,6 +830,10 @@ public abstract class ColumnPage {
   }
 
   public PageLevelDictionary getColumnPageDictionary() {
+    throw new UnsupportedOperationException("Operation not supported");
+  }
+
+  public int getActualRowCount() {
     throw new UnsupportedOperationException("Operation not supported");
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/SafeDecimalColumnPage.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/SafeDecimalColumnPage.java
@@ -218,5 +218,6 @@ public class SafeDecimalColumnPage extends DecimalColumnPage {
   @Override
   public void freeMemory() {
     byteArrayData = null;
+    super.freeMemory();
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/SafeFixLengthColumnPage.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/SafeFixLengthColumnPage.java
@@ -388,7 +388,7 @@ public class SafeFixLengthColumnPage extends ColumnPage {
     }
   }
 
-  protected void ensureArraySize(int requestSize, DataType dataType) {
+  private void ensureArraySize(int requestSize, DataType dataType) {
     if (dataType == DataTypes.BYTE) {
       if (requestSize >= byteData.length) {
         byte[] newArray = new byte[arrayElementCount + 16];
@@ -436,4 +436,8 @@ public class SafeFixLengthColumnPage extends ColumnPage {
           "not support value conversion on " + dataType + " page");
     }
   }
+  public int getActualRowCount() {
+    return arrayElementCount;
+  }
+
 }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/SafeVarLengthColumnPage.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/SafeVarLengthColumnPage.java
@@ -40,6 +40,7 @@ public class SafeVarLengthColumnPage extends VarLengthColumnPageBase {
   @Override
   public void freeMemory() {
     byteArrayData = null;
+    rowOffset.freeMemory();
   }
 
   @Override

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/SafeVarLengthColumnPage.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/SafeVarLengthColumnPage.java
@@ -40,7 +40,7 @@ public class SafeVarLengthColumnPage extends VarLengthColumnPageBase {
   @Override
   public void freeMemory() {
     byteArrayData = null;
-    rowOffset.freeMemory();
+    super.freeMemory();
   }
 
   @Override

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/UnsafeDecimalColumnPage.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/UnsafeDecimalColumnPage.java
@@ -266,13 +266,13 @@ public class UnsafeDecimalColumnPage extends DecimalColumnPage {
   private void convertValueForDecimalType(ColumnPageValueConverter codec) {
     switch (decimalConverter.getDecimalConverterType()) {
       case DECIMAL_INT:
-        for (int i = 0; i < rowOffset.getActualRowCount() - 1; i++) {
+        for (int i = 0; i < pageSize; i++) {
           long offset = (long)i << intBits;
           codec.encode(i, CarbonUnsafe.getUnsafe().getInt(baseAddress, baseOffset + offset));
         }
         break;
       case DECIMAL_LONG:
-        for (int i = 0; i < rowOffset.getActualRowCount() - 1; i++) {
+        for (int i = 0; i < pageSize; i++) {
           long offset = (long)i << longBits;
           codec.encode(i, CarbonUnsafe.getUnsafe().getLong(baseAddress, baseOffset + offset));
         }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/UnsafeDecimalColumnPage.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/UnsafeDecimalColumnPage.java
@@ -119,7 +119,7 @@ public class UnsafeDecimalColumnPage extends DecimalColumnPage {
       memoryBlock = null;
       baseAddress = null;
       baseOffset = 0;
-      rowOffset.freeMemory();
+      super.freeMemory();
     }
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/UnsafeVarLengthColumnPage.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/UnsafeVarLengthColumnPage.java
@@ -49,7 +49,7 @@ public class UnsafeVarLengthColumnPage extends VarLengthColumnPageBase {
       memoryBlock = null;
       baseAddress = null;
       baseOffset = 0;
-      rowOffset.freeMemory();
+      super.freeMemory();
     }
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/UnsafeVarLengthColumnPage.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/UnsafeVarLengthColumnPage.java
@@ -49,6 +49,7 @@ public class UnsafeVarLengthColumnPage extends VarLengthColumnPageBase {
       memoryBlock = null;
       baseAddress = null;
       baseOffset = 0;
+      rowOffset.freeMemory();
     }
   }
 
@@ -65,7 +66,7 @@ public class UnsafeVarLengthColumnPage extends VarLengthColumnPageBase {
       throw new RuntimeException(e);
     }
     CarbonUnsafe.getUnsafe().copyMemory(bytes, CarbonUnsafe.BYTE_ARRAY_OFFSET + offset,
-        baseAddress, baseOffset + rowOffset.get(rowId), length);
+        baseAddress, baseOffset + rowOffset.getInt(rowId), length);
   }
 
   @Override
@@ -89,20 +90,20 @@ public class UnsafeVarLengthColumnPage extends VarLengthColumnPageBase {
 
   @Override
   public byte[] getBytes(int rowId) {
-    int length = rowOffset.get(rowId + 1) - rowOffset.get(rowId);
+    int length = rowOffset.getInt(rowId + 1) - rowOffset.getInt(rowId);
     byte[] bytes = new byte[length];
-    CarbonUnsafe.getUnsafe().copyMemory(baseAddress, baseOffset + rowOffset.get(rowId),
+    CarbonUnsafe.getUnsafe().copyMemory(baseAddress, baseOffset + rowOffset.getInt(rowId),
         bytes, CarbonUnsafe.BYTE_ARRAY_OFFSET, length);
     return bytes;
   }
 
   @Override
   public byte[][] getByteArrayPage() {
-    byte[][] bytes = new byte[rowOffset.size() - 1][];
-    for (int rowId = 0; rowId < rowOffset.size() - 1; rowId++) {
-      int length = rowOffset.get(rowId + 1) - rowOffset.get(rowId);
+    byte[][] bytes = new byte[rowOffset.getActualRowCount() - 1][];
+    for (int rowId = 0; rowId < rowOffset.getActualRowCount() - 1; rowId++) {
+      int length = rowOffset.getInt(rowId + 1) - rowOffset.getInt(rowId);
       byte[] rowData = new byte[length];
-      CarbonUnsafe.getUnsafe().copyMemory(baseAddress, baseOffset + rowOffset.get(rowId),
+      CarbonUnsafe.getUnsafe().copyMemory(baseAddress, baseOffset + rowOffset.getInt(rowId),
           rowData, CarbonUnsafe.BYTE_ARRAY_OFFSET, length);
       bytes[rowId] = rowData;
     }
@@ -111,7 +112,7 @@ public class UnsafeVarLengthColumnPage extends VarLengthColumnPageBase {
 
   @Override
   void copyBytes(int rowId, byte[] dest, int destOffset, int length) {
-    CarbonUnsafe.getUnsafe().copyMemory(baseAddress, baseOffset + rowOffset.get(rowId),
+    CarbonUnsafe.getUnsafe().copyMemory(baseAddress, baseOffset + rowOffset.getInt(rowId),
         dest, CarbonUnsafe.BYTE_ARRAY_OFFSET + destOffset, length);
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/VarLengthColumnPageBase.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/VarLengthColumnPageBase.java
@@ -20,6 +20,7 @@ package org.apache.carbondata.core.datastore.page;
 import java.io.IOException;
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
+import org.apache.carbondata.core.constants.CarbonV3DataFormatConstants;
 import org.apache.carbondata.core.datastore.ColumnType;
 import org.apache.carbondata.core.datastore.TableSpec;
 import org.apache.carbondata.core.memory.CarbonUnsafe;
@@ -150,7 +151,8 @@ public abstract class VarLengthColumnPageBase extends ColumnPage {
       byte[] lvEncodedBytes, int size) throws MemoryException {
     TableSpec.ColumnSpec spec = TableSpec.ColumnSpec
         .newInstance(columnSpec.getFieldName(), DataTypes.INT, ColumnType.MEASURE);
-    ColumnPage rowOffset = ColumnPage.newPage(spec, DataTypes.INT, size);
+    ColumnPage rowOffset = ColumnPage.newPage(spec, DataTypes.INT,
+        CarbonV3DataFormatConstants.NUMBER_OF_ROWS_PER_BLOCKLET_COLUMN_PAGE_DEFAULT);
     int offset;
     int rowId = 0;
     int counter = 0;
@@ -184,7 +186,8 @@ public abstract class VarLengthColumnPageBase extends ColumnPage {
     int rowId = 0;
     TableSpec.ColumnSpec spec = TableSpec.ColumnSpec
         .newInstance(columnSpec.getFieldName(), DataTypes.INT, ColumnType.MEASURE);
-    ColumnPage rowOffset = ColumnPage.newPage(spec, DataTypes.INT, 1024);
+    ColumnPage rowOffset = ColumnPage.newPage(spec, DataTypes.INT,
+        CarbonV3DataFormatConstants.NUMBER_OF_ROWS_PER_BLOCKLET_COLUMN_PAGE_DEFAULT);
     int length;
     int offset;
     int lvEncodedOffset = 0;
@@ -211,7 +214,8 @@ public abstract class VarLengthColumnPageBase extends ColumnPage {
     int rowId = 0;
     TableSpec.ColumnSpec spec = TableSpec.ColumnSpec
         .newInstance(columnSpec.getFieldName(), DataTypes.INT, ColumnType.MEASURE);
-    ColumnPage rowOffset = ColumnPage.newPage(spec, DataTypes.INT, 1024);
+    ColumnPage rowOffset = ColumnPage.newPage(spec, DataTypes.INT,
+        CarbonV3DataFormatConstants.NUMBER_OF_ROWS_PER_BLOCKLET_COLUMN_PAGE_DEFAULT);
     int length;
     int offset;
     int lvEncodedOffset = 0;
@@ -456,6 +460,16 @@ public abstract class VarLengthColumnPageBase extends ColumnPage {
       baseAddress = newBlock.getBaseObject();
       baseOffset = newBlock.getBaseOffset();
       capacity = newSize;
+    }
+  }
+
+  /**
+   * free memory as needed
+   */
+  public void freeMemory() {
+    if (null != rowOffset) {
+      rowOffset.freeMemory();
+      rowOffset = null;
     }
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/VarLengthColumnPageBase.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/VarLengthColumnPageBase.java
@@ -18,10 +18,9 @@
 package org.apache.carbondata.core.datastore.page;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
+import org.apache.carbondata.core.datastore.ColumnType;
 import org.apache.carbondata.core.datastore.TableSpec;
 import org.apache.carbondata.core.memory.CarbonUnsafe;
 import org.apache.carbondata.core.memory.MemoryBlock;
@@ -53,7 +52,7 @@ public abstract class VarLengthColumnPageBase extends ColumnPage {
   Object baseAddress;
 
   // the offset of row in the unsafe memory, its size is pageSize + 1
-  List<Integer> rowOffset;
+  ColumnPage rowOffset;
 
   // the length of bytes added in the page
   int totalLength;
@@ -66,7 +65,14 @@ public abstract class VarLengthColumnPageBase extends ColumnPage {
 
   VarLengthColumnPageBase(TableSpec.ColumnSpec columnSpec, DataType dataType, int pageSize) {
     super(columnSpec, dataType, pageSize);
-    rowOffset = new ArrayList<>();
+    TableSpec.ColumnSpec spec = TableSpec.ColumnSpec
+        .newInstance(columnSpec.getFieldName(), DataTypes.INT, ColumnType.MEASURE);
+    try {
+      rowOffset =
+          ColumnPage.newPage(spec, DataTypes.INT, pageSize);
+    } catch (MemoryException e) {
+      throw new RuntimeException(e);
+    }
     totalLength = 0;
   }
 
@@ -142,14 +148,18 @@ public abstract class VarLengthColumnPageBase extends ColumnPage {
 
   private static ColumnPage getDecimalColumnPage(TableSpec.ColumnSpec columnSpec,
       byte[] lvEncodedBytes, int size) throws MemoryException {
-    List<Integer> rowOffset = new ArrayList<>();
+    TableSpec.ColumnSpec spec = TableSpec.ColumnSpec
+        .newInstance(columnSpec.getFieldName(), DataTypes.INT, ColumnType.MEASURE);
+    ColumnPage rowOffset = ColumnPage.newPage(spec, DataTypes.INT, size);
     int offset;
     int rowId = 0;
+    int counter = 0;
     for (offset = 0; offset < lvEncodedBytes.length; offset += size) {
-      rowOffset.add(offset);
+      rowOffset.putInt(counter, offset);
       rowId++;
+      counter++;
     }
-    rowOffset.add(offset);
+    rowOffset.putInt(counter, offset);
 
     VarLengthColumnPageBase page;
     if (unsafe) {
@@ -160,10 +170,7 @@ public abstract class VarLengthColumnPageBase extends ColumnPage {
 
     // set total length and rowOffset in page
     page.totalLength = offset;
-    page.rowOffset = new ArrayList<>();
-    for (int i = 0; i < rowOffset.size(); i++) {
-      page.rowOffset.add(rowOffset.get(i));
-    }
+    page.rowOffset = rowOffset;
     for (int i = 0; i < rowId; i++) {
       page.putBytes(i, lvEncodedBytes, i * size, size);
     }
@@ -175,24 +182,25 @@ public abstract class VarLengthColumnPageBase extends ColumnPage {
       throws MemoryException {
     // extract length and data, set them to rowOffset and unsafe memory correspondingly
     int rowId = 0;
-    List<Integer> rowOffset = new ArrayList<>();
-    List<Integer> rowLength = new ArrayList<>();
+    TableSpec.ColumnSpec spec = TableSpec.ColumnSpec
+        .newInstance(columnSpec.getFieldName(), DataTypes.INT, ColumnType.MEASURE);
+    ColumnPage rowOffset = ColumnPage.newPage(spec, DataTypes.INT, 1024);
     int length;
     int offset;
     int lvEncodedOffset = 0;
-
+    int counter = 0;
     // extract Length field in input and calculate total length
     for (offset = 0; lvEncodedOffset < lvEncodedBytes.length; offset += length) {
       length = ByteUtil.toInt(lvEncodedBytes, lvEncodedOffset);
-      rowOffset.add(offset);
-      rowLength.add(length);
+      rowOffset.putInt(counter, offset);
       lvEncodedOffset += lvLength + length;
       rowId++;
+      counter++;
     }
-    rowOffset.add(offset);
+    rowOffset.putInt(counter, offset);
     VarLengthColumnPageBase page =
         getVarLengthColumnPage(columnSpec, lvEncodedBytes, dataType, lvLength, rowId, rowOffset,
-            rowLength, offset);
+            offset);
     return page;
   }
 
@@ -201,31 +209,32 @@ public abstract class VarLengthColumnPageBase extends ColumnPage {
       throws MemoryException {
     // extract length and data, set them to rowOffset and unsafe memory correspondingly
     int rowId = 0;
-    List<Integer> rowOffset = new ArrayList<>();
-    List<Integer> rowLength = new ArrayList<>();
+    TableSpec.ColumnSpec spec = TableSpec.ColumnSpec
+        .newInstance(columnSpec.getFieldName(), DataTypes.INT, ColumnType.MEASURE);
+    ColumnPage rowOffset = ColumnPage.newPage(spec, DataTypes.INT, 1024);
     int length;
     int offset;
     int lvEncodedOffset = 0;
-
+    int counter = 0;
     // extract Length field in input and calculate total length
     for (offset = 0; lvEncodedOffset < lvEncodedBytes.length; offset += length) {
       length = ByteUtil.toShort(lvEncodedBytes, lvEncodedOffset);
-      rowOffset.add(offset);
-      rowLength.add(length);
+      rowOffset.putInt(counter, offset);
       lvEncodedOffset += lvLength + length;
       rowId++;
+      counter++;
     }
-    rowOffset.add(offset);
+    rowOffset.putInt(counter, offset);
 
     VarLengthColumnPageBase page =
         getVarLengthColumnPage(columnSpec, lvEncodedBytes, dataType, lvLength, rowId, rowOffset,
-            rowLength, offset);
+             offset);
     return page;
   }
 
   private static VarLengthColumnPageBase getVarLengthColumnPage(TableSpec.ColumnSpec columnSpec,
-      byte[] lvEncodedBytes, DataType dataType, int lvLength, int rowId, List<Integer> rowOffset,
-      List<Integer> rowLength, int offset) throws MemoryException {
+      byte[] lvEncodedBytes, DataType dataType, int lvLength, int rowId, ColumnPage rowOffset,
+      int offset) throws MemoryException {
     int lvEncodedOffset;
     int length;
     int numRows = rowId;
@@ -240,15 +249,12 @@ public abstract class VarLengthColumnPageBase extends ColumnPage {
 
     // set total length and rowOffset in page
     page.totalLength = offset;
-    page.rowOffset = new ArrayList<>();
-    for (int i = 0; i < rowOffset.size(); i++) {
-      page.rowOffset.add(rowOffset.get(i));
-    }
+    page.rowOffset = rowOffset;
 
     // set data in page
     lvEncodedOffset = 0;
     for (int i = 0; i < numRows; i++) {
-      length = rowLength.get(i);
+      length = rowOffset.getInt(i + 1) - rowOffset.getInt(i);
       page.putBytes(i, lvEncodedBytes, lvEncodedOffset + lvLength, length);
       lvEncodedOffset += lvLength + length;
     }
@@ -296,9 +302,9 @@ public abstract class VarLengthColumnPageBase extends ColumnPage {
           + " exceed this limit at rowId " + rowId);
     }
     if (rowId == 0) {
-      rowOffset.add(0);
+      rowOffset.putInt(0, 0);
     }
-    rowOffset.add(rowOffset.get(rowId) + bytes.length);
+    rowOffset.putInt(rowId + 1, rowOffset.getInt(rowId) + bytes.length);
     putBytesAtRow(rowId, bytes);
     totalLength += bytes.length;
   }
@@ -379,7 +385,7 @@ public abstract class VarLengthColumnPageBase extends ColumnPage {
     int offset = 0;
     byte[] data = new byte[totalLength];
     for (int rowId = 0; rowId < pageSize; rowId++) {
-      int length = rowOffset.get(rowId + 1) - rowOffset.get(rowId);
+      int length = rowOffset.getInt(rowId + 1) - rowOffset.getInt(rowId);
       copyBytes(rowId, data, offset, length);
       offset += length;
     }
@@ -395,9 +401,9 @@ public abstract class VarLengthColumnPageBase extends ColumnPage {
   public byte[] getLVFlattenedBytePage() throws IOException {
     // output LV encoded byte array
     int offset = 0;
-    byte[] data = new byte[totalLength + ((rowOffset.size() - 1) * 4)];
-    for (int rowId = 0; rowId < rowOffset.size() - 1; rowId++) {
-      int length = rowOffset.get(rowId + 1) - rowOffset.get(rowId);
+    byte[] data = new byte[totalLength + ((rowOffset.getActualRowCount() - 1) * 4)];
+    for (int rowId = 0; rowId < rowOffset.getActualRowCount() - 1; rowId++) {
+      int length = rowOffset.getInt(rowId + 1) - rowOffset.getInt(rowId);
       ByteUtil.setInt(data, offset, length);
       copyBytes(rowId, data, offset + 4, length);
       offset += 4 + length;
@@ -408,9 +414,9 @@ public abstract class VarLengthColumnPageBase extends ColumnPage {
   @Override public byte[] getComplexChildrenLVFlattenedBytePage() throws IOException {
     // output LV encoded byte array
     int offset = 0;
-    byte[] data = new byte[totalLength + ((rowOffset.size() - 1) * 2)];
-    for (int rowId = 0; rowId < rowOffset.size() - 1; rowId++) {
-      short length = (short) (rowOffset.get(rowId + 1) - rowOffset.get(rowId));
+    byte[] data = new byte[totalLength + ((rowOffset.getActualRowCount() - 1) * 2)];
+    for (int rowId = 0; rowId < rowOffset.getActualRowCount() - 1; rowId++) {
+      short length = (short) (rowOffset.getInt(rowId + 1) - rowOffset.getInt(rowId));
       ByteUtil.setShort(data, offset, length);
       copyBytes(rowId, data, offset + 2, length);
       offset += 2 + length;
@@ -423,8 +429,8 @@ public abstract class VarLengthColumnPageBase extends ColumnPage {
     // output LV encoded byte array
     int offset = 0;
     byte[] data = new byte[totalLength];
-    for (int rowId = 0; rowId < rowOffset.size() - 1; rowId++) {
-      int length =  (rowOffset.get(rowId + 1) - rowOffset.get(rowId));
+    for (int rowId = 0; rowId < rowOffset.getActualRowCount() - 1; rowId++) {
+      int length =  (rowOffset.getInt(rowId + 1) - rowOffset.getInt(rowId));
       copyBytes(rowId, data, offset, length);
       offset += length;
     }


### PR DESCRIPTION
Problem

Query is taking more time when number of elements in array type is more.

Root Cause

This is because offset of array values are stored in list and when number of elements are high creating a big list to store offset is taking more time 

Solution:

Instead of list use column page to store offset so when number of elements are high there will not be any gc.

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

