### PR TITLE
[Carbondata 2885]Broadcast Issue and Small file distribution Issue

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/scan/result/iterator/AbstractDetailQueryResultIterator.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/iterator/AbstractDetailQueryResultIterator.java
@@ -254,6 +254,11 @@ public abstract class AbstractDetailQueryResultIterator<E> extends CarbonIterato
 
   private DataBlockIterator getDataBlockIterator() {
     if (blockExecutionInfos.size() > 0) {
+      try {
+        fileReader.finish();
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
       BlockExecutionInfo executionInfo = blockExecutionInfos.get(0);
       blockExecutionInfos.remove(executionInfo);
       return new DataBlockIterator(executionInfo, fileReader, batchSize, queryStatisticsModel,

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonRelation.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonRelation.scala
@@ -158,39 +158,48 @@ case class CarbonRelation(
   private var sizeInBytesLocalValue = 0L
 
   def sizeInBytes: Long = {
-    val tableStatusNewLastUpdatedTime = SegmentStatusManager.getTableStatusLastModifiedTime(
-      carbonTable.getAbsoluteTableIdentifier)
-    if (tableStatusLastUpdateTime != tableStatusNewLastUpdatedTime) {
-      if (new SegmentStatusManager(carbonTable.getAbsoluteTableIdentifier)
-        .getValidAndInvalidSegments.getValidSegments.isEmpty) {
-        sizeInBytesLocalValue = 0L
-      } else {
-        val tablePath = carbonTable.getTablePath
-        val fileType = FileFactory.getFileType(tablePath)
-        if (FileFactory.isFileExist(tablePath, fileType)) {
-          // get the valid segments
-          val segments = new SegmentStatusManager(carbonTable.getAbsoluteTableIdentifier)
-            .getValidAndInvalidSegments.getValidSegments.asScala
-          var size = 0L
-          // for each segment calculate the size
-          segments.foreach {validSeg =>
-            // for older store
-            if (null != validSeg.getLoadMetadataDetails.getDataSize &&
-                null != validSeg.getLoadMetadataDetails.getIndexSize) {
-              size = size + validSeg.getLoadMetadataDetails.getDataSize.toLong +
-                     validSeg.getLoadMetadataDetails.getIndexSize.toLong
-            } else {
-              size = size + FileFactory.getDirectorySize(
-                CarbonTablePath.getSegmentPath(tablePath, validSeg.getSegmentNo))
+    if (carbonTable.isExternalTable) {
+      val tablePath = carbonTable.getTablePath
+      val fileType = FileFactory.getFileType(tablePath)
+      if (FileFactory.isFileExist(tablePath, fileType)) {
+        sizeInBytesLocalValue = FileFactory.getDirectorySize(tablePath)
+      }
+    } else {
+      val tableStatusNewLastUpdatedTime = SegmentStatusManager.getTableStatusLastModifiedTime(
+        carbonTable.getAbsoluteTableIdentifier)
+      if (tableStatusLastUpdateTime != tableStatusNewLastUpdatedTime) {
+        if (new SegmentStatusManager(carbonTable.getAbsoluteTableIdentifier)
+          .getValidAndInvalidSegments.getValidSegments.isEmpty) {
+          sizeInBytesLocalValue = 0L
+        } else {
+          val tablePath = carbonTable.getTablePath
+          val fileType = FileFactory.getFileType(tablePath)
+          if (FileFactory.isFileExist(tablePath, fileType)) {
+            // get the valid segments
+            val segments = new SegmentStatusManager(carbonTable.getAbsoluteTableIdentifier)
+              .getValidAndInvalidSegments.getValidSegments.asScala
+            var size = 0L
+            // for each segment calculate the size
+            segments.foreach { validSeg =>
+              // for older store
+              if (null != validSeg.getLoadMetadataDetails.getDataSize &&
+                  null != validSeg.getLoadMetadataDetails.getIndexSize) {
+                size = size + validSeg.getLoadMetadataDetails.getDataSize.toLong +
+                       validSeg.getLoadMetadataDetails.getIndexSize.toLong
+              } else {
+                size = size + FileFactory.getDirectorySize(
+                  CarbonTablePath.getSegmentPath(tablePath, validSeg.getSegmentNo))
+              }
             }
+            // update the new table status time
+            tableStatusLastUpdateTime = tableStatusNewLastUpdatedTime
+            // update the new size
+            sizeInBytesLocalValue = size
           }
-          // update the new table status time
-          tableStatusLastUpdateTime = tableStatusNewLastUpdatedTime
-          // update the new size
-          sizeInBytesLocalValue = size
         }
       }
     }
+
     sizeInBytesLocalValue
   }
 


### PR DESCRIPTION
Issue  :-
1.  In External Table Carbon Relation sizeInByte is wrong (always 0) because of this Join Queries are identified for broadcast even Table actual size is > 10MB( default broadcast).This is making fail some of the join table ( table which should select sortmergeJoin but because of wrong calculation it gone for broadcast join) 

2.  if Merge_small_file task distribution is enabled  ,Join queries are failed (TPCH). 
carbon opens many carbon files but it not getting closed. 

Root Cause :- 1. Current relation size calculation is based on tablestatus file but since External Table does not have tablestatus file so always zero was returned.
2. if Merge_small_file task distribution is enabled carbon opens many carbon files but it not getting closed. 
Solution :- 
1. if Table is External Table then calculate size from TablePath .
2. close the carbon files for scan is finished.


Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 NA
 - [ ] Any backward compatibility impacted?
 NA
 - [ ] Document update required?
NA
 - [ ] Testing done
     Manually  testing in 3 node cluster  
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA
