### PR TITLE
[CARBONDATA-2649] Fixed arrayIndexOutOfBoundException while loading Blocklet DataMap after alter add column operation

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/indexstore/BlockletDataMapIndexStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/BlockletDataMapIndexStore.java
@@ -197,7 +197,8 @@ public class BlockletDataMapIndexStore
         // as segmentId will be same for all the dataMaps and segmentProperties cache is
         // maintained at segment level so it need to be called only once for clearing
         SegmentPropertiesAndSchemaHolder.getInstance()
-            .invalidate(segmentId, dataMaps.get(0).getSegmentPropertiesIndex());
+            .invalidate(segmentId, dataMaps.get(0).getSegmentPropertiesIndex(),
+                tableSegmentUniqueIdentifierWrapper.isAddTableBlockToUnsafe());
       }
     }
     lruCache.remove(tableSegmentUniqueIdentifierWrapper.getTableBlockIndexUniqueIdentifier()

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockDataMap.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockDataMap.java
@@ -224,7 +224,7 @@ public class BlockDataMap extends CoarseGrainDataMap
         byte[][] updatedMaxValues =
             CarbonUtil.updateMinMaxValues(fileFooter, maxValues, minValues, false);
         summaryRow = loadToUnsafeBlock(schema, taskSummarySchema, fileFooter, segmentProperties,
-            blockletDataMapInfo.getMinMaxCacheColumns(), blockInfo.getFilePath(), summaryRow,
+            getMinMaxCacheColumns(), blockInfo.getFilePath(), summaryRow,
             blockMetaInfo, updatedMinValues, updatedMaxValues);
       }
     }
@@ -286,8 +286,8 @@ public class BlockDataMap extends CoarseGrainDataMap
           TableBlockInfo previousBlockInfo =
               previousDataFileFooter.getBlockInfo().getTableBlockInfo();
           summaryRow = loadToUnsafeBlock(schema, taskSummarySchema, previousDataFileFooter,
-              segmentProperties, blockletDataMapInfo.getMinMaxCacheColumns(),
-              previousBlockInfo.getFilePath(), summaryRow,
+              segmentProperties, getMinMaxCacheColumns(), previousBlockInfo.getFilePath(),
+              summaryRow,
               blockletDataMapInfo.getBlockMetaInfoMap().get(previousBlockInfo.getFilePath()),
               blockMinValues, blockMaxValues);
           // flag to check whether last file footer entry is different from previous entry.
