### PR TITLE
[CARBONDATA-2781] Added fix for Null Pointer Excpetion when create datamap killed from UI

### DIFF
--- a/integration/spark2/src/main/java/org/apache/carbondata/datamap/PreAggregateDataMapProvider.java
+++ b/integration/spark2/src/main/java/org/apache/carbondata/datamap/PreAggregateDataMapProvider.java
@@ -39,11 +39,15 @@ public class PreAggregateDataMapProvider extends DataMapProvider {
   protected PreAggregateTableHelper helper;
   protected CarbonDropTableCommand dropTableCommand;
   protected SparkSession sparkSession;
+  private String dbName;
+  private String tableName;
 
   PreAggregateDataMapProvider(CarbonTable table, DataMapSchema schema,
       SparkSession sparkSession) {
     super(table, schema);
     this.sparkSession = sparkSession;
+    this.dbName = table.getDatabaseName();
+    this.tableName = table.getTableName() + '_' + schema.getDataMapName();
   }
 
   @Override
@@ -74,11 +78,10 @@ public class PreAggregateDataMapProvider extends DataMapProvider {
 
   @Override
   public void cleanMeta() {
-    DataMapSchema dataMapSchema = getDataMapSchema();
     dropTableCommand = new CarbonDropTableCommand(
         true,
-        new Some<>(dataMapSchema.getRelationIdentifier().getDatabaseName()),
-        dataMapSchema.getRelationIdentifier().getTableName(),
+        new Some<>(dbName),
+        tableName,
         true);
     dropTableCommand.processMetadata(sparkSession);
   }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/datamap/CarbonCreateDataMapCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/datamap/CarbonCreateDataMapCommand.scala
@@ -181,7 +181,11 @@ case class CarbonCreateDataMapCommand(
 
   override def undoMetadata(sparkSession: SparkSession, exception: Exception): Seq[Row] = {
     if (dataMapProvider != null) {
-      dataMapProvider.cleanMeta()
+        CarbonDropDataMapCommand(
+          dataMapName,
+          true,
+          Some(TableIdentifier(mainTable.getTableName, Some(mainTable.getDatabaseName))),
+          forceDrop = false).run(sparkSession)
     }
     Seq.empty
   }


### PR DESCRIPTION
### What was the issue?
In undo meta, datamap was not being dropped.

### What is the solution?
Datamap gets dropped when create command is killed from UI during undo meta.

 - [x] Any interfaces changed?
 NA
 - [x] Any backward compatibility impacted?
 NA
 - [x] Document update required?
NA
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
Tested in Local
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA
