### PR TITLE
[CARBONDATA-2817]Thread Leak in Update and in No sort flow

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/util/BlockletDataMapUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/BlockletDataMapUtil.java
@@ -115,7 +115,7 @@ public class BlockletDataMapUtil {
         CarbonTable.updateTableByTableInfo(carbonTable, carbonTable.getTableInfo());
       }
       String blockPath = footer.getBlockInfo().getTableBlockInfo().getFilePath();
-      if (null != fileNameToMetaInfoMapping && null == blockMetaInfoMap.get(blockPath)) {
+      if (null == blockMetaInfoMap.get(blockPath)) {
         BlockMetaInfo blockMetaInfo = createBlockMetaInfo(fileNameToMetaInfoMapping, blockPath);
         // if blockMetaInfo is null that means the file has been deleted from the file system.
         // This can happen in case IUD scenarios where after deleting or updating the data the
@@ -123,8 +123,6 @@ public class BlockletDataMapUtil {
         if (null != blockMetaInfo) {
           blockMetaInfoMap.put(blockPath, blockMetaInfo);
         }
-      } else {
-        blockMetaInfoMap.put(blockPath, new BlockMetaInfo(new String[] {},0));
       }
     }
     return blockMetaInfoMap;

--- a/processing/src/main/java/org/apache/carbondata/processing/store/writer/v3/CarbonFactDataWriterImplV3.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/writer/v3/CarbonFactDataWriterImplV3.java
@@ -350,14 +350,25 @@ public class CarbonFactDataWriterImplV3 extends AbstractFactDataWriter {
    * @throws CarbonDataWriterException
    */
   public void closeWriter() throws CarbonDataWriterException {
-    commitCurrentFile(true);
+    CarbonDataWriterException exception = null;
     try {
+      commitCurrentFile(true);
       writeIndexFile();
-    } catch (IOException e) {
+    } catch (Exception e) {
       LOGGER.error(e, "Problem while writing the index file");
-      throw new CarbonDataWriterException("Problem while writing the index file", e);
+      exception = new CarbonDataWriterException("Problem while writing the index file", e);
+    } finally {
+      try {
+        closeExecutorService();
+      } catch (CarbonDataWriterException e) {
+        if (null == exception) {
+          exception = e;
+        }
+      }
     }
-    closeExecutorService();
+    if (null != exception) {
+      throw exception;
+    }
   }
 
   @Override public void writeFooterToFile() throws CarbonDataWriterException {


### PR DESCRIPTION
Issue :-  After Update Command is finished , Loading threads are not getting stopped. 

Root Cause :- 
1. In Update flow  DataLoadExecutor 's close method is not called so all Executors services are not closed.
2. In Exceptions are not handled property in AFDW class's closeExecutorService() which is cuasing Thread leak if Job is killed from SparkUI..  

Solution :- 
1.  Add Task Completion Listener and  call close method of DataLoadExecutor  to it .
2. Handle Exception in closeExecutor Service so that all Writer steps Threads can be closed.



Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 NO
 - [ ] Any backward compatibility impacted?
 NO
 - [ ] Document update required?
NO
 - [ ] Testing done
      Verified in cluster manually .  
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
  NA
