### PR TITLE
[CARBONDATA-2772] Size based dictionary fallback is failing even thre…

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/localdictionary/generator/ColumnLocalDictionaryGenerator.java
+++ b/core/src/main/java/org/apache/carbondata/core/localdictionary/generator/ColumnLocalDictionaryGenerator.java
@@ -33,8 +33,6 @@ public class ColumnLocalDictionaryGenerator implements LocalDictionaryGenerator 
    */
   private DictionaryStore dictionaryHolder;
 
-  private long currentSize;
-
   public ColumnLocalDictionaryGenerator(int threshold, int lvLength) {
     // adding 1 to threshold for null value
     int newThreshold = threshold + 1;
@@ -54,7 +52,6 @@ public class ColumnLocalDictionaryGenerator implements LocalDictionaryGenerator 
     } catch (DictionaryThresholdReachedException e) {
       // do nothing
     }
-    currentSize += byteBuffer.array().length;
   }
 
   /**
@@ -64,11 +61,6 @@ public class ColumnLocalDictionaryGenerator implements LocalDictionaryGenerator 
    * @return dictionary value
    */
   @Override public int generateDictionary(byte[] data) throws DictionaryThresholdReachedException {
-    currentSize += data.length;
-    if (currentSize >= Integer.MAX_VALUE) {
-      throw new DictionaryThresholdReachedException(
-          "Unable to generate dictionary. Dictionary Size crossed 2GB limit");
-    }
     return this.dictionaryHolder.putIfAbsent(data);
   }
 


### PR DESCRIPTION
Issue:- Size Based Fallback happened even threshold is not reached.
RootCause:- Current size calculation is wrong. it is calculated for each data. instead of generated dictionary data . 

Solution :- Current size should be calculated only for generated dictionary data.


Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
       Tests manually in 3 Node setup with 2 billion records.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

