### PR TITLE
[CARBONDATA-2753] Fix Compatibility issues

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/metadata/AbsoluteTableIdentifier.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/AbsoluteTableIdentifier.java
@@ -36,6 +36,11 @@ public class AbsoluteTableIdentifier implements Serializable {
    */
   private String tablePath;
 
+  /**
+   * dictionary path of the table
+   */
+  private String dictionaryPath;
+
 
   /**
    * carbon table identifier which will have table name and table database
@@ -146,4 +151,11 @@ public class AbsoluteTableIdentifier implements Serializable {
     return carbonTableIdentifier.toString();
   }
 
+  public String getDictionaryPath() {
+    return dictionaryPath;
+  }
+
+  public void setDictionaryPath(String dictionaryPath) {
+    this.dictionaryPath = dictionaryPath;
+  }
 }

--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/CarbonTable.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/CarbonTable.java
@@ -805,7 +805,11 @@ public class CarbonTable implements Serializable {
    * @return absolute table identifier
    */
   public AbsoluteTableIdentifier getAbsoluteTableIdentifier() {
-    return tableInfo.getOrCreateAbsoluteTableIdentifier();
+    AbsoluteTableIdentifier absoluteTableIdentifier =
+        tableInfo.getOrCreateAbsoluteTableIdentifier();
+    absoluteTableIdentifier.setDictionaryPath(
+        tableInfo.getFactTable().getTableProperties().get(CarbonCommonConstants.DICTIONARY_PATH));
+    return absoluteTableIdentifier;
   }
 
   /**

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/FilterUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/FilterUtil.java
@@ -56,12 +56,10 @@ import org.apache.carbondata.core.keygenerator.KeyGenerator;
 import org.apache.carbondata.core.keygenerator.factory.KeyGeneratorFactory;
 import org.apache.carbondata.core.keygenerator.mdkey.MultiDimKeyVarLengthGenerator;
 import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
-import org.apache.carbondata.core.metadata.CarbonMetadata;
 import org.apache.carbondata.core.metadata.ColumnIdentifier;
 import org.apache.carbondata.core.metadata.datatype.DataType;
 import org.apache.carbondata.core.metadata.datatype.DataTypes;
 import org.apache.carbondata.core.metadata.encoder.Encoding;
-import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
 import org.apache.carbondata.core.metadata.schema.table.column.CarbonColumn;
 import org.apache.carbondata.core.metadata.schema.table.column.CarbonDimension;
 import org.apache.carbondata.core.metadata.schema.table.column.CarbonMeasure;
@@ -1386,22 +1384,17 @@ public final class FilterUtil {
       CarbonDimension carbonDimension) throws IOException {
     String dictionaryPath = null;
     ColumnIdentifier columnIdentifier = carbonDimension.getColumnIdentifier();
-    CarbonTable carbonTable = CarbonMetadata.getInstance()
-        .getCarbonTable(dictionarySourceAbsoluteTableIdentifier.getDatabaseName(),
-            dictionarySourceAbsoluteTableIdentifier.getTableName());
-    if (null != carbonTable) {
-      dictionaryPath = carbonTable.getTableInfo().getFactTable().getTableProperties()
-          .get(CarbonCommonConstants.DICTIONARY_PATH);
-      if (null != carbonDimension.getColumnSchema().getParentColumnTableRelations()
-          && carbonDimension.getColumnSchema().getParentColumnTableRelations().size() == 1) {
-        dictionarySourceAbsoluteTableIdentifier = QueryUtil
-            .getTableIdentifierForColumn(carbonDimension);
-        columnIdentifier = new ColumnIdentifier(
-            carbonDimension.getColumnSchema().getParentColumnTableRelations().get(0).getColumnId(),
-            carbonDimension.getColumnProperties(), carbonDimension.getDataType());
-      } else {
-        dictionarySourceAbsoluteTableIdentifier = carbonTable.getAbsoluteTableIdentifier();
-      }
+    String dicPath = dictionarySourceAbsoluteTableIdentifier.getDictionaryPath();
+    if (null != dicPath && !dicPath.trim().isEmpty()) {
+      dictionaryPath = dicPath;
+    }
+    if (null != carbonDimension.getColumnSchema().getParentColumnTableRelations()
+        && carbonDimension.getColumnSchema().getParentColumnTableRelations().size() == 1) {
+      dictionarySourceAbsoluteTableIdentifier =
+          QueryUtil.getTableIdentifierForColumn(carbonDimension);
+      columnIdentifier = new ColumnIdentifier(
+          carbonDimension.getColumnSchema().getParentColumnTableRelations().get(0).getColumnId(),
+          carbonDimension.getColumnProperties(), carbonDimension.getDataType());
     }
     DictionaryColumnUniqueIdentifier dictionaryColumnUniqueIdentifier =
         new DictionaryColumnUniqueIdentifier(dictionarySourceAbsoluteTableIdentifier,

--- a/core/src/test/java/org/apache/carbondata/core/indexstore/blockletindex/TestBlockletDataMapFactory.java
+++ b/core/src/test/java/org/apache/carbondata/core/indexstore/blockletindex/TestBlockletDataMapFactory.java
@@ -77,6 +77,12 @@ public class TestBlockletDataMapFactory {
             UUID.randomUUID().toString());
     Deencapsulation.setField(tableInfo, "identifier", absoluteTableIdentifier);
     Deencapsulation.setField(carbonTable, "tableInfo", tableInfo);
+    new MockUp<CarbonTable>() {
+      @Mock
+      public AbsoluteTableIdentifier getAbsoluteTableIdentifier(){
+        return absoluteTableIdentifier;
+      }
+    };
     blockletDataMapFactory = new BlockletDataMapFactory(carbonTable, new DataMapSchema());
     Deencapsulation.setField(blockletDataMapFactory, "cache",
         CacheProvider.getInstance().createCache(CacheType.DRIVER_BLOCKLET_DATAMAP));


### PR DESCRIPTION
Dictionary path is set to the AbsolteTableIdentifier. So that the child tables/dependent tables can use the dictionary path of parent/own.

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [x] Testing done
        Manual Testing
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

