### PR TITLE
[CARBONDATA-2929][DataMap] Add block skipped info for explain command

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockDataMap.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockDataMap.java
@@ -566,6 +566,16 @@ public class BlockDataMap extends CoarseGrainDataMap
     }
   }
 
+  // get total block number in this datamap
+  protected int getTotalBlocks() {
+    if (isLegacyStore) {
+      // dummy value
+      return 0;
+    } else {
+      return memoryDMStore.getRowCount();
+    }
+  }
+
   // get total blocklet number in this datamap
   protected int getTotalBlocklets() {
     if (isLegacyStore) {
@@ -627,6 +637,7 @@ public class BlockDataMap extends CoarseGrainDataMap
     } else {
       ExplainCollector.setShowPruningInfo(true);
       ExplainCollector.addTotalBlocklets(totalBlocklets);
+      ExplainCollector.addTotalBlocks(getTotalBlocks());
       ExplainCollector.addDefaultDataMapPruningHit(hitBlocklets);
     }
     return blocklets;

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMap.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMap.java
@@ -47,6 +47,8 @@ import org.apache.carbondata.core.util.BlockletDataMapUtil;
 public class BlockletDataMap extends BlockDataMap implements Serializable {
 
   private static final long serialVersionUID = -2170289352240810993L;
+  // total block number in this datamap
+  private int blockNum = 0;
 
   @Override
   public void init(DataMapModel dataMapModel) throws IOException, MemoryException {
@@ -128,6 +130,7 @@ public class BlockletDataMap extends BlockDataMap implements Serializable {
         if (null == tempFilePath || !tempFilePath.equals(blockInfo.getFilePath())) {
           tempFilePath = blockInfo.getFilePath();
           relativeBlockletId = 0;
+          blockNum++;
         }
         summaryRow = loadToUnsafe(schema, taskSummarySchema, fileFooter, segmentProperties,
             getMinMaxCacheColumns(), blockInfo.getFilePath(), summaryRow,
@@ -252,6 +255,15 @@ public class BlockletDataMap extends BlockDataMap implements Serializable {
     } else {
       //in blocklet datamap, each entry contains info of one blocklet
       return 1;
+    }
+  }
+
+  @Override
+  protected int getTotalBlocks() {
+    if (isLegacyStore) {
+      return super.getTotalBlocklets();
+    } else {
+      return blockNum;
     }
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/profiler/ExplainCollector.java
+++ b/core/src/main/java/org/apache/carbondata/core/profiler/ExplainCollector.java
@@ -108,19 +108,26 @@ public class ExplainCollector {
     }
   }
 
-  public static void recordCGDataMapPruning(DataMapWrapperSimpleInfo dataMapWrapperSimpleInfo,
-      int numBlocklets) {
+  public static void setDefaultDataMapPruningBlockHit(int numBlocks) {
     if (enabled()) {
       TablePruningInfo scan = getCurrentTablePruningInfo();
-      scan.setNumBlockletsAfterCGPruning(dataMapWrapperSimpleInfo, numBlocklets);
+      scan.setNumBlocksAfterDefaultPruning(numBlocks);
+    }
+  }
+
+  public static void recordCGDataMapPruning(DataMapWrapperSimpleInfo dataMapWrapperSimpleInfo,
+      int numBlocklets, int numBlocks) {
+    if (enabled()) {
+      TablePruningInfo scan = getCurrentTablePruningInfo();
+      scan.setNumBlockletsAfterCGPruning(dataMapWrapperSimpleInfo, numBlocklets, numBlocks);
     }
   }
 
   public static void recordFGDataMapPruning(DataMapWrapperSimpleInfo dataMapWrapperSimpleInfo,
-      int numBlocklets) {
+      int numBlocklets, int numBlocks) {
     if (enabled()) {
       TablePruningInfo scan = getCurrentTablePruningInfo();
-      scan.setNumBlockletsAfterFGPruning(dataMapWrapperSimpleInfo, numBlocklets);
+      scan.setNumBlockletsAfterFGPruning(dataMapWrapperSimpleInfo, numBlocklets, numBlocks);
     }
   }
 
@@ -128,6 +135,13 @@ public class ExplainCollector {
     if (enabled()) {
       TablePruningInfo scan = getCurrentTablePruningInfo();
       scan.addTotalBlocklets(numBlocklets);
+    }
+  }
+
+  public static void addTotalBlocks(int numBlocks) {
+    if (enabled()) {
+      TablePruningInfo scan = getCurrentTablePruningInfo();
+      scan.addTotalBlocks(numBlocks);
     }
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/profiler/TablePruningInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/profiler/TablePruningInfo.java
@@ -26,17 +26,25 @@ import org.apache.carbondata.core.datamap.dev.expr.DataMapWrapperSimpleInfo;
 @InterfaceAudience.Internal
 public class TablePruningInfo {
 
+  private int totalBlocks;
   private int totalBlocklets;
   private String filterStatement;
   private boolean showPruningInfo;
 
+  private int numBlocksAfterDefaultPruning;
   private int numBlockletsAfterDefaultPruning = 0;
 
   private DataMapWrapperSimpleInfo cgDataMap;
+  private int numBlocksAfterCGPruning;
   private int numBlockletsAfterCGPruning;
 
   private DataMapWrapperSimpleInfo fgDataMap;
+  private int numBlocksAfterFGPruning;
   private int numBlockletsAfterFGPruning;
+
+  void addTotalBlocks(int numBlocks) {
+    this.totalBlocks += numBlocks;
+  }
 
   void addTotalBlocklets(int numBlocklets) {
     this.totalBlocklets += numBlocklets;
@@ -50,19 +58,30 @@ public class TablePruningInfo {
     this.showPruningInfo = showPruningInfo;
   }
 
+  void setNumBlocksAfterDefaultPruning(int numBlocks) {
+    this.numBlocksAfterDefaultPruning = numBlocks;
+  }
+
+  /**
+   * To get blocklet number no matter what cache level(block/blocklet) it is,
+   * we accumulate blocklet number in default datamap instead of setting it
+   * in CarbonInputFormat
+   */
   void addNumBlockletsAfterDefaultPruning(int numBlocklets) {
     this.numBlockletsAfterDefaultPruning += numBlocklets;
   }
 
   void setNumBlockletsAfterCGPruning(DataMapWrapperSimpleInfo dataMapWrapperSimpleInfo,
-      int numBlocklets) {
+      int numBlocklets, int numBlocks) {
     this.cgDataMap = dataMapWrapperSimpleInfo;
+    this.numBlocksAfterCGPruning = numBlocks;
     this.numBlockletsAfterCGPruning = numBlocklets;
   }
 
   void setNumBlockletsAfterFGPruning(DataMapWrapperSimpleInfo dataMapWrapperSimpleInfo,
-      int numBlocklets) {
+      int numBlocklets, int numBlocks) {
     this.fgDataMap = dataMapWrapperSimpleInfo;
+    this.numBlocksAfterFGPruning = numBlocks;
     this.numBlockletsAfterFGPruning = numBlocklets;
   }
 
@@ -71,31 +90,39 @@ public class TablePruningInfo {
     if (showPruningInfo) {
       StringBuilder builder = new StringBuilder();
       builder
-          .append(" - total blocklets: ").append(totalBlocklets).append("\n")
+          .append(" - total: ").append(totalBlocks).append(" blocks, ")
+          .append(totalBlocklets).append(" blocklets").append("\n")
           .append(" - filter: ").append(filterStatement).append("\n");
+      int skipBlocks = totalBlocks - numBlocksAfterDefaultPruning;
       int skipBlocklets = totalBlocklets - numBlockletsAfterDefaultPruning;
       builder
           .append(" - pruned by Main DataMap").append("\n")
-          .append("    - skipped blocklets: ").append(skipBlocklets).append("\n");
+          .append("    - skipped: ").append(skipBlocks).append(" blocks, ")
+          .append(skipBlocklets).append(" blocklets").append("\n");
       if (cgDataMap != null) {
+        skipBlocks = numBlocksAfterDefaultPruning - numBlocksAfterCGPruning;
         skipBlocklets = numBlockletsAfterDefaultPruning - numBlockletsAfterCGPruning;
         builder
             .append(" - pruned by CG DataMap").append("\n")
             .append("    - name: ").append(cgDataMap.getDataMapWrapperName()).append("\n")
             .append("    - provider: ").append(cgDataMap.getDataMapWrapperProvider()).append("\n")
-            .append("    - skipped blocklets: ").append(skipBlocklets).append("\n");
+            .append("    - skipped: ").append(skipBlocks).append(" blocks, ")
+            .append(skipBlocklets).append(" blocklets").append("\n");;
       }
       if (fgDataMap != null) {
         if (numBlockletsAfterCGPruning != 0) {
+          skipBlocks = numBlocksAfterCGPruning - numBlocksAfterFGPruning;
           skipBlocklets = numBlockletsAfterCGPruning - numBlockletsAfterFGPruning;
         } else {
+          skipBlocks = numBlocksAfterDefaultPruning - numBlocksAfterFGPruning;
           skipBlocklets = numBlockletsAfterDefaultPruning - numBlockletsAfterFGPruning;
         }
         builder
             .append(" - pruned by FG DataMap").append("\n")
             .append("    - name: ").append(fgDataMap.getDataMapWrapperName()).append("\n")
             .append("    - provider: ").append(fgDataMap.getDataMapWrapperProvider()).append("\n")
-            .append("    - skipped blocklets: ").append(skipBlocklets).append("\n");
+            .append("    - skipped: ").append(skipBlocks).append(" blocks, ")
+            .append(skipBlocklets).append(" blocklets").append("\n");;
       }
       return builder.toString();
     } else {

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/datamap/lucene/LuceneFineGrainDataMapSuite.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/datamap/lucene/LuceneFineGrainDataMapSuite.scala
@@ -621,14 +621,14 @@ class LuceneFineGrainDataMapSuite extends QueryTest with BeforeAndAfterAll {
       assertResult(
         """== CarbonData Profiler ==
           |Table Scan on main
-          | - total blocklets: 1
+          | - total: 1 blocks, 1 blocklets
           | - filter: TEXT_MATCH('name:bob')
           | - pruned by Main DataMap
-          |    - skipped blocklets: 0
+          |    - skipped: 0 blocks, 0 blocklets
           | - pruned by FG DataMap
           |    - name: dm
           |    - provider: lucene
-          |    - skipped blocklets: 1
+          |    - skipped: 1 blocks, 1 blocklets
           |""".stripMargin)(rows(0).getString(0))
     } finally {
       LuceneFineGrainDataMapSuite.deleteFile(file1)

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggregateTableSelection.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggregateTableSelection.scala
@@ -386,10 +386,10 @@ class TestPreAggregateTableSelection extends SparkQueryTest with BeforeAndAfterA
     assertResult(
       """== CarbonData Profiler ==
         |Table Scan on maintable
-        | - total blocklets: 1
+        | - total: 1 blocks, 1 blocklets
         | - filter: none
         | - pruned by Main DataMap
-        |    - skipped blocklets: 0
+        |    - skipped: 0 blocks, 0 blocklets
         |""".stripMargin)(rows(0).getString(0))
   }
 
@@ -400,10 +400,10 @@ class TestPreAggregateTableSelection extends SparkQueryTest with BeforeAndAfterA
         |Query rewrite based on DataMap:
         | - agg1 (preaggregate)
         |Table Scan on maintable_agg1
-        | - total blocklets: 1
+        | - total: 1 blocks, 1 blocklets
         | - filter: none
         | - pruned by Main DataMap
-        |    - skipped blocklets: 0
+        |    - skipped: 0 blocks, 0 blocklets
         |""".stripMargin)(rows(0).getString(0))
   }
 
@@ -415,10 +415,10 @@ class TestPreAggregateTableSelection extends SparkQueryTest with BeforeAndAfterA
         |Query rewrite based on DataMap:
         | - agg1 (preaggregate)
         |Table Scan on maintable_agg1
-        | - total blocklets: 1
+        | - total: 1 blocks, 1 blocklets
         | - filter: (maintable_name <> null and maintable_name = a)
         | - pruned by Main DataMap
-        |    - skipped blocklets: 1
+        |    - skipped: 1 blocks, 1 blocklets
         |""".stripMargin)(rows(0).getString(0))
 
   }
@@ -431,17 +431,17 @@ class TestPreAggregateTableSelection extends SparkQueryTest with BeforeAndAfterA
     assert(rows(0).getString(0).contains(
       """
         |Table Scan on maintable
-        | - total blocklets: 1
+        | - total: 1 blocks, 1 blocklets
         | - filter: ((id <> null and id < 3) and name <> null)
         | - pruned by Main DataMap
-        |    - skipped blocklets: 0""".stripMargin))
+        |    - skipped: 0 blocks, 0 blocklets""".stripMargin))
     assert(rows(0).getString(0).contains(
       """
         |Table Scan on maintableavg
-        | - total blocklets: 1
+        | - total: 1 blocks, 1 blocklets
         | - filter: name <> null
         | - pruned by Main DataMap
-        |    - skipped blocklets: 0""".stripMargin))
+        |    - skipped: 0 blocks, 0 blocklets""".stripMargin))
 
   }
 

--- a/integration/spark2/src/test/scala/org/apache/carbondata/datamap/bloom/BloomCoarseGrainDataMapSuite.scala
+++ b/integration/spark2/src/test/scala/org/apache/carbondata/datamap/bloom/BloomCoarseGrainDataMapSuite.scala
@@ -719,8 +719,18 @@ class BloomCoarseGrainDataMapSuite extends QueryTest with BeforeAndAfterAll with
          | FROM $bloomDMSampleTable
          | WHERE num1 = 1
            """.stripMargin).collect()
+
     assert(explainString(0).getString(0).contains(
-      "- name: datamap2\n    - provider: bloomfilter\n    - skipped blocklets: 1"))
+      """
+        |Table Scan on carbon_bloom
+        | - total: 3 blocks, 3 blocklets
+        | - filter: (num1 <> null and num1 = 1)
+        | - pruned by Main DataMap
+        |    - skipped: 1 blocks, 1 blocklets
+        | - pruned by CG DataMap
+        |    - name: datamap2
+        |    - provider: bloomfilter
+        |    - skipped: 1 blocks, 1 blocklets""".stripMargin))
 
     explainString = sql(
       s"""
@@ -728,8 +738,18 @@ class BloomCoarseGrainDataMapSuite extends QueryTest with BeforeAndAfterAll with
          | FROM $bloomDMSampleTable
          | WHERE dictString = 'S21'
            """.stripMargin).collect()
+
     assert(explainString(0).getString(0).contains(
-      "- name: datamap2\n    - provider: bloomfilter\n    - skipped blocklets: 0"))
+      """
+        |Table Scan on carbon_bloom
+        | - total: 3 blocks, 3 blocklets
+        | - filter: (dictstring <> null and dictstring = S21)
+        | - pruned by Main DataMap
+        |    - skipped: 1 blocks, 1 blocklets
+        | - pruned by CG DataMap
+        |    - name: datamap2
+        |    - provider: bloomfilter
+        |    - skipped: 0 blocks, 0 blocklets""".stripMargin))
 
   }
 


### PR DESCRIPTION

This pr will add block skipped info by counting distinct file path from hit blocklet. It shows like below:
```
|== CarbonData Profiler ==
Table Scan on test
 - total: 125 blocks, 250 blocklets
 - filter: (l_partkey <> null and l_partkey = 1006)
 - pruned by Main DataMap
    - skipped: 119 blocks, 238 blocklets
 - pruned by CG DataMap
    - name: dm
    - provider: bloomfilter
    - skipped: 6 blocks, 12 blocklets
```

```
|== CarbonData Profiler ==
Table Scan on test
 - total: 125 blocks, 250 blocklets
 - filter: TEXT_MATCH('l_shipmode:AIR')
 - pruned by Main DataMap
    - skipped: 0 blocks, 0 blocklets
 - pruned by FG DataMap
    - name: dm
    - provider: lucene
    - skipped: 12 blocks, 80 blocklets
```


Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

