### PR TITLE
[HOTFIX] Fix a spelling mistake after PR2511 merged.

### DIFF
--- a/datamap/examples/src/minmaxdatamap/main/java/org/apache/carbondata/datamap/examples/MinMaxIndexDataMap.java
+++ b/datamap/examples/src/minmaxdatamap/main/java/org/apache/carbondata/datamap/examples/MinMaxIndexDataMap.java
@@ -33,6 +33,7 @@ import org.apache.carbondata.core.datamap.dev.cgdatamap.CoarseGrainDataMap;
 import org.apache.carbondata.core.datastore.block.SegmentProperties;
 import org.apache.carbondata.core.datastore.impl.FileFactory;
 import org.apache.carbondata.core.fileoperations.AtomicFileOperations;
+import org.apache.carbondata.core.fileoperations.AtomicFileOperationFactory;
 import org.apache.carbondata.core.indexstore.Blocklet;
 import org.apache.carbondata.core.indexstore.PartitionSpec;
 import org.apache.carbondata.core.memory.MemoryException;
@@ -93,7 +94,8 @@ public class MinMaxIndexDataMap extends CoarseGrainDataMap {
     BufferedReader buffReader = null;
     InputStreamReader inStream = null;
     MinMaxIndexBlockDetails[] readMinMax = null;
-    AtomicFileOperations fileOperation = AtomicFileOperationsF(filePath, FileFactory.getFileType(filePath));
+    AtomicFileOperations fileOperation =
+        AtomicFileOperationFactory.getAtomicFileOperations(filePath);
 
     try {
       if (!FileFactory.isFileExist(filePath, FileFactory.getFileType(filePath))) {


### PR DESCRIPTION
spelling mistakes: AtomicFileOperationsF
use: AtomicFileOperationFactory.getAtomicFileOperations

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

