### PR TITLE
[CARBONDATA-2724][DataMap]Unsupported create datamap on table with V1 or V2 format data

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/datamap/CarbonCreateDataMapCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/datamap/CarbonCreateDataMapCommand.scala
@@ -26,9 +26,10 @@ import org.apache.carbondata.common.exceptions.sql.{MalformedCarbonCommandExcept
 import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.core.datamap.{DataMapProvider, DataMapStoreManager}
 import org.apache.carbondata.core.datamap.status.DataMapStatusManager
+import org.apache.carbondata.core.metadata.ColumnarFormatVersion
 import org.apache.carbondata.core.metadata.schema.datamap.{DataMapClassProvider, DataMapProperty}
 import org.apache.carbondata.core.metadata.schema.table.{CarbonTable, DataMapSchema}
-import org.apache.carbondata.core.util.CarbonProperties
+import org.apache.carbondata.core.util.{CarbonProperties, CarbonUtil}
 import org.apache.carbondata.datamap.{DataMapManager, IndexDataMapProvider}
 import org.apache.carbondata.events._
 
@@ -77,6 +78,11 @@ case class CarbonCreateDataMapCommand(
           || dmProviderName.equalsIgnoreCase(DataMapClassProvider.TIMESERIES.toString))) {
       throw new MalformedCarbonCommandException(s"Streaming table does not support creating " +
                                                 s"$dmProviderName datamap")
+    }
+
+    if (mainTable !=null && CarbonUtil.getFormatVersion(mainTable) != ColumnarFormatVersion.V3) {
+      throw new MalformedCarbonCommandException(s"Unsupported operation on table with " +
+                                                s"V1 or V2 format data")
     }
 
     dataMapSchema = new DataMapSchema(dataMapName, dmProviderName)


### PR DESCRIPTION
[CARBONDATA-2724]Unsupported create datamap on table with V1 or V2 format data

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 NA
 - [x] Any backward compatibility impacted?
 NA
 - [x] Document update required?
NA
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       test pass in environment
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA
