### PR TITLE
[HOTFIX]Fixed reflection issue in Query 

### DIFF
--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
@@ -464,7 +464,9 @@ class CarbonScanRDD[T: ClassTag](
 
       // TODO: rewrite this logic to call free memory in FailureListener on failures. On success,
       // TODO: no memory leak should be there, resources should be freed on success completion.
-      val listeners = CarbonReflectionUtils.getField("onCompleteCallbacks", context)
+      val onCompleteCallbacksField = context.getClass.getDeclaredField("onCompleteCallbacks")
+      onCompleteCallbacksField.setAccessible(true)
+      val listeners = onCompleteCallbacksField.get(context)
         .asInstanceOf[ArrayBuffer[TaskCompletionListener]]
 
       val isAdded = listeners.exists(p => p.isInstanceOf[InsertTaskCompletionListener])

--- a/integration/spark-common/src/main/scala/org/apache/spark/util/CarbonReflectionUtils.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/util/CarbonReflectionUtils.scala
@@ -52,9 +52,9 @@ object CarbonReflectionUtils {
    * @return
    */
   def getField[T: TypeTag : reflect.ClassTag](name: String, obj: T): Any = {
-    val field = obj.getClass.getDeclaredField(name)
-    field.setAccessible(true)
-    field.get(obj)
+    val im = rm.reflect(obj)
+    im.symbol.typeSignature.members.find(_.name.toString.equals(name))
+      .map(l => im.reflectField(l.asTerm).get).getOrElse(null)
   }
 
   def getUnresolvedRelation(


### PR DESCRIPTION
Problem: Reflection call is taking more time while getting the task context listener.
Solution: Now instead of calling CarbonReflectionUtil.scala added code in CarbonScanRDD

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

