### PR TITLE
[CARBONDATA-2910] Support backward compatability in fileformat and added tests for load with different sort orders

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datamap/dev/DataMap.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/dev/DataMap.java
@@ -24,6 +24,8 @@ import org.apache.carbondata.core.datastore.block.SegmentProperties;
 import org.apache.carbondata.core.indexstore.Blocklet;
 import org.apache.carbondata.core.indexstore.PartitionSpec;
 import org.apache.carbondata.core.memory.MemoryException;
+import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
+import org.apache.carbondata.core.scan.expression.Expression;
 import org.apache.carbondata.core.scan.filter.resolver.FilterResolverIntf;
 
 /**
@@ -38,11 +40,18 @@ public interface DataMap<T extends Blocklet> {
   void init(DataMapModel dataMapModel) throws MemoryException, IOException;
 
   /**
-   * Prune the datamap with filter expression and partition information. It returns the list of
-   * blocklets where these filters can exist.
+   * Prune the datamap with resolved filter expression and partition information.
+   * It returns the list of blocklets where these filters can exist.
    */
   List<T> prune(FilterResolverIntf filterExp, SegmentProperties segmentProperties,
       List<PartitionSpec> partitions) throws IOException;
+
+  /**
+   * Prune the datamap with filter expression and partition information. It returns the list of
+   * blocklets where these filters can exist.
+   */
+  List<T> prune(Expression filter, SegmentProperties segmentProperties,
+      List<PartitionSpec> partitions, AbsoluteTableIdentifier identifier) throws IOException;
 
   // TODO Move this method to Abstract class
   /**

--- a/core/src/main/java/org/apache/carbondata/core/datamap/dev/cgdatamap/CoarseGrainDataMap.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/dev/cgdatamap/CoarseGrainDataMap.java
@@ -16,10 +16,17 @@
  */
 package org.apache.carbondata.core.datamap.dev.cgdatamap;
 
+import java.io.IOException;
+import java.util.List;
+
 import org.apache.carbondata.common.annotations.InterfaceAudience;
 import org.apache.carbondata.common.annotations.InterfaceStability;
 import org.apache.carbondata.core.datamap.dev.DataMap;
+import org.apache.carbondata.core.datastore.block.SegmentProperties;
 import org.apache.carbondata.core.indexstore.Blocklet;
+import org.apache.carbondata.core.indexstore.PartitionSpec;
+import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
+import org.apache.carbondata.core.scan.expression.Expression;
 
 /**
  * DataMap for Coarse Grain level, see {@link org.apache.carbondata.core.datamap.DataMapLevel#CG}
@@ -28,4 +35,9 @@ import org.apache.carbondata.core.indexstore.Blocklet;
 @InterfaceStability.Evolving
 public abstract class CoarseGrainDataMap implements DataMap<Blocklet> {
 
+  @Override
+  public List<Blocklet> prune(Expression expression, SegmentProperties segmentProperties,
+      List<PartitionSpec> partitions, AbsoluteTableIdentifier identifier) throws IOException {
+    throw new UnsupportedOperationException("Filter expression not supported");
+  }
 }

--- a/core/src/main/java/org/apache/carbondata/core/datamap/dev/fgdatamap/FineGrainDataMap.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/dev/fgdatamap/FineGrainDataMap.java
@@ -16,9 +16,16 @@
  */
 package org.apache.carbondata.core.datamap.dev.fgdatamap;
 
+import java.io.IOException;
+import java.util.List;
+
 import org.apache.carbondata.common.annotations.InterfaceAudience;
 import org.apache.carbondata.common.annotations.InterfaceStability;
 import org.apache.carbondata.core.datamap.dev.DataMap;
