### PR TITLE
[HOTFIX] Correct metrics and avoid twice read when prefetch is disabled

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/scan/scanner/impl/BlockletFullScanner.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/scanner/impl/BlockletFullScanner.java
@@ -84,9 +84,6 @@ public class BlockletFullScanner implements BlockletScanner {
     String blockletId = blockExecutionInfo.getBlockIdString() + CarbonCommonConstants.FILE_SEPARATOR
         + rawBlockletColumnChunks.getDataBlock().blockletIndex();
     scannedResult.setBlockletId(blockletId);
-    if (!blockExecutionInfo.isPrefetchBlocklet()) {
-      readBlocklet(rawBlockletColumnChunks);
-    }
     DimensionRawColumnChunk[] dimensionRawColumnChunks =
         rawBlockletColumnChunks.getDimensionRawColumnChunks();
     DimensionColumnPage[][] dimensionColumnDataChunks =


### PR DESCRIPTION
When prefetch is disabled in full scan queries read twice the data. This PR removes extra read.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

