### PR TITLE
[CARBONDATA-2698][CARBONDATA-2700][CARBONDATA-2732][BloomDataMap] block some oprerations of bloomfilter datamap

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datamap/dev/DataMapFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/dev/DataMapFactory.java
@@ -144,4 +144,17 @@ public abstract class DataMapFactory<T extends DataMap> {
     }
   }
 
+  /**
+   * whether to block operation on corresponding table or column.
+   * For example, bloomfilter datamap will block changing datatype for bloomindex column.
+   * By default it will not block any operation.
+   *
+   * @param operation table operation
+   * @param targets objects which the operation impact on
+   * @return true the operation will be blocked;false the operation will not be blocked
+   */
+  public boolean isOperationBlocked(TableOperation operation, Object... targets) {
+    return false;
+  }
+
 }

--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/CarbonTable.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/CarbonTable.java
@@ -1053,11 +1053,12 @@ public class CarbonTable implements Serializable {
   /**
    * methods returns true if operation is allowed for the corresponding datamap or not
    * if this operation makes datamap stale it is not allowed
-   * @param carbonTable
-   * @param operation
-   * @return
+   * @param carbonTable carbontable to be operated
+   * @param operation which operation on the table,such as drop column,change datatype.
+   * @param targets objects which the operation impact on,such as column
+   * @return true allow;false not allow
    */
-  public boolean canAllow(CarbonTable carbonTable, TableOperation operation) {
+  public boolean canAllow(CarbonTable carbonTable, TableOperation operation, Object... targets) {
     try {
       List<TableDataMap> datamaps = DataMapStoreManager.getInstance().getAllDataMap(carbonTable);
       if (!datamaps.isEmpty()) {
@@ -1066,6 +1067,10 @@ public class CarbonTable implements Serializable {
               DataMapStoreManager.getInstance().getDataMapFactoryClass(
                   carbonTable, dataMap.getDataMapSchema());
           if (factoryClass.willBecomeStale(operation)) {
+            return false;
+          }
+          // check whether the operation is blocked for datamap
+          if (factoryClass.isOperationBlocked(operation, targets)) {
             return false;
           }
         }

--- a/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomCoarseGrainDataMapFactory.java
+++ b/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomCoarseGrainDataMapFactory.java
@@ -377,7 +377,8 @@ public class BloomCoarseGrainDataMapFactory extends DataMapFactory<CoarseGrainDa
     }
   }
 
-  @Override public boolean willBecomeStale(TableOperation operation) {
+  @Override
+  public boolean willBecomeStale(TableOperation operation) {
     switch (operation) {
       case ALTER_RENAME:
         return false;
@@ -395,6 +396,40 @@ public class BloomCoarseGrainDataMapFactory extends DataMapFactory<CoarseGrainDa
         return true;
       case PARTITION:
         return true;
+      default:
+        return false;
+    }
+  }
+
+  @Override
+  public boolean isOperationBlocked(TableOperation operation, Object... targets) {
+    switch (operation) {
+      case ALTER_DROP: {
+        // alter table drop columns
+        // will be blocked if the columns in bloomfilter datamap
+        List<String> columnsToDrop = (List<String>) targets[0];
+        List<String> indexedColumnNames = dataMapMeta.getIndexedColumnNames();
+        for (String indexedcolumn : indexedColumnNames) {
+          for (String column : columnsToDrop) {
+            if (column.equalsIgnoreCase(indexedcolumn)) {
+              return true;
+            }
+          }
+        }
+        return false;
+      }
+      case ALTER_CHANGE_DATATYPE: {
+        // alter table change one column datatype
+        // will be blocked if the column in bloomfilter datamap
+        String columnToChangeDatatype = (String) targets[0];
+        List<String> indexedColumnNames = dataMapMeta.getIndexedColumnNames();
+        for (String indexedcolumn : indexedColumnNames) {
+          if (indexedcolumn.equalsIgnoreCase(columnToChangeDatatype)) {
+            return true;
+          }
+        }
+        return false;
+      }
       default:
         return false;
     }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/schema/CarbonAlterTableDataTypeChangeCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/schema/CarbonAlterTableDataTypeChangeCommand.scala
@@ -55,7 +55,8 @@ private[sql] case class CarbonAlterTableDataTypeChangeCommand(
         .validateTableAndAcquireLock(dbName, tableName, locksToBeAcquired)(sparkSession)
       val metastore = CarbonEnv.getInstance(sparkSession).carbonMetastore
       carbonTable = CarbonEnv.getCarbonTable(Some(dbName), tableName)(sparkSession)
-      if (!carbonTable.canAllow(carbonTable, TableOperation.ALTER_CHANGE_DATATYPE)) {
+      if (!carbonTable.canAllow(carbonTable, TableOperation.ALTER_CHANGE_DATATYPE,
+        alterTableDataTypeChangeModel.columnName)) {
         throw new MalformedCarbonCommandException(
           "alter table change datatype is not supported for index datamap")
       }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/schema/CarbonAlterTableDropColumnCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/schema/CarbonAlterTableDropColumnCommand.scala
@@ -58,7 +58,8 @@ private[sql] case class CarbonAlterTableDropColumnCommand(
         .validateTableAndAcquireLock(dbName, tableName, locksToBeAcquired)(sparkSession)
       val metastore = CarbonEnv.getInstance(sparkSession).carbonMetastore
       carbonTable = CarbonEnv.getCarbonTable(Some(dbName), tableName)(sparkSession)
-      if (!carbonTable.canAllow(carbonTable, TableOperation.ALTER_DROP)) {
+      if (!carbonTable.canAllow(carbonTable, TableOperation.ALTER_DROP,
+          alterTableDropColumnModel.columns.asJava)) {
         throw new MalformedCarbonCommandException(
           "alter table drop column is not supported for index datamap")
       }

--- a/integration/spark2/src/test/scala/org/apache/carbondata/datamap/bloom/BloomCoarseGrainDataMapSuite.scala
+++ b/integration/spark2/src/test/scala/org/apache/carbondata/datamap/bloom/BloomCoarseGrainDataMapSuite.scala
@@ -26,6 +26,8 @@ import org.apache.spark.sql.{CarbonSession, DataFrame}
 import org.apache.spark.sql.test.util.QueryTest
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 
+import org.apache.carbondata.common.exceptions.sql.{MalformedCarbonCommandException, MalformedDataMapCommandException}
+import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.datamap.status.DataMapStatusManager
 import org.apache.carbondata.core.util.CarbonProperties
 
@@ -411,6 +413,103 @@ class BloomCoarseGrainDataMapSuite extends QueryTest with BeforeAndAfterAll with
 
     // we do not care about the datamap name here, only to validate the query results are them same
     checkQuery("fakeDm", shouldHit = false)
+  }
+
+  test("test block change datatype for bloomfilter index datamap") {
+    sql(
+      s"""
+         | CREATE TABLE $normalTable(id INT, name STRING, city STRING, age INT,
+         | s1 STRING, s2 STRING, s3 STRING, s4 STRING, s5 STRING, s6 STRING, s7 STRING, s8 STRING)
+         | STORED BY 'carbondata' TBLPROPERTIES('table_blocksize'='128')
+         | """.stripMargin)
+
+    sql(
+      s"""
+         | CREATE DATAMAP $dataMapName ON TABLE $normalTable
+         | USING 'bloomfilter' WITH DEFERRED REBUILD
+         | DMProperties( 'INDEX_COLUMNS'='city,id', 'BLOOM_SIZE'='640000')
+      """.stripMargin)
+    val exception: MalformedCarbonCommandException = intercept[MalformedCarbonCommandException] {
+      sql(s"ALTER TABLE $normalTable CHANGE id id bigint")
+    }
+    assert(exception.getMessage.contains(
+      "alter table change datatype is not supported for index datamap"))
+  }
+
+  test("test drop index columns for bloomfilter datamap") {
+    sql(
+      s"""
+         | CREATE TABLE $normalTable(id INT, name STRING, city STRING, age INT,
+         | s1 STRING, s2 STRING, s3 STRING, s4 STRING, s5 STRING, s6 STRING, s7 STRING, s8 STRING)
+         | STORED BY 'carbondata' TBLPROPERTIES('table_blocksize'='128')
+         |  """.stripMargin)
+    sql(
+      s"""
+         | CREATE DATAMAP $dataMapName ON TABLE $normalTable
+         | USING 'bloomfilter'
+         | WITH DEFERRED REBUILD
+         | DMProperties('INDEX_COLUMNS'='city,id', 'BLOOM_SIZE'='640000')
+      """.stripMargin)
+    val exception: MalformedCarbonCommandException = intercept[MalformedCarbonCommandException] {
+      sql(s"alter table $normalTable drop columns(name, id)")
+    }
+    assert(exception.getMessage.contains(
+      "alter table drop column is not supported for index datamap"))
+  }
+
+  test("test bloom datamap: bloom index column is local dictionary") {
+    sql(
+      s"""
+         | CREATE TABLE $normalTable(c1 string, c2 int, c3 string)
+         | STORED BY 'carbondata'
+         | """.stripMargin)
+    // c1 is local dictionary and will create bloom index on it
+    sql(
+      s"""
+         | CREATE TABLE $bloomDMSampleTable(c1 string, c2 int, c3 string)
+         | STORED BY 'carbondata'
+         | TBLPROPERTIES('local_dictionary_include'='c1', 'local_dictionary_threshold'='1000')
+         | """.stripMargin)
+    sql(
+      s"""
+         | CREATE DATAMAP $dataMapName on table $bloomDMSampleTable
+         | using 'bloomfilter'
+         | DMPROPERTIES('index_columns'='c1, c2')
+         | """.stripMargin)
+    sql(
+      s"""
+         | INSERT INTO $bloomDMSampleTable
+         | values ('c1v11', 11, 'c3v11'), ('c1v12', 12, 'c3v12')
+         | """.stripMargin)
+    sql(
+      s"""
+         | INSERT INTO $normalTable values ('c1v11', 11, 'c3v11'),
+         | ('c1v12', 12, 'c3v12')
+         | """.stripMargin)
+    checkAnswer(sql(s"select * from $bloomDMSampleTable"),
+      sql(s"select * from $normalTable"))
+    checkAnswer(sql(s"select * from $bloomDMSampleTable where c1 = 'c1v12'"),
+      sql(s"select * from $normalTable where c1 = 'c1v12'"))
+  }
+
+  test("test create bloomfilter datamap which index column datatype is complex ") {
+    sql(
+      s"""
+         | CREATE TABLE $normalTable(id INT, name STRING, city Array<INT>, age INT,
+         | s1 STRING, s2 STRING, s3 STRING, s4 STRING, s5 STRING, s6 STRING, s7 STRING, s8 STRING)
+         | STORED BY 'carbondata'
+         | """.stripMargin)
+    val exception: MalformedDataMapCommandException = intercept[MalformedDataMapCommandException] {
+      sql(
+        s"""
+           | CREATE DATAMAP $dataMapName ON TABLE $normalTable
+           | USING 'bloomfilter'
+           | WITH DEFERRED REBUILD
+           | DMProperties('INDEX_COLUMNS'='city,id', 'BLOOM_SIZE'='640000')
+           | """.stripMargin)
+    }
+    assert(exception.getMessage.contains(
+      "BloomFilter datamap does not support complex datatype column"))
   }
 
   override protected def afterAll(): Unit = {


### PR DESCRIPTION
1.Block create bloomfilter datamap index on column which its datatype is complex type;
2.Block change datatype for bloomfilter index datamap;
3.Block dropping index columns for bloomfilter index datamap

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed? 
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

