### PR TITLE
[CARBONDATA-2960] SDK Reader fix with projection columns

### DIFF
--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonInputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonInputFormat.java
@@ -775,9 +775,18 @@ m filterExpression
   public String[] projectAllColumns(CarbonTable carbonTable) {
     List<ColumnSchema> colList = carbonTable.getTableInfo().getFactTable().getListOfColumns();
     List<String> projectColumn = new ArrayList<>();
+    int childDimCount = 0;
     for (ColumnSchema cols : colList) {
       if (cols.getSchemaOrdinal() != -1) {
-        projectColumn.add(cols.getColumnName());
+        if (childDimCount == 0) {
+          projectColumn.add(cols.getColumnName());
+        }
+        if (childDimCount > 0) {
+          childDimCount--;
+        }
+        if (cols.getDataType().isComplexType()) {
+          childDimCount += cols.getNumberOfChild();
+        }
       }
     }
     String[] projectionColumns = new String[projectColumn.size()];

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonInputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonInputFormat.java
@@ -775,6 +775,8 @@ m filterExpression
   public String[] projectAllColumns(CarbonTable carbonTable) {
     List<ColumnSchema> colList = carbonTable.getTableInfo().getFactTable().getListOfColumns();
     List<String> projectColumn = new ArrayList<>();
+    // childCount will recursively count the number of children for any parent
+    // complex type and add just the parent column name while skipping the child columns.
     int childDimCount = 0;
     for (ColumnSchema cols : colList) {
       if (cols.getSchemaOrdinal() != -1) {

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestNonTransactionalCarbonTableForMapType.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestNonTransactionalCarbonTableForMapType.scala
@@ -20,14 +20,19 @@ package org.apache.carbondata.spark.testsuite.createTable
 import java.io.File
 
 import org.apache.commons.io.FileUtils
+import org.apache.hadoop.conf.Configuration
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.test.util.QueryTest
 import org.scalatest.BeforeAndAfterAll
+
+import org.apache.carbondata.sdk.file.CarbonReader
 
 /**
  * test cases for SDK complex map data type support
  */
 class TestNonTransactionalCarbonTableForMapType extends QueryTest with BeforeAndAfterAll {
+
+  private val conf: Configuration = new Configuration(false)
 
   private val nonTransactionalCarbonTable = new TestNonTransactionalCarbonTable
   private val writerPath = nonTransactionalCarbonTable.writerPath
@@ -399,6 +404,43 @@ class TestNonTransactionalCarbonTableForMapType extends QueryTest with BeforeAnd
 
   override def beforeAll(): Unit = {
     dropSchema
+  }
+
+  test("SDK Reader Without Projection Columns"){
+    deleteDirectory(writerPath)
+    val mySchema =
+      """
+        |{
+        |  "name": "address",
+        |  "type": "record",
+        |  "fields": [
+        |    {
+        |      "name": "name",
+        |      "type": "string"
+        |    },
+        |    {
+        |      "name": "age",
+        |      "type": "int"
+        |    },
+        |    {
+        |      "name": "arrayRecord",
+        |      "type": {
+        |        "type": "array",
+        |        "items": {
+        |           "name": "houseDetails",
+        |           "type": "map",
+        |           "values": "string"
+        |        }
+        |      }
+        |    }
+        |  ]
+        |}
+      """.stripMargin
+    val json = """ {"name":"bob", "age":10, "arrayRecord": [{"101": "Rahul", "102": "Pawan"}]} """.stripMargin
+    nonTransactionalCarbonTable.WriteFilesWithAvroWriter(2, mySchema, json)
+
+    val reader = CarbonReader.builder(writerPath, "_temp").isTransactionalTable(false).build(conf)
+    println("Done test")
   }
 
   test("Read sdk writer Avro output Map Type") {

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestNonTransactionalCarbonTableForMapType.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestNonTransactionalCarbonTableForMapType.scala
@@ -440,8 +440,19 @@ class TestNonTransactionalCarbonTableForMapType extends QueryTest with BeforeAnd
     nonTransactionalCarbonTable.WriteFilesWithAvroWriter(2, mySchema, json)
 
     val reader = CarbonReader.builder(writerPath, "_temp").isTransactionalTable(false).build(conf)
+    reader.close()
+    val exception1 = intercept[Exception] {
+      val reader1 = CarbonReader.builder(writerPath, "_temp")
+        .projection(Array[String] { "arrayRecord.houseDetails" }).isTransactionalTable(false)
+        .build(conf)
+      reader1.close()
+    }
+    assert(exception1.getMessage
+      .contains(
+        "Complex child columns projection NOT supported through CarbonReader"))
     println("Done test")
   }
+
 
   test("Read sdk writer Avro output Map Type") {
     buildMapSchema(3)

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonReaderBuilder.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonReaderBuilder.java
@@ -206,8 +206,9 @@ public class CarbonReaderBuilder {
     if (projectionColumns != null) {
       // set the user projection
       int len = projectionColumns.length;
+      //      TODO : Handle projection of complex child columns
       for (int i = 0; i < len; i++) {
-        if (projectionColumns[i].contains("\\.")) {
+        if (projectionColumns[i].contains(".")) {
           throw new UnsupportedOperationException(
               "Complex child columns projection NOT supported through CarbonReader");
         }

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonReaderBuilder.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonReaderBuilder.java
@@ -205,6 +205,13 @@ public class CarbonReaderBuilder {
 
     if (projectionColumns != null) {
       // set the user projection
+      int len = projectionColumns.length;
+      for (int i = 0; i < len; i++) {
+        if (projectionColumns[i].contains("\\.")) {
+          throw new UnsupportedOperationException(
+              "Complex child columns projection NOT supported through CarbonReader");
+        }
+      }
       format.setColumnProjection(job.getConfiguration(), projectionColumns);
     }
 


### PR DESCRIPTION
SDK Reader was not working when all projection columns were given.
Added exception for Complex child projections too.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [x] Testing done
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

