### PR TITLE
[CARBONDATA-2751] Fixed Thread leak issue in data loading and Compatibility issue

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/impl/DimensionRawColumnChunk.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/impl/DimensionRawColumnChunk.java
@@ -141,7 +141,8 @@ public class DimensionRawColumnChunk extends AbstractRawColumnChunk {
   }
 
   public CarbonDictionary getLocalDictionary() {
-    if (null != getDataChunkV3().local_dictionary && null == localDictionary) {
+    if (null != getDataChunkV3() && null != getDataChunkV3().local_dictionary
+        && null == localDictionary) {
       try {
         localDictionary = getDictionary(getDataChunkV3().local_dictionary);
       } catch (IOException | MemoryException e) {

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/VarLengthColumnPageBase.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/VarLengthColumnPageBase.java
@@ -172,6 +172,7 @@ public abstract class VarLengthColumnPageBase extends ColumnPage {
 
     // set total length and rowOffset in page
     page.totalLength = offset;
+    page.rowOffset.freeMemory();
     page.rowOffset = rowOffset;
     for (int i = 0; i < rowId; i++) {
       page.putBytes(i, lvEncodedBytes, i * size, size);
@@ -253,6 +254,7 @@ public abstract class VarLengthColumnPageBase extends ColumnPage {
 
     // set total length and rowOffset in page
     page.totalLength = offset;
+    page.rowOffset.freeMemory();
     page.rowOffset = rowOffset;
 
     // set data in page

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/steps/DataWriterProcessorStepImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/steps/DataWriterProcessorStepImpl.java
@@ -278,13 +278,10 @@ public class DataWriterProcessorStepImpl extends AbstractDataLoadProcessorStep {
       if (null != rangeExecutorService) {
         rangeExecutorService.shutdownNow();
       }
-
       if (null != this.carbonFactHandlers && !this.carbonFactHandlers.isEmpty()) {
-        synchronized (this.localDictionaryGeneratorMap) {
-          for (CarbonFactHandler carbonFactHandler : this.carbonFactHandlers) {
-            carbonFactHandler.finish();
-            carbonFactHandler.closeHandler();
-          }
+        for (CarbonFactHandler carbonFactHandler : this.carbonFactHandlers) {
+          carbonFactHandler.finish();
+          carbonFactHandler.closeHandler();
         }
       }
     }

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/steps/DataWriterProcessorStepImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/steps/DataWriterProcessorStepImpl.java
@@ -189,8 +189,8 @@ public class DataWriterProcessorStepImpl extends AbstractDataLoadProcessorStep {
         rowsNotExist = false;
         dataHandler = CarbonFactHandlerFactory
             .createCarbonFactHandler(model);
-        dataHandler.initialise();
         carbonFactHandlers.add(dataHandler);
+        dataHandler.initialise();
       }
       processBatch(insideRangeIterator.next(), dataHandler);
     }

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/steps/InputProcessorStepImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/steps/InputProcessorStepImpl.java
@@ -88,7 +88,9 @@ public class InputProcessorStepImpl extends AbstractDataLoadProcessorStep {
   @Override public void close() {
     if (!closed) {
       super.close();
-      executorService.shutdown();
+      if (null != executorService) {
+        executorService.shutdownNow();
+      }
       for (CarbonIterator inputIterator : inputIterators) {
         inputIterator.close();
       }


### PR DESCRIPTION
**### Problem:**

- Thread leak when user is killing data loading process from UI

- NPE when user is querying old store.

**### Solution** 

- When carbondata file writing is in progress during data loading and user is killing it from UI Producer and consumer thread are not getting shutdown. Need to handle the same in close method
- Old store (V1/V2) does not have datachunk3 object so while filling the local dictionary it is checking whether local dictionary is present in datachunk3 or not but datachunk3 null check is missing

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Tested in 3 Node cluster
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

