### PR TITLE
[CARBONDATA-2926] fixed ArrayIndexOutOfBoundException with varchar columns and empty sort_columns

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/TableSpec.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/TableSpec.java
@@ -42,8 +42,8 @@ public class TableSpec {
   // dictionary + no dictionary + complex + measure
   // when sort_columns are empty, no columns are selected for sorting.
   // so, spec will not be in above order.
-  // Hence NoDictionaryDimensionSpec will be useful and it will be subset of dimensionSpec.
-  private List<DimensionSpec> NoDictionaryDimensionSpec;
+  // Hence noDictionaryDimensionSpec will be useful and it will be subset of dimensionSpec.
+  private List<DimensionSpec> noDictionaryDimensionSpec;
 
   // number of simple dimensions
   private int numSimpleDimensions;
@@ -65,7 +65,7 @@ public class TableSpec {
     }
     dimensionSpec = new DimensionSpec[dimensions.size()];
     measureSpec = new MeasureSpec[measures.size()];
-    NoDictionaryDimensionSpec = new ArrayList<>();
+    noDictionaryDimensionSpec = new ArrayList<>();
     addDimensions(dimensions);
     addMeasures(measures);
   }
@@ -77,12 +77,12 @@ public class TableSpec {
       if (dimension.isComplex()) {
         DimensionSpec spec = new DimensionSpec(ColumnType.COMPLEX, dimension);
         dimensionSpec[dimIndex++] = spec;
-        NoDictionaryDimensionSpec.add(spec);
+        noDictionaryDimensionSpec.add(spec);
       } else if (dimension.getDataType() == DataTypes.TIMESTAMP && !dimension
           .isDirectDictionaryEncoding()) {
         DimensionSpec spec = new DimensionSpec(ColumnType.PLAIN_VALUE, dimension);
         dimensionSpec[dimIndex++] = spec;
-        NoDictionaryDimensionSpec.add(spec);
+        noDictionaryDimensionSpec.add(spec);
       } else if (dimension.isDirectDictionaryEncoding()) {
         DimensionSpec spec = new DimensionSpec(ColumnType.DIRECT_DICTIONARY, dimension);
         dimensionSpec[dimIndex++] = spec;
@@ -92,7 +92,7 @@ public class TableSpec {
       } else {
         DimensionSpec spec = new DimensionSpec(ColumnType.PLAIN_VALUE, dimension);
         dimensionSpec[dimIndex++] = spec;
-        NoDictionaryDimensionSpec.add(spec);
+        noDictionaryDimensionSpec.add(spec);
       }
     }
   }
