### PR TITLE
[CARBONDATA-2831] Added Support Merge index files read from non transactional table

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/readcommitter/LatestFilesReadCommittedScope.java
+++ b/core/src/main/java/org/apache/carbondata/core/readcommitter/LatestFilesReadCommittedScope.java
@@ -119,7 +119,11 @@ public class LatestFilesReadCommittedScope implements ReadCommittedScope {
       index = new LinkedList<>();
     }
     for (String indexPath : index) {
-      indexFileStore.put(indexPath, null);
+      if (indexPath.endsWith(CarbonTablePath.MERGE_INDEX_FILE_EXT)) {
+        indexFileStore.put(indexPath, indexPath.substring(indexPath.lastIndexOf('/') + 1));
+      } else {
+        indexFileStore.put(indexPath, null);
+      }
     }
     return indexFileStore;
   }
@@ -171,9 +175,9 @@ public class LatestFilesReadCommittedScope implements ReadCommittedScope {
             "No Index files are present in the table location :" + carbonFilePath);
       }
       for (int i = 0; i < carbonIndexFiles.length; i++) {
-        // TODO. If Required to support merge index, then this code has to be modified.
         // TODO. Nested File Paths.
-        if (carbonIndexFiles[i].getName().endsWith(CarbonTablePath.INDEX_FILE_EXT)) {
+        if (carbonIndexFiles[i].getName().endsWith(CarbonTablePath.INDEX_FILE_EXT)
+            || carbonIndexFiles[i].getName().endsWith(CarbonTablePath.MERGE_INDEX_FILE_EXT)) {
           // Get Segment Name from the IndexFile.
           String indexFilePath =
               FileFactory.getUpdatedFilePath(carbonIndexFiles[i].getAbsolutePath());

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestNonTransactionalCarbonTable.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestNonTransactionalCarbonTable.scala
@@ -33,7 +33,7 @@ import org.apache.avro.file.DataFileWriter
 import org.apache.avro.generic.{GenericDatumReader, GenericDatumWriter, GenericRecord}
 import org.apache.avro.io.{DecoderFactory, Encoder}
 import org.apache.commons.io.FileUtils
-import org.apache.spark.sql.Row
+import org.apache.spark.sql.{CarbonEnv, Row}
 import org.apache.spark.sql.test.util.QueryTest
 import org.junit.Assert
 import org.scalatest.BeforeAndAfterAll
@@ -1103,7 +1103,10 @@ class TestNonTransactionalCarbonTable extends QueryTest with BeforeAndAfterAll {
       "'carbondata'")
     sql(s"""insert into normalTable1 values ("aaaaa", 12, 20)""").show(200, false)
     sql("DROP TABLE IF EXISTS sdkOutputTable")
-    val fileLocation = storeLocation + "/normaltable1/Fact/Part0/Segment_0"
+    val carbonTable = CarbonEnv
+      .getCarbonTable(Option("default"), "normalTable1")(sqlContext.sparkSession)
+    sql("describe formatted normalTable1").show(200, false)
+    val fileLocation = carbonTable.getSegmentPath("0")
     sql(
       s"""CREATE EXTERNAL TABLE sdkOutputTable STORED BY 'carbondata' LOCATION
          |'$fileLocation' """.stripMargin)

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestNonTransactionalCarbonTable.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestNonTransactionalCarbonTable.scala
@@ -1097,18 +1097,19 @@ class TestNonTransactionalCarbonTable extends QueryTest with BeforeAndAfterAll {
   }
 
   test("test SDK Read with merge index file") {
-    sql("DROP TABLE IF EXISTS t1")
+    sql("DROP TABLE IF EXISTS normalTable1")
     sql(
-      "create table if not exists t1 (name string, age int, height double) STORED BY 'carbondata'")
-    sql(s"""insert into t1 values ("aaaaa", 12, 20)""").show(200, false)
+      "create table if not exists normalTable1(name string, age int, height double) STORED BY " +
+      "'carbondata'")
+    sql(s"""insert into normalTable1 values ("aaaaa", 12, 20)""").show(200, false)
     sql("DROP TABLE IF EXISTS sdkOutputTable")
-    val fileLocation = storeLocation + "/t1/Fact/Part0/Segment_0"
+    val fileLocation = storeLocation + "/normaltable1/Fact/Part0/Segment_0"
     sql(
       s"""CREATE EXTERNAL TABLE sdkOutputTable STORED BY 'carbondata' LOCATION
          |'$fileLocation' """.stripMargin)
     checkAnswer(sql("select * from sdkOutputTable"), Seq(Row("aaaaa", 12, 20)))
     sql("DROP TABLE sdkOutputTable")
-    sql("DROP TABLE t1")
+    sql("DROP TABLE normalTable1")
   }
 
   // --------------------------------------------- AVRO test cases ---------------------------

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestNonTransactionalCarbonTable.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestNonTransactionalCarbonTable.scala
@@ -1096,6 +1096,22 @@ class TestNonTransactionalCarbonTable extends QueryTest with BeforeAndAfterAll {
     cleanTestData()
   }
 
+  test("test SDK Read with merge index file") {
+    sql("DROP TABLE IF EXISTS t1")
+    sql(
+      "create table if not exists t1 (name string, age int, height double) STORED BY 'carbondata'")
+    sql(s"""insert into t1 values ("aaaaa", 12, 20)""").show(200, false)
+    sql("DROP TABLE IF EXISTS sdkOutputTable")
+    val fileLocation = storeLocation + "/t1/Fact/Part0/Segment_0"
+    sql(
+      s"""CREATE EXTERNAL TABLE sdkOutputTable STORED BY 'carbondata' LOCATION
+         |'$fileLocation' """.stripMargin)
+    checkAnswer(sql("select * from sdkOutputTable"), Seq(Row("aaaaa", 12, 20)))
+    sql("DROP TABLE sdkOutputTable")
+    sql("DROP TABLE t1")
+  }
+
+  // --------------------------------------------- AVRO test cases ---------------------------
   private def WriteFilesWithAvroWriter(rows: Int,
       mySchema: String,
       json: String) = {


### PR DESCRIPTION
problem : Currently  SDK read/ nontransactional table read from external
table gives null output when carbonMergeindex file is present instead of
carobnindex files.

cause : In LatestFileReadCommitted, while taking snapshot, merge index
files were not considered.

solution: consider the merge index files while taking snapshot

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed? NA
 
 - [ ] Any backward compatibility impacted? NA
 
 - [ ] Document update required? NA

 - [ ] Testing done. Added UT       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. NA

