### PR TITLE
[CARBONDATA-2883][ExternalFormat] block some operations  on external format table

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/CarbonTable.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/CarbonTable.java
@@ -64,6 +64,8 @@ import org.apache.carbondata.core.util.path.CarbonTablePath;
 import static org.apache.carbondata.core.metadata.schema.datamap.DataMapClassProvider.MV;
 import static org.apache.carbondata.core.util.CarbonUtil.thriftColumnSchemaToWrapperColumnSchema;
 
+import org.apache.commons.lang3.StringUtils;
+
 /**
  * Mapping class for Carbon actual table
  */
@@ -1275,5 +1277,14 @@ public class CarbonTable implements Serializable {
       }
     }
     return false;
+  }
+
+  /**
+   * if format is 'carbondata' or '' or null, return false
+   * else return true.
+   */
+  public boolean isExternalFormatTable() {
+    String format = tableInfo.getFormat();
+    return StringUtils.isNotEmpty(format) && !format.equalsIgnoreCase("carbondata");
   }
 }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/mutation/CarbonProjectForDeleteCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/mutation/CarbonProjectForDeleteCommand.scala
@@ -49,7 +49,9 @@ private[sql] case class CarbonProjectForDeleteCommand(
     if (!carbonTable.getTableInfo.isTransactionalTable) {
       throw new MalformedCarbonCommandException("Unsupported operation on non transactional table")
     }
-
+    if (carbonTable.isExternalFormatTable) {
+      throw new MalformedCarbonCommandException("Unsupported operation on external format table")
+    }
     if (SegmentStatusManager.isCompactionInProgress(carbonTable)) {
       throw new ConcurrentOperationException(carbonTable, "compaction", "data delete")
     }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/mutation/CarbonProjectForUpdateCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/mutation/CarbonProjectForUpdateCommand.scala
@@ -67,6 +67,9 @@ private[sql] case class CarbonProjectForUpdateCommand(
       }
 
     }
+    if (carbonTable.isExternalFormatTable) {
+      throw new MalformedCarbonCommandException("Unsupported operation on external format table")
+    }
     if (!carbonTable.getTableInfo.isTransactionalTable) {
       throw new MalformedCarbonCommandException("Unsupported operation on non transactional table")
     }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/schema/CarbonAlterTableAddColumnCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/schema/CarbonAlterTableAddColumnCommand.scala
@@ -59,6 +59,9 @@ private[sql] case class CarbonAlterTableAddColumnCommand(
       // up relation should be called after acquiring the lock
       val metastore = CarbonEnv.getInstance(sparkSession).carbonMetastore
       carbonTable = CarbonEnv.getCarbonTable(Some(dbName), tableName)(sparkSession)
+      if (carbonTable.isExternalFormatTable) {
+        throw new MalformedCarbonCommandException("Unsupported operation on external format table")
+      }
       if (!carbonTable.canAllow(carbonTable, TableOperation.ALTER_ADD_COLUMN)) {
         throw new MalformedCarbonCommandException(
           "alter table add column is not supported for index datamap")

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/schema/CarbonAlterTableDataTypeChangeCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/schema/CarbonAlterTableDataTypeChangeCommand.scala
@@ -55,6 +55,9 @@ private[sql] case class CarbonAlterTableDataTypeChangeCommand(
         .validateTableAndAcquireLock(dbName, tableName, locksToBeAcquired)(sparkSession)
       val metastore = CarbonEnv.getInstance(sparkSession).carbonMetastore
       carbonTable = CarbonEnv.getCarbonTable(Some(dbName), tableName)(sparkSession)
+      if (carbonTable.isExternalFormatTable) {
+        throw new MalformedCarbonCommandException("Unsupported operation on external format table")
+      }
       if (!carbonTable.canAllow(carbonTable, TableOperation.ALTER_CHANGE_DATATYPE,
         alterTableDataTypeChangeModel.columnName)) {
         throw new MalformedCarbonCommandException(

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/schema/CarbonAlterTableDropColumnCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/schema/CarbonAlterTableDropColumnCommand.scala
@@ -58,6 +58,9 @@ private[sql] case class CarbonAlterTableDropColumnCommand(
         .validateTableAndAcquireLock(dbName, tableName, locksToBeAcquired)(sparkSession)
       val metastore = CarbonEnv.getInstance(sparkSession).carbonMetastore
       carbonTable = CarbonEnv.getCarbonTable(Some(dbName), tableName)(sparkSession)
+      if (carbonTable.isExternalFormatTable) {
+        throw new MalformedCarbonCommandException("Unsupported operation on external format table")
+      }
       if (!carbonTable.canAllow(carbonTable, TableOperation.ALTER_DROP,
           alterTableDropColumnModel.columns.asJava)) {
         throw new MalformedCarbonCommandException(

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonDescribeFormattedCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonDescribeFormattedCommand.scala
@@ -207,6 +207,15 @@ private[sql] case class CarbonDescribeFormattedCommand(
         tblProps.get(CarbonCommonConstants.FLAT_FOLDER),
         CarbonCommonConstants.DEFAULT_FLAT_FOLDER))
     }
+    // if table use external format, then add the external format Information.
+    if (carbonTable.isExternalFormatTable) {
+      results ++= Seq(("", "", ""), ("##Detailed External-Format Information", "", ""))
+      results ++= Seq((CarbonCommonConstants.FORMAT, carbonTable.getTableInfo.getFormat, ""))
+      results ++= carbonTable.getTableInfo.getFormatProperties.asScala.map(pair => {
+        (pair._1, pair._2.replaceAll("\r|\n", "")
+          .replaceAll("\\s", ""), "")
+      })
+    }
 
     results ++= Seq(("", "", ""), ("##Detailed Column property", "", ""))
     if (colPropStr.length() > 0) {


### PR DESCRIPTION
Now some operatons are not supported for external format table, so those operations will be blocked as bellows:
**1. update data on external format table
2. delete data on external format table
3. add columns on external format table
4. drop columns on external format table
5. change column datatype on external format table**

The  operation in following scenario is not allowed:
**create external format table if table columns not in tblproperty '{format}.header'** 

**And add external format information for command 'desc formatted table'.**
e.g.
CREATE TABLE fact_carbon_csv_table(empname String, empno int, designation string)
 STORED BY 'carbondata'
 TBLPROPERTIES(
 'format'='csv',
 'csv.header'='empno, empname, designation, salary',
 'csv.delimiter'='|'
)
desc formatted fact_carbon_csv_table:
|##Detailed External-Format Information|                                                   |
|format                                              |csv                                                      |
|csv.delimiter                                     ||                                                          |
|csv.header                                        |empno,empname,designation,salary |


Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
       No
 - [x] Any backward compatibility impacted?
       No
 - [x] Document update required?
       No
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       has added test case. 
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
       NA