+import org.apache.carbondata.core.datastore.block.SegmentProperties;
+import org.apache.carbondata.core.indexstore.PartitionSpec;
+import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
+import org.apache.carbondata.core.scan.expression.Expression;
 
 /**
  * DataMap for Fine Grain level, see {@link org.apache.carbondata.core.datamap.DataMapLevel#FG}
@@ -27,4 +34,9 @@ import org.apache.carbondata.core.datamap.dev.DataMap;
 @InterfaceStability.Evolving
 public abstract class FineGrainDataMap implements DataMap<FineGrainBlocklet> {
 
+  @Override
+  public List<FineGrainBlocklet> prune(Expression filter, SegmentProperties segmentProperties,
+      List<PartitionSpec> partitions, AbsoluteTableIdentifier identifier) throws IOException {
+    throw new UnsupportedOperationException("Filter expression not supported");
+  }
 }

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockDataMap.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockDataMap.java
@@ -102,7 +102,8 @@ public class BlockDataMap extends CoarseGrainDataMap
     BlockletDataMapModel blockletDataMapInfo = (BlockletDataMapModel) dataMapModel;
     DataFileFooterConverter fileFooterConverter = new DataFileFooterConverter();
     List<DataFileFooter> indexInfo = fileFooterConverter
-        .getIndexInfo(blockletDataMapInfo.getFilePath(), blockletDataMapInfo.getFileData());
+        .getIndexInfo(blockletDataMapInfo.getFilePath(), blockletDataMapInfo.getFileData(),
+            blockletDataMapInfo.getCarbonTable().isTransactionalTable());
     Path path = new Path(blockletDataMapInfo.getFilePath());
     // store file path only in case of partition table, non transactional table and flat folder
     // structure

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockDataMap.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockDataMap.java
@@ -640,11 +640,10 @@ public class BlockDataMap extends CoarseGrainDataMap
   }
 
   @Override
-  public List<Blocklet> prune(Expression expression, SegmentProperties segmentProperties,
+  public List<Blocklet> prune(Expression expression, SegmentProperties properties,
       List<PartitionSpec> partitions, AbsoluteTableIdentifier identifier) throws IOException {
     FilterResolverIntf filterResolverIntf = null;
     if (expression != null) {
-      SegmentProperties properties = getSegmentProperties();
       QueryModel.FilterProcessVO processVO =
           new QueryModel.FilterProcessVO(properties.getDimensions(), properties.getMeasures(),
               new ArrayList<CarbonDimension>());
@@ -654,7 +653,7 @@ public class BlockDataMap extends CoarseGrainDataMap
       rangeFilterOptimizer.optimizeFilter();
       filterResolverIntf = CarbonTable.resolveFilter(expression, identifier);
     }
-    return prune(filterResolverIntf, segmentProperties, partitions);
+    return prune(filterResolverIntf, properties, partitions);
   }
 
   @Override

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockDataMap.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockDataMap.java
@@ -40,17 +40,24 @@ import org.apache.carbondata.core.indexstore.row.DataMapRow;
 import org.apache.carbondata.core.indexstore.row.DataMapRowImpl;
 import org.apache.carbondata.core.indexstore.schema.CarbonRowSchema;
 import org.apache.carbondata.core.memory.MemoryException;
+import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
 import org.apache.carbondata.core.metadata.blocklet.DataFileFooter;
 import org.apache.carbondata.core.metadata.blocklet.index.BlockletIndex;
 import org.apache.carbondata.core.metadata.blocklet.index.BlockletMinMaxIndex;
+import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
 import org.apache.carbondata.core.metadata.schema.table.column.CarbonColumn;
+import org.apache.carbondata.core.metadata.schema.table.column.CarbonDimension;
 import org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema;
 import org.apache.carbondata.core.profiler.ExplainCollector;
+import org.apache.carbondata.core.scan.expression.Expression;
 import org.apache.carbondata.core.scan.filter.FilterExpressionProcessor;
 import org.apache.carbondata.core.scan.filter.FilterUtil;
 import org.apache.carbondata.core.scan.filter.executer.FilterExecuter;
 import org.apache.carbondata.core.scan.filter.executer.ImplicitColumnFilterExecutor;
+import org.apache.carbondata.core.scan.filter.intf.FilterOptimizer;
+import org.apache.carbondata.core.scan.filter.optimizer.RangeFilterOptmizer;
 import org.apache.carbondata.core.scan.filter.resolver.FilterResolverIntf;
+import org.apache.carbondata.core.scan.model.QueryModel;
 import org.apache.carbondata.core.util.BlockletDataMapUtil;
 import org.apache.carbondata.core.util.ByteUtil;
 import org.apache.carbondata.core.util.CarbonUtil;
@@ -630,6 +637,24 @@ public class BlockDataMap extends CoarseGrainDataMap
           .useMinMaxForBlockletPruning(filterResolverIntf, getMinMaxCacheColumns());
     }
     return useMinMaxForPruning;
+  }
+
+  @Override
+  public List<Blocklet> prune(Expression expression, SegmentProperties segmentProperties,
+      List<PartitionSpec> partitions, AbsoluteTableIdentifier identifier) throws IOException {
+    FilterResolverIntf filterResolverIntf = null;
+    if (expression != null) {
+      SegmentProperties properties = getSegmentProperties();
+      QueryModel.FilterProcessVO processVO =
+          new QueryModel.FilterProcessVO(properties.getDimensions(), properties.getMeasures(),
+              new ArrayList<CarbonDimension>());
+      QueryModel.processFilterExpression(processVO, expression, null, null);
+      // Optimize Filter Expression and fit RANGE filters is conditions apply.
+      FilterOptimizer rangeFilterOptimizer = new RangeFilterOptmizer(expression);
+      rangeFilterOptimizer.optimizeFilter();
+      filterResolverIntf = CarbonTable.resolveFilter(expression, identifier);
+    }
+    return prune(filterResolverIntf, segmentProperties, partitions);
   }
 
   @Override

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMapFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMapFactory.java
@@ -49,6 +49,7 @@ import org.apache.carbondata.core.memory.MemoryException;
 import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
 import org.apache.carbondata.core.metadata.schema.table.DataMapSchema;
+import org.apache.carbondata.core.scan.filter.resolver.FilterResolverIntf;
 import org.apache.carbondata.core.util.BlockletDataMapUtil;
 import org.apache.carbondata.core.util.path.CarbonTablePath;
 import org.apache.carbondata.events.Event;
@@ -387,7 +388,7 @@ public class BlockletDataMapFactory extends CoarseGrainDataMapFactory
     List<CoarseGrainDataMap> dataMaps = getDataMaps(segment);
     for (CoarseGrainDataMap dataMap : dataMaps) {
       blocklets.addAll(
-          dataMap.prune(null, getSegmentProperties(segment), partitions));
+          dataMap.prune((FilterResolverIntf) null, getSegmentProperties(segment), partitions));
     }
     return blocklets;
   }

--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/CarbonTable.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/CarbonTable.java
@@ -1017,7 +1017,10 @@ public class CarbonTable implements Serializable {
 
   public void processFilterExpression(Expression filterExpression,
       boolean[] isFilterDimensions, boolean[] isFilterMeasures) {
-    QueryModel.processFilterExpression(this, filterExpression, isFilterDimensions,
+    QueryModel.FilterProcessVO processVO =
+        new QueryModel.FilterProcessVO(getDimensionByTableName(getTableName()),
+            getMeasureByTableName(getTableName()), getImplicitDimensionByTableName(getTableName()));
+    QueryModel.processFilterExpression(processVO, filterExpression, isFilterDimensions,
         isFilterMeasures);
 
     if (null != filterExpression) {
@@ -1031,11 +1034,11 @@ public class CarbonTable implements Serializable {
   /**
    * Resolve the filter expression.
    */
