### PR TITLE
[CARBONDATA-2946] Unify conversion while writing to Bloom

### DIFF
--- a/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/AbstractBloomDataMapWriter.java
+++ b/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/AbstractBloomDataMapWriter.java
@@ -36,6 +36,7 @@ import org.apache.carbondata.core.metadata.datatype.DataTypes;
 import org.apache.carbondata.core.metadata.encoder.Encoding;
 import org.apache.carbondata.core.metadata.schema.table.column.CarbonColumn;
 import org.apache.carbondata.core.util.CarbonUtil;
+import org.apache.carbondata.core.util.DataTypeUtil;
 
 import org.apache.hadoop.util.bloom.CarbonBloomFilter;
 import org.apache.hadoop.util.bloom.Key;
@@ -52,6 +53,7 @@ public abstract class AbstractBloomDataMapWriter extends DataMapWriter {
   private List<String> currentDMFiles;
   private List<DataOutputStream> currentDataOutStreams;
   protected List<CarbonBloomFilter> indexBloomFilters;
+  private boolean[] isNoDictionaryPrimitive;
 
   AbstractBloomDataMapWriter(String tablePath, String dataMapName, List<CarbonColumn> indexColumns,
       Segment segment, String shardName, SegmentProperties segmentProperties,
@@ -64,6 +66,11 @@ public abstract class AbstractBloomDataMapWriter extends DataMapWriter {
     currentDMFiles = new ArrayList<>(indexColumns.size());
     currentDataOutStreams = new ArrayList<>(indexColumns.size());
     indexBloomFilters = new ArrayList<>(indexColumns.size());
+    // to get the null value of the no dictionary primitive column
+    isNoDictionaryPrimitive = new boolean[indexColumns.size()];
+    for (int i = 0; i < indexColumns.size(); i++) {
+      isNoDictionaryPrimitive[i] = checkNoDictionaryPrimitiveDataType(i);
+    }
     initDataMapFile();
     resetBloomFilters();
   }
@@ -119,10 +126,26 @@ public abstract class AbstractBloomDataMapWriter extends DataMapWriter {
     for (int rowId = 0; rowId < pageSize; rowId++) {
       // for each indexed column, add the data to index
       for (int i = 0; i < indexColumns.size(); i++) {
-        Object data = pages[i].getData(rowId);
-        addValue2BloomIndex(i, data);
+        // in primitive no dictionary page, null is written as 0.
+        // check the null bitsets from the page and consider it as null value
+        if (isNoDictionaryPrimitive[i] && pages[i].getNullBits().get(rowId)) {
+          addValue2BloomIndex(i, null);
+        } else {
+          Object data = pages[i].getData(rowId);
+          addValue2BloomIndex(i, data);
+        }
       }
     }
+  }
+
+  private boolean checkNoDictionaryPrimitiveDataType(int index) {
+    if (indexColumns.get(index).isDimension() && !(
+        indexColumns.get(index).hasEncoding(Encoding.DICTIONARY) || indexColumns.get(index)
+            .hasEncoding(Encoding.DIRECT_DICTIONARY)) && DataTypeUtil
+        .isPrimitiveColumn(indexColumns.get(index).getDataType())) {
+      return true;
+    }
+    return false;
   }
 
   protected void addValue2BloomIndex(int indexColIdx, Object value) {

--- a/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomCoarseGrainDataMap.java
+++ b/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomCoarseGrainDataMap.java
@@ -288,12 +288,16 @@ public class BloomCoarseGrainDataMap extends CoarseGrainDataMap {
       format.setTimeZone(TimeZone.getTimeZone("GMT"));
 
       literalValue = format.format(new Date((long) expressionValue / 1000));
-    } else if (le.getLiteralExpDataType() == DataTypes.TIMESTAMP) {
+    } else if (le.getLiteralExpDataType() == DataTypes.TIMESTAMP && (
+        this.name2Col.get(columnName).hasEncoding(Encoding.DICTIONARY) || this.name2Col
+            .get(columnName).hasEncoding(Encoding.DIRECT_DICTIONARY))) {
       DateFormat format =
           new SimpleDateFormat(CarbonCommonConstants.CARBON_TIMESTAMP_DEFAULT_FORMAT);
       // the below settings are set statically according to TimeStampDirectDirectionaryGenerator
       format.setLenient(false);
       literalValue = format.format(new Date((long) expressionValue / 1000));
+    } else if (le.getLiteralExpDataType() == DataTypes.TIMESTAMP) {
+      literalValue = (long) expressionValue / 1000L;
     } else {
       literalValue = expressionValue;
     }
@@ -323,12 +327,12 @@ public class BloomCoarseGrainDataMap extends CoarseGrainDataMap {
     if (null != filterLiteralValue) {
       strFilterValue = String.valueOf(filterLiteralValue);
     }
-
-    Object convertedValue = this.name2Converters.get(carbonColumn.getColName()).convert(
-        strFilterValue, badRecordLogHolder);
+    Object convertedValue = null;
 
     byte[] internalFilterValue;
     if (carbonColumn.isMeasure()) {
+      convertedValue = this.name2Converters.get(carbonColumn.getColName())
+          .convert(strFilterValue, badRecordLogHolder);
       // for measures, the value is already the type, just convert it to bytes.
       if (convertedValue == null) {
         convertedValue = DataConvertUtil.getNullValueForMeasure(carbonColumn.getDataType(),
@@ -336,26 +340,20 @@ public class BloomCoarseGrainDataMap extends CoarseGrainDataMap {
       }
       // Carbon stores boolean as byte. Here we convert it for `getValueAsBytes`
       if (carbonColumn.getDataType().equals(DataTypes.BOOLEAN)) {
-        convertedValue = BooleanConvert.boolean2Byte((Boolean)convertedValue);
+        convertedValue = BooleanConvert.boolean2Byte((Boolean) convertedValue);
       }
       internalFilterValue = CarbonUtil.getValueAsBytes(carbonColumn.getDataType(), convertedValue);
-    } else if (carbonColumn.hasEncoding(Encoding.DIRECT_DICTIONARY) ||
-        carbonColumn.hasEncoding(Encoding.DICTIONARY)) {
+    } else if (carbonColumn.hasEncoding(Encoding.DIRECT_DICTIONARY) || carbonColumn
+        .hasEncoding(Encoding.DICTIONARY)) {
+      convertedValue = this.name2Converters.get(carbonColumn.getColName())
+          .convert(strFilterValue, badRecordLogHolder);
       // for dictionary/date columns, convert the surrogate key to bytes
       internalFilterValue = CarbonUtil.getValueAsBytes(DataTypes.INT, convertedValue);
     } else {
-      // for non dictionary dimensions, numeric columns will be of original data,
-      // so convert the data to bytes
-      if (DataTypeUtil.isPrimitiveColumn(carbonColumn.getDataType())) {
-        if (convertedValue == null) {
-          convertedValue = DataConvertUtil.getNullValueForMeasure(carbonColumn.getDataType(),
-              carbonColumn.getColumnSchema().getScale());
-        }
-        internalFilterValue =
-            CarbonUtil.getValueAsBytes(carbonColumn.getDataType(), convertedValue);
-      } else {
-        internalFilterValue = (byte[]) convertedValue;
-      }
+      // for non dictionary dimensions, convert the filter value to bytes based on the data type
+      internalFilterValue = DataTypeUtil
+          .getBytesDataDataTypeForNoDictionaryColumn(filterLiteralValue,
+              carbonColumn.getDataType());
     }
     if (internalFilterValue.length == 0) {
       internalFilterValue = CarbonCommonConstants.MEMBER_DEFAULT_VAL_ARRAY;

--- a/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomDataMapBuilder.java
+++ b/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomDataMapBuilder.java
@@ -65,7 +65,8 @@ public class BloomDataMapBuilder extends AbstractBloomDataMapWriter implements D
   protected byte[] convertNonDictionaryValue(int indexColIdx, Object value) {
     // no dictionary measure columns will be of original data, so convert it to bytes
     if (DataTypeUtil.isPrimitiveColumn(indexColumns.get(indexColIdx).getDataType())) {
-      return CarbonUtil.getValueAsBytes(indexColumns.get(indexColIdx).getDataType(), value);
+      return DataTypeUtil.getBytesDataDataTypeForNoDictionaryColumn(value,
+          indexColumns.get(indexColIdx).getDataType());
     }
     return (byte[]) value;
   }

--- a/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomDataMapWriter.java
+++ b/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomDataMapWriter.java
@@ -79,7 +79,8 @@ public class BloomDataMapWriter extends AbstractBloomDataMapWriter {
       return DataConvertUtil.getRawBytesForVarchar((byte[]) value);
     } else if (DataTypeUtil.isPrimitiveColumn(indexColumns.get(indexColIdx).getDataType())) {
       // get bytes for the original value of the no dictionary column
-      return CarbonUtil.getValueAsBytes(indexColumns.get(indexColIdx).getDataType(), value);
+      return DataTypeUtil.getBytesDataDataTypeForNoDictionaryColumn(value,
+          indexColumns.get(indexColIdx).getDataType());
     } else {
       return DataConvertUtil.getRawBytes((byte[]) value);
     }

--- a/integration/spark2/src/main/scala/org/apache/carbondata/datamap/IndexDataMapRebuildRDD.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/datamap/IndexDataMapRebuildRDD.scala
@@ -271,10 +271,6 @@ class RawBytesReadSupport(segmentProperties: SegmentProperties, indexColumns: Ar
         if (DataTypeUtil.isPrimitiveColumn(col.getDataType)) {
           var dataFromBytes = DataTypeUtil
             .getDataBasedOnDataTypeForNoDictionaryColumn(bytes, col.getDataType)
-          if (dataFromBytes == null) {
-            dataFromBytes = DataConvertUtil
-              .getNullValueForMeasure(col.getDataType, col.getColumnSchema.getScale)
-          }
           // for timestamp the above method will give the original data, so it should be
           // converted again to the format to be loaded (without micros)
           if (null != dataFromBytes && col.getDataType == DataTypes.TIMESTAMP) {


### PR DESCRIPTION
**Problem:**
Bloom filter writing is like measure column. So backward compatibility is not ensured. If we are writing it as like measure column, filter queries will fail.
Lets take an INT column with value "1" as example.
Old store stores it as {-128, 0, 0, 1} = direct int to byte conversion using org.apache.carbondata.core.util.DataTypeUtil#getBytesDataDataTypeForNoDictionaryColumn
New store stores it as {0, 0, 0, 0, 0, 0, 0, 1} = value to byte array using org.apache.carbondata.core.util.CarbonUtil#getValueAsBytes

So while querying the data from bloom, filter value conversion and the comparison goes wrong.

**Solution:**
Write the bloom also same as that of no dictionary column. Take care of null bitsets(i.e null values) as null would have been written as 0 as the page is written like that of measure.

Unify the writing of bloom data for a no dictionary column. **Use direct datatype to byte conversion so that both old store and the new store no dictionary column writing will be same**.

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

