### PR TITLE
[CARBONDATA-2819] Fixed cannot drop preagg datamap on table which has other type datamaps

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggregateDrop.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggregateDrop.scala
@@ -129,6 +129,38 @@ class TestPreAggregateDrop extends QueryTest with BeforeAndAfterAll {
     assert(e.getMessage.contains("Table or view 'maintable' not found in"))
   }
 
+  test("drop preaggregate datamap whose main table has other type datamaps") {
+    sql("drop table if exists maintable")
+    sql("create table maintable (a string, b string, c string) stored by 'carbondata'")
+    sql(
+      "create datamap bloom1 on table maintable using 'bloomfilter'" +
+      " dmproperties('index_columns'='a')")
+    sql(
+      "create datamap preagg1 on table maintable using 'preaggregate' as select" +
+      " a,sum(b) from maintable group by a")
+    sql("drop datamap if exists bloom1 on table maintable")
+    sql("drop datamap if exists preagg1 on table maintable")
+    checkExistence(sql("SHOW DATAMAP ON TABLE maintable"), false, "preagg1", "bloom1")
+    sql(
+      "create datamap bloom1 on table maintable using 'bloomfilter'" +
+      " dmproperties('index_columns'='a')")
+    sql(
+      "create datamap preagg1 on table maintable using 'preaggregate' as select" +
+      " a,sum(b) from maintable group by a")
+    sql("drop datamap if exists preagg1 on table maintable")
+    sql("drop datamap if exists bloom1 on table maintable")
+    checkExistence(sql("SHOW DATAMAP ON TABLE maintable"), false, "preagg1", "bloom1")
+    sql(
+      "create datamap bloom1 on table maintable using 'bloomfilter'" +
+      " dmproperties('index_columns'='a')")
+    sql(
+      "create datamap preagg1 on table maintable using 'preaggregate' as select" +
+      " a,sum(b) from maintable group by a")
+    sql("drop table if exists maintable")
+    checkExistence(sql("show tables"), false, "maintable_preagg1", "maintable")
+    checkExistence(sql("show datamap"), false, "preagg1", "bloom1")
+  }
+
   override def afterAll() {
     sql("drop table if exists maintable")
     sql("drop table if exists maintable1")


### PR DESCRIPTION
As we know, carbon now write preagg datamap info to main table schema and write other type datamap info like bloom or lucene to .dmschema file in _system folder. When dropping datamap, we should both check the .dmschema files and main table info if has the datamap which to be deleted. 

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
       No
 - [x] Any backward compatibility impacted?
       No
 - [x] Document update required?
       No
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       add test case
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
        NA