-  public FilterResolverIntf resolveFilter(Expression filterExpression) {
+  public static FilterResolverIntf resolveFilter(Expression filterExpression,
+      AbsoluteTableIdentifier identifier) {
     try {
       FilterExpressionProcessor filterExpressionProcessor = new FilterExpressionProcessor();
-      return filterExpressionProcessor.getFilterResolver(
-          filterExpression, getAbsoluteTableIdentifier());
+      return filterExpressionProcessor.getFilterResolver(filterExpression, identifier);
     } catch (Exception e) {
       throw new RuntimeException("Error while resolving filter expression", e);
     }

--- a/core/src/main/java/org/apache/carbondata/core/scan/executor/impl/AbstractQueryExecutor.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/executor/impl/AbstractQueryExecutor.java
@@ -52,6 +52,7 @@ import org.apache.carbondata.core.metadata.encoder.Encoding;
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
 import org.apache.carbondata.core.metadata.schema.table.column.CarbonDimension;
 import org.apache.carbondata.core.metadata.schema.table.column.CarbonMeasure;
+import org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema;
 import org.apache.carbondata.core.scan.executor.QueryExecutor;
 import org.apache.carbondata.core.scan.executor.exception.QueryExecutionException;
 import org.apache.carbondata.core.scan.executor.infos.BlockExecutionInfo;
@@ -214,6 +215,14 @@ public abstract class AbstractQueryExecutor<E> implements QueryExecutor<E> {
         if (null == fileFooter) {
           blockInfo.setDetailInfo(null);
           fileFooter = CarbonUtil.readMetadatFile(blockInfo);
+          // In case of non transactional table just set columnuniqueid as columnName to support
+          // backward compatabiity. non transactional tables column uniqueid is always equal to
+          // columnname
+          if (!queryModel.getTable().isTransactionalTable()) {
+            for (ColumnSchema columnSchema : fileFooter.getColumnInTable()) {
+              columnSchema.setColumnUniqueId(columnSchema.getColumnName());
+            }
+          }
           filePathToFileFooterMapping.put(blockInfo.getFilePath(), fileFooter);
           blockInfo.setDetailInfo(blockletDetailInfo);
         }

--- a/core/src/main/java/org/apache/carbondata/core/scan/executor/util/QueryUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/executor/util/QueryUtil.java
@@ -48,6 +48,7 @@ import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
 import org.apache.carbondata.core.metadata.schema.table.RelationIdentifier;
 import org.apache.carbondata.core.metadata.schema.table.column.CarbonDimension;
 import org.apache.carbondata.core.metadata.schema.table.column.CarbonMeasure;
+import org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema;
 import org.apache.carbondata.core.scan.complextypes.ArrayQueryType;
 import org.apache.carbondata.core.scan.complextypes.MapQueryType;
 import org.apache.carbondata.core.scan.complextypes.PrimitiveQueryType;
@@ -728,6 +729,24 @@ public class QueryUtil {
           .valueOf(compressor.unCompressByte(present_bit_stream));
     } else {
       return new BitSet(1);
+    }
+  }
+
+  /**
+   * In case of non transactional table just set columnuniqueid as columnName to support
+   * backward compatabiity. non transactional tables column uniqueid is always equal to
+   * columnname
+   */
+  public static void updateColumnUniqueIdForNonTransactionTable(List<ColumnSchema> columnSchemas) {
+    for (ColumnSchema columnSchema : columnSchemas) {
+      // In case of complex types only add the name after removing parent names.
+      int index = columnSchema.getColumnName().lastIndexOf(".");
+      if (index >= 0) {
+        columnSchema.setColumnUniqueId(columnSchema.getColumnName()
+            .substring(index + 1, columnSchema.getColumnName().length()));
+      } else {
+        columnSchema.setColumnUniqueId(columnSchema.getColumnName());
+      }
     }
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/scan/expression/ColumnExpression.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/expression/ColumnExpression.java
@@ -98,6 +98,13 @@ public class ColumnExpression extends LeafExpression {
     return dataType;
   }
 
+  public void reset() {
+    dimension = null;
+    measure = null;
+    isDimension = false;
+    isMeasure = false;
+  }
+
   @Override
   public ExpressionResult evaluate(RowIntf value) {
     return new ExpressionResult(dataType, (null == value ? null : value.getVal(colIndex)));

--- a/core/src/main/java/org/apache/carbondata/core/scan/model/QueryModelBuilder.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/model/QueryModelBuilder.java
@@ -311,14 +311,19 @@ public class QueryModelBuilder {
     queryModel.setReadPageByPage(readPageByPage);
     queryModel.setProjection(projection);
 
-    // set the filter to the query model in order to filter blocklet before scan
-    boolean[] isFilterDimensions = new boolean[table.getDimensionOrdinalMax()];
-    boolean[] isFilterMeasures = new boolean[table.getAllMeasures().size()];
-    table.processFilterExpression(filterExpression, isFilterDimensions, isFilterMeasures);
-    queryModel.setIsFilterDimensions(isFilterDimensions);
-    queryModel.setIsFilterMeasures(isFilterMeasures);
-    FilterResolverIntf filterIntf = table.resolveFilter(filterExpression);
-    queryModel.setFilterExpressionResolverTree(filterIntf);
+    if (table.isTransactionalTable()) {
+      // set the filter to the query model in order to filter blocklet before scan
+      boolean[] isFilterDimensions = new boolean[table.getDimensionOrdinalMax()];
+      boolean[] isFilterMeasures = new boolean[table.getAllMeasures().size()];
+      table.processFilterExpression(filterExpression, isFilterDimensions, isFilterMeasures);
+      queryModel.setIsFilterDimensions(isFilterDimensions);
+      queryModel.setIsFilterMeasures(isFilterMeasures);
+      FilterResolverIntf filterIntf =
+          CarbonTable.resolveFilter(filterExpression, table.getAbsoluteTableIdentifier());
+      queryModel.setFilterExpressionResolverTree(filterIntf);
+    } else {
+      queryModel.setFilterExpression(filterExpression);
+    }
     return queryModel;
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/util/AbstractDataFileFooterConverter.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/AbstractDataFileFooterConverter.java
@@ -43,6 +43,7 @@ import org.apache.carbondata.core.metadata.schema.table.RelationIdentifier;
 import org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema;
 import org.apache.carbondata.core.metadata.schema.table.column.ParentColumnTableRelation;
 import org.apache.carbondata.core.reader.CarbonIndexFileReader;
+import org.apache.carbondata.core.scan.executor.util.QueryUtil;
 import org.apache.carbondata.core.util.path.CarbonTablePath;
 import org.apache.carbondata.format.BlockIndex;
 
@@ -140,10 +141,6 @@ public abstract class AbstractDataFileFooterConverter {
 
   /**
    * Below method will be used to get the index info from index file
-   *
-   * @param filePath           file path of the index file
-   * @return list of index info
-   * @throws IOException problem while reading the index file
    */
   public List<DataFileFooter> getIndexInfo(String filePath, byte[] fileData,
       boolean isTransactionalTable) throws IOException {
@@ -165,13 +162,8 @@ public abstract class AbstractDataFileFooterConverter {
       for (int i = 0; i < table_columns.size(); i++) {
         columnSchemaList.add(thriftColumnSchemaToWrapperColumnSchema(table_columns.get(i)));
       }
-      // In case of non transactional table just set columnuniqueid as columnName to support
-      // backward compatabiity. non transactional tables column uniqueid is always equal to
-      // columnname
       if (!isTransactionalTable) {
-        for (ColumnSchema columnSchema : columnSchemaList) {
-          columnSchema.setColumnUniqueId(columnSchema.getColumnName());
-        }
+        QueryUtil.updateColumnUniqueIdForNonTransactionTable(columnSchemaList);
       }
       // get the segment info
       SegmentInfo segmentInfo = getSegmentInfo(readIndexHeader.getSegment_info());

--- a/core/src/main/java/org/apache/carbondata/core/util/AbstractDataFileFooterConverter.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/AbstractDataFileFooterConverter.java
@@ -135,6 +135,18 @@ public abstract class AbstractDataFileFooterConverter {
    * @throws IOException problem while reading the index file
    */
   public List<DataFileFooter> getIndexInfo(String filePath, byte[] fileData) throws IOException {
+    return getIndexInfo(filePath, fileData, true);
+  }
+
+  /**
+   * Below method will be used to get the index info from index file
+   *
+   * @param filePath           file path of the index file
+   * @return list of index info
+   * @throws IOException problem while reading the index file
+   */
+  public List<DataFileFooter> getIndexInfo(String filePath, byte[] fileData,
+      boolean isTransactionalTable) throws IOException {
     CarbonIndexFileReader indexReader = new CarbonIndexFileReader();
     List<DataFileFooter> dataFileFooters = new ArrayList<DataFileFooter>();
     String parentPath = filePath.substring(0, filePath.lastIndexOf("/"));
@@ -152,6 +164,14 @@ public abstract class AbstractDataFileFooterConverter {
           readIndexHeader.getTable_columns();
       for (int i = 0; i < table_columns.size(); i++) {
         columnSchemaList.add(thriftColumnSchemaToWrapperColumnSchema(table_columns.get(i)));
+      }
+      // In case of non transactional table just set columnuniqueid as columnName to support
+      // backward compatabiity. non transactional tables column uniqueid is always equal to
+      // columnname
+      if (!isTransactionalTable) {
+        for (ColumnSchema columnSchema : columnSchemaList) {
+          columnSchema.setColumnUniqueId(columnSchema.getColumnName());
+        }
       }
       // get the segment info
       SegmentInfo segmentInfo = getSegmentInfo(readIndexHeader.getSegment_info());

--- a/core/src/main/java/org/apache/carbondata/core/util/BlockletDataMapUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/BlockletDataMapUtil.java
@@ -91,17 +91,18 @@ public class BlockletDataMapUtil {
           identifier.getIndexFilePath() + CarbonCommonConstants.FILE_SEPARATOR + identifier
               .getIndexFileName()) });
     }
-    DataFileFooterConverter fileFooterConverter = new DataFileFooterConverter();
     Map<String, BlockMetaInfo> blockMetaInfoMap = new HashMap<>();
-    List<DataFileFooter> indexInfo = fileFooterConverter.getIndexInfo(
-        identifier.getIndexFilePath() + CarbonCommonConstants.FILE_SEPARATOR + identifier
-            .getIndexFileName(), indexFileStore.getFileData(identifier.getIndexFileName()));
     CarbonTable carbonTable = identifierWrapper.getCarbonTable();
     if (carbonTable != null) {
       isTransactionalTable = carbonTable.getTableInfo().isTransactionalTable();
       tableColumnList =
           carbonTable.getTableInfo().getFactTable().getListOfColumns();
     }
+    DataFileFooterConverter fileFooterConverter = new DataFileFooterConverter();
+    List<DataFileFooter> indexInfo = fileFooterConverter.getIndexInfo(
+        identifier.getIndexFilePath() + CarbonCommonConstants.FILE_SEPARATOR + identifier
+            .getIndexFileName(), indexFileStore.getFileData(identifier.getIndexFileName()),
+        isTransactionalTable);
     for (DataFileFooter footer : indexInfo) {
       if ((!isTransactionalTable) && (tableColumnList.size() != 0) &&
           !isSameColumnSchemaList(footer.getColumnInTable(), tableColumnList)) {
@@ -255,7 +256,7 @@ public class BlockletDataMapUtil {
       return false;
     }
     for (int i = 0; i < tableColumnList.size(); i++) {
-      if (!indexFileColumnList.get(i).equalsWithStrictCheck(tableColumnList.get(i))) {
+      if (!tableColumnList.contains(indexFileColumnList.get(i))) {
         return false;
       }
     }

--- a/core/src/main/java/org/apache/carbondata/core/util/BlockletDataMapUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/BlockletDataMapUtil.java
@@ -248,7 +248,7 @@ public class BlockletDataMapUtil {
     return true;
   }
 
-  private static boolean isSameColumnSchemaList(List<ColumnSchema> indexFileColumnList,
+  public static boolean isSameColumnSchemaList(List<ColumnSchema> indexFileColumnList,
       List<ColumnSchema> tableColumnList) {
     if (indexFileColumnList.size() != tableColumnList.size()) {
       LOG.error("Index file's column size is " + indexFileColumnList.size()

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableInputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableInputFormat.java
@@ -198,11 +198,11 @@ public class CarbonTableInputFormat<T> extends CarbonInputFormat<T> {
     Expression filter = getFilterPredicates(job.getConfiguration());
     // this will be null in case of corrupt schema file.
     PartitionInfo partitionInfo = carbonTable.getPartitionInfo(carbonTable.getTableName());
-    carbonTable.processFilterExpression(filter, null, null);
 
     // prune partitions for filter query on partition table
     BitSet matchedPartitions = null;
     if (partitionInfo != null && partitionInfo.getPartitionType() != PartitionType.NATIVE_HIVE) {
+      carbonTable.processFilterExpression(filter, null, null);
       matchedPartitions = setMatchedPartitions(null, filter, partitionInfo, null);
       if (matchedPartitions != null) {
         if (matchedPartitions.cardinality() == 0) {
@@ -213,11 +213,9 @@ public class CarbonTableInputFormat<T> extends CarbonInputFormat<T> {
       }
     }
 
-    FilterResolverIntf filterInterface = carbonTable.resolveFilter(filter);
-
     // do block filtering and get split
     List<InputSplit> splits =
-        getSplits(job, filterInterface, filteredSegmentToAccess, matchedPartitions, partitionInfo,
+        getSplits(job, filter, filteredSegmentToAccess, matchedPartitions, partitionInfo,
             null, updateStatusManager);
     // pass the invalid segment to task side in order to remove index entry in task side
     if (invalidSegments.size() > 0) {
@@ -442,9 +440,7 @@ public class CarbonTableInputFormat<T> extends CarbonInputFormat<T> {
       if (null == carbonTable) {
         throw new IOException("Missing/Corrupt schema file for table.");
       }
-
       carbonTable.processFilterExpression(filter, null, null);
-
       // prune partitions for filter query on partition table
       String partitionIds = job.getConfiguration().get(ALTER_PARTITION_ID);
       // matchedPartitions records partitionIndex, not partitionId
@@ -461,9 +457,8 @@ public class CarbonTableInputFormat<T> extends CarbonInputFormat<T> {
         }
       }
 
-      FilterResolverIntf filterInterface = carbonTable.resolveFilter(filter);
       // do block filtering and get split
-      List<InputSplit> splits = getSplits(job, filterInterface, segmentList, matchedPartitions,
+      List<InputSplit> splits = getSplits(job, filter, segmentList, matchedPartitions,
           partitionInfo, oldPartitionIdList, new SegmentUpdateStatusManager(carbonTable));
       // pass the invalid segment to task side in order to remove index entry in task side
       if (invalidSegments.size() > 0) {
@@ -513,7 +508,7 @@ public class CarbonTableInputFormat<T> extends CarbonInputFormat<T> {
    * @return
    * @throws IOException
    */
-  private List<InputSplit> getSplits(JobContext job, FilterResolverIntf filterResolver,
+  private List<InputSplit> getSplits(JobContext job, Expression expression,
       List<Segment> validSegments, BitSet matchedPartitions, PartitionInfo partitionInfo,
       List<Integer> oldPartitionIdList, SegmentUpdateStatusManager updateStatusManager)
       throws IOException {
@@ -527,7 +522,7 @@ public class CarbonTableInputFormat<T> extends CarbonInputFormat<T> {
 
     // for each segment fetch blocks matching filter in Driver BTree
     List<org.apache.carbondata.hadoop.CarbonInputSplit> dataBlocksOfSegment =
-        getDataBlocksOfSegment(job, carbonTable, filterResolver, matchedPartitions,
+        getDataBlocksOfSegment(job, carbonTable, expression, matchedPartitions,
             validSegments, partitionInfo, oldPartitionIdList);
     numBlocks = dataBlocksOfSegment.size();
     for (org.apache.carbondata.hadoop.CarbonInputSplit inputSplit : dataBlocksOfSegment) {
@@ -615,7 +610,7 @@ public class CarbonTableInputFormat<T> extends CarbonInputFormat<T> {
               toBeCleanedSegments);
     }
     List<ExtendedBlocklet> blocklets =
-        blockletMap.prune(filteredSegment, null, partitions);
+        blockletMap.prune(filteredSegment, (FilterResolverIntf) null, partitions);
     for (ExtendedBlocklet blocklet : blocklets) {
       String blockName = blocklet.getPath();
       blockName = CarbonTablePath.getCarbonDataFileName(blockName);

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableInputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableInputFormat.java
@@ -227,8 +227,7 @@ public class CarbonTableInputFormat<T> extends CarbonInputFormat<T> {
     }
 
     // add all splits of streaming
-    List<InputSplit> splitsOfStreaming =
-        getSplitsOfStreaming(job, streamSegments, carbonTable, filterInterface);
+    List<InputSplit> splitsOfStreaming = getSplitsOfStreaming(job, streamSegments, carbonTable);
     if (!splitsOfStreaming.isEmpty()) {
       splits.addAll(splitsOfStreaming);
     }
@@ -356,7 +355,8 @@ public class CarbonTableInputFormat<T> extends CarbonInputFormat<T> {
           Expression filter = getFilterPredicates(job.getConfiguration());
           if (filter != null) {
             carbonTable.processFilterExpression(filter, null, null);
-            filterResolverIntf = carbonTable.resolveFilter(filter);
+            filterResolverIntf =
+                CarbonTable.resolveFilter(filter, carbonTable.getAbsoluteTableIdentifier());
           }
         }
       }

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/testutil/StoreCreator.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/testutil/StoreCreator.java
@@ -197,8 +197,6 @@ public class StoreCreator {
       File storeDir = new File(storePath);
       CarbonUtil.deleteFoldersAndFiles(storeDir);
     }
-    CarbonProperties.getInstance().addProperty(CarbonCommonConstants.STORE_LOCATION_HDFS,
-        storePath);
 
     CarbonTable table = createTable(absoluteTableIdentifier);
     writeDictionary(csvPath, table);

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/testutil/StoreCreator.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/testutil/StoreCreator.java
@@ -105,7 +105,7 @@ public class StoreCreator {
   private String storePath = null;
   private String csvPath;
   private boolean dictionary;
-  private List<String> sortCOls = new ArrayList<>();
+  private List<String> sortColumns = new ArrayList<>();
 
   public StoreCreator(String storePath, String csvPath) {
     this(storePath, csvPath, false);
@@ -116,11 +116,11 @@ public class StoreCreator {
     this.csvPath = csvPath;
     String dbName = "testdb";
     String tableName = "testtable";
-    sortCOls.add("date");
-    sortCOls.add("country");
-    sortCOls.add("name");
-    sortCOls.add("phonetype");
-    sortCOls.add("serialname");
+    sortColumns.add("date");
+    sortColumns.add("country");
+    sortColumns.add("name");
+    sortColumns.add("phonetype");
+    sortColumns.add("serialname");
     absoluteTableIdentifier = AbsoluteTableIdentifier.from(storePath + "/testdb/testtable",
         new CarbonTableIdentifier(dbName, tableName, UUID.randomUUID().toString()));
     this.dictionary = dictionary;
@@ -229,7 +229,7 @@ public class StoreCreator {
     id.setColumnReferenceId(id.getColumnUniqueId());
     id.setDimensionColumn(true);
     id.setSchemaOrdinal(schemaOrdinal++);
-    if (sortCOls.contains(id.getColumnName())) {
+    if (sortColumns.contains(id.getColumnName())) {
       id.setSortColumn(true);
     }
     columnSchemas.add(id);
@@ -242,7 +242,7 @@ public class StoreCreator {
     date.setDimensionColumn(true);
     date.setColumnReferenceId(id.getColumnUniqueId());
     date.setSchemaOrdinal(schemaOrdinal++);
-    if (sortCOls.contains(date.getColumnName())) {
+    if (sortColumns.contains(date.getColumnName())) {
       date.setSortColumn(true);
     }
     columnSchemas.add(date);
@@ -255,7 +255,7 @@ public class StoreCreator {
     country.setDimensionColumn(true);
     country.setSortColumn(true);
     country.setSchemaOrdinal(schemaOrdinal++);
-    if (sortCOls.contains(country.getColumnName())) {
+    if (sortColumns.contains(country.getColumnName())) {
       country.setSortColumn(true);
     }
     country.setColumnReferenceId(id.getColumnUniqueId());
@@ -268,7 +268,7 @@ public class StoreCreator {
     name.setColumnUniqueId(UUID.randomUUID().toString());
     name.setDimensionColumn(true);
     name.setSchemaOrdinal(schemaOrdinal++);
-    if (sortCOls.contains(name.getColumnName())) {
+    if (sortColumns.contains(name.getColumnName())) {
       name.setSortColumn(true);
     }
     name.setColumnReferenceId(id.getColumnUniqueId());
@@ -281,7 +281,7 @@ public class StoreCreator {
     phonetype.setColumnUniqueId(UUID.randomUUID().toString());
     phonetype.setDimensionColumn(true);
     phonetype.setSchemaOrdinal(schemaOrdinal++);
-    if (sortCOls.contains(phonetype.getColumnName())) {
+    if (sortColumns.contains(phonetype.getColumnName())) {
       phonetype.setSortColumn(true);
     }
     phonetype.setColumnReferenceId(id.getColumnUniqueId());
@@ -294,7 +294,7 @@ public class StoreCreator {
     serialname.setColumnUniqueId(UUID.randomUUID().toString());
     serialname.setDimensionColumn(true);
     serialname.setSchemaOrdinal(schemaOrdinal++);
-    if (sortCOls.contains(serialname.getColumnName())) {
+    if (sortColumns.contains(serialname.getColumnName())) {
       serialname.setSortColumn(true);
     }
     serialname.setColumnReferenceId(id.getColumnUniqueId());
@@ -399,8 +399,8 @@ public class StoreCreator {
     reader.close();
   }
 
-  public void setSortCOls(List<String> sortCOls) {
-    this.sortCOls = sortCOls;
+  public void setSortColumns(List<String> sortColumns) {
+    this.sortColumns = sortColumns;
   }
 
   /**

--- a/hadoop/src/test/java/org/apache/carbondata/hadoop/ft/CarbonTableInputFormatTest.java
+++ b/hadoop/src/test/java/org/apache/carbondata/hadoop/ft/CarbonTableInputFormatTest.java
@@ -56,13 +56,16 @@ import org.junit.Test;
 
 public class CarbonTableInputFormatTest {
   // changed setUp to static init block to avoid un wanted multiple time store creation
+  private static StoreCreator creator;
   static {
     CarbonProperties.getInstance().
         addProperty(CarbonCommonConstants.CARBON_BADRECORDS_LOC, "/tmp/carbon/badrecords");
     CarbonProperties.getInstance()
         .addProperty(CarbonCommonConstants.CARBON_SYSTEM_FOLDER_LOCATION, "/tmp/carbon/");
     try {
-      StoreCreator.createCarbonStore();
+      creator = new StoreCreator(new File("target/store").getAbsolutePath(),
+          new File("../hadoop/src/test/resources/data.csv").getCanonicalPath());
+      creator.createCarbonStore();
     } catch (Exception e) {
       Assert.fail("create table failed: " + e.getMessage());
     }
@@ -73,10 +76,10 @@ public class CarbonTableInputFormatTest {
     JobConf jobConf = new JobConf(new Configuration());
     Job job = Job.getInstance(jobConf);
     job.getConfiguration().set("query.id", UUID.randomUUID().toString());
-    String tblPath = StoreCreator.getAbsoluteTableIdentifier().getTablePath();
+    String tblPath = creator.getAbsoluteTableIdentifier().getTablePath();
     FileInputFormat.addInputPath(job, new Path(tblPath));
-    CarbonTableInputFormat.setDatabaseName(job.getConfiguration(), StoreCreator.getAbsoluteTableIdentifier().getDatabaseName());
-    CarbonTableInputFormat.setTableName(job.getConfiguration(), StoreCreator.getAbsoluteTableIdentifier().getTableName());
+    CarbonTableInputFormat.setDatabaseName(job.getConfiguration(), creator.getAbsoluteTableIdentifier().getDatabaseName());
+    CarbonTableInputFormat.setTableName(job.getConfiguration(), creator.getAbsoluteTableIdentifier().getTableName());
     Expression expression = new EqualToExpression(new ColumnExpression("country", DataTypes.STRING),
         new LiteralExpression("china", DataTypes.STRING));
     CarbonTableInputFormat.setFilterPredicates(job.getConfiguration(), expression);
@@ -92,12 +95,12 @@ public class CarbonTableInputFormatTest {
     JobConf jobConf = new JobConf(new Configuration());
     Job job = Job.getInstance(jobConf);
     job.getConfiguration().set("query.id", UUID.randomUUID().toString());
-    String tblPath = StoreCreator.getAbsoluteTableIdentifier().getTablePath();
+    String tblPath = creator.getAbsoluteTableIdentifier().getTablePath();
     FileInputFormat.addInputPath(job, new Path(tblPath));
-    CarbonTableInputFormat.setDatabaseName(job.getConfiguration(), StoreCreator.getAbsoluteTableIdentifier().getDatabaseName());
-    CarbonTableInputFormat.setTableName(job.getConfiguration(), StoreCreator.getAbsoluteTableIdentifier().getTableName());
+    CarbonTableInputFormat.setDatabaseName(job.getConfiguration(), creator.getAbsoluteTableIdentifier().getDatabaseName());
+    CarbonTableInputFormat.setTableName(job.getConfiguration(), creator.getAbsoluteTableIdentifier().getTableName());
     // list files to get the carbondata file
-    String segmentPath = CarbonTablePath.getSegmentPath(StoreCreator.getAbsoluteTableIdentifier().getTablePath(), "0");
+    String segmentPath = CarbonTablePath.getSegmentPath(creator.getAbsoluteTableIdentifier().getTablePath(), "0");
     File segmentDir = new File(segmentPath);
     if (segmentDir.exists() && segmentDir.isDirectory()) {
       File[] files = segmentDir.listFiles(new FileFilter() {
@@ -134,7 +137,7 @@ public class CarbonTableInputFormatTest {
       Assert.assertTrue("failed", false);
       throw e;
     } finally {
-      StoreCreator.clearDataMaps();
+      creator.clearDataMaps();
     }
   }
 
@@ -153,7 +156,7 @@ public class CarbonTableInputFormatTest {
       e.printStackTrace();
       Assert.assertTrue("failed", false);
     } finally {
-      StoreCreator.clearDataMaps();
+      creator.clearDataMaps();
     }
   }
 
@@ -173,7 +176,7 @@ public class CarbonTableInputFormatTest {
     } catch (Exception e) {
       Assert.assertTrue("failed", false);
     } finally {
-      StoreCreator.clearDataMaps();
+      creator.clearDataMaps();
     }
   }
 
@@ -245,7 +248,7 @@ public class CarbonTableInputFormatTest {
     job.setMapperClass(Map.class);
     job.setInputFormatClass(CarbonTableInputFormat.class);
     job.setOutputFormatClass(TextOutputFormat.class);
-    AbsoluteTableIdentifier abs = StoreCreator.getAbsoluteTableIdentifier();
+    AbsoluteTableIdentifier abs = creator.getAbsoluteTableIdentifier();
     if (projection != null) {
       CarbonTableInputFormat.setColumnProjection(job.getConfiguration(), projection);
     }

--- a/hadoop/src/test/java/org/apache/carbondata/hadoop/ft/CarbonTableOutputFormatTest.java
+++ b/hadoop/src/test/java/org/apache/carbondata/hadoop/ft/CarbonTableOutputFormatTest.java
@@ -54,7 +54,8 @@ public class CarbonTableOutputFormatTest {
     CarbonProperties.getInstance()
         .addProperty(CarbonCommonConstants.CARBON_SYSTEM_FOLDER_LOCATION, "/tmp/carbon/");
     try {
-      carbonLoadModel = StoreCreator.createTableAndLoadModel();
+      carbonLoadModel = new StoreCreator(new File("target/store").getAbsolutePath(),
+          new File("../hadoop/src/test/resources/data.csv").getCanonicalPath()).createTableAndLoadModel();
     } catch (Exception e) {
       Assert.fail("create table failed: " + e.getMessage());
     }

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/allqueries/TestQueryWithColumnMetCacheAndCacheLevelProperty.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/allqueries/TestQueryWithColumnMetCacheAndCacheLevelProperty.scala
@@ -33,6 +33,7 @@ import org.apache.carbondata.core.indexstore.blockletindex.{BlockDataMap, Blockl
 import org.apache.carbondata.core.indexstore.schema.CarbonRowSchema
 import org.apache.carbondata.core.indexstore.Blocklet
 import org.apache.carbondata.core.metadata.datatype.DataTypes
+import org.apache.carbondata.core.metadata.schema.table.CarbonTable
 import org.apache.carbondata.core.metadata.schema.table.column.CarbonDimension
 import org.apache.carbondata.core.scan.expression.conditional.NotEqualsExpression
 import org.apache.carbondata.core.scan.expression.logical.AndExpression
@@ -300,7 +301,8 @@ class TestQueryWithColumnMetCacheAndCacheLevelProperty extends QueryTest with Be
     val notEqualsExpression = new NotEqualsExpression(columnExpression, literalNullExpression)
     val equalsExpression = new NotEqualsExpression(columnExpression, literalValueExpression)
     val andExpression = new AndExpression(notEqualsExpression, equalsExpression)
-    val resolveFilter: FilterResolverIntf = carbonTable.resolveFilter(andExpression)
+    val resolveFilter: FilterResolverIntf =
+      CarbonTable.resolveFilter(andExpression, carbonTable.getAbsoluteTableIdentifier)
     val exprWrapper = DataMapChooser.getDefaultDataMap(carbonTable, resolveFilter)
     val segment = new Segment("0")
     // get the pruned blocklets

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestNonTransactionalCarbonTable.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestNonTransactionalCarbonTable.scala
@@ -1040,19 +1040,14 @@ class TestNonTransactionalCarbonTable extends QueryTest with BeforeAndAfterAll {
     buildTestDataOtherDataType(3, Array[String]("age"))
     // put other sdk writer output to same path,
     // which has same column names but different sort column
-    val exception =
-    intercept[IOException] {
-      sql("select * from sdkOutputTable").show(false)
-    }
-    assert(exception.getMessage()
-      .contains("Problem in loading segment blocks."))
+    checkAnswer(sql("select * from sdkOutputTable"),
+      Seq(Row(true, 0, 0.0),
+          Row(true, 1, 0.5),
+          Row(true, 2, 1.0),
+          Row(true, 0, 0.0),
+          Row(true, 1, 0.5),
+          Row(true, 2, 1.0)))
 
-    val exception1 =
-      intercept[IOException] {
-        sql("select count(*) from sdkOutputTable").show(false)
-      }
-    assert(exception1.getMessage()
-      .contains("Problem in loading segment blocks."))
 
     sql("DROP TABLE sdkOutputTable")
     // drop table should not delete the files

--- a/streaming/src/test/java/org/apache/carbondata/streaming/CarbonStreamOutputFormatTest.java
+++ b/streaming/src/test/java/org/apache/carbondata/streaming/CarbonStreamOutputFormatTest.java
@@ -70,7 +70,8 @@ public class CarbonStreamOutputFormatTest extends TestCase {
             tablePath,
             new CarbonTableIdentifier(dbName, tableName, UUID.randomUUID().toString()));
 
-    CarbonTable table = StoreCreator.createTable(identifier);
+    CarbonTable table = new StoreCreator(new File("target/store").getAbsolutePath(),
+        new File("../hadoop/src/test/resources/data.csv").getCanonicalPath()).createTable(identifier);
 
     String factFilePath = new File("../hadoop/src/test/resources/data.csv").getCanonicalPath();
     carbonLoadModel = StoreCreator.buildCarbonLoadModel(table, factFilePath, identifier);


### PR DESCRIPTION
1. The data loaded by old version with all dictionary exclude can now work with fileformat if the segment folder is given for reading.
2. Now user can specify different sort options per load while loading data through sdk, fileformat can read now.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

