### PR TITLE
[CARBONDATA-2562][ExternalFormat] Support build file leve index for external format table

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/DataMapSchema.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/DataMapSchema.java
@@ -236,7 +236,7 @@ public class DataMapSchema implements Serializable, Writable {
     } else if (StringUtils.isBlank(columns)) {
       throw new MalformedDataMapCommandException(INDEX_COLUMNS + " DMPROPERTY is blank");
     } else {
-      return columns.split(",", -1);
+      return StringUtils.stripAll(columns.split(",", -1));
     }
   }
 

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/externalformat/CsvBasedCarbonTableSuite.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/externalformat/CsvBasedCarbonTableSuite.scala
@@ -24,6 +24,7 @@ import org.apache.spark.sql.test.util.QueryTest
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants
+import org.apache.carbondata.core.datastore.impl.FileFactory
 import org.apache.carbondata.core.statusmanager.SegmentStatusManager
 import org.apache.carbondata.core.util.CarbonProperties
 import org.apache.carbondata.core.util.path.CarbonTablePath
@@ -121,7 +122,7 @@ class CsvBasedCarbonTableSuite extends QueryTest
     val metadataPath = CarbonTablePath.getMetadataPath(tblInfo.getTablePath)
     val details = SegmentStatusManager.readLoadMetadata(metadataPath)
     assertResult(1)(details.length)
