### PR TITLE
[CARBONDATA-2922] support long string columns with spark FileFormat and SDK with "long_string_columns" TableProperties

### DIFF
--- a/docs/sdk-guide.md
+++ b/docs/sdk-guide.md
@@ -339,8 +339,7 @@ public CarbonWriterBuilder taskNo(long taskNo);
 *                g. complex_delimiter_level_2 -- value to Split the nested complexTypeData
 *                h. quotechar
 *                i. escapechar
-*                j. sort_scope -- "local_sort", "no_sort", "batch_sort"
-*
+*                
 *                Default values are as follows.
 *
 *                a. bad_records_logger_enable -- "false"
@@ -352,7 +351,6 @@ public CarbonWriterBuilder taskNo(long taskNo);
 *                g. complex_delimiter_level_2 -- ":"
 *                h. quotechar -- "\""
 *                i. escapechar -- "\\"
-*                j. sort_scope -- "local_sort"
 *
 * @return updated CarbonWriterBuilder
 */
@@ -370,6 +368,9 @@ public CarbonWriterBuilder withLoadOptions(Map<String, String> options);
 * c. local_dictionary_threshold -- positive value, default is 10000
 * d. local_dictionary_enable -- true / false. Default is false
 * e. sort_columns -- comma separated column. "c1,c2". Default all dimensions are sorted.
+* j. sort_scope -- "local_sort", "no_sort", "batch_sort". default value is "local_sort"
+* k. long_string_columns -- comma separated string columns which are more than 32k length. 
+*                           default value is null.
 *
 * @return updated CarbonWriterBuilder
 */

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestNonTransactionalCarbonTable.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestNonTransactionalCarbonTable.scala
@@ -2365,7 +2365,7 @@ class TestNonTransactionalCarbonTable extends QueryTest with BeforeAndAfterAll {
     fields(1) = new Field("intField", DataTypes.INT)
     val writer: CarbonWriter = CarbonWriter.builder
       .outputPath(writerPath)
-      .withLoadOptions(options)
+      .withTableProperties(options)
       .buildWriterForCSVInput(new Schema(fields))
     writer.write(Array("carbon", "1"))
     writer.write(Array("hydrogen", "10"))

--- a/integration/spark-datasource/src/main/scala/org/apache/spark/sql/carbondata/execution/datasources/CarbonSparkDataSourceUtil.scala
+++ b/integration/spark-datasource/src/main/scala/org/apache/spark/sql/carbondata/execution/datasources/CarbonSparkDataSourceUtil.scala
@@ -228,6 +228,12 @@ object CarbonSparkDataSourceUtil {
       case _ => null
     }
     builder.sortBy(sortCols)
+    val longStringColumns: String = options
+      .getOrElse(CarbonCommonConstants.LONG_STRING_COLUMNS, null)
+    if (longStringColumns != null) {
+      val loadOptions = Map(CarbonCommonConstants.LONG_STRING_COLUMNS -> longStringColumns).asJava
+      builder.withTableProperties(loadOptions)
+    }
     builder.uniqueIdentifier(System.currentTimeMillis())
     val model = builder.buildLoadModel(schema)
     val tableInfo = model.getCarbonDataLoadSchema.getCarbonTable.getTableInfo

--- a/integration/spark-datasource/src/main/scala/org/apache/spark/sql/util/SparkTypeConverter.scala
+++ b/integration/spark-datasource/src/main/scala/org/apache/spark/sql/util/SparkTypeConverter.scala
@@ -83,6 +83,7 @@ private[spark] object SparkTypeConverter {
         case CarbonDataTypes.BOOLEAN => BooleanType
         case CarbonDataTypes.TIMESTAMP => TimestampType
         case CarbonDataTypes.DATE => DateType
+        case CarbonDataTypes.VARCHAR => StringType
       }
     }
   }

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/Field.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/Field.java
@@ -214,6 +214,11 @@ public class Field {
     this.columnComment = columnComment;
   }
 
+  /* for SDK, change string type to varchar by default for parent columns */
+  public void updateDataTypeToVarchar() {
+    this.type = DataTypes.VARCHAR;
+  }
+
   /*can use to change the case of the schema */
   public void updateNameToLowerCase() {
     this.name = name.toLowerCase();


### PR DESCRIPTION
**problem:** Exception if we try long string column for Spark file format 

**Solution:** For Varchar data type respective spark data type was selected, hence the exception.
Spark don't have limit for string data type. so map varchar to string type.
Tested with more than 32K length string and added a UT

Also for SDK **(required for AVRO)** and spark file format, supported the longstring columns table property.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed? NA.
 
 - [ ] Any backward compatibility impacted? NA
 
 - [ ] Document update required? updated

 - [ ] Testing done. 
  Added UT       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. NA

