### PR TITLE
[CARBONDATA-2875]Two different threads overwriting the same carbondatafile.

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/mutate/CarbonUpdateUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/mutate/CarbonUpdateUtil.java
@@ -708,7 +708,7 @@ public class CarbonUpdateUtil {
    * @return
    */
   public static long readCurrentTime() {
-    return System.currentTimeMillis();
+    return System.nanoTime();
   }
 
   /**


### PR DESCRIPTION
Problem :- During concurrent load through two different threads in a external table for non transactional tables , two different threads were overwriting the same carbondata file.

Solution : This was happening because both the threads were assigning the same filename for the carbondata files so one was overwriting the other.This problem chances is  reduced by changing the timestamp attached to the filename from millisecond to nanosecond. 



Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [x] Testing done
        Manually.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

