### PR TITLE
[CARBONDATA-2939] SDK interfaces are compatible with old SDK version

### DIFF
--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonReaderBuilder.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonReaderBuilder.java
@@ -234,4 +234,16 @@ public class CarbonReaderBuilder {
     }
   }
 
+  /**
+   * Build CarbonReader with default configuration
+   *
+   * @param <T>
+   * @return CarbonReader
+   * @throws IOException
+   * @throws InterruptedException
+   */
+  public <T> CarbonReader<T> build()
+      throws IOException, InterruptedException {
+    return build(new Configuration(false));
+  }
 }

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonWriterBuilder.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonWriterBuilder.java
@@ -382,12 +382,14 @@ public class CarbonWriterBuilder {
    * This writer is not thread safe,
    * use buildThreadSafeWriterForCSVInput in multi thread environment
    * Build a {@link CarbonWriter}, which accepts row in CSV format
-   * @param schema carbon Schema object {org.apache.carbondata.sdk.file.Schema}
-   * @param configuration  configuration for support multiple use
-   *                       with different SK/AK to write concurrently to S3.
-   * @return CSVCarbonWriter
-   * @throws IOException
-   * @throws InvalidLoadOptionException
+   *
+   * @param schema        carbon Schema object {org.apache.carbondata.sdk.file.Schema}
+   * @param configuration configuration for support multiple use
+   *                      with different SK/AK to write concurrently to S3.
+   * @return CSVCarbonWriter object for csv input,not thread safe
+   * @throws IOException                throws io exception if error occurs while build  writer
+   * @throws InvalidLoadOptionException throws invalid load option exception
+   *                                    if error occurs while build  writer
    */
   public CarbonWriter buildWriterForCSVInput(Schema schema, Configuration configuration)
       throws IOException, InvalidLoadOptionException {
@@ -401,12 +403,14 @@ public class CarbonWriterBuilder {
   /**
    * This writer is not thread safe,
    * use buildThreadSafeWriterForCSVInput in multi thread environment,
-   * use default configuration
+   * use default configuration. If you want to multiple use with
+   * different SK/AK to write concurrently to S3, please use another method.
    *
    * @param schema carbon Schema object {org.apache.carbondata.sdk.file.Schema}
-   *    * @return CSVCarbonWriter
-   * @throws IOException
-   * @throws InvalidLoadOptionException
+   * @return CSVCarbonWriter object for csv input,not thread safe
+   * @throws IOException                throws io exception if error occurs while build  writer
+   * @throws InvalidLoadOptionException throws invalid load option exception
+   *                                    if error occurs while build  writer
    */
   public CarbonWriter buildWriterForCSVInput(Schema schema)
       throws IOException, InvalidLoadOptionException {
@@ -416,13 +420,14 @@ public class CarbonWriterBuilder {
   /**
    * Build a {@link CarbonWriter}, which accepts row in CSV format
    *
-   * @param schema       carbon Schema object {org.apache.carbondata.sdk.file.Schema}
-   * @param numOfThreads number of threads() in which .write will be called.
-   * @param configuration  configuration for support multiple use
-   *                       with different SK/AK to write concurrently to S3.
-   * @return CSVCarbonWriter
-   * @throws IOException
-   * @throws InvalidLoadOptionException
+   * @param schema        carbon Schema object {org.apache.carbondata.sdk.file.Schema}
+   * @param numOfThreads  number of threads() in which .write will be called.
+   * @param configuration configuration for support multiple use
+   *                      with different SK/AK to write concurrently to S3.
+   * @return thread safe CSVCarbonWriter object for csv input
+   * @throws IOException                throws io exception if error occurs while build  writer
+   * @throws InvalidLoadOptionException throws invalid load option exception
+   *                                    if error occurs while build  writer
    */
   public CarbonWriter buildThreadSafeWriterForCSVInput(Schema schema, short numOfThreads,
       Configuration configuration) throws IOException, InvalidLoadOptionException {
@@ -440,13 +445,15 @@ public class CarbonWriterBuilder {
 
   /**
    * Build a {@link CarbonWriter}, which accepts row in CSV format,
-   * with default configuration
+   * with default configuration. If you want to multiple use with
+   * different SK/AK to write concurrently to S3, please use another method.
    *
    * @param schema       carbon Schema object {org.apache.carbondata.sdk.file.Schema}
    * @param numOfThreads number of threads() in which .write will be called.
-   * @return CSVCarbonWriter
-   * @throws IOException
-   * @throws InvalidLoadOptionException
+   * @return thread safe CSVCarbonWriter object for csv input
+   * @throws IOException                throws io exception if error occurs while build  writer
+   * @throws InvalidLoadOptionException throws invalid load option exception
+   *                                    if error occurs while build  writer
    */
   public CarbonWriter buildThreadSafeWriterForCSVInput(Schema schema, short numOfThreads)
       throws IOException, InvalidLoadOptionException {
@@ -458,12 +465,13 @@ public class CarbonWriterBuilder {
    * use buildThreadSafeWriterForAvroInput in multi thread environment
    * Build a {@link CarbonWriter}, which accepts Avro object
    *
-   * @param avroSchema avro Schema object {org.apache.avro.Schema}
-   * @param configuration  configuration for support multiple use
-   *                       with different SK/AK to write concurrently to S3.
+   * @param avroSchema    avro Schema object {org.apache.avro.Schema}
+   * @param configuration configuration for support multiple use
+   *                      with different SK/AK to write concurrently to S3.
    * @return AvroCarbonWriter
-   * @throws IOException
-   * @throws InvalidLoadOptionException
+   * @throws IOException                throws io exception if error occurs while build  writer
+   * @throws InvalidLoadOptionException throws invalid load option exception
+   *                                    if error occurs while build  writer
    */
   public CarbonWriter buildWriterForAvroInput(org.apache.avro.Schema avroSchema,
       Configuration configuration) throws IOException, InvalidLoadOptionException {
@@ -483,12 +491,14 @@ public class CarbonWriterBuilder {
    * This writer is not thread safe,
    * use buildThreadSafeWriterForAvroInput in multi thread environment
    * Build a {@link CarbonWriter}, which accepts Avro object
-   * with default configuration
+   * with default configuration. If you want to multiple use with
+   * different SK/AK to write concurrently to S3, please use another method.
    *
    * @param avroSchema avro Schema object {org.apache.avro.Schema}
-   * @return AvroCarbonWriter
-   * @throws IOException
-   * @throws InvalidLoadOptionException
+   * @return AvroCarbonWriter object,is not thread safe
+   * @throws IOException                throws io exception if error occurs while build  writer
+   * @throws InvalidLoadOptionException throws invalid load option exception
+   *                                    if error occurs while build  writer
    */
   public CarbonWriter buildWriterForAvroInput(org.apache.avro.Schema avroSchema)
       throws IOException, InvalidLoadOptionException {
@@ -498,13 +508,14 @@ public class CarbonWriterBuilder {
   /**
    * Build a {@link CarbonWriter}, which accepts Avro object
    *
-   * @param avroSchema   avro Schema object {org.apache.avro.Schema}
-   * @param numOfThreads number of threads() in which .write will be called.
-   * @param configuration  configuration for support multiple use
-   *                       with different SK/AK to write concurrently to S3.
-   * @return AvroCarbonWriter
-   * @throws IOException
-   * @throws InvalidLoadOptionException
+   * @param avroSchema    avro Schema object {org.apache.avro.Schema}
+   * @param numOfThreads  number of threads() in which .write will be called.
+   * @param configuration configuration for support multiple use
+   *                      with different SK/AK to write concurrently to S3.
+   * @return AvroCarbonWriter object, thread safe.
+   * @throws IOException                throws io exception if error occurs while build  writer
+   * @throws InvalidLoadOptionException throws invalid load option exception
+   *                                    if error occurs while build  writer
    */
   public CarbonWriter buildThreadSafeWriterForAvroInput(org.apache.avro.Schema avroSchema,
       short numOfThreads, Configuration configuration)
@@ -528,12 +539,15 @@ public class CarbonWriterBuilder {
 
   /**
    * Build a {@link CarbonWriter}, which accepts Avro object
+   * Use default configuration. If you want to multiple use with
+   * different SK/AK to write concurrently to S3, please use another method.
    *
    * @param avroSchema   avro Schema object {org.apache.avro.Schema}
    * @param numOfThreads number of threads() in which .write will be called.
-   * @return AvroCarbonWriter
-   * @throws IOException
-   * @throws InvalidLoadOptionException
+   * @return Thread safe AvroCarbonWriter object for avro input
+   * @throws IOException                throws io exception if error occurs while build  writer
+   * @throws InvalidLoadOptionException throws invalid load option exception
+   *                                    if error occurs while build  writer
    */
   public CarbonWriter buildThreadSafeWriterForAvroInput(org.apache.avro.Schema avroSchema,
       short numOfThreads)
@@ -549,9 +563,10 @@ public class CarbonWriterBuilder {
    * @param carbonSchema  carbon Schema object
    * @param configuration configuration for support multiple use
    *                      with different SK/AK to write concurrently to S3.
-   * @return JsonCarbonWriter
-   * @throws IOException
-   * @throws InvalidLoadOptionException
+   * @return JsonCarbonWriter object
+   * @throws IOException                throws io exception if error occurs while build  writer
+   * @throws InvalidLoadOptionException throws invalid load option exception
+   *                                    if error occurs while build  writer
    */
   public JsonCarbonWriter buildWriterForJsonInput(Schema carbonSchema, Configuration configuration)
       throws IOException, InvalidLoadOptionException {
@@ -569,9 +584,10 @@ public class CarbonWriterBuilder {
    * Build a {@link CarbonWriter}, which accepts Json object
    *
    * @param carbonSchema carbon Schema object
-   * @return JsonCarbonWriter
-   * @throws IOException
-   * @throws InvalidLoadOptionException
+   * @return JsonCarbonWriter object
+   * @throws IOException                throws io exception if error occurs while build  writer
+   * @throws InvalidLoadOptionException throws invalid load option exception
+   *                                    if error occurs while build  writer
    */
   public JsonCarbonWriter buildWriterForJsonInput(Schema carbonSchema)
       throws IOException, InvalidLoadOptionException {
@@ -580,15 +596,17 @@ public class CarbonWriterBuilder {
 
   /**
    * Can use this writer in multi-thread instance.
-   *
+   * <p>
    * Build a {@link CarbonWriter}, which accepts Json object
-   * @param carbonSchema carbon Schema object
-   * @param numOfThreads number of threads() in which .write will be called.
-   * @param configuration  configuration for support multiple use
-   *                       with different SK/AK to write concurrently to S3.
-   * @return JsonCarbonWriter
-   * @throws IOException
-   * @throws InvalidLoadOptionException
+   *
+   * @param carbonSchema  carbon Schema object
+   * @param numOfThreads  number of threads() in which .write will be called.
+   * @param configuration configuration for support multiple use
+   *                      with different SK/AK to write concurrently to S3.
+   * @return JsonCarbonWriter object for json input
+   * @throws IOException                throws io exception if error occurs while build  writer
+   * @throws InvalidLoadOptionException throws invalid load option exception
+   *                                    if error occurs while build  writer
    */
   public JsonCarbonWriter buildThreadSafeWriterForJsonInput(Schema carbonSchema, short numOfThreads,
       Configuration configuration) throws IOException, InvalidLoadOptionException {

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonWriterBuilder.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonWriterBuilder.java
@@ -383,6 +383,8 @@ public class CarbonWriterBuilder {
    * use buildThreadSafeWriterForCSVInput in multi thread environment
    * Build a {@link CarbonWriter}, which accepts row in CSV format
    * @param schema carbon Schema object {org.apache.carbondata.sdk.file.Schema}
+   * @param configuration  configuration for support multiple use
+   *                       with different SK/AK to write concurrently to S3.
    * @return CSVCarbonWriter
    * @throws IOException
    * @throws InvalidLoadOptionException
@@ -397,10 +399,27 @@ public class CarbonWriterBuilder {
   }
 
   /**
+   * This writer is not thread safe,
+   * use buildThreadSafeWriterForCSVInput in multi thread environment,
+   * use default configuration
    *
-   * Build a {@link CarbonWriter}, which accepts row in CSV format
    * @param schema carbon Schema object {org.apache.carbondata.sdk.file.Schema}
+   *    * @return CSVCarbonWriter
+   * @throws IOException
+   * @throws InvalidLoadOptionException
+   */
+  public CarbonWriter buildWriterForCSVInput(Schema schema)
+      throws IOException, InvalidLoadOptionException {
+    return buildWriterForCSVInput(schema, new Configuration(false));
+  }
+
+  /**
+   * Build a {@link CarbonWriter}, which accepts row in CSV format
+   *
+   * @param schema       carbon Schema object {org.apache.carbondata.sdk.file.Schema}
    * @param numOfThreads number of threads() in which .write will be called.
+   * @param configuration  configuration for support multiple use
+   *                       with different SK/AK to write concurrently to S3.
    * @return CSVCarbonWriter
    * @throws IOException
    * @throws InvalidLoadOptionException
@@ -420,10 +439,28 @@ public class CarbonWriterBuilder {
   }
 
   /**
+   * Build a {@link CarbonWriter}, which accepts row in CSV format,
+   * with default configuration
+   *
+   * @param schema       carbon Schema object {org.apache.carbondata.sdk.file.Schema}
+   * @param numOfThreads number of threads() in which .write will be called.
+   * @return CSVCarbonWriter
+   * @throws IOException
+   * @throws InvalidLoadOptionException
+   */
+  public CarbonWriter buildThreadSafeWriterForCSVInput(Schema schema, short numOfThreads)
+      throws IOException, InvalidLoadOptionException {
+    return buildThreadSafeWriterForCSVInput(schema, numOfThreads, new Configuration(false));
+  }
+
+  /**
    * This writer is not thread safe,
    * use buildThreadSafeWriterForAvroInput in multi thread environment
    * Build a {@link CarbonWriter}, which accepts Avro object
+   *
    * @param avroSchema avro Schema object {org.apache.avro.Schema}
+   * @param configuration  configuration for support multiple use
+   *                       with different SK/AK to write concurrently to S3.
    * @return AvroCarbonWriter
    * @throws IOException
    * @throws InvalidLoadOptionException
@@ -443,9 +480,28 @@ public class CarbonWriterBuilder {
   }
 
   /**
+   * This writer is not thread safe,
+   * use buildThreadSafeWriterForAvroInput in multi thread environment
    * Build a {@link CarbonWriter}, which accepts Avro object
+   * with default configuration
+   *
    * @param avroSchema avro Schema object {org.apache.avro.Schema}
+   * @return AvroCarbonWriter
+   * @throws IOException
+   * @throws InvalidLoadOptionException
+   */
+  public CarbonWriter buildWriterForAvroInput(org.apache.avro.Schema avroSchema)
+      throws IOException, InvalidLoadOptionException {
+    return buildWriterForAvroInput(avroSchema, new Configuration());
+  }
+
+  /**
+   * Build a {@link CarbonWriter}, which accepts Avro object
+   *
+   * @param avroSchema   avro Schema object {org.apache.avro.Schema}
    * @param numOfThreads number of threads() in which .write will be called.
+   * @param configuration  configuration for support multiple use
+   *                       with different SK/AK to write concurrently to S3.
    * @return AvroCarbonWriter
    * @throws IOException
    * @throws InvalidLoadOptionException
@@ -471,10 +527,28 @@ public class CarbonWriterBuilder {
   }
 
   /**
+   * Build a {@link CarbonWriter}, which accepts Avro object
+   *
+   * @param avroSchema   avro Schema object {org.apache.avro.Schema}
+   * @param numOfThreads number of threads() in which .write will be called.
+   * @return AvroCarbonWriter
+   * @throws IOException
+   * @throws InvalidLoadOptionException
+   */
+  public CarbonWriter buildThreadSafeWriterForAvroInput(org.apache.avro.Schema avroSchema,
+      short numOfThreads)
+      throws IOException, InvalidLoadOptionException {
+    return buildThreadSafeWriterForAvroInput(avroSchema, numOfThreads, new Configuration(false));
+  }
+
+  /**
    * This writer is not thread safe,
    * use buildThreadSafeWriterForJsonInput in multi thread environment
    * Build a {@link CarbonWriter}, which accepts Json object
-   * @param carbonSchema carbon Schema object
+   *
+   * @param carbonSchema  carbon Schema object
+   * @param configuration configuration for support multiple use
+   *                      with different SK/AK to write concurrently to S3.
    * @return JsonCarbonWriter
    * @throws IOException
    * @throws InvalidLoadOptionException
@@ -490,11 +564,28 @@ public class CarbonWriterBuilder {
   }
 
   /**
+   * This writer is not thread safe,
+   * use buildThreadSafeWriterForJsonInput in multi thread environment
+   * Build a {@link CarbonWriter}, which accepts Json object
+   *
+   * @param carbonSchema carbon Schema object
+   * @return JsonCarbonWriter
+   * @throws IOException
+   * @throws InvalidLoadOptionException
+   */
+  public JsonCarbonWriter buildWriterForJsonInput(Schema carbonSchema)
+      throws IOException, InvalidLoadOptionException {
+    return buildWriterForJsonInput(carbonSchema, new Configuration(false));
+  }
+
+  /**
    * Can use this writer in multi-thread instance.
    *
    * Build a {@link CarbonWriter}, which accepts Json object
    * @param carbonSchema carbon Schema object
    * @param numOfThreads number of threads() in which .write will be called.
+   * @param configuration  configuration for support multiple use
+   *                       with different SK/AK to write concurrently to S3.
    * @return JsonCarbonWriter
    * @throws IOException
    * @throws InvalidLoadOptionException

--- a/store/sdk/src/test/java/org/apache/carbondata/sdk/file/AvroCarbonWriterTest.java
+++ b/store/sdk/src/test/java/org/apache/carbondata/sdk/file/AvroCarbonWriterTest.java
@@ -75,7 +75,7 @@ public class AvroCarbonWriterTest {
             "   \"fields\" : ["
             + "{ \"name\" : \"name\", \"type\" : \"string\" },"
             + "{ \"name\" : \"age\", \"type\" : \"int\" }]" +
-        "}";
+            "}";
 
     String json = "{\"name\":\"bob\", \"age\":10}";
 
@@ -84,6 +84,51 @@ public class AvroCarbonWriterTest {
     try {
       CarbonWriter writer = CarbonWriter.builder().outputPath(path).isTransactionalTable(true)
           .buildWriterForAvroInput(new Schema.Parser().parse(avroSchema), TestUtil.configuration);
+
+      for (int i = 0; i < 100; i++) {
+        writer.write(record);
+      }
+      writer.close();
+    } catch (Exception e) {
+      e.printStackTrace();
+      Assert.fail(e.getMessage());
+    }
+
+    File segmentFolder = new File(CarbonTablePath.getSegmentPath(path, "null"));
+    Assert.assertTrue(segmentFolder.exists());
+
+    File[] dataFiles = segmentFolder.listFiles(new FileFilter() {
+      @Override public boolean accept(File pathname) {
+        return pathname.getName().endsWith(CarbonCommonConstants.FACT_FILE_EXT);
+      }
+    });
+    Assert.assertNotNull(dataFiles);
+    Assert.assertEquals(1, dataFiles.length);
+
+    FileUtils.deleteDirectory(new File(path));
+  }
+
+  @Test
+  public void testWriteBasicWithDefaultConfiguration() throws IOException {
+    FileUtils.deleteDirectory(new File(path));
+
+    // Avro schema
+    String avroSchema =
+        "{" +
+            "   \"type\" : \"record\"," +
+            "   \"name\" : \"Acme\"," +
+            "   \"fields\" : ["
+            + "{ \"name\" : \"name\", \"type\" : \"string\" },"
+            + "{ \"name\" : \"age\", \"type\" : \"int\" }]" +
+            "}";
+
+    String json = "{\"name\":\"bob\", \"age\":10}";
+
+    // conversion to GenericData.Record
+    GenericData.Record record = TestUtil.jsonToAvro(json, avroSchema);
+    try {
+      CarbonWriter writer = CarbonWriter.builder().outputPath(path).isTransactionalTable(true)
+          .buildWriterForAvroInput(new Schema.Parser().parse(avroSchema));
 
       for (int i = 0; i < 100; i++) {
         writer.write(record);

--- a/store/sdk/src/test/java/org/apache/carbondata/sdk/file/AvroCarbonWriterTest.java
+++ b/store/sdk/src/test/java/org/apache/carbondata/sdk/file/AvroCarbonWriterTest.java
@@ -75,7 +75,7 @@ public class AvroCarbonWriterTest {
             "   \"fields\" : ["
             + "{ \"name\" : \"name\", \"type\" : \"string\" },"
             + "{ \"name\" : \"age\", \"type\" : \"int\" }]" +
-            "}";
+        "}";
 
     String json = "{\"name\":\"bob\", \"age\":10}";
 

--- a/store/sdk/src/test/java/org/apache/carbondata/sdk/file/CSVCarbonWriterTest.java
+++ b/store/sdk/src/test/java/org/apache/carbondata/sdk/file/CSVCarbonWriterTest.java
@@ -156,6 +156,62 @@ public class CSVCarbonWriterTest {
   }
 
   @Test
+  public void testCompatibilityAndAllPrimitiveDataType() throws IOException {
+    String path = "./testWriteFiles";
+    FileUtils.deleteDirectory(new File(path));
+
+    Field[] fields = new Field[9];
+    fields[0] = new Field("stringField", DataTypes.STRING);
+    fields[1] = new Field("intField", DataTypes.INT);
+    fields[2] = new Field("shortField", DataTypes.SHORT);
+    fields[3] = new Field("longField", DataTypes.LONG);
+    fields[4] = new Field("doubleField", DataTypes.DOUBLE);
+    fields[5] = new Field("boolField", DataTypes.BOOLEAN);
+    fields[6] = new Field("dateField", DataTypes.DATE);
+    fields[7] = new Field("timeField", DataTypes.TIMESTAMP);
+    fields[8] = new Field("decimalField", DataTypes.createDecimalType(8, 2));
+
+    try {
+      CarbonWriterBuilder builder = CarbonWriter.builder()
+          .isTransactionalTable(true)
+          .outputPath(path);
+
+      CarbonWriter writer = builder.buildWriterForCSVInput(new Schema(fields));
+
+      for (int i = 0; i < 100; i++) {
+        String[] row = new String[]{
+            "robot" + (i % 10),
+            String.valueOf(i),
+            String.valueOf(i),
+            String.valueOf(Long.MAX_VALUE - i),
+            String.valueOf((double) i / 2),
+            String.valueOf(true),
+            "2019-03-02",
+            "2019-02-12 03:03:34"
+        };
+        writer.write(row);
+      }
+      writer.close();
+    } catch (Exception e) {
+      e.printStackTrace();
+      Assert.fail(e.getMessage());
+    }
+
+    File segmentFolder = new File(CarbonTablePath.getSegmentPath(path, "null"));
+    Assert.assertTrue(segmentFolder.exists());
+
+    File[] dataFiles = segmentFolder.listFiles(new FileFilter() {
+      @Override public boolean accept(File pathname) {
+        return pathname.getName().endsWith(CarbonCommonConstants.FACT_FILE_EXT);
+      }
+    });
+    Assert.assertNotNull(dataFiles);
+    Assert.assertTrue(dataFiles.length > 0);
+
+    FileUtils.deleteDirectory(new File(path));
+  }
+
+  @Test
   public void test2Blocklet() throws IOException {
     String path = "./testWriteFiles";
     FileUtils.deleteDirectory(new File(path));
@@ -252,6 +308,7 @@ public class CSVCarbonWriterTest {
     carbonWriter.close();
 
   }
+
   @Test
   public void testWrongSchemaFieldsValidation() throws IOException{
     CarbonWriter carbonWriter = null;


### PR DESCRIPTION
SDK interfaces are compatible with old SDK version, including CarbonReader build and CarbonWriter buildWrite*** with default null Configuration.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 No
 - [x] Any backward compatibility impacted?
 compatibility old version
 - [x] Document update required?
Yes
 - [x] Testing done
    add test case
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
No