### PR TITLE
[CARBONDATA-2734] Fix struct of date issue in create table 

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/complexType/TestComplexDataType.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/complexType/TestComplexDataType.scala
@@ -667,4 +667,11 @@ class TestComplexDataType extends QueryTest with BeforeAndAfterAll {
     checkAnswer(sql("select a.b from test where id=3 or a.c=3"),Seq(Row(5),Row(2)))
   }
 
+  /* test struct of date*/
+  test("test struct complex type with date") {
+    sql("DROP TABLE IF EXISTS test")
+    sql("create table test(a struct<b:date>) stored by 'carbondata'")
+    sql("insert into test select '1992-02-19' ")
+    checkAnswer(sql("select * from test "), Row(Row(java.sql.Date.valueOf("1992-02-19"))))
+  }
 }

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/complexType/TestComplexDataType.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/complexType/TestComplexDataType.scala
@@ -669,9 +669,17 @@ class TestComplexDataType extends QueryTest with BeforeAndAfterAll {
 
   /* test struct of date*/
   test("test struct complex type with date") {
+    var backupdateFormat = CarbonProperties.getInstance().getProperty(
+      CarbonCommonConstants.CARBON_DATE_FORMAT, CarbonCommonConstants.CARBON_DATE_DEFAULT_FORMAT)
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.CARBON_DATE_FORMAT,
+        CarbonCommonConstants.CARBON_DATE_DEFAULT_FORMAT)
     sql("DROP TABLE IF EXISTS test")
     sql("create table test(a struct<b:date>) stored by 'carbondata'")
     sql("insert into test select '1992-02-19' ")
     checkAnswer(sql("select * from test "), Row(Row(java.sql.Date.valueOf("1992-02-19"))))
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.CARBON_DATE_FORMAT,
+        backupdateFormat)
   }
 }

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
@@ -1330,6 +1330,10 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
         Field(field.column, Some("Timestamp"), field.name, Some(null),
           field.parent, field.storeType, field.schemaOrdinal,
           field.precision, field.scale, field.rawSchema, field.columnComment)
+      case "date" =>
+        Field(field.column, Some("Date"), field.name, Some(null),
+          field.parent, field.storeType, field.schemaOrdinal,
+          field.precision, field.scale, field.rawSchema, field.columnComment)
       case "numeric" => Field(field.column, Some("Numeric"), field.name, Some(null), field.parent,
         field.storeType, field.schemaOrdinal, field.precision, field.scale, field.rawSchema,
         field.columnComment)
@@ -1401,6 +1405,8 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
       case "Float" => Field(parentName + "." + field.column, Some("Double"),
         Some(parentName + "." + field.name.getOrElse(None)), Some(null), parentName)
       case "Timestamp" => Field(parentName + "." + field.column, Some("Timestamp"),
+        Some(parentName + "." + field.name.getOrElse(None)), Some(null), parentName)
+      case "Date" => Field(parentName + "." + field.column, Some("Date"),
         Some(parentName + "." + field.name.getOrElse(None)), Some(null), parentName)
       case "Numeric" => Field(parentName + "." + field.column, Some("Numeric"),
         Some(parentName + "." + field.name.getOrElse(None)), Some(null), parentName)


### PR DESCRIPTION
problem: Struct of date is not supported currently in create table flow
as date datatype check is missing during parsing.
Hence child date column was not appended with parent name, leading to
StringOutOfIndex exception.

solution: Handle the date DataType as a complex child during column
formation.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?NA
 
 - [ ] Any backward compatibility impacted?NA
 
 - [ ] Document update required?NA

 - [ ] Testing done. Updated the UT.

 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

