### PR TITLE
[CARBONDATA-2770][BloomDataMap] Optimize code to get blocklet id when rebuilding datamap

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/scan/collector/impl/RowIdRawBasedResultCollector.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/collector/impl/RowIdRawBasedResultCollector.java
@@ -134,7 +134,7 @@ public class RowIdRawBasedResultCollector extends AbstractScannedResultCollector
       // 3 for blockletId, pageId, rowId
       Object[] row = new Object[1 + queryMeasures.length + 3];
       scannedResult.incrementCounter();
-      row[1 + queryMeasures.length] = scannedResult.getBlockletNumber();
+      row[1 + queryMeasures.length] = Integer.parseInt(scannedResult.getBlockletNumber());
       row[1 + queryMeasures.length + 1] = scannedResult.getCurrentPageCounter();
       ByteArrayWrapper wrapper = new ByteArrayWrapper();
       wrapper.setDictionaryKey(dictionaryKeyArrayBatch.get(i));

--- a/core/src/main/java/org/apache/carbondata/core/scan/collector/impl/RowIdRestructureBasedRawResultCollector.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/collector/impl/RowIdRestructureBasedRawResultCollector.java
@@ -106,7 +106,7 @@ public class RowIdRestructureBasedRawResultCollector extends RestructureBasedRaw
       // 3 for blockletId, pageId, rowId
       Object[] row = new Object[1 + queryMeasures.length + 3];
       scannedResult.incrementCounter();
-      row[1 + queryMeasures.length] = scannedResult.getBlockletNumber();
+      row[1 + queryMeasures.length] = Integer.parseInt(scannedResult.getBlockletNumber());
       row[1 + queryMeasures.length + 1] = scannedResult.getCurrentPageCounter();
       ByteArrayWrapper wrapper = new ByteArrayWrapper();
       wrapper.setDictionaryKey(dictionaryKeyArrayBatch.get(i));

--- a/integration/spark2/src/main/scala/org/apache/carbondata/datamap/IndexDataMapRebuildRDD.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/datamap/IndexDataMapRebuildRDD.scala
@@ -357,20 +357,12 @@ class IndexDataMapRebuildRDD[K, V](
         // skip clear datamap and we will do this adter rebuild
         reader.setSkipClearDataMapAtClose(true)
 
-        var blockletId = 0
-        var firstRow = true
         while (reader.nextKeyValue()) {
           val rowWithPosition = reader.getCurrentValue
           val size = rowWithPosition.length
+          val blockletId = rowWithPosition(size - 3).asInstanceOf[Int]
           val pageId = rowWithPosition(size - 2).asInstanceOf[Int]
           val rowId = rowWithPosition(size - 1).asInstanceOf[Int]
-
-          if (!firstRow && pageId == 0 && rowId == 0) {
-            // new blocklet started, increase blockletId
-            blockletId = blockletId + 1
-          } else {
-            firstRow = false
-          }
 
           refresher.addRow(blockletId, pageId, rowId, rowWithPosition)
         }


### PR DESCRIPTION
we should get exactly number of blocklet id from blocklet scanned result instead of building it ourselves.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

