### PR TITLE
[HOTFIX] Improved BlockDataMap caching performance during first time query

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/SegmentIndexFileStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/SegmentIndexFileStore.java
@@ -25,6 +25,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 
 import org.apache.carbondata.common.logging.LogService;
 import org.apache.carbondata.common.logging.LogServiceFactory;
@@ -77,7 +78,7 @@ public class SegmentIndexFileStore {
 
   public SegmentIndexFileStore() {
     carbonIndexMap = new HashMap<>();
-    carbonIndexMapWithFullPath = new HashMap<>();
+    carbonIndexMapWithFullPath = new TreeMap<>();
     carbonMergeFileToIndexFilesMap = new HashMap<>();
   }
 
@@ -259,12 +260,14 @@ public class SegmentIndexFileStore {
       carbonMergeFileToIndexFilesMap.put(mergeFilePath, file_names);
       List<ByteBuffer> fileData = mergedBlockIndex.getFileData();
       CarbonFile mergeFile = FileFactory.getCarbonFile(mergeFilePath);
+      String mergeFileAbsolutePath = mergeFile.getParentFile().getAbsolutePath();
       assert (file_names.size() == fileData.size());
       for (int i = 0; i < file_names.size(); i++) {
-        carbonIndexMap.put(file_names.get(i), fileData.get(i).array());
-        carbonIndexMapWithFullPath.put(
-            mergeFile.getParentFile().getAbsolutePath() + CarbonCommonConstants.FILE_SEPARATOR
-                + file_names.get(i), fileData.get(i).array());
+        byte[] data = fileData.get(i).array();
+        carbonIndexMap.put(file_names.get(i), data);
+        carbonIndexMapWithFullPath
+            .put(mergeFileAbsolutePath + CarbonCommonConstants.FILE_SEPARATOR + file_names.get(i),
+                data);
       }
     } finally {
       thriftReader.close();

--- a/core/src/main/java/org/apache/carbondata/core/metadata/CarbonTableIdentifier.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/CarbonTableIdentifier.java
@@ -28,6 +28,10 @@ public class CarbonTableIdentifier implements Serializable {
   private static final long serialVersionUID = -0L;
 
   /**
+   * variable for storing tableUnique name. As it is constant it should be constructed only once
+   */
+  private String tableUniqueName;
+  /**
    * database name
    */
   private String databaseName;
@@ -49,6 +53,7 @@ public class CarbonTableIdentifier implements Serializable {
     this.databaseName = databaseName;
     this.tableName = tableName;
     this.tableId = tableId;
+    tableUniqueName = databaseName + '_' + tableName;
   }
 
   /**
@@ -76,7 +81,7 @@ public class CarbonTableIdentifier implements Serializable {
    * @return table unique name
    */
   public String getTableUniqueName() {
-    return databaseName + '_' + tableName;
+    return tableUniqueName;
   }
 
   /**
@@ -134,6 +139,6 @@ public class CarbonTableIdentifier implements Serializable {
    * return unique table name
    */
   @Override public String toString() {
-    return databaseName + '_' + tableName;
+    return tableUniqueName;
   }
 }


### PR DESCRIPTION
Things done as part of this PR
1. Created taskSumamry and FileFooterEntry schema once and stored in member variable. Everytime creation of schema was a costly operation as time to prune dataMaps increased because of that.
2. Used TreeMap instead of HashMap while adding the complete file path and data to the map diring merge file read. Using TreeMap improved the map filling performance by 10 sec for 1200 entries.

 - [ ] Any interfaces changed?
 No
 - [ ] Any backward compatibility impacted?
 No
 - [ ] Document update required?
No
 - [ ] Testing done
Verified manually       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA
