### PR TITLE
[CARBONDATA-2649] Handled executor min/max pruning when filter column in not cached in driver for CACHE_LEVEL=BLOCKLET

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/indexstore/BlockletDetailInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/BlockletDetailInfo.java
@@ -72,6 +72,13 @@ public class BlockletDetailInfo implements Serializable, Writable {
    * flag to check for store from 1.1 or any prior version
    */
   private boolean isLegacyStore;
+  /**
+   * flag to check whether to serialize min max values. The flag will be set to true in case
+   * 1. When CACHE_LEVEL = BLOCKLET and filter column min/max in not cached in the driver using the
+   * property COLUMN_META_CACHE
+   * 2. for CACHE_LEVEL = BLOCK, it will always be true which is also the default value
+   */
+  private boolean useMinMaxForPruning = true;
 
   public int getRowCount() {
     return rowCount;
@@ -185,6 +192,7 @@ public class BlockletDetailInfo implements Serializable, Writable {
     out.write(blockletInfoBinary);
     out.writeLong(blockSize);
     out.writeBoolean(isLegacyStore);
+    out.writeBoolean(useMinMaxForPruning);
   }
 
   @Override public void readFields(DataInput in) throws IOException {
@@ -215,6 +223,7 @@ public class BlockletDetailInfo implements Serializable, Writable {
     setBlockletInfoFromBinary();
     blockSize = in.readLong();
     isLegacyStore = in.readBoolean();
+    useMinMaxForPruning = in.readBoolean();
   }
 
   /**
@@ -252,6 +261,7 @@ public class BlockletDetailInfo implements Serializable, Writable {
     detailInfo.columnSchemaBinary = columnSchemaBinary;
     detailInfo.blockSize = blockSize;
     detailInfo.isLegacyStore = isLegacyStore;
+    detailInfo.useMinMaxForPruning = useMinMaxForPruning;
     return detailInfo;
   }
 
@@ -296,5 +306,13 @@ public class BlockletDetailInfo implements Serializable, Writable {
 
   public void setColumnSchemas(List<ColumnSchema> columnSchemas) {
     this.columnSchemas = columnSchemas;
+  }
+
+  public boolean isUseMinMaxForPruning() {
+    return useMinMaxForPruning;
+  }
+
+  public void setUseMinMaxForPruning(boolean useMinMaxForPruning) {
+    this.useMinMaxForPruning = useMinMaxForPruning;
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMap.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMap.java
@@ -212,7 +212,8 @@ public class BlockletDataMap extends BlockDataMap implements Serializable {
         .convertToSafeRow();
     short relativeBlockletId = safeRow.getShort(BLOCKLET_ID_INDEX);
     String filePath = getFilePath();
-    return createBlocklet(safeRow, getFileNameWithFilePath(safeRow, filePath), relativeBlockletId);
+    return createBlocklet(safeRow, getFileNameWithFilePath(safeRow, filePath), relativeBlockletId,
+        false);
   }
 
   protected short getBlockletId(DataMapRow dataMapRow) {
@@ -222,15 +223,17 @@ public class BlockletDataMap extends BlockDataMap implements Serializable {
     return dataMapRow.getShort(BLOCKLET_ID_INDEX);
   }
 
-  protected ExtendedBlocklet createBlocklet(DataMapRow row, String fileName, short blockletId) {
+  protected ExtendedBlocklet createBlocklet(DataMapRow row, String fileName, short blockletId,
+      boolean useMinMaxForPruning) {
     if (isLegacyStore) {
-      return super.createBlocklet(row, fileName, blockletId);
+      return super.createBlocklet(row, fileName, blockletId, useMinMaxForPruning);
     }
     ExtendedBlocklet blocklet = new ExtendedBlocklet(fileName, blockletId + "");
     BlockletDetailInfo detailInfo = getBlockletDetailInfo(row, blockletId, blocklet);
     detailInfo.setColumnSchemas(getColumnSchema());
     detailInfo.setBlockletInfoBinary(row.getByteArray(BLOCKLET_INFO_INDEX));
     detailInfo.setPagesCount(row.getShort(BLOCKLET_PAGE_COUNT_INDEX));
+    detailInfo.setUseMinMaxForPruning(useMinMaxForPruning);
     blocklet.setDetailInfo(detailInfo);
     return blocklet;
   }

--- a/core/src/main/java/org/apache/carbondata/core/scan/executor/impl/AbstractQueryExecutor.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/executor/impl/AbstractQueryExecutor.java
@@ -160,7 +160,7 @@ public abstract class AbstractQueryExecutor<E> implements QueryExecutor<E> {
     // and measure column start index
     queryProperties.filterMeasures = new HashSet<>();
     queryProperties.complexFilterDimension = new HashSet<>();
-    QueryUtil.getAllFilterDimensions(queryModel.getFilterExpressionResolverTree(),
+    QueryUtil.getAllFilterDimensionsAndMeasures(queryModel.getFilterExpressionResolverTree(),
         queryProperties.complexFilterDimension, queryProperties.filterMeasures);
 
     CarbonTable carbonTable = queryModel.getTable();
@@ -204,7 +204,9 @@ public abstract class AbstractQueryExecutor<E> implements QueryExecutor<E> {
       // 1. old stores (1.1 or any prior version to 1.1) where blocklet information is not
       // available so read the blocklet information from block file
       // 2. CACHE_LEVEL is set to block
-      if (blockletDetailInfo.getBlockletInfo() == null) {
+      // 3. CACHE_LEVEL is BLOCKLET but filter column min/max is not cached in driver
+      if (blockletDetailInfo.getBlockletInfo() == null || blockletDetailInfo
+          .isUseMinMaxForPruning()) {
         readAndFillBlockletInfo(filePathToFileFooterMapping, tableBlockInfos, blockInfo,
             blockletDetailInfo);
       } else {

--- a/core/src/main/java/org/apache/carbondata/core/scan/executor/util/QueryUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/executor/util/QueryUtil.java
@@ -634,7 +634,7 @@ public class QueryUtil {
     return parentBlockIndex;
   }
 
-  public static void getAllFilterDimensions(FilterResolverIntf filterResolverTree,
+  public static void getAllFilterDimensionsAndMeasures(FilterResolverIntf filterResolverTree,
       Set<CarbonDimension> filterDimensions, Set<CarbonMeasure> filterMeasure) {
     if (null == filterResolverTree) {
       return;


### PR DESCRIPTION
Things handled as part of this PR:
1. Modified code to use min/max in executor pruning for Blocklet dataMap when filter column min/max is not cached in driver. When column to be cached in driver are specified and CACHE_LEVEL = BLOCKLET, then executor min/max pruning was not happening which can increase the query time.

2. Removed unwanted addition of schemaEvolutionEntry to schema on Alter SET and UNSET table properties

 - [ ] Any interfaces changed?
No 
 - [ ] Any backward compatibility impacted?
 No
 - [ ] Document update required?
No
 - [ ] Testing done
Yes       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA
