### PR TITLE
[CARBONDATA-2862][DataMap] Fix exception message for datamap rebuild command

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/datamap/CarbonDataMapRebuildCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/datamap/CarbonDataMapRebuildCommand.scala
@@ -41,8 +41,13 @@ case class CarbonDataMapRebuildCommand(
       .asScala
       .find(p => p.getDataMapName.equalsIgnoreCase(dataMapName))
     if (schemaOption.isEmpty) {
-      throw new MalformedDataMapCommandException(
-        s"Datamap with name $dataMapName does not exist on table ${tableIdentifier.get.table}")
+      if (tableIdentifier.isDefined) {
+        throw new MalformedDataMapCommandException(
+          s"Datamap with name $dataMapName does not exist on table ${tableIdentifier.get.table}")
+      } else {
+        throw new MalformedDataMapCommandException(
+          s"Datamap with name $dataMapName does not exist on any table")
+      }
     }
     val schema = schemaOption.get
     if (!schema.isLazy) {


### PR DESCRIPTION
Since datamap rebuild command support execute without specify table name, and it will scan all datamap instead, so error message has no need to get table name, else will get exception. This PR modify the error message to show detail table name on demand.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

