### PR TITLE
[CARBONDATA-2819] Fixed cannot drop preagg datamap on table if the tab…

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/util/SessionParams.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/SessionParams.java
@@ -17,11 +17,13 @@
 
 package org.apache.carbondata.core.util;
 
+import java.io.IOException;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.carbondata.common.constants.LoggerAction;
+import org.apache.carbondata.common.exceptions.sql.NoSuchDataMapException;
 import org.apache.carbondata.common.logging.LogService;
 import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.cache.CacheProvider;
@@ -30,6 +32,8 @@ import org.apache.carbondata.core.constants.CarbonCommonConstantsInternal;
 import org.apache.carbondata.core.constants.CarbonLoadOptionConstants;
 import org.apache.carbondata.core.datamap.DataMapStoreManager;
 import org.apache.carbondata.core.exception.InvalidConfigurationException;
+import org.apache.carbondata.core.metadata.schema.datamap.DataMapClassProvider;
+import org.apache.carbondata.core.metadata.schema.table.DataMapSchema;
 
 import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_CUSTOM_BLOCK_DISTRIBUTION;
 import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_SEARCH_MODE_ENABLE;
@@ -213,13 +217,20 @@ public class SessionParams implements Serializable, Cloneable {
           isValid = true;
         } else if (key.startsWith(CarbonCommonConstants.CARBON_DATAMAP_VISIBLE)) {
           String[] keyArray = key.split("\\.");
-          isValid = DataMapStoreManager.getInstance().isDataMapExist(
-              keyArray[keyArray.length - 3],
-              keyArray[keyArray.length - 2],
-              keyArray[keyArray.length - 1]);
-          if (!isValid) {
+          try {
+            DataMapSchema dataMapSchema =
+                DataMapStoreManager.getInstance().getDataMapSchema(keyArray[keyArray.length - 1]);
+            if (DataMapClassProvider.PREAGGREGATE.getShortName()
+                .equalsIgnoreCase(dataMapSchema.getProviderName())) {
+              throw new InvalidConfigurationException(
+                  "Preagg datamap is not supported for this configuration.");
+            }
+          } catch (NoSuchDataMapException e) {
             throw new InvalidConfigurationException(
-                String.format("Invalid configuration of %s, datamap does not exist", key));
+                String.format("Invalid configuration of %s, datamap does not exist.", key));
+          } catch (IOException e) {
+            throw new InvalidConfigurationException("While getting datamap IOException happend,",
+                e);
           }
         } else if (key.startsWith(CarbonCommonConstants.CARBON_LOAD_DATAMAPS_PARALLEL)) {
           isValid = CarbonUtil.validateBoolean(value);

--- a/integration/spark2/src/main/java/org/apache/carbondata/datamap/PreAggregateDataMapProvider.java
+++ b/integration/spark2/src/main/java/org/apache/carbondata/datamap/PreAggregateDataMapProvider.java
@@ -17,6 +17,7 @@
 
 package org.apache.carbondata.datamap;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -24,6 +25,7 @@ import org.apache.carbondata.common.annotations.InterfaceAudience;
 import org.apache.carbondata.common.exceptions.sql.MalformedDataMapCommandException;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.datamap.DataMapProvider;
+import org.apache.carbondata.core.datamap.DataMapStoreManager;
 import org.apache.carbondata.core.datamap.dev.DataMapFactory;
 import org.apache.carbondata.core.metadata.schema.datamap.DataMapProperty;
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
@@ -77,13 +79,14 @@ public class PreAggregateDataMapProvider extends DataMapProvider {
   }
 
   @Override
-  public void cleanMeta() {
+  public void cleanMeta() throws IOException {
     dropTableCommand = new CarbonDropTableCommand(
         true,
         new Some<>(dbName),
         tableName,
         true);
     dropTableCommand.processMetadata(sparkSession);
+    DataMapStoreManager.getInstance().dropDataMapSchema(dataMapSchema.getDataMapName());
   }
 
   @Override

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/datamap/CarbonDataMapShowCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/datamap/CarbonDataMapShowCommand.scala
@@ -59,9 +59,6 @@ case class CarbonDataMapShowCommand(tableIdentifier: Option[TableIdentifier])
       case Some(table) =>
         Checker.validateTableExists(table.database, table.table, sparkSession)
         val carbonTable = CarbonEnv.getCarbonTable(table)(sparkSession)
-        if (carbonTable.hasDataMapSchema) {
-          dataMapSchemaList.addAll(carbonTable.getTableInfo.getDataMapSchemaList)
-        }
         val indexSchemas = DataMapStoreManager.getInstance().getDataMapSchemasOfTable(carbonTable)
         if (!indexSchemas.isEmpty) {
           dataMapSchemaList.addAll(indexSchemas)


### PR DESCRIPTION
1.Use "SET carbon.datamap.visible.{dbName}.{mainTable}.{datamapName} = {true or false}",if datamap provider is 'preagg',block this configuration.
2.When create preagg datamap, now also create its datamap schema file in system folder.
3.Use command "show datamap on table {tableName}" will get its all datamaps from datamap schema files

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed? No
 
 - [ ] Any backward compatibility impacted? No
 
 - [ ] Document update required? No

 - [ ] Testing done NA
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

