### PR TITLE
[CARBONDATA-2923] Log the hit information of streaming segments

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/stream/StreamPruner.java
+++ b/core/src/main/java/org/apache/carbondata/core/stream/StreamPruner.java
@@ -45,6 +45,8 @@ public class StreamPruner {
   private CarbonTable carbonTable;
   private FilterExecuter filterExecuter;
 
+  private int totalFileNums = 0;
+
   public StreamPruner(CarbonTable carbonTable) {
     this.carbonTable = carbonTable;
   }
@@ -138,6 +140,11 @@ public class StreamPruner {
         }
       }
     }
+    totalFileNums = streamFileList.size();
     return streamFileList;
+  }
+
+  public int getTotalFileNums() {
+    return totalFileNums;
   }
 }

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonInputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonInputFormat.java
@@ -123,6 +123,8 @@ public abstract class CarbonInputFormat<T> extends FileInputFormat<Void, T> {
   // record segment number and hit blocks
   protected int numSegments = 0;
   protected int numStreamSegments = 0;
+  protected int numStreamFiles = 0;
+  protected int hitedStreamFiles = 0;
   protected int numBlocks = 0;
 
   public int getNumSegments() {
@@ -131,6 +133,14 @@ public abstract class CarbonInputFormat<T> extends FileInputFormat<Void, T> {
 
   public int getNumStreamSegments() {
     return numStreamSegments;
+  }
+
+  public int getNumStreamFiles() {
+    return numStreamFiles;
+  }
+
+  public int getHitedStreamFiles() {
+    return hitedStreamFiles;
   }
 
   public int getNumBlocks() {

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableInputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableInputFormat.java
@@ -363,7 +363,9 @@ public class CarbonTableInputFormat<T> extends CarbonInputFormat<T> {
       StreamPruner streamPruner = new StreamPruner(carbonTable);
       streamPruner.init(filterResolverIntf);
       List<StreamFile> streamFiles = streamPruner.prune(streamSegments);
-
+      // record the hit information of the streaming files
+      this.hitedStreamFiles = streamFiles.size();
+      this.numStreamFiles = streamPruner.getTotalFileNums();
       for (StreamFile streamFile : streamFiles) {
         Path path = new Path(streamFile.getFilePath());
         long length = streamFile.getFileSize();

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
@@ -165,14 +165,18 @@ class CarbonScanRDD[T: ClassTag](
         if (batchPartitions.isEmpty) {
           partitions = streamPartitions.toArray
         } else {
-          logInfo(
-            s"""
-               | Identified no.of Streaming Blocks: ${ streamPartitions.size },
-          """.stripMargin)
           // should keep the order by index of partition
           batchPartitions.appendAll(streamPartitions)
           partitions = batchPartitions.toArray
         }
+        logInfo(
+          s"""
+             | Identified no.of.streaming splits/tasks: ${ streamPartitions.size },
+             | no.of.streaming files: ${format.getHitedStreamFiles},
+             | no.of.total streaming files: ${format.getNumStreamFiles},
+             | no.of.total streaming segement: ${format.getNumStreamSegments}
+          """.stripMargin)
+
       }
       partitions
     } finally {


### PR DESCRIPTION
Log the hit information of streaming segments after the hit information of batch segments.

18/09/09 20:03:30 INFO CarbonScanRDD: 
 Identified no.of.blocks: 1,
 no.of.tasks: 1,
 no.of.nodes: 0,
 parallelism: 2
       
18/09/09 20:03:30 INFO CarbonScanRDD: 
 Identified no.of.streaming splits/tasks: 1,
 no.of.streaming files: 1,
 no.of.total streaming files: 2,
 no.of.total streaming segement: 1


 - [x] Any interfaces changed?
 no
 - [x] Any backward compatibility impacted?
 no
 - [x] Document update required?
 no
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
           check the log information
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
small changes
