### PR TITLE
[CARBONDATA-2740]segment file is not getting deleted if load fails and correct the error message for local dictionary validation

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/localdictionary/LocalDictionarySupportCreateTableTest.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/localdictionary/LocalDictionarySupportCreateTableTest.scala
@@ -2165,7 +2165,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
     }
     assert(exception.getMessage
       .contains(
-        "None of the child columns specified in the complex dataType column(s) in " +
+        "None of the child columns of complex dataType column st specified in " +
         "local_dictionary_include are not of string dataType."))
   }
 
@@ -2183,7 +2183,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
     }
     assert(exception.getMessage
       .contains(
-        "None of the child columns specified in the complex dataType column(s) in " +
+        "None of the child columns of complex dataType column city specified in " +
         "local_dictionary_include are not of string dataType."))
   }
 
@@ -2322,7 +2322,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
     }
     assert(exception.getMessage
       .contains(
-        "None of the child columns specified in the complex dataType column(s) in " +
+        "None of the child columns of complex dataType column city specified in " +
         "local_dictionary_include are not of string dataType."))
   }
 

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
@@ -491,8 +491,9 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
         .exists(x => x.column.equalsIgnoreCase(dictColm) && x.children.isDefined &&
                      null != x.children.get &&
                      !validateChildColumnsRecursively(x))) {
-        val errMsg = "None of the child columns specified in the complex dataType column(s) in " +
-                     "local_dictionary_include are not of string dataType."
+        val errMsg =
+          s"None of the child columns of complex dataType column $dictColm specified in " +
+          "local_dictionary_include are not of string dataType."
         throw new MalformedCarbonCommandException(errMsg)
       }
     }

--- a/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -17,6 +17,7 @@
 
 package org.apache.carbondata.spark.rdd
 
+import java.io.File
 import java.text.SimpleDateFormat
 import java.util
 import java.util.TimeZone
@@ -558,6 +559,10 @@ object CarbonDataRDDFactory {
         if (carbonLoadModel.isCarbonTransactionalTable) {
           // delete segment is applicable for transactional table
           CarbonLoaderUtil.deleteSegment(carbonLoadModel, carbonLoadModel.getSegmentId.toInt)
+          // delete corresponding segment file from metadata
+          val segmentFile = CarbonTablePath.getSegmentFilesLocation(carbonLoadModel.getTablePath) +
+                            File.separator + segmentFileName
+          FileFactory.deleteFile(segmentFile, FileFactory.getFileType(segmentFile))
           clearDataMapFiles(carbonTable, carbonLoadModel.getSegmentId)
         }
         LOGGER.info("********clean up done**********")

--- a/processing/src/main/java/org/apache/carbondata/processing/store/CarbonFactDataHandlerModel.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/CarbonFactDataHandlerModel.java
@@ -334,6 +334,7 @@ public class CarbonFactDataHandlerModel {
     carbonFactDataHandlerModel.setStoreLocation(tempStoreLocation);
     carbonFactDataHandlerModel.setDimLens(segmentProperties.getDimColumnsCardinality());
     carbonFactDataHandlerModel.setSegmentProperties(segmentProperties);
+    carbonFactDataHandlerModel.setSegmentId(loadModel.getSegmentId());
     carbonFactDataHandlerModel
         .setNoDictionaryCount(segmentProperties.getNumberOfNoDictionaryDimension());
     carbonFactDataHandlerModel.setDimensionCount(


### PR DESCRIPTION
### Problem
error message is wrong when complex column which does not have any string datatype column is given in local dictionary exclude column.
when data load is failed, corresponding segment file is not getting deleted.
### Solution:
error message is corrected
when data load is failed, segment file will be deleted