### PR TITLE
[CARBONDATA-2829][CARBONDATA-2832] Fix creating merge index on older V1 V2 store

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonAlterTableCompactionCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonAlterTableCompactionCommand.scala
@@ -37,6 +37,7 @@ import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.datastore.impl.FileFactory
 import org.apache.carbondata.core.exception.ConcurrentOperationException
 import org.apache.carbondata.core.locks.{CarbonLockFactory, LockUsage}
+import org.apache.carbondata.core.metadata.ColumnarFormatVersion
 import org.apache.carbondata.core.metadata.schema.table.{CarbonTable, TableInfo}
 import org.apache.carbondata.core.mutate.CarbonUpdateUtil
 import org.apache.carbondata.core.statusmanager.SegmentStatusManager
@@ -122,6 +123,15 @@ case class CarbonAlterTableCompactionCommand(
           "Unsupported alter operation on carbon table: Merge index is not supported on streaming" +
           " table")
       }
+      val version = CarbonUtil.getFormatVersion(table)
+      val isOlderVersion = version == ColumnarFormatVersion.V1 ||
+                           version == ColumnarFormatVersion.V2
+      if (isOlderVersion) {
+        throw new MalformedCarbonCommandException(
+          "Unsupported alter operation on carbon table: Merge index is not supported on V1 V2 " +
+          "store segments")
+      }
+
       val alterTableMergeIndexEvent: AlterTableMergeIndexEvent =
         AlterTableMergeIndexEvent(sparkSession, table, alterTableModel)
       OperationListenerBus.getInstance


### PR DESCRIPTION
Block merge index creation for the old store V1 V2 versions

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [x] Testing done
        Manual Testing
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

