### PR TITLE
[CARBONDATA-2767][CarbonStore] Fix task locality issue

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -1882,6 +1882,13 @@ public final class CarbonCommonConstants {
 
   public static final String CARBON_MERGE_INDEX_IN_SEGMENT_DEFAULT = "true";
 
+  /**
+   * config carbon scan task locality
+   */
+  public static final String CARBON_TASK_LOCALITY = "carbon.task.locality";
+
+  public static final String CARBON_TASK_LOCALITY_DEFAULT = "true";
+
   private CarbonCommonConstants() {
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -1884,6 +1884,8 @@ public final class CarbonCommonConstants {
 
   /**
    * config carbon scan task locality
+   * true: it will execute tasks as close to the data, the locality is important,
+   * false: it will execute tasks immediately, not paying attention to the locality
    */
   public static final String CARBON_TASK_LOCALITY = "carbon.task.locality";
 

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
@@ -1655,4 +1655,11 @@ public final class CarbonProperties {
       return CarbonCommonConstants.CARBON_SEARCH_QUERY_TIMEOUT_DEFAULT;
     }
   }
+
+  public static boolean isTaskLocality() {
+    String taskLocality = getInstance().getProperty(
+        CarbonCommonConstants.CARBON_TASK_LOCALITY,
+        CarbonCommonConstants.CARBON_TASK_LOCALITY_DEFAULT);
+    return taskLocality.equalsIgnoreCase("true");
+  }
 }

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
@@ -87,7 +87,7 @@ class CarbonScanRDD[T: ClassTag](
   }
   private var vectorReader = false
 
-  private val isTaskLocality = CarbonProperties.isTaskLocality
+  @transient private val isTaskLocality = CarbonProperties.isTaskLocality
 
   private val bucketedTable = tableInfo.getFactTable.getBucketingInfo
   private val storageFormat = tableInfo.getFormat
@@ -748,8 +748,7 @@ class CarbonScanRDD[T: ClassTag](
         .getLocations
         .filter(_ != "localhost")
     } else {
-      // in cloud scenario, computation and storage are separated.
-      // not require preferred locations
+      // when the computation and the storage are separated, not require the preferred locations
       Seq.empty[String]
     }
   }

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <snappy.version>1.1.2.6</snappy.version>
-    <hadoop.version>2.7.2</hadoop.version>
+    <hadoop.version>2.8.3</hadoop.version>
     <scala.binary.version>2.11</scala.binary.version>
     <scala.version>2.11.8</scala.version>
     <hadoop.deps.scope>compile</hadoop.deps.scope>

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <snappy.version>1.1.2.6</snappy.version>
-    <hadoop.version>2.8.3</hadoop.version>
+    <hadoop.version>2.7.2</hadoop.version>
     <scala.binary.version>2.11</scala.binary.version>
     <scala.version>2.11.8</scala.version>
     <hadoop.deps.scope>compile</hadoop.deps.scope>
@@ -586,6 +586,9 @@
     </profile>
     <profile>
       <id>horizon</id>
+      <properties>
+        <hadoop.version>2.8.3</hadoop.version>
+      </properties>
       <modules>
         <module>store/horizon</module>
         <module>store/sql</module>

--- a/store/horizon/src/main/java/org/apache/carbondata/horizon/rest/controller/Horizon.java
+++ b/store/horizon/src/main/java/org/apache/carbondata/horizon/rest/controller/Horizon.java
@@ -17,9 +17,6 @@
 
 package org.apache.carbondata.horizon.rest.controller;
 
-import java.io.File;
-import java.io.IOException;
-
 import org.apache.carbondata.store.api.conf.StoreConf;
 
 import org.springframework.boot.SpringApplication;