@@ -109,7 +109,7 @@ public class TableSpec {
   }
 
   public List<DimensionSpec> getNoDictionaryDimensionSpec() {
-    return NoDictionaryDimensionSpec;
+    return noDictionaryDimensionSpec;
   }
 
   public MeasureSpec getMeasureSpec(int measureIndex) {

--- a/core/src/main/java/org/apache/carbondata/core/datastore/TableSpec.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/TableSpec.java
@@ -20,6 +20,7 @@ package org.apache.carbondata.core.datastore;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.carbondata.core.metadata.datatype.DataType;
@@ -35,6 +36,14 @@ public class TableSpec {
   // column spec for each dimension and measure
   private DimensionSpec[] dimensionSpec;
   private MeasureSpec[] measureSpec;
+
+  // Many places we might have to access no-dictionary column spec.
+  // but no-dictionary column spec are not always in below order like,
+  // dictionary + no dictionary + complex + measure
+  // when sort_columns are empty, no columns are selected for sorting.
+  // so, spec will not be in above order.
+  // Hence NoDictionaryDimensionSpec will be useful and it will be subset of dimensionSpec.
+  private List<DimensionSpec> NoDictionaryDimensionSpec;
 
   // number of simple dimensions
   private int numSimpleDimensions;
@@ -56,6 +65,7 @@ public class TableSpec {
     }
     dimensionSpec = new DimensionSpec[dimensions.size()];
     measureSpec = new MeasureSpec[measures.size()];
+    NoDictionaryDimensionSpec = new ArrayList<>();
     addDimensions(dimensions);
     addMeasures(measures);
   }
@@ -67,10 +77,12 @@ public class TableSpec {
       if (dimension.isComplex()) {
         DimensionSpec spec = new DimensionSpec(ColumnType.COMPLEX, dimension);
         dimensionSpec[dimIndex++] = spec;
+        NoDictionaryDimensionSpec.add(spec);
       } else if (dimension.getDataType() == DataTypes.TIMESTAMP && !dimension
           .isDirectDictionaryEncoding()) {
         DimensionSpec spec = new DimensionSpec(ColumnType.PLAIN_VALUE, dimension);
         dimensionSpec[dimIndex++] = spec;
+        NoDictionaryDimensionSpec.add(spec);
       } else if (dimension.isDirectDictionaryEncoding()) {
         DimensionSpec spec = new DimensionSpec(ColumnType.DIRECT_DICTIONARY, dimension);
         dimensionSpec[dimIndex++] = spec;
@@ -80,6 +92,7 @@ public class TableSpec {
       } else {
         DimensionSpec spec = new DimensionSpec(ColumnType.PLAIN_VALUE, dimension);
         dimensionSpec[dimIndex++] = spec;
+        NoDictionaryDimensionSpec.add(spec);
       }
     }
   }
@@ -93,6 +106,10 @@ public class TableSpec {
 
   public DimensionSpec getDimensionSpec(int dimensionIndex) {
     return dimensionSpec[dimensionIndex];
+  }
+
+  public List<DimensionSpec> getNoDictionaryDimensionSpec() {
+    return NoDictionaryDimensionSpec;
   }
 
   public MeasureSpec getMeasureSpec(int measureIndex) {

--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/TableSchemaBuilder.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/TableSchemaBuilder.java
@@ -50,6 +50,8 @@ public class TableSchemaBuilder {
 
   private List<ColumnSchema> dimension = new LinkedList<>();
 
+  private List<ColumnSchema> varCharColumns = new LinkedList<>();
+
   private List<ColumnSchema> complex = new LinkedList<>();
 
   private List<ColumnSchema> measures = new LinkedList<>();
@@ -107,6 +109,7 @@ public class TableSchemaBuilder {
     schema.setSchemaEvolution(schemaEvol);
     List<ColumnSchema> allColumns = new LinkedList<>(sortColumns);
     allColumns.addAll(dimension);
+    allColumns.addAll(varCharColumns);
     allColumns.addAll(complex);
     allColumns.addAll(measures);
     schema.setListOfColumns(allColumns);
@@ -214,7 +217,11 @@ public class TableSchemaBuilder {
           || isComplexChild) {
         complex.add(newColumn);
       } else {
-        dimension.add(newColumn);
+        if (field.getDataType() == DataTypes.VARCHAR) {
+          varCharColumns.add(newColumn);
+        } else {
+          dimension.add(newColumn);
+        }
       }
     }
     if (newColumn.isDimensionColumn()) {

--- a/integration/spark-common-cluster-test/src/test/scala/org/apache/carbondata/cluster/sdv/generated/SDKwriterTestCase.scala
+++ b/integration/spark-common-cluster-test/src/test/scala/org/apache/carbondata/cluster/sdv/generated/SDKwriterTestCase.scala
@@ -755,6 +755,37 @@ class SDKwriterTestCase extends QueryTest with BeforeAndAfterEach {
     sql(s"CREATE EXTERNAL TABLE sdkTable STORED BY 'carbondata' LOCATION '$writerPath'")
     checkAnswer(sql("select count(*) from sdkTable"), Seq(Row(5)))
   }
+
+  test("Test sdk with longstring with empty sort column and some direct dictionary columns") {
+    // here we specify the longstring column as varchar
+    val schema = new StringBuilder()
+      .append("[ \n")
+      .append("   {\"address\":\"varchar\"},\n")
+      .append("   {\"date1\":\"date\"},\n")
+      .append("   {\"date2\":\"date\"},\n")
+      .append("   {\"age\":\"int\"}\n")
+      .append("]")
+      .toString()
+    val builder = CarbonWriter.builder()
+    val writer = builder
+      .outputPath(writerPath)
+      .sortBy(Array[String]())
+      .buildWriterForCSVInput(Schema.parseJson(schema))
+
+    for (i <- 0 until 5) {
+      writer
+        .write(Array[String](RandomStringUtils.randomAlphabetic(40000),
+          "1999-12-01",
+          "1998-12-01",
+          i.toString))
+    }
+    writer.close()
+
+    assert(FileFactory.getCarbonFile(writerPath).exists)
+    sql("DROP TABLE IF EXISTS sdkTable")
+    sql(s"CREATE EXTERNAL TABLE sdkTable STORED BY 'carbondata' LOCATION '$writerPath'")
+    checkAnswer(sql("select count(*) from sdkTable"), Seq(Row(5)))
+  }
 }
 
 object avroUtil{

--- a/processing/src/main/java/org/apache/carbondata/processing/store/CarbonFactDataHandlerModel.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/CarbonFactDataHandlerModel.java
@@ -222,14 +222,16 @@ public class CarbonFactDataHandlerModel {
       simpleDimsLen[i] = dimLens[i];
     }
 
+    int noDictionayDimensionIndex = 0;
     // for dynamic page size in write step if varchar columns exist
     List<Integer> varcharDimIdxInNoDict = new ArrayList<>();
     for (DataField dataField : configuration.getDataFields()) {
       CarbonColumn column = dataField.getColumn();
-      if (!column.isComplex() && !dataField.hasDictionaryEncoding() &&
-              column.getDataType() == DataTypes.VARCHAR) {
-        // ordinal is set in CarbonTable.fillDimensionsAndMeasuresForTables()
-        varcharDimIdxInNoDict.add(column.getOrdinal() - simpleDimsCount);
+      if (!dataField.hasDictionaryEncoding()) {
+        if (!column.isComplex() && column.getDataType() == DataTypes.VARCHAR) {
+          varcharDimIdxInNoDict.add(noDictionayDimensionIndex);
+        }
+        noDictionayDimensionIndex++;
       }
     }
 

--- a/processing/src/main/java/org/apache/carbondata/processing/store/TablePage.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/TablePage.java
@@ -187,9 +187,10 @@ public class TablePage {
     if (noDictionaryCount > 0 || complexColumnCount > 0) {
       TableSpec tableSpec = model.getTableSpec();
       byte[][] noDictAndComplex = WriteStepRowUtil.getNoDictAndComplexDimension(row);
-      List<TableSpec.DimensionSpec> NoDictionaryDimSpec = tableSpec.getNoDictionaryDimensionSpec();
+      List<TableSpec.DimensionSpec> noDictionaryDimensionSpec =
+          tableSpec.getNoDictionaryDimensionSpec();
       for (int i = 0; i < noDictAndComplex.length; i++) {
-        if (NoDictionaryDimSpec.get(i).getSchemaDataType()
+        if (noDictionaryDimensionSpec.get(i).getSchemaDataType()
             == DataTypes.VARCHAR) {
           byte[] valueWithLength = addIntLengthToByteArray(noDictAndComplex[i]);
           noDictDimensionPages[i].putData(rowId, valueWithLength);

--- a/processing/src/main/java/org/apache/carbondata/processing/store/TablePage.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/TablePage.java
@@ -187,8 +187,9 @@ public class TablePage {
     if (noDictionaryCount > 0 || complexColumnCount > 0) {
       TableSpec tableSpec = model.getTableSpec();
       byte[][] noDictAndComplex = WriteStepRowUtil.getNoDictAndComplexDimension(row);
+      List<TableSpec.DimensionSpec> NoDictionaryDimSpec = tableSpec.getNoDictionaryDimensionSpec();
       for (int i = 0; i < noDictAndComplex.length; i++) {
-        if (tableSpec.getDimensionSpec(dictDimensionPages.length + i).getSchemaDataType()
+        if (NoDictionaryDimSpec.get(i).getSchemaDataType()
             == DataTypes.VARCHAR) {
           byte[] valueWithLength = addIntLengthToByteArray(noDictAndComplex[i]);
           noDictDimensionPages[i].putData(rowId, valueWithLength);

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonWriterBuilder.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonWriterBuilder.java
@@ -299,12 +299,6 @@ public class CarbonWriterBuilder {
    */
   public CarbonWriterBuilder withTableProperties(Map<String, String> options) {
     Objects.requireNonNull(options, "Table properties should not be null");
-    //validate the options.
-    if (options.size() > 5) {
-      throw new IllegalArgumentException("Supports only 5 options now. "
-          + "Refer method header or documentation");
-    }
-
     Set<String> supportedOptions = new HashSet<>(Arrays
         .asList("table_blocksize", "table_blocklet_size", "local_dictionary_threshold",
             "local_dictionary_enable", "sort_columns", "sort_scope", "long_string_columns"));


### PR DESCRIPTION
problem: 
ArrayIndexOutOfBoundException if varchar column is present before dictionary columns along with empty sort_columns.

root cause:
CarbonFactDataHandlerColumnar.isVarcharColumnFull() method uses model.getVarcharDimIdxInNoDict()
and index of varchar column in no dictonary array became negative.
currently index was calculated based on ordinal-number of dictionary columns. This can go negative in no_sort column case,

solution:
**take the varchar dimension index from no dictionary array from at runtime based on schema.**

**Also hotfix: removed number validation in table properties of sdk, now we support 7 properties**

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed? NA
 
 - [ ] Any backward compatibility impacted? NA
 
 - [ ] Document update required? NA

 - [ ] Testing done
updated UT       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. NA

