### PR TITLE
[CARBONDATA-2902][DataMap] Fix showing negative pruning result for explain command

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMap.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMap.java
@@ -48,7 +48,8 @@ public class BlockletDataMap extends BlockDataMap implements Serializable {
 
   private static final long serialVersionUID = -2170289352240810993L;
 
-  @Override public void init(DataMapModel dataMapModel) throws IOException, MemoryException {
+  @Override
+  public void init(DataMapModel dataMapModel) throws IOException, MemoryException {
     super.init(dataMapModel);
   }
 
@@ -60,6 +61,7 @@ public class BlockletDataMap extends BlockDataMap implements Serializable {
    * @throws IOException
    * @throws MemoryException
    */
+  @Override
   protected DataMapRowImpl loadMetadata(CarbonRowSchema[] taskSummarySchema,
       SegmentProperties segmentProperties, BlockletDataMapModel blockletDataMapInfo,
       List<DataFileFooter> indexInfo) throws IOException, MemoryException {
@@ -72,6 +74,7 @@ public class BlockletDataMap extends BlockDataMap implements Serializable {
     }
   }
 
+  @Override
   protected CarbonRowSchema[] getTaskSummarySchema() {
     if (isLegacyStore) {
       return super.getTaskSummarySchema();
@@ -86,6 +89,7 @@ public class BlockletDataMap extends BlockDataMap implements Serializable {
     }
   }
 
+  @Override
   protected CarbonRowSchema[] getFileFooterEntrySchema() {
     if (isLegacyStore) {
       return super.getFileFooterEntrySchema();
@@ -203,6 +207,7 @@ public class BlockletDataMap extends BlockDataMap implements Serializable {
     return summaryRow;
   }
 
+  @Override
   public ExtendedBlocklet getDetailedBlocklet(String blockletId) {
     if (isLegacyStore) {
       return super.getDetailedBlocklet(blockletId);
@@ -216,6 +221,7 @@ public class BlockletDataMap extends BlockDataMap implements Serializable {
         false);
   }
 
+  @Override
   protected short getBlockletId(DataMapRow dataMapRow) {
     if (isLegacyStore) {
       return super.getBlockletId(dataMapRow);
@@ -223,6 +229,7 @@ public class BlockletDataMap extends BlockDataMap implements Serializable {
     return dataMapRow.getShort(BLOCKLET_ID_INDEX);
   }
 
+  @Override
   protected ExtendedBlocklet createBlocklet(DataMapRow row, String fileName, short blockletId,
       boolean useMinMaxForPruning) {
     if (isLegacyStore) {
@@ -236,6 +243,25 @@ public class BlockletDataMap extends BlockDataMap implements Serializable {
     detailInfo.setUseMinMaxForPruning(useMinMaxForPruning);
     blocklet.setDetailInfo(detailInfo);
     return blocklet;
+  }
+
+  @Override
+  protected short getBlockletNumOfEntry(int index) {
+    if (isLegacyStore) {
+      return super.getBlockletNumOfEntry(index);
+    } else {
+      //in blocklet datamap, each entry contains info of one blocklet
+      return 1;
+    }
+  }
+
+  @Override
+  protected int getTotalBlocklets() {
+    if (isLegacyStore) {
+      return super.getTotalBlocklets();
+    } else {
+      return memoryDMStore.getRowCount();
+    }
   }
 
 }

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMapFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMapFactory.java
@@ -97,8 +97,7 @@ public class BlockletDataMapFactory extends CoarseGrainDataMapFactory
    * @return
    */
   public static DataMap createDataMap(CarbonTable carbonTable) {
-    boolean cacheLevelBlock =
-        BlockletDataMapUtil.isCacheLevelBlock(carbonTable, CACHE_LEVEL_BLOCKLET);
+    boolean cacheLevelBlock = BlockletDataMapUtil.isCacheLevelBlock(carbonTable);
     if (cacheLevelBlock) {
       // case1: when CACHE_LEVEL = BLOCK
       return new BlockDataMap();

--- a/core/src/main/java/org/apache/carbondata/core/profiler/ExplainCollector.java
+++ b/core/src/main/java/org/apache/carbondata/core/profiler/ExplainCollector.java
@@ -94,11 +94,17 @@ public class ExplainCollector {
     }
   }
 
-  public static void recordDefaultDataMapPruning(DataMapWrapperSimpleInfo dataMapWrapperSimpleInfo,
-      int numBlocklets) {
+  public static void setShowPruningInfo(boolean showPruningInfo) {
     if (enabled()) {
       TablePruningInfo scan = getCurrentTablePruningInfo();
-      scan.setNumBlockletsAfterDefaultPruning(dataMapWrapperSimpleInfo, numBlocklets);
+      scan.setShowPruningInfo(showPruningInfo);
+    }
+  }
+
+  public static void addDefaultDataMapPruningHit(int numBlocklets) {
+    if (enabled()) {
+      TablePruningInfo scan = getCurrentTablePruningInfo();
+      scan.addNumBlockletsAfterDefaultPruning(numBlocklets);
     }
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/profiler/TablePruningInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/profiler/TablePruningInfo.java
@@ -28,9 +28,9 @@ public class TablePruningInfo {
 
   private int totalBlocklets;
   private String filterStatement;
+  private boolean showPruningInfo;
 
-  private DataMapWrapperSimpleInfo defaultDataMap;
-  private int numBlockletsAfterDefaultPruning;
+  private int numBlockletsAfterDefaultPruning = 0;
 
   private DataMapWrapperSimpleInfo cgDataMap;
   private int numBlockletsAfterCGPruning;
@@ -46,10 +46,12 @@ public class TablePruningInfo {
     this.filterStatement = filterStatement;
   }
 
-  void setNumBlockletsAfterDefaultPruning(DataMapWrapperSimpleInfo dataMapWrapperSimpleInfo,
-      int numBlocklets) {
-    this.defaultDataMap = dataMapWrapperSimpleInfo;
-    this.numBlockletsAfterDefaultPruning = numBlocklets;
+  void setShowPruningInfo(boolean showPruningInfo) {
+    this.showPruningInfo = showPruningInfo;
+  }
+
+  void addNumBlockletsAfterDefaultPruning(int numBlocklets) {
+    this.numBlockletsAfterDefaultPruning += numBlocklets;
   }
 
   void setNumBlockletsAfterCGPruning(DataMapWrapperSimpleInfo dataMapWrapperSimpleInfo,
@@ -66,37 +68,38 @@ public class TablePruningInfo {
 
   @Override
   public String toString() {
-    StringBuilder builder = new StringBuilder();
-    builder
-        .append(" - total blocklets: ").append(totalBlocklets).append("\n")
-        .append(" - filter: ").append(filterStatement).append("\n");
-    if (defaultDataMap != null) {
+    if (showPruningInfo) {
+      StringBuilder builder = new StringBuilder();
+      builder
+          .append(" - total blocklets: ").append(totalBlocklets).append("\n")
+          .append(" - filter: ").append(filterStatement).append("\n");
       int skipBlocklets = totalBlocklets - numBlockletsAfterDefaultPruning;
       builder
           .append(" - pruned by Main DataMap").append("\n")
           .append("    - skipped blocklets: ").append(skipBlocklets).append("\n");
-    }
-    if (cgDataMap != null) {
-      int skipBlocklets = numBlockletsAfterDefaultPruning - numBlockletsAfterCGPruning;
-      builder
-          .append(" - pruned by CG DataMap").append("\n")
-          .append("    - name: ").append(cgDataMap.getDataMapWrapperName()).append("\n")
-          .append("    - provider: ").append(cgDataMap.getDataMapWrapperProvider()).append("\n")
-          .append("    - skipped blocklets: ").append(skipBlocklets).append("\n");
-    }
-    if (fgDataMap != null) {
-      int skipBlocklets;
-      if (numBlockletsAfterCGPruning != 0) {
-        skipBlocklets = numBlockletsAfterCGPruning - numBlockletsAfterFGPruning;
-      } else {
-        skipBlocklets = numBlockletsAfterDefaultPruning - numBlockletsAfterFGPruning;
+      if (cgDataMap != null) {
+        skipBlocklets = numBlockletsAfterDefaultPruning - numBlockletsAfterCGPruning;
+        builder
+            .append(" - pruned by CG DataMap").append("\n")
+            .append("    - name: ").append(cgDataMap.getDataMapWrapperName()).append("\n")
+            .append("    - provider: ").append(cgDataMap.getDataMapWrapperProvider()).append("\n")
+            .append("    - skipped blocklets: ").append(skipBlocklets).append("\n");
       }
-      builder
-          .append(" - pruned by FG DataMap").append("\n")
-          .append("    - name: ").append(fgDataMap.getDataMapWrapperName()).append("\n")
-          .append("    - provider: ").append(fgDataMap.getDataMapWrapperProvider()).append("\n")
-          .append("    - skipped blocklets: ").append(skipBlocklets).append("\n");
+      if (fgDataMap != null) {
+        if (numBlockletsAfterCGPruning != 0) {
+          skipBlocklets = numBlockletsAfterCGPruning - numBlockletsAfterFGPruning;
+        } else {
+          skipBlocklets = numBlockletsAfterDefaultPruning - numBlockletsAfterFGPruning;
+        }
+        builder
+            .append(" - pruned by FG DataMap").append("\n")
+            .append("    - name: ").append(fgDataMap.getDataMapWrapperName()).append("\n")
+            .append("    - provider: ").append(fgDataMap.getDataMapWrapperProvider()).append("\n")
+            .append("    - skipped blocklets: ").append(skipBlocklets).append("\n");
+      }
+      return builder.toString();
+    } else {
+      return "";
     }
-    return builder.toString();
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/util/BlockletDataMapUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/BlockletDataMapUtil.java
@@ -45,6 +45,7 @@ import org.apache.carbondata.core.indexstore.BlockMetaInfo;
 import org.apache.carbondata.core.indexstore.TableBlockIndexUniqueIdentifier;
 import org.apache.carbondata.core.indexstore.TableBlockIndexUniqueIdentifierWrapper;
 import org.apache.carbondata.core.indexstore.blockletindex.BlockletDataMapDistributable;
+import org.apache.carbondata.core.indexstore.blockletindex.BlockletDataMapFactory;
 import org.apache.carbondata.core.indexstore.blockletindex.SegmentIndexFileStore;
 import org.apache.carbondata.core.metadata.blocklet.DataFileFooter;
 import org.apache.carbondata.core.metadata.datatype.DataType;
@@ -236,18 +237,14 @@ public class BlockletDataMapUtil {
 
   /**
    * Method to check if CACHE_LEVEL is set to BLOCK or BLOCKLET
-   *
-   * @param carbonTable
-   * @param cacheLevelBlocklet
-   * @return
    */
-  public static boolean isCacheLevelBlock(CarbonTable carbonTable, String cacheLevelBlocklet) {
+  public static boolean isCacheLevelBlock(CarbonTable carbonTable) {
     String cacheLevel = carbonTable.getTableInfo().getFactTable().getTableProperties()
         .get(CarbonCommonConstants.CACHE_LEVEL);
-    if (!cacheLevelBlocklet.equals(cacheLevel)) {
-      return true;
+    if (BlockletDataMapFactory.CACHE_LEVEL_BLOCKLET.equals(cacheLevel)) {
+      return false;
     }
-    return false;
+    return true;
   }
 
   private static boolean isSameColumnSchemaList(List<ColumnSchema> indexFileColumnList,

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonInputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonInputFormat.java
@@ -37,7 +37,6 @@ import org.apache.carbondata.core.datamap.dev.expr.DataMapWrapperSimpleInfo;
 import org.apache.carbondata.core.exception.InvalidConfigurationException;
 import org.apache.carbondata.core.indexstore.ExtendedBlocklet;
 import org.apache.carbondata.core.indexstore.PartitionSpec;
-import org.apache.carbondata.core.indexstore.blockletindex.BlockletDataMapFactory;
 import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
 import org.apache.carbondata.core.metadata.ColumnarFormatVersion;
 import org.apache.carbondata.core.metadata.schema.PartitionInfo;
@@ -467,8 +466,6 @@ m filterExpression
     List<ExtendedBlocklet> prunedBlocklets =
         dataMapExprWrapper.prune(segmentIds, partitionsToPrune);
 
-    ExplainCollector.recordDefaultDataMapPruning(
-        DataMapWrapperSimpleInfo.fromDataMapWrapper(dataMapExprWrapper), prunedBlocklets.size());
     if (prunedBlocklets.size() == 0) {
       return prunedBlocklets;
     }
@@ -523,8 +520,7 @@ m filterExpression
       List<ExtendedBlocklet> previousDataMapPrunedBlocklets,
       List<ExtendedBlocklet> otherDataMapPrunedBlocklets) {
     List<ExtendedBlocklet> prunedBlocklets = null;
-    if (BlockletDataMapUtil.isCacheLevelBlock(
-        carbonTable, BlockletDataMapFactory.CACHE_LEVEL_BLOCKLET)) {
+    if (BlockletDataMapUtil.isCacheLevelBlock(carbonTable)) {
       prunedBlocklets = new ArrayList<>();
       for (ExtendedBlocklet otherBlocklet : otherDataMapPrunedBlocklets) {
         if (previousDataMapPrunedBlocklets.contains(otherBlocklet)) {


### PR DESCRIPTION
For legacy store, print no pruning info
For cache_level = block, get number of blocklets of hit blocks, print skipped blocklet info
For cache_level = blocklet, get number of blocklets of hit blocklets, print skipped blocklet info


Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
  
        1.local test with multi blocklets;        
        2.BloomCoarseGrainDataMapSuite
            - test("test create bloom datamap on newly added column") 
        3.TestPreAggregateTableSelection:
            - test("explain projection query")
            - test("explain projection query hit datamap")
            - test("explain filter query")
            - test("explain query with multiple table")

 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

