### PR TITLE
[CARBONDATA-2874] Support SDK writer as thread safe api  

### DIFF
--- a/docs/sdk-guide.md
+++ b/docs/sdk-guide.md
@@ -369,6 +369,7 @@ public CarbonWriterBuilder withTableProperties(Map<String, String> options);
 
 ```
 /**
+* this writer is not thread safe, use buildThreadSafeWriterForCSVInput in multi thread environment
 * Build a {@link CarbonWriter}, which accepts row in CSV format object
 * @param schema carbon Schema object {org.apache.carbondata.sdk.file.Schema}
 * @return CSVCarbonWriter
@@ -378,8 +379,24 @@ public CarbonWriterBuilder withTableProperties(Map<String, String> options);
 public CarbonWriter buildWriterForCSVInput(org.apache.carbondata.sdk.file.Schema schema) throws IOException, InvalidLoadOptionException;
 ```
 
+```
+/**
+* Can use this writer in multi-thread instance.
+* Build a {@link CarbonWriter}, which accepts row in CSV format
+* @param schema carbon Schema object {org.apache.carbondata.sdk.file.Schema}
+* @param numOfThreads number of threads() in which .write will be called.              
+* @return CSVCarbonWriter
+* @throws IOException
+* @throws InvalidLoadOptionException
+*/
+public CarbonWriter buildThreadSafeWriterForCSVInput(Schema schema, short numOfThreads)
+  throws IOException, InvalidLoadOptionException;
+```
+
+
 ```  
 /**
+* this writer is not thread safe, use buildThreadSafeWriterForAvroInput in multi thread environment
 * Build a {@link CarbonWriter}, which accepts Avro format object
 * @param avroSchema avro Schema object {org.apache.avro.Schema}
 * @return AvroCarbonWriter 
@@ -391,6 +408,22 @@ public CarbonWriter buildWriterForAvroInput(org.apache.avro.Schema schema) throw
 
 ```
 /**
+* Can use this writer in multi-thread instance.
+* Build a {@link CarbonWriter}, which accepts Avro object
+* @param avroSchema avro Schema object {org.apache.avro.Schema}
+* @param numOfThreads number of threads() in which .write will be called.
+* @return AvroCarbonWriter
+* @throws IOException
+* @throws InvalidLoadOptionException
+*/
+public CarbonWriter buildThreadSafeWriterForAvroInput(org.apache.avro.Schema avroSchema, short numOfThreads)
+  throws IOException, InvalidLoadOptionException
+```
+
+
+```
+/**
+* this writer is not thread safe, use buildThreadSafeWriterForJsonInput in multi thread environment
 * Build a {@link CarbonWriter}, which accepts Json object
 * @param carbonSchema carbon Schema object
 * @return JsonCarbonWriter
@@ -398,6 +431,19 @@ public CarbonWriter buildWriterForAvroInput(org.apache.avro.Schema schema) throw
 * @throws InvalidLoadOptionException
 */
 public JsonCarbonWriter buildWriterForJsonInput(Schema carbonSchema);
+```
+
+```
+/**
+* Can use this writer in multi-thread instance.
+* Build a {@link CarbonWriter}, which accepts Json object
+* @param carbonSchema carbon Schema object
+* @param numOfThreads number of threads() in which .write will be called.
+* @return JsonCarbonWriter
+* @throws IOException
+* @throws InvalidLoadOptionException
+*/
+public JsonCarbonWriter buildThreadSafeWriterForJsonInput(Schema carbonSchema, short numOfThreads)
 ```
 
 ### Class org.apache.carbondata.sdk.file.CarbonWriter
@@ -408,7 +454,7 @@ public JsonCarbonWriter buildWriterForJsonInput(Schema carbonSchema);
 *                      which is one row of data.
 * If CSVCarbonWriter, object is of type String[], which is one row of data
 * If JsonCarbonWriter, object is of type String, which is one row of json
-* Note: This API is not thread safe
+* Note: This API is not thread safe if writer is not built with number of threads argument.
 * @param object
 * @throws IOException
 */
@@ -696,7 +742,6 @@ Find example code at [CarbonReaderExample](https://github.com/apache/carbondata/
    *
    * @param dataFilePath complete path including carbondata file name
    * @return Schema object
-   * @throws IOException
    */
   public static Schema readSchemaInDataFile(String dataFilePath);
 ```

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/DataLoadProcessBuilder.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/DataLoadProcessBuilder.java
@@ -313,6 +313,9 @@ public final class DataLoadProcessBuilder {
     }
     TableSpec tableSpec = new TableSpec(carbonTable);
     configuration.setTableSpec(tableSpec);
