### PR TITLE
[CARBONDATA-2753] Fix Compatibility issues while querying on 1.3 Store

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/metadata/SegmentFileStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/SegmentFileStore.java
@@ -580,7 +580,7 @@ public class SegmentFileStore {
    * Gets all index files from this segment
    * @return
    */
-  public Map<String, String> getIndexOrMergeFiles() {
+  public Map<String, String> getIndexOrMergeFiles() throws IOException {
     Map<String, String> indexFiles = new HashMap<>();
     if (segmentFile != null) {
       for (Map.Entry<String, FolderDetails> entry : getLocationMap().entrySet()) {
@@ -597,7 +597,14 @@ public class SegmentFileStore {
           Set<String> files = entry.getValue().getFiles();
           if (null != files && !files.isEmpty()) {
             for (String indexFile : files) {
-              indexFiles.put(location + CarbonCommonConstants.FILE_SEPARATOR + indexFile, null);
+              String indexFilePath = location + CarbonCommonConstants.FILE_SEPARATOR + indexFile;
+              // In the 1.3 store, files field contain the carbonindex files names
+              // even if they are merged to a carbonindexmerge file. In that case we have to check
+              // for the physical existence of the file to decide
+              // on whether it is already merged or not.
+              if (FileFactory.isFileExist(indexFilePath)) {
+                indexFiles.put(indexFilePath, null);
+              }
             }
           }
         }


### PR DESCRIPTION
**Problem:**
Currently,in the segmentFile we are writing the index files list in files field, only if it exists, otherwise it will be empty(in case if it is merged to merge index file). But in the old store, we were writing both the files and mergeFileName fields even if the index files are merged.

**Solution:**
While querying we have to check the physical existence of the index files listed in the files field. If it physically exists, then we have to consider that.

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [x] Testing done
        Manual Testing with Old Store
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