-    assertResult(csvFile)(details(0).getFactFilePath)
+    assertResult(FileFactory.getCarbonFile(csvFile).getAbsolutePath)(details(0).getFactFilePath)
 
     CarbonProperties.getInstance().addProperty(CarbonCommonConstants.ENABLE_VECTOR_READER, "true")
     // check query on csv based carbontable

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/externalformat/CsvExternalFormatWithIndexDataMapSuite.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/externalformat/CsvExternalFormatWithIndexDataMapSuite.scala
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.spark.testsuite.externalformat
+
+
+import org.apache.spark.sql.test.util.QueryTest
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
+
+import org.apache.carbondata.core.constants.CarbonCommonConstants
+import org.apache.carbondata.core.util.CarbonProperties
+
+class CsvExternalFormatWithIndexDataMapSuite extends QueryTest
+  with BeforeAndAfterEach with BeforeAndAfterAll {
+  val carbonTable = "fact_carbon_table"
+  val csvCarbonTable = "fact_carbon_csv_table"
+  val indexOnCsvCarbonTablePrefix = "index_on_fact_csv_"
+  val csvFile = s"$resourcesPath/datawithoutheader.csv"
+
+  private def createNormalTableForComparison(): Unit = {
+    sql(
+      s"""
+         | CREATE TABLE $carbonTable(empno smallint, empname String, designation string,
+         | doj String, workgroupcategory int, workgroupcategoryname String,deptno int,
+         | deptname String, projectcode int, projectjoindate String,projectenddate String,
+         | attendance String, utilization String,salary String)
+         | STORED BY 'carbondata'
+       """.stripMargin
+    )
+  }
+
+  private def loadNormalTableForComparison(): Unit = {
+    sql(
+      s"""
+         | LOAD DATA LOCAL INPATH '$csvFile' INTO TABLE $carbonTable
+         | OPTIONS('DELIMITER'=',',
+         | 'QUOTECHAR'='\"',
+         | 'FILEHEADER'='EMPno, empname,designation, doj, workgroupcategory, workgroupcategoryname, deptno, deptname, projectcode, projectjoindate, projectenddate, attendance, utilization, SALARY')
+        """.stripMargin)
+  }
+
+  override protected def afterAll(): Unit = {
+    sql(s"DROP TABLE IF EXISTS $carbonTable")
+    sql(s"DROP TABLE IF EXISTS $csvCarbonTable")
+  }
+
+  override protected def beforeEach(): Unit = {
+    sql(s"DROP TABLE IF EXISTS $carbonTable")
+    sql(s"DROP TABLE IF EXISTS $csvCarbonTable")
+  }
+
+  override protected def afterEach(): Unit = {
+    sql(s"DROP TABLE IF EXISTS $carbonTable")
+    sql(s"DROP TABLE IF EXISTS $csvCarbonTable")
+  }
+
+  private def checkQuery() {
+    // query all the columns
+    checkAnswer(sql(s"SELECT eMPno, empname,designation, doj, workgroupcategory, workgroupcategoryname, deptno, deptname, projectcode, projectjoindate, projectenddate, attendance, utilization, SALARY FROM $csvCarbonTable WHERE empno = 15"),
+      sql(s"SELECT eMPno, empname,designation, doj, workgroupcategory, workgroupcategoryname, deptno, deptname, projectcode, projectjoindate, projectenddate, attendance, utilization, SALARY FROM $carbonTable WHERE empno = 15"))
+    // query part of the columns
+    checkAnswer(sql(s"SELECT empno,empname, deptname, doj FROM $csvCarbonTable WHERE empno = 15"),
+      sql(s"SELECT empno,empname, deptname, doj FROM $carbonTable WHERE empno = 15"))
+    // sequence of projection column are not same with that in DDL
+    checkAnswer(sql(s"SELECT empname, empno, deptname, doj FROM $csvCarbonTable WHERE empno = 15"),
+      sql(s"SELECT empname, empno, deptname, doj FROM $carbonTable WHERE empno = 15"))
+    // query with greater
+    checkAnswer(sql(s"SELECT empname, empno, deptname, doj FROM $csvCarbonTable WHERE empno > 15"),
+      sql(s"SELECT empname, empno, deptname, doj FROM $carbonTable WHERE empno > 15"))
+    // query with filter on dimension
+    checkAnswer(sql(s"SELECT empname, empno, deptname, doj FROM $csvCarbonTable WHERE empname = 'ayushi'"),
+      sql(s"SELECT empname, empno, deptname, doj FROM $carbonTable WHERE empname = 'ayushi'"))
+    // aggreate query
+    checkAnswer(sql(s"SELECT designation, sum(empno), avg(empno) FROM $csvCarbonTable GROUP BY designation"),
+      sql(s"SELECT designation, sum(empno), avg(empno) FROM $carbonTable GROUP BY designation"))
+  }
+
+  test("building and rebuilding bloomfilter datamap on CSV external format table") {
+    createNormalTableForComparison()
+    sql(
+      s"""
+         | CREATE TABLE $csvCarbonTable(empno smallint, empname String, designation string,
+         | doj String, workgroupcategory int, workgroupcategoryname String,deptno int,
+         | deptname String, projectcode int, projectjoindate String,projectenddate String,
+         | attendance String, utilization String,salary String)
+         | STORED BY 'carbondata'
+         | TBLPROPERTIES(
+         | 'format'='csv',
+         | 'csv.header'='eMPno, empname,designation, doj, workgroupcategory, workgroupcategoryname, deptno, deptname, projectcode, projectjoindate, projectenddate, attendance, utilization, SALARY'
+         | )
+       """.stripMargin
+    )
+
+    loadNormalTableForComparison()
+    loadNormalTableForComparison()
+    sql(s"ALTER TABLE $csvCarbonTable ADD SEGMENT LOCATION '$csvFile'")
+    sql(s"ALTER TABLE $csvCarbonTable ADD SEGMENT LOCATION '$csvFile'")
+    // create index datamap on external format table, this will trigger rebuiding datamap on existing data
+    sql(
+      s"""
+         | CREATE DATAMAP ${indexOnCsvCarbonTablePrefix}1
+         | ON TABLE $csvCarbonTable
+         | USING 'bloomfilter'
+         | DMPROPERTIES(
+         | 'INDEX_COLUMNS'='empname,empno'
+         | )
+       """.stripMargin)
+    sql(
+      s"""
+         | CREATE DATAMAP ${indexOnCsvCarbonTablePrefix}2
+         | ON TABLE $csvCarbonTable
+         | USING 'bloomfilter'
+         | DMPROPERTIES(
+         | 'INDEX_COLUMNS'='deptno,designation, doj, workgroupcategory, workgroupcategoryname'
+         | )
+       """.stripMargin)
+    sql(
+      s"""
+         | CREATE DATAMAP ${indexOnCsvCarbonTablePrefix}3
+         | ON TABLE $csvCarbonTable
+         | USING 'bloomfilter'
+         | DMPROPERTIES(
+         | 'INDEX_COLUMNS'='projectcode'
+         | )
+       """.stripMargin)
+    checkExistence(sql(s"SHOW DATAMAP ON TABLE $csvCarbonTable"), true,
+      s"${indexOnCsvCarbonTablePrefix}1", s"${indexOnCsvCarbonTablePrefix}2", s"${indexOnCsvCarbonTablePrefix}3")
+
+    loadNormalTableForComparison()
+    loadNormalTableForComparison()
+    // add segment for csv based carbontable, this will trigger direct building datamap
+    sql(s"ALTER TABLE $csvCarbonTable ADD SEGMENT LOCATION '$csvFile'")
+    sql(s"ALTER TABLE $csvCarbonTable ADD SEGMENT LOCATION '$csvFile'")
+
+    assert(sql(s"SHOW SEGMENTS FOR TABLE $csvCarbonTable").collect().length == sql(s"SHOW SEGMENTS FOR TABLE $csvCarbonTable").collect().length)
+
+    // note that currently the query does not use datamap yet
+    CarbonProperties.getInstance().addProperty(CarbonCommonConstants.ENABLE_VECTOR_READER, "false")
+    checkQuery()
+    CarbonProperties.getInstance().addProperty(CarbonCommonConstants.ENABLE_VECTOR_READER, "true")
+    checkQuery()
+    CarbonProperties.getInstance().addProperty(CarbonCommonConstants.ENABLE_VECTOR_READER,
+      CarbonCommonConstants.ENABLE_VECTOR_READER_DEFAULT)
+  }
+
+}

--- a/integration/spark-common/src/main/java/org/apache/carbondata/spark/format/CsvToCarbonReadSupport.java
+++ b/integration/spark-common/src/main/java/org/apache/carbondata/spark/format/CsvToCarbonReadSupport.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.spark.format;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.carbondata.common.annotations.InterfaceAudience;
+import org.apache.carbondata.common.annotations.InterfaceStability;
+import org.apache.carbondata.core.constants.CarbonCommonConstants;
+import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
+import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
+import org.apache.carbondata.core.metadata.schema.table.column.CarbonColumn;
+import org.apache.carbondata.core.util.CarbonProperties;
+import org.apache.carbondata.hadoop.readsupport.CarbonReadSupport;
+import org.apache.carbondata.processing.loading.DataField;
+import org.apache.carbondata.processing.loading.converter.BadRecordLogHolder;
+import org.apache.carbondata.processing.loading.converter.FieldConverter;
+import org.apache.carbondata.processing.loading.converter.impl.FieldEncoderFactory;
+
+/**
+ * read support for csv, it will convert csv data to carbon converted values.
+ */
+@InterfaceStability.Evolving
+@InterfaceAudience.Internal
+public class CsvToCarbonReadSupport<T> implements CarbonReadSupport<T> {
+  private CarbonColumn[] carbonColumns;
+  private FieldConverter[] fieldConverters;
+  private BadRecordLogHolder badRecordLogHolder;
+  private Object[] finalOutputValues;
+
+  @Override
+  public void initialize(CarbonColumn[] carbonColumns, CarbonTable carbonTable)
+      throws IOException {
+    this.carbonColumns = carbonColumns;
+    this.finalOutputValues = new Object[carbonColumns.length];
+    this.initFieldConverters(carbonTable);
+  }
+
+  private void initFieldConverters(CarbonTable carbonTable) throws IOException {
+    AbsoluteTableIdentifier absoluteTableIdentifier = AbsoluteTableIdentifier.from(
+        carbonTable.getTablePath(), carbonTable.getCarbonTableIdentifier());
+    String nullFormat = "\\N";
+    Map<Object, Integer>[] localCaches = new Map[carbonColumns.length];
+    this.fieldConverters = new FieldConverter[carbonColumns.length];
+
+    for (int i = 0; i < carbonColumns.length; i++) {
+      localCaches[i] = new ConcurrentHashMap<>();
+      DataField dataField = new DataField(carbonColumns[i]);
+      String dateFormat = CarbonProperties.getInstance().getProperty(
+          CarbonCommonConstants.CARBON_DATE_FORMAT,
+          CarbonCommonConstants.CARBON_DATE_DEFAULT_FORMAT);
+      dataField.setDateFormat(dateFormat);
+      String tsFormat = CarbonProperties.getInstance().getProperty(
+          CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT,
+          CarbonCommonConstants.CARBON_TIMESTAMP_DEFAULT_FORMAT);
+      dataField.setTimestampFormat(tsFormat);
+      FieldConverter fieldConverter = FieldEncoderFactory.getInstance()
+          .createFieldEncoder(dataField, absoluteTableIdentifier, i, nullFormat, null, false,
+              localCaches[i], false, "");
+      this.fieldConverters[i] = fieldConverter;
+    }
+
+    this.badRecordLogHolder = new BadRecordLogHolder();
+    this.badRecordLogHolder.setLogged(false);
+  }
+
+  @Override
+  public T readRow(Object[] data) {
+    for (int i = 0; i < carbonColumns.length; i++) {
+      Object originValue = data[i];
+      finalOutputValues[i] = fieldConverters[i].convert(originValue, badRecordLogHolder);
+    }
+    return (T) finalOutputValues;
+  }
+
+  @Override
+  public void close() {
+    for (int i = 0; i < fieldConverters.length; i++) {
+      fieldConverters[i].clear();
+    }
+  }
+}

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/KeyVal.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/KeyVal.scala
@@ -143,7 +143,8 @@ class RestructureResultImpl extends RestructureResult[Int, Boolean] {
 trait RefreshResult[K, V] extends Serializable {
   /**
    * Previously index datamap refresh is per segment, for CARBONDATA-2685 it will refresh
-   * all segments in a batch. The structure is taskNo -> (segmentNo, status)
+   * all segments in a batch. The structure is taskNo -> (segmentNo, status).
+   * While for file-leve index, the structure is segmentNo -> (factFilePath, status)
    */
   def getKey(key: String, value: (String, Boolean)): (K, V)
 }

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/FileLevelDataMapBuildRdd.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/FileLevelDataMapBuildRdd.scala
@@ -1,0 +1,316 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.spark.rdd
+
+import java.io.IOException
+import java.text.SimpleDateFormat
+import java.util
+import java.util.Date
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+import org.apache.hadoop.mapred.TaskAttemptID
+import org.apache.hadoop.mapreduce.{RecordReader, TaskType}
+import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl
+import org.apache.spark.{Partition, TaskContext}
+import org.apache.spark.sql.SparkSession
+
+import org.apache.carbondata.common.logging.LogServiceFactory
+import org.apache.carbondata.core.constants.CarbonCommonConstants
+import org.apache.carbondata.core.datamap.{DataMapStoreManager, Segment}
+import org.apache.carbondata.core.datamap.dev.DataMapBuilder
+import org.apache.carbondata.core.datastore.impl.FileFactory
+import org.apache.carbondata.core.metadata.schema.table.{CarbonTable, DataMapSchema, TableInfo}
+import org.apache.carbondata.core.statusmanager.{FileFormat, SegmentStatusManager}
+import org.apache.carbondata.core.util.CarbonUtil
+import org.apache.carbondata.core.util.path.CarbonTablePath
+import org.apache.carbondata.events.{BuildDataMapPostExecutionEvent, BuildDataMapPreExecutionEvent, OperationContext, OperationListenerBus}
+import org.apache.carbondata.hadoop.{CarbonInputSplit, CarbonMultiBlockSplit, CsvRecordReader}
+import org.apache.carbondata.hadoop.api.{CarbonInputFormat, CarbonTableInputFormat}
+import org.apache.carbondata.spark.{RefreshResult, RefreshResultImpl}
+import org.apache.carbondata.spark.format.CsvToCarbonReadSupport
+import org.apache.carbondata.spark.util.SparkDataTypeConverterImpl
+
+object FileLevelDataMapBuildRdd {
+  private val LOGGER = LogServiceFactory.getLogService(this.getClass.getName)
+
+  /**
+   * for directly building datamap in a data loading procedure
+   */
+  def directlyBuildDataMap(
+      sparkSession: SparkSession,
+      carbonTable: CarbonTable,
+      segment: Segment,
+      factFilePath: String,
+      dmSchemas: List[DataMapSchema]): Unit = {
+    val segment2FactFilePath = new util.HashMap[Segment, String]()
+    segment2FactFilePath.put(segment, factFilePath)
+    buildDataMapInternal(sparkSession, carbonTable, segment2FactFilePath, dmSchemas)
+  }
+
+  /**
+   * for building datamap on existed data
+   */
+  def buildDataMapOnExistedTable(
+      sparkSession: SparkSession,
+      carbonTable: CarbonTable,
+      dmSchemas: java.util.List[DataMapSchema]): Unit = {
+    val validSegments = new SegmentStatusManager(carbonTable.getAbsoluteTableIdentifier)
+      .getValidAndInvalidSegments().getValidSegments.asScala
+    val segment2FactFilePath = new util.HashMap[Segment, String]()
+    validSegments.foreach { p =>
+      segment2FactFilePath.put(p, p.getLoadMetadataDetails.getFactFilePath)
+    }
+    buildDataMapInternal(sparkSession, carbonTable, segment2FactFilePath, dmSchemas.asScala.toList)
+  }
+
+  /**
+   * build specified datamap for specified segment
+   * @param segment2FactFilePath fact files for corresponding segment
+   */
+  private def buildDataMapInternal(
+      sparkSession: SparkSession,
+      carbonTable: CarbonTable,
+      segment2FactFilePath: java.util.Map[Segment, String],
+      dmSchemas: List[DataMapSchema]): Unit = {
+    LOGGER.error(s"building datamap" +
+                 s" ${ dmSchemas.map(p => p.getDataMapName).mkString(", ") }" +
+                 s" for table ${ carbonTable.getDatabaseName }.${ carbonTable.getTableName }")
+    val operationContext = new OperationContext()
+    dmSchemas.foreach { dmSchema =>
+      val buildDataMapPreExecutionEvent = BuildDataMapPreExecutionEvent(sparkSession,
+        carbonTable.getAbsoluteTableIdentifier,
+        mutable.Seq[String](dmSchema.getDataMapName))
+      OperationListenerBus.getInstance().fireEvent(buildDataMapPreExecutionEvent, operationContext)
+    }
+
+    def firePostEvent(): Unit = {
+      dmSchemas.foreach { dmSchema =>
+        val buildDataMapPostExecutionEvent = BuildDataMapPostExecutionEvent(sparkSession,
+          carbonTable.getAbsoluteTableIdentifier)
+        OperationListenerBus.getInstance().fireEvent(buildDataMapPostExecutionEvent,
+          operationContext)
+      }
+    }
+
+    // segment -> (dmName, dmStorePath)
+    val segment2DmPath = segment2FactFilePath.asScala.keySet.map { segment =>
+      val dm2StorePath = dmSchemas.map { dmSchema =>
+        val dmStorePath = CarbonTablePath.getDataMapStorePath(carbonTable.getTablePath,
+          segment.getSegmentNo, dmSchema.getDataMapName)
+       dmSchema.getDataMapName -> dmStorePath
+      }.filter(p => !FileFactory.isFileExist(p._2)).toMap
+      segment.getSegmentNo -> dm2StorePath
+    }.toMap
+
+    segment2DmPath.foreach { p =>
+      p._2.values.foreach { dmPath =>
+        if (!FileFactory.mkdirs(dmPath, FileFactory.getFileType(dmPath))) {
+          firePostEvent()
+          throw new IOException(
+            s"Failed to create directory $dmPath for building datamap ${p._1}")
+        }
+      }
+    }
+
+    val status = new FileLevelDataMapBuildRdd[String, (String, Boolean)](
+      sparkSession,
+      new RefreshResultImpl(),
+      segment2FactFilePath,
+      dmSchemas,
+      carbonTable.getTableInfo
+    ).collect()
+
+    val failedSegments = status
+      .filter { case (segmentId, (filePath, buildStatus)) =>
+        !buildStatus
+      }
+      .map { case (segmentId, _) =>
+        val dmPath = segment2DmPath.apply(segmentId).values
+        val cleanResult = dmPath.map(p =>
+          FileFactory.deleteAllCarbonFilesOfDir(FileFactory.getCarbonFile(p)))
+        if (cleanResult.exists(!_)) {
+          LOGGER.error(s"Failed to clean up datamap store for segment_$segmentId")
+          false
+        } else {
+          true
+        }
+      }
+
+    firePostEvent()
+
+    if (failedSegments.nonEmpty) {
+      val msg = s"Failed to build all datamaps for table" +
+                s" ${carbonTable.getDatabaseName}.${carbonTable.getTableName}"
+      if (failedSegments.exists(!_)) {
+        throw new Exception(s"$msg and clean up failed.")
+      } else {
+        throw new Exception(s"$msg and clean up successfully.")
+      }
+    }
+  }
+}
+
+class FileLevelDataMapBuildRdd[K, V](
+    sparkSession: SparkSession,
+    result: RefreshResult[K, V],
+    segment2FactFilePath: java.util.Map[Segment, String],
+    dmSchemas: List[DataMapSchema],
+    @transient tableInfo: TableInfo) extends CarbonRDDWithTableInfo[(K, V)](
+  sparkSession.sparkContext, Nil, tableInfo.serialize()) {
+  val FILE_LEVEL_INDEX_SHARD_PREFIX: String = "FileLevel_"
+
+  private val jobTrackerId: String = {
+    val formatter = new SimpleDateFormat("yyyyMMddHHmm")
+    formatter.format(new Date())
+  }
+
+  private val storageFormat = tableInfo.getFormat
+
+  /**
+   * each segment each fact file is a partition
+   */
+  override def getPartitions: Array[Partition] = {
+    segment2FactFilePath.asScala
+      .flatMap { case (segment, filePathStr) =>
+        filePathStr.split(",")
+          .map { filePath =>
+            val carbonFile = FileFactory.getCarbonFile(filePath)
+            val split = new CarbonInputSplit(segment.getSegmentNo,
+              new Path(carbonFile.getPath),
+              0,
+              carbonFile.getSize,
+              carbonFile.getLocations,
+              carbonFile.getLocations,
+              FileFormat.EXTERNAL)
+            new CarbonMultiBlockSplit(Seq(split).asJava, carbonFile.getLocations)
+          }
+      }
+      .zipWithIndex
+      .map(split => new CarbonSparkPartition(id, split._2, split._1))
+      .toArray
+  }
+
+  override def internalCompute(split: Partition,
+      context: TaskContext): Iterator[(K, V)] = {
+    val LOGGER = LogServiceFactory.getLogService(this.getClass.getName)
+    val carbonTable = CarbonTable.buildFromTableInfo(getTableInfo)
+    var status = false
+
+    val inputSplit = split.asInstanceOf[CarbonSparkPartition].split.value
+    val inputFilePath = inputSplit.getAllSplits.get(0).getPath.toString
+
+    val segmentId = inputSplit.getAllSplits.get(0).getSegment.getSegmentNo
+    LOGGER.error(s"processing segment_$segmentId with file path: $inputFilePath}")
+    val segment = segment2FactFilePath.keySet().asScala.find(p => p.getSegmentNo.equals(segmentId))
+    if (segment.isDefined) {
+      val attemptId = new TaskAttemptID(jobTrackerId, id, TaskType.MAP, split.index, 0)
+      val attemptContext = new TaskAttemptContextImpl(new Configuration(), attemptId)
+      attemptContext.getConfiguration.set(
+        CarbonCommonConstants.CARBON_EXTERNAL_FORMAT_CONF_KEY, storageFormat)
+
+      var dataMapbuilders: Seq[DataMapBuilder] = null
+      var recordReader: RecordReader[Void, Object] = null
+      try {
+        dataMapbuilders = dmSchemas.map { dmSchema =>
+          val dmFactory =
+            DataMapStoreManager.getInstance().getDataMapFactoryClass(carbonTable, dmSchema)
+          // the name of the shard here is base64 encoded fact file path
+          val builder = dmFactory.createBuilder(segment.get,
+            FILE_LEVEL_INDEX_SHARD_PREFIX + CarbonUtil.encodeToString(inputFilePath.getBytes), null)
+          builder.initialize()
+          builder
+        }
+
+        val allIndexColumns = dmSchemas.flatten(p => p.getIndexColumns).distinct.toArray
+        val format = prepareInputFormat(attemptContext.getConfiguration, allIndexColumns)
+        recordReader = format.createRecordReader(inputSplit, attemptContext)
+        recordReader.asInstanceOf[CsvRecordReader[Object]].setVectorReader(false)
+        // here we will convert raw value from file to carbon,
+        // so that we can reuse the query procedure of the datamap
+        recordReader.asInstanceOf[CsvRecordReader[Object]].setReadSupport(
+          new CsvToCarbonReadSupport[Object])
+
+        recordReader.initialize(inputSplit, attemptContext)
+
+        // since the return  here contains all the index columns from all the datamaps,
+        // we need to pick exactly the same columns as the datamap wanted, so here we will get the
+        // column index among all the columns for each datamap.
+        // Also we want to reuse the tmp row for each datamap during processing,
+        // so here we allocate the space ahead and will reuse it later.
+        val col2Idx = allIndexColumns.zipWithIndex.toMap
+        val dmColIndicesAndTmpRowPair = dmSchemas.indices.map { dmIdx =>
+          val indice = dmSchemas(dmIdx).getIndexColumns.map(col => col2Idx(col))
+          val tmpRow = new Array[Object](indice.length)
+          (indice, tmpRow)
+        }
+
+        while (recordReader.nextKeyValue()) {
+          val row = recordReader.getCurrentValue.asInstanceOf[Array[Object]]
+          // pick corresponding values for the index columns
+          dmSchemas.indices.foreach { dmIdx =>
+            val dmColIdxArray = dmColIndicesAndTmpRowPair(dmIdx)._1
+            val builder = dataMapbuilders(dmIdx)
+            val tmpRow = dmColIndicesAndTmpRowPair(dmIdx)._2
+            tmpRow.indices.foreach { idx =>
+              tmpRow(idx) = row(dmColIdxArray(idx))
+            }
+            // we do not have and care about the block/blocklet/page id here
+            builder.addRow(0, 0, 0, tmpRow)
+          }
+        }
+
+        dataMapbuilders.foreach(_.finish())
+        status = true
+      } finally {
+        CarbonUtil.closeStream(recordReader)
+        dataMapbuilders.filter(null != _).foreach(_.close())
+      }
+    }
+
+    new Iterator[(K, V)] {
+      var finished = false
+      override def hasNext: Boolean = {
+        !finished
+      }
+
+      override def next(): (K, V) = {
+        finished = true
+        result.getKey(segmentId, (inputFilePath, status))
+      }
+    }
+  }
+
+  private def prepareInputFormat(conf: Configuration,
+      projectionCols: Array[String]): CarbonInputFormat[Object] = {
+    val format: CarbonInputFormat[Object] = new CarbonTableInputFormat[Object]
+
+    CarbonInputFormat.setTableInfo(conf, getTableInfo)
+    CarbonInputFormat.setDatabaseName(conf, getTableInfo.getDatabaseName)
+    CarbonInputFormat.setTableName(conf, getTableInfo.getFactTable.getTableName)
+    CarbonInputFormat.setDataTypeConverter(conf, classOf[SparkDataTypeConverterImpl])
+    val identifier = getTableInfo.getOrCreateAbsoluteTableIdentifier()
+    CarbonInputFormat.setTablePath(conf, identifier.appendWithLocalPrefix(identifier.getTablePath))
+    CarbonInputFormat.setColumnProjection(conf, projectionCols)
+
+    format
+  }
+}

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchemaCommon.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchemaCommon.scala
@@ -22,9 +22,7 @@ import java.util.UUID
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
-import scala.collection.mutable.ListBuffer
 
-import org.apache.commons.lang3.StringUtils
 import org.apache.spark.SparkContext
 import org.apache.spark.sql.SQLContext
 import org.apache.spark.sql.catalyst.TableIdentifier
@@ -33,8 +31,6 @@ import org.apache.spark.sql.util.CarbonException
 import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.datamap.Segment
-import org.apache.carbondata.core.datastore.impl.FileFactory
-import org.apache.carbondata.core.exception.InvalidConfigurationException
 import org.apache.carbondata.core.indexstore.PartitionSpec
 import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier
 import org.apache.carbondata.core.metadata.datatype.{DataType, DataTypes, DecimalType}
@@ -900,8 +896,10 @@ class TableNewProcessor(cm: TableModel) {
           s" as external file format")
       }
       tableInfo.setFormat(format.get)
-      val formatProperties = cm.tableProperties.filter(pair =>
-        pair._1.startsWith(s"${format.get.toLowerCase}.")).asJava
+      val formatProperties = new util.HashMap[String, String]()
+      cm.tableProperties
+        .filter(pair => pair._1.startsWith(s"${format.get.toLowerCase}."))
+        .foreach(p => formatProperties.put(p._1, p._2))
       tableInfo.setFormatProperties(formatProperties)
     }
     tableInfo

--- a/integration/spark2/src/main/java/org/apache/carbondata/datamap/IndexDataMapProvider.java
+++ b/integration/spark2/src/main/java/org/apache/carbondata/datamap/IndexDataMapProvider.java
@@ -33,6 +33,7 @@ import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
 import org.apache.carbondata.core.metadata.schema.table.DataMapSchema;
 import org.apache.carbondata.core.metadata.schema.table.RelationIdentifier;
 import org.apache.carbondata.core.metadata.schema.table.column.CarbonColumn;
+import org.apache.carbondata.spark.rdd.FileLevelDataMapBuildRdd;
 
 import org.apache.spark.sql.SparkSession;
 
@@ -99,7 +100,15 @@ public class IndexDataMapProvider extends DataMapProvider {
 
   @Override
   public void rebuild() {
-    IndexDataMapRebuildRDD.rebuildDataMap(sparkSession, getMainTable(), getDataMapSchema());
+    CarbonTable mainTable = getMainTable();
+    if (mainTable.getTableInfo().getFormat().equalsIgnoreCase("carbondata")
+        || mainTable.getTableInfo().getFormat().isEmpty()) {
+      IndexDataMapRebuildRDD.rebuildDataMap(sparkSession, getMainTable(), getDataMapSchema());
+    } else {
+      List<DataMapSchema> dmSchema = new ArrayList<>(1);
+      dmSchema.add(getDataMapSchema());
+      FileLevelDataMapBuildRdd.buildDataMapOnExistedTable(sparkSession, mainTable, dmSchema);
+    }
   }
 
   private DataMapFactory<? extends DataMap> createDataMapFactory()


### PR DESCRIPTION
+ support directly generate file level index
+ support create and generate file index on existing data
+ We will flatten the input files recursively and remove the duplicated
input files in one load

The folder structure of the index file looks like below:
${datamap_name}/${segment_name}/File_level_${fact_file1_path_with_base64_encoding}/${column_name}.bloomindex
                             ../File_level_${fact_file2_path_with_base64_encoding}/${column_name}.bloomindex

Note that in this commit, the index datamap is not used during query.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 `Only internal used interfaces has been changed`
 - [x] Any backward compatibility impacted?
 `NO`
 - [x] Document update required?
`NO`
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
`Added tests`
        - How it is tested? Please attach test report.
`Tested in local machine`
        - Is it a performance related change? Please attach the performance test report.
`NO`
        - Any additional information to help reviewers in testing this change.
`NA`
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
`NA`
