### PR TITLE
[CARBONDATA-2905] Set stream property for streaming table

### DIFF
--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/TestStreamingTableOperation.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/TestStreamingTableOperation.scala
@@ -215,10 +215,6 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
 
   // normal table not support streaming ingest
   test("normal table not support streaming ingest and alter normal table's streaming property") {
-    // alter normal table's streaming property
-    val msg = intercept[MalformedCarbonCommandException](sql("alter table streaming.batch_table set tblproperties('streaming'='false')"))
-    assertResult("Streaming property value is incorrect")(msg.getMessage)
-
     val identifier = new TableIdentifier("batch_table", Option("streaming"))
     val carbonTable = CarbonEnv.getInstance(spark).carbonMetastore.lookupRelation(identifier)(spark)
       .asInstanceOf[CarbonRelation].metaData.carbonTable
@@ -1330,10 +1326,6 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
       case _ =>
         assert(false, "should support set table to streaming")
     }
-
-    // alter streaming table's streaming property
-    val msg = intercept[MalformedCarbonCommandException](sql("alter table streaming.stream_table_handoff set tblproperties('streaming'='false')"))
-    assertResult("Streaming property can not be changed once it is 'true'")(msg.getMessage)
 
     val segments = sql("show segments for table streaming.stream_table_handoff").collect()
     assert(segments.length == 2 || segments.length == 3)


### PR DESCRIPTION
For streaming table with table property "streaming"="true", we should allow set the streaming table property to false. After setting to false, only batch segments will be queried.

 - [X] Any interfaces changed?
 No
 - [X] Any backward compatibility impacted?
 No
 - [X] Document update required?
No
 - [X] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
 rerun all test      
 - [X] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA