### PR TITLE
[CARBONDATA-2819] Fixed cannot drop preagg datamap on table if the table has other type datamaps

### DIFF
--- a/examples/spark2/src/main/scala/org/apache/carbondata/examples/PreAggregateDataMapExample.scala
+++ b/examples/spark2/src/main/scala/org/apache/carbondata/examples/PreAggregateDataMapExample.scala
@@ -37,7 +37,7 @@ object PreAggregateDataMapExample {
 
   def exampleBody(spark : SparkSession): Unit = {
     val rootPath = new File(this.getClass.getResource("/").getPath
-                            + "../../../..").getCanonicalPath
+                            + "../../../..").getCanonicalPath.replace("\\", "/")
     val testData = s"$rootPath/integration/spark-common-test/src/test/resources/sample.csv"
 
     // 1. simple usage for Pre-aggregate tables creation and query
@@ -175,7 +175,7 @@ object PreAggregateDataMapExample {
 
     // create pre-aggregate table by datamap
     spark.sql("""
-       CREATE datamap preagg_avg on table personTable using 'preaggregate' as
+       CREATE datamap preagg_avg_dm on table personTable using 'preaggregate' as
        | select id,avg(age) from personTable group by id
               """.stripMargin)
 

--- a/integration/spark2/src/main/java/org/apache/carbondata/datamap/PreAggregateDataMapProvider.java
+++ b/integration/spark2/src/main/java/org/apache/carbondata/datamap/PreAggregateDataMapProvider.java
@@ -17,6 +17,7 @@
 
 package org.apache.carbondata.datamap;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -24,6 +25,7 @@ import org.apache.carbondata.common.annotations.InterfaceAudience;
 import org.apache.carbondata.common.exceptions.sql.MalformedDataMapCommandException;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.datamap.DataMapProvider;
+import org.apache.carbondata.core.datamap.DataMapStoreManager;
 import org.apache.carbondata.core.datamap.dev.DataMapFactory;
 import org.apache.carbondata.core.metadata.schema.datamap.DataMapProperty;
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
@@ -77,13 +79,15 @@ public class PreAggregateDataMapProvider extends DataMapProvider {
   }
 
   @Override
-  public void cleanMeta() {
+  public void cleanMeta() throws IOException {
+    DataMapSchema dataMapSchema = getDataMapSchema();
     dropTableCommand = new CarbonDropTableCommand(
         true,
         new Some<>(dbName),
         tableName,
         true);
     dropTableCommand.processMetadata(sparkSession);
+    DataMapStoreManager.getInstance().dropDataMapSchema(dataMapSchema.getDataMapName());
   }
 
   @Override

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/datamap/CarbonDataMapShowCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/datamap/CarbonDataMapShowCommand.scala
@@ -59,9 +59,6 @@ case class CarbonDataMapShowCommand(tableIdentifier: Option[TableIdentifier])
       case Some(table) =>
         Checker.validateTableExists(table.database, table.table, sparkSession)
         val carbonTable = CarbonEnv.getCarbonTable(table)(sparkSession)
-        if (carbonTable.hasDataMapSchema) {
-          dataMapSchemaList.addAll(carbonTable.getTableInfo.getDataMapSchemaList)
-        }
         val indexSchemas = DataMapStoreManager.getInstance().getDataMapSchemasOfTable(carbonTable)
         if (!indexSchemas.isEmpty) {
           dataMapSchemaList.addAll(indexSchemas)

--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/TestStreamingTableOperation.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/TestStreamingTableOperation.scala
@@ -286,6 +286,7 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
     sql("create datamap p1 on table agg_table using 'preaggregate' as select name, sum(salary) from agg_table group by name")
     // No data should be loaded into aggregate table as hand-off is not yet fired
     checkAnswer(sql("select * from agg_table_p1"), Seq())
+    sql("drop table agg_table")
   }
 
   test("test if data is loaded into preaggregate after handoff is fired") {
@@ -618,6 +619,7 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
         Row("name_12", 240000.0),
         Row("name_13", 260000.0),
         Row("name_14", 280000.0)))
+    sql("drop table agg_table3")
   }
 
   // bad records


### PR DESCRIPTION
1.Use "SET carbon.datamap.visible.{dbName}.{mainTable}.{datamapName} = {true or false}",if datamap provider is 'preagg',block this configuration.
2.When create preagg datamap, now also create its datamap schema file in system folder.
3.Use command "show datamap on table {tableName}" will get its all datamaps from datamap schema files

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?No
 
 - [ ] Any backward compatibility impacted? No
 
 - [ ] Document update required? No

 - [ ] Testing done 
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

