### PR TITLE
[CARBONDATA-2714][Merge Index] Fixed block dataMap cache refresh issue after creation of merge index file

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/writer/CarbonIndexFileMergeWriter.java
+++ b/core/src/main/java/org/apache/carbondata/core/writer/CarbonIndexFileMergeWriter.java
@@ -151,7 +151,7 @@ public class CarbonIndexFileMergeWriter {
     String path = CarbonTablePath.getSegmentFilesLocation(table.getTablePath())
         + CarbonCommonConstants.FILE_SEPARATOR + newSegmentFileName;
     SegmentFileStore.writeSegmentFile(segmentFileStore.getSegmentFile(), path);
-    SegmentFileStore.updateSegmentFile(table.getTablePath(), segmentId, newSegmentFileName,
+    SegmentFileStore.updateSegmentFile(table, segmentId, newSegmentFileName,
         table.getCarbonTableIdentifier().getTableId(), segmentFileStore);
 
     for (CarbonFile file : indexFiles) {

--- a/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -519,7 +519,7 @@ object CarbonDataRDDFactory {
           String.valueOf(carbonLoadModel.getFactTimeStamp))
 
       SegmentFileStore.updateSegmentFile(
-        carbonTable.getTablePath,
+        carbonTable,
         carbonLoadModel.getSegmentId,
         segmentFileName,
         carbonTable.getCarbonTableIdentifier.getTableId,


### PR DESCRIPTION
Things handled as part of this PR
1. Fixed block dataMap cache refresh issue after creation of merge index file

**Problem:**
Block DataMap cache not getting refreshed after creation of merge index file due to which queries still look for index file and fail.

**Analysis:**
Merge index file creation involves modification of segment file. If a query is executed without merge Index file creation then cache will be loaded. Once merge Index file is created the index file entries will be removed from segment file and merge index file entry will be added. In this process the cache is not getting refreshed and the tableIdentifiers created still have the mergeIndexFIleName as null.

**Fix:**
After updating table status file clear the dataMap cache for all segmentId's on which dataMap is being created

 - [ ] Any interfaces changed?
 No
 - [ ] Any backward compatibility impacted?
 No
 - [ ] Document update required?
No
 - [ ] Testing done
Added test case
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA
