### PR TITLE
[CARBONDATA-2744]Streaming lock is not released even Batch processing…

### DIFF
--- a/integration/spark-common/src/main/scala/org/apache/carbondata/streaming/StreamSinkFactory.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/streaming/StreamSinkFactory.scala
@@ -78,13 +78,13 @@ object StreamSinkFactory {
     }
   }
 
+
   def createStreamTableSink(
       sparkSession: SparkSession,
       hadoopConf: Configuration,
       carbonTable: CarbonTable,
       parameters: Map[String, String]): Sink = {
 
-    lock(carbonTable)
 
     validateParameters(parameters)
 


### PR DESCRIPTION
Issue Detail :-  if Streaming Application is running , DDLs like finish streaming ,close streaming are blocked. 
ideally DDLs like finish streaming ,close streaming should be blocked if  Batch Processing is running. if Batch processing is not happening then DDL's should be allowed from JDBCServer/Beeline.

Root Cause :- Streaming lock is taken on application start and it is released onQueryTerminate event of CarbonStreamingQueryListener ,this event will be called when stop() is called on StreamingQuery which means streaming Lock will be released  on Either Streaming Query should be terminated Or complete Streaming Application should be terminated till then all stream lock DDL's are blocked.

Solution :-  on AddBatch take streaming lock and once Batch is processed ,release the streaming lock.

Note:- 
a. If close streaming is called OR streaming Table is updated with 'streaming'='false'  and on Trigger time to AddBatch, addBatch will throw Exception and StreamingQuery should be start again.

b. if DDLs like finish streaming ,close streaming  started 1st and addBatch started 2nd.  addBatch will throw "can not acquire lock" Exception and StreamingQuery should be start again.


Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 NO
 - [ ] Any backward compatibility impacted?
 NO
 - [ ] Document update required?
NO
 - [ ] Testing done

Manually verified below scenarios 
a. Call StreamingFinished when addBatch is Done.
b. Whether  New Batch works after Streaming Finish DDL success. it creates new Streaming Segment
c.  New Batch while Streaming Finnish DDL was running
d. Call Streaming Finish when Add Batch was Running 

Verified above scenarios for other DDL' also (close streaming,set SET TBLPROPERTIES('streaming'='false')

 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NO 
