### PR TITLE
[CARBONDATA-2834] Remove unnecessary nested looping over loadMetadatadetails.

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/statusmanager/SegmentUpdateStatusManager.java
+++ b/core/src/main/java/org/apache/carbondata/core/statusmanager/SegmentUpdateStatusManager.java
@@ -779,6 +779,33 @@ public class SegmentUpdateStatusManager {
     }
     return range;
   }
+
+  /**
+   * Returns the invalid timestamp range of a segment.
+   * @return
+   */
+  public List<UpdateVO> getInvalidTimestampRange() {
+    List<UpdateVO> ranges = new ArrayList<UpdateVO>();
+    for (LoadMetadataDetails segment : segmentDetails) {
+      if ((SegmentStatus.LOAD_FAILURE == segment.getSegmentStatus()
+          || SegmentStatus.COMPACTED == segment.getSegmentStatus()
+          || SegmentStatus.MARKED_FOR_DELETE == segment.getSegmentStatus())) {
+        UpdateVO range = new UpdateVO();
+        range.setSegmentId(segment.getLoadName());
+        range.setFactTimestamp(segment.getLoadStartTime());
+        if (!segment.getUpdateDeltaStartTimestamp().isEmpty() &&
+            !segment.getUpdateDeltaEndTimestamp().isEmpty()) {
+          range.setUpdateDeltaStartTimestamp(
+              CarbonUpdateUtil.getTimeStampAsLong(segment.getUpdateDeltaStartTimestamp()));
+          range.setLatestUpdateTimestamp(
+              CarbonUpdateUtil.getTimeStampAsLong(segment.getUpdateDeltaEndTimestamp()));
+        }
+        ranges.add(range);
+      }
+    }
+    return ranges;
+  }
+
   /**
    *
    * @param block

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableInputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableInputFormat.java
@@ -180,10 +180,7 @@ public class CarbonTableInputFormat<T> extends CarbonInputFormat<T> {
       }
       // remove entry in the segment index if there are invalid segments
       invalidSegments.addAll(segments.getInvalidSegments());
-      for (Segment invalidSegmentId : invalidSegments) {
-        invalidTimestampsList
-            .add(updateStatusManager.getInvalidTimestampRange(invalidSegmentId.getSegmentNo()));
-      }
+      invalidTimestampsList.addAll(updateStatusManager.getInvalidTimestampRange());
       if (invalidSegments.size() > 0) {
         DataMapStoreManager.getInstance()
             .clearInvalidSegments(getOrCreateCarbonTable(job.getConfiguration()), invalidSegments);


### PR DESCRIPTION
removed nested for loop which causes query performance degradation if there are huge number of entries for compacted segments in tablestatus file.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

