### PR TITLE
[CARBONDATA-2760] Reduce Memory footprint and store size for local dictionary encoded columns

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -1878,6 +1878,8 @@ public final class CarbonCommonConstants {
 
   public static final String CARBON_MERGE_INDEX_IN_SEGMENT_DEFAULT = "true";
 
+  public static final short LOCAL_DICT_ENCODED_BYTEARRAY_SIZE = 3;
+
   private CarbonCommonConstants() {
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/SafeFixLengthColumnPage.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/SafeFixLengthColumnPage.java
@@ -399,49 +399,49 @@ public class SafeFixLengthColumnPage extends ColumnPage {
   private void ensureArraySize(int requestSize, DataType dataType) {
     if (dataType == DataTypes.BYTE) {
       if (requestSize >= byteData.length) {
-        byte[] newArray = new byte[arrayElementCount + 16];
+        byte[] newArray = new byte[arrayElementCount * 2];
         System.arraycopy(byteData, 0, newArray, 0, arrayElementCount);
         byteData = newArray;
       }
     } else if (dataType == DataTypes.SHORT) {
       if (requestSize >= shortData.length) {
-        short[] newArray = new short[arrayElementCount + 16];
+        short[] newArray = new short[arrayElementCount * 2];
         System.arraycopy(shortData, 0, newArray, 0, arrayElementCount);
         shortData = newArray;
       }
     } else if (dataType == DataTypes.SHORT_INT) {
       if (requestSize >= shortIntData.length / 3) {
-        byte[] newArray = new byte[(arrayElementCount * 3) + (16 * 3)];
+        byte[] newArray = new byte[arrayElementCount * 6];
         System.arraycopy(shortIntData, 0, newArray, 0, arrayElementCount * 3);
         shortIntData = newArray;
       }
     } else if (dataType == DataTypes.INT) {
       if (requestSize >= intData.length) {
-        int[] newArray = new int[arrayElementCount + 16];
+        int[] newArray = new int[arrayElementCount * 2];
         System.arraycopy(intData, 0, newArray, 0, arrayElementCount);
         intData = newArray;
       }
     } else if (dataType == DataTypes.LONG) {
       if (requestSize >= longData.length) {
-        long[] newArray = new long[arrayElementCount + 16];
+        long[] newArray = new long[arrayElementCount * 2];
         System.arraycopy(longData, 0, newArray, 0, arrayElementCount);
         longData = newArray;
       }
     } else if (dataType == DataTypes.FLOAT) {
       if (requestSize >= floatData.length) {
-        float[] newArray = new float[arrayElementCount + 16];
+        float[] newArray = new float[arrayElementCount * 2];
         System.arraycopy(floatData, 0, newArray, 0, arrayElementCount);
         floatData = newArray;
       }
     } else if (dataType == DataTypes.DOUBLE) {
       if (requestSize >= doubleData.length) {
-        double[] newArray = new double[arrayElementCount + 16];
+        double[] newArray = new double[arrayElementCount * 2];
         System.arraycopy(doubleData, 0, newArray, 0, arrayElementCount);
         doubleData = newArray;
       }
     } else if (dataType == DataTypes.BYTE_ARRAY) {
       if (requestSize >= fixedLengthdata.length) {
-        byte[][] newArray = new byte[arrayElementCount + 16][];
+        byte[][] newArray = new byte[arrayElementCount * 2][];
         int index = 0;
         for (byte[] data : fixedLengthdata) {
           newArray[index++] = data;

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/SafeFixLengthColumnPage.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/SafeFixLengthColumnPage.java
@@ -17,6 +17,8 @@
 
 package org.apache.carbondata.core.datastore.page;
 
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
 import java.io.IOException;
 import java.math.BigDecimal;
 
@@ -48,11 +50,6 @@ public class SafeFixLengthColumnPage extends ColumnPage {
     this.fixedLengthdata = new byte[pageSize][];
   }
 
-  SafeFixLengthColumnPage(TableSpec.ColumnSpec columnSpec, DataType dataType, int pageSize,
-      int eachRowSize) {
-    super(columnSpec, dataType, pageSize);
-    this.fixedLengthdata = new byte[pageSize][];
-  }
   /**
    * Set byte value at rowId
    */
@@ -108,7 +105,9 @@ public class SafeFixLengthColumnPage extends ColumnPage {
    */
   @Override
   public void putBytes(int rowId, byte[] bytes) {
+    ensureArraySize(rowId, DataTypes.BYTE_ARRAY);
     this.fixedLengthdata[rowId] = bytes;
+    arrayElementCount++;
   }
 
   @Override
@@ -258,9 +257,12 @@ public class SafeFixLengthColumnPage extends ColumnPage {
   /**
    * Get string page
    */
-  @Override
-  public byte[][] getByteArrayPage() {
-    throw new UnsupportedOperationException("invalid data type: " + dataType);
+  @Override public byte[][] getByteArrayPage() {
+    byte[][] data = new byte[arrayElementCount][];
+    for (int i = 0; i < arrayElementCount; i++) {
+      data[i] = fixedLengthdata[i];
+    }
+    return data;
   }
 
   @Override
@@ -269,8 +271,13 @@ public class SafeFixLengthColumnPage extends ColumnPage {
   }
 
   @Override
-  public byte[] getComplexChildrenLVFlattenedBytePage() {
-    throw new UnsupportedOperationException("internal error");
+  public byte[] getComplexChildrenLVFlattenedBytePage() throws IOException {
+    ByteArrayOutputStream stream = new ByteArrayOutputStream();
+    DataOutputStream out = new DataOutputStream(stream);
+    for (int i = 0; i < arrayElementCount; i++) {
+      out.write(fixedLengthdata[i]);
+    }
+    return stream.toByteArray();
   }
 
   @Override
@@ -350,6 +357,7 @@ public class SafeFixLengthColumnPage extends ColumnPage {
     floatData = null;
     doubleData = null;
     shortIntData = null;
+    fixedLengthdata = null;
   }
 
   /**
@@ -430,6 +438,15 @@ public class SafeFixLengthColumnPage extends ColumnPage {
         double[] newArray = new double[arrayElementCount + 16];
         System.arraycopy(doubleData, 0, newArray, 0, arrayElementCount);
         doubleData = newArray;
+      }
+    } else if (dataType == DataTypes.BYTE_ARRAY) {
+      if (requestSize >= fixedLengthdata.length) {
+        byte[][] newArray = new byte[arrayElementCount + 16][];
+        int index = 0;
+        for (byte[] data : fixedLengthdata) {
+          newArray[index++] = data;
+        }
+        fixedLengthdata = newArray;
       }
     } else {
       throw new UnsupportedOperationException(

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/UnsafeFixLengthColumnPage.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/UnsafeFixLengthColumnPage.java
@@ -380,13 +380,8 @@ public class UnsafeFixLengthColumnPage extends ColumnPage {
 
   @Override public byte[] getComplexChildrenLVFlattenedBytePage() {
     byte[] data = new byte[totalLength];
-    int numberOfRows = getEndLoop();
-    int destOffset = 0;
-    for (int i = 0; i < numberOfRows; i++) {
-      CarbonUnsafe.getUnsafe().copyMemory(baseAddress, baseOffset + destOffset, data,
-          CarbonUnsafe.BYTE_ARRAY_OFFSET + destOffset, eachRowSize);
-      destOffset += eachRowSize;
-    }
+    CarbonUnsafe.getUnsafe()
+        .copyMemory(baseAddress, baseOffset, data, CarbonUnsafe.BYTE_ARRAY_OFFSET, totalLength);
     return data;
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/ColumnPageDecoder.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/ColumnPageDecoder.java
@@ -29,4 +29,6 @@ public interface ColumnPageDecoder {
    */
   ColumnPage decode(byte[] input, int offset, int length) throws MemoryException, IOException;
 
+  ColumnPage decode(byte[] input, int offset, int length, boolean isLVEncoded)
+      throws MemoryException, IOException;
 }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/adaptive/AdaptiveDeltaFloatingCodec.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/adaptive/AdaptiveDeltaFloatingCodec.java
@@ -104,8 +104,13 @@ public class AdaptiveDeltaFloatingCodec extends AdaptiveCodec {
       @Override
       public ColumnPage decode(byte[] input, int offset, int length)
           throws MemoryException, IOException {
-        ColumnPage page = ColumnPage.decompress(meta, input, offset, length);
+        ColumnPage page = ColumnPage.decompress(meta, input, offset, length, false);
         return LazyColumnPage.newPage(page, converter);
+      }
+
+      @Override public ColumnPage decode(byte[] input, int offset, int length, boolean isLVEncoded)
+          throws MemoryException, IOException {
+        return decode(input, offset, length);
       }
     };
   }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/adaptive/AdaptiveDeltaIntegralCodec.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/adaptive/AdaptiveDeltaIntegralCodec.java
@@ -117,9 +117,14 @@ public class AdaptiveDeltaIntegralCodec extends AdaptiveCodec {
         if (DataTypes.isDecimal(meta.getSchemaDataType())) {
           page = ColumnPage.decompressDecimalPage(meta, input, offset, length);
         } else {
-          page = ColumnPage.decompress(meta, input, offset, length);
+          page = ColumnPage.decompress(meta, input, offset, length, false);
         }
         return LazyColumnPage.newPage(page, converter);
+      }
+
+      @Override public ColumnPage decode(byte[] input, int offset, int length, boolean isLVEncoded)
+          throws MemoryException, IOException {
+        return decode(input, offset, length);
       }
     };
   }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/adaptive/AdaptiveFloatingCodec.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/adaptive/AdaptiveFloatingCodec.java
@@ -96,8 +96,13 @@ public class AdaptiveFloatingCodec extends AdaptiveCodec {
       @Override
       public ColumnPage decode(byte[] input, int offset, int length)
           throws MemoryException, IOException {
-        ColumnPage page = ColumnPage.decompress(meta, input, offset, length);
+        ColumnPage page = ColumnPage.decompress(meta, input, offset, length, false);
         return LazyColumnPage.newPage(page, converter);
+      }
+
+      @Override public ColumnPage decode(byte[] input, int offset, int length, boolean isLVEncoded)
+          throws MemoryException, IOException {
+        return decode(input, offset, length);
       }
     };
   }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/adaptive/AdaptiveIntegralCodec.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/adaptive/AdaptiveIntegralCodec.java
@@ -97,9 +97,14 @@ public class AdaptiveIntegralCodec extends AdaptiveCodec {
         if (DataTypes.isDecimal(meta.getSchemaDataType())) {
           page = ColumnPage.decompressDecimalPage(meta, input, offset, length);
         } else {
-          page = ColumnPage.decompress(meta, input, offset, length);
+          page = ColumnPage.decompress(meta, input, offset, length, false);
         }
         return LazyColumnPage.newPage(page, converter);
+      }
+
+      @Override public ColumnPage decode(byte[] input, int offset, int length, boolean isLVEncoded)
+          throws MemoryException, IOException {
+        return decode(input, offset, length);
       }
     };
   }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/compress/DirectCompressCodec.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/compress/DirectCompressCodec.java
@@ -108,9 +108,15 @@ public class DirectCompressCodec implements ColumnPageCodec {
       if (DataTypes.isDecimal(dataType)) {
         decodedPage = ColumnPage.decompressDecimalPage(meta, input, offset, length);
       } else {
-        decodedPage = ColumnPage.decompress(meta, input, offset, length);
+        decodedPage = ColumnPage.decompress(meta, input, offset, length, false);
       }
       return LazyColumnPage.newPage(decodedPage, converter);
+    }
+
+    @Override public ColumnPage decode(byte[] input, int offset, int length, boolean isLVEncoded)
+        throws MemoryException, IOException {
+      return LazyColumnPage
+          .newPage(ColumnPage.decompress(meta, input, offset, length, isLVEncoded), converter);
     }
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/rle/RLECodec.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/rle/RLECodec.java
@@ -308,6 +308,11 @@ public class RLECodec implements ColumnPageCodec {
       return resultPage;
     }
 
+    @Override public ColumnPage decode(byte[] input, int offset, int length, boolean isLVEncoded)
+        throws MemoryException, IOException {
+      return decode(input, offset, length);
+    }
+
     private void decodeBytePage(DataInputStream in, ColumnPage decodedPage)
         throws IOException {
       int rowId = 0;

--- a/core/src/main/java/org/apache/carbondata/core/localdictionary/PageLevelDictionary.java
+++ b/core/src/main/java/org/apache/carbondata/core/localdictionary/PageLevelDictionary.java
@@ -56,7 +56,7 @@ public class PageLevelDictionary {
 
   private DataType dataType;
 
-  private  boolean isComplexTypePrimitive;
+  private boolean isComplexTypePrimitive;
 
   public PageLevelDictionary(LocalDictionaryGenerator localDictionaryGenerator, String columnName,
       DataType dataType, boolean isComplexTypePrimitive) {

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/IncludeFilterExecuterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/IncludeFilterExecuterImpl.java
@@ -106,15 +106,18 @@ public class IncludeFilterExecuterImpl implements FilterExecuter {
       DimensionRawColumnChunk dimensionRawColumnChunk =
           rawBlockletColumnChunks.getDimensionRawColumnChunks()[chunkIndex];
       BitSetGroup bitSetGroup = new BitSetGroup(dimensionRawColumnChunk.getPagesCount());
+      filterValues = dimColumnExecuterInfo.getFilterKeys();
+      boolean isDecoded = false;
       for (int i = 0; i < dimensionRawColumnChunk.getPagesCount(); i++) {
         if (dimensionRawColumnChunk.getMaxValues() != null) {
           if (isScanRequired(dimensionRawColumnChunk.getMaxValues()[i],
               dimensionRawColumnChunk.getMinValues()[i], dimColumnExecuterInfo.getFilterKeys())) {
             DimensionColumnPage dimensionColumnPage = dimensionRawColumnChunk.decodeColumnPage(i);
-            if (null == filterValues) {
+            if (!isDecoded) {
               filterValues =  FilterUtil
                   .getEncodedFilterValues(dimensionRawColumnChunk.getLocalDictionary(),
                       dimColumnExecuterInfo.getFilterKeys());
+              isDecoded = true;
             }
             BitSet bitSet = getFilteredIndexes(dimensionColumnPage,
                 dimensionRawColumnChunk.getRowCount()[i], useBitsetPipeLine,


### PR DESCRIPTION
**Why this PR?**
1. Local dictionary encoded page is using unsafevarlenghtcolumn column page which internally maintains offset of each value in another column page because of this memory footprint is high.
2. for complex primitive string data type column page while compressing, it is converting to LV even if it is encoded with dictionary values, because of this store size is high.

**Solution:**
1. Use UnsafeFixedLength Column page for local dictionary encoded columns
2. No need to convert to LV during query if local dictionary is present so use UnsafeFixLength Column page

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
       All Testcase will take care. Tested in 3 Node setup with 135 million records
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

