### PR TITLE
[CARBONDATA-2758] Fix for filling data with enabled Local Dictionary having continous null values greater than default batch size throws array index out of bound

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/LocalDictDimensionDataChunkStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/LocalDictDimensionDataChunkStore.java
@@ -60,8 +60,8 @@ public class LocalDictDimensionDataChunkStore implements DimensionDataChunkStore
     }
     int surrogate = dimensionDataChunkStore.getSurrogate(rowId);
     if (surrogate == CarbonCommonConstants.MEMBER_DEFAULT_VAL_SURROGATE_KEY) {
-      vector.putNull(rowId);
-      vector.getDictionaryVector().putNull(rowId);
+      vector.putNull(vectorRow);
+      vector.getDictionaryVector().putNull(vectorRow);
       return;
     }
     vector.putNotNull(vectorRow);


### PR DESCRIPTION
Description: Before vector filled with row so whenever the batch for a particular row is finished it should need to start again with zero into next batch.
Sol: vector offset already maintains the same.
Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed? No
 
 - [ ] Any backward compatibility impacted? No
 
 - [ ] Document update required? No

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. NA

