### PR TITLE
[CARBONDATA-2812] Implement freeMemory for complex pages

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/ColumnPageWrapper.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/ColumnPageWrapper.java
@@ -163,7 +163,10 @@ public class ColumnPageWrapper implements DimensionColumnPage {
 
   @Override
   public void freeMemory() {
-
+    if (null != columnPage) {
+      columnPage.freeMemory();
+      columnPage = null;
+    }
   }
 
   public boolean isAdaptiveComplexPrimitive() {


### PR DESCRIPTION
**Problem:**
The memory used by the ColumnPageWrapper (for complex data types) is not cleared and so it requires more memory to Load and Query.

**Solution:**
Clear the used memory in the freeMemory method.

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [x] Testing done
        Manual Testing
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