@@ -311,7 +311,7 @@ public class BlockDataMap extends CoarseGrainDataMap
     if (isLastFileFooterEntryNeedToBeAdded) {
       summaryRow =
           loadToUnsafeBlock(schema, taskSummarySchema, previousDataFileFooter, segmentProperties,
-              blockletDataMapInfo.getMinMaxCacheColumns(),
+              getMinMaxCacheColumns(),
               previousDataFileFooter.getBlockInfo().getTableBlockInfo().getFilePath(), summaryRow,
               blockletDataMapInfo.getBlockMetaInfoMap()
                   .get(previousDataFileFooter.getBlockInfo().getTableBlockInfo().getFilePath()),
@@ -530,7 +530,7 @@ public class BlockDataMap extends CoarseGrainDataMap
     return false;
   }
 
-  private List<CarbonColumn> getMinMaxCacheColumns() {
+  protected List<CarbonColumn> getMinMaxCacheColumns() {
     return SegmentPropertiesAndSchemaHolder.getInstance()
         .getSegmentPropertiesWrapper(segmentPropertiesIndex).getMinMaxCacheColumns();
   }

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMap.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMap.java
@@ -126,7 +126,7 @@ public class BlockletDataMap extends BlockDataMap implements Serializable {
           relativeBlockletId = 0;
         }
         summaryRow = loadToUnsafe(schema, taskSummarySchema, fileFooter, segmentProperties,
-            blockletDataMapInfo.getMinMaxCacheColumns(), blockInfo.getFilePath(), summaryRow,
+            getMinMaxCacheColumns(), blockInfo.getFilePath(), summaryRow,
             blockMetaInfo, relativeBlockletId);
         // this is done because relative blocklet id need to be incremented based on the
         // total number of blocklets

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMapModel.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMapModel.java
@@ -16,13 +16,11 @@
  */
 package org.apache.carbondata.core.indexstore.blockletindex;
 
-import java.util.List;
 import java.util.Map;
 
 import org.apache.carbondata.core.datamap.dev.DataMapModel;
 import org.apache.carbondata.core.indexstore.BlockMetaInfo;
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
-import org.apache.carbondata.core.metadata.schema.table.column.CarbonColumn;
 
 /**
  * It is the model object to keep the information to build or initialize BlockletDataMap.
@@ -35,8 +33,6 @@ public class BlockletDataMapModel extends DataMapModel {
 
   private CarbonTable carbonTable;
 
-  private List<CarbonColumn> minMaxCacheColumns;
-
   private String segmentId;
 
   private boolean addToUnsafe = true;
@@ -48,7 +44,6 @@ public class BlockletDataMapModel extends DataMapModel {
     this.blockMetaInfoMap = blockMetaInfoMap;
     this.segmentId = segmentId;
     this.carbonTable = carbonTable;
-    this.minMaxCacheColumns = carbonTable.getMinMaxCacheColumns();
   }
 
   public BlockletDataMapModel(CarbonTable carbonTable, String filePath,
@@ -76,9 +71,5 @@ public class BlockletDataMapModel extends DataMapModel {
 
   public CarbonTable getCarbonTable() {
     return carbonTable;
-  }
-
-  public List<CarbonColumn> getMinMaxCacheColumns() {
-    return minMaxCacheColumns;
   }
 }

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/allqueries/TestQueryWithColumnMetCacheAndCacheLevelProperty.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/allqueries/TestQueryWithColumnMetCacheAndCacheLevelProperty.scala
@@ -257,4 +257,15 @@ class TestQueryWithColumnMetCacheAndCacheLevelProperty extends QueryTest with Be
       Row(5))
   }
 
+  test("verify column caching with alter add column") {
+    sql("drop table if exists alter_add_column_min_max")
+    sql("create table alter_add_column_min_max (imei string,AMSize string,channelsId string,ActiveCountry string, Activecity string,gamePointId double,deviceInformationId double,productionDate Timestamp,deliveryDate timestamp,deliverycharge double) STORED BY 'org.apache.carbondata.format' TBLPROPERTIES('table_blocksize'='1','COLUMN_META_CACHE'='AMSize','CACHE_LEVEL'='BLOCKLET')")
+    sql("insert into alter_add_column_min_max select '1AA1','8RAM size','4','Chinese','guangzhou',2738,1,'2014-07-01 12:07:28','2014-07-01 12:07:28',25")
+    sql("alter table alter_add_column_min_max add columns(age int, name string)")
+    sql("ALTER TABLE alter_add_column_min_max SET TBLPROPERTIES('COLUMN_META_CACHE'='age,name')")
+    sql("insert into alter_add_column_min_max select '1AA1','8RAM size','4','Chinese','guangzhou',2738,1,'2014-07-01 12:07:28','2014-07-01 12:07:28',25,29,'Rahul'")
+    checkAnswer(sql("select count(*) from alter_add_column_min_max where AMSize='8RAM size'"), Row(2))
+    sql("drop table if exists alter_add_column_min_max")
+  }
+
 }


### PR DESCRIPTION
Things done as part of this PR
1. Fixed arrayIndexOutOfBoundException while loading Blocklet DataMap after alter add column operation

**Problem:**
Array Index out of bound exception was thrown after alter add column operation.

**Analysis:**
After alter add column operation if COLUMN_META_CACHE is set on the newly added columns, then on executing select query on the data  loaded before alter operation threw exception. This was because minMaxCache caching columns were fetched irrespective of the segmentProperties. Data loaded before alter add column operation will not have the newly added columns in its columnSchemaList and hence can throw exception if non existent column are not removed from min/max column cache.

**Solution:**
Fetch the min/max cache columns  based on segmentProperties

 - [ ] Any interfaces changed?
 No
 - [ ] Any backward compatibility impacted?
 No
 - [ ] Document update required?
 No
 - [ ] Testing done
 Added test case       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
 NA
