### PR TITLE
[CARBONDATA-2895] Fix Query result count is more than actual csv rows with Batch-sort in save to disk (sort temp files) scenario.

### DIFF
--- a/processing/src/main/java/org/apache/carbondata/processing/loading/sort/impl/UnsafeBatchParallelReadMergeSorterImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/sort/impl/UnsafeBatchParallelReadMergeSorterImpl.java
@@ -62,6 +62,8 @@ public class UnsafeBatchParallelReadMergeSorterImpl extends AbstractMergeSorter 
 
   private AtomicLong rowCounter;
 
+  /* will be incremented for each batch. This ID is used in sort temp files name,
+   to identify files of that batch */
   private AtomicInteger batchId;
 
   public UnsafeBatchParallelReadMergeSorterImpl(AtomicLong rowCounter) {


### PR DESCRIPTION
**probelm:** Query result mismatch with Batch-sort in save to disk (sort temp files) scenario.

**scenario:**
a) Configure batchsort but give batch size more than UnsafeMemoryManager.INSTANCE.getUsableMemory().
b) Load data that is greater than batch size. Observe that unsafeMemoryManager save to disk happened as it cannot process one batch.  
c) so load happens in 2 batch. 
d) When query the results. There result data rows is more than expected data rows.


**root cause:**
For each batch, createSortDataRows() will be called.
Files saved to disk during sorting of previous batch was considered for this batch.


**solution:**
Files saved to disk during sorting of previous batch ,should not be considered for this batch.
Hence use batchID as rangeID field of sorttempfiles.
So getFilesToMergeSort() will select files of only this batch.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed? NA
 
 - [ ] Any backward compatibility impacted? NA
 
 - [ ] Document update required? NA

 - [ ] Testing done. done
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.  NA

