### PR TITLE
[CARBONDATA-2902][DataMap] Fix showing negative pruning result for explain command

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockDataMap.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockDataMap.java
@@ -551,7 +551,8 @@ public class BlockDataMap extends CoarseGrainDataMap
       // dummy value
       return 0;
     } else {
-      return ByteBuffer.wrap(getBlockletRowCountForEachBlock()).getShort(index);
+      return ByteBuffer.wrap(getBlockletRowCountForEachBlock()).getShort(
+          index * CarbonCommonConstants.SHORT_SIZE_IN_BYTE);
     }
   }
 


### PR DESCRIPTION
#2676 used method `ByteBuffer.getShort(int index)` to get number of blocklets in block, but it used wrong parameter. The `index` is index of byte instead of index of short. So it needs to multiply bytes of short type

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

