### PR TITLE
[CARBONDATA-2738]Block Preaggregate, Compaction, Dictionary Exclude/Include for child columns for Complex datatype

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestLoadDataWithMalformedCarbonCommandException.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestLoadDataWithMalformedCarbonCommandException.scala
@@ -83,16 +83,20 @@ class TestLoadDataWithMalformedCarbonCommandException extends QueryTest with Bef
     val e = intercept[MalformedCarbonCommandException] {
       buildTableWithNoExistDictExclude()
     }
-    assert(e.getMessage.equals("DICTIONARY_EXCLUDE column: ccc does not exist in table. " +
-      "Please check create table statement."))
+    assert(e.getMessage
+      .equals(
+        "DICTIONARY_EXCLUDE column: ccc does not exist in table or unsupported for complex child " +
+        "column. Please check create table statement."))
   }
 
   test("test load data with dictionary include columns which no exist in table.") {
     val e = intercept[MalformedCarbonCommandException] {
       buildTableWithNoExistDictInclude()
     }
-    assert(e.getMessage.equals("DICTIONARY_INCLUDE column: aaa does not exist in table. " +
-      "Please check create table statement."))
+    assert(e.getMessage
+      .equals(
+        "DICTIONARY_INCLUDE column: aaa does not exist in table or unsupported for complex child " +
+        "column. Please check create table statement."))
   }
 
   test("test load data with dictionary include is same with dictionary exclude") {

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
@@ -722,16 +722,13 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
         .foreach { dictExcludeCol =>
           if (!fields.exists(x => x.column.equalsIgnoreCase(dictExcludeCol))) {
             val errormsg = "DICTIONARY_EXCLUDE column: " + dictExcludeCol +
-                           " does not exist in table. Please check create table statement."
+                           " does not exist in table or unsupported for complex child column. " +
+                           "Please check create table statement."
             throw new MalformedCarbonCommandException(errormsg)
           } else {
             val dataType = fields.find(x =>
               x.column.equalsIgnoreCase(dictExcludeCol)).get.dataType.get
-            if (isComplexDimDictionaryExclude(dataType)) {
-              val errormsg = "DICTIONARY_EXCLUDE is unsupported for complex datatype column: " +
-                             dictExcludeCol
-              throw new MalformedCarbonCommandException(errormsg)
-            } else if (!isDataTypeSupportedForDictionary_Exclude(dataType)) {
+            if (!isDataTypeSupportedForDictionary_Exclude(dataType)) {
               val errorMsg = "DICTIONARY_EXCLUDE is unsupported for " + dataType.toLowerCase() +
                              " data type column: " + dictExcludeCol
               throw new MalformedCarbonCommandException(errorMsg)
@@ -750,7 +747,8 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
       dictIncludeCols.foreach { distIncludeCol =>
         if (!fields.exists(x => x.column.equalsIgnoreCase(distIncludeCol.trim))) {
           val errormsg = "DICTIONARY_INCLUDE column: " + distIncludeCol.trim +
-                         " does not exist in table. Please check create table statement."
+                         " does not exist in table or unsupported for complex child column. " +
+                         "Please check create table statement."
           throw new MalformedCarbonCommandException(errormsg)
         }
         if (varcharCols.exists(x => x.equalsIgnoreCase(distIncludeCol.trim))) {
@@ -874,7 +872,7 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
    * detects whether datatype is part of dictionary_exclude
    */
   def isDataTypeSupportedForDictionary_Exclude(columnDataType: String): Boolean = {
-    val dataTypes = Array("string", "timestamp", "int", "long", "bigint")
+    val dataTypes = Array("string", "timestamp", "int", "long", "bigint", "struct", "array")
     dataTypes.exists(x => x.equalsIgnoreCase(columnDataType))
   }
 

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/events/MergeIndexEventListener.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/events/MergeIndexEventListener.scala
@@ -112,7 +112,8 @@ class MergeIndexEventListener extends OperationEventListener with Logging {
                 String]()
               loadFolderDetailsArray.foreach(loadMetadataDetails => {
                 segmentFileNameMap
-                  .put(loadMetadataDetails.getLoadName, loadMetadataDetails.getSegmentFile)
+                  .put(loadMetadataDetails.getLoadName,
+                    String.valueOf(loadMetadataDetails.getLoadStartTime))
               })
               CommonUtil.mergeIndexFiles(sparkSession.sparkContext,
                 validSegmentIds,
@@ -160,7 +161,8 @@ class MergeIndexEventListener extends OperationEventListener with Logging {
       .readLoadMetadata(carbonTable.getMetadataPath)
     val segmentFileNameMap: java.util.Map[String, String] = new util.HashMap[String, String]()
     loadFolderDetailsArray.foreach(loadMetadataDetails => {
-      segmentFileNameMap.put(loadMetadataDetails.getLoadName, loadMetadataDetails.getSegmentFile)
+      segmentFileNameMap
+        .put(loadMetadataDetails.getLoadName, String.valueOf(loadMetadataDetails.getLoadStartTime))
     })
     // filter out only the valid segments from the list of compacted segments
     // Example: say compacted segments list contains 0.1, 3.1, 6.1, 0.2.

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonAlterTableCompactionCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonAlterTableCompactionCommand.scala
@@ -82,6 +82,12 @@ case class CarbonAlterTableCompactionCommand(
       throw new MalformedCarbonCommandException("Unsupported operation on non transactional table")
     }
 
+    if (table.getTableInfo.getFactTable.getListOfColumns.asScala
+      .exists(m => m.getDataType.isComplexType)) {
+      throw new UnsupportedOperationException(
+        "Compaction is unsupported for Table containing Complex Columns")
+    }
+
     if (CarbonUtil.hasAggregationDataMap(table) ||
         (table.isChildDataMap && null == operationContext.getProperty(table.getTableName))) {
       // If the compaction request is of 'streaming' type then we need to generate loadCommands

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/strategy/StreamingTableStrategy.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/strategy/StreamingTableStrategy.scala
@@ -34,7 +34,7 @@ private[sql] class StreamingTableStrategy(sparkSession: SparkSession) extends Sp
 
   override def apply(plan: LogicalPlan): Seq[SparkPlan] = {
     plan match {
-      case CarbonProjectForUpdateCommand(_, databaseNameOp, tableName) =>
+      case CarbonProjectForUpdateCommand(_, databaseNameOp, tableName, columns) =>
         rejectIfStreamingTable(
           TableIdentifier(tableName, databaseNameOp),
           "Data update")


### PR DESCRIPTION
Block Preaggregate, Compaction, Dictionary Exclude/Include for child columns and Update Complex datatype columns  for Complex datatype

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [x] Testing done
       Test cases added
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

