### PR TITLE
[CARBONDATA-2940]Fix BufferUnderFlowException for ComplexPushDown

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/blocklet/BlockletEncodedColumnPage.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/blocklet/BlockletEncodedColumnPage.java
@@ -213,7 +213,7 @@ public class BlockletEncodedColumnPage {
           new DecoderBasedFallbackEncoder(encodedColumnPage, pageIndex, localDictionaryGenerator)));
     } else {
       fallbackFutureQueue.add(fallbackExecutorService.submit(
-          new ActualDataBasedFallbackEncoder(encodedColumnPage, encodedColumnPageList.size())));
+          new ActualDataBasedFallbackEncoder(encodedColumnPage, pageIndex)));
     }
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/scan/collector/impl/DictionaryBasedResultCollector.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/collector/impl/DictionaryBasedResultCollector.java
@@ -231,6 +231,9 @@ public class DictionaryBasedResultCollector extends AbstractScannedResultCollect
         childColumnByteBuffer
             .put(queryDimensions[i].getDimension(), buffer);
         mergedComplexDimensionDataMap.put(complexParentOrdinal, childColumnByteBuffer);
+      } else if (!queryDimensions[i].getDimension().isComplex()) {
+        // If Dimension is not a Complex Column, then increment index for noDictionaryComplexColumn
+        noDictionaryComplexColumnIndex++;
       }
     }
   }

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/complexType/TestComplexDataType.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/complexType/TestComplexDataType.scala
@@ -1015,6 +1015,9 @@ class TestComplexDataType extends QueryTest with BeforeAndAfterAll {
       "create table table1 (id int, name string, structField struct<intval:int, stringval:string>) stored by 'carbondata'")
     sql("insert into table1 values(null,'aaa','23$bb')")
     checkAnswer(sql("select * from table1"),Seq(Row(null,"aaa", Row(23,"bb"))))
+    checkAnswer(sql("select id,name,structField.intval,structField.stringval from table1"),Seq(Row(null,"aaa",23,"bb")))
+    checkAnswer(sql("select id,name,structField.intval,structField.stringval,name from table1"),Seq(Row(null,"aaa",23,"bb","aaa")))
+    checkAnswer(sql("select id,name,structField.intval,name,structField.stringval from table1"),Seq(Row(null,"aaa",23,"aaa","bb")))
   }
 
 }


### PR DESCRIPTION
**Problem:**
BufferUnderFlow Exception was thrown, as buffer data was filled with wrong values.
**Solution:**
Check for if column is of Primitive Dimension column with ComplexParentOrdinal = -1 and not Complex and increment Buffer index for NoDictionaryKeys.

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [x] Testing done
        Added testcase scenario
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

