### PR TITLE
[CARBONDATA-2818] Presto Upgrade to 0.206

### DIFF
--- a/integration/presto/pom.xml
+++ b/integration/presto/pom.xml
@@ -31,7 +31,7 @@
   <packaging>presto-plugin</packaging>
 
   <properties>
-    <presto.version>0.187</presto.version>
+    <presto.version>0.208</presto.version>
     <dev.path>${basedir}/../../dev</dev.path>
     <jacoco.append>true</jacoco.append>
   </properties>

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/CarbonVectorBatch.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/CarbonVectorBatch.java
@@ -36,7 +36,7 @@ import org.apache.carbondata.presto.readers.ShortStreamReader;
 import org.apache.carbondata.presto.readers.SliceStreamReader;
 import org.apache.carbondata.presto.readers.TimestampStreamReader;
 
-import com.facebook.presto.spi.block.SliceArrayBlock;
+import com.facebook.presto.spi.block.Block;
 
 public class CarbonVectorBatch {
 
@@ -63,7 +63,7 @@ public class CarbonVectorBatch {
 
     for (int i = 0; i < schema.length; ++i) {
       columns[i] = createDirectStreamReader(maxRows, dataTypes[i], schema[i], dictionaries[i],
-          readSupport.getSliceArrayBlock(i));
+          readSupport.getDictionaryBlock(i));
     }
   }
 