+    if (loadModel.getSdkUserCores() > 0) {
+      configuration.setWritingCoresCount(loadModel.getSdkUserCores());
+    }
     return configuration;
   }
 

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/model/CarbonLoadModel.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/model/CarbonLoadModel.java
@@ -59,6 +59,9 @@ public class CarbonLoadModel implements Serializable {
    */
   private boolean carbonTransactionalTable = true;
 
+  /* Number of thread in which sdk writer is used */
+  private short sdkUserCores;
+
   private String csvHeader;
   private String[] csvHeaderColumns;
   private String csvDelimiter;
@@ -392,7 +395,6 @@ public class CarbonLoadModel implements Serializable {
     this.colDictFilePath = colDictFilePath;
   }
 
-
   public DictionaryServiceProvider getDictionaryServiceProvider() {
     return dictionaryServiceProvider;
   }
@@ -470,6 +472,7 @@ public class CarbonLoadModel implements Serializable {
     copy.sortColumnsBoundsStr = sortColumnsBoundsStr;
     copy.loadMinSize = loadMinSize;
     copy.parentTablePath = parentTablePath;
+    copy.sdkUserCores = sdkUserCores;
     return copy;
   }
 
@@ -525,8 +528,10 @@ public class CarbonLoadModel implements Serializable {
     copyObj.sortColumnsBoundsStr = sortColumnsBoundsStr;
     copyObj.loadMinSize = loadMinSize;
     copyObj.parentTablePath = parentTablePath;
+    copyObj.sdkUserCores = sdkUserCores;
     return copyObj;
   }
+
 
   /**
    * @param tablePath The tablePath to set.
@@ -541,7 +546,6 @@ public class CarbonLoadModel implements Serializable {
   public String getTablePath() {
     return tablePath;
   }
-
   /**
    * getLoadMetadataDetails.
    *
@@ -550,6 +554,7 @@ public class CarbonLoadModel implements Serializable {
   public List<LoadMetadataDetails> getLoadMetadataDetails() {
     return loadMetadataDetails;
   }
+
 
   /**
    * Get the current load metadata.
@@ -572,7 +577,6 @@ public class CarbonLoadModel implements Serializable {
   public void setLoadMetadataDetails(List<LoadMetadataDetails> loadMetadataDetails) {
     this.loadMetadataDetails = loadMetadataDetails;
   }
-
   /**
    * getSegmentUpdateStatusManager
    *
@@ -850,6 +854,7 @@ public class CarbonLoadModel implements Serializable {
   public void setTimestampformat(String timestampformat) {
     this.timestampformat = timestampformat;
   }
+
   public String getSkipEmptyLine() {
     return skipEmptyLine;
   }
@@ -857,7 +862,6 @@ public class CarbonLoadModel implements Serializable {
   public void setSkipEmptyLine(String skipEmptyLine) {
     this.skipEmptyLine = skipEmptyLine;
   }
-
 
   public boolean isLoadWithoutConverterStep() {
     return isLoadWithoutConverterStep;
@@ -903,7 +907,6 @@ public class CarbonLoadModel implements Serializable {
   public void setMergedSegmentIds(List<String> mergedSegmentIds) {
     this.mergedSegmentIds = mergedSegmentIds;
   }
-
   public List<String> getMergedSegmentIds() {
     if (null == mergedSegmentIds) {
       mergedSegmentIds = new ArrayList<>(CarbonCommonConstants.DEFAULT_COLLECTION_SIZE);
@@ -911,4 +914,11 @@ public class CarbonLoadModel implements Serializable {
     return mergedSegmentIds;
   }
 
+  public short getSdkUserCores() {
+    return sdkUserCores;
+  }
+
+  public void setSdkUserCores(short sdkUserCores) {
+    this.sdkUserCores = sdkUserCores;
+  }
 }

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/steps/InputProcessorStepImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/steps/InputProcessorStepImpl.java
@@ -47,6 +47,8 @@ public class InputProcessorStepImpl extends AbstractDataLoadProcessorStep {
 
   private CarbonIterator<Object[]>[] inputIterators;
 
+  private short sdkUserCore;
+
   /**
    * executor service to execute the query
    */
@@ -56,6 +58,7 @@ public class InputProcessorStepImpl extends AbstractDataLoadProcessorStep {
       CarbonIterator<Object[]>[] inputIterators) {
     super(configuration, null);
     this.inputIterators = inputIterators;
+    this.sdkUserCore = configuration.getWritingCoresCount();
   }
 
   @Override public DataField[] getOutput() {
@@ -75,7 +78,7 @@ public class InputProcessorStepImpl extends AbstractDataLoadProcessorStep {
   @Override public Iterator<CarbonRowBatch>[] execute() {
     int batchSize = CarbonProperties.getInstance().getBatchSize();
     List<CarbonIterator<Object[]>>[] readerIterators =
-        CarbonDataProcessorUtil.partitionInputReaderIterators(inputIterators);
+        CarbonDataProcessorUtil.partitionInputReaderIterators(inputIterators, sdkUserCore);
     Iterator<CarbonRowBatch>[] outIterators = new Iterator[readerIterators.length];
     for (int i = 0; i < outIterators.length; i++) {
       outIterators[i] =

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/steps/JsonInputProcessorStepImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/steps/JsonInputProcessorStepImpl.java
@@ -41,10 +41,13 @@ public class JsonInputProcessorStepImpl extends AbstractDataLoadProcessorStep {
 
   boolean isRawDataRequired = false;
 
+  short sdkUserCore;
+
   public JsonInputProcessorStepImpl(CarbonDataLoadConfiguration configuration,
       CarbonIterator<Object[]>[] inputIterators) {
     super(configuration, null);
     this.inputIterators = inputIterators;
+    sdkUserCore = configuration.getWritingCoresCount();
   }
 
   @Override public DataField[] getOutput() {
@@ -61,7 +64,7 @@ public class JsonInputProcessorStepImpl extends AbstractDataLoadProcessorStep {
   @Override public Iterator<CarbonRowBatch>[] execute() {
     int batchSize = CarbonProperties.getInstance().getBatchSize();
     List<CarbonIterator<Object[]>>[] readerIterators =
-        CarbonDataProcessorUtil.partitionInputReaderIterators(inputIterators);
+        CarbonDataProcessorUtil.partitionInputReaderIterators(inputIterators, sdkUserCore);
     Iterator<CarbonRowBatch>[] outIterators = new Iterator[readerIterators.length];
     for (int i = 0; i < outIterators.length; i++) {
       outIterators[i] =

--- a/processing/src/main/java/org/apache/carbondata/processing/util/CarbonDataProcessorUtil.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/util/CarbonDataProcessorUtil.java
@@ -659,9 +659,14 @@ public final class CarbonDataProcessorUtil {
    * @return
    */
   public static List<CarbonIterator<Object[]>>[] partitionInputReaderIterators(
-      CarbonIterator<Object[]>[] inputIterators) {
+      CarbonIterator<Object[]>[] inputIterators, short sdkUserCores) {
     // Get the number of cores configured in property.
-    int numberOfCores = CarbonProperties.getInstance().getNumberOfCores();
+    int numberOfCores;
+    if (sdkUserCores > 0) {
+      numberOfCores = sdkUserCores;
+    } else {
+      numberOfCores = CarbonProperties.getInstance().getNumberOfCores();
+    }
     // Get the minimum of number of cores and iterators size to get the number of parallel threads
     // to be launched.
     int parallelThreadNumber = Math.min(inputIterators.length, numberOfCores);

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonWriterBuilder.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonWriterBuilder.java
@@ -409,7 +409,7 @@ public class CarbonWriterBuilder {
     if (numOfThreads <= 0) {
       throw new IllegalArgumentException(" numOfThreads must be greater than 0");
     }
-    CarbonLoadModel loadModel = createLoadModel();
+    CarbonLoadModel loadModel = buildLoadModel(schema);
     loadModel.setSdkUserCores(numOfThreads);
     return new CSVCarbonWriter(loadModel);
   }
@@ -455,7 +455,7 @@ public class CarbonWriterBuilder {
     if (numOfThreads <= 0) {
       throw new IllegalArgumentException(" numOfThreads must be greater than 0");
     }
-    CarbonLoadModel loadModel = createLoadModel();
+    CarbonLoadModel loadModel = buildLoadModel(schema);
     // AVRO records are pushed to Carbon as Object not as Strings. This was done in order to
     // handle multi level complex type support. As there are no conversion converter step is
     // removed from the load. LoadWithoutConverter flag is going to point to the Loader Builder
@@ -503,7 +503,7 @@ public class CarbonWriterBuilder {
       throw new IllegalArgumentException(" numOfThreads must be greater than 0");
     }
     this.schema = carbonSchema;
-    CarbonLoadModel loadModel = createLoadModel();
+    CarbonLoadModel loadModel = buildLoadModel(schema);
     loadModel.setJsonFileLoad(true);
     loadModel.setSdkUserCores(numOfThreads);
     return new JsonCarbonWriter(loadModel);

--- a/store/sdk/src/test/java/org/apache/carbondata/sdk/file/ConcurrentSdkWriterTest.java
+++ b/store/sdk/src/test/java/org/apache/carbondata/sdk/file/ConcurrentSdkWriterTest.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.sdk.file;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.carbondata.core.metadata.datatype.DataTypes;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * multi-thread Test suite for {@link CSVCarbonWriter}
+ */
+public class ConcurrentSdkWriterTest {
+
+  private static final int recordsPerItr = 10;
+  private static final short numOfThreads = 4;
+
+  @Test
+  public void testWriteFiles() throws IOException {
+    String path = "./testWriteFiles";
+    FileUtils.deleteDirectory(new File(path));
+
+    Field[] fields = new Field[2];
+    fields[0] = new Field("name", DataTypes.STRING);
+    fields[1] = new Field("age", DataTypes.INT);
+
+
+
+    ExecutorService executorService = Executors.newFixedThreadPool(numOfThreads);
+    try {
+      CarbonWriterBuilder builder = CarbonWriter.builder()
+          .outputPath(path);
+      CarbonWriter writer =
+          builder.buildThreadSafeWriterForCSVInput(new Schema(fields), numOfThreads);
+      // write in multi-thread
+      for (int i = 0; i < numOfThreads; i++) {
+        executorService.submit(new WriteLogic(writer));
+      }
+      executorService.shutdown();
+      executorService.awaitTermination(2, TimeUnit.HOURS);
+      writer.close();
+    } catch (Exception e) {
+      e.printStackTrace();
+      Assert.fail(e.getMessage());
+    }
+
+    // read the files and verify the count
+    CarbonReader reader;
+    try {
+      reader = CarbonReader
+          .builder(path, "_temp")
+          .projection(new String[]{"name", "age"})
+          .build();
+      int i = 0;
+      while (reader.hasNext()) {
+        Object[] row = (Object[]) reader.readNextRow();
+        i++;
+      }
+      Assert.assertEquals(i, numOfThreads * recordsPerItr);
+      reader.close();
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+      Assert.fail(e.getMessage());
+    }
+
+    FileUtils.deleteDirectory(new File(path));
+  }
+
+  class WriteLogic implements Runnable {
+    CarbonWriter writer;
+
+    WriteLogic(CarbonWriter writer) {
+      this.writer = writer;
+    }
+
+    @Override public void run() {
+      try {
+        for (int i = 0; i < recordsPerItr; i++) {
+          writer.write(new String[] { "robot" + (i % 10), String.valueOf(i),
+              String.valueOf((double) i / 2) });
+        }
+      } catch (IOException e) {
+        e.printStackTrace();
+        Assert.fail(e.getMessage());
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Problem: Currently CarbonWriter.write() not a thread safe. if multiple threads calls .write() for one writer.
Data count inconsistency is observed.

root casue: As all the threads are writing to same batch of blocking queue. need to synchronize this. Else one thread data overwrite the other thread data.

Solution: 
a) DataLoadExecutor is using only one iterator, take number of threads as input and internally create that many iterator to loop over the data. This will reduce the blocking time of queue as each iterator has its own queue.
b) InputProcessor step is taking only default 2 cores (2 thread) for data load in SDK flow, can use the same number as number of threads created by user.
c) writer step is using only 2 cores  (2 thread). can use the same number as number of threads created by user.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed? NA. Added new interface
 
 - [ ] Any backward compatibility impacted? NA
 
 - [ ] Document update required? yes,  udpated

 - [ ] Testing done. Yes, updated the test case
      
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. NA

