### PR TITLE
[CARBONDATA-2874] Support SDK writer as thread safe api

### DIFF
--- a/docs/sdk-guide.md
+++ b/docs/sdk-guide.md
@@ -390,7 +390,6 @@ public JsonCarbonWriter buildWriterForJsonInput(Schema carbonSchema);
 *                      which is one row of data.
 * If CSVCarbonWriter, object is of type String[], which is one row of data
 * If JsonCarbonWriter, object is of type String, which is one row of json
-* Note: This API is not thread safe
 * @param object
 * @throws IOException
 */

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/iterator/CarbonOutputIteratorWrapper.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/iterator/CarbonOutputIteratorWrapper.java
@@ -45,7 +45,7 @@ public class CarbonOutputIteratorWrapper extends CarbonIterator<Object[]> {
 
   private RowBatch readBatch;
 
-  private static Object lockObject = new Object();
+  private static final Object lockObject = new Object();
   private ArrayBlockingQueue<RowBatch> queue = new ArrayBlockingQueue<>(10);
 
   public void write(Object[] row) throws InterruptedException {

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/iterator/CarbonOutputIteratorWrapper.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/iterator/CarbonOutputIteratorWrapper.java
@@ -52,10 +52,12 @@ public class CarbonOutputIteratorWrapper extends CarbonIterator<Object[]> {
       // already might be closed forcefully
       return;
     }
-    if (!loadBatch.addRow(row)) {
-      loadBatch.readyRead();
-      queue.put(loadBatch);
-      loadBatch = new RowBatch(batchSize);
+    synchronized (this) {
+      if (!loadBatch.addRow(row)) {
+        loadBatch.readyRead();
+        queue.put(loadBatch);
+        loadBatch = new RowBatch(batchSize);
+      }
     }
   }
 

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/iterator/CarbonOutputIteratorWrapper.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/iterator/CarbonOutputIteratorWrapper.java
@@ -45,6 +45,7 @@ public class CarbonOutputIteratorWrapper extends CarbonIterator<Object[]> {
 
   private RowBatch readBatch;
 
+  private static Object lockObject = new Object();
   private ArrayBlockingQueue<RowBatch> queue = new ArrayBlockingQueue<>(10);
 
   public void write(Object[] row) throws InterruptedException {
@@ -52,7 +53,7 @@ public class CarbonOutputIteratorWrapper extends CarbonIterator<Object[]> {
       // already might be closed forcefully
       return;
     }
-    synchronized (this) {
+    synchronized (lockObject) {
       if (!loadBatch.addRow(row)) {
         loadBatch.readyRead();
         queue.put(loadBatch);

--- a/store/sdk/src/test/java/org/apache/carbondata/sdk/file/ConcurrentSdkWriterTest.java
+++ b/store/sdk/src/test/java/org/apache/carbondata/sdk/file/ConcurrentSdkWriterTest.java
@@ -50,13 +50,14 @@ public class ConcurrentSdkWriterTest {
       CarbonWriter writer = builder.buildWriterForCSVInput(new Schema(fields));
       // write in multi-thread
       for (int i = 0; i < poolSize; i++) {
-        executorService.submit(new writeLogic(writer));
+        executorService.submit(new WriteLogic(writer));
       }
       executorService.shutdown();
       executorService.awaitTermination(2, TimeUnit.HOURS);
       writer.close();
     } catch (Exception e) {
       e.printStackTrace();
+      Assert.fail(e.getMessage());
     }
 
     // read the files and verify the count
@@ -74,15 +75,16 @@ public class ConcurrentSdkWriterTest {
       reader.close();
     } catch (InterruptedException e) {
       e.printStackTrace();
+      Assert.fail(e.getMessage());
     }
 
     FileUtils.deleteDirectory(new File(path));
   }
 
-  class writeLogic implements Runnable {
+  class WriteLogic implements Runnable {
     CarbonWriter writer;
 
-    writeLogic(CarbonWriter writer) {
+    WriteLogic(CarbonWriter writer) {
       this.writer = writer;
     }
 
@@ -95,6 +97,7 @@ public class ConcurrentSdkWriterTest {
         }
       } catch (IOException e) {
         e.printStackTrace();
+        Assert.fail(e.getMessage());
       }
     }
   }

--- a/store/sdk/src/test/java/org/apache/carbondata/sdk/file/ConcurrentSdkWriterTest.java
+++ b/store/sdk/src/test/java/org/apache/carbondata/sdk/file/ConcurrentSdkWriterTest.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.sdk.file;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.carbondata.core.metadata.datatype.DataTypes;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * multi-thread Test suite for {@link CSVCarbonWriter}
+ */
+public class ConcurrentSdkWriterTest {
+
+  @Test public void testWriteFiles() throws IOException {
+    String path = "./testWriteFiles";
+    FileUtils.deleteDirectory(new File(path));
+
+    Field[] fields = new Field[2];
+    fields[0] = new Field("name", DataTypes.STRING);
+    fields[1] = new Field("age", DataTypes.INT);
+
+    int poolSize = 6;
+    ExecutorService executorService = Executors.newFixedThreadPool(poolSize);
+    try {
+      CarbonWriterBuilder builder =
+          CarbonWriter.builder().outputPath(path).uniqueIdentifier(555).taskNo(123);
+      CarbonWriter writer = builder.buildWriterForCSVInput(new Schema(fields));
+      // write in multi-thread
+      for (int i = 0; i < poolSize; i++) {
+        executorService.submit(new writeLogic(writer));
+      }
+      executorService.shutdown();
+      executorService.awaitTermination(2, TimeUnit.HOURS);
+      writer.close();
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+
+    // read the files and verify the count
+    CarbonReader reader;
+    try {
+      reader =
+          CarbonReader.builder(path, "_temp").projection(new String[] { "name", "age" }).build();
+      int i = 0;
+      while (reader.hasNext()) {
+        Object[] row = (Object[]) reader.readNextRow();
+        i++;
+      }
+      // count should be 60 records
+      Assert.assertEquals(i, 60);
+      reader.close();
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+
+    FileUtils.deleteDirectory(new File(path));
+  }
+
+  class writeLogic implements Runnable {
+    CarbonWriter writer;
+
+    writeLogic(CarbonWriter writer) {
+      this.writer = writer;
+    }
+
+    @Override public void run() {
+
+      try {
+        for (int i = 0; i < 10; i++) {
+          writer.write(new String[] { "robot" + (i % 10), String.valueOf(i),
+              String.valueOf((double) i / 2) });
+        }
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Problem: Currently CarbonWriter.write() not a thread safe. if multiple threads calls .write() for one writer.
Data count inconsistency is observed.

root casue: As all the threads are writing to same batch of blocking queue. need to synchronize this. Else one thread data overwrite the other thread data.

Solution: Synchronize the write() method.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed? NA
 
 - [ ] Any backward compatibility impacted? NA
 
 - [ ] Document update required? NA

 - [ ] Testing done. NA
        
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.  NA

