### PR TITLE
[CARBONDATA-2856][BloomDataMap] Fix bug in bloom index on multiple dictionary columns

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
@@ -1843,7 +1843,7 @@ public final class CarbonUtil {
         surrogate ^= data[startOffsetOfData + 3] & 0xFF;
         return surrogate;
       default:
-        throw new IllegalArgumentException("Int cannot me more than 4 bytes");
+        throw new IllegalArgumentException("Int cannot be more than 4 bytes");
     }
   }
   /**

--- a/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomDataMapWriter.java
+++ b/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomDataMapWriter.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import org.apache.carbondata.common.annotations.InterfaceAudience;
 import org.apache.carbondata.core.datamap.Segment;
 import org.apache.carbondata.core.datastore.block.SegmentProperties;
-import org.apache.carbondata.core.keygenerator.KeyGenerator;
 import org.apache.carbondata.core.keygenerator.columnar.ColumnarSplitter;
 import org.apache.carbondata.core.metadata.datatype.DataTypes;
 import org.apache.carbondata.core.metadata.schema.table.column.CarbonColumn;
@@ -43,13 +42,10 @@ import org.apache.commons.collections.Predicate;
  */
 @InterfaceAudience.Internal
 public class BloomDataMapWriter extends AbstractBloomDataMapWriter {
-  private KeyGenerator keyGenerator;
   private ColumnarSplitter columnarSplitter;
   // for the dict/sort/date column, they are encoded in MDK,
   // this maps the index column name to the index in MDK
   private Map<String, Integer> indexCol2MdkIdx;
-  // this gives the reverse map to indexCol2MdkIdx
-  private Map<Integer, String> mdkIdx2IndexCol;
 
   BloomDataMapWriter(String tablePath, String dataMapName, List<CarbonColumn> indexColumns,
       Segment segment, String shardName, SegmentProperties segmentProperties,
@@ -58,10 +54,8 @@ public class BloomDataMapWriter extends AbstractBloomDataMapWriter {
     super(tablePath, dataMapName, indexColumns, segment, shardName, segmentProperties,
         bloomFilterSize, bloomFilterFpp, compressBloom);
 
-    keyGenerator = segmentProperties.getDimensionKeyGenerator();
     columnarSplitter = segmentProperties.getFixedLengthKeySplitter();
     this.indexCol2MdkIdx = new HashMap<>();
-    this.mdkIdx2IndexCol = new HashMap<>();
     int idx = 0;
     for (final CarbonDimension dimension : segmentProperties.getDimensions()) {
       if (!dimension.isGlobalDictionaryEncoding() && !dimension.isDirectDictionaryEncoding()) {
@@ -74,7 +68,6 @@ public class BloomDataMapWriter extends AbstractBloomDataMapWriter {
       });
       if (isExistInIndex) {
         this.indexCol2MdkIdx.put(dimension.getColName(), idx);
-        this.mdkIdx2IndexCol.put(idx, dimension.getColName());
       }
       idx++;
     }
@@ -92,31 +85,10 @@ public class BloomDataMapWriter extends AbstractBloomDataMapWriter {
   protected byte[] convertDictionaryValue(int indexColIdx, Object value) {
     // input value from onPageAdded in load process is byte[]
 
-    // This is used to deal with the multiple global dictionary column as index columns.
-    // The KeyGenerator works with the whole MDK while the value here only represent part of it,
-    // so we need to pad fake bytes to it in corresponding position.
-    int totalSize = 0;
-    for (int size : columnarSplitter.getBlockKeySize()) {
-      totalSize += size;
-    }
-    byte[] fakeMdkBytes = new byte[totalSize];
-
-    // put this bytes to corresponding position
+    // for dict columns including dictionary and date columns decode value to get the surrogate key
     int thisKeyIdx = indexCol2MdkIdx.get(indexColumns.get(indexColIdx).getColName());
-    int destPos = 0;
-    for (int keyIdx = 0; keyIdx < columnarSplitter.getBlockKeySize().length; keyIdx++) {
-      if (thisKeyIdx == keyIdx) {
-        System.arraycopy(value, 0, fakeMdkBytes, destPos,
-            columnarSplitter.getBlockKeySize()[thisKeyIdx]);
-        break;
-      }
-      destPos += columnarSplitter.getBlockKeySize()[keyIdx];
-    }
-
-    // for dict columns including dictionary and date columns
-    // decode value to get the surrogate key
-    int surrogateKey = (int) keyGenerator.getKey(fakeMdkBytes,
-        indexCol2MdkIdx.get(indexColumns.get(indexColIdx).getColName()));
+    int surrogateKey = CarbonUtil.getSurrogateInternal((byte[]) value, 0,
+        columnarSplitter.getBlockKeySize()[thisKeyIdx]);
     // store the dictionary key in bloom
     return CarbonUtil.getValueAsBytes(DataTypes.INT, surrogateKey);
   }

--- a/integration/spark2/src/test/scala/org/apache/carbondata/datamap/bloom/BloomCoarseGrainDataMapFunctionSuite.scala
+++ b/integration/spark2/src/test/scala/org/apache/carbondata/datamap/bloom/BloomCoarseGrainDataMapFunctionSuite.scala
@@ -709,7 +709,7 @@ class BloomCoarseGrainDataMapFunctionSuite  extends QueryTest with BeforeAndAfte
       s"""
          | CREATE TABLE $bloomDMSampleTable(empno string, doj date, salary float)
          | STORED BY 'carbondata'
-         | TBLPROPERTIES('SORT_COLUMNS'='empno,doj', 'DICTIONARY_INCLUDE'='doj')
+         | TBLPROPERTIES('SORT_COLUMNS'='empno,doj', 'DICTIONARY_INCLUDE'='doj,empno')
        """.stripMargin)
     sql(
       s"""


### PR DESCRIPTION
During direct generating bloom index for dictionary and date columns, we
will use MdkKeyGenerator to get the surrogate key. But the
MdkKeyGenerator is for all MDK, so we need to pad fake bytes to mdk.
Finally, the generator will only deal with the real parts of the mdk and
get the final value.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 `NO`
 - [x] Any backward compatibility impacted?
 `NO`
 - [x] Document update required?
`NO`
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
`Test modified to cover this problem`
        - How it is tested? Please attach test report.
`Tested in local machine`
        - Is it a performance related change? Please attach the performance test report.
`NO`
        - Any additional information to help reviewers in testing this change.
      `NA` 
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
`NA`
