### PR TITLE
[CARBONDATA-2964] Fix for unsupported float data type bug

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/scan/collector/impl/AbstractScannedResultCollector.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/collector/impl/AbstractScannedResultCollector.java
@@ -145,6 +145,8 @@ public abstract class AbstractScannedResultCollector implements ScannedResultCol
         return dataChunk.getLong(index);
       } else if (dataType == DataTypes.FLOAT) {
         return dataChunk.getFloat(index);
+      } else if (dataType == DataTypes.BYTE) {
+        return dataChunk.getByte(index);
       } else if (DataTypes.isDecimal(dataType)) {
         BigDecimal bigDecimalMsrValue = dataChunk.getDecimal(index);
         if (null != bigDecimalMsrValue && carbonMeasure.getScale() > bigDecimalMsrValue.scale()) {

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonMetadataUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonMetadataUtil.java
@@ -464,7 +464,7 @@ public class CarbonMetadataUtil {
   private static int compareMeasureData(byte[] first, byte[] second, DataType dataType) {
     ByteBuffer firstBuffer = null;
     ByteBuffer secondBuffer = null;
-    if (dataType == DataTypes.BOOLEAN) {
+    if (dataType == DataTypes.BOOLEAN || dataType == DataTypes.BYTE) {
       return first[0] - second[0];
     } else if (dataType == DataTypes.DOUBLE) {
       firstBuffer = ByteBuffer.allocate(8);
@@ -474,6 +474,20 @@ public class CarbonMetadataUtil {
       firstBuffer.flip();
       secondBuffer.flip();
       double compare = firstBuffer.getDouble() - secondBuffer.getDouble();
+      if (compare > 0) {
+        compare = 1;
+      } else if (compare < 0) {
+        compare = -1;
+      }
+      return (int) compare;
+    } else if (dataType == DataTypes.FLOAT) {
+      firstBuffer = ByteBuffer.allocate(8);
+      firstBuffer.put(first);
+      secondBuffer = ByteBuffer.allocate(8);
+      secondBuffer.put(second);
+      firstBuffer.flip();
+      secondBuffer.flip();
+      double compare = firstBuffer.getFloat() - secondBuffer.getFloat();
       if (compare > 0) {
         compare = 1;
       } else if (compare < 0) {

--- a/docs/ddl-of-carbondata.md
+++ b/docs/ddl-of-carbondata.md
@@ -127,7 +127,7 @@ CarbonData DDL statements are documented here,which includes:
      This property is for users to specify which columns belong to the MDK(Multi-Dimensions-Key) index.
      * If users don't specify "SORT_COLUMN" property, by default MDK index be built by using all dimension columns except complex data type column. 
      * If this property is specified but with empty argument, then the table will be loaded without sort.
-	 * This supports only string, date, timestamp, short, int, long, and boolean data types.
+	 * This supports only string, date, timestamp, short, int, long, byte and boolean data types.
      Suggested use cases : Only build MDK index for required columns,it might help to improve the data loading performance.
 
      ```

--- a/docs/sdk-guide.md
+++ b/docs/sdk-guide.md
@@ -191,6 +191,8 @@ Each of SQL data types are mapped into data types of SDK. Following are the mapp
 | BIGINT | DataTypes.LONG |
 | DOUBLE | DataTypes.DOUBLE |
 | VARCHAR | DataTypes.STRING |
+| FLOAT | DataTypes.FLOAT |
+| BYTE | DataTypes.BYTE |
 | DATE | DataTypes.DATE |
 | TIMESTAMP | DataTypes.TIMESTAMP |
 | STRING | DataTypes.STRING |

--- a/docs/supported-data-types-in-carbondata.md
+++ b/docs/supported-data-types-in-carbondata.md
@@ -25,6 +25,10 @@
     * BIGINT
     * DOUBLE
     * DECIMAL
+    * FLOAT
+    * BYTE
+    
+    **NOTE**: Float and Bytes are only supported for SDK and FileFormat.
 
   * Date/Time Types
     * TIMESTAMP

--- a/store/sdk/src/test/java/org/apache/carbondata/sdk/file/CSVCarbonWriterTest.java
+++ b/store/sdk/src/test/java/org/apache/carbondata/sdk/file/CSVCarbonWriterTest.java
@@ -458,6 +458,8 @@ public class CSVCarbonWriterTest {
         for (int j = 0; j < 3; j++) {
           actualRow[j].toString().equalsIgnoreCase(expectedRow[j]);
         }
+        assert(actualRow[1] instanceof Byte);
+        assert(actualRow[2] instanceof Float);
       }
       carbonReader.close();
     } catch (Exception e) {


### PR DESCRIPTION
**Problem:**
1. If multiple pages are present for the blocklet then during comparator creation, float and byte check was not there therefore Unsupported data type exception was thrown.
2. Byte data was being read as Double.

**Solution:**
1. Add check for float 
2. In AbstractScannedResultCollector Byte condition was not present due to which it was going to Double flow.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 
 - [x] Any backward compatibility impacted?
 
 - [x] Document update required?

 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
