### PR TITLE
[CARBONDATA-2938][DataMap] Update comment of blockletId in IndexDataMapRebuildRDD

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/carbondata/datamap/IndexDataMapRebuildRDD.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/datamap/IndexDataMapRebuildRDD.scala
@@ -356,7 +356,9 @@ class IndexDataMapRebuildRDD[K, V](
         // skip clear datamap and we will do this adter rebuild
         reader.setSkipClearDataMapAtClose(true)
 
-        // Note that blockletId in rowWithPosition does not work properly,
+        // Note that datamap rebuilding is based on query, the blockletId in rowWithPosition
+        // is set to relative number in carbondata file in query process.
+        // In order to get absolute blockletId in shard like the one filled in loading process,
         // here we use another way to generate it.
         var blockletId = 0
         var firstRow = true


### PR DESCRIPTION
**Background**:
#2539 Tried to make use of blocklet id information from query when rebuilding datamap.
#2565 Revert PR2539 since it would cause wrong answer when testing on table with large mount of data

**What's in this PR**:
Update comment to explain why blocklet id information from query does not work



Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

