### PR TITLE
[CARBONDATA-2774][BloomDataMap] Exception should be thrown if expression do not satisfy bloomFilter's requirement

### DIFF
--- a/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomCoarseGrainDataMap.java
+++ b/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomCoarseGrainDataMap.java
@@ -203,7 +203,9 @@ public class BloomCoarseGrainDataMap extends CoarseGrainDataMap {
         }
         return queryModels;
       } else {
-        LOGGER.warn("BloomFilter can only support the 'equal' filter like 'Col = PlainValue'");
+        String errorMsg = "BloomFilter can only support the 'equal' filter like 'Col = PlainValue'";
+        LOGGER.warn(errorMsg);
+        throw new RuntimeException(errorMsg);
       }
     } else if (expression instanceof InExpression) {
       Expression left = ((InExpression) expression).getLeft();
@@ -226,7 +228,9 @@ public class BloomCoarseGrainDataMap extends CoarseGrainDataMap {
         }
         return queryModels;
       } else {
-        LOGGER.warn("BloomFilter can only support the 'in' filter like 'Col in (PlainValues)'");
+        String errorMsg = "BloomFilter can only support the 'in' filter like 'Col in PlainValue'";
+        LOGGER.warn(errorMsg);
+        throw new RuntimeException(errorMsg);
       }
     }
 


### PR DESCRIPTION
If query on string column with bloom index  using number as filter value, we would get wrong result. Because DDL will wrap the filter with a datatype conversion, and DatamapChooser chooses datamap by searching column deep down to all children of filter expression. However, bloom filter required the expression is simply `column =/in filterValue`.  So bloom will fail to build any querymodel and no hit blocklet, such that we will get an empty result.

To avoid getting wrong answer silently, we thrown exception instead of only giving a error log currently.

For users who wants to get correct result, can fix the SQL using corresponding data type or disable bloom datamap.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

