### PR TITLE
[CARBONDATA-2954]Fix error when create external table command fired if path already exists

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/CarbonTable.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/CarbonTable.java
@@ -261,7 +261,11 @@ public class CarbonTable implements Serializable {
     CarbonFile[] carbonFiles = tablePath.listFiles();
     for (CarbonFile carbonFile : carbonFiles) {
       if (carbonFile.isDirectory()) {
-        return getFirstIndexFile(carbonFile);
+        if (getFirstIndexFile(carbonFile) == null) {
+          continue;
+        } else {
+          return getFirstIndexFile(carbonFile);
+        }
       } else if (carbonFile.getName().endsWith(CarbonTablePath.INDEX_FILE_EXT)) {
         return carbonFile;
       }

--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/CarbonTable.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/CarbonTable.java
@@ -261,6 +261,8 @@ public class CarbonTable implements Serializable {
     CarbonFile[] carbonFiles = tablePath.listFiles();
     for (CarbonFile carbonFile : carbonFiles) {
       if (carbonFile.isDirectory()) {
+        // if the list has directories that doesn't contain index files,
+        // continue checking other files/directories in the list.
         if (getFirstIndexFile(carbonFile) == null) {
           continue;
         } else {

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
@@ -2230,7 +2230,11 @@ public final class CarbonUtil {
       if (dataFile.getName().endsWith(CarbonCommonConstants.FACT_FILE_EXT)) {
         return dataFile.getAbsolutePath();
       } else if (dataFile.isDirectory()) {
-        return getFilePathExternalFilePath(dataFile.getAbsolutePath(), configuration);
+        if (getFilePathExternalFilePath(dataFile.getAbsolutePath(), configuration) == null) {
+          continue;
+        } else {
+          return getFilePathExternalFilePath(dataFile.getAbsolutePath(), configuration);
+        }
       }
     }
     return null;

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
@@ -2230,6 +2230,8 @@ public final class CarbonUtil {
       if (dataFile.getName().endsWith(CarbonCommonConstants.FACT_FILE_EXT)) {
         return dataFile.getAbsolutePath();
       } else if (dataFile.isDirectory()) {
+        // if the list has directories that doesn't contain data files,
+        // continue checking other files/directories in the list.
         if (getFilePathExternalFilePath(dataFile.getAbsolutePath(), configuration) == null) {
           continue;
         } else {
@@ -2237,6 +2239,7 @@ public final class CarbonUtil {
         }
       }
     }
+    //returning null only if the path doesn't have data files.
     return null;
   }
 

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestNonTransactionalCarbonTable.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestNonTransactionalCarbonTable.scala
@@ -750,7 +750,6 @@ class TestNonTransactionalCarbonTable extends QueryTest with BeforeAndAfterAll {
     FileFactory.getCarbonFile(path2, FileFactory.getFileType(path2))
     FileFactory.mkdirs(path2, FileFactory.getFileType(path2))
 
-
     sql("DROP TABLE IF EXISTS sdkOutputTable")
 
     // with schema
@@ -807,10 +806,6 @@ class TestNonTransactionalCarbonTable extends QueryTest with BeforeAndAfterAll {
 
     cleanTestData()
   }
-
-
-
-
 
   test("Read sdk writer output multiple files ") {
     buildTestDataMultipleFiles()

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestNonTransactionalCarbonTable.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestNonTransactionalCarbonTable.scala
@@ -740,6 +740,17 @@ class TestNonTransactionalCarbonTable extends QueryTest with BeforeAndAfterAll {
   test("test create External Table With Schema, should ignore the schema provided") {
     buildTestDataSingleFile()
     assert(new File(writerPath).exists())
+
+    val path1 = writerPath + "/0testdir"
+    val path2 = writerPath + "/testdir"
+
+    FileFactory.getCarbonFile(path1, FileFactory.getFileType(path1))
+    FileFactory.mkdirs(path1, FileFactory.getFileType(path1))
+
+    FileFactory.getCarbonFile(path2, FileFactory.getFileType(path2))
+    FileFactory.mkdirs(path2, FileFactory.getFileType(path2))
+
+
     sql("DROP TABLE IF EXISTS sdkOutputTable")
 
     // with schema
@@ -796,6 +807,10 @@ class TestNonTransactionalCarbonTable extends QueryTest with BeforeAndAfterAll {
 
     cleanTestData()
   }
+
+
+
+
 
   test("Read sdk writer output multiple files ") {
     buildTestDataMultipleFiles()

--- a/store/sdk/src/test/java/org/apache/carbondata/sdk/file/CarbonReaderTest.java
+++ b/store/sdk/src/test/java/org/apache/carbondata/sdk/file/CarbonReaderTest.java
@@ -220,11 +220,14 @@ public class CarbonReaderTest extends TestCase {
     TestUtil.writeFilesAndVerify(200, new Schema(fields), path, false, false);
 
     ColumnExpression columnExpression = new ColumnExpression("name", DataTypes.STRING);
-    EqualToExpression equalToExpression =
-        new EqualToExpression(columnExpression, new LiteralExpression("robot1", DataTypes.STRING));
+    EqualToExpression equalToExpression = new EqualToExpression(columnExpression,
+        new LiteralExpression("robot1", DataTypes.STRING));
 
-    CarbonReader reader = CarbonReader.builder(path, "_temp").isTransactionalTable(false)
-        .projection(new String[] { "name", "age" }).filter(equalToExpression)
+    CarbonReader reader = CarbonReader
+        .builder(path, "_temp")
+        .isTransactionalTable(false)
+        .projection(new String[]{"name", "age"})
+        .filter(equalToExpression)
         .build(conf);
 
     int i = 0;

--- a/store/sdk/src/test/java/org/apache/carbondata/sdk/file/CarbonReaderTest.java
+++ b/store/sdk/src/test/java/org/apache/carbondata/sdk/file/CarbonReaderTest.java
@@ -27,6 +27,7 @@ import org.apache.carbondata.common.exceptions.sql.InvalidLoadOptionException;
 import org.apache.carbondata.common.logging.LogService;
 import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
+import org.apache.carbondata.core.datastore.impl.FileFactory;
 import org.apache.carbondata.core.metadata.datatype.DataTypes;
 import org.apache.carbondata.core.metadata.schema.table.DiskBasedDMSchemaStorageProvider;
 import org.apache.carbondata.core.scan.expression.ColumnExpression;
@@ -201,6 +202,17 @@ public class CarbonReaderTest extends TestCase {
     String path = "./testWriteFiles";
     FileUtils.deleteDirectory(new File(path));
 
+    String path1 = path + "/0testdir";
+    String path2 = path + "/testdir";
+
+    FileUtils.deleteDirectory(new File(path));
+
+    FileFactory.getCarbonFile(path1, FileFactory.getFileType(path1));
+    FileFactory.mkdirs(path1, FileFactory.getFileType(path1));
+
+    FileFactory.getCarbonFile(path2, FileFactory.getFileType(path2));
+    FileFactory.mkdirs(path2, FileFactory.getFileType(path2));
+
     Field[] fields = new Field[2];
     fields[0] = new Field("name", DataTypes.STRING);
     fields[1] = new Field("age", DataTypes.INT);
@@ -208,14 +220,11 @@ public class CarbonReaderTest extends TestCase {
     TestUtil.writeFilesAndVerify(200, new Schema(fields), path, false, false);
 
     ColumnExpression columnExpression = new ColumnExpression("name", DataTypes.STRING);
-    EqualToExpression equalToExpression = new EqualToExpression(columnExpression,
-        new LiteralExpression("robot1", DataTypes.STRING));
+    EqualToExpression equalToExpression =
+        new EqualToExpression(columnExpression, new LiteralExpression("robot1", DataTypes.STRING));
 
-    CarbonReader reader = CarbonReader
-        .builder(path, "_temp")
-        .isTransactionalTable(false)
-        .projection(new String[]{"name", "age"})
-        .filter(equalToExpression)
+    CarbonReader reader = CarbonReader.builder(path, "_temp").isTransactionalTable(false)
+        .projection(new String[] { "name", "age" }).filter(equalToExpression)
         .build(conf);
 
     int i = 0;


### PR DESCRIPTION
Problem : Creating a external table and providing a valid location having some empty directory and .carbondata files was giving "operation not allowed: invalid datapath provided" error.

Solution: It was happening because if the location was having some empty directory getFilePathExternalFilePath method in carbonutil.java was returning null due to the presence of empty directory.So made a slight modification to prevent this problem.



 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [x] Testing done
        manually tested.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

