### PR TITLE
[wip][CARBONDATA-2740]flat folder handling for implicit column and other bug fix

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/util/path/CarbonTablePath.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/path/CarbonTablePath.java
@@ -374,6 +374,20 @@ public class CarbonTablePath {
   }
 
   /**
+   * Return store path for datamap based on the dataMapName,
+   *
+   * @return store path based on datamapname
+   */
+  public static String getDataMapStorePath(String tablePath, String dataMapName) {
+    return new StringBuilder()
+        .append(tablePath)
+        .append(File.separator)
+        .append(dataMapName)
+        .toString();
+  }
+
+
+  /**
    * To manage data file name and composition
    */
   public static class DataFileUtil {

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/localdictionary/LocalDictionarySupportCreateTableTest.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/localdictionary/LocalDictionarySupportCreateTableTest.scala
@@ -2165,7 +2165,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
     }
     assert(exception.getMessage
       .contains(
-        "None of the child columns specified in the complex dataType column(s) in " +
+        "None of the child columns of complex datatype column st specified in " +
         "local_dictionary_include are not of string dataType."))
   }
 
@@ -2183,7 +2183,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
     }
     assert(exception.getMessage
       .contains(
-        "None of the child columns specified in the complex dataType column(s) in " +
+        "None of the child columns of complex datatype column city specified in " +
         "local_dictionary_include are not of string dataType."))
   }
 
@@ -2322,7 +2322,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
     }
     assert(exception.getMessage
       .contains(
-        "None of the child columns specified in the complex dataType column(s) in " +
+        "None of the child columns of complex datatype column city specified in " +
         "local_dictionary_include are not of string dataType."))
   }
 

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
@@ -472,8 +472,9 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
         .exists(x => x.column.equalsIgnoreCase(dictColm) && x.children.isDefined &&
                      null != x.children.get &&
                      !validateChildColumnsRecursively(x))) {
-        val errMsg = "None of the child columns specified in the complex dataType column(s) in " +
-                     "local_dictionary_include are not of string dataType."
+        val errMsg =
+          s"None of the child columns of complex datatype column $dictColm specified in " +
+          "local_dictionary_include are not of string dataType."
         throw new MalformedCarbonCommandException(errMsg)
       }
     }

--- a/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -17,6 +17,7 @@
 
 package org.apache.carbondata.spark.rdd
 
+import java.io.File
 import java.text.SimpleDateFormat
 import java.util
 import java.util.TimeZone
@@ -556,6 +557,10 @@ object CarbonDataRDDFactory {
         if (carbonLoadModel.isCarbonTransactionalTable) {
           // delete segment is applicable for transactional table
           CarbonLoaderUtil.deleteSegment(carbonLoadModel, carbonLoadModel.getSegmentId.toInt)
+          // delete corresponding segment file from metadata
+          val segmentFile = CarbonTablePath.getSegmentFilesLocation(carbonLoadModel.getTablePath) +
+                            File.separator + segmentFileName
+          FileFactory.deleteFile(segmentFile, FileFactory.getFileType(segmentFile))
           clearDataMapFiles(carbonTable, carbonLoadModel.getSegmentId)
         }
         LOGGER.info("********clean up done**********")

--- a/processing/src/main/java/org/apache/carbondata/processing/store/CarbonFactDataHandlerModel.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/CarbonFactDataHandlerModel.java
@@ -300,6 +300,7 @@ public class CarbonFactDataHandlerModel {
     carbonFactDataHandlerModel.setStoreLocation(tempStoreLocation);
     carbonFactDataHandlerModel.setDimLens(segmentProperties.getDimColumnsCardinality());
     carbonFactDataHandlerModel.setSegmentProperties(segmentProperties);
+    carbonFactDataHandlerModel.setSegmentId(loadModel.getSegmentId());
     carbonFactDataHandlerModel
         .setNoDictionaryCount(segmentProperties.getNumberOfNoDictionaryDimension());
     carbonFactDataHandlerModel.setDimensionCount(


### PR DESCRIPTION
### Problem
1) When flat folder is enabled for table, pruning is not happening for implicit column.
2) error message is wrong when complex column which does not have any string datatype column is given in local dictionary and exclude column.
3) when data load is failed, corresponding segment file is not getting deleted.

### Solution:
1) when flat folder is enabled, based on the segment number present in the carbondata file name,  pruning is taken care
2) error message is corrected
3) when data load is failed, segment file will be deleted


