### PR TITLE
[CARBONDATA-2858] Fix external table schema bug

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSource.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSource.scala
@@ -324,9 +324,7 @@ object CarbonSource {
       tableDesc.copy(storage = updatedFormat)
     } else {
       val tableInfo = CarbonUtil.convertGsonToTableInfo(properties.asJava)
-      val isExternal = properties.getOrElse("isExternal", "false")
-      val isTransactionalTable = properties.getOrElse("isTransactional", "true")
-        .contains("true")
+      val isTransactionalTable = properties.getOrElse("isTransactional", "true").contains("true")
       tableInfo.setTransactionalTable(isTransactionalTable)
       if (isTransactionalTable && !metaStore.isReadFromHiveMetaStore) {
         CarbonInputFormatUtil.setS3Configurations(sparkSession.sessionState.newHadoopConf())
@@ -351,10 +349,7 @@ object CarbonSource {
       query: Option[LogicalPlan]): Map[String, String] = {
     val model = createTableInfoFromParams(properties, dataSchema, identifier, query, sparkSession)
     val tableInfo: TableInfo = TableNewProcessor(model)
-    val isExternal = properties.getOrElse("isExternal", "false")
-    val isTransactionalTable = properties.getOrElse("isTransactional", "true")
-      .contains("true")
-    val tablePath = properties.getOrElse("path", "")
+    val isTransactionalTable = properties.getOrElse("isTransactional", "true").contains("true")
     tableInfo.setTablePath(identifier.getTablePath)
     tableInfo.setTransactionalTable(isTransactionalTable)
     tableInfo.setDatabaseName(identifier.getDatabaseName)


### PR DESCRIPTION
If user specifies schema in CREATE EXTERNAL TABLE, we should:
1. Validate the schema against the inferred schema from the table path. 
2. Honor the schema specified by the user instead of the inferred schema (full schema)

 - [X] Any interfaces changed?
 No
 - [X] Any backward compatibility impacted?
 No
 - [X] Document update required?
No
 - [X] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
  two test case added  
 - [X] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA