### PR TITLE
[CARBONDATA-2901] Fixed JVM crash in Load scenario when unsafe memory allocation is failed.

### DIFF
--- a/processing/src/main/java/org/apache/carbondata/processing/loading/sort/unsafe/UnsafeSortDataRows.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/sort/unsafe/UnsafeSortDataRows.java
@@ -142,17 +142,17 @@ public class UnsafeSortDataRows {
 
   private UnsafeCarbonRowPage createUnsafeRowPage()
       throws MemoryException, CarbonSortKeyAndGroupByException {
-      MemoryBlock baseBlock =
-          UnsafeMemoryManager.allocateMemoryWithRetry(this.taskId, inMemoryChunkSize);
-      boolean isMemoryAvailable =
-          UnsafeSortMemoryManager.INSTANCE.isMemoryAvailable(baseBlock.size());
-      if (isMemoryAvailable) {
-        UnsafeSortMemoryManager.INSTANCE.allocateDummyMemory(baseBlock.size());
-      } else {
-        // merge and spill in-memory pages to disk if memory is not enough
-        unsafeInMemoryIntermediateFileMerger.tryTriggerInmemoryMerging(true);
-      }
-      return new UnsafeCarbonRowPage(tableFieldStat, baseBlock, !isMemoryAvailable, taskId);
+    MemoryBlock baseBlock =
+        UnsafeMemoryManager.allocateMemoryWithRetry(this.taskId, inMemoryChunkSize);
+    boolean isMemoryAvailable =
+        UnsafeSortMemoryManager.INSTANCE.isMemoryAvailable(baseBlock.size());
+    if (isMemoryAvailable) {
+      UnsafeSortMemoryManager.INSTANCE.allocateDummyMemory(baseBlock.size());
+    } else {
+      // merge and spill in-memory pages to disk if memory is not enough
+      unsafeInMemoryIntermediateFileMerger.tryTriggerInmemoryMerging(true);
+    }
+    return new UnsafeCarbonRowPage(tableFieldStat, baseBlock, !isMemoryAvailable, taskId);
   }
 
   public boolean canAdd() {


### PR DESCRIPTION
Problem: Jvm crash in Load scenario when unsafe memory allocation is failed.

scenario: 
a) Have many cores while loading. suggested more than 10. [carbon.number.of.cores.while.loading]
b) Load huge data with local sort, more than 5GB (keeping default unsafe memory manager as 512 MB)
c) when task failes due to not enough unsafae memory, JVM crashes with SIGSEGV.


root casue:
while sorting, all iterator threads are waiting at UnsafeSortDataRows.addRowBatch as all iterator works on one row page.
Only one iterator thread will try to allocate memory. Before that it has freed current page in handlePreviousPage().
When allocate memory failed, row page will still have that old reference. next thread will again use same reference and call handlePreviousPage().
So, Jvm crashes as freed memory is accessed.


solution:
When allocation failed, set row page reference to null.
So, that next thread will not do any operation.