### PR TITLE
[CARBONDATA-2953]fixed dataload failure with sort columns and query wrong result from other session

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/datamap/CarbonDataMapShowCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/datamap/CarbonDataMapShowCommand.scala
@@ -57,8 +57,8 @@ case class CarbonDataMapShowCommand(tableIdentifier: Option[TableIdentifier])
     val dataMapSchemaList: util.List[DataMapSchema] = new util.ArrayList[DataMapSchema]()
     tableIdentifier match {
       case Some(table) =>
-        Checker.validateTableExists(table.database, table.table, sparkSession)
         val carbonTable = CarbonEnv.getCarbonTable(table)(sparkSession)
+        Checker.validateTableExists(table.database, table.table, sparkSession)
         if (carbonTable.hasDataMapSchema) {
           dataMapSchemaList.addAll(carbonTable.getTableInfo.getDataMapSchemaList)
         }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonFileMetastore.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonFileMetastore.scala
@@ -580,7 +580,10 @@ class CarbonFileMetastore extends CarbonMetaStore {
             tableModifiedTimeStore.get(CarbonCommonConstants.DATABASE_DEFAULT_NAME))) {
         metadata.carbonTables = metadata.carbonTables.filterNot(
           table => table.getTableName.equalsIgnoreCase(tableIdentifier.table) &&
-        table.getDatabaseName.equalsIgnoreCase(tableIdentifier.database.getOrElse("default")))
+                   table.getDatabaseName
+                     .equalsIgnoreCase(tableIdentifier.database
+                       .getOrElse(SparkSession.getActiveSession.get.sessionState.catalog
+                         .getCurrentDatabase)))
         updateSchemasUpdatedTime(lastModifiedTime)
         isRefreshed = true
       }

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/partition/impl/RawRowComparator.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/partition/impl/RawRowComparator.java
@@ -57,7 +57,6 @@ public class RawRowComparator implements Comparator<CarbonRow> {
           if (difference != 0) {
             return difference;
           }
-          noDicIdx++;
         } else {
           byte[] colA = (byte[]) o1.getObject(colIdx);
           byte[] colB = (byte[]) o2.getObject(colIdx);
@@ -66,6 +65,7 @@ public class RawRowComparator implements Comparator<CarbonRow> {
             return diff;
           }
         }
+        noDicIdx++;
       } else {
         int colA = (int) o1.getObject(colIdx);
         int colB = (int) o2.getObject(colIdx);

--- a/processing/src/main/java/org/apache/carbondata/processing/sort/sortdata/IntermediateSortTempRowComparator.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/sort/sortdata/IntermediateSortTempRowComparator.java
@@ -66,7 +66,6 @@ public class IntermediateSortTempRowComparator implements Comparator<Intermediat
           if (difference != 0) {
             return difference;
           }
-          noDicTypeIdx++;
         } else {
           byte[] byteArr1 = (byte[]) rowA.getNoDictSortDims()[nonDictIndex];
           byte[] byteArr2 = (byte[]) rowB.getNoDictSortDims()[nonDictIndex];
@@ -77,6 +76,7 @@ public class IntermediateSortTempRowComparator implements Comparator<Intermediat
           }
         }
         nonDictIndex++;
+        noDicTypeIdx++;
       } else {
         int dimFieldA = rowA.getDictSortDims()[dictIndex];
         int dimFieldB = rowB.getDictSortDims()[dictIndex];

--- a/processing/src/main/java/org/apache/carbondata/processing/sort/sortdata/NewRowComparator.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/sort/sortdata/NewRowComparator.java
@@ -68,7 +68,6 @@ public class NewRowComparator implements Comparator<Object[]>, Serializable {
             if (difference != 0) {
               return difference;
             }
-            dataTypeIdx++;
           } else {
             byte[] byteArr1 = (byte[]) rowA[index];
             byte[] byteArr2 = (byte[]) rowB[index];
@@ -79,6 +78,7 @@ public class NewRowComparator implements Comparator<Object[]>, Serializable {
             }
           }
         }
+        dataTypeIdx++;
       } else {
         int dimFieldA = (int) rowA[index];
         int dimFieldB = (int) rowB[index];


### PR DESCRIPTION
### Problem:
1) when dataload is done with sort columns, it fails with following exeptions
2) when two sessions are running in parallel, the follow below steps in session1
		drop table
		create table
		load data to table
   follow below step in session2
		query on table(select * from table limit 1), then the query returns null result instead of proper result

### Solution
1) During sorting, the index increament for no dictionary measure data was not happening correctly, hence was trying to cast to byte array and failing
2) If table is dropped from first session and created again, and queries from another session, the metastore needs to be updated for newly created table, but since the database in identifier was None. we were trying to get old table from default database, here need to get from current database

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 NA
 - [x] Any backward compatibility impacted?
 NA
 - [x] Document update required?
NA
 - [x] Testing done
Tested in three node cluster, and existing test cases will take care
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA
