### PR TITLE
[CARBONDATA-2778]Fixed bug when select after delete and cleanup is showing empty records

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/mutate/CarbonUpdateUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/mutate/CarbonUpdateUtil.java
@@ -541,22 +541,6 @@ public class CarbonUpdateUtil {
               compareTimestampsAndDelete(invalidFile, forceDelete, false);
             }
 
-            CarbonFile[] blockRelatedFiles = updateStatusManager
-                    .getAllBlockRelatedFiles(allSegmentFiles,
-                            block.getActualBlockName());
-
-            // now for each invalid index file need to check the query execution time out
-            // and then delete.
-
-            for (CarbonFile invalidFile : blockRelatedFiles) {
-
-              if (compareTimestampsAndDelete(invalidFile, forceDelete, false)) {
-                if (invalidFile.getName().endsWith(CarbonCommonConstants.UPDATE_INDEX_FILE_EXT)) {
-                  updateSegmentFile = true;
-                }
-              }
-            }
-
           } else {
             invalidDeleteDeltaFiles = updateStatusManager
                     .getDeleteDeltaInvalidFilesList(block, false,

--- a/core/src/main/java/org/apache/carbondata/core/statusmanager/SegmentUpdateStatusManager.java
+++ b/core/src/main/java/org/apache/carbondata/core/statusmanager/SegmentUpdateStatusManager.java
@@ -826,31 +826,4 @@ public class SegmentUpdateStatusManager {
 
     return files.toArray(new CarbonFile[files.size()]);
   }
-
-  /**
-   *
-   * @param allSegmentFiles
-   * @return
-   */
-  public CarbonFile[] getAllBlockRelatedFiles(CarbonFile[] allSegmentFiles,
-      String actualBlockName) {
-    List<CarbonFile> files = new ArrayList<>(CarbonCommonConstants.DEFAULT_COLLECTION_SIZE);
-
-    for (CarbonFile eachFile : allSegmentFiles) {
-
-      // for carbon data.
-      if (eachFile.getName().equalsIgnoreCase(actualBlockName)) {
-        files.add(eachFile);
-      }
-
-      // get carbon index files of the block.
-      String indexFileName = CarbonTablePath.getCarbonIndexFileName(actualBlockName);
-      if (eachFile.getName().equalsIgnoreCase(indexFileName)) {
-        files.add(eachFile);
-      }
-
-    }
-
-    return files.toArray(new CarbonFile[files.size()]);
-  }
 }


### PR DESCRIPTION
Problem: In case if delete operation when it is found that the data being deleted is leading to a state where one complete block data is getting deleted. In that case the status if that block is marked for delete and during the next delete operation run the block is deleted along with its carbonIndex file. The problem arises due to deletion of carbonIndex file because for multiple blocks there can be one carbonIndex file as one carbonIndex file represents one task.

Solution: Do not delete the carbondata and carbonIndex file. After compaction it will automatically take care of deleting the stale data and stale segments.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

