### PR TITLE
[CARBONDATA-2942] Add read and write support for writing min max based on configurable bytes count

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -1835,11 +1835,11 @@ public final class CarbonCommonConstants {
    * property to be used for specifying the max character limit for string/varchar data type till
    * where storing min/max in data file will be considered
    */
-  public static final String CARBON_STRING_ALLOWED_CHARACTER_COUNT =
-      "carbon.string.allowed.character.count";
-  public static final String CARBON_STRING_ALLOWED_CHARACTER_COUNT_DEFAULT = "500";
-  public static final int CARBON_STRING_ALLOWED_CHARACTER_COUNT_MIN = 10;
-  public static final int CARBON_STRING_ALLOWED_CHARACTER_COUNT_MAX = 1000;
+  public static final String CARBON_MINMAX_ALLOWED_BYTE_COUNT =
+      "carbon.minmax.allowed.byte.count";
+  public static final String CARBON_MINMAX_ALLOWED_BYTE_COUNT_DEFAULT = "200";
+  public static final int CARBON_MINMAX_ALLOWED_BYTE_COUNT_MIN = 10;
+  public static final int CARBON_MINMAX_ALLOWED_BYTE_COUNT_MAX = 1000;
 
   private CarbonCommonConstants() {
   }

--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -1832,7 +1832,7 @@ public final class CarbonCommonConstants {
   public static final short LOCAL_DICT_ENCODED_BYTEARRAY_SIZE = 3;
 
   /**
-   * property to be used for specifying the max character limit for string/varchar data type till
+   * property to be used for specifying the max byte limit for string/varchar data type till
    * where storing min/max in data file will be considered
    */
   public static final String CARBON_MINMAX_ALLOWED_BYTE_COUNT =

--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -1831,6 +1831,16 @@ public final class CarbonCommonConstants {
 
   public static final short LOCAL_DICT_ENCODED_BYTEARRAY_SIZE = 3;
 
+  /**
+   * property to be used for specifying the max character limit for string/varchar data type till
+   * where storing min/max in data file will be considered
+   */
+  public static final String CARBON_STRING_ALLOWED_CHARACTER_COUNT =
+      "carbon.string.allowed.character.count";
+  public static final String CARBON_STRING_ALLOWED_CHARACTER_COUNT_DEFAULT = "500";
+  public static final int CARBON_STRING_ALLOWED_CHARACTER_COUNT_MIN = 10;
+  public static final int CARBON_STRING_ALLOWED_CHARACTER_COUNT_MAX = 1000;
+
   private CarbonCommonConstants() {
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/DataRefNode.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/DataRefNode.java
@@ -130,7 +130,7 @@ public interface DataRefNode {
    * Return the array which contains the flag for each column whether the min max for that column
    * is written in metadata or not
    *
-   * @return
+   * @return min max flag for each column
    */
-  boolean[] isMinMaxSet();
+  boolean[] minMaxFlagArray();
 }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/DataRefNode.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/DataRefNode.java
@@ -125,4 +125,12 @@ public interface DataRefNode {
    * @return
    */
   BitSetGroup getIndexedData();
+
+  /**
+   * Return the array which contains the flag for each column whether the min max for that column
+   * is written in metadata or not
+   *
+   * @return
+   */
+  boolean[] isMinMaxSet();
 }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/AbstractRawColumnChunk.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/AbstractRawColumnChunk.java
@@ -29,6 +29,8 @@ public abstract class AbstractRawColumnChunk {
 
   private byte[][] maxValues;
 
+  private boolean[] minMaxFlagArray;
+
   protected ByteBuffer rawData;
 
   private int[] offsets;
@@ -120,4 +122,11 @@ public abstract class AbstractRawColumnChunk {
     this.dataChunkV3 = dataChunkV3;
   }
 
+  public boolean[] getMinMaxFlagArray() {
+    return minMaxFlagArray;
+  }
+
+  public void setMinMaxFlagArray(boolean[] minMaxFlagArray) {
+    this.minMaxFlagArray = minMaxFlagArray;
+  }
 }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/ColumnPageEncoder.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/ColumnPageEncoder.java
@@ -131,6 +131,7 @@ public abstract class ColumnPageEncoder {
         CarbonUtil.getValueAsBytes(inputPage.getDataType(), inputPage.getStatistics().getMin()));
     index.addToMax_values(max);
     index.addToMin_values(min);
+    index.addToMin_max_presence(inputPage.getStatistics().writeMinMax());
     return index;
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/statistics/DummyStatsCollector.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/statistics/DummyStatsCollector.java
@@ -48,6 +48,10 @@ public class DummyStatsCollector implements ColumnPageStatsCollector {
       return BYTE_ARRAY;
     }
 
+    @Override public boolean writeMinMax() {
+      return true;
+    }
+
   };
 
   @Override public void updateNull(int rowId) {

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/statistics/KeyPageStatsCollector.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/statistics/KeyPageStatsCollector.java
@@ -107,6 +107,10 @@ public class KeyPageStatsCollector implements ColumnPageStatsCollector {
         return dataType;
       }
 
+      @Override public boolean writeMinMax() {
+        return true;
+      }
+
     };
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/statistics/LVStringStatsCollector.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/statistics/LVStringStatsCollector.java
@@ -117,14 +117,14 @@ public abstract class LVStringStatsCollector implements ColumnPageStatsCollector
     return new SimpleStatsResult() {
 
       @Override public Object getMin() {
-        if (null == min) {
+        if (null == min || ignoreWritingMinMax) {
           min = new byte[0];
         }
         return min;
       }
 
       @Override public Object getMax() {
-        if (null == max) {
+        if (null == max || ignoreWritingMinMax) {
           max = new byte[0];
         }
         return max;

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/statistics/LVStringStatsCollector.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/statistics/LVStringStatsCollector.java
@@ -19,13 +19,30 @@ package org.apache.carbondata.core.datastore.page.statistics;
 
 import java.math.BigDecimal;
 
+import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.metadata.datatype.DataType;
 import org.apache.carbondata.core.metadata.datatype.DataTypes;
 import org.apache.carbondata.core.util.ByteUtil;
+import org.apache.carbondata.core.util.CarbonProperties;
 
 public abstract class LVStringStatsCollector implements ColumnPageStatsCollector {
 
+  /**
+   * allowed character limit for to be considered for storing min max
+   */
+  protected static final int allowedMinMaxCharacterLimit = Integer.parseInt(
+      CarbonProperties.getInstance()
+          .getProperty(CarbonCommonConstants.CARBON_STRING_ALLOWED_CHARACTER_COUNT));
+  /**
+   * variables for storing min max value
+   */
   private byte[] min, max;
+  /**
+   * This flag will be used to decide whether to write min/max in the metadata or not. This will be
+   * helpful for reducing the store size in scenarios where the numbers of characters in
+   * string/varchar type columns are more
+   */
+  private boolean ignoreWritingMinMax;
 
   @Override
   public void updateNull(int rowId) {
@@ -66,23 +83,33 @@ public abstract class LVStringStatsCollector implements ColumnPageStatsCollector
 
   @Override
   public void update(byte[] value) {
+    // return if min/max need not be written
+    if (isIgnoreMinMaxFlagSet(value)) {
+      return;
+    }
     // input value is LV encoded
     byte[] newValue = getActualValue(value);
     if (min == null) {
       min = newValue;
     }
-
     if (null == max) {
       max = newValue;
     }
-
     if (ByteUtil.UnsafeComparer.INSTANCE.compareTo(min, newValue) > 0) {
       min = newValue;
     }
-
     if (ByteUtil.UnsafeComparer.INSTANCE.compareTo(max, newValue) < 0) {
       max = newValue;
     }
+  }
+
+  private boolean isIgnoreMinMaxFlagSet(byte[] value) {
+    if (!ignoreWritingMinMax) {
+      if (null != value && value.length > 2) {
+        ignoreWritingMinMax = true;
+      }
+    }
+    return ignoreWritingMinMax;
   }
 
   @Override
@@ -90,10 +117,16 @@ public abstract class LVStringStatsCollector implements ColumnPageStatsCollector
     return new SimpleStatsResult() {
 
       @Override public Object getMin() {
+        if (null == min) {
+          min = new byte[0];
+        }
         return min;
       }
 
       @Override public Object getMax() {
+        if (null == max) {
+          max = new byte[0];
+        }
         return max;
       }
 
@@ -103,6 +136,10 @@ public abstract class LVStringStatsCollector implements ColumnPageStatsCollector
 
       @Override public DataType getDataType() {
         return DataTypes.STRING;
+      }
+
+      @Override public boolean writeMinMax() {
+        return !ignoreWritingMinMax;
       }
 
     };

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/statistics/LVStringStatsCollector.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/statistics/LVStringStatsCollector.java
@@ -30,9 +30,9 @@ public abstract class LVStringStatsCollector implements ColumnPageStatsCollector
   /**
    * allowed character limit for to be considered for storing min max
    */
-  protected static final int allowedMinMaxCharacterLimit = Integer.parseInt(
+  protected static final int allowedMinMaxByteLimit = Integer.parseInt(
       CarbonProperties.getInstance()
-          .getProperty(CarbonCommonConstants.CARBON_STRING_ALLOWED_CHARACTER_COUNT));
+          .getProperty(CarbonCommonConstants.CARBON_MINMAX_ALLOWED_BYTE_COUNT));
   /**
    * variables for storing min max value
    */
@@ -105,7 +105,7 @@ public abstract class LVStringStatsCollector implements ColumnPageStatsCollector
 
   private boolean isIgnoreMinMaxFlagSet(byte[] value) {
     if (!ignoreWritingMinMax) {
-      if (null != value && value.length > 2) {
+      if (null != value && value.length > allowedMinMaxByteLimit) {
         ignoreWritingMinMax = true;
       }
     }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/statistics/PrimitivePageStatsCollector.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/statistics/PrimitivePageStatsCollector.java
@@ -349,4 +349,8 @@ public class PrimitivePageStatsCollector implements ColumnPageStatsCollector, Si
     return dataType;
   }
 
+  @Override public boolean writeMinMax() {
+    return true;
+  }
+
 }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/statistics/SimpleStatsResult.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/statistics/SimpleStatsResult.java
@@ -29,4 +29,6 @@ public interface SimpleStatsResult {
 
   DataType getDataType();
 
+  boolean writeMinMax();
+
 }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/statistics/TablePageStatistics.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/statistics/TablePageStatistics.java
@@ -35,6 +35,13 @@ public class TablePageStatistics {
   // max os each measure column
   private byte[][] measureMaxValue;
 
+  /**
+   * array for storing the flag which will say whether to store min/max for dimension or not
+   * Note: Currently this array is being used only for dimensions. It can extended further to store
+   * the flag for measures also
+   */
+  private boolean[] writeMinMaxForDimensions;
+
   public TablePageStatistics(EncodedColumnPage[] dimensions,
       EncodedColumnPage[] measures) {
     int numDimensionsExpanded = dimensions.length;
@@ -43,6 +50,7 @@ public class TablePageStatistics {
     this.dimensionMaxValue = new byte[numDimensionsExpanded][];
     this.measureMinValue = new byte[numMeasures][];
     this.measureMaxValue = new byte[numMeasures][];
+    this.writeMinMaxForDimensions = new boolean[numDimensionsExpanded];
     updateDimensionMinMax(dimensions);
     updateMeasureMinMax(measures);
   }
@@ -52,6 +60,7 @@ public class TablePageStatistics {
       SimpleStatsResult stats = dimensions[i].getStats();
       dimensionMaxValue[i] = CarbonUtil.getValueAsBytes(stats.getDataType(), stats.getMax());
       dimensionMinValue[i] = CarbonUtil.getValueAsBytes(stats.getDataType(), stats.getMin());
+      writeMinMaxForDimensions[i] = stats.writeMinMax();
     }
   }
 
@@ -77,6 +86,10 @@ public class TablePageStatistics {
 
   public byte[][] getMeasureMaxValue() {
     return measureMaxValue;
+  }
+
+  public boolean[] getWriteMinMaxForDimensions() {
+    return writeMinMaxForDimensions;
   }
 
 }

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/UnsafeMemoryDMStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/UnsafeMemoryDMStore.java
@@ -108,6 +108,11 @@ public class UnsafeMemoryDMStore extends AbstractMemoryDMStore {
               .putByte(memoryBlock.getBaseObject(), memoryBlock.getBaseOffset() + runningLength,
                   row.getByte(index));
           runningLength += row.getSizeInBytes(index);
+        } else if (dataType == DataTypes.BOOLEAN) {
+          getUnsafe()
+              .putBoolean(memoryBlock.getBaseObject(), memoryBlock.getBaseOffset() + runningLength,
+                  row.getBoolean(index));
+          runningLength += row.getSizeInBytes(index);
         } else if (dataType == DataTypes.SHORT) {
           getUnsafe()
               .putShort(memoryBlock.getBaseObject(), memoryBlock.getBaseOffset() + runningLength,

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMapRowIndexes.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMapRowIndexes.java
@@ -40,12 +40,14 @@ public interface BlockletDataMapRowIndexes {
 
   int BLOCK_LENGTH = 8;
 
+  int BLOCK_MIN_MAX_FLAG = 9;
+
   // below variables are specific for blockletDataMap
-  int BLOCKLET_INFO_INDEX = 9;
+  int BLOCKLET_INFO_INDEX = 10;
 
-  int BLOCKLET_PAGE_COUNT_INDEX = 10;
+  int BLOCKLET_PAGE_COUNT_INDEX = 11;
 
-  int BLOCKLET_ID_INDEX = 11;
+  int BLOCKLET_ID_INDEX = 12;
 
   // Summary dataMap row indexes
   int TASK_MIN_VALUES_INDEX = 0;
@@ -56,5 +58,7 @@ public interface BlockletDataMapRowIndexes {
 
   int SUMMARY_SEGMENTID = 3;
 
-  int SUMMARY_INDEX_PATH = 4;
+  int TASK_MIN_MAX_FLAG = 4;
+
+  int SUMMARY_INDEX_PATH = 5;
 }

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataRefNode.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataRefNode.java
@@ -17,7 +17,6 @@
 package org.apache.carbondata.core.indexstore.blockletindex;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.List;
 
 import org.apache.carbondata.core.constants.CarbonV3DataFormatConstants;
@@ -135,16 +134,12 @@ public class BlockletDataRefNode implements DataRefNode {
   }
 
   @Override
-  public boolean[] isMinMaxSet() {
+  public boolean[] minMaxFlagArray() {
     BlockletIndex blockletIndex =
         blockInfos.get(index).getDetailInfo().getBlockletInfo().getBlockletIndex();
     boolean[] isMinMaxSet = null;
     if (null != blockletIndex) {
       isMinMaxSet = blockletIndex.getMinMaxIndex().getIsMinMaxSet();
-      if (null == isMinMaxSet) {
-        isMinMaxSet = new boolean[blockletIndex.getMinMaxIndex().getMaxValues().length];
-        Arrays.fill(isMinMaxSet, true);
-      }
     }
     return isMinMaxSet;
   }

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataRefNode.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataRefNode.java
@@ -17,6 +17,7 @@
 package org.apache.carbondata.core.indexstore.blockletindex;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 
 import org.apache.carbondata.core.constants.CarbonV3DataFormatConstants;
@@ -131,6 +132,21 @@ public class BlockletDataRefNode implements DataRefNode {
       return blockletIndex.getMinMaxIndex().getMinValues();
     }
     return null;
+  }
+
+  @Override
+  public boolean[] isMinMaxSet() {
+    BlockletIndex blockletIndex =
+        blockInfos.get(index).getDetailInfo().getBlockletInfo().getBlockletIndex();
+    boolean[] isMinMaxSet = null;
+    if (null != blockletIndex) {
+      isMinMaxSet = blockletIndex.getMinMaxIndex().getIsMinMaxSet();
+      if (null == isMinMaxSet) {
+        isMinMaxSet = new boolean[blockletIndex.getMinMaxIndex().getMaxValues().length];
+        Arrays.fill(isMinMaxSet, true);
+      }
+    }
+    return isMinMaxSet;
   }
 
   @Override

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/row/DataMapRow.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/row/DataMapRow.java
@@ -69,6 +69,10 @@ public abstract class DataMapRow implements Serializable {
 
   public abstract int getLengthInBytes(int ordinal);
 
+  public abstract void setBoolean(boolean value, int ordinal);
+
+  public abstract boolean getBoolean(int ordinal);
+
   public int getTotalSizeInBytes() {
     int len = 0;
     for (int i = 0; i < schemas.length; i++) {

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/row/DataMapRowImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/row/DataMapRowImpl.java
@@ -41,6 +41,15 @@ public class DataMapRowImpl extends DataMapRow {
     return ((byte[]) data[ordinal]).length;
   }
 
+  @Override public void setBoolean(boolean value, int ordinal) {
+    assert (schemas[ordinal].getDataType() == DataTypes.BOOLEAN);
+    data[ordinal] = value;
+  }
+
+  @Override public boolean getBoolean(int ordinal) {
+    return (boolean) data[ordinal];
+  }
+
   @Override public DataMapRow getRow(int ordinal) {
     return (DataMapRow) data[ordinal];
   }

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/row/UnsafeDataMapRow.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/row/UnsafeDataMapRow.java
@@ -86,6 +86,15 @@ public class UnsafeDataMapRow extends DataMapRow {
     return length;
   }
 
+  @Override public void setBoolean(boolean value, int ordinal) {
+    throw new UnsupportedOperationException("Not supported to set on unsafe row");
+  }
+
+  @Override public boolean getBoolean(int ordinal) {
+    return getUnsafe()
+        .getBoolean(block.getBaseObject(), block.getBaseOffset() + pointer + getPosition(ordinal));
+  }
+
   private int getLengthInBytes(int ordinal, int position) {
     int length;
     switch (schemas[ordinal].getSchemaType()) {
@@ -187,6 +196,13 @@ public class UnsafeDataMapRow extends DataMapRow {
           if (dataType == DataTypes.BYTE) {
             row.setByte(
                 getUnsafe().getByte(
+                    block.getBaseObject(),
+                    block.getBaseOffset() + pointer + runningLength),
+                i);
+            runningLength += schema.getLength();
+          } else if (dataType == DataTypes.BOOLEAN) {
+            row.setBoolean(
+                getUnsafe().getBoolean(
                     block.getBaseObject(),
                     block.getBaseOffset() + pointer + runningLength),
                 i);

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/schema/SchemaGenerator.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/schema/SchemaGenerator.java
@@ -56,6 +56,9 @@ public class SchemaGenerator {
     indexSchemas.add(new CarbonRowSchema.VariableCarbonRowSchema(DataTypes.BYTE_ARRAY));
     // for storing block length.
     indexSchemas.add(new CarbonRowSchema.FixedCarbonRowSchema(DataTypes.LONG));
+    // for storing min max flag for each column which reflects whether min max for a column is
+    // written in the metadata or not.
+    addMinMaxFlagSchema(indexSchemas, segmentProperties);
     CarbonRowSchema[] schema = indexSchemas.toArray(new CarbonRowSchema[indexSchemas.size()]);
     return schema;
   }
@@ -85,6 +88,9 @@ public class SchemaGenerator {
     indexSchemas.add(new CarbonRowSchema.VariableCarbonRowSchema(DataTypes.BYTE_ARRAY));
     // for storing block length.
     indexSchemas.add(new CarbonRowSchema.FixedCarbonRowSchema(DataTypes.LONG));
+    // for storing min max flag for each column which reflects whether min max for a column is
+    // written in the metadata or not.
+    addMinMaxFlagSchema(indexSchemas, segmentProperties);
     //for blocklet info
     indexSchemas.add(new CarbonRowSchema.VariableCarbonRowSchema(DataTypes.BYTE_ARRAY));
     // for number of pages.
@@ -115,6 +121,9 @@ public class SchemaGenerator {
     // for storing segmentid
     taskMinMaxSchemas
         .add(new CarbonRowSchema.VariableCarbonRowSchema(DataTypes.BYTE_ARRAY));
+    // for storing min max flag for each column which reflects whether min max for a column is
+    // written in the metadata or not.
+    addMinMaxFlagSchema(taskMinMaxSchemas, segmentProperties);
     // store path only in case of partition table or non transactional table
     if (filePathToBeStored) {
       // for storing file path
@@ -166,6 +175,25 @@ public class SchemaGenerator {
               mapSchemas);
       minMaxSchemas.add(mapSchema);
     }
+  }
+
+  /**
+   * Method to add min max flag schema for all the dimensions
+   *
+   * @param indexSchemas
+   * @param segmentProperties
+   */
+  private static void addMinMaxFlagSchema(List<CarbonRowSchema> indexSchemas,
+      SegmentProperties segmentProperties) {
+    int totalDimensions = segmentProperties.getDimensions().size();
+    CarbonRowSchema[] minMaxFlagSchemas = new CarbonRowSchema[totalDimensions];
+    for (int i = 0; i < totalDimensions; i++) {
+      minMaxFlagSchemas[i] = new CarbonRowSchema.FixedCarbonRowSchema(DataTypes.BOOLEAN);
+    }
+    CarbonRowSchema structMinMaxFlagSchema =
+        new CarbonRowSchema.StructCarbonRowSchema(DataTypes.createDefaultStructType(),
+            minMaxFlagSchemas);
+    indexSchemas.add(structMinMaxFlagSchema);
   }
 
   /**

--- a/core/src/main/java/org/apache/carbondata/core/metadata/blocklet/BlockletInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/blocklet/BlockletInfo.java
@@ -221,7 +221,7 @@ public class BlockletInfo implements Serializable, Writable {
       output.writeInt(measureChunksLength.get(i));
     }
     writeChunkInfoForOlderVersions(output);
-
+    blockletIndex.write(output);
   }
 
   /**
@@ -288,6 +288,8 @@ public class BlockletInfo implements Serializable, Writable {
       measureChunksLength.add(input.readInt());
     }
     readChunkInfoForOlderVersions(input);
+    blockletIndex = new BlockletIndex();
+    blockletIndex.readFields(input);
   }
 
   /**

--- a/core/src/main/java/org/apache/carbondata/core/metadata/blocklet/BlockletInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/blocklet/BlockletInfo.java
@@ -221,7 +221,7 @@ public class BlockletInfo implements Serializable, Writable {
       output.writeInt(measureChunksLength.get(i));
     }
     writeChunkInfoForOlderVersions(output);
-    blockletIndex.write(output);
+
   }
 
   /**
@@ -288,8 +288,6 @@ public class BlockletInfo implements Serializable, Writable {
       measureChunksLength.add(input.readInt());
     }
     readChunkInfoForOlderVersions(input);
-    blockletIndex = new BlockletIndex();
-    blockletIndex.readFields(input);
   }
 
   /**

--- a/core/src/main/java/org/apache/carbondata/core/metadata/blocklet/index/BlockletIndex.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/blocklet/index/BlockletIndex.java
@@ -17,17 +17,12 @@
 
 package org.apache.carbondata.core.metadata.blocklet.index;
 
-import java.io.DataInput;
-import java.io.DataOutput;
-import java.io.IOException;
 import java.io.Serializable;
-
-import org.apache.hadoop.io.Writable;
 
 /**
  * Persist Index of all blocklets in one file
  */
-public class BlockletIndex implements Serializable, Writable {
+public class BlockletIndex implements Serializable {
 
   /**
    * serialization version
@@ -80,12 +75,4 @@ public class BlockletIndex implements Serializable, Writable {
     this.minMaxIndex = minMaxIndex;
   }
 
-  @Override public void write(DataOutput out) throws IOException {
-    minMaxIndex.write(out);
-  }
-
-  @Override public void readFields(DataInput in) throws IOException {
-    minMaxIndex = new BlockletMinMaxIndex();
-    minMaxIndex.readFields(in);
-  }
 }

--- a/core/src/main/java/org/apache/carbondata/core/metadata/blocklet/index/BlockletIndex.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/blocklet/index/BlockletIndex.java
@@ -17,12 +17,17 @@
 
 package org.apache.carbondata.core.metadata.blocklet.index;
 
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
 import java.io.Serializable;
+
+import org.apache.hadoop.io.Writable;
 
 /**
  * Persist Index of all blocklets in one file
  */
-public class BlockletIndex implements Serializable {
+public class BlockletIndex implements Serializable, Writable {
 
   /**
    * serialization version
@@ -75,4 +80,12 @@ public class BlockletIndex implements Serializable {
     this.minMaxIndex = minMaxIndex;
   }
 
+  @Override public void write(DataOutput out) throws IOException {
+    minMaxIndex.write(out);
+  }
+
+  @Override public void readFields(DataInput in) throws IOException {
+    minMaxIndex = new BlockletMinMaxIndex();
+    minMaxIndex.readFields(in);
+  }
 }

--- a/core/src/main/java/org/apache/carbondata/core/metadata/blocklet/index/BlockletMinMaxIndex.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/blocklet/index/BlockletMinMaxIndex.java
@@ -21,6 +21,8 @@ import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.util.List;
 
+import org.apache.commons.lang3.ArrayUtils;
+
 /**
  * Below class holds the information of max and min value of all the columns in a blocklet
  */
@@ -41,16 +43,23 @@ public class BlockletMinMaxIndex implements Serializable {
    */
   private byte[][] maxValues;
 
+  /**
+   * flag to check whether min max is written for a column or not
+   */
+  private boolean[] isMinMaxSet;
+
   public BlockletMinMaxIndex() {
   }
 
-  public BlockletMinMaxIndex(List<ByteBuffer> minValues, List<ByteBuffer> maxValues) {
+  public BlockletMinMaxIndex(List<ByteBuffer> minValues, List<ByteBuffer> maxValues,
+      List<Boolean> isMinMaxSet) {
     this.minValues = new byte[minValues.size()][];
     this.maxValues = new byte[maxValues.size()][];
     for (int i = 0; i < minValues.size(); i++) {
       this.minValues[i] = minValues.get(i).array();
       this.maxValues[i] = maxValues.get(i).array();
     }
+    this.isMinMaxSet = ArrayUtils.toPrimitive(isMinMaxSet.toArray(new Boolean[isMinMaxSet.size()]));
   }
 
   /**
@@ -79,6 +88,14 @@ public class BlockletMinMaxIndex implements Serializable {
    */
   public void setMaxValues(byte[][] maxValues) {
     this.maxValues = maxValues;
+  }
+
+  public boolean[] getIsMinMaxSet() {
+    return isMinMaxSet;
+  }
+
+  public void setIsMinMaxSet(boolean[] isMinMaxSet) {
+    this.isMinMaxSet = isMinMaxSet;
   }
 
 }

--- a/core/src/main/java/org/apache/carbondata/core/metadata/blocklet/index/BlockletMinMaxIndex.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/blocklet/index/BlockletMinMaxIndex.java
@@ -17,16 +17,20 @@
 
 package org.apache.carbondata.core.metadata.blocklet.index;
 
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
 import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.util.List;
 
 import org.apache.commons.lang3.ArrayUtils;
+import org.apache.hadoop.io.Writable;
 
 /**
  * Below class holds the information of max and min value of all the columns in a blocklet
  */
-public class BlockletMinMaxIndex implements Serializable {
+public class BlockletMinMaxIndex implements Serializable, Writable {
 
   /**
    * serialization version
@@ -98,4 +102,18 @@ public class BlockletMinMaxIndex implements Serializable {
     this.isMinMaxSet = isMinMaxSet;
   }
 
+  @Override public void write(DataOutput out) throws IOException {
+    out.writeShort(isMinMaxSet.length);
+    for (int i = 0; i < isMinMaxSet.length; i++) {
+      out.writeBoolean(isMinMaxSet[i]);
+    }
+  }
+
+  @Override public void readFields(DataInput in) throws IOException {
+    int minMaxFlagLength = in.readShort();
+    isMinMaxSet = new boolean[minMaxFlagLength];
+    for (int i = 0; i < minMaxFlagLength; i++) {
+      isMinMaxSet[i] = in.readBoolean();
+    }
+  }
 }

--- a/core/src/main/java/org/apache/carbondata/core/metadata/blocklet/index/BlockletMinMaxIndex.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/blocklet/index/BlockletMinMaxIndex.java
@@ -17,20 +17,16 @@
 
 package org.apache.carbondata.core.metadata.blocklet.index;
 
-import java.io.DataInput;
-import java.io.DataOutput;
-import java.io.IOException;
 import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.util.List;
 
 import org.apache.commons.lang3.ArrayUtils;
-import org.apache.hadoop.io.Writable;
 
 /**
  * Below class holds the information of max and min value of all the columns in a blocklet
  */
-public class BlockletMinMaxIndex implements Serializable, Writable {
+public class BlockletMinMaxIndex implements Serializable {
 
   /**
    * serialization version
@@ -102,18 +98,4 @@ public class BlockletMinMaxIndex implements Serializable, Writable {
     this.isMinMaxSet = isMinMaxSet;
   }
 
-  @Override public void write(DataOutput out) throws IOException {
-    out.writeShort(isMinMaxSet.length);
-    for (int i = 0; i < isMinMaxSet.length; i++) {
-      out.writeBoolean(isMinMaxSet[i]);
-    }
-  }
-
-  @Override public void readFields(DataInput in) throws IOException {
-    int minMaxFlagLength = in.readShort();
-    isMinMaxSet = new boolean[minMaxFlagLength];
-    for (int i = 0; i < minMaxFlagLength; i++) {
-      isMinMaxSet[i] = in.readBoolean();
-    }
-  }
 }

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/FilterExpressionProcessor.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/FilterExpressionProcessor.java
@@ -206,13 +206,14 @@ public class FilterExpressionProcessor implements FilterProcessor {
    * @param dataRefNode
    */
   private void addBlockBasedOnMinMaxValue(FilterExecuter filterExecuter,
-      List<DataRefNode> listOfDataBlocksToScan, DataRefNode dataRefNode) {
+      List<DataRefNode> listOfDataBlocksToScan, DataRefNode dataRefNode, boolean[] isMinMaxSet) {
     if (null == dataRefNode.getColumnsMinValue() || null == dataRefNode.getColumnsMaxValue()) {
       listOfDataBlocksToScan.add(dataRefNode);
       return;
     }
     BitSet bitSet = filterExecuter
-        .isScanRequired(dataRefNode.getColumnsMaxValue(), dataRefNode.getColumnsMinValue());
+        .isScanRequired(dataRefNode.getColumnsMaxValue(), dataRefNode.getColumnsMinValue(),
+            isMinMaxSet);
     if (!bitSet.isEmpty()) {
       listOfDataBlocksToScan.add(dataRefNode);
     }
@@ -472,13 +473,13 @@ public class FilterExpressionProcessor implements FilterProcessor {
   }
 
   public static boolean isScanRequired(FilterExecuter filterExecuter, byte[][] maxValue,
-      byte[][] minValue) {
+      byte[][] minValue, boolean[] isMinMaxSet) {
     if (filterExecuter instanceof ImplicitColumnFilterExecutor) {
       return ((ImplicitColumnFilterExecutor) filterExecuter)
-          .isFilterValuesPresentInAbstractIndex(maxValue, minValue);
+          .isFilterValuesPresentInAbstractIndex(maxValue, minValue, isMinMaxSet);
     } else {
       // otherwise decide based on min/max value
-      BitSet bitSet = filterExecuter.isScanRequired(maxValue, minValue);
+      BitSet bitSet = filterExecuter.isScanRequired(maxValue, minValue, isMinMaxSet);
       return !bitSet.isEmpty();
     }
   }

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/AndFilterExecuterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/AndFilterExecuterImpl.java
@@ -56,12 +56,13 @@ public class AndFilterExecuterImpl implements FilterExecuter, ImplicitColumnFilt
         rightExecuter.applyFilter(value, dimOrdinalMax);
   }
 
-  @Override public BitSet isScanRequired(byte[][] blockMaxValue, byte[][] blockMinValue) {
-    BitSet leftFilters = leftExecuter.isScanRequired(blockMaxValue, blockMinValue);
+  @Override public BitSet isScanRequired(byte[][] blockMaxValue, byte[][] blockMinValue,
+      boolean[] isMinMaxSet) {
+    BitSet leftFilters = leftExecuter.isScanRequired(blockMaxValue, blockMinValue, isMinMaxSet);
     if (leftFilters.isEmpty()) {
       return leftFilters;
     }
-    BitSet rightFilter = rightExecuter.isScanRequired(blockMaxValue, blockMinValue);
+    BitSet rightFilter = rightExecuter.isScanRequired(blockMaxValue, blockMinValue, isMinMaxSet);
     if (rightFilter.isEmpty()) {
       return rightFilter;
     }
@@ -77,14 +78,14 @@ public class AndFilterExecuterImpl implements FilterExecuter, ImplicitColumnFilt
 
   @Override
   public BitSet isFilterValuesPresentInBlockOrBlocklet(byte[][] maxValue, byte[][] minValue,
-      String uniqueBlockPath) {
+      String uniqueBlockPath, boolean[] isMinMaxSet) {
     BitSet leftFilters = null;
     if (leftExecuter instanceof ImplicitColumnFilterExecutor) {
       leftFilters = ((ImplicitColumnFilterExecutor) leftExecuter)
-          .isFilterValuesPresentInBlockOrBlocklet(maxValue, minValue,uniqueBlockPath);
+          .isFilterValuesPresentInBlockOrBlocklet(maxValue, minValue,uniqueBlockPath, isMinMaxSet);
     } else {
       leftFilters = leftExecuter
-          .isScanRequired(maxValue, minValue);
+          .isScanRequired(maxValue, minValue, isMinMaxSet);
     }
     if (leftFilters.isEmpty()) {
       return leftFilters;
@@ -92,9 +93,9 @@ public class AndFilterExecuterImpl implements FilterExecuter, ImplicitColumnFilt
     BitSet rightFilter = null;
     if (rightExecuter instanceof ImplicitColumnFilterExecutor) {
       rightFilter = ((ImplicitColumnFilterExecutor) rightExecuter)
-          .isFilterValuesPresentInBlockOrBlocklet(maxValue, minValue, uniqueBlockPath);
+          .isFilterValuesPresentInBlockOrBlocklet(maxValue, minValue, uniqueBlockPath, isMinMaxSet);
     } else {
-      rightFilter = rightExecuter.isScanRequired(maxValue, minValue);
+      rightFilter = rightExecuter.isScanRequired(maxValue, minValue, isMinMaxSet);
     }
     if (rightFilter.isEmpty()) {
       return rightFilter;
@@ -104,15 +105,16 @@ public class AndFilterExecuterImpl implements FilterExecuter, ImplicitColumnFilt
   }
 
   @Override
-  public Boolean isFilterValuesPresentInAbstractIndex(byte[][] maxValue, byte[][] minValue) {
+  public Boolean isFilterValuesPresentInAbstractIndex(byte[][] maxValue, byte[][] minValue,
+      boolean[] isMinMaxSet) {
     Boolean leftRes;
     BitSet tempFilter;
     if (leftExecuter instanceof ImplicitColumnFilterExecutor) {
       leftRes = ((ImplicitColumnFilterExecutor) leftExecuter)
-          .isFilterValuesPresentInAbstractIndex(maxValue, minValue);
+          .isFilterValuesPresentInAbstractIndex(maxValue, minValue, isMinMaxSet);
     } else {
       tempFilter = leftExecuter
-          .isScanRequired(maxValue, minValue);
+          .isScanRequired(maxValue, minValue, isMinMaxSet);
       leftRes = !tempFilter.isEmpty();
     }
     if (!leftRes) {
@@ -122,10 +124,10 @@ public class AndFilterExecuterImpl implements FilterExecuter, ImplicitColumnFilt
     Boolean rightRes = null;
     if (rightExecuter instanceof ImplicitColumnFilterExecutor) {
       rightRes = ((ImplicitColumnFilterExecutor) rightExecuter)
-          .isFilterValuesPresentInAbstractIndex(maxValue, minValue);
+          .isFilterValuesPresentInAbstractIndex(maxValue, minValue, isMinMaxSet);
     } else {
       tempFilter = rightExecuter
-          .isScanRequired(maxValue, minValue);
+          .isScanRequired(maxValue, minValue, isMinMaxSet);
       rightRes = !tempFilter.isEmpty();
     }
 

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/ExcludeFilterExecuterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/ExcludeFilterExecuterImpl.java
@@ -434,7 +434,8 @@ public class ExcludeFilterExecuterImpl implements FilterExecuter {
   }
 
   @Override
-  public BitSet isScanRequired(byte[][] blockMaxValue, byte[][] blockMinValue) {
+  public BitSet isScanRequired(byte[][] blockMaxValue, byte[][] blockMinValue,
+      boolean[] isMinMaxSet) {
     BitSet bitSet = new BitSet(1);
     bitSet.flip(0, 1);
     return bitSet;

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/FalseFilterExecutor.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/FalseFilterExecutor.java
@@ -51,7 +51,8 @@ public class FalseFilterExecutor implements FilterExecuter {
   }
 
   @Override
-  public BitSet isScanRequired(byte[][] blockMaxValue, byte[][] blockMinValue) {
+  public BitSet isScanRequired(byte[][] blockMaxValue, byte[][] blockMinValue,
+      boolean[] isMinMaxSet) {
     return new BitSet();
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/FilterExecuter.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/FilterExecuter.java
@@ -48,13 +48,15 @@ public interface FilterExecuter {
    *
    * @param blockMaxValue, maximum value of the
    * @param blockMinValue
+   * @param isMinMaxSet  flag to specify whether min max for the filter dimension is written or not
    * @return BitSet
    */
-  BitSet isScanRequired(byte[][] blockMaxValue, byte[][] blockMinValue);
+  BitSet isScanRequired(byte[][] blockMaxValue, byte[][] blockMinValue, boolean[] isMinMaxSet);
 
   /**
    * It just reads necessary block for filter executor, it does not uncompress the data.
+   *
    * @param rawBlockletColumnChunks
    */
-  void readColumnChunks(RawBlockletColumnChunks rawBlockletColumnChunks)throws IOException;
+  void readColumnChunks(RawBlockletColumnChunks rawBlockletColumnChunks) throws IOException;
 }

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/ImplicitColumnFilterExecutor.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/ImplicitColumnFilterExecutor.java
@@ -34,7 +34,7 @@ public interface ImplicitColumnFilterExecutor {
    * @return
    */
   BitSet isFilterValuesPresentInBlockOrBlocklet(byte[][] maxValue, byte[][] minValue,
-      String uniqueBlockPath);
+      String uniqueBlockPath, boolean[] isMinMaxSet);
 
   /**
    * This method will validate the abstract index
@@ -43,5 +43,6 @@ public interface ImplicitColumnFilterExecutor {
    *
    * @return
    */
-  Boolean isFilterValuesPresentInAbstractIndex(byte[][] maxValue, byte[][] minValue);
+  Boolean isFilterValuesPresentInAbstractIndex(byte[][] maxValue, byte[][] minValue,
+      boolean[] isMinMaxSet);
 }

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/ImplicitIncludeFilterExecutorImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/ImplicitIncludeFilterExecutorImpl.java
@@ -59,8 +59,8 @@ public class ImplicitIncludeFilterExecutorImpl
     return false;
   }
 
-  @Override
-  public BitSet isScanRequired(byte[][] blockMaxValue, byte[][] blockMinValue) {
+  @Override public BitSet isScanRequired(byte[][] blockMaxValue, byte[][] blockMinValue,
+      boolean[] isMinMaxSet) {
     return null;
   }
 
@@ -71,7 +71,7 @@ public class ImplicitIncludeFilterExecutorImpl
 
   @Override
   public BitSet isFilterValuesPresentInBlockOrBlocklet(byte[][] maxValue, byte[][] minValue,
-      String uniqueBlockPath) {
+      String uniqueBlockPath, boolean[] isMinMaxSet) {
     BitSet bitSet = new BitSet(1);
     boolean isScanRequired = false;
     String shortBlockId = CarbonTablePath.getShortBlockId(uniqueBlockPath);
@@ -104,7 +104,8 @@ public class ImplicitIncludeFilterExecutorImpl
   }
 
   @Override
-  public Boolean isFilterValuesPresentInAbstractIndex(byte[][] maxValue, byte[][] minValue) {
+  public Boolean isFilterValuesPresentInAbstractIndex(byte[][] maxValue, byte[][] minValue,
+      boolean[] isMinMaxSet) {
     return true;
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/IncludeFilterExecuterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/IncludeFilterExecuterImpl.java
@@ -108,13 +108,11 @@ public class IncludeFilterExecuterImpl implements FilterExecuter {
       BitSetGroup bitSetGroup = new BitSetGroup(dimensionRawColumnChunk.getPagesCount());
       filterValues = dimColumnExecuterInfo.getFilterKeys();
       boolean isDecoded = false;
-      boolean isMinMaxSetForFilterDimension =
-          rawBlockletColumnChunks.getDataBlock().isMinMaxSet()[chunkIndex];
       for (int i = 0; i < dimensionRawColumnChunk.getPagesCount(); i++) {
         if (dimensionRawColumnChunk.getMaxValues() != null) {
-          if (!isMinMaxSetForFilterDimension || isScanRequired(
-              dimensionRawColumnChunk.getMaxValues()[i], dimensionRawColumnChunk.getMinValues()[i],
-              dimColumnExecuterInfo.getFilterKeys())) {
+          if (isScanRequired(dimensionRawColumnChunk.getMaxValues()[i],
+              dimensionRawColumnChunk.getMinValues()[i], dimColumnExecuterInfo.getFilterKeys(),
+              dimensionRawColumnChunk.getMinMaxFlagArray()[i])) {
             DimensionColumnPage dimensionColumnPage = dimensionRawColumnChunk.decodeColumnPage(i);
             if (!isDecoded) {
               filterValues =  FilterUtil
@@ -461,12 +459,8 @@ public class IncludeFilterExecuterImpl implements FilterExecuter {
     if (isDimensionPresentInCurrentBlock) {
       filterValues = dimColumnExecuterInfo.getFilterKeys();
       chunkIndex = dimColumnEvaluatorInfo.getColumnIndexInMinMaxByteArray();
-      // scan all the data is minMax is not written for the column
-      if (!isMinMaxSet[chunkIndex]) {
-        isScanRequired = true;
-      } else {
-        isScanRequired = isScanRequired(blkMaxVal[chunkIndex], blkMinVal[chunkIndex], filterValues);
-      }
+      isScanRequired = isScanRequired(blkMaxVal[chunkIndex], blkMinVal[chunkIndex], filterValues,
+          isMinMaxSet[chunkIndex]);
     } else if (isMeasurePresentInCurrentBlock) {
       chunkIndex = msrColumnEvaluatorInfo.getColumnIndexInMinMaxByteArray();
       isScanRequired = isScanRequired(blkMaxVal[chunkIndex], blkMinVal[chunkIndex],
@@ -480,7 +474,12 @@ public class IncludeFilterExecuterImpl implements FilterExecuter {
     return bitSet;
   }
 
-  private boolean isScanRequired(byte[] blkMaxVal, byte[] blkMinVal, byte[][] filterValues) {
+  private boolean isScanRequired(byte[] blkMaxVal, byte[] blkMinVal, byte[][] filterValues,
+      boolean isMinMaxSet) {
+    if (!isMinMaxSet) {
+      // scan complete data if min max is not written for a given column
+      return true;
+    }
     boolean isScanRequired = false;
     for (int k = 0; k < filterValues.length; k++) {
       // filter value should be in range of max and min value i.e

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/OrFilterExecuterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/OrFilterExecuterImpl.java
@@ -52,9 +52,10 @@ public class OrFilterExecuterImpl implements FilterExecuter {
   }
 
   @Override
-  public BitSet isScanRequired(byte[][] blockMaxValue, byte[][] blockMinValue) {
-    BitSet leftFilters = leftExecuter.isScanRequired(blockMaxValue, blockMinValue);
-    BitSet rightFilters = rightExecuter.isScanRequired(blockMaxValue, blockMinValue);
+  public BitSet isScanRequired(byte[][] blockMaxValue, byte[][] blockMinValue,
+      boolean[] isMinMaxSet) {
+    BitSet leftFilters = leftExecuter.isScanRequired(blockMaxValue, blockMinValue, isMinMaxSet);
+    BitSet rightFilters = rightExecuter.isScanRequired(blockMaxValue, blockMinValue, isMinMaxSet);
     leftFilters.or(rightFilters);
     return leftFilters;
   }

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RestructureExcludeFilterExecutorImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RestructureExcludeFilterExecutorImpl.java
@@ -63,7 +63,8 @@ public class RestructureExcludeFilterExecutorImpl extends RestructureEvaluatorIm
   }
 
   @Override
-  public BitSet isScanRequired(byte[][] blockMaxValue, byte[][] blockMinValue) {
+  public BitSet isScanRequired(byte[][] blockMaxValue, byte[][] blockMinValue,
+      boolean[] isMinMaxSet) {
     BitSet bitSet = new BitSet(1);
     bitSet.flip(0, 1);
     return bitSet;

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RestructureIncludeFilterExecutorImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RestructureIncludeFilterExecutorImpl.java
@@ -61,7 +61,7 @@ public class RestructureIncludeFilterExecutorImpl extends RestructureEvaluatorIm
     throw new FilterUnsupportedException("Unsupported RestructureIncludeFilterExecutorImpl on row");
   }
 
-  public BitSet isScanRequired(byte[][] blkMaxVal, byte[][] blkMinVal) {
+  public BitSet isScanRequired(byte[][] blkMaxVal, byte[][] blkMinVal, boolean[] isMinMaxSet) {
     BitSet bitSet = new BitSet(1);
     bitSet.set(0, isDefaultValuePresentInFilterValues);
     return bitSet;

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RowLevelFilterExecuterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RowLevelFilterExecuterImpl.java
@@ -597,7 +597,8 @@ public class RowLevelFilterExecuterImpl implements FilterExecuter {
   }
 
   @Override
-  public BitSet isScanRequired(byte[][] blockMaxValue, byte[][] blockMinValue) {
+  public BitSet isScanRequired(byte[][] blockMaxValue, byte[][] blockMinValue,
+      boolean[] isMinMaxSet) {
     BitSet bitSet = new BitSet(1);
     bitSet.set(0);
     return bitSet;

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RowLevelRangeGrtThanFiterExecuterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RowLevelRangeGrtThanFiterExecuterImpl.java
@@ -125,12 +125,9 @@ public class RowLevelRangeGrtThanFiterExecuterImpl extends RowLevelFilterExecute
         isScanRequired =
             isScanRequired(maxValue, msrFilterRangeValues, msrColEvalutorInfoList.get(0).getType());
       } else {
-        if (!isMinMaxSet[dimensionChunkIndex[0]]) {
-          isScanRequired = true;
-        } else {
-          maxValue = blockMaxValue[dimensionChunkIndex[0]];
-          isScanRequired = isScanRequired(maxValue, filterRangeValues);
-        }
+        maxValue = blockMaxValue[dimensionChunkIndex[0]];
+        isScanRequired =
+            isScanRequired(maxValue, filterRangeValues, isMinMaxSet[dimensionChunkIndex[0]]);
       }
     } else {
       isScanRequired = isDefaultValuePresentInFilter;
@@ -143,7 +140,11 @@ public class RowLevelRangeGrtThanFiterExecuterImpl extends RowLevelFilterExecute
   }
 
 
-  private boolean isScanRequired(byte[] blockMaxValue, byte[][] filterValues) {
+  private boolean isScanRequired(byte[] blockMaxValue, byte[][] filterValues, boolean isMinMaxSet) {
+    if (!isMinMaxSet) {
+      // scan complete data if min max is not written for a given column
+      return true;
+    }
     boolean isScanRequired = false;
     for (int k = 0; k < filterValues.length; k++) {
       // filter value should be in range of max and min value i.e
@@ -198,12 +199,10 @@ public class RowLevelRangeGrtThanFiterExecuterImpl extends RowLevelFilterExecute
       BitSetGroup bitSetGroup = new BitSetGroup(rawColumnChunk.getPagesCount());
       FilterExecuter filterExecuter = null;
       boolean isExclude = false;
-      boolean isMinMaxSetForFilterDimension =
-          rawBlockletColumnChunks.getDataBlock().isMinMaxSet()[chunkIndex];
       for (int i = 0; i < rawColumnChunk.getPagesCount(); i++) {
         if (rawColumnChunk.getMaxValues() != null) {
-          if (!isMinMaxSetForFilterDimension || isScanRequired(rawColumnChunk.getMaxValues()[i],
-              this.filterRangeValues)) {
+          if (isScanRequired(rawColumnChunk.getMaxValues()[i],
+              this.filterRangeValues, rawColumnChunk.getMinMaxFlagArray()[i])) {
             int compare = ByteUtil.UnsafeComparer.INSTANCE
                 .compareTo(filterRangeValues[0], rawColumnChunk.getMinValues()[i]);
             if (compare < 0) {

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RowLevelRangeLessThanEqualFilterExecuterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RowLevelRangeLessThanEqualFilterExecuterImpl.java
@@ -126,12 +126,9 @@ public class RowLevelRangeLessThanEqualFilterExecuterImpl extends RowLevelFilter
         isScanRequired =
             isScanRequired(minValue, msrFilterRangeValues, msrColEvalutorInfoList.get(0).getType());
       } else {
-        if (!isMinMaxSet[dimensionChunkIndex[0]]) {
-          isScanRequired = true;
-        } else {
-          minValue = blockMinValue[dimensionChunkIndex[0]];
-          isScanRequired = isScanRequired(minValue, filterRangeValues);
-        }
+        minValue = blockMinValue[dimensionChunkIndex[0]];
+        isScanRequired =
+            isScanRequired(minValue, filterRangeValues, isMinMaxSet[dimensionChunkIndex[0]]);
       }
     } else {
       isScanRequired = isDefaultValuePresentInFilter;
@@ -142,7 +139,11 @@ public class RowLevelRangeLessThanEqualFilterExecuterImpl extends RowLevelFilter
     return bitSet;
   }
 
-  private boolean isScanRequired(byte[] blockMinValue, byte[][] filterValues) {
+  private boolean isScanRequired(byte[] blockMinValue, byte[][] filterValues, boolean isMinMaxSet) {
+    if (!isMinMaxSet) {
+      // scan complete data if min max is not written for a given column
+      return true;
+    }
     boolean isScanRequired = false;
     for (int k = 0; k < filterValues.length; k++) {
       // and filter-min should be positive
@@ -198,12 +199,10 @@ public class RowLevelRangeLessThanEqualFilterExecuterImpl extends RowLevelFilter
       BitSetGroup bitSetGroup = new BitSetGroup(rawColumnChunk.getPagesCount());
       FilterExecuter filterExecuter = null;
       boolean isExclude = false;
-      boolean isMinMaxSetForFilterDimension =
-          rawBlockletColumnChunks.getDataBlock().isMinMaxSet()[chunkIndex];
       for (int i = 0; i < rawColumnChunk.getPagesCount(); i++) {
         if (rawColumnChunk.getMinValues() != null) {
-          if (!isMinMaxSetForFilterDimension || isScanRequired(rawColumnChunk.getMinValues()[i],
-              this.filterRangeValues)) {
+          if (isScanRequired(rawColumnChunk.getMinValues()[i], this.filterRangeValues,
+              rawColumnChunk.getMinMaxFlagArray()[i])) {
             BitSet bitSet;
             DimensionColumnPage dimensionColumnPage = rawColumnChunk.decodeColumnPage(i);
             if (null != rawColumnChunk.getLocalDictionary()) {

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RowLevelRangeLessThanFilterExecuterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RowLevelRangeLessThanFilterExecuterImpl.java
@@ -115,7 +115,8 @@ public class RowLevelRangeLessThanFilterExecuterImpl extends RowLevelFilterExecu
     }
   }
 
-  @Override public BitSet isScanRequired(byte[][] blockMaxValue, byte[][] blockMinValue) {
+  @Override public BitSet isScanRequired(byte[][] blockMaxValue, byte[][] blockMinValue,
+      boolean[] isMinMaxSet) {
     BitSet bitSet = new BitSet(1);
     byte[] minValue = null;
     boolean isScanRequired = false;
@@ -125,8 +126,12 @@ public class RowLevelRangeLessThanFilterExecuterImpl extends RowLevelFilterExecu
         isScanRequired =
             isScanRequired(minValue, msrFilterRangeValues, msrColEvalutorInfoList.get(0).getType());
       } else {
-        minValue = blockMinValue[dimensionChunkIndex[0]];
-        isScanRequired = isScanRequired(minValue, filterRangeValues);
+        if (!isMinMaxSet[dimensionChunkIndex[0]]) {
+          isScanRequired = true;
+        } else {
+          minValue = blockMinValue[dimensionChunkIndex[0]];
+          isScanRequired = isScanRequired(minValue, filterRangeValues);
+        }
       }
     } else {
       isScanRequired = isDefaultValuePresentInFilter;
@@ -193,9 +198,12 @@ public class RowLevelRangeLessThanFilterExecuterImpl extends RowLevelFilterExecu
       BitSetGroup bitSetGroup = new BitSetGroup(rawColumnChunk.getPagesCount());
       FilterExecuter filterExecuter = null;
       boolean isExclude = false;
+      boolean isMinMaxSetForFilterDimension =
+          rawBlockletColumnChunks.getDataBlock().isMinMaxSet()[chunkIndex];
       for (int i = 0; i < rawColumnChunk.getPagesCount(); i++) {
         if (rawColumnChunk.getMinValues() != null) {
-          if (isScanRequired(rawColumnChunk.getMinValues()[i], this.filterRangeValues)) {
+          if (!isMinMaxSetForFilterDimension || isScanRequired(rawColumnChunk.getMinValues()[i],
+              this.filterRangeValues)) {
             BitSet bitSet;
             DimensionColumnPage dimensionColumnPage = rawColumnChunk.decodeColumnPage(i);
             if (null != rawColumnChunk.getLocalDictionary()) {

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/TrueFilterExecutor.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/TrueFilterExecutor.java
@@ -58,7 +58,8 @@ public class TrueFilterExecutor implements FilterExecuter {
    * @param blockMinValue
    * @return BitSet
    */
-  public BitSet isScanRequired(byte[][] blockMaxValue, byte[][] blockMinValue) {
+  public BitSet isScanRequired(byte[][] blockMaxValue, byte[][] blockMinValue,
+      boolean[] isMinMaxSet) {
     BitSet bitSet = new BitSet(1);
     bitSet.flip(0, 1);
     return bitSet;

--- a/core/src/main/java/org/apache/carbondata/core/scan/scanner/impl/BlockletFilterScanner.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/scanner/impl/BlockletFilterScanner.java
@@ -122,11 +122,11 @@ public class BlockletFilterScanner extends BlockletFullScanner {
         bitSet = ((ImplicitColumnFilterExecutor) filterExecuter)
             .isFilterValuesPresentInBlockOrBlocklet(
                 dataBlock.getColumnsMaxValue(),
-                dataBlock.getColumnsMinValue(), blockletId, dataBlock.isMinMaxSet());
+                dataBlock.getColumnsMinValue(), blockletId, dataBlock.minMaxFlagArray());
       } else {
         bitSet = this.filterExecuter
             .isScanRequired(dataBlock.getColumnsMaxValue(),
-                dataBlock.getColumnsMinValue(), dataBlock.isMinMaxSet());
+                dataBlock.getColumnsMinValue(), dataBlock.minMaxFlagArray());
       }
       return !bitSet.isEmpty();
     }

--- a/core/src/main/java/org/apache/carbondata/core/scan/scanner/impl/BlockletFilterScanner.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/scanner/impl/BlockletFilterScanner.java
@@ -122,11 +122,11 @@ public class BlockletFilterScanner extends BlockletFullScanner {
         bitSet = ((ImplicitColumnFilterExecutor) filterExecuter)
             .isFilterValuesPresentInBlockOrBlocklet(
                 dataBlock.getColumnsMaxValue(),
-                dataBlock.getColumnsMinValue(), blockletId);
+                dataBlock.getColumnsMinValue(), blockletId, dataBlock.isMinMaxSet());
       } else {
         bitSet = this.filterExecuter
             .isScanRequired(dataBlock.getColumnsMaxValue(),
-                dataBlock.getColumnsMinValue());
+                dataBlock.getColumnsMinValue(), dataBlock.isMinMaxSet());
       }
       return !bitSet.isEmpty();
     }

--- a/core/src/main/java/org/apache/carbondata/core/stream/StreamPruner.java
+++ b/core/src/main/java/org/apache/carbondata/core/stream/StreamPruner.java
@@ -100,7 +100,8 @@ public class StreamPruner {
     }
     byte[][] maxValue = streamFile.getMinMaxIndex().getMaxValues();
     byte[][] minValue = streamFile.getMinMaxIndex().getMinValues();
-    BitSet bitSet = filterExecuter.isScanRequired(maxValue, minValue);
+    BitSet bitSet = filterExecuter
+        .isScanRequired(maxValue, minValue, streamFile.getMinMaxIndex().getIsMinMaxSet());
     if (!bitSet.isEmpty()) {
       return true;
     } else {

--- a/core/src/main/java/org/apache/carbondata/core/util/AbstractDataFileFooterConverter.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/AbstractDataFileFooterConverter.java
@@ -19,7 +19,9 @@ package org.apache.carbondata.core.util;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.BitSet;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -418,9 +420,19 @@ public abstract class AbstractDataFileFooterConverter {
         blockletIndexThrift.getB_tree_index();
     org.apache.carbondata.format.BlockletMinMaxIndex minMaxIndex =
         blockletIndexThrift.getMin_max_index();
+    List<Boolean> isMInMaxSet = null;
+    // Below logic is added to handle backward compatibility
+    if (minMaxIndex.isSetMin_max_presence()) {
+      isMInMaxSet = minMaxIndex.getMin_max_presence();
+    } else {
+      Boolean[] minMaxFlag = new Boolean[minMaxIndex.getMax_values().size()];
+      Arrays.fill(minMaxFlag, true);
+      isMInMaxSet = Arrays.asList(minMaxFlag);
+    }
     return new BlockletIndex(
         new BlockletBTreeIndex(btreeIndex.getStart_key(), btreeIndex.getEnd_key()),
-        new BlockletMinMaxIndex(minMaxIndex.getMin_values(), minMaxIndex.getMax_values()));
+        new BlockletMinMaxIndex(minMaxIndex.getMin_values(), minMaxIndex.getMax_values(),
+            isMInMaxSet));
   }
 
   /**

--- a/core/src/main/java/org/apache/carbondata/core/util/BlockletDataMapUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/BlockletDataMapUtil.java
@@ -48,6 +48,7 @@ import org.apache.carbondata.core.indexstore.blockletindex.BlockletDataMapDistri
 import org.apache.carbondata.core.indexstore.blockletindex.BlockletDataMapFactory;
 import org.apache.carbondata.core.indexstore.blockletindex.SegmentIndexFileStore;
 import org.apache.carbondata.core.metadata.blocklet.DataFileFooter;
+import org.apache.carbondata.core.metadata.blocklet.index.BlockletMinMaxIndex;
 import org.apache.carbondata.core.metadata.datatype.DataType;
 import org.apache.carbondata.core.metadata.datatype.DataTypes;
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
@@ -484,5 +485,24 @@ public class BlockletDataMapUtil {
       }
     }
     return false;
+  }
+
+  /**
+   * Method to update the min max flag. For CACHE_LEVEL=BLOCK, for any column if min max is not
+   * written in any of the blocklet then for that column the flag will be false for the
+   * complete block
+   *
+   * @param minMaxIndex
+   * @param minMaxFlag
+   */
+  public static void updateMinMaxFlag(BlockletMinMaxIndex minMaxIndex, boolean[] minMaxFlag) {
+    boolean[] isMinMaxSet = minMaxIndex.getIsMinMaxSet();
+    if (null != isMinMaxSet) {
+      for (int i = 0; i < minMaxFlag.length; i++) {
+        if (!isMinMaxSet[i]) {
+          minMaxFlag[i] = isMinMaxSet[i];
+        }
+      }
+    }
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonMetadataUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonMetadataUtil.java
@@ -210,8 +210,6 @@ public class CarbonMetadataUtil {
         // if writeMonMaxFlag is set to false for the dimension at index i, then update the page
         // and blocklet min/max with empty byte array
         if (!writeMinMaxFlag.get(i)) {
-          columnMaxData[i] = new byte[0];
-          columnMinData[i] = new byte[0];
           maxCol[i] = new byte[0];
           minCol[i] = new byte[0];
           continue;
@@ -298,8 +296,7 @@ public class CarbonMetadataUtil {
         if (!stats.writeMinMax()) {
           mergedWriteMinMaxFlag[i] = stats.writeMinMax();
           String columnName = encodedColumnPage.getActualPage().getColumnSpec().getFieldName();
-          LOGGER.info("Min Max writing ignored for column " + columnName + " from page 0 to "
-              + encodedBlocklet.getNumberOfPages());
+          LOGGER.info("Min Max writing of blocklet ignored for column with name " + columnName);
           break;
         }
       }

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonMetadataUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonMetadataUtil.java
@@ -19,12 +19,14 @@ package org.apache.carbondata.core.util;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.apache.carbondata.core.datastore.blocklet.BlockletEncodedColumnPage;
 import org.apache.carbondata.core.datastore.blocklet.EncodedBlocklet;
 import org.apache.carbondata.core.datastore.compression.CompressorFactory;
 import org.apache.carbondata.core.datastore.page.encoding.EncodedColumnPage;
+import org.apache.carbondata.core.datastore.page.statistics.SimpleStatsResult;
 import org.apache.carbondata.core.datastore.page.statistics.TablePageStatistics;
 import org.apache.carbondata.core.metadata.ColumnarFormatVersion;
 import org.apache.carbondata.core.metadata.datatype.DataType;
@@ -107,7 +109,8 @@ public class CarbonMetadataUtil {
     }
 
     return new org.apache.carbondata.core.metadata.blocklet.index.BlockletMinMaxIndex(
-            minMaxIndex.getMin_values(), minMaxIndex.getMax_values());
+        minMaxIndex.getMin_values(), minMaxIndex.getMax_values(),
+        minMaxIndex.getMin_max_presence());
   }
 
   /**
@@ -124,6 +127,7 @@ public class CarbonMetadataUtil {
     for (int i = 0; i < minMaxIndex.getMaxValues().length; i++) {
       blockletMinMaxIndex.addToMax_values(ByteBuffer.wrap(minMaxIndex.getMaxValues()[i]));
       blockletMinMaxIndex.addToMin_values(ByteBuffer.wrap(minMaxIndex.getMinValues()[i]));
+      blockletMinMaxIndex.addToMin_max_presence(minMaxIndex.getIsMinMaxSet()[i]);
     }
 
     return blockletMinMaxIndex;
@@ -177,20 +181,30 @@ public class CarbonMetadataUtil {
   public static BlockletIndex getBlockletIndex(EncodedBlocklet encodedBlocklet,
       List<CarbonMeasure> carbonMeasureList) {
     BlockletMinMaxIndex blockletMinMaxIndex = new BlockletMinMaxIndex();
-
+    // merge writeMinMax flag for all the dimensions
+    List<Boolean> writeMinMaxFlag =
+        mergeWriteMinMaxFlagForAllPages(blockletMinMaxIndex, encodedBlocklet);
     // Calculating min/max for every each column.
     TablePageStatistics stats =
         new TablePageStatistics(getEncodedColumnPages(encodedBlocklet, true, 0),
             getEncodedColumnPages(encodedBlocklet, false, 0));
     byte[][] minCol = stats.getDimensionMinValue().clone();
     byte[][] maxCol = stats.getDimensionMaxValue().clone();
-
     for (int pageIndex = 0; pageIndex < encodedBlocklet.getNumberOfPages(); pageIndex++) {
       stats = new TablePageStatistics(getEncodedColumnPages(encodedBlocklet, true, pageIndex),
           getEncodedColumnPages(encodedBlocklet, false, pageIndex));
       byte[][] columnMaxData = stats.getDimensionMaxValue();
       byte[][] columnMinData = stats.getDimensionMinValue();
       for (int i = 0; i < maxCol.length; i++) {
+        // if writeMonMaxFlag is set to false for the dimension at index i, then update the page
+        // and blocklet min/max with empty byte array
+        if (!writeMinMaxFlag.get(i)) {
+          columnMaxData[i] = new byte[0];
+          columnMinData[i] = new byte[0];
+          maxCol[i] = new byte[0];
+          minCol[i] = new byte[0];
+          continue;
+        }
         if (ByteUtil.UnsafeComparer.INSTANCE.compareTo(columnMaxData[i], maxCol[i]) > 0) {
           maxCol[i] = columnMaxData[i];
         }
@@ -250,6 +264,39 @@ public class CarbonMetadataUtil {
   }
 
   /**
+   * This method will combine the writeMinMax flag from all the pages. If any page for a given
+   * dimension has writeMinMax flag set to false then min max for that dimension will nto be
+   * written in any of the page and metadata
+   *
+   * @param blockletMinMaxIndex
+   * @param encodedBlocklet
+   */
+  private static List<Boolean> mergeWriteMinMaxFlagForAllPages(
+      BlockletMinMaxIndex blockletMinMaxIndex, EncodedBlocklet encodedBlocklet) {
+    Boolean[] mergedWriteMinMaxFlag =
+        new Boolean[encodedBlocklet.getNumberOfDimension() + encodedBlocklet.getNumberOfMeasure()];
+    // set writeMinMax flag to true for all the columns by default and then update if stats object
+    // has the this flag set to false
+    Arrays.fill(mergedWriteMinMaxFlag, true);
+    for (int i = 0; i < encodedBlocklet.getNumberOfDimension(); i++) {
+      for (int pageIndex = 0; pageIndex < encodedBlocklet.getNumberOfPages(); pageIndex++) {
+        EncodedColumnPage encodedColumnPage =
+            encodedBlocklet.getEncodedDimensionColumnPages().get(i).getEncodedColumnPageList()
+                .get(pageIndex);
+        SimpleStatsResult stats = encodedColumnPage.getStats();
+        if (!stats.writeMinMax()) {
+          mergedWriteMinMaxFlag[i] = stats.writeMinMax();
+          break;
+        }
+      }
+    }
+    List<Boolean> min_max_presence = Arrays.asList(mergedWriteMinMaxFlag);
+    blockletMinMaxIndex.setMin_max_presence(min_max_presence);
+    return min_max_presence;
+  }
+
+  /**
+   * Right now it is set to default values. We may use this in future
    * set the compressor.
    * before 1.5.0, we set a enum 'compression_codec';
    * after 1.5.0, we use string 'compressor_name' instead

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
@@ -41,6 +41,7 @@ import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_
 import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_DATA_FILE_VERSION;
 import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_DATE_FORMAT;
 import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_DYNAMIC_ALLOCATION_SCHEDULER_TIMEOUT;
+import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_MINMAX_ALLOWED_BYTE_COUNT;
 import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_PREFETCH_BUFFERSIZE;
 import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_SCHEDULER_MIN_REGISTERED_RESOURCES_RATIO;
 import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_SCHEDULER_MIN_REGISTERED_RESOURCES_RATIO_DEFAULT;
@@ -49,7 +50,6 @@ import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_
 import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_SEARCH_MODE_SCAN_THREAD;
 import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_SEARCH_MODE_WORKER_WORKLOAD_LIMIT;
 import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_SORT_FILE_WRITE_BUFFER_SIZE;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_STRING_ALLOWED_CHARACTER_COUNT;
 import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_TASK_DISTRIBUTION;
 import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_TASK_DISTRIBUTION_BLOCK;
 import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_TASK_DISTRIBUTION_BLOCKLET;
@@ -194,6 +194,9 @@ public final class CarbonProperties {
         break;
       case CARBON_LOAD_SORT_MEMORY_SPILL_PERCENTAGE:
         validateSortMemorySpillPercentage();
+        break;
+      case CARBON_MINMAX_ALLOWED_BYTE_COUNT:
+        validateStringCharacterLimit();
         break;
       // TODO : Validation for carbon.lock.type should be handled for addProperty flow
       default:
@@ -1561,26 +1564,28 @@ public final class CarbonProperties {
     int allowedCharactersLimit = 0;
     try {
       allowedCharactersLimit = Integer.parseInt(carbonProperties
-          .getProperty(CARBON_STRING_ALLOWED_CHARACTER_COUNT,
-              CarbonCommonConstants.CARBON_STRING_ALLOWED_CHARACTER_COUNT_DEFAULT));
-      if (allowedCharactersLimit < CarbonCommonConstants.CARBON_STRING_ALLOWED_CHARACTER_COUNT_MIN
+          .getProperty(CARBON_MINMAX_ALLOWED_BYTE_COUNT,
+              CarbonCommonConstants.CARBON_MINMAX_ALLOWED_BYTE_COUNT_DEFAULT));
+      if (allowedCharactersLimit < CarbonCommonConstants.CARBON_MINMAX_ALLOWED_BYTE_COUNT_MIN
           || allowedCharactersLimit
-          > CarbonCommonConstants.CARBON_STRING_ALLOWED_CHARACTER_COUNT_MAX) {
-        LOGGER.info("The character limit for string type value \"" + allowedCharactersLimit
+          > CarbonCommonConstants.CARBON_MINMAX_ALLOWED_BYTE_COUNT_MAX) {
+        LOGGER.info("The min max byte limit for string type value \"" + allowedCharactersLimit
             + "\" is invalid. Using the default value \""
-            + CarbonCommonConstants.CARBON_STRING_ALLOWED_CHARACTER_COUNT_DEFAULT);
-        carbonProperties.setProperty(CARBON_STRING_ALLOWED_CHARACTER_COUNT,
-            CarbonCommonConstants.CARBON_STRING_ALLOWED_CHARACTER_COUNT_DEFAULT);
+            + CarbonCommonConstants.CARBON_MINMAX_ALLOWED_BYTE_COUNT_DEFAULT);
+        carbonProperties.setProperty(CARBON_MINMAX_ALLOWED_BYTE_COUNT,
+            CarbonCommonConstants.CARBON_MINMAX_ALLOWED_BYTE_COUNT_DEFAULT);
       } else {
+        LOGGER.info(
+            "Considered value for min max byte limit for string is: " + allowedCharactersLimit);
         carbonProperties
-            .setProperty(CARBON_STRING_ALLOWED_CHARACTER_COUNT, allowedCharactersLimit + "");
+            .setProperty(CARBON_MINMAX_ALLOWED_BYTE_COUNT, allowedCharactersLimit + "");
       }
     } catch (NumberFormatException e) {
-      LOGGER.info("The character limit for string type value \"" + allowedCharactersLimit
+      LOGGER.info("The min max byte limit for string type value \"" + allowedCharactersLimit
           + "\" is invalid. Using the default value \""
-          + CarbonCommonConstants.CARBON_STRING_ALLOWED_CHARACTER_COUNT_DEFAULT);
-      carbonProperties.setProperty(CARBON_STRING_ALLOWED_CHARACTER_COUNT,
-          CarbonCommonConstants.CARBON_STRING_ALLOWED_CHARACTER_COUNT_DEFAULT);
+          + CarbonCommonConstants.CARBON_MINMAX_ALLOWED_BYTE_COUNT_DEFAULT);
+      carbonProperties.setProperty(CARBON_MINMAX_ALLOWED_BYTE_COUNT,
+          CarbonCommonConstants.CARBON_MINMAX_ALLOWED_BYTE_COUNT_DEFAULT);
     }
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
@@ -49,6 +49,7 @@ import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_
 import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_SEARCH_MODE_SCAN_THREAD;
 import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_SEARCH_MODE_WORKER_WORKLOAD_LIMIT;
 import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_SORT_FILE_WRITE_BUFFER_SIZE;
+import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_STRING_ALLOWED_CHARACTER_COUNT;
 import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_TASK_DISTRIBUTION;
 import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_TASK_DISTRIBUTION_BLOCK;
 import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_TASK_DISTRIBUTION_BLOCKLET;
@@ -258,6 +259,7 @@ public final class CarbonProperties {
     validateSortStorageMemory();
     validateEnableQueryStatistics();
     validateSortMemorySpillPercentage();
+    validateStringCharacterLimit();
   }
 
   /**
@@ -1549,6 +1551,36 @@ public final class CarbonProperties {
       carbonProperties.setProperty(
           CARBON_LOAD_SORT_MEMORY_SPILL_PERCENTAGE,
           CarbonLoadOptionConstants.CARBON_LOAD_SORT_MEMORY_SPILL_PERCENTAGE_DEFAULT);
+    }
+  }
+
+  /**
+   * This method validates the allowed character limit for storing min/max for string type
+   */
+  private void validateStringCharacterLimit() {
+    int allowedCharactersLimit = 0;
+    try {
+      allowedCharactersLimit = Integer.parseInt(carbonProperties
+          .getProperty(CARBON_STRING_ALLOWED_CHARACTER_COUNT,
+              CarbonCommonConstants.CARBON_STRING_ALLOWED_CHARACTER_COUNT_DEFAULT));
+      if (allowedCharactersLimit < CarbonCommonConstants.CARBON_STRING_ALLOWED_CHARACTER_COUNT_MIN
+          || allowedCharactersLimit
+          > CarbonCommonConstants.CARBON_STRING_ALLOWED_CHARACTER_COUNT_MAX) {
+        LOGGER.info("The character limit for string type value \"" + allowedCharactersLimit
+            + "\" is invalid. Using the default value \""
+            + CarbonCommonConstants.CARBON_STRING_ALLOWED_CHARACTER_COUNT_DEFAULT);
+        carbonProperties.setProperty(CARBON_STRING_ALLOWED_CHARACTER_COUNT,
+            CarbonCommonConstants.CARBON_STRING_ALLOWED_CHARACTER_COUNT_DEFAULT);
+      } else {
+        carbonProperties
+            .setProperty(CARBON_STRING_ALLOWED_CHARACTER_COUNT, allowedCharactersLimit + "");
+      }
+    } catch (NumberFormatException e) {
+      LOGGER.info("The character limit for string type value \"" + allowedCharactersLimit
+          + "\" is invalid. Using the default value \""
+          + CarbonCommonConstants.CARBON_STRING_ALLOWED_CHARACTER_COUNT_DEFAULT);
+      carbonProperties.setProperty(CARBON_STRING_ALLOWED_CHARACTER_COUNT,
+          CarbonCommonConstants.CARBON_STRING_ALLOWED_CHARACTER_COUNT_DEFAULT);
     }
   }
 }

--- a/core/src/test/java/org/apache/carbondata/core/indexstore/blockletindex/TestBlockletDataMap.java
+++ b/core/src/test/java/org/apache/carbondata/core/indexstore/blockletindex/TestBlockletDataMap.java
@@ -35,7 +35,7 @@ public class TestBlockletDataMap extends AbstractDictionaryCacheTest {
 
     new MockUp<ImplicitIncludeFilterExecutorImpl>() {
       @Mock BitSet isFilterValuesPresentInBlockOrBlocklet(byte[][] maxValue, byte[][] minValue,
-          String uniqueBlockPath) {
+          String uniqueBlockPath, boolean[] isMinMaxSet) {
         BitSet bitSet = new BitSet(1);
         bitSet.set(8);
         return bitSet;
@@ -45,13 +45,14 @@ public class TestBlockletDataMap extends AbstractDictionaryCacheTest {
     BlockDataMap blockletDataMap = new BlockletDataMap();
     Method method = BlockDataMap.class
         .getDeclaredMethod("addBlockBasedOnMinMaxValue", FilterExecuter.class, byte[][].class,
-            byte[][].class, String.class, int.class);
+            byte[][].class, boolean[].class, String.class, int.class);
     method.setAccessible(true);
 
     byte[][] minValue = { ByteUtil.toBytes("sfds") };
     byte[][] maxValue = { ByteUtil.toBytes("resa") };
+    boolean[] minMaxFlag = new boolean[] {true};
     Object result = method
-        .invoke(blockletDataMap, implicitIncludeFilterExecutor, minValue, maxValue,
+        .invoke(blockletDataMap, implicitIncludeFilterExecutor, minValue, maxValue, minMaxFlag,
             "/opt/store/default/carbon_table/Fact/Part0/Segment_0/part-0-0_batchno0-0-1514989110586.carbondata",
             0);
     assert ((boolean) result);

--- a/core/src/test/java/org/apache/carbondata/core/util/CarbonMetadataUtilTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/util/CarbonMetadataUtilTest.java
@@ -172,10 +172,13 @@ public class CarbonMetadataUtilTest {
     List<ByteBuffer> maxList = new ArrayList<>();
     maxList.add(ByteBuffer.wrap(byteArr1));
 
+    List<Boolean> isMinMaxSet = new ArrayList<>();
+    isMinMaxSet.add(true);
+
     org.apache.carbondata.core.metadata.blocklet.index.BlockletMinMaxIndex
         blockletMinMaxIndex =
         new org.apache.carbondata.core.metadata.blocklet.index.BlockletMinMaxIndex(minList,
-            maxList);
+            maxList, isMinMaxSet);
     org.apache.carbondata.core.metadata.blocklet.index.BlockletBTreeIndex
         blockletBTreeIndex =
         new org.apache.carbondata.core.metadata.blocklet.index.BlockletBTreeIndex(startKey,

--- a/core/src/test/java/org/apache/carbondata/core/util/RangeFilterProcessorTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/util/RangeFilterProcessorTest.java
@@ -320,7 +320,7 @@ public class RangeFilterProcessorTest {
     Deencapsulation.setField(range, "isDimensionPresentInCurrentBlock", true);
     Deencapsulation.setField(range, "lessThanExp", true);
     Deencapsulation.setField(range, "greaterThanExp", true);
-    result = range.isScanRequired(BlockMin, BlockMax, filterMinMax);
+    result = range.isScanRequired(BlockMin, BlockMax, filterMinMax, true);
     Assert.assertFalse(result);
   }
 
@@ -336,7 +336,7 @@ public class RangeFilterProcessorTest {
     Deencapsulation.setField(range, "isDimensionPresentInCurrentBlock", true);
     Deencapsulation.setField(range, "lessThanExp", true);
     Deencapsulation.setField(range, "greaterThanExp", true);
-    result = range.isScanRequired(BlockMin, BlockMax, filterMinMax);
+    result = range.isScanRequired(BlockMin, BlockMax, filterMinMax, true);
     Assert.assertFalse(result);
   }
 
@@ -352,7 +352,7 @@ public class RangeFilterProcessorTest {
     Deencapsulation.setField(range, "isDimensionPresentInCurrentBlock", true);
     Deencapsulation.setField(range, "lessThanExp", true);
     Deencapsulation.setField(range, "greaterThanExp", true);
-    result = range.isScanRequired(BlockMin, BlockMax, filterMinMax);
+    result = range.isScanRequired(BlockMin, BlockMax, filterMinMax, true);
     Assert.assertTrue(result);
   }
 
@@ -370,7 +370,7 @@ public class RangeFilterProcessorTest {
     Deencapsulation.setField(range, "lessThanExp", true);
     Deencapsulation.setField(range, "greaterThanExp", true);
 
-    result = range.isScanRequired(BlockMin, BlockMax, filterMinMax);
+    result = range.isScanRequired(BlockMin, BlockMax, filterMinMax, true);
     rangeCovered = Deencapsulation.getField(range, "isRangeFullyCoverBlock");
     Assert.assertTrue(result);
     Assert.assertTrue(rangeCovered);
@@ -390,7 +390,7 @@ public class RangeFilterProcessorTest {
     Deencapsulation.setField(range, "lessThanExp", true);
     Deencapsulation.setField(range, "greaterThanExp", true);
 
-    result = range.isScanRequired(BlockMin, BlockMax, filterMinMax);
+    result = range.isScanRequired(BlockMin, BlockMax, filterMinMax, true);
     startBlockMinIsDefaultStart = Deencapsulation.getField(range, "startBlockMinIsDefaultStart");
     Assert.assertTrue(result);
     Assert.assertTrue(startBlockMinIsDefaultStart);
@@ -410,7 +410,7 @@ public class RangeFilterProcessorTest {
     Deencapsulation.setField(range, "lessThanExp", true);
     Deencapsulation.setField(range, "greaterThanExp", true);
 
-    result = range.isScanRequired(BlockMin, BlockMax, filterMinMax);
+    result = range.isScanRequired(BlockMin, BlockMax, filterMinMax, true);
     endBlockMaxisDefaultEnd = Deencapsulation.getField(range, "endBlockMaxisDefaultEnd");
     Assert.assertTrue(result);
     Assert.assertTrue(endBlockMaxisDefaultEnd);

--- a/datamap/examples/src/minmaxdatamap/main/java/org/apache/carbondata/datamap/examples/MinMaxIndexDataMap.java
+++ b/datamap/examples/src/minmaxdatamap/main/java/org/apache/carbondata/datamap/examples/MinMaxIndexDataMap.java
@@ -140,7 +140,7 @@ public class MinMaxIndexDataMap extends CoarseGrainDataMap {
 
           BitSet bitSet = filterExecuter.isScanRequired(
               readMinMaxDataMap[blkIdx][blkltIdx].getMaxValues(),
-              readMinMaxDataMap[blkIdx][blkltIdx].getMinValues());
+              readMinMaxDataMap[blkIdx][blkltIdx].getMinValues(), null);
           if (!bitSet.isEmpty()) {
             String blockFileName = indexFilePath[blkIdx].substring(
                 indexFilePath[blkIdx].lastIndexOf(File.separatorChar) + 1,

--- a/format/src/main/thrift/carbondata.thrift
+++ b/format/src/main/thrift/carbondata.thrift
@@ -45,6 +45,7 @@ struct BlockletBTreeIndex{
 struct BlockletMinMaxIndex{
     1: required list<binary> min_values; //Min value of all columns of one blocklet Bit-Packed
     2: required list<binary> max_values; //Max value of all columns of one blocklet Bit-Packed
+    3: optional list<bool> min_max_presence; // flag to specify whether min max is written for a column or not
 }
 
 /**

--- a/integration/spark-datasource/src/test/scala/org/apache/spark/sql/carbondata/datasource/TestCreateTableUsingSparkCarbonFileFormat.scala
+++ b/integration/spark-datasource/src/test/scala/org/apache/spark/sql/carbondata/datasource/TestCreateTableUsingSparkCarbonFileFormat.scala
@@ -19,23 +19,29 @@ package org.apache.spark.sql.carbondata.datasource
 
 import java.io.File
 import java.text.SimpleDateFormat
+import java.util
 import java.util.{Date, Random}
+
+import scala.collection.JavaConverters._
 
 import org.apache.commons.io.FileUtils
 import org.apache.commons.lang.RandomStringUtils
 import org.scalatest.{BeforeAndAfterAll, FunSuite}
 import org.apache.spark.util.SparkUtil
 import org.apache.spark.sql.carbondata.datasource.TestUtil.{spark, _}
+
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.constants.{CarbonCommonConstants, CarbonV3DataFormatConstants}
 import org.apache.carbondata.core.datastore.filesystem.CarbonFile
 import org.apache.carbondata.core.datastore.impl.FileFactory
 import org.apache.carbondata.core.metadata.datatype.DataTypes
-import org.apache.carbondata.core.util.{CarbonProperties, CarbonUtil}
+import org.apache.carbondata.core.util.{CarbonProperties, CarbonUtil, DataFileFooterConverter}
 import org.apache.carbondata.sdk.file.{CarbonWriter, Field, Schema}
 import org.apache.hadoop.conf.Configuration
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.carbondata.execution.datasources.CarbonFileIndexReplaceRule
+
+import org.apache.carbondata.core.metadata.blocklet.DataFileFooter
 
 class TestCreateTableUsingSparkCarbonFileFormat extends FunSuite with BeforeAndAfterAll {
 
@@ -46,6 +52,9 @@ class TestCreateTableUsingSparkCarbonFileFormat extends FunSuite with BeforeAndA
   }
 
   override def afterAll(): Unit = {
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.CARBON_MINMAX_ALLOWED_BYTE_COUNT,
+        CarbonCommonConstants.CARBON_MINMAX_ALLOWED_BYTE_COUNT_DEFAULT)
     spark.sql("DROP TABLE IF EXISTS sdkOutputTable")
   }
 
@@ -328,8 +337,10 @@ class TestCreateTableUsingSparkCarbonFileFormat extends FunSuite with BeforeAndA
     assert(new File(filePath).exists())
     cleanTestData()
   }
-  test("Read data having multi blocklet ") {
-    buildTestDataMuliBlockLet(700000)
+  test("Read data having multi blocklet and validate min max flag") {
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.CARBON_MINMAX_ALLOWED_BYTE_COUNT, "40")
+    buildTestDataMuliBlockLet(750000, 50000)
     assert(new File(writerPath).exists())
     spark.sql("DROP TABLE IF EXISTS sdkOutputTable")
 
@@ -342,38 +353,79 @@ class TestCreateTableUsingSparkCarbonFileFormat extends FunSuite with BeforeAndA
         s"""CREATE TABLE sdkOutputTable USING carbon LOCATION
            |'$writerPath' """.stripMargin)
     }
-    spark.sql("select count(*) from sdkOutputTable").show(false)
-    val result=checkAnswer(spark.sql("select count(*) from sdkOutputTable"),Seq(Row(700000)))
+    val result=checkAnswer(spark.sql("select count(*) from sdkOutputTable"),Seq(Row(800000)))
     if(result.isDefined){
       assert(false,result.get)
     }
+    checkAnswer(spark
+      .sql(
+        "select count(*) from sdkOutputTable where from_email='Email for testing min max for " +
+        "allowed chars'"),
+      Seq(Row(50000)))
+    //expected answer for min max flag. FInally there should be 2 blocklets with one blocklet
+    // having min max flag as false for email column and other as true
+    val blocklet1MinMaxFlag = Array(true, true, true, true, true, false, true, true, true)
+    val blocklet2MinMaxFlag = Array(true, true, true, true, true, true, true, true, true)
+    val expectedMinMaxFlag = Array(blocklet1MinMaxFlag, blocklet2MinMaxFlag)
+    validateMinMaxFlag(expectedMinMaxFlag, 2)
+
     spark.sql("DROP TABLE sdkOutputTable")
     // drop table should not delete the files
     assert(new File(writerPath).exists())
     cleanTestData()
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.CARBON_MINMAX_ALLOWED_BYTE_COUNT,
+        CarbonCommonConstants.CARBON_MINMAX_ALLOWED_BYTE_COUNT_DEFAULT)
   }
-  def buildTestDataMuliBlockLet(records :Int): Unit ={
+  def buildTestDataMuliBlockLet(recordsInBlocklet1 :Int, recordsInBlocklet2 :Int): Unit ={
     FileUtils.deleteDirectory(new File(writerPath))
     val fields=new Array[Field](8)
-    fields(0)=new Field("myid",DataTypes.INT);
-    fields(1)=new Field("event_id",DataTypes.STRING);
-    fields(2)=new Field("eve_time",DataTypes.DATE);
-    fields(3)=new Field("ingestion_time",DataTypes.TIMESTAMP);
-    fields(4)=new Field("alldate",DataTypes.createArrayType(DataTypes.DATE));
-    fields(5)=new Field("subject",DataTypes.STRING);
-    fields(6)=new Field("from_email",DataTypes.STRING);
-    fields(7)=new Field("sal",DataTypes.DOUBLE);
+    fields(0)=new Field("myid",DataTypes.INT)
+    fields(1)=new Field("event_id",DataTypes.STRING)
+    fields(2)=new Field("eve_time",DataTypes.DATE)
+    fields(3)=new Field("ingestion_time",DataTypes.TIMESTAMP)
+    fields(4)=new Field("alldate",DataTypes.createArrayType(DataTypes.DATE))
+    fields(5)=new Field("subject",DataTypes.STRING)
+    fields(6)=new Field("from_email",DataTypes.STRING)
+    fields(7)=new Field("sal",DataTypes.DOUBLE)
     import scala.collection.JavaConverters._
+    val emailDataBlocklet1 = "FromEmail"
+    val emailDataBlocklet2 = "Email for testing min max for allowed chars"
     try{
       val options=Map("bad_records_action"->"FORCE","complex_delimiter_level_1"->"$").asJava
       val writer=CarbonWriter.builder().outputPath(writerPath).withBlockletSize(16).sortBy(Array("myid","ingestion_time","event_id")).withLoadOptions(options).buildWriterForCSVInput(new Schema(fields),spark.sessionState.newHadoopConf())
       val timeF=new SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
       val date_F=new SimpleDateFormat("yyyy-MM-dd")
-      for(i<-1 to records){
+      for(i<- 1 to recordsInBlocklet1){
         val time=new Date(System.currentTimeMillis())
-        writer.write(Array(""+i,"event_"+i,""+date_F.format(time),""+timeF.format(time),""+date_F.format(time)+"$"+date_F.format(time),"Subject_0","FromEmail",""+new Random().nextDouble()))
+        writer.write(Array(""+i,"event_"+i,""+date_F.format(time),""+timeF.format(time),""+date_F.format(time)+"$"+date_F.format(time),"Subject_0",emailDataBlocklet1,""+new Random().nextDouble()))
+      }
+      for(i<- 1 to recordsInBlocklet2){
+        val time=new Date(System.currentTimeMillis())
+        writer.write(Array(""+i,"event_"+i,""+date_F.format(time),""+timeF.format(time),""+date_F.format(time)+"$"+date_F.format(time),"Subject_0",emailDataBlocklet2,""+new Random().nextDouble()))
       }
       writer.close()
+    }
+  }
+
+  /**
+   * read carbon index file and  validate the min max flag written in each blocklet
+   *
+   * @param expectedMinMaxFlag
+   * @param numBlocklets
+   */
+  private def validateMinMaxFlag(expectedMinMaxFlag: Array[Array[Boolean]],
+      numBlocklets: Int): Unit = {
+    val carbonFiles: Array[File] = new File(writerPath).listFiles()
+    val carbonIndexFile = carbonFiles.filter(file => file.getName.endsWith(".carbonindex"))(0)
+    val converter: DataFileFooterConverter = new DataFileFooterConverter(new Configuration(false))
+    val carbonIndexFilePath = FileFactory.getUpdatedFilePath(carbonIndexFile.getCanonicalPath)
+    val indexMetadata: List[DataFileFooter] = converter
+      .getIndexInfo(carbonIndexFilePath, null, false).asScala.toList
+    assert(indexMetadata.size == numBlocklets)
+    indexMetadata.zipWithIndex.foreach { filefooter =>
+      val isMinMaxSet: Array[Boolean] = filefooter._1.getBlockletIndex.getMinMaxIndex.getIsMinMaxSet
+      assert(isMinMaxSet.sameElements(expectedMinMaxFlag(filefooter._2)))
     }
   }
 

--- a/integration/spark-datasource/src/test/scala/org/apache/spark/sql/carbondata/datasource/TestUtil.scala
+++ b/integration/spark-datasource/src/test/scala/org/apache/spark/sql/carbondata/datasource/TestUtil.scala
@@ -25,6 +25,9 @@ import org.apache.spark.sql.{DataFrame, Row, SparkSession}
 import org.apache.spark.sql.catalyst.plans.logical
 import org.apache.spark.sql.catalyst.util.sideBySide
 
+import org.apache.carbondata.core.constants.CarbonCommonConstants
+import org.apache.carbondata.core.util.CarbonProperties
+
 object TestUtil {
 
   val rootPath = new File(this.getClass.getResource("/").getPath
@@ -44,6 +47,8 @@ object TestUtil {
   if (!spark.sparkContext.version.startsWith("2.1")) {
     spark.experimental.extraOptimizations = Seq(new CarbonFileIndexReplaceRule)
   }
+  CarbonProperties.getInstance()
+    .addProperty(CarbonCommonConstants.CARBON_MINMAX_ALLOWED_BYTE_COUNT, "40")
 
   def checkAnswer(df: DataFrame, expectedAnswer: java.util.List[Row]):Unit = {
     checkAnswer(df, expectedAnswer.asScala) match {

--- a/integration/spark2/src/main/scala/org/apache/carbondata/stream/CarbonStreamRecordReader.java
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/stream/CarbonStreamRecordReader.java
@@ -421,8 +421,9 @@ public class CarbonStreamRecordReader extends RecordReader<Void, Object> {
       BlockletMinMaxIndex minMaxIndex = CarbonMetadataUtil.convertExternalMinMaxIndex(
           header.getBlocklet_index().getMin_max_index());
       if (minMaxIndex != null) {
-        BitSet bitSet =
-            filter.isScanRequired(minMaxIndex.getMaxValues(), minMaxIndex.getMinValues());
+        BitSet bitSet = filter
+            .isScanRequired(minMaxIndex.getMaxValues(), minMaxIndex.getMinValues(),
+                minMaxIndex.getIsMinMaxSet());
         if (bitSet.isEmpty()) {
           return false;
         } else {

--- a/integration/spark2/src/test/scala/org/apache/spark/sql/CarbonGetTableDetailComandTestCase.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/sql/CarbonGetTableDetailComandTestCase.scala
@@ -43,9 +43,9 @@ class CarbonGetTableDetailCommandTestCase extends QueryTest with BeforeAndAfterA
     assertResult(2)(result.length)
     assertResult("table_info1")(result(0).getString(0))
     // 2087 is the size of carbon table. Note that since 1.5.0, we add additional compressor name in metadata
-    assertResult(2201)(result(0).getLong(1))
+    assertResult(2216)(result(0).getLong(1))
     assertResult("table_info2")(result(1).getString(0))
-    assertResult(2201)(result(1).getLong(1))
+    assertResult(2216)(result(1).getLong(1))
   }
 
   override def afterAll: Unit = {

--- a/integration/spark2/src/test/scala/org/apache/spark/sql/CarbonGetTableDetailComandTestCase.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/sql/CarbonGetTableDetailComandTestCase.scala
@@ -43,9 +43,9 @@ class CarbonGetTableDetailCommandTestCase extends QueryTest with BeforeAndAfterA
     assertResult(2)(result.length)
     assertResult("table_info1")(result(0).getString(0))
     // 2087 is the size of carbon table. Note that since 1.5.0, we add additional compressor name in metadata
-    assertResult(2187)(result(0).getLong(1))
+    assertResult(2201)(result(0).getLong(1))
     assertResult("table_info2")(result(1).getString(0))
-    assertResult(2187)(result(1).getLong(1))
+    assertResult(2201)(result(1).getLong(1))
   }
 
   override def afterAll: Unit = {

--- a/processing/src/main/java/org/apache/carbondata/processing/store/writer/v3/CarbonFactDataWriterImplV3.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/writer/v3/CarbonFactDataWriterImplV3.java
@@ -327,9 +327,10 @@ public class CarbonFactDataWriterImplV3 extends AbstractFactDataWriter {
           model.getSegmentProperties().getDimensions().size());
       BlockletBTreeIndex bTreeIndex = new BlockletBTreeIndex(index.b_tree_index.getStart_key(),
           index.b_tree_index.getEnd_key());
-      BlockletMinMaxIndex minMaxIndex = new BlockletMinMaxIndex();
-      minMaxIndex.setMinValues(toByteArray(index.getMin_max_index().getMin_values()));
-      minMaxIndex.setMaxValues(toByteArray(index.getMin_max_index().getMax_values()));
+      BlockletMinMaxIndex minMaxIndex =
+          new BlockletMinMaxIndex(index.getMin_max_index().getMin_values(),
+              index.getMin_max_index().getMin_values(),
+              index.getMin_max_index().getMin_max_presence());
       org.apache.carbondata.core.metadata.blocklet.index.BlockletIndex bIndex =
           new org.apache.carbondata.core.metadata.blocklet.index.BlockletIndex(bTreeIndex,
               minMaxIndex);

--- a/processing/src/main/java/org/apache/carbondata/processing/store/writer/v3/CarbonFactDataWriterImplV3.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/writer/v3/CarbonFactDataWriterImplV3.java
@@ -329,7 +329,7 @@ public class CarbonFactDataWriterImplV3 extends AbstractFactDataWriter {
           index.b_tree_index.getEnd_key());
       BlockletMinMaxIndex minMaxIndex =
           new BlockletMinMaxIndex(index.getMin_max_index().getMin_values(),
-              index.getMin_max_index().getMin_values(),
+              index.getMin_max_index().getMax_values(),
               index.getMin_max_index().getMin_max_presence());
       org.apache.carbondata.core.metadata.blocklet.index.BlockletIndex bIndex =
           new org.apache.carbondata.core.metadata.blocklet.index.BlockletIndex(bTreeIndex,

--- a/streaming/src/main/java/org/apache/carbondata/streaming/segment/StreamSegment.java
+++ b/streaming/src/main/java/org/apache/carbondata/streaming/segment/StreamSegment.java
@@ -20,6 +20,7 @@ package org.apache.carbondata.streaming.segment;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -257,6 +258,10 @@ public class StreamSegment {
           CarbonUtil.getValueAsBytes(mrsStats[index].getDataType(), mrsStats[index].getMin());
     }
     minMaxIndex.setMinValues(minIndexes);
+    // TODO: handle the min max writing for string type based on character limit for streaming
+    boolean[] isMinMaxSet = new boolean[dimStats.length + mrsStats.length];
+    Arrays.fill(isMinMaxSet, true);
+    minMaxIndex.setIsMinMaxSet(isMinMaxSet);
     return minMaxIndex;
   }
 


### PR DESCRIPTION
**This PR contains**
support for writing min max based on configurable bytes count for transactional and non transactional table which covers standard carbon table, File format and SDK.
A new system level configurable property is introduced. Please find the details below for the same.
![image](https://user-images.githubusercontent.com/12965647/45622361-5e561180-baa1-11e8-8cda-2f5abdd2c35b.png) 

- [ ] Any interfaces changed?
 No
 - [ ] Any backward compatibility impacted?
 Yes. The same is handled
 - [ ] Document update required?
Yes. Will be updated in another PR
 - [ ] Testing done
Added test case and verified manually       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA
