### PR TITLE
[CARBONDATA-2585] Fix local dictionary for both table level and system level property based on priority

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -932,6 +932,11 @@ public final class CarbonCommonConstants {
   public static final String LOCAL_DICTIONARY_ENABLE_DEFAULT = "false";
 
   /**
+   * System property to enable or disable local dictionary generation
+   */
+  public static final String LOCAL_DICTIONARY_SYSTEM_ENABLE = "carbon.local.dictionary.enable";
+
+  /**
    * Threshold value for local dictionary
    */
   public static final String LOCAL_DICTIONARY_THRESHOLD = "local_dictionary_threshold";

--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -932,9 +932,11 @@ public final class CarbonCommonConstants {
   public static final String LOCAL_DICTIONARY_ENABLE_DEFAULT = "false";
 
   /**
-   * System property to enable or disable local dictionary generation
+   * System property to enable or disable local dictionary generation, If this is configured, then
+   * irrespective of table property configured for local dictionary, this value will be considered
    */
-  public static final String LOCAL_DICTIONARY_SYSTEM_ENABLE = "carbon.local.dictionary.enable";
+  public static final String ENABLE_SYSTEM_LEVEL_LOCAL_DICTIONARY =
+      "carbon.local.dictionary.enable";
 
   /**
    * Threshold value for local dictionary

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
@@ -875,6 +875,15 @@ public final class CarbonProperties {
   }
 
   /**
+   * This method will be used to add a new property which need not be serialized
+   *
+   * @param key
+   */
+  public void addNonSerializableProperty(String key, String value) {
+    carbonProperties.setProperty(key, value);
+  }
+
+  /**
    * Remove the specified key in property
    */
   public CarbonProperties removeProperty(String key) {

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/localdictionary/LocalDictionarySupportAlterTableTest.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/localdictionary/LocalDictionarySupportAlterTableTest.scala
@@ -1409,7 +1409,7 @@ class LocalDictionarySupportAlterTableTest extends QueryTest with BeforeAndAfter
 
   test("test alter table add column system level property and table level property") {
     CarbonProperties.getInstance()
-      .addProperty(CarbonCommonConstants.LOCAL_DICTIONARY_SYSTEM_ENABLE, "false")
+      .addProperty(CarbonCommonConstants.ENABLE_SYSTEM_LEVEL_LOCAL_DICTIONARY, "false")
     sql("drop table if exists local1")
     sql(
       """
@@ -1435,7 +1435,7 @@ class LocalDictionarySupportAlterTableTest extends QueryTest with BeforeAndAfter
 
   test("test alter table add column system level property") {
     CarbonProperties.getInstance()
-      .addProperty(CarbonCommonConstants.LOCAL_DICTIONARY_SYSTEM_ENABLE, "false")
+      .addProperty(CarbonCommonConstants.ENABLE_SYSTEM_LEVEL_LOCAL_DICTIONARY, "false")
     sql("drop table if exists local1")
     sql(
       """
@@ -1458,7 +1458,7 @@ class LocalDictionarySupportAlterTableTest extends QueryTest with BeforeAndAfter
   override protected def afterAll(): Unit = {
     sql("DROP TABLE IF EXISTS LOCAL1")
     CarbonProperties.getInstance()
-      .addProperty(CarbonCommonConstants.LOCAL_DICTIONARY_SYSTEM_ENABLE,
+      .addProperty(CarbonCommonConstants.ENABLE_SYSTEM_LEVEL_LOCAL_DICTIONARY,
         CarbonCommonConstants.LOCAL_DICTIONARY_ENABLE_DEFAULT)
   }
 }

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/localdictionary/LocalDictionarySupportCreateTableTest.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/localdictionary/LocalDictionarySupportCreateTableTest.scala
@@ -2430,7 +2430,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
 
   test("test local dictionary for system level configuration") {
     sql("drop table if exists local1")
-    CarbonProperties.getInstance().addProperty(CarbonCommonConstants.LOCAL_DICTIONARY_SYSTEM_ENABLE, "false")
+    CarbonProperties.getInstance().addProperty(CarbonCommonConstants.ENABLE_SYSTEM_LEVEL_LOCAL_DICTIONARY, "false")
     // should not throw exception as system level it is false and table level is not configured
       sql(
         """
@@ -2442,7 +2442,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
 
   test("test local dictionary for system level configuration and table level priority") {
     sql("drop table if exists local1")
-    CarbonProperties.getInstance().addProperty(CarbonCommonConstants.LOCAL_DICTIONARY_SYSTEM_ENABLE, "false")
+    CarbonProperties.getInstance().addProperty(CarbonCommonConstants.ENABLE_SYSTEM_LEVEL_LOCAL_DICTIONARY, "false")
     // should not throw exception as system level it is false and table level is not configured
     intercept[MalformedCarbonCommandException] {
       sql(
@@ -2459,7 +2459,7 @@ class LocalDictionarySupportCreateTableTest extends QueryTest with BeforeAndAfte
   override protected def afterAll(): Unit = {
     sql("DROP TABLE IF EXISTS LOCAL1")
     CarbonProperties.getInstance()
-      .addProperty(CarbonCommonConstants.LOCAL_DICTIONARY_SYSTEM_ENABLE,
+      .addProperty(CarbonCommonConstants.ENABLE_SYSTEM_LEVEL_LOCAL_DICTIONARY,
         CarbonCommonConstants.LOCAL_DICTIONARY_ENABLE_DEFAULT)
   }
 }

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/CarbonScalaUtil.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/CarbonScalaUtil.scala
@@ -535,7 +535,7 @@ object CarbonScalaUtil {
    * this method validates the local dictionary columns configurations
    *
    * @param tableProperties
-   * @param localDictColumns
+   * @param localDictColumns local dictionary columns for validation, can be include/exclude
    */
   def validateLocalDictionaryColumns(tableProperties: mutable.Map[String, String],
       localDictColumns: Seq[String]): Unit = {
@@ -664,8 +664,9 @@ object CarbonScalaUtil {
   /**
    * This method validates the local dictionary configured columns
    *
-   * @param fields
-   * @param tableProperties
+   * @param fields all the fields of table
+   * @param tableProperties table properties of table which has local dictionary configured props
+   * @param localDictColumns local dictionary columns, can be include/exclude columns
    */
   def validateLocalConfiguredDictionaryColumns(fields: Seq[Field],
       tableProperties: mutable.Map[String, String], localDictColumns: Seq[String]): Unit = {

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
@@ -310,7 +310,7 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
       tableProperties
         .put(CarbonCommonConstants.LOCAL_DICTIONARY_ENABLE,
           CarbonProperties.getInstance()
-            .getProperty(CarbonCommonConstants.LOCAL_DICTIONARY_SYSTEM_ENABLE,
+            .getProperty(CarbonCommonConstants.ENABLE_SYSTEM_LEVEL_LOCAL_DICTIONARY,
               CarbonCommonConstants.LOCAL_DICTIONARY_ENABLE_DEFAULT))
     }
 

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
@@ -116,7 +116,8 @@ class CarbonEnv {
 
           CarbonMetaStoreFactory.createCarbonMetaStore(sparkSession.conf)
         }
-        CarbonProperties.getInstance.addProperty(CarbonCommonConstants.IS_DRIVER_INSTANCE, "true")
+        CarbonProperties.getInstance
+          .addNonSerializableProperty(CarbonCommonConstants.IS_DRIVER_INSTANCE, "true")
         initialized = true
       }
     }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSparkSqlParserUtil.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSparkSqlParserUtil.scala
@@ -27,8 +27,7 @@ import org.apache.spark.sql.catalyst.parser.ParserUtils.operationNotAllowed
 import org.apache.spark.sql.catalyst.parser.SqlBaseParser._
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.command.{PartitionerField, TableModel, TableNewProcessor}
-import org.apache.spark.sql.execution.command.table.{CarbonCreateTableAsSelectCommand,
-CarbonCreateTableCommand}
+import org.apache.spark.sql.execution.command.table.{CarbonCreateTableAsSelectCommand, CarbonCreateTableCommand}
 import org.apache.spark.sql.types.StructField
 
 import org.apache.carbondata.common.exceptions.sql.MalformedCarbonCommandException
@@ -37,6 +36,7 @@ import org.apache.carbondata.core.datastore.impl.FileFactory
 import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier
 import org.apache.carbondata.core.metadata.datatype.DataTypes
 import org.apache.carbondata.core.metadata.schema.SchemaReader
+import org.apache.carbondata.core.util.CarbonProperties
 import org.apache.carbondata.core.util.path.CarbonTablePath
 import org.apache.carbondata.spark.CarbonOption
 import org.apache.carbondata.spark.util.{CarbonScalaUtil, CommonUtil}
@@ -164,7 +164,9 @@ object CarbonSparkSqlParserUtil {
       if (null == isLocalDic_enabled) {
         table.getFactTable.getTableProperties
           .put(CarbonCommonConstants.LOCAL_DICTIONARY_ENABLE,
-            CarbonCommonConstants.LOCAL_DICTIONARY_ENABLE_DEFAULT)
+            CarbonProperties.getInstance()
+              .getProperty(CarbonCommonConstants.LOCAL_DICTIONARY_SYSTEM_ENABLE,
+                CarbonCommonConstants.LOCAL_DICTIONARY_ENABLE_DEFAULT))
       }
       isLocalDic_enabled = table.getFactTable.getTableProperties
         .get(CarbonCommonConstants.LOCAL_DICTIONARY_ENABLE)

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSparkSqlParserUtil.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSparkSqlParserUtil.scala
@@ -165,7 +165,7 @@ object CarbonSparkSqlParserUtil {
         table.getFactTable.getTableProperties
           .put(CarbonCommonConstants.LOCAL_DICTIONARY_ENABLE,
             CarbonProperties.getInstance()
-              .getProperty(CarbonCommonConstants.LOCAL_DICTIONARY_SYSTEM_ENABLE,
+              .getProperty(CarbonCommonConstants.ENABLE_SYSTEM_LEVEL_LOCAL_DICTIONARY,
                 CarbonCommonConstants.LOCAL_DICTIONARY_ENABLE_DEFAULT))
       }
       isLocalDic_enabled = table.getFactTable.getTableProperties


### PR DESCRIPTION
### What are the changes
Added a System level Property for local dictionary Support.
Property 'carbon.local.dictionary.enable' can be set to true/false to enable/disable local dictionary at system level.
If table level property LOCAL_DICTIONARY_ENABLE is configured,  then Local Dictionary generation will be considered based on the table level property irrespective of the system level property.
If not, then the System level property '**carbon.local.dictionary.enable**' value will be considered for local dictionary generation.

By default, both '**carbon.local.dictionary.enable**' and LOCAL_DICTIONARY_ENABLE are false (Local Dictionary generation is disabled).

 - [x] Any interfaces changed?
 NA
 - [x] Any backward compatibility impacted?
 NA
 - [x] Document update required?
Yes
 - [x] Testing done
UTs are added and existing test cases will take care
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
Test cases are added
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA
