### PR TITLE
[CARBONDATA-2888] Support multi level subfolder for SDK read and fileformat read

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/SegmentIndexFileStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/SegmentIndexFileStore.java
@@ -341,6 +341,24 @@ public class SegmentIndexFileStore {
   /**
    * List all the index files of the segment.
    *
+   * @param carbonFile directory
+   */
+  public static void getCarbonIndexFilesRecursively(CarbonFile carbonFile,
+      List<CarbonFile> indexFiles) {
+    CarbonFile[] carbonFiles = carbonFile.listFiles();
+    for (CarbonFile file : carbonFiles) {
+      if (file.isDirectory()) {
+        getCarbonIndexFilesRecursively(file, indexFiles);
+      } else if ((file.getName().endsWith(CarbonTablePath.INDEX_FILE_EXT) || file.getName()
+          .endsWith(CarbonTablePath.MERGE_INDEX_FILE_EXT)) && file.getSize() > 0) {
+        indexFiles.add(file);
+      }
+    }
+  }
+
+  /**
+   * List all the index files of the segment.
+   *
    * @param segmentPath
    * @return
    */

--- a/core/src/main/java/org/apache/carbondata/core/readcommitter/LatestFilesReadCommittedScope.java
+++ b/core/src/main/java/org/apache/carbondata/core/readcommitter/LatestFilesReadCommittedScope.java
@@ -175,7 +175,9 @@ public class LatestFilesReadCommittedScope implements ReadCommittedScope {
     CarbonFile[] carbonIndexFiles = null;
     if (file.isDirectory()) {
       if (segmentId == null) {
-        carbonIndexFiles = SegmentIndexFileStore.getCarbonIndexFiles(file);
+        List<CarbonFile> indexFiles = new ArrayList<>();
+        SegmentIndexFileStore.getCarbonIndexFilesRecursively(file, indexFiles);
+        carbonIndexFiles = indexFiles.toArray(new CarbonFile[0]);
       } else {
         String segmentPath = CarbonTablePath.getSegmentPath(carbonFilePath, segmentId);
         carbonIndexFiles = SegmentIndexFileStore.getCarbonIndexFiles(segmentPath);

--- a/integration/spark-datasource/src/test/scala/org/apache/spark/sql/carbondata/datasource/SparkCarbonDataSourceTest.scala
+++ b/integration/spark-datasource/src/test/scala/org/apache/spark/sql/carbondata/datasource/SparkCarbonDataSourceTest.scala
@@ -591,23 +591,27 @@ class SparkCarbonDataSourceTest extends FunSuite with BeforeAndAfterAll {
   }
 
   test("test write using multi subfolder") {
-    FileFactory.deleteAllCarbonFilesOfDir(FileFactory.getCarbonFile(warehouse1 + "/test_folder"))
-    import spark.implicits._
-    val df = spark.sparkContext.parallelize(1 to 10)
-      .map(x => ("a" + x % 10, "b", x))
-      .toDF("c1", "c2", "number")
+    if (!spark.sparkContext.version.startsWith("2.1")) {
+      FileFactory.deleteAllCarbonFilesOfDir(FileFactory.getCarbonFile(warehouse1 + "/test_folder"))
+      import spark.implicits._
+      val df = spark.sparkContext.parallelize(1 to 10)
+        .map(x => ("a" + x % 10, "b", x))
+        .toDF("c1", "c2", "number")
 
-    // Saves dataframe to carbon file
-    df.write.format("carbon").save(warehouse1 + "/test_folder/1/"+System.nanoTime())
-    df.write.format("carbon").save(warehouse1 + "/test_folder/2/"+System.nanoTime())
-    df.write.format("carbon").save(warehouse1 + "/test_folder/3/"+System.nanoTime())
+      // Saves dataframe to carbon file
+      df.write.format("carbon").save(warehouse1 + "/test_folder/1/" + System.nanoTime())
+      df.write.format("carbon").save(warehouse1 + "/test_folder/2/" + System.nanoTime())
+      df.write.format("carbon").save(warehouse1 + "/test_folder/3/" + System.nanoTime())
 
-    val frame = spark.read.format("carbon").load(warehouse1 + "/test_folder")
-    assert(frame.count() == 30)
-    val mapSize = DataMapStoreManager.getInstance().getAllDataMaps.size()
-    DataMapStoreManager.getInstance().clearDataMaps(AbsoluteTableIdentifier.from(warehouse1+"/test_folder"))
-    assert(mapSize > DataMapStoreManager.getInstance().getAllDataMaps.size())
-    FileFactory.deleteAllCarbonFilesOfDir(FileFactory.getCarbonFile(warehouse1 + "/test_folder"))
+      val frame = spark.read.format("carbon").load(warehouse1 + "/test_folder")
+      assert(frame.count() == 30)
+      assert(frame.where("c1='a1'").count() == 3)
+      val mapSize = DataMapStoreManager.getInstance().getAllDataMaps.size()
+      DataMapStoreManager.getInstance()
+        .clearDataMaps(AbsoluteTableIdentifier.from(warehouse1 + "/test_folder"))
+      assert(mapSize > DataMapStoreManager.getInstance().getAllDataMaps.size())
+      FileFactory.deleteAllCarbonFilesOfDir(FileFactory.getCarbonFile(warehouse1 + "/test_folder"))
+    }
   }
   override protected def beforeAll(): Unit = {
     drop

--- a/integration/spark-datasource/src/test/scala/org/apache/spark/sql/carbondata/datasource/SparkCarbonDataSourceTest.scala
+++ b/integration/spark-datasource/src/test/scala/org/apache/spark/sql/carbondata/datasource/SparkCarbonDataSourceTest.scala
@@ -590,7 +590,25 @@ class SparkCarbonDataSourceTest extends FunSuite with BeforeAndAfterAll {
     }
   }
 
+  test("test write using multi subfolder") {
+    FileFactory.deleteAllCarbonFilesOfDir(FileFactory.getCarbonFile(warehouse1 + "/test_folder"))
+    import spark.implicits._
+    val df = spark.sparkContext.parallelize(1 to 10)
+      .map(x => ("a" + x % 10, "b", x))
+      .toDF("c1", "c2", "number")
 
+    // Saves dataframe to carbon file
+    df.write.format("carbon").save(warehouse1 + "/test_folder/1/"+System.nanoTime())
+    df.write.format("carbon").save(warehouse1 + "/test_folder/2/"+System.nanoTime())
+    df.write.format("carbon").save(warehouse1 + "/test_folder/3/"+System.nanoTime())
+
+    val frame = spark.read.format("carbon").load(warehouse1 + "/test_folder")
+    assert(frame.count() == 30)
+    val mapSize = DataMapStoreManager.getInstance().getAllDataMaps.size()
+    DataMapStoreManager.getInstance().clearDataMaps(AbsoluteTableIdentifier.from(warehouse1+"/test_folder"))
+    assert(mapSize > DataMapStoreManager.getInstance().getAllDataMaps.size())
+    FileFactory.deleteAllCarbonFilesOfDir(FileFactory.getCarbonFile(warehouse1 + "/test_folder"))
+  }
   override protected def beforeAll(): Unit = {
     drop
   }


### PR DESCRIPTION
This PR supports multi-level subfolders read for SDK Reader and spark's carbon fileformat reader.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

