### PR TITLE
[CARBONDATA-2766] Added null check on filestatus

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/AbstractDFSCarbonFile.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/AbstractDFSCarbonFile.java
@@ -99,6 +99,9 @@ public abstract class AbstractDFSCarbonFile implements CarbonFile {
   }
 
   @Override public boolean createNewFile() {
+    if (fileStatus == null) {
+      throw new RuntimeException("Unable to get file status, Please check logs for details.");
+    }
     Path path = fileStatus.getPath();
     FileSystem fs;
     try {
@@ -110,14 +113,23 @@ public abstract class AbstractDFSCarbonFile implements CarbonFile {
   }
 
   @Override public String getAbsolutePath() {
+    if (fileStatus == null) {
+      throw new RuntimeException("Unable to get file status, Please check logs for details.");
+    }
     return fileStatus.getPath().toString();
   }
 
   @Override public String getName() {
+    if (fileStatus == null) {
+      throw new RuntimeException("Unable to get file status, Please check logs for details.");
+    }
     return fileStatus.getPath().getName();
   }
 
   @Override public boolean isDirectory() {
+    if (fileStatus == null) {
+      throw new RuntimeException("Unable to get file status, Please check logs for details.");
+    }
     return fileStatus.isDirectory();
   }
 
@@ -143,6 +155,9 @@ public abstract class AbstractDFSCarbonFile implements CarbonFile {
   }
 
   @Override public long getSize() {
+    if (fileStatus == null) {
+      throw new RuntimeException("Unable to get file status, Please check logs for details.");
+    }
     return fileStatus.getLen();
   }
 
@@ -175,6 +190,9 @@ public abstract class AbstractDFSCarbonFile implements CarbonFile {
   }
 
   @Override public long getLastModifiedTime() {
+    if (fileStatus == null) {
+      throw new RuntimeException("Unable to get file status, Please check logs for details.");
+    }
     return fileStatus.getModificationTime();
   }
 
@@ -552,6 +570,9 @@ public abstract class AbstractDFSCarbonFile implements CarbonFile {
   @Override
   public String[] getLocations() throws IOException {
     BlockLocation[] blkLocations;
+    if (fileStatus == null) {
+      throw new RuntimeException("Unable to get file status, Please check logs for details.");
+    }
     if (fileStatus instanceof LocatedFileStatus) {
       blkLocations = ((LocatedFileStatus)fileStatus).getBlockLocations();
     } else {

--- a/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/HDFSCarbonFile.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/HDFSCarbonFile.java
@@ -94,6 +94,9 @@ public class HDFSCarbonFile extends AbstractDFSCarbonFile {
 
   @Override
   public CarbonFile getParentFile() {
+    if (fileStatus == null) {
+      throw new RuntimeException("Unable to get file status, Please check logs for details.");
+    }
     Path parent = fileStatus.getPath().getParent();
     return null == parent ? null : new HDFSCarbonFile(parent, hadoopConf);
   }
@@ -101,6 +104,9 @@ public class HDFSCarbonFile extends AbstractDFSCarbonFile {
   @Override
   public boolean renameForce(String changetoName) {
     FileSystem fs;
+    if (fileStatus == null) {
+      throw new RuntimeException("Unable to get file status, Please check logs for details.");
+    }
     try {
       fs = fileStatus.getPath().getFileSystem(hadoopConf);
       if (fs instanceof DistributedFileSystem) {

--- a/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/S3CarbonFile.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/S3CarbonFile.java
@@ -61,6 +61,9 @@ public class S3CarbonFile extends HDFSCarbonFile {
   @Override
   public boolean renameForce(String changetoName) {
     FileSystem fs;
+    if (fileStatus == null) {
+      throw new RuntimeException("Unable to get file status, Please check logs for details.");
+    }
     try {
       deleteFile(changetoName, FileFactory.getFileType(changetoName));
       fs = fileStatus.getPath().getFileSystem(hadoopConf);
@@ -120,6 +123,9 @@ public class S3CarbonFile extends HDFSCarbonFile {
 
   @Override
   public CarbonFile getParentFile() {
+    if (fileStatus == null) {
+      throw new RuntimeException("Unable to get file status, Please check logs for details.");
+    }
     Path parent = fileStatus.getPath().getParent();
     return null == parent ? null : new S3CarbonFile(parent, hadoopConf);
   }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/ViewFSCarbonFile.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/ViewFSCarbonFile.java
@@ -84,6 +84,9 @@ public class ViewFSCarbonFile extends AbstractDFSCarbonFile {
   }
 
   @Override public CarbonFile getParentFile() {
+    if (fileStatus == null) {
+      throw new RuntimeException("Unable to get file status, Please check logs for details.");
+    }
     Path parent = fileStatus.getPath().getParent();
     return null == parent ? null : new ViewFSCarbonFile(parent);
   }
@@ -91,6 +94,9 @@ public class ViewFSCarbonFile extends AbstractDFSCarbonFile {
   @Override
   public boolean renameForce(String changetoName) {
     FileSystem fs;
+    if (fileStatus == null) {
+      throw new RuntimeException("Unable to get file status, Please check logs for details.");
+    }
     try {
       fs = fileStatus.getPath().getFileSystem(FileFactory.getConfiguration());
       if (fs instanceof ViewFileSystem) {


### PR DESCRIPTION
**Problem:**  While doing any operation on Carbon File if file status acquiring throws exception then it is logged and not thrown again therefore if any further operation on that object required filestatus then it can throw NPE.

**Solution:** Add null check and throw proper exception.
Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

