### PR TITLE
[HotFix][CARBONDATA-2788][BloomDataMap] Fix bugs in incorrect query result with bloom datamap

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/indexstore/Blocklet.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/Blocklet.java
@@ -34,23 +34,9 @@ public class Blocklet implements Writable,Serializable {
   /** id to identify the blocklet inside the block (it is a sequential number) */
   private String blockletId;
 
-  /**
-   * flag to specify whether to consider blocklet Id in equals and hashcode comparison. This is
-   * because when CACHE_LEVEL='BLOCK' which is default value, the blocklet ID returned by
-   * BlockDataMap pruning will always be -1 and other datamaps will give the the correct blocklet
-   * ID. Therefore if we compare -1 with correct blocklet ID the comparison will become wrong and
-   * always false will be returned resulting in incorrect result. Default value for flag is true.
-   */
-  private boolean compareBlockletIdForObjectMatching = true;
-
   public Blocklet(String filePath, String blockletId) {
     this.filePath = filePath;
     this.blockletId = blockletId;
-  }
-
-  public Blocklet(String filePath, String blockletId, boolean compareBlockletIdForObjectMatching) {
-    this(filePath, blockletId);
-    this.compareBlockletIdForObjectMatching = compareBlockletIdForObjectMatching;
   }
 
   // For serialization purpose
@@ -84,9 +70,6 @@ public class Blocklet implements Writable,Serializable {
     if (filePath != null ? !filePath.equals(blocklet.filePath) : blocklet.filePath != null) {
       return false;
     }
-    if (!compareBlockletIdForObjectMatching) {
-      return true;
-    }
     return blockletId != null ?
         blockletId.equals(blocklet.blockletId) :
         blocklet.blockletId == null;
@@ -95,9 +78,7 @@ public class Blocklet implements Writable,Serializable {
   @Override public int hashCode() {
     int result = filePath != null ? filePath.hashCode() : 0;
     result = 31 * result;
-    if (compareBlockletIdForObjectMatching) {
-      result += blockletId != null ? blockletId.hashCode() : 0;
-    }
+    result += blockletId != null ? blockletId.hashCode() : 0;
     return result;
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/ExtendedBlocklet.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/ExtendedBlocklet.java
@@ -37,11 +37,6 @@ public class ExtendedBlocklet extends Blocklet {
     super(filePath, blockletId);
   }
 
-  public ExtendedBlocklet(String filePath, String blockletId,
-      boolean compareBlockletIdForObjectMatching) {
-    super(filePath, blockletId, compareBlockletIdForObjectMatching);
-  }
-
   public BlockletDetailInfo getDetailInfo() {
     return detailInfo;
   }

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMap.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMap.java
@@ -212,8 +212,7 @@ public class BlockletDataMap extends BlockDataMap implements Serializable {
         .convertToSafeRow();
     short relativeBlockletId = safeRow.getShort(BLOCKLET_ID_INDEX);
     String filePath = getFilePath();
-    return createBlocklet(safeRow, getFileNameWithFilePath(safeRow, filePath), relativeBlockletId,
-        false);
+    return createBlocklet(safeRow, getFileNameWithFilePath(safeRow, filePath), relativeBlockletId);
   }
 
   protected short getBlockletId(DataMapRow dataMapRow) {
@@ -223,17 +222,15 @@ public class BlockletDataMap extends BlockDataMap implements Serializable {
     return dataMapRow.getShort(BLOCKLET_ID_INDEX);
   }
 
-  protected ExtendedBlocklet createBlocklet(DataMapRow row, String fileName, short blockletId,
-      boolean useMinMaxForPruning) {
+  protected ExtendedBlocklet createBlocklet(DataMapRow row, String fileName, short blockletId) {
     if (isLegacyStore) {
-      return super.createBlocklet(row, fileName, blockletId, useMinMaxForPruning);
+      return super.createBlocklet(row, fileName, blockletId);
     }
     ExtendedBlocklet blocklet = new ExtendedBlocklet(fileName, blockletId + "");
     BlockletDetailInfo detailInfo = getBlockletDetailInfo(row, blockletId, blocklet);
     detailInfo.setColumnSchemas(getColumnSchema());
     detailInfo.setBlockletInfoBinary(row.getByteArray(BLOCKLET_INFO_INDEX));
     detailInfo.setPagesCount(row.getShort(BLOCKLET_PAGE_COUNT_INDEX));
-    detailInfo.setUseMinMaxForPruning(useMinMaxForPruning);
     blocklet.setDetailInfo(detailInfo);
     return blocklet;
   }


### PR DESCRIPTION
This PR solve three problems which will affect the correctness of the query on bloom.

1. optimize blockletId in rebuilding datamap

After review the code, we found that modification in PR2539 is not needed, so we revert that PR.

2. bugs in overflow for blocklet count

Carbondata stores blocklet count for each block in byte data type, when
a block contains more than 128 blocklets, it will overflow the byte
limits.
Here we change the data type to short.

3. Fix bug in querying with bloom datamap with block cache level enabled

In block cache level scenario, previously the main BlockDataMap return
block as pruned blocklet with its blockletId=-1;
However, other index datamap such as BloomDataMap return actual blocklet
with correct blockletId. Due to the behaviour of Blocklet's hashcode,
some blocklets will be uncorrectly marked as duplicated and dropped.
Thus cause incorrect query result.

To fix this problem, we will return all blocklets with correct
blockletId for the block instead of returning a fake blocklet with
blockletId=-1.
This will not affect the following procedure.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