@@ -73,7 +73,7 @@ public class CarbonVectorBatch {
   }
 
   private CarbonColumnVectorImpl createDirectStreamReader(int batchSize, DataType dataType,
-      StructField field, Dictionary dictionary, SliceArrayBlock dictionarySliceArrayBlock) {
+      StructField field, Dictionary dictionary, Block dictionaryBlock) {
     if (dataType == DataTypes.BOOLEAN) {
       return new BooleanStreamReader(batchSize, field.getDataType(), dictionary);
     } else if (dataType == DataTypes.SHORT) {
@@ -87,7 +87,7 @@ public class CarbonVectorBatch {
     } else if (dataType == DataTypes.DOUBLE) {
       return new DoubleStreamReader(batchSize, field.getDataType(), dictionary);
     } else if (dataType == DataTypes.STRING) {
-      return new SliceStreamReader(batchSize, field.getDataType(), dictionarySliceArrayBlock);
+      return new SliceStreamReader(batchSize, field.getDataType(), dictionaryBlock);
     } else if (DataTypes.isDecimal(dataType)) {
       return new DecimalSliceStreamReader(batchSize, (DecimalType) field.getDataType(), dictionary);
     } else {

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/CarbondataSplitManager.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/CarbondataSplitManager.java
@@ -64,7 +64,8 @@ public class CarbondataSplitManager implements ConnectorSplitManager {
   }
 
   public ConnectorSplitSource getSplits(ConnectorTransactionHandle transactionHandle,
-      ConnectorSession session, ConnectorTableLayoutHandle layout) {
+      ConnectorSession session, ConnectorTableLayoutHandle layout,
+      SplitSchedulingStrategy splitSchedulingStrategy) {
     CarbondataTableLayoutHandle layoutHandle = (CarbondataTableLayoutHandle) layout;
     CarbondataTableHandle tableHandle = layoutHandle.getTable();
     SchemaTableName key = tableHandle.getSchemaTableName();

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/readers/BooleanStreamReader.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/readers/BooleanStreamReader.java
@@ -25,7 +25,6 @@ import org.apache.carbondata.core.util.DataTypeUtil;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.BooleanType;
 import com.facebook.presto.spi.type.Type;
 
@@ -43,7 +42,7 @@ public class BooleanStreamReader extends CarbonColumnVectorImpl
   public BooleanStreamReader(int batchSize, DataType dataType, Dictionary dictionary) {
     super(batchSize, dataType);
     this.batchSize = batchSize;
-    this.builder = type.createBlockBuilder(new BlockBuilderStatus(), batchSize);
+    this.builder = type.createBlockBuilder(null, batchSize);
     this.dictionary = dictionary;
   }
 
@@ -74,7 +73,7 @@ public class BooleanStreamReader extends CarbonColumnVectorImpl
   }
 
   @Override public void reset() {
-    builder = type.createBlockBuilder(new BlockBuilderStatus(), batchSize);
+    builder = type.createBlockBuilder(null, batchSize);
   }
 
 }

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/readers/DecimalSliceStreamReader.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/readers/DecimalSliceStreamReader.java
@@ -30,7 +30,6 @@ import org.apache.carbondata.core.util.DataTypeUtil;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.DecimalType;
 import com.facebook.presto.spi.type.Decimals;
 import com.facebook.presto.spi.type.Type;
@@ -42,6 +41,8 @@ import static com.facebook.presto.spi.type.Decimals.rescale;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static io.airlift.slice.Slices.utf8Slice;
+
+
 
 
 /**
@@ -61,7 +62,7 @@ public class DecimalSliceStreamReader extends CarbonColumnVectorImpl
     super(batchSize, dataType);
     this.type = DecimalType.createDecimalType(dataType.getPrecision(), dataType.getScale());
     this.batchSize = batchSize;
-    this.builder = type.createBlockBuilder(new BlockBuilderStatus(), batchSize);
+    this.builder = type.createBlockBuilder(null, batchSize);
     this.dictionary = dictionary;
   }
 
@@ -93,7 +94,7 @@ public class DecimalSliceStreamReader extends CarbonColumnVectorImpl
   }
 
   @Override public void reset() {
-    builder = type.createBlockBuilder(new BlockBuilderStatus(), batchSize);
+    builder = type.createBlockBuilder(null, batchSize);
   }
 
   private void decimalBlockWriter(BigDecimal value) {

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/readers/DoubleStreamReader.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/readers/DoubleStreamReader.java
@@ -25,7 +25,6 @@ import org.apache.carbondata.core.util.DataTypeUtil;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.DoubleType;
 import com.facebook.presto.spi.type.Type;
 
@@ -45,7 +44,7 @@ public class DoubleStreamReader extends CarbonColumnVectorImpl implements Presto
   public DoubleStreamReader(int batchSize, DataType dataType, Dictionary dictionary) {
     super(batchSize, dataType);
     this.batchSize = batchSize;
-    this.builder = type.createBlockBuilder(new BlockBuilderStatus(), batchSize);
+    this.builder = type.createBlockBuilder(null, batchSize);
     this.dictionary = dictionary;
   }
 
@@ -76,6 +75,6 @@ public class DoubleStreamReader extends CarbonColumnVectorImpl implements Presto
   }
 
   @Override public void reset() {
-    builder = type.createBlockBuilder(new BlockBuilderStatus(), batchSize);
+    builder = type.createBlockBuilder(null, batchSize);
   }
 }

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/readers/IntegerStreamReader.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/readers/IntegerStreamReader.java
@@ -25,7 +25,6 @@ import org.apache.carbondata.core.util.DataTypeUtil;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.IntegerType;
 import com.facebook.presto.spi.type.Type;
 
@@ -43,7 +42,7 @@ public class IntegerStreamReader extends CarbonColumnVectorImpl
   public IntegerStreamReader(int batchSize, DataType dataType, Dictionary dictionary) {
     super(batchSize, dataType);
     this.batchSize = batchSize;
-    this.builder = type.createBlockBuilder(new BlockBuilderStatus(), batchSize);
+    this.builder = type.createBlockBuilder(null, batchSize);
     this.dictionary = dictionary;
   }
 
@@ -74,7 +73,7 @@ public class IntegerStreamReader extends CarbonColumnVectorImpl
   }
 
   @Override public void reset() {
-    builder = type.createBlockBuilder(new BlockBuilderStatus(), batchSize);
+    builder = type.createBlockBuilder(null, batchSize);
   }
 
 }

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/readers/LongStreamReader.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/readers/LongStreamReader.java
@@ -25,7 +25,6 @@ import org.apache.carbondata.core.util.DataTypeUtil;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.BigintType;
 import com.facebook.presto.spi.type.Type;
 
@@ -42,7 +41,7 @@ public class LongStreamReader extends CarbonColumnVectorImpl implements PrestoVe
   public LongStreamReader(int batchSize, DataType dataType, Dictionary dictionary) {
     super(batchSize, dataType);
     this.batchSize = batchSize;
-    this.builder = type.createBlockBuilder(new BlockBuilderStatus(), batchSize);
+    this.builder = type.createBlockBuilder(null, batchSize);
     this.dictionary = dictionary;
   }
 
@@ -73,6 +72,6 @@ public class LongStreamReader extends CarbonColumnVectorImpl implements PrestoVe
   }
 
   @Override public void reset() {
-    builder = type.createBlockBuilder(new BlockBuilderStatus(), batchSize);
+    builder = type.createBlockBuilder(null, batchSize);
   }
 }

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/readers/ObjectStreamReader.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/readers/ObjectStreamReader.java
@@ -22,7 +22,6 @@ import org.apache.carbondata.core.scan.result.vector.impl.CarbonColumnVectorImpl
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.IntegerType;
 import com.facebook.presto.spi.type.Type;
 
@@ -40,7 +39,7 @@ public class ObjectStreamReader extends CarbonColumnVectorImpl implements Presto
   public ObjectStreamReader(int batchSize, DataType dataType) {
     super(batchSize, dataType);
     this.batchSize = batchSize;
-    this.builder = type.createBlockBuilder(new BlockBuilderStatus(), batchSize);
+    this.builder = type.createBlockBuilder(null, batchSize);
   }
 
   @Override public Block buildBlock() {
@@ -60,7 +59,7 @@ public class ObjectStreamReader extends CarbonColumnVectorImpl implements Presto
   }
 
   @Override public void reset() {
-    builder = type.createBlockBuilder(new BlockBuilderStatus(), batchSize);
+    builder = type.createBlockBuilder(null, batchSize);
   }
 
 }

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/readers/ShortStreamReader.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/readers/ShortStreamReader.java
@@ -25,7 +25,6 @@ import org.apache.carbondata.core.util.DataTypeUtil;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.SmallintType;
 import com.facebook.presto.spi.type.Type;
 
@@ -42,7 +41,7 @@ public class ShortStreamReader extends CarbonColumnVectorImpl implements PrestoV
   public ShortStreamReader(int batchSize, DataType dataType, Dictionary dictionary) {
     super(batchSize, dataType);
     this.batchSize = batchSize;
-    this.builder = type.createBlockBuilder(new BlockBuilderStatus(), batchSize);
+    this.builder = type.createBlockBuilder(null, batchSize);
     this.dictionary = dictionary;
   }
 
@@ -73,6 +72,6 @@ public class ShortStreamReader extends CarbonColumnVectorImpl implements PrestoV
   }
 
   @Override public void reset() {
-    builder = type.createBlockBuilder(new BlockBuilderStatus(), batchSize);
+    builder = type.createBlockBuilder(null, batchSize);
   }
 }

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/readers/SliceStreamReader.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/readers/SliceStreamReader.java
@@ -22,9 +22,7 @@ import org.apache.carbondata.core.scan.result.vector.impl.CarbonColumnVectorImpl
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.block.DictionaryBlock;
-import com.facebook.presto.spi.block.SliceArrayBlock;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.VarcharType;
 
@@ -40,26 +38,28 @@ public class SliceStreamReader extends CarbonColumnVectorImpl implements PrestoV
   protected Type type = VarcharType.VARCHAR;
 
   protected BlockBuilder builder;
+
   int[] values;
-  private SliceArrayBlock dictionarySliceArrayBlock;
+
+  private Block dictionaryBlock;
 
   public SliceStreamReader(int batchSize, DataType dataType,
-      SliceArrayBlock dictionarySliceArrayBlock) {
+      Block dictionaryBlock) {
     super(batchSize, dataType);
     this.batchSize = batchSize;
-    if (dictionarySliceArrayBlock == null) {
-      this.builder = type.createBlockBuilder(new BlockBuilderStatus(), batchSize);
+    if (dictionaryBlock == null) {
+      this.builder = type.createBlockBuilder(null, batchSize);
     } else {
-      this.dictionarySliceArrayBlock = dictionarySliceArrayBlock;
+      this.dictionaryBlock = dictionaryBlock;
       this.values = new int[batchSize];
     }
   }
 
   @Override public Block buildBlock() {
-    if (dictionarySliceArrayBlock == null) {
+    if (dictionaryBlock == null) {
       return builder.build();
     } else {
-      return new DictionaryBlock(batchSize, dictionarySliceArrayBlock, values);
+      return new DictionaryBlock(batchSize, dictionaryBlock, values);
     }
   }
 
@@ -82,12 +82,12 @@ public class SliceStreamReader extends CarbonColumnVectorImpl implements PrestoV
   }
 
   @Override public void putNull(int rowId) {
-    if (dictionarySliceArrayBlock == null) {
+    if (dictionaryBlock == null) {
       builder.appendNull();
     }
   }
 
   @Override public void reset() {
-    builder = type.createBlockBuilder(new BlockBuilderStatus(), batchSize);
+    builder = type.createBlockBuilder(null, batchSize);
   }
 }

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/readers/TimestampStreamReader.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/readers/TimestampStreamReader.java
@@ -25,7 +25,6 @@ import org.apache.carbondata.core.util.DataTypeUtil;
 
 import com.facebook.presto.spi.block.Block;
 import com.facebook.presto.spi.block.BlockBuilder;
-import com.facebook.presto.spi.block.BlockBuilderStatus;
 import com.facebook.presto.spi.type.TimestampType;
 import com.facebook.presto.spi.type.Type;
 
@@ -43,7 +42,7 @@ public class TimestampStreamReader extends CarbonColumnVectorImpl
   public TimestampStreamReader(int batchSize, DataType dataType, Dictionary dictionary) {
     super(batchSize, dataType);
     this.batchSize = batchSize;
-    this.builder = type.createBlockBuilder(new BlockBuilderStatus(), batchSize);
+    this.builder = type.createBlockBuilder(null, batchSize);
     this.dictionary = dictionary;
   }
 
@@ -74,6 +73,6 @@ public class TimestampStreamReader extends CarbonColumnVectorImpl
   }
 
   @Override public void reset() {
-    builder = type.createBlockBuilder(new BlockBuilderStatus(), batchSize);
+    builder = type.createBlockBuilder(null, batchSize);
   }
 }


### PR DESCRIPTION
This PR upgraded the Presto version from 0.187 to 0.206, the CarbondataSplitManager has been changed to accommodate the SplitSchedulingStrategy, also the SliceArrayBlock has now been removed from this version so we have to add the VariableWidthBlock for Dictionary. BlockBuilderStatus access has also been changed to protected instead of public so we have to pass null. Also, now the implementation of Stream Readers uses Block.

 - [ Y] Any interfaces changed?
 
 - [ Y] Any backward compatibility impacted?
 
 - [ N] Document update required?

 - [ Y] Testing was done
All Unit test cases are passing and have run queries manually to test them.
       


