### PR TITLE
[CARBONDATA-2925]Wrong data displayed for spark file format if carbon…

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/indexstore/BlockletDetailInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/BlockletDetailInfo.java
@@ -51,7 +51,8 @@ public class BlockletDetailInfo implements Serializable, Writable {
 
   private short versionNumber;
 
-  private short blockletId;
+  // default blockletId should be -1,which means consider all the blocklets in block
+  private short blockletId = -1;
 
   private int[] dimLens;
 


### PR DESCRIPTION
Issue:- if Carbon file has multiple  blocklet ,in select query wrong data displayed. 
Root Cause :- it is showing records of only for 1st  Blocklet and other blocklet in that block is getting skipped. This is because default blocklet is 0 and CarbonFileformat create blockletInfo with default configuration (not changed blockletID).
Solution :- Set default blockletID to -1  so that all blocklets are considered.
refer org.apache.carbondata.core.scan.executor.impl.AbstractQueryExecutor#readAndFillBlockletInfo

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 NA
 - [ ] Any backward compatibility impacted?
 NA
 - [ ] Document update required?
NA
 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
     Manually and Testcase also added
   - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA
