### PR TITLE
[WIP][CARBONDATA-2931][BloomDataMap] Optimize bloom datamap pruning

### DIFF
--- a/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomDataMapDistributable.java
+++ b/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomDataMapDistributable.java
@@ -24,28 +24,30 @@ import org.apache.carbondata.core.datamap.DataMapDistributable;
 
 @InterfaceAudience.Internal
 class BloomDataMapDistributable extends DataMapDistributable {
-  /**
-   * parent folder of the bloomindex file
-   */
+
+  // parent folder of the bloomindex file
   private String indexPath;
 
-  /**
-   * List of index shards which are already got filtered through CG index operation.
-   * This is used for merge shard which cannot prune shard in `toDistributable` function.
-   * Other case will be set to Null
-   */
+  // shards needed to scan
   private Set<String> filteredShards;
 
-  BloomDataMapDistributable(String indexPath, Set<String> filteredShards) {
+  private boolean useMergeShard;
+
+  BloomDataMapDistributable(String indexPath, Set<String> filteredShards, boolean useMergeShard) {
     this.indexPath = indexPath;
     this.filteredShards = filteredShards;
+    this.useMergeShard = useMergeShard;
+  }
+
+  public Set<String> getFilteredShards() {
+    return filteredShards;
   }
 
   public String getIndexPath() {
     return indexPath;
   }
 
-  public Set<String> getFilteredShards() {
-    return filteredShards;
+  public boolean getUseMergeShard() {
+    return useMergeShard;
   }
 }


### PR DESCRIPTION
1. re-use shard pruning info from default datamap. File scan will be only used to determined whether we can use merged shard, instead of getting full shard path.
2. create one BloomCoarseGrainDataMap object per segment instead of per shard. (This is also  preparation for parallel segment pruning). For merged shard, no effect.


Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

