### PR TITLE
[wip][CARBONDATA-2765]handle flat folder support for implicit column

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/util/path/CarbonTablePath.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/path/CarbonTablePath.java
@@ -632,6 +632,18 @@ public class CarbonTablePath {
   }
 
   /**
+   * This method will get the segmentId from the block name
+   * if blockname is part-0-0_batchno0-0-0-1531995644238.carbondata - segmentid is 0
+   * if blockname is part-0-0_batchno0-0-9-1531995644238.carbondata - segmentid is 9
+   * @param blockName
+   * @return
+   */
+  public static String getSegmentIdFromBlockName(String blockName) {
+    String[] splitFile = blockName.substring(blockName.lastIndexOf("part") + 1).split("-");
+    return splitFile[splitFile.length - 2];
+  }
+
+  /**
    * adds data part prefix to given value
    * @return partition prefix
    */

--- a/core/src/test/java/org/apache/carbondata/core/metadata/schema/table/CarbonTableTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/metadata/schema/table/CarbonTableTest.java
@@ -25,6 +25,7 @@ import org.apache.carbondata.core.metadata.encoder.Encoding;
 import org.apache.carbondata.core.metadata.schema.table.column.CarbonDimension;
 import org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
+import org.apache.carbondata.core.util.path.CarbonTablePath;
 
 import junit.framework.TestCase;
 import org.junit.AfterClass;
@@ -66,6 +67,13 @@ public class CarbonTableTest extends TestCase {
   @Test public void testDimensionPresentInTableIsProper() {
     CarbonDimension dimension = new CarbonDimension(getColumnarDimensionColumn(), 0, -1, -1);
     assertTrue(carbonTable.getDimensionByName("carbonTestTable", "IMEI").equals(dimension));
+  }
+
+  @Test public void testSegmentIdFromBlockName(){
+    String blockName1 = "part-0-0_batchno0-0-0-1531995644238.carbondata";
+    String blockName2 = "part-0-0_batchno0-0-9-1531995644238.carbondata";
+    assertEquals(0, Integer.parseInt(CarbonTablePath.getSegmentIdFromBlockName(blockName1)));
+    assertEquals(9, Integer.parseInt(CarbonTablePath.getSegmentIdFromBlockName(blockName2)));
   }
 
   static ColumnSchema getColumnarDimensionColumn() {


### PR DESCRIPTION
Handle flat folder for implicit column

### Problem:
for implicit column, the blocklet id was getting wrong beacuse of path, as the carbondata files will be present after table path in case of flat folder.

### Solution:
check whether the table is standard table(where store path is Fact/Part0/Segment_), if not, form the blocklet id correctly(in case of flat folder)


Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 NA
 - [x] Any backward compatibility impacted?
 NA
 - [x] Document update required?
NA
 - [x] Testing done
Added UT and tested in three node cluster
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA
