### PR TITLE
[CARBONDATA-2869] Add support for Avro Map data type support for SDK

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -640,6 +640,7 @@ public final class CarbonCommonConstants {
   public static final String TIMESTAMP = "Timestamp";
   public static final String ARRAY = "array";
   public static final String STRUCT = "struct";
+  public static final String MAP = "map";
   public static final String FROM = "from";
   /**
    * FACT_UPDATE_EXTENSION.

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/ComplexColumnPage.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/ComplexColumnPage.java
@@ -117,6 +117,7 @@ public class ComplexColumnPage {
     if ((complexColumnInfoList.get(columnPageIndex).isNoDictionary() &&
         !((DataTypes.isStructType(dataType) ||
             DataTypes.isArrayType(dataType) ||
+            DataTypes.isMapType(dataType) ||
             (dataType == DataTypes.STRING) ||
             (dataType == DataTypes.VARCHAR) ||
             (dataType == DataTypes.DATE) ||

--- a/core/src/main/java/org/apache/carbondata/core/metadata/converter/ThriftWrapperSchemaConverterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/converter/ThriftWrapperSchemaConverterImpl.java
@@ -156,6 +156,8 @@ public class ThriftWrapperSchemaConverterImpl implements SchemaConverter {
       return org.apache.carbondata.format.DataType.ARRAY;
     } else if (DataTypes.isStructType(dataType)) {
       return org.apache.carbondata.format.DataType.STRUCT;
+    } else if (DataTypes.isMapType(dataType)) {
+      return org.apache.carbondata.format.DataType.MAP;
     } else if (dataType.getId() == DataTypes.VARCHAR.getId()) {
       return org.apache.carbondata.format.DataType.VARCHAR;
     } else {
@@ -496,6 +498,8 @@ public class ThriftWrapperSchemaConverterImpl implements SchemaConverter {
         return DataTypes.createDefaultArrayType();
       case STRUCT:
         return DataTypes.createDefaultStructType();
+      case MAP:
+        return DataTypes.createDefaultMapType();
       case VARCHAR:
         return DataTypes.VARCHAR;
       default:

--- a/core/src/main/java/org/apache/carbondata/core/metadata/datatype/MapType.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/datatype/MapType.java
@@ -66,4 +66,12 @@ public class MapType extends DataType {
     result = prime * result + valueType.hashCode();
     return result;
   }
+
+  public DataType getKeyType() {
+    return keyType;
+  }
+
+  public DataType getValueType() {
+    return valueType;
+  }
 }

--- a/core/src/main/java/org/apache/carbondata/core/scan/complextypes/ArrayQueryType.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/complextypes/ArrayQueryType.java
@@ -88,6 +88,14 @@ public class ArrayQueryType extends ComplexQueryType implements GenericQueryType
   }
 
   @Override public Object getDataBasedOnDataType(ByteBuffer dataBuffer) {
+    Object[] data = fillData(dataBuffer);
+    if (data == null) {
+      return null;
+    }
+    return DataTypeUtil.getDataTypeConverter().wrapWithGenericArrayData(data);
+  }
+
+  protected Object[] fillData(ByteBuffer dataBuffer) {
     int dataLength = dataBuffer.getInt();
     if (dataLength == -1) {
       return null;
@@ -96,7 +104,7 @@ public class ArrayQueryType extends ComplexQueryType implements GenericQueryType
     for (int i = 0; i < dataLength; i++) {
       data[i] = children.getDataBasedOnDataType(dataBuffer);
     }
-    return DataTypeUtil.getDataTypeConverter().wrapWithGenericArrayData(data);
+    return data;
   }
 
   @Override public Object getDataBasedOnColumn(ByteBuffer dataBuffer, CarbonDimension parent,

--- a/core/src/main/java/org/apache/carbondata/core/scan/complextypes/MapQueryType.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/complextypes/MapQueryType.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.core.scan.complextypes;
+
+import java.nio.ByteBuffer;
+
+import org.apache.carbondata.core.util.DataTypeUtil;
+
+/**
+ * handles querying map data type columns
+ */
+public class MapQueryType extends ArrayQueryType {
+
+  public MapQueryType(String name, String parentname, int blockIndex) {
+    super(name, parentname, blockIndex);
+  }
+
+  /**
+   * Map data is internally stored as Array<Struct<key,Value>>. So first the data is filled in the
+   * stored format and then each record is separated out to fill key and value separately. This is
+   * because for spark integration it expects the data as ArrayBasedMapData(keyArray, valueArray)
+   * and for SDK it will be an object array in the same format as returned to spark
+   *
+   * @param dataBuffer
+   * @return
+   */
+  @Override
+  public Object getDataBasedOnDataType(ByteBuffer dataBuffer) {
+    Object[] data = fillData(dataBuffer);
+    if (data == null) {
+      return null;
+    }
+    Object[] keyArray = new Object[data.length];
+    Object[] valueArray = new Object[data.length];
+    for (int i = 0; i < data.length; i++) {
+      Object[] keyValue = DataTypeUtil.getDataTypeConverter().unwrapGenericRowToObject(data[i]);
+      keyArray[i] = keyValue[0];
+      valueArray[i] = keyValue[1];
+    }
+    return DataTypeUtil.getDataTypeConverter().wrapWithArrayBasedMapData(keyArray, valueArray);
+  }
+
+}

--- a/core/src/main/java/org/apache/carbondata/core/util/AbstractDataFileFooterConverter.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/AbstractDataFileFooterConverter.java
@@ -289,7 +289,7 @@ public abstract class AbstractDataFileFooterConverter {
     ColumnSchema wrapperColumnSchema = new ColumnSchema();
     wrapperColumnSchema.setColumnUniqueId(externalColumnSchema.getColumn_id());
     wrapperColumnSchema.setColumnName(externalColumnSchema.getColumn_name());
-    DataType dataType = thriftDataTyopeToWrapperDataType(externalColumnSchema.data_type);
+    DataType dataType = CarbonUtil.thriftDataTyopeToWrapperDataType(externalColumnSchema.data_type);
     if (DataTypes.isDecimal(dataType)) {
       DecimalType decimalType = (DecimalType) dataType;
       decimalType.setPrecision(externalColumnSchema.getPrecision());
@@ -400,45 +400,6 @@ public abstract class AbstractDataFileFooterConverter {
     return new BlockletIndex(
         new BlockletBTreeIndex(btreeIndex.getStart_key(), btreeIndex.getEnd_key()),
         new BlockletMinMaxIndex(minMaxIndex.getMin_values(), minMaxIndex.getMax_values()));
-  }
-
-  /**
-   * Below method will be used to convert the thrift data type to wrapper data
-   * type
-   *
-   * @param dataTypeThrift
-   * @return dataType wrapper
-   */
-  protected DataType thriftDataTyopeToWrapperDataType(
-      org.apache.carbondata.format.DataType dataTypeThrift) {
-    switch (dataTypeThrift) {
-      case BOOLEAN:
-        return DataTypes.BOOLEAN;
-      case STRING:
-        return DataTypes.STRING;
-      case SHORT:
-        return DataTypes.SHORT;
-      case INT:
-        return DataTypes.INT;
-      case LONG:
-        return DataTypes.LONG;
-      case DOUBLE:
-        return DataTypes.DOUBLE;
-      case DECIMAL:
-        return DataTypes.createDefaultDecimalType();
-      case DATE:
-        return DataTypes.DATE;
-      case TIMESTAMP:
-        return DataTypes.TIMESTAMP;
-      case ARRAY:
-        return DataTypes.createDefaultArrayType();
-      case STRUCT:
-        return DataTypes.createDefaultStructType();
-      case VARCHAR:
-        return DataTypes.VARCHAR;
-      default:
-        return DataTypes.STRING;
-    }
   }
 
   /**

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
@@ -2229,6 +2229,8 @@ public final class CarbonUtil {
         return DataTypes.createDefaultArrayType();
       case STRUCT:
         return DataTypes.createDefaultStructType();
+      case MAP:
+        return DataTypes.createDefaultMapType();
       case VARCHAR:
         return DataTypes.VARCHAR;
       default:

--- a/core/src/main/java/org/apache/carbondata/core/util/DataTypeConverter.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/DataTypeConverter.java
@@ -32,6 +32,8 @@ public interface DataTypeConverter {
 
   Object wrapWithGenericArrayData(Object data);
   Object wrapWithGenericRow(Object[] fields);
+  Object wrapWithArrayBasedMapData(Object[] keyArray, Object[] valueArray);
+  Object[] unwrapGenericRowToObject(Object data);
 
   Object[] convertCarbonSchemaToSparkSchema(CarbonColumn[] carbonColumns);
 }

--- a/core/src/main/java/org/apache/carbondata/core/util/DataTypeConverterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/DataTypeConverterImpl.java
@@ -88,8 +88,19 @@ public class DataTypeConverterImpl implements DataTypeConverter, Serializable {
   }
 
   @Override
+  public Object[] unwrapGenericRowToObject(Object data) {
+    Object[] splitData = (Object[]) data;
+    return splitData;
+  }
+
+  @Override
   public Object wrapWithGenericRow(Object[] fields) {
     return fields;
+  }
+
+  @Override
+  public Object wrapWithArrayBasedMapData(Object[] keyArray, Object[] valueArray) {
+    return new Object[] { keyArray, valueArray };
   }
 
   @Override

--- a/format/src/main/thrift/schema.thrift
+++ b/format/src/main/thrift/schema.thrift
@@ -36,6 +36,7 @@ enum DataType {
 	ARRAY = 20,
 	STRUCT = 21,
 	VARCHAR = 22,
+	MAP = 23,
 }
 
 /**

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonInputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonInputFormat.java
@@ -751,7 +751,7 @@ m filterExpression
     List<String> projectColumn = new ArrayList<>();
     for (ColumnSchema cols : colList) {
       if (cols.getSchemaOrdinal() != -1) {
-        projectColumn.add(cols.getColumnUniqueId());
+        projectColumn.add(cols.getColumnName());
       }
     }
     String[] projectionColumns = new String[projectColumn.size()];

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestNonTransactionalCarbonTable.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestNonTransactionalCarbonTable.scala
@@ -1116,7 +1116,7 @@ class TestNonTransactionalCarbonTable extends QueryTest with BeforeAndAfterAll {
   }
 
   // --------------------------------------------- AVRO test cases ---------------------------
-  private def WriteFilesWithAvroWriter(rows: Int,
+  def WriteFilesWithAvroWriter(rows: Int,
       mySchema: String,
       json: String) = {
     // conversion to GenericData.Record

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestNonTransactionalCarbonTableForMapType.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestNonTransactionalCarbonTableForMapType.scala
@@ -1,0 +1,417 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.spark.testsuite.createTable
+
+import java.io.File
+
+import org.apache.commons.io.FileUtils
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.test.util.QueryTest
+import org.scalatest.BeforeAndAfterAll
+
+/**
+ * test cases for SDK complex map data type support
+ */
+class TestNonTransactionalCarbonTableForMapType extends QueryTest with BeforeAndAfterAll {
+
+  private val nonTransactionalCarbonTable = new TestNonTransactionalCarbonTable
+  private val writerPath = nonTransactionalCarbonTable.writerPath
+
+  private def deleteDirectory(path: String): Unit = {
+    FileUtils.deleteDirectory(new File(path))
+  }
+
+  def buildMapSchema(rows: Int): Unit = {
+    deleteDirectory(writerPath)
+    val mySchema =
+      """
+        |{
+        |  "name": "address",
+        |  "type": "record",
+        |  "fields": [
+        |    {
+        |      "name": "name",
+        |      "type": "string"
+        |    },
+        |    {
+        |      "name": "age",
+        |      "type": "int"
+        |    },
+        |    {
+        |      "name": "mapRecord",
+        |      "type": {
+        |        "type": "map",
+        |        "values": "string"
+        |      }
+        |    }
+        |  ]
+        |}
+      """.stripMargin
+    val json =
+      """ {"name":"bob", "age":10, "mapRecord": {"street": "k-lane", "city": "bangalore"}} """.stripMargin
+    nonTransactionalCarbonTable.WriteFilesWithAvroWriter(rows, mySchema, json)
+  }
+
+  def buildMapSchemaWith2Levels(rows: Int): Unit = {
+    deleteDirectory(writerPath)
+    val mySchema =
+      """
+        |{
+        |  "name": "address",
+        |  "type": "record",
+        |  "fields": [
+        |    {
+        |      "name": "name",
+        |      "type": "string"
+        |    },
+        |    {
+        |      "name": "age",
+        |      "type": "int"
+        |    },
+        |    {
+        |      "name": "mapRecord",
+        |      "type": {
+        |        "type": "map",
+        |        "values": {
+        |            "type": "map",
+        |            "values": "string"
+        |        }
+        |      }
+        |    }
+        |  ]
+        |}
+      """.stripMargin
+    val json = """ {"name":"bob", "age":10, "mapRecord": {"details": {"street": "k-lane", "city": "bangalore"}}} """.stripMargin
+    nonTransactionalCarbonTable.WriteFilesWithAvroWriter(rows, mySchema, json)
+  }
+
+  def buildMapSchemaWith6Levels(rows: Int): Unit = {
+    deleteDirectory(writerPath)
+    val mySchema =
+      """
+        |{
+        |  "name": "address",
+        |  "type": "record",
+        |  "fields": [
+        |    {
+        |      "name": "name",
+        |      "type": "string"
+        |    },
+        |    {
+        |      "name": "age",
+        |      "type": "int"
+        |    },
+        |    {
+        |      "name": "mapRecord",
+        |      "type": {
+        |        "type": "map",
+        |        "values": {
+        |          "type": "map",
+        |          "values": {
+        |            "type": "map",
+        |            "values": {
+        |              "type": "map",
+        |              "values": {
+        |                "type": "map",
+        |                "values": {
+        |                  "type": "map",
+        |                  "values": {
+        |                    "type": "map",
+        |                    "values": "string"
+        |                  }
+        |                }
+        |              }
+        |            }
+        |          }
+        |        }
+        |      }
+        |    }
+        |  ]
+        |}
+      """.stripMargin
+    val json =
+      """ {"name":"bob", "age":10, "mapRecord": {"topLevel": {"level1": {"level2": {"level3":
+        |{"level4": {"level5": {"street": "k-lane", "city": "bangalore"}}}}}}}} """
+        .stripMargin
+    nonTransactionalCarbonTable.WriteFilesWithAvroWriter(rows, mySchema, json)
+  }
+
+  def buildMapSchemaWithArrayTypeAsValue(rows: Int): Unit = {
+    deleteDirectory(writerPath)
+    val mySchema =
+      """
+        {
+        |  "name": "address",
+        |  "type": "record",
+        |  "fields": [
+        |    {
+        |      "name": "name",
+        |      "type": "string"
+        |    },
+        |    {
+        |      "name": "age",
+        |      "type": "int"
+        |    },
+        |    {
+        |      "name": "mapRecord",
+        |      "type": {
+        |        "type": "map",
+        |        "values": {
+        |          "type": "array",
+        |          "items": {
+        |            "name": "street",
+        |            "type": "string"
+        |          }
+        |        }
+        |      }
+        |    }
+        |  ]
+        |}
+      """.stripMargin
+    val json = """ {"name":"bob", "age":10, "mapRecord": {"city": ["city1","city2"]}} """.stripMargin
+    nonTransactionalCarbonTable.WriteFilesWithAvroWriter(rows, mySchema, json)
+  }
+
+  def buildMapSchemaWithStructTypeAsValue(rows: Int): Unit = {
+    deleteDirectory(writerPath)
+    val mySchema =
+      """
+        |{
+        |  "name": "address",
+        |  "type": "record",
+        |  "fields": [
+        |    {
+        |      "name": "name",
+        |      "type": "string"
+        |    },
+        |    {
+        |      "name": "age",
+        |      "type": "int"
+        |    },
+        |    {
+        |      "name": "mapRecord",
+        |      "type": {
+        |        "type": "map",
+        |        "values": {
+        |          "type": "record",
+        |          "name": "my_address",
+        |          "fields": [
+        |            {
+        |              "name": "street",
+        |              "type": "string"
+        |            },
+        |            {
+        |              "name": "city",
+        |              "type": "string"
+        |            }
+        |          ]
+        |        }
+        |      }
+        |    }
+        |  ]
+        |}
+      """.stripMargin
+    val json = """ {"name":"bob", "age":10, "mapRecord": {"details": {"street":"street1", "city":"bang"}}} """.stripMargin
+    nonTransactionalCarbonTable.WriteFilesWithAvroWriter(rows, mySchema, json)
+  }
+
+  def buildStructSchemaWithMapTypeAsValue(rows: Int): Unit = {
+    deleteDirectory(writerPath)
+    val mySchema =
+      """
+        |{
+        |  "name": "address",
+        |  "type": "record",
+        |  "fields": [
+        |    {
+        |      "name": "name",
+        |      "type": "string"
+        |    },
+        |    {
+        |      "name": "age",
+        |      "type": "int"
+        |    },
+        |    {
+        |      "name": "structRecord",
+        |      "type": {
+        |        "type": "record",
+        |        "name": "my_address",
+        |        "fields": [
+        |          {
+        |            "name": "street",
+        |            "type": "string"
+        |          },
+        |          {
+        |            "name": "houseDetails",
+        |            "type": {
+        |               "type": "map",
+        |               "values": "string"
+        |             }
+        |          }
+        |        ]
+        |      }
+        |    }
+        |  ]
+        |}
+      """.stripMargin
+    val json = """ {"name":"bob", "age":10, "structRecord": {"street":"street1", "houseDetails": {"101": "Rahul", "102": "Pawan"}}} """.stripMargin
+    nonTransactionalCarbonTable.WriteFilesWithAvroWriter(rows, mySchema, json)
+  }
+
+  def buildArraySchemaWithMapTypeAsValue(rows: Int): Unit = {
+    deleteDirectory(writerPath)
+    val mySchema =
+      """
+        |{
+        |  "name": "address",
+        |  "type": "record",
+        |  "fields": [
+        |    {
+        |      "name": "name",
+        |      "type": "string"
+        |    },
+        |    {
+        |      "name": "age",
+        |      "type": "int"
+        |    },
+        |    {
+        |      "name": "arrayRecord",
+        |      "type": {
+        |        "type": "array",
+        |        "items": {
+        |           "name": "houseDetails",
+        |           "type": "map",
+        |           "values": "string"
+        |        }
+        |      }
+        |    }
+        |  ]
+        |}
+      """.stripMargin
+    val json = """ {"name":"bob", "age":10, "arrayRecord": [{"101": "Rahul", "102": "Pawan"}]} """.stripMargin
+    nonTransactionalCarbonTable.WriteFilesWithAvroWriter(rows, mySchema, json)
+  }
+
+  private def dropSchema: Unit = {
+    deleteDirectory(writerPath)
+    sql("DROP TABLE IF EXISTS sdkMapOutputTable")
+  }
+
+  override def beforeAll(): Unit = {
+    dropSchema
+  }
+
+  test("Read sdk writer Avro output Map Type") {
+    buildMapSchema(3)
+    assert(new File(writerPath).exists())
+    sql("DROP TABLE IF EXISTS sdkMapOutputTable")
+    sql(
+      s"""CREATE EXTERNAL TABLE sdkMapOutputTable STORED BY 'carbondata' LOCATION
+          |'$writerPath' """.stripMargin)
+    checkAnswer(sql("select count(*) from sdkMapOutputTable where maprecord['street']='abc'"),
+      Row(0))
+    checkAnswer(sql("select count(*) from sdkMapOutputTable where maprecord['street']='k-lane'"),
+      Row(3))
+    checkAnswer(sql("select  maprecord['street'] from sdkMapOutputTable"),
+      Seq(Row("k-lane"), Row("k-lane"), Row("k-lane")))
+    checkAnswer(sql("select * from sdkMapOutputTable"), Seq(
+      Row("bob", 10, Map("city" -> "bangalore", "street" -> "k-lane")),
+      Row("bob", 10, Map("city" -> "bangalore", "street" -> "k-lane")),
+      Row("bob", 10, Map("city" -> "bangalore", "street" -> "k-lane"))))
+  }
+
+  test("Read sdk writer Avro output Map Type with nested 2 levels") {
+    buildMapSchemaWith2Levels(3)
+    assert(new File(writerPath).exists())
+    sql("DROP TABLE IF EXISTS sdkMapOutputTable")
+    sql(
+      s"""CREATE EXTERNAL TABLE sdkMapOutputTable STORED BY 'carbondata' LOCATION
+          |'$writerPath' """.stripMargin)
+    checkAnswer(sql("select maprecord['details'] from sdkMapOutputTable"), Seq(
+      Row(Map("city" -> "bangalore", "street" -> "k-lane")),
+      Row(Map("city" -> "bangalore", "street" -> "k-lane")),
+      Row(Map("city" -> "bangalore", "street" -> "k-lane"))))
+  }
+
+  test("Read sdk writer Avro output Map Type with nested 6 levels") {
+    buildMapSchemaWith6Levels(3)
+    assert(new File(writerPath).exists())
+    sql("DROP TABLE IF EXISTS sdkMapOutputTable")
+    sql(
+      s"""CREATE EXTERNAL TABLE sdkMapOutputTable STORED BY 'carbondata' LOCATION
+          |'$writerPath' """.stripMargin)
+    checkAnswer(sql("select count(*) from sdkMapOutputTable"), Row(3))
+  }
+
+  test("Read sdk writer Avro output Map Type with array type as value") {
+    buildMapSchemaWithArrayTypeAsValue(3)
+    assert(new File(writerPath).exists())
+    sql("DROP TABLE IF EXISTS sdkMapOutputTable")
+    sql(
+      s"""CREATE EXTERNAL TABLE sdkMapOutputTable STORED BY 'carbondata' LOCATION
+          |'$writerPath' """.stripMargin)
+    checkAnswer(sql("select * from sdkMapOutputTable"), Seq(
+      Row("bob", 10, Map("city" -> Seq("city1", "city2"))),
+      Row("bob", 10, Map("city" -> Seq("city1", "city2"))),
+      Row("bob", 10, Map("city" -> Seq("city1", "city2")))))
+  }
+
+  test("Read sdk writer Avro output Map Type with struct type as value") {
+    buildMapSchemaWithStructTypeAsValue(3)
+    assert(new File(writerPath).exists())
+    sql("DROP TABLE IF EXISTS sdkMapOutputTable")
+    sql(
+      s"""CREATE EXTERNAL TABLE sdkMapOutputTable STORED BY 'carbondata' LOCATION
+          |'$writerPath' """.stripMargin)
+    checkAnswer(sql("select * from sdkMapOutputTable"), Seq(
+      Row("bob", 10, Map("details" -> Row("street1", "bang"))),
+      Row("bob", 10, Map("details" -> Row("street1", "bang"))),
+      Row("bob", 10, Map("details" -> Row("street1", "bang")))))
+  }
+
+  test("Read sdk writer Avro output Map Type with map type as child to struct type") {
+    buildStructSchemaWithMapTypeAsValue(3)
+    assert(new File(writerPath).exists())
+    sql("DROP TABLE IF EXISTS sdkMapOutputTable")
+    sql(
+      s"""CREATE EXTERNAL TABLE sdkMapOutputTable STORED BY 'carbondata' LOCATION
+          |'$writerPath' """.stripMargin)
+    checkAnswer(sql("select * from sdkMapOutputTable"), Seq(
+      Row("bob", 10, Row("street1", Map("101" -> "Rahul", "102" -> "Pawan"))),
+      Row("bob", 10, Row("street1", Map("101" -> "Rahul", "102" -> "Pawan"))),
+      Row("bob", 10, Row("street1", Map("101" -> "Rahul", "102" -> "Pawan")))))
+  }
+
+  test("Read sdk writer Avro output Map Type with map type as child to array type") {
+    buildArraySchemaWithMapTypeAsValue(3)
+    assert(new File(writerPath).exists())
+    sql("DROP TABLE IF EXISTS sdkMapOutputTable")
+    sql(
+      s"""CREATE EXTERNAL TABLE sdkMapOutputTable STORED BY 'carbondata' LOCATION
+          |'$writerPath' """.stripMargin)
+    checkAnswer(sql("select * from sdkMapOutputTable"), Seq(
+      Row("bob", 10, Seq(Map("101" -> "Rahul", "102" -> "Pawan"))),
+      Row("bob", 10, Seq(Map("101" -> "Rahul", "102" -> "Pawan"))),
+      Row("bob", 10, Seq(Map("101" -> "Rahul", "102" -> "Pawan")))))
+  }
+
+  override def afterAll(): Unit = {
+    dropSchema
+  }
+
+}

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/DataTypeConverterUtil.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/DataTypeConverterUtil.scala
@@ -46,6 +46,7 @@ object DataTypeConverterUtil {
       case "date" => DataTypes.DATE
       case "array" => DataTypes.createDefaultArrayType
       case "struct" => DataTypes.createDefaultStructType
+      case "map" => DataTypes.createDefaultMapType
       case _ => convertToCarbonTypeForSpark2(dataType)
     }
   }
@@ -72,6 +73,8 @@ object DataTypeConverterUtil {
           DataTypes.createDefaultArrayType()
         } else if (others != null && others.startsWith("structtype")) {
           DataTypes.createDefaultStructType()
+        } else if (others != null && others.startsWith("maptype")) {
+          DataTypes.createDefaultMapType
         } else if (others != null && others.startsWith("char")) {
           DataTypes.STRING
         } else if (others != null && others.startsWith("varchar")) {
@@ -104,6 +107,7 @@ object DataTypeConverterUtil {
       case "timestamp" => ThriftDataType.TIMESTAMP
       case "array" => ThriftDataType.ARRAY
       case "struct" => ThriftDataType.STRUCT
+      case "map" => ThriftDataType.MAP
       case "varchar" => ThriftDataType.VARCHAR
       case _ => ThriftDataType.STRING
     }

--- a/integration/spark-datasource/src/main/scala/org/apache/carbondata/converter/SparkDataTypeConverterImpl.java
+++ b/integration/spark-datasource/src/main/scala/org/apache/carbondata/converter/SparkDataTypeConverterImpl.java
@@ -29,6 +29,7 @@ import org.apache.carbondata.core.metadata.schema.table.column.CarbonMeasure;
 import org.apache.carbondata.core.util.DataTypeConverter;
 
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
+import org.apache.spark.sql.catalyst.util.ArrayBasedMapData;
 import org.apache.spark.sql.catalyst.util.GenericArrayData;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.DecimalType;
@@ -98,6 +99,17 @@ public final class SparkDataTypeConverterImpl implements DataTypeConverter, Seri
   @Override
   public Object wrapWithGenericRow(Object[] fields) {
     return new GenericInternalRow(fields);
+  }
+
+  @Override
+  public Object wrapWithArrayBasedMapData(Object[] keyArray, Object[] valueArray) {
+    return new ArrayBasedMapData(new GenericArrayData(keyArray), new GenericArrayData(valueArray));
+  }
+
+  @Override
+  public Object[] unwrapGenericRowToObject(Object data) {
+    GenericInternalRow row = (GenericInternalRow) data;
+    return row.values();
   }
 
   private static org.apache.spark.sql.types.DataType convertCarbonToSparkDataType(

--- a/integration/spark-datasource/src/main/scala/org/apache/spark/sql/util/CarbonMetastoreTypes.scala
+++ b/integration/spark-datasource/src/main/scala/org/apache/spark/sql/util/CarbonMetastoreTypes.scala
@@ -88,6 +88,8 @@ object CarbonMetastoreTypes extends RegexParsers {
           fields.map(f => s"${ f.name }:${ toMetastoreType(f.dataType) }")
             .mkString(",")
         }>"
+      case MapType(keyType, valueType, _) =>
+        s"map<${ toMetastoreType(keyType) }, ${ toMetastoreType(valueType) }>"
       case StringType => "string"
       case FloatType => "float"
       case IntegerType => "int"

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/strategy/CarbonLateDecodeStrategy.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/strategy/CarbonLateDecodeStrategy.scala
@@ -465,6 +465,7 @@ private[sql] class CarbonLateDecodeStrategy extends SparkStrategy {
   private def isComplexAttribute(attribute: Attribute) = attribute.dataType match {
     case ArrayType(dataType, _) => true
     case StructType(_) => true
+    case MapType(_, _, _) => true
     case _ => false
   }
 

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonRelation.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonRelation.scala
@@ -63,6 +63,9 @@ case class CarbonRelation(
         case "struct" =>
           CarbonMetastoreTypes.toDataType(
             s"struct<${SparkTypeConverter.getStructChildren(carbonTable, dim.getColName)}>")
+        case "map" =>
+          CarbonMetastoreTypes.toDataType(
+            s"map<${SparkTypeConverter.getMapChildren(carbonTable, dim.getColName)}>")
         case dType =>
           val dataType = addDecimalScaleAndPrecision(dimval, dType)
           CarbonMetastoreTypes.toDataType(dataType)
@@ -105,6 +108,9 @@ case class CarbonRelation(
           case "struct" =>
             CarbonMetastoreTypes.toDataType(
               s"struct<${SparkTypeConverter.getStructChildren(carbonTable, column.getColName)}>")
+          case "map" =>
+            CarbonMetastoreTypes.toDataType(
+              s"map<${SparkTypeConverter.getMapChildren(carbonTable, column.getColName)}>")
           case dType =>
             val dataType = SparkTypeConverter.addDecimalScaleAndPrecision(column, dType)
             CarbonMetastoreTypes.toDataType(dataType)

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/optimizer/CarbonFilters.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/optimizer/CarbonFilters.scala
@@ -422,6 +422,7 @@ object CarbonFilters {
       case TimestampType => true
       case ArrayType(_, _) => true
       case StructType(_) => true
+      case MapType(_, _, _) => true
       case DecimalType() => true
       case _ => false
     }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/optimizer/CarbonLateDecodeRule.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/optimizer/CarbonLateDecodeRule.scala
@@ -744,6 +744,8 @@ class CarbonLateDecodeRule extends Rule[LogicalPlan] with PredicateHelper {
           })
         case ar : ArrayType =>
           attrName.contains(a.name + "[") || attrName.contains(a.name + ".")
+        case m: MapType =>
+          attrName.contains(a.name + "[")
         case _ => false
       }
     }

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/converter/impl/FieldEncoderFactory.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/converter/impl/FieldEncoderFactory.java
@@ -139,7 +139,7 @@ public class FieldEncoderFactory {
       AbsoluteTableIdentifier absoluteTableIdentifier, DictionaryClient client, Boolean useOnePass,
       Map<Object, Integer> localCache, int index, String nullFormat, Boolean isEmptyBadRecords) {
     DataType dataType = carbonColumn.getDataType();
-    if (DataTypes.isArrayType(dataType)) {
+    if (DataTypes.isArrayType(dataType) || DataTypes.isMapType(dataType)) {
       List<CarbonDimension> listOfChildDimensions =
           ((CarbonDimension) carbonColumn).getListOfChildDimensions();
       // Create array parser with complex delimiter
@@ -165,8 +165,6 @@ public class FieldEncoderFactory {
                 client, useOnePass, localCache, index, nullFormat, isEmptyBadRecords));
       }
       return structDataType;
-    } else if (DataTypes.isMapType(dataType)) {
-      throw new UnsupportedOperationException("Complex type Map is not supported yet");
     } else {
       return new PrimitiveDataType(carbonColumn, parentName, carbonColumn.getColumnId(),
           (CarbonDimension) carbonColumn, absoluteTableIdentifier, client, useOnePass,

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/parser/CarbonParserFactory.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/parser/CarbonParserFactory.java
@@ -54,7 +54,7 @@ public final class CarbonParserFactory {
   private static GenericParser createParser(CarbonColumn carbonColumn, String[] complexDelimiters,
       String nullFormat, int depth) {
     DataType dataType = carbonColumn.getDataType();
-    if (DataTypes.isArrayType(dataType)) {
+    if (DataTypes.isArrayType(dataType) || DataTypes.isMapType(dataType)) {
       List<CarbonDimension> listOfChildDimensions =
           ((CarbonDimension) carbonColumn).getListOfChildDimensions();
       // Create array parser with complex delimiter
@@ -72,8 +72,6 @@ public final class CarbonParserFactory {
         parser.addChildren(createParser(dimension, complexDelimiters, nullFormat, depth + 1));
       }
       return parser;
-    } else if (DataTypes.isMapType(dataType)) {
-      throw new UnsupportedOperationException("Complex type Map is not supported yet");
     } else {
       return new PrimitiveParserImpl();
     }

--- a/processing/src/main/java/org/apache/carbondata/processing/util/CarbonDataProcessorUtil.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/util/CarbonDataProcessorUtil.java
@@ -372,13 +372,17 @@ public final class CarbonDataProcessorUtil {
     for (int i = 0; i < hierarchies.length; i++) {
       String[] levels = hierarchies[i].split(CarbonCommonConstants.HASH_SPC_CHARACTER);
       String[] levelInfo = levels[0].split(CarbonCommonConstants.COLON_SPC_CHARACTER);
-      GenericDataType g = levelInfo[1].toLowerCase().contains(CarbonCommonConstants.ARRAY) ?
+      String level1Info = levelInfo[1].toLowerCase();
+      GenericDataType g = (level1Info.contains(CarbonCommonConstants.ARRAY) || level1Info
+          .contains(CarbonCommonConstants.MAP)) ?
           new ArrayDataType(levelInfo[0], "", levelInfo[3]) :
           new StructDataType(levelInfo[0], "", levelInfo[3]);
       complexTypesMap.put(levelInfo[0], g);
       for (int j = 1; j < levels.length; j++) {
         levelInfo = levels[j].split(CarbonCommonConstants.COLON_SPC_CHARACTER);
-        if (levelInfo[1].toLowerCase().contains(CarbonCommonConstants.ARRAY)) {
+        String levelInfo1 = levelInfo[1].toLowerCase();
+        if (levelInfo1.contains(CarbonCommonConstants.ARRAY) || levelInfo1
+            .contains(CarbonCommonConstants.MAP)) {
           g.addChildren(new ArrayDataType(levelInfo[0], levelInfo[2], levelInfo[3]));
         } else if (levelInfo[1].toLowerCase().contains(CarbonCommonConstants.STRUCT)) {
           g.addChildren(new StructDataType(levelInfo[0], levelInfo[2], levelInfo[3]));

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/AvroCarbonWriter.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/AvroCarbonWriter.java
@@ -19,7 +19,10 @@ package org.apache.carbondata.sdk.file;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
 
@@ -29,7 +32,9 @@ import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.keygenerator.directdictionary.timestamp.DateDirectDictionaryGenerator;
 import org.apache.carbondata.core.metadata.datatype.DataType;
 import org.apache.carbondata.core.metadata.datatype.DataTypes;
+import org.apache.carbondata.core.metadata.datatype.MapType;
 import org.apache.carbondata.core.metadata.datatype.StructField;
+import org.apache.carbondata.core.metadata.datatype.StructType;
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
 import org.apache.carbondata.hadoop.api.CarbonTableOutputFormat;
 import org.apache.carbondata.hadoop.internal.ObjectArrayWritable;
@@ -134,6 +139,38 @@ public class AvroCarbonWriter extends CarbonWriter {
         // also carbon internally needs float as double
         out = Double.parseDouble(fieldValue.toString());
         break;
+      case MAP:
+        // Note: Avro object takes care of removing the duplicates so we should not handle it again
+        // Map will be internally stored as Array<Struct<Key,Value>>
+        Map mapEntries = (HashMap) fieldValue;
+        Object[] arrayMapChildObjects = new Object[mapEntries.size()];
+        if (!mapEntries.isEmpty()) {
+          Iterator iterator = mapEntries.entrySet().iterator();
+          int counter = 0;
+          while (iterator.hasNext()) {
+            // size is 2 because map will have key and value
+            Object[] mapChildObjects = new Object[2];
+            Map.Entry mapEntry = (HashMap.Entry) iterator.next();
+            // evaluate key
+            Object keyObject = avroFieldToObject(
+                new Schema.Field(avroField.name(), Schema.create(Schema.Type.STRING),
+                    avroField.doc(), avroField.defaultVal()), mapEntry.getKey());
+            // evaluate value
+            Object valueObject = avroFieldToObject(
+                new Schema.Field(avroField.name(), avroField.schema().getValueType(),
+                    avroField.doc(), avroField.defaultVal()), mapEntry.getValue());
+            if (keyObject != null) {
+              mapChildObjects[0] = keyObject;
+            }
+            if (valueObject != null) {
+              mapChildObjects[1] = valueObject;
+            }
+            StructObject keyValueObject = new StructObject(mapChildObjects);
+            arrayMapChildObjects[counter++] = keyValueObject;
+          }
+        }
+        out = new ArrayObject(arrayMapChildObjects);
+        break;
       case RECORD:
         List<Schema.Field> fields = avroField.schema().getFields();
 
@@ -207,36 +244,51 @@ public class AvroCarbonWriter extends CarbonWriter {
   }
 
   private static Field prepareFields(Schema.Field avroField) {
-    String FieldName = avroField.name();
+    String fieldName = avroField.name();
     Schema childSchema = avroField.schema();
     Schema.Type type = childSchema.getType();
     LogicalType logicalType = childSchema.getLogicalType();
     switch (type) {
       case BOOLEAN:
-        return new Field(FieldName, DataTypes.BOOLEAN);
+        return new Field(fieldName, DataTypes.BOOLEAN);
       case INT:
         if (logicalType instanceof LogicalTypes.Date) {
-          return new Field(FieldName, DataTypes.DATE);
+          return new Field(fieldName, DataTypes.DATE);
         } else {
           LOGGER.warn("Unsupported logical type. Considering Data Type as INT for " + childSchema
               .getName());
-          return new Field(FieldName, DataTypes.INT);
+          return new Field(fieldName, DataTypes.INT);
         }
       case LONG:
         if (logicalType instanceof LogicalTypes.TimestampMillis
             || logicalType instanceof LogicalTypes.TimestampMicros) {
-          return new Field(FieldName, DataTypes.TIMESTAMP);
+          return new Field(fieldName, DataTypes.TIMESTAMP);
         } else {
           LOGGER.warn("Unsupported logical type. Considering Data Type as LONG for " + childSchema
               .getName());
-          return new Field(FieldName, DataTypes.LONG);
+          return new Field(fieldName, DataTypes.LONG);
         }
       case DOUBLE:
-        return new Field(FieldName, DataTypes.DOUBLE);
+        return new Field(fieldName, DataTypes.DOUBLE);
       case STRING:
-        return new Field(FieldName, DataTypes.STRING);
+        return new Field(fieldName, DataTypes.STRING);
       case FLOAT:
-        return new Field(FieldName, DataTypes.DOUBLE);
+        return new Field(fieldName, DataTypes.DOUBLE);
+      case MAP:
+        // recursively get the sub fields
+        ArrayList<StructField> mapSubFields = new ArrayList<>();
+        StructField mapField = prepareSubFields("val", childSchema);
+        if (null != mapField) {
+          // key value field will be wrapped inside a map struct field
+          StructField keyValueField = mapField.getChildren().get(0);
+          // value dataType will be at position 1 in the fields
+          DataType valueType =
+              ((StructType) keyValueField.getDataType()).getFields().get(1).getDataType();
+          MapType mapType = DataTypes.createMapType(DataTypes.STRING, valueType);
+          mapSubFields.add(keyValueField);
+          return new Field(fieldName, mapType, mapSubFields);
+        }
+        return null;
       case RECORD:
         // recursively get the sub fields
         ArrayList<StructField> structSubFields = new ArrayList<>();
@@ -246,7 +298,7 @@ public class AvroCarbonWriter extends CarbonWriter {
             structSubFields.add(structField);
           }
         }
-        return new Field(FieldName, "struct", structSubFields);
+        return new Field(fieldName, "struct", structSubFields);
       case ARRAY:
         // recursively get the sub fields
         ArrayList<StructField> arraySubField = new ArrayList<>();
@@ -254,7 +306,7 @@ public class AvroCarbonWriter extends CarbonWriter {
         StructField structField = prepareSubFields("val", childSchema.getElementType());
         if (structField != null) {
           arraySubField.add(structField);
-          return new Field(FieldName, "array", arraySubField);
+          return new Field(fieldName, "array", arraySubField);
         } else {
           return null;
         }
@@ -266,35 +318,54 @@ public class AvroCarbonWriter extends CarbonWriter {
     }
   }
 
-  private static StructField prepareSubFields(String FieldName, Schema childSchema) {
+  private static StructField prepareSubFields(String fieldName, Schema childSchema) {
     Schema.Type type = childSchema.getType();
     LogicalType logicalType = childSchema.getLogicalType();
     switch (type) {
       case BOOLEAN:
-        return new StructField(FieldName, DataTypes.BOOLEAN);
+        return new StructField(fieldName, DataTypes.BOOLEAN);
       case INT:
         if (logicalType instanceof LogicalTypes.Date) {
-          return new StructField(FieldName, DataTypes.DATE);
+          return new StructField(fieldName, DataTypes.DATE);
         } else {
           LOGGER.warn("Unsupported logical type. Considering Data Type as INT for " + childSchema
               .getName());
-          return new StructField(FieldName, DataTypes.INT);
+          return new StructField(fieldName, DataTypes.INT);
         }
       case LONG:
         if (logicalType instanceof LogicalTypes.TimestampMillis
             || logicalType instanceof LogicalTypes.TimestampMicros) {
-          return new StructField(FieldName, DataTypes.TIMESTAMP);
+          return new StructField(fieldName, DataTypes.TIMESTAMP);
         } else {
           LOGGER.warn("Unsupported logical type. Considering Data Type as LONG for " + childSchema
               .getName());
-          return new StructField(FieldName, DataTypes.LONG);
+          return new StructField(fieldName, DataTypes.LONG);
         }
       case DOUBLE:
-        return new StructField(FieldName, DataTypes.DOUBLE);
+        return new StructField(fieldName, DataTypes.DOUBLE);
       case STRING:
-        return new StructField(FieldName, DataTypes.STRING);
+        return new StructField(fieldName, DataTypes.STRING);
       case FLOAT:
-        return new StructField(FieldName, DataTypes.DOUBLE);
+        return new StructField(fieldName, DataTypes.DOUBLE);
+      case MAP:
+        // recursively get the sub fields
+        ArrayList<StructField> keyValueFields = new ArrayList<>();
+        // for Avro key dataType is always fixed as String
+        StructField keyField = new StructField(fieldName + ".key", DataTypes.STRING);
+        StructField valueField = prepareSubFields(fieldName + ".value", childSchema.getValueType());
+        if (null != valueField) {
+          keyValueFields.add(keyField);
+          keyValueFields.add(valueField);
+          StructField mapKeyValueField =
+              new StructField(fieldName, DataTypes.createStructType(keyValueFields));
+          // value dataType will be at position 1 in the fields
+          MapType mapType =
+              DataTypes.createMapType(DataTypes.STRING, mapKeyValueField.getDataType());
+          List<StructField> mapStructFields = new ArrayList<>();
+          mapStructFields.add(mapKeyValueField);
+          return new StructField(fieldName, mapType, mapStructFields);
+        }
+        return null;
       case RECORD:
         // recursively get the sub fields
         ArrayList<StructField> structSubFields = new ArrayList<>();
@@ -304,13 +375,13 @@ public class AvroCarbonWriter extends CarbonWriter {
             structSubFields.add(structField);
           }
         }
-        return (new StructField(FieldName, DataTypes.createStructType(structSubFields)));
+        return (new StructField(fieldName, DataTypes.createStructType(structSubFields)));
       case ARRAY:
         // recursively get the sub fields
         // array will have only one sub field.
-        DataType subType = getMappingDataTypeForArrayRecord(childSchema.getElementType());
+        DataType subType = getMappingDataTypeForCollectionRecord(childSchema.getElementType());
         if (subType != null) {
-          return (new StructField(FieldName, DataTypes.createArrayType(subType)));
+          return (new StructField(fieldName, DataTypes.createArrayType(subType)));
         } else {
           return null;
         }
@@ -322,7 +393,7 @@ public class AvroCarbonWriter extends CarbonWriter {
     }
   }
 
-  private static DataType getMappingDataTypeForArrayRecord(Schema childSchema) {
+  private static DataType getMappingDataTypeForCollectionRecord(Schema childSchema) {
     LogicalType logicalType = childSchema.getLogicalType();
     switch (childSchema.getType()) {
       case BOOLEAN:
@@ -358,6 +429,16 @@ public class AvroCarbonWriter extends CarbonWriter {
         return DataTypes.STRING;
       case FLOAT:
         return DataTypes.DOUBLE;
+      case MAP:
+        // recursively get the sub fields
+        StructField mapField = prepareSubFields("val", childSchema);
+        if (mapField != null) {
+          DataType ketType = ((StructType) mapField.getDataType()).getFields().get(0).getDataType();
+          DataType valueType =
+              ((StructType) mapField.getDataType()).getFields().get(1).getDataType();
+          return DataTypes.createMapType(ketType, valueType);
+        }
+        return null;
       case RECORD:
         // recursively get the sub fields
         ArrayList<StructField> structSubFields = new ArrayList<>();
@@ -370,7 +451,7 @@ public class AvroCarbonWriter extends CarbonWriter {
         return DataTypes.createStructType(structSubFields);
       case ARRAY:
         // array will have only one sub field.
-        DataType subType = getMappingDataTypeForArrayRecord(childSchema.getElementType());
+        DataType subType = getMappingDataTypeForCollectionRecord(childSchema.getElementType());
         if (subType != null) {
           return DataTypes.createArrayType(subType);
         } else {

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonWriterBuilder.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonWriterBuilder.java
@@ -653,6 +653,12 @@ public class CarbonWriterBuilder {
             DataType complexType = DataTypes.createStructType(structFieldsArray);
             tableSchemaBuilder
                 .addColumn(new StructField(field.getFieldName(), complexType), valIndex, false);
+          } else if (field.getDataType().getName().equalsIgnoreCase("MAP")) {
+            // Loop through the inner columns for MapType
+            DataType mapType =
+                DataTypes.createMapType(DataTypes.STRING, field.getChildren().get(0).getDataType());
+            tableSchemaBuilder
+                .addColumn(new StructField(field.getFieldName(), mapType), valIndex, false);
           }
         } else {
           ColumnSchema columnSchema = tableSchemaBuilder

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/Field.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/Field.java
@@ -38,7 +38,7 @@ public class Field {
   private DataType type;
   private List<StructField> children;
   private String parent;
-  private String storeType = "columnnar";
+  private String storeType = "columnar";
   private int schemaOrdinal = -1;
   private int precision = 0;
   private int scale = 0;
@@ -78,8 +78,9 @@ public class Field {
       this.type = DataTypes.createDefaultArrayType();
     } else if (type.equalsIgnoreCase("struct")) {
       this.type = DataTypes.createDefaultStructType();
-    }
-    else {
+    } else if (type.equalsIgnoreCase("map")) {
+      this.type = DataTypes.createDefaultMapType();
+    } else {
       throw new IllegalArgumentException("unsupported data type: " + type);
     }
   }
@@ -113,8 +114,7 @@ public class Field {
       this.type = DataTypes.createArrayType(fields.get(0).getDataType());
     } else if (type.equalsIgnoreCase("struct")) {
       this.type = DataTypes.createStructType(fields);
-    }
-    else {
+    } else {
       throw new IllegalArgumentException("unsupported data type: " + type);
     }
   }


### PR DESCRIPTION
This PR supports Avro Map data type support. It supports reading and writing complex map data type data using SDK.

For reading and writing Map data type using SDK refer the below test classes for reference
1. TestNonTransactionalCarbonTableForMapType.scala
2.  CarbonReaderTest.java

 - [ ] Any interfaces changed?
 No
 - [ ] Any backward compatibility impacted?
 No
 - [ ] Document update required?
No
 - [ ] Testing done
Add test cases  for verification
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA
