### PR TITLE
[CARBONDATA-2606][Complex DataType Enhancements]Fix Null result if projection column have null primitive column and struct

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/complexType/TestComplexDataType.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/complexType/TestComplexDataType.scala
@@ -885,4 +885,12 @@ class TestComplexDataType extends QueryTest with BeforeAndAfterAll {
     checkExistence(sql("select * from table1"),true,"1.0E9")
   }
 
+  test("test null values in primitive data type and select all data types including complex data type") {
+    sql("DROP TABLE IF EXISTS table1")
+    sql(
+      "create table table1 (id int, name string, structField struct<intval:int, stringval:string>) stored by 'carbondata'")
+    sql("insert into table1 values(null,'aaa','23$bb')")
+    checkAnswer(sql("select * from table1"),Seq(Row(null,"aaa", Row(23,"bb"))))
+  }
+
 }


### PR DESCRIPTION
**Problem:**
In case if the actual value of the primitive data type is null, by PR#[2489](https://github.com/apache/carbondata/pull/2489), we are moving all the null values to the end of the collected row without considering the data type.

**Solution:**
Place null in the end of output iff the null value is of complex primitive column.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [x] Testing done
        UT added
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

