### PR TITLE
[HOTFIX] improve sdk multi-thread performance

### DIFF
--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableOutputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableOutputFormat.java
@@ -475,8 +475,7 @@ public class CarbonTableOutputFormat extends FileOutputFormat<NullWritable, Obje
 
     @Override public void write(NullWritable aVoid, ObjectArrayWritable objects)
         throws InterruptedException {
-      int iteratorLength = iterators.length;
-      int iteratorNum = (int) (counter.incrementAndGet() % iteratorLength);
+      int iteratorNum = (int) (counter.incrementAndGet() % iterators.length);
       synchronized (iterators[iteratorNum]) {
         iterators[iteratorNum].write(objects.get());
       }

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/DataLoadProcessBuilder.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/DataLoadProcessBuilder.java
@@ -313,8 +313,8 @@ public final class DataLoadProcessBuilder {
     }
     TableSpec tableSpec = new TableSpec(carbonTable);
     configuration.setTableSpec(tableSpec);
-    if (loadModel.getSdkUserCores() > 0) {
-      configuration.setWritingCoresCount(loadModel.getSdkUserCores());
+    if (loadModel.getSdkWriterCores() > 0) {
+      configuration.setWritingCoresCount(loadModel.getSdkWriterCores());
     }
     return configuration;
   }

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/model/CarbonLoadModel.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/model/CarbonLoadModel.java
@@ -60,7 +60,7 @@ public class CarbonLoadModel implements Serializable {
   private boolean carbonTransactionalTable = true;
 
   /* Number of thread in which sdk writer is used */
-  private short sdkUserCores;
+  private short sdkWriterCores;
 
   private String csvHeader;
   private String[] csvHeaderColumns;
@@ -472,7 +472,7 @@ public class CarbonLoadModel implements Serializable {
     copy.sortColumnsBoundsStr = sortColumnsBoundsStr;
     copy.loadMinSize = loadMinSize;
     copy.parentTablePath = parentTablePath;
-    copy.sdkUserCores = sdkUserCores;
+    copy.sdkWriterCores = sdkWriterCores;
     return copy;
   }
 
@@ -528,7 +528,7 @@ public class CarbonLoadModel implements Serializable {
     copyObj.sortColumnsBoundsStr = sortColumnsBoundsStr;
     copyObj.loadMinSize = loadMinSize;
     copyObj.parentTablePath = parentTablePath;
-    copyObj.sdkUserCores = sdkUserCores;
+    copyObj.sdkWriterCores = sdkWriterCores;
     return copyObj;
   }
 
@@ -914,11 +914,11 @@ public class CarbonLoadModel implements Serializable {
     return mergedSegmentIds;
   }
 
-  public short getSdkUserCores() {
-    return sdkUserCores;
+  public short getSdkWriterCores() {
+    return sdkWriterCores;
   }
 
-  public void setSdkUserCores(short sdkUserCores) {
-    this.sdkUserCores = sdkUserCores;
+  public void setSdkWriterCores(short sdkWriterCores) {
+    this.sdkWriterCores = sdkWriterCores;
   }
 }

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/steps/InputProcessorStepImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/steps/InputProcessorStepImpl.java
@@ -47,7 +47,8 @@ public class InputProcessorStepImpl extends AbstractDataLoadProcessorStep {
 
   private CarbonIterator<Object[]>[] inputIterators;
 
-  private short sdkUserCore;
+  // cores used in SDK writer, set by the user
+  private short sdkWriterCores;
 
   /**
    * executor service to execute the query
@@ -58,7 +59,7 @@ public class InputProcessorStepImpl extends AbstractDataLoadProcessorStep {
       CarbonIterator<Object[]>[] inputIterators) {
     super(configuration, null);
     this.inputIterators = inputIterators;
-    this.sdkUserCore = configuration.getWritingCoresCount();
+    this.sdkWriterCores = configuration.getWritingCoresCount();
   }
 
   @Override public DataField[] getOutput() {
@@ -78,7 +79,7 @@ public class InputProcessorStepImpl extends AbstractDataLoadProcessorStep {
   @Override public Iterator<CarbonRowBatch>[] execute() {
     int batchSize = CarbonProperties.getInstance().getBatchSize();
     List<CarbonIterator<Object[]>>[] readerIterators =
-        CarbonDataProcessorUtil.partitionInputReaderIterators(inputIterators, sdkUserCore);
+        CarbonDataProcessorUtil.partitionInputReaderIterators(inputIterators, sdkWriterCores);
     Iterator<CarbonRowBatch>[] outIterators = new Iterator[readerIterators.length];
     for (int i = 0; i < outIterators.length; i++) {
       outIterators[i] =

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/steps/InputProcessorStepWithNoConverterImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/steps/InputProcessorStepWithNoConverterImpl.java
@@ -63,13 +63,14 @@ public class InputProcessorStepWithNoConverterImpl extends AbstractDataLoadProce
 
   private Map<Integer, GenericDataType> dataFieldsWithComplexDataType;
 
-  private short sdkUserCore;
+  // cores used in SDK writer, set by the user
+  private short sdkWriterCores;
 
   public InputProcessorStepWithNoConverterImpl(CarbonDataLoadConfiguration configuration,
       CarbonIterator<Object[]>[] inputIterators) {
     super(configuration, null);
     this.inputIterators = inputIterators;
-    sdkUserCore = configuration.getWritingCoresCount();
+    sdkWriterCores = configuration.getWritingCoresCount();
   }
 
   @Override public DataField[] getOutput() {
@@ -136,7 +137,7 @@ public class InputProcessorStepWithNoConverterImpl extends AbstractDataLoadProce
   @Override public Iterator<CarbonRowBatch>[] execute() {
     int batchSize = CarbonProperties.getInstance().getBatchSize();
     List<CarbonIterator<Object[]>>[] readerIterators =
-        CarbonDataProcessorUtil.partitionInputReaderIterators(this.inputIterators, sdkUserCore);
+        CarbonDataProcessorUtil.partitionInputReaderIterators(this.inputIterators, sdkWriterCores);
     Iterator<CarbonRowBatch>[] outIterators = new Iterator[readerIterators.length];
     for (int i = 0; i < outIterators.length; i++) {
       outIterators[i] =

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/steps/JsonInputProcessorStepImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/steps/JsonInputProcessorStepImpl.java
@@ -39,15 +39,16 @@ public class JsonInputProcessorStepImpl extends AbstractDataLoadProcessorStep {
 
   private CarbonIterator<Object[]>[] inputIterators;
 
-  boolean isRawDataRequired = false;
+  private boolean isRawDataRequired = false;
 
-  short sdkUserCore;
+  // cores used in SDK writer, set by the user
+  private short sdkWriterCores;
 
   public JsonInputProcessorStepImpl(CarbonDataLoadConfiguration configuration,
       CarbonIterator<Object[]>[] inputIterators) {
     super(configuration, null);
     this.inputIterators = inputIterators;
-    sdkUserCore = configuration.getWritingCoresCount();
+    sdkWriterCores = configuration.getWritingCoresCount();
   }
 
   @Override public DataField[] getOutput() {
@@ -64,7 +65,7 @@ public class JsonInputProcessorStepImpl extends AbstractDataLoadProcessorStep {
   @Override public Iterator<CarbonRowBatch>[] execute() {
     int batchSize = CarbonProperties.getInstance().getBatchSize();
     List<CarbonIterator<Object[]>>[] readerIterators =
-        CarbonDataProcessorUtil.partitionInputReaderIterators(inputIterators, sdkUserCore);
+        CarbonDataProcessorUtil.partitionInputReaderIterators(inputIterators, sdkWriterCores);
     Iterator<CarbonRowBatch>[] outIterators = new Iterator[readerIterators.length];
     for (int i = 0; i < outIterators.length; i++) {
       outIterators[i] =

--- a/processing/src/main/java/org/apache/carbondata/processing/util/CarbonDataProcessorUtil.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/util/CarbonDataProcessorUtil.java
@@ -659,11 +659,11 @@ public final class CarbonDataProcessorUtil {
    * @return
    */
   public static List<CarbonIterator<Object[]>>[] partitionInputReaderIterators(
-      CarbonIterator<Object[]>[] inputIterators, short sdkUserCores) {
+      CarbonIterator<Object[]>[] inputIterators, short sdkWriterCores) {
     // Get the number of cores configured in property.
     int numberOfCores;
-    if (sdkUserCores > 0) {
-      numberOfCores = sdkUserCores;
+    if (sdkWriterCores > 0) {
+      numberOfCores = sdkWriterCores;
     } else {
       numberOfCores = CarbonProperties.getInstance().getNumberOfCores();
     }

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonWriterBuilder.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonWriterBuilder.java
@@ -416,7 +416,7 @@ public class CarbonWriterBuilder {
       throw new IllegalArgumentException(" numOfThreads must be greater than 0");
     }
     CarbonLoadModel loadModel = buildLoadModel(schema);
-    loadModel.setSdkUserCores(numOfThreads);
+    loadModel.setSdkWriterCores(numOfThreads);
     return new CSVCarbonWriter(loadModel);
   }
 
@@ -467,7 +467,7 @@ public class CarbonWriterBuilder {
     // removed from the load. LoadWithoutConverter flag is going to point to the Loader Builder
     // which will skip Conversion Step.
     loadModel.setLoadWithoutConverterStep(true);
-    loadModel.setSdkUserCores(numOfThreads);
+    loadModel.setSdkWriterCores(numOfThreads);
     return new AvroCarbonWriter(loadModel);
   }
 
@@ -511,7 +511,7 @@ public class CarbonWriterBuilder {
     this.schema = carbonSchema;
     CarbonLoadModel loadModel = buildLoadModel(schema);
     loadModel.setJsonFileLoad(true);
-    loadModel.setSdkUserCores(numOfThreads);
+    loadModel.setSdkWriterCores(numOfThreads);
     return new JsonCarbonWriter(loadModel);
   }
 

--- a/store/sdk/src/test/java/org/apache/carbondata/sdk/file/ConcurrentAvroSdkWriterTest.java
+++ b/store/sdk/src/test/java/org/apache/carbondata/sdk/file/ConcurrentAvroSdkWriterTest.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.sdk.file;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.avro.generic.GenericData;
+import org.apache.commons.io.FileUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * multi-thread Test suite for {@link CSVCarbonWriter}
+ */
+public class ConcurrentAvroSdkWriterTest {
+
+  private static final int recordsPerItr = 10;
+  private static final short numOfThreads = 4;
+
+  @Test public void testWriteFiles() throws IOException {
+    String path = "./testWriteFiles";
+    FileUtils.deleteDirectory(new File(path));
+
+    String mySchema =
+        "{" + "  \"name\": \"address\", " + "   \"type\": \"record\", " + "    \"fields\": [  "
+            + "  { \"name\": \"name\", \"type\": \"string\"}, "
+            + "  { \"name\": \"age\", \"type\": \"int\"}, " + "  { " + "    \"name\": \"address\", "
+            + "      \"type\": { " + "    \"type\" : \"record\", "
+            + "        \"name\" : \"my_address\", " + "        \"fields\" : [ "
+            + "    {\"name\": \"street\", \"type\": \"string\"}, "
+            + "    {\"name\": \"city\", \"type\": \"string\"} " + "  ]} " + "  } " + "] " + "}";
+
+    String json =
+        "{\"name\":\"bob\", \"age\":10, \"address\" : {\"street\":\"abc\", \"city\":\"bang\"}}";
+
+    // conversion to GenericData.Record
+    org.apache.avro.Schema avroSchema = new org.apache.avro.Schema.Parser().parse(mySchema);
+    GenericData.Record record = TestUtil.jsonToAvro(json, mySchema);
+
+    ExecutorService executorService = Executors.newFixedThreadPool(numOfThreads);
+    try {
+      CarbonWriterBuilder builder = CarbonWriter.builder().outputPath(path);
+      CarbonWriter writer = builder.buildThreadSafeWriterForAvroInput(avroSchema, numOfThreads);
+      // write in multi-thread
+      for (int i = 0; i < numOfThreads; i++) {
+        executorService.submit(new WriteLogic(writer, record));
+      }
+      executorService.shutdown();
+      executorService.awaitTermination(2, TimeUnit.HOURS);
+      writer.close();
+    } catch (Exception e) {
+      e.printStackTrace();
+      Assert.fail(e.getMessage());
+    }
+
+    // read the files and verify the count
+    CarbonReader reader;
+    try {
+      reader =
+          CarbonReader.builder(path, "_temp").projection(new String[] { "name", "age" }).build();
+      int i = 0;
+      while (reader.hasNext()) {
+        Object[] row = (Object[]) reader.readNextRow();
+        i++;
+      }
+      Assert.assertEquals(i, numOfThreads * recordsPerItr);
+      reader.close();
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+      Assert.fail(e.getMessage());
+    }
+
+    FileUtils.deleteDirectory(new File(path));
+  }
+
+  class WriteLogic implements Runnable {
+    CarbonWriter writer;
+    GenericData.Record record;
+
+    WriteLogic(CarbonWriter writer, GenericData.Record record) {
+      this.writer = writer;
+      this.record = record;
+    }
+
+    @Override public void run() {
+      try {
+        for (int i = 0; i < recordsPerItr; i++) {
+          writer.write(record);
+        }
+      } catch (IOException e) {
+        e.printStackTrace();
+        Assert.fail(e.getMessage());
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
**problem:** currently SDK writer will create multiple iterators in multi-thread scenario.  But filling each iterator is not happening concurrently as it is synchronized at method level.

**solution:** In SDK multi-thread write scenario, don't synchronize method level. Synchronize at iterator level. As each iterator has its own queue, it can be done concurrently.
**Also for Avro can use sdkUserCore in input processor step.**

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed? NA
 
 - [ ] Any backward compatibility impacted? NA
 
 - [ ] Document update required? NA

 - [ ] Testing done. UT is added.       

 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.  NA