@@ -33,18 +30,7 @@ public class Horizon {
 
   public static void main(String[] args) {
     String storeConfFile = System.getProperty(StoreConf.STORE_CONF_FILE);
-    if (storeConfFile == null) {
-      storeConfFile = getStoreConfFile();
-    }
     start(storeConfFile);
-  }
-
-  static String getStoreConfFile() {
-    try {
-      return new File(".").getCanonicalPath() + "/store/conf/store.conf";
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
   }
 
   public static void start(String storeConfFile) {
@@ -52,12 +38,16 @@ public class Horizon {
   }
 
   static <T> void start(final Class<T> classTag, String storeConfFile) {
-    System.setProperty("carbonstore.conf.file", storeConfFile);
-    new Thread() {
+    if (storeConfFile != null) {
+      System.setProperty("carbonstore.conf.file", storeConfFile);
+    }
+    Thread thread = new Thread() {
       public void run() {
         context = SpringApplication.run(classTag);
       }
-    }.start();
+    };
+    thread.setDaemon(true);
+    thread.start();
   }
 
   public static void stop() {

--- a/store/sql/pom.xml
+++ b/store/sql/pom.xml
@@ -16,6 +16,7 @@
 
   <properties>
     <dev.path>${basedir}/../../dev</dev.path>
+    <spring.version>1.5.14.RELEASE</spring.version>
   </properties>
 
   <dependencies>
@@ -34,6 +35,33 @@
           <artifactId>carbondata-lucene</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-aws</artifactId>
+      <version>${hadoop.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-s3</artifactId>
+      <version>	1.10.6</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>4.5.2</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -81,4 +109,109 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>shade</id>
+      <properties>
+        <hadoop.deps.scope>provided</hadoop.deps.scope>
+        <spark.deps.scope>provided</spark.deps.scope>
+        <scala.deps.scope>provided</scala.deps.scope>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-shade-plugin</artifactId>
+            <dependencies>
+              <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring.version}</version>
+              </dependency>
+            </dependencies>
+            <configuration>
+              <keepDependenciesWithProvidedScope>false</keepDependenciesWithProvidedScope>
+              <createDependencyReducedPom>true</createDependencyReducedPom>
+              <outputFile>${project.build.directory}/horizon-sql-shade.jar</outputFile>
+              <artifactSet>
+                <includes>
+                  <include>*:*</include>
+                  <!--use the following line if we only want carbondata related classes-->
+                  <!--<include>org.apache.carbondata:*</include>-->
+                </includes>
+                <excludes>
+                  <exclude>org.apache.hadoop:hadoop-annotations</exclude>
+                  <exclude>org.apache.hadoop:hadoop-auth</exclude>
+                  <exclude>org.apache.hadoop:hadoop-client</exclude>
+                  <exclude>org.apache.hadoop:hadoop-common</exclude>
+                  <exclude>org.apache.hadoop:hadoop-hdfs</exclude>
+                  <exclude>org.apache.hadoop:hadoop-hdfs-client</exclude>
+                  <exclude>org.apache.hadoop:hadoop-mapreduce-client-app</exclude>
+                  <exclude>org.apache.hadoop:hadoop-mapreduce-client-common</exclude>
+                  <exclude>org.apache.hadoop:hadoop-mapreduce-client-core</exclude>
+                  <exclude>org.apache.hadoop:hadoop-mapreduce-client-jobclient</exclude>
+                  <exclude>org.apache.hadoop:hadoop-mapreduce-client-shuffle</exclude>
+                  <exclude>org.apache.hadoop:hadoop-yarn-api</exclude>
+                  <exclude>org.apache.hadoop:hadoop-yarn-client</exclude>
+                  <exclude>org.apache.hadoop:hadoop-yarn-common</exclude>
+                  <exclude>org.apache.hadoop:hadoop-yarn-server-common</exclude>
+                  <exclude>org.apache.spark:*</exclude>
+                  <exclude>org.apache.zookeeper:*</exclude>
+                  <exclude>org.apache.avro:*</exclude>
+                  <exclude>com.google.guava:guava</exclude>
+                  <exclude>org.xerial.snappy:snappy-java</exclude>
+                  <!--add more items to be excluded from the assembly-->
+                </excludes>
+              </artifactSet>
+
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>org/datanucleus/**</exclude>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                    <exclude>META-INF/vfs-providers.xml</exclude>
+                    <exclude>io/netty/**</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+            </configuration>
+            <executions>
+              <execution>
+                <phase>package</phase>
+                <goals>
+                  <goal>shade</goal>
+                </goals>
+                <configuration>
+                  <transformers>
+                    <transformer
+                            implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                      <resource>META-INF/spring.handlers</resource>
+                    </transformer>
+                    <transformer
+                            implementation="org.springframework.boot.maven.PropertiesMergingResourceTransformer">
+                      <resource>META-INF/spring.factories</resource>
+                    </transformer>
+                    <transformer
+                            implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                      <resource>META-INF/spring.schemas</resource>
+                    </transformer>
+                    <transformer
+                            implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                    <transformer
+                            implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                      <mainClass>sg.butterfly.emenu.api.config.EmenuApp</mainClass>
+                    </transformer>
+                  </transformers>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/store/sql/pom.xml
+++ b/store/sql/pom.xml
@@ -50,7 +50,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-s3</artifactId>
-      <version>	1.10.6</version>
+      <version>1.10.6</version>
       <exclusions>
         <exclusion>
           <groupId>com.fasterxml.jackson.core</groupId>

--- a/store/sql/src/main/java/org/apache/carbondata/horizon/rest/controller/SqlHorizon.java
+++ b/store/sql/src/main/java/org/apache/carbondata/horizon/rest/controller/SqlHorizon.java
@@ -17,45 +17,51 @@
 
 package org.apache.carbondata.horizon.rest.controller;
 
-import java.io.File;
 import java.io.IOException;
+import java.net.InetAddress;
+import java.util.Iterator;
+import java.util.Map;
 
+import org.apache.carbondata.common.logging.LogService;
+import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.util.CarbonProperties;
 import org.apache.carbondata.store.api.conf.StoreConf;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.spark.sql.CarbonSessionBuilder;
 import org.apache.spark.sql.SparkSession;
 
 public class SqlHorizon extends Horizon {
 
-  static SparkSession session;
+  private static LogService LOGGER =
+      LogServiceFactory.getLogService(SqlHorizon.class.getCanonicalName());
+
+  private static SparkSession session;
+  private static Configuration configuration;
+  private static String storeLocation;
 
   private static void createSession(String[] args) throws IOException {
-    String rootPath = new File(SqlHorizon.class.getResource("/").getPath()
-        + "../../../..").getCanonicalPath();
-    String storeLocation = rootPath + "/examples/spark2/target/store";
-    String warehouse = rootPath + "/examples/spark2/target/warehouse";
-    String metastoredb = rootPath + "/examples/spark2/target";
-
     CarbonProperties.getInstance()
+        .addProperty(CarbonCommonConstants.STORE_LOCATION, storeLocation)
+        .addProperty(CarbonCommonConstants.CARBON_TASK_LOCALITY, "false")
         .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, "yyyy/MM/dd HH:mm:ss")
         .addProperty(CarbonCommonConstants.CARBON_DATE_FORMAT, "yyyy/MM/dd")
         .addProperty(CarbonCommonConstants.ENABLE_UNSAFE_COLUMN_PAGE, "true")
         .addProperty(CarbonCommonConstants.CARBON_BADRECORDS_LOC, "");
 
-    int workThreadNum = 2;
-    String masterUrl = "local[" + workThreadNum + "]";
-
-    SparkSession.Builder baseBuilder = SparkSession
-        .builder()
-        .master(masterUrl)
+    SparkSession.Builder baseBuilder = SparkSession.builder()
         .appName("Horizon-SQL")
-        .config("spark.ui.port", 9000)
-        .config("spark.sql.warehouse.dir", warehouse)
-        .config("spark.driver.host", "localhost")
+        .config("spark.ui.port", 9876)
         .config("spark.sql.crossJoin.enabled", "true");
-    session = new CarbonSessionBuilder(baseBuilder).build(storeLocation, metastoredb, true);
+
+    Iterator<Map.Entry<String, String>> iterator = configuration.iterator();
+    while (iterator.hasNext()) {
+      Map.Entry<String, String> entry = iterator.next();
+      baseBuilder.config(entry.getKey(), entry.getValue());
+    }
+
+    session = new CarbonSessionBuilder(baseBuilder).build(storeLocation, null, true);
   }
 
   static SparkSession getSession() {
@@ -63,20 +69,38 @@ public class SqlHorizon extends Horizon {
   }
 
   public static void main(String[] args) {
+    if (args.length < 5) {
+      LOGGER.error("Usage: SqlHorizon <store location> <fs.s3a.endpoint> <fs.s3a.access.key>"
+          + " <fs.s3a.secret.key> <fs.s3a.impl>");
+      return;
+    }
+
+    try {
+      storeLocation = args[0];
+      configuration = new Configuration();
+      configuration.set("fs.s3a.endpoint", args[1]);
+      configuration.set("fs.s3a.access.key", args[2]);
+      configuration.set("fs.s3a.secret.key", args[3]);
+      configuration.set("fs.s3a.impl", args[4]);
+
+      String ip = InetAddress.getLocalHost().getHostAddress();
+      LOGGER.audit("Driver IP: " + ip);
+    } catch (IOException e) {
+      LOGGER.error(e);
+      throw new RuntimeException(e);
+    }
+
     // Start Spring
     String storeConfFile = System.getProperty(StoreConf.STORE_CONF_FILE);
-    if (storeConfFile == null) {
-      storeConfFile = getStoreConfFile();
-    }
     start(SqlHorizon.class, storeConfFile);
 
     try {
-      // Start CarbonSession
-      Thread.sleep(3000);
       createSession(args);
       Thread.sleep(Long.MAX_VALUE);
     } catch (IOException | InterruptedException e) {
+      LOGGER.error(e);
       throw new RuntimeException(e);
     }
   }
+
 }

--- a/store/sql/src/main/java/org/apache/carbondata/horizon/rest/util/Upload.java
+++ b/store/sql/src/main/java/org/apache/carbondata/horizon/rest/util/Upload.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.horizon.rest.util;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Properties;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.IOUtils;
+
+/**
+ * a util to upload a local file to s3
+ */
+
+public class Upload {
+
+  private static Configuration configuration = null;
+
+  public static void main(String[] args) throws IOException {
+    if (args.length < 2) {
+      System.err.println("Usage: Upload <local file> <s3 path> [overwrite]");
+      return;
+    }
+
+    String sourceFile = args[0];
+    String targetFile = args[1];
+    boolean isOverWrite = false;
+    if (args.length >= 3) {
+      isOverWrite = Boolean.valueOf(args[2]);
+    }
+
+    upload(sourceFile, targetFile, isOverWrite);
+  }
+
+  public static void upload(String sourceFile, String targetFile, boolean isOverWrite)
+      throws IOException {
+    Configuration hadoopConf = getConfiguration();
+
+    Path sourcePath = new Path(sourceFile);
+    FileSystem sourceFileSystem = sourcePath.getFileSystem(hadoopConf);
+    if (!sourceFileSystem.exists(sourcePath)) {
+      throw new IOException("source file not exists: " + sourceFile);
+    }
+
+    Path targetPath = new Path(targetFile);
+    FileSystem targetFileSystem = targetPath.getFileSystem(hadoopConf);
+    if (targetFileSystem.exists(targetPath) && !isOverWrite) {
+      throw new IOException("target file exists: " + targetFile);
+    }
+
+    IOUtils.copyBytes(sourceFileSystem.open(sourcePath),
+        targetFileSystem.create(targetPath, isOverWrite), 1024 * 4, true);
+
+    sourceFileSystem.close();
+    targetFileSystem.close();
+  }
+
+  public static synchronized Configuration getConfiguration() {
+    if (configuration == null) {
+      configuration = new Configuration();
+      Properties properties = System.getProperties();
+      for (Map.Entry<Object, Object> entry : properties.entrySet()) {
+        Object key = entry.getKey();
+        Object value = entry.getValue();
+        if (key instanceof String && value instanceof String) {
+          String keyStr = (String) key;
+          if (keyStr.startsWith("hadoop.")) {
+            configuration.set(keyStr.substring("hadoop.".length()), (String) value);
+          }
+        }
+      }
+    }
+
+    return configuration;
+  }
+}


### PR DESCRIPTION
If the Spark cluster and the Hadoop cluster are two different machine cluster, the Spark tasks will run in RACK_LOCAL mode.

So no need to provide the preferred locations to the task.


 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

