### PR TITLE
[CARBONDATA-2886] Select Filter Comppatibility Fixed

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/scan/executor/impl/AbstractQueryExecutor.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/executor/impl/AbstractQueryExecutor.java
@@ -383,8 +383,9 @@ public abstract class AbstractQueryExecutor<E> implements QueryExecutor<E> {
           blockletInfo.getBlockletIndex().getMinMaxIndex().getMaxValues());
       // update min and max values in case of old store for measures as min and max is written
       // opposite for measures in old store ( store <= 1.1 version)
+      byte[][] tempMaxValues = maxValues;
       maxValues = CarbonUtil.updateMinMaxValues(fileFooter, maxValues, minValues, false);
-      minValues = CarbonUtil.updateMinMaxValues(fileFooter, maxValues, minValues, true);
+      minValues = CarbonUtil.updateMinMaxValues(fileFooter, tempMaxValues, minValues, true);
       info.setDataBlockFromOldStore(true);
     }
     blockletInfo.getBlockletIndex().getMinMaxIndex().setMaxValues(maxValues);


### PR DESCRIPTION
Problem : Select Filter Query with INT data type was showing incorrect result in case of table creation and loading on old version and queried on new version. The min max values in case of legacy table were not being updated properly so the check inside the blocklet was not happening. 
Solution : Correctly updated the min max values.

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [x] Testing done
       Manually tested.
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

