### PR TITLE
[CARBONDATA-2945] Support ingest JSON record using StreamSQL

### DIFF
--- a/examples/spark2/src/main/scala/org/apache/carbondata/examples/StreamSQLExample.scala
+++ b/examples/spark2/src/main/scala/org/apache/carbondata/examples/StreamSQLExample.scala
@@ -17,7 +17,6 @@
 
 package org.apache.carbondata.examples
 
-import java.io.File
 import java.net.ServerSocket
 
 import org.apache.carbondata.examples.util.ExampleUtils
@@ -26,13 +25,9 @@ import org.apache.carbondata.examples.util.ExampleUtils
 object StreamSQLExample {
   def main(args: Array[String]) {
 
-    // setup paths
-    val rootPath = new File(this.getClass.getResource("/").getPath
-                            + "../../../..").getCanonicalPath
-
     val spark = ExampleUtils.createCarbonSession("StructuredStreamingExample", 4)
-
     val requireCreateTable = true
+    val recordFormat = "json" // or "csv"
 
     if (requireCreateTable) {
       // drop table if exists previously
@@ -56,7 +51,7 @@ object StreamSQLExample {
     }
 
     spark.sql(
-      """
+      s"""
         | CREATE TABLE source (
         | id INT,
         | name STRING,
@@ -69,7 +64,9 @@ object StreamSQLExample {
         | 'streaming'='source',
         | 'format'='socket',
         | 'host'='localhost',
-        | 'port'='7071')
+        | 'port'='7071',
+        | 'record_format'='$recordFormat'
+        | )
       """.stripMargin)
 
     val serverSocket = new ServerSocket(7071)
@@ -86,7 +83,7 @@ object StreamSQLExample {
 
     // start writing data into the socket
     import StructuredStreamingExample.{showTableCount, writeSocket}
-    val thread1 = writeSocket(serverSocket)
+    val thread1 = writeSocket(serverSocket, recordFormat)
     val thread2 = showTableCount(spark, "sink")
 
     System.out.println("type enter to interrupt streaming")

--- a/examples/spark2/src/main/scala/org/apache/carbondata/examples/StreamSQLExample.scala
+++ b/examples/spark2/src/main/scala/org/apache/carbondata/examples/StreamSQLExample.scala
@@ -27,7 +27,7 @@ object StreamSQLExample {
 
     val spark = ExampleUtils.createCarbonSession("StructuredStreamingExample", 4)
     val requireCreateTable = true
-    val recordFormat = "json" // or "csv"
+    val recordFormat = "json" // can be "json" or "csv"
 
     if (requireCreateTable) {
       // drop table if exists previously
@@ -40,7 +40,6 @@ object StreamSQLExample {
            | CREATE TABLE sink(
            | id INT,
            | name STRING,
-           | city STRING,
            | salary FLOAT,
            | file struct<school:array<string>, age:int>
            | )
@@ -55,7 +54,6 @@ object StreamSQLExample {
         | CREATE TABLE source (
         | id INT,
         | name STRING,
-        | city STRING,
         | salary FLOAT,
         | file struct<school:array<string>, age:int>
         | )

--- a/examples/spark2/src/main/scala/org/apache/carbondata/examples/StructuredStreamingExample.scala
+++ b/examples/spark2/src/main/scala/org/apache/carbondata/examples/StructuredStreamingExample.scala
@@ -176,7 +176,7 @@ object StructuredStreamingExample {
     thread
   }
 
-  def writeSocket(serverSocket: ServerSocket): Thread = {
+  def writeSocket(serverSocket: ServerSocket, recordFormat: String = "csv"): Thread = {
     val thread = new Thread() {
       override def run(): Unit = {
         // wait for client to connection request and accept
@@ -187,9 +187,15 @@ object StructuredStreamingExample {
           // write 5 records per iteration
           for (_ <- 0 to 1000) {
             index = index + 1
-            socketWriter.println(index.toString + ",name_" + index
-                                 + ",city_" + index + "," + (index * 10000.00).toString +
-                                 ",school_" + index + ":school_" + index + index + "$" + index)
+            recordFormat match {
+              case "csv" =>
+                socketWriter.println(index.toString + ",name_" + index
+                                     + ",city_" + index + "," + (index * 10000.00).toString +
+                                     ",school_" + index + ":school_" + index + index + "$" + index)
+              case "json" =>
+                socketWriter.println(
+                  s"""{"id":$index,"name":"name_$index","city":"city_$index","salary":${index * 10000.00},"file":{"school":["school_1","school_2"],"age":$index}}""")
+            }
           }
           socketWriter.flush()
           Thread.sleep(1000)

--- a/examples/spark2/src/main/scala/org/apache/carbondata/examples/StructuredStreamingExample.scala
+++ b/examples/spark2/src/main/scala/org/apache/carbondata/examples/StructuredStreamingExample.scala
@@ -52,7 +52,6 @@ object StructuredStreamingExample {
              | CREATE TABLE ${ streamTableName }(
              | id INT,
              | name STRING,
-             | city STRING,
              | salary FLOAT,
              | file struct<school:array<string>, age:int>
              | )
@@ -66,7 +65,6 @@ object StructuredStreamingExample {
              | CREATE TABLE ${ streamTableName }(
              | id INT,
              | name STRING,
-             | city STRING,
              | salary FLOAT
              | )
              | STORED BY 'carbondata'
@@ -190,11 +188,11 @@ object StructuredStreamingExample {
             recordFormat match {
               case "csv" =>
                 socketWriter.println(index.toString + ",name_" + index
-                                     + ",city_" + index + "," + (index * 10000.00).toString +
+                                     + "," + (index * 10000.00).toString +
                                      ",school_" + index + ":school_" + index + index + "$" + index)
               case "json" =>
                 socketWriter.println(
-                  s"""{"id":$index,"name":"name_$index","city":"city_$index","salary":${index * 10000.00},"file":{"school":["school_1","school_2"],"age":$index}}""")
+                  s"""{"id":$index,"name":"s","salary":4.3,"file":{"school":["a","b"],"age":6}}""")
             }
           }
           socketWriter.flush()


### PR DESCRIPTION
Support ingest JSON record from Kafka/socket stream source in StreamSQL
A tblproperty called "record_format" is added, for example, following creates a stream source table on kafka whose record format is json
```
CREATE TABLE source (
    id INT,
    name STRING,
    city STRING,
    salary FLOAT,
    file struct<school:array<string>, age:int>
)
STORED AS carbondata
TBLPROPERTIES(
    'streaming'='source',
    'format'='kafka',
    'kafka.bootstrap.servers'='localhost:9092',
    'subscribe'='test',
    'record_format'='json'   // can be csv or json
)
```
Please refer to StreamSQLExample for more detail

 - [X] Any interfaces changed?
 No
 - [X] Any backward compatibility impacted?
 No
 - [X] Document update required?
Yes
 - [X] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [X] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA