### PR TITLE
[CARBONDATA-2753] Fix Compatibility issue with Preaggregate table

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/DataMapSchemaFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/DataMapSchemaFactory.java
@@ -28,9 +28,11 @@ public class DataMapSchemaFactory {
    * @return data map schema
    */
   public DataMapSchema getDataMapSchema(String dataMapName, String providerName) {
-    if (providerName.equalsIgnoreCase(DataMapClassProvider.PREAGGREGATE.toString())) {
+    if (providerName.equalsIgnoreCase(DataMapClassProvider.PREAGGREGATE.toString()) || providerName
+        .equalsIgnoreCase(DataMapClassProvider.PREAGGREGATE.getClassName())) {
       return new AggregationDataMapSchema(dataMapName, providerName);
-    } else if (providerName.equalsIgnoreCase(DataMapClassProvider.TIMESERIES.toString())) {
+    } else if (providerName.equalsIgnoreCase(DataMapClassProvider.TIMESERIES.toString())
+        || providerName.equalsIgnoreCase(DataMapClassProvider.TIMESERIES.getClassName())) {
       return new AggregationDataMapSchema(dataMapName, providerName);
     } else {
       return new DataMapSchema(dataMapName, providerName);


### PR DESCRIPTION
Problem: User creates maintable and load data and create preaggregate datamap on maintable using old version and loads data into maintable using new version and dataload fails.

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

