### PR TITLE
[CARBONDATA-2956] CarbonReader support use configuration to read S3 data

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/CarbonTable.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/CarbonTable.java
@@ -63,6 +63,8 @@ import org.apache.carbondata.core.util.path.CarbonTablePath;
 import static org.apache.carbondata.core.metadata.schema.datamap.DataMapClassProvider.MV;
 import static org.apache.carbondata.core.util.CarbonUtil.thriftColumnSchemaToWrapperColumnSchema;
 
+import org.apache.hadoop.conf.Configuration;
+
 /**
  * Mapping class for Carbon actual table
  */
@@ -236,9 +238,10 @@ public class CarbonTable implements Serializable {
 
   public static CarbonTable buildTable(
       String tablePath,
-      String tableName) throws IOException {
+      String tableName,
+      Configuration configuration) throws IOException {
     TableInfo tableInfoInfer = CarbonUtil.buildDummyTableInfo(tablePath, "null", "null");
-    CarbonFile carbonFile = getFirstIndexFile(FileFactory.getCarbonFile(tablePath));
+    CarbonFile carbonFile = getFirstIndexFile(FileFactory.getCarbonFile(tablePath, configuration));
     if (carbonFile == null) {
       throw new RuntimeException("Carbon index file not exists.");
     }

--- a/core/src/main/java/org/apache/carbondata/core/readcommitter/LatestFilesReadCommittedScope.java
+++ b/core/src/main/java/org/apache/carbondata/core/readcommitter/LatestFilesReadCommittedScope.java
@@ -178,7 +178,7 @@ public class LatestFilesReadCommittedScope implements ReadCommittedScope {
 
   @Override public void takeCarbonIndexFileSnapShot() throws IOException {
     // Read the current file Path get the list of indexes from the path.
-    CarbonFile file = FileFactory.getCarbonFile(carbonFilePath);
+    CarbonFile file = FileFactory.getCarbonFile(carbonFilePath, configuration);
 
     CarbonFile[] carbonIndexFiles = null;
     if (file.isDirectory()) {

--- a/examples/spark2/src/main/java/org/apache/carbondata/examples/sdk/SDKS3ReadExample.java
+++ b/examples/spark2/src/main/java/org/apache/carbondata/examples/sdk/SDKS3ReadExample.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.examples.sdk;
+
+import org.apache.carbondata.common.logging.LogService;
+import org.apache.carbondata.common.logging.LogServiceFactory;
+import org.apache.carbondata.core.metadata.datatype.DataTypes;
+import org.apache.carbondata.core.scan.expression.ColumnExpression;
+import org.apache.carbondata.core.scan.expression.LiteralExpression;
+import org.apache.carbondata.core.scan.expression.conditional.EqualToExpression;
+import org.apache.carbondata.sdk.file.*;
+
+import org.apache.hadoop.conf.Configuration;
+
+import static org.apache.hadoop.fs.s3a.Constants.ACCESS_KEY;
+import static org.apache.hadoop.fs.s3a.Constants.ENDPOINT;
+import static org.apache.hadoop.fs.s3a.Constants.SECRET_KEY;
+
+/**
+ * Example for testing carbonReader on S3
+ */
+public class SDKS3ReadExample {
+    public static void main(String[] args) throws Exception {
+        LogService logger = LogServiceFactory.getLogService(SDKS3ReadExample.class.getName());
+        if (args == null || args.length < 3) {
+            logger.error("Usage: java CarbonS3Example: <access-key> <secret-key>"
+                + "<s3-endpoint> [table-path-on-s3]");
+            System.exit(0);
+        }
+
+        String path = "s3a://sdk/WriterOutput";
+        if (args.length > 3) {
+            path=args[3];
+        }
+
+        // Read data
+
+        EqualToExpression equalToExpression = new EqualToExpression(
+            new ColumnExpression("name", DataTypes.STRING),
+            new LiteralExpression("robot1", DataTypes.STRING));
+
+        Configuration configuration = new Configuration();
+        configuration.set(ACCESS_KEY, args[0]);
+        configuration.set(SECRET_KEY, args[1]);
+        configuration.set(ENDPOINT, args[2]);
+        CarbonReader reader = CarbonReader
+            .builder(path, "_temp")
+            .projection(new String[]{"name", "age"})
+            .filter(equalToExpression)
+            .build(configuration);
+
+        System.out.println("\nData:");
+        int i = 0;
+        while (i < 20 && reader.hasNext()) {
+            Object[] row = (Object[]) reader.readNextRow();
+            System.out.println(row[0] + " " + row[1]);
+            i++;
+        }
+        System.out.println("\nFinished");
+        reader.close();
+
+        // Read without filter
+        CarbonReader reader2 = CarbonReader
+            .builder(path, "_temp")
+            .projection(new String[]{"name", "age"})
+            .build(configuration);
+
+        System.out.println("\nData:");
+        i = 0;
+        while (i < 20 && reader2.hasNext()) {
+            Object[] row = (Object[]) reader2.readNextRow();
+            System.out.println(row[0] + " " + row[1]);
+            i++;
+        }
+        System.out.println("\nFinished");
+        reader2.close();
+    }
+}

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonReaderBuilder.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonReaderBuilder.java
@@ -188,7 +188,7 @@ public class CarbonReaderBuilder {
           .buildFromTablePath(tableName, "default", tablePath, UUID.randomUUID().toString());
     } else {
       if (filterExpression != null) {
-        table = CarbonTable.buildTable(tablePath, tableName);
+        table = CarbonTable.buildTable(tablePath, tableName, configuration);
       } else {
         table = CarbonTable.buildDummyTable(tablePath);
       }


### PR DESCRIPTION
[CARBONDATA-2956] CarbonReader support use configuration to read S3 data
1.with filter
2.without filter function

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 NO
 - [ ] Any backward compatibility impacted?
 NO
 - [ ] Document update required?
NO
 - [ ] Testing done
     add example
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NO