### PR TITLE
[CARBONDATA-2965] Support scan performance benchmark in CarbonCli tool

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/util/DataFileFooterConverterV3.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/DataFileFooterConverterV3.java
@@ -59,12 +59,16 @@ public class DataFileFooterConverterV3 extends AbstractDataFileFooterConverter {
    */
   @Override public DataFileFooter readDataFileFooter(TableBlockInfo tableBlockInfo)
       throws IOException {
-    DataFileFooter dataFileFooter = new DataFileFooter();
     CarbonHeaderReader carbonHeaderReader = new CarbonHeaderReader(tableBlockInfo.getFilePath());
     FileHeader fileHeader = carbonHeaderReader.readHeader();
     CarbonFooterReaderV3 reader =
         new CarbonFooterReaderV3(tableBlockInfo.getFilePath(), tableBlockInfo.getBlockOffset());
     FileFooter3 footer = reader.readFooterVersion3();
+    return convertDataFileFooter(fileHeader, footer);
+  }
+
+  public DataFileFooter convertDataFileFooter(FileHeader fileHeader, FileFooter3 footer) {
+    DataFileFooter dataFileFooter = new DataFileFooter();
     dataFileFooter.setVersionId(ColumnarFormatVersion.valueOf((short) fileHeader.getVersion()));
     dataFileFooter.setNumberOfRows(footer.getNum_rows());
     dataFileFooter.setSegmentInfo(getSegmentInfo(footer.getSegment_info()));

--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,7 @@
     <module>store/sdk</module>
     <module>store/search</module>
     <module>assembly</module>
+    <module>tools/cli</module>
   </modules>
 
   <properties>
@@ -716,12 +717,6 @@
       <modules>
         <module>datamap/mv/plan</module>
         <module>datamap/mv/core</module>
-      </modules>
-    </profile>
-    <profile>
-      <id>tools</id>
-      <modules>
-        <module>tools/cli</module>
       </modules>
     </profile>
   </profiles>

--- a/tools/cli/pom.xml
+++ b/tools/cli/pom.xml
@@ -25,6 +25,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>servlet-api</artifactId>
+      <version>2.5</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/tools/cli/src/main/java/org/apache/carbondata/tool/CarbonCli.java
+++ b/tools/cli/src/main/java/org/apache/carbondata/tool/CarbonCli.java
@@ -47,6 +47,11 @@ public class CarbonCli {
         .withDescription("the path which contains carbondata files, nested folder is supported")
         .withLongOpt("path")
         .create("p");
+    Option file = OptionBuilder.withArgName("file")
+        .hasArg()
+        .withDescription("the carbondata file path")
+        .withLongOpt("file")
+        .create("f");
 
     Option command = OptionBuilder
         .withArgName("command name")
@@ -70,6 +75,7 @@ public class CarbonCli {
     Options options = new Options();
     options.addOption(help);
     options.addOption(path);
+    options.addOption(file);
     options.addOption(command);
     options.addOption(all);
     options.addOption(schema);
@@ -101,13 +107,9 @@ public class CarbonCli {
       return;
     }
 
-    String path;
+    String path = "";
     if (line.hasOption("p")) {
       path = line.getOptionValue("path");
-    } else {
-      System.err.println("path is required");
-      printHelp(options);
-      return;
     }
     out.println("Input Folder: " + path);
 

--- a/tools/cli/src/main/java/org/apache/carbondata/tool/CarbonCli.java
+++ b/tools/cli/src/main/java/org/apache/carbondata/tool/CarbonCli.java
@@ -51,7 +51,7 @@ public class CarbonCli {
     Option command = OptionBuilder
         .withArgName("command name")
         .hasArg()
-        .withDescription("command to execute, supported commands are: summary")
+        .withDescription("command to execute, supported commands are: summary, benchmark")
         .isRequired(true)
         .create("cmd");
 
@@ -87,27 +87,47 @@ public class CarbonCli {
   static void run(String[] args, PrintStream out) {
     Options options = buildOptions();
     CommandLineParser parser = new PosixParser();
+
+    CommandLine line;
     try {
-      CommandLine line = parser.parse(options, args);
-      if (line.hasOption("h")) {
-        printHelp(options);
-        return;
-      }
-
-      String cmd = line.getOptionValue("cmd");
-      if (cmd.equalsIgnoreCase("summary")) {
-        runSummaryCommand(line, options, out);
-      } else {
-        out.println("command " + cmd + " is not supported");
-        printHelp(options);
-        return;
-      }
-
-      out.flush();
+      line = parser.parse(options, args);
     } catch (ParseException exp) {
       out.println("Parsing failed. Reason: " + exp.getMessage());
+      return;
+    }
+
+    if (line.hasOption("h")) {
+      printHelp(options);
+      return;
+    }
+
+    String path;
+    if (line.hasOption("p")) {
+      path = line.getOptionValue("path");
+    } else {
+      System.err.println("path is required");
+      printHelp(options);
+      return;
+    }
+    out.println("Input Folder: " + path);
+
+    String cmd = line.getOptionValue("cmd");
+    Command command;
+    if (cmd.equalsIgnoreCase("summary")) {
+      command = new DataSummary(path, out);
+    } else if (cmd.equalsIgnoreCase("benchmark")) {
+      command = new ScanBenchmark(path, out);
+    } else {
+      out.println("command " + cmd + " is not supported");
+      printHelp(options);
+      return;
+    }
+
+    try {
+      command.run(line);
+      out.flush();
     } catch (IOException | MemoryException e) {
-      out.println(out);
+      e.printStackTrace();
     }
   }
 
@@ -116,42 +136,4 @@ public class CarbonCli {
     formatter.printHelp("CarbonCli", options);
   }
 
-  private static void runSummaryCommand(CommandLine line, Options options, PrintStream out)
-      throws IOException, MemoryException {
-    String path = "";
-    if (line.hasOption("p")) {
-      path = line.getOptionValue("path");
-    } else {
-      System.err.println("path is required");
-      printHelp(options);
-      return;
-    }
-    DataSummary summary = new DataSummary(path, out);
-    if (summary.isEmpty()) {
-      System.out.println("no data file found");
-      return;
-    }
-    out.println("Input Folder: " + path);
-    summary.printBasic();
-    boolean printAll = false;
-    if (line.hasOption("a")) {
-      printAll = true;
-    }
-    if (line.hasOption("s") || printAll) {
-      summary.printSchema();
-    }
-    if (line.hasOption("m") || printAll) {
-      summary.printSegments();
-    }
-    if (line.hasOption("t") || printAll) {
-      summary.printTableProperties();
-    }
-    if (line.hasOption("b") || printAll) {
-      summary.printBlockletDetail();
-    }
-    if (line.hasOption("c")) {
-      String columName = line.getOptionValue("c");
-      summary.printColumnStats(columName);
-    }
-  }
 }

--- a/tools/cli/src/main/java/org/apache/carbondata/tool/Command.java
+++ b/tools/cli/src/main/java/org/apache/carbondata/tool/Command.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.tool;
+
+import java.io.IOException;
+
+import org.apache.carbondata.core.memory.MemoryException;
+
+import org.apache.commons.cli.CommandLine;
+
+interface Command {
+  void run(CommandLine line) throws IOException, MemoryException;
+}

--- a/tools/cli/src/main/java/org/apache/carbondata/tool/FileCollector.java
+++ b/tools/cli/src/main/java/org/apache/carbondata/tool/FileCollector.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.tool;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.carbondata.common.Strings;
+import org.apache.carbondata.core.datastore.filesystem.CarbonFile;
+import org.apache.carbondata.core.datastore.impl.FileFactory;
+import org.apache.carbondata.core.util.path.CarbonTablePath;
+import org.apache.carbondata.format.BlockletInfo3;
+import org.apache.carbondata.format.FileFooter3;
+
+/**
+ * A helper to collect all data files, schema file, table status file in a given folder
+ */
+class FileCollector {
+
+  private long numBlock;
+  private long numShard;
+  private long numBlocklet;
+  private long numPage;
+  private long numRow;
+  private long totalDataSize;
+
+  // file path mapping to file object
+  private LinkedHashMap<String, DataFile> dataFiles = new LinkedHashMap<>();
+  private CarbonFile tableStatusFile;
+  private CarbonFile schemaFile;
+
+  private PrintStream out;
+
+  FileCollector(PrintStream out) {
+    this.out = out;
+  }
+
+  void collectFiles(String dataFolder) throws IOException {
+    Set<String> shards = new HashSet<>();
+    CarbonFile folder = FileFactory.getCarbonFile(dataFolder);
+    List<CarbonFile> files = folder.listFiles(true);
+    List<DataFile> unsortedFiles = new ArrayList<>();
+    for (CarbonFile file : files) {
+      if (isColumnarFile(file.getName())) {
+        DataFile dataFile = new DataFile(file);
+        dataFile.collectAllMeta();
+        unsortedFiles.add(dataFile);
+        collectNum(dataFile.getFooter());
+        shards.add(dataFile.getShardName());
+        totalDataSize += file.getSize();
+      } else if (file.getName().endsWith(CarbonTablePath.TABLE_STATUS_FILE)) {
+        tableStatusFile = file;
+      } else if (file.getName().startsWith(CarbonTablePath.SCHEMA_FILE)) {
+        schemaFile = file;
+      } else if (isStreamFile(file.getName())) {
+        out.println("WARN: input path contains streaming file, this tool does not support it yet, "
+            + "skipping it...");
+      }
+    }
+    unsortedFiles.sort((o1, o2) -> {
+      if (o1.getShardName().equalsIgnoreCase(o2.getShardName())) {
+        return Integer.parseInt(o1.getPartNo()) - Integer.parseInt(o2.getPartNo());
+      } else {
+        return o1.getShardName().compareTo(o2.getShardName());
+      }
+    });
+    for (DataFile collectedFile : unsortedFiles) {
+      this.dataFiles.put(collectedFile.getFilePath(), collectedFile);
+    }
+    numShard = shards.size();
+  }
+
+  private void collectNum(FileFooter3 footer) {
+    numBlock++;
+    numBlocklet += footer.blocklet_index_list.size();
+    numRow += footer.num_rows;
+    for (BlockletInfo3 blockletInfo3 : footer.blocklet_info_list3) {
+      numPage += blockletInfo3.number_number_of_pages;
+    }
+  }
+
+  private boolean isColumnarFile(String fileName) {
+    // if the timestamp in file name is "0", it is a streaming file
+    return fileName.endsWith(CarbonTablePath.CARBON_DATA_EXT) &&
+        !CarbonTablePath.DataFileUtil.getTimeStampFromFileName(fileName).equals("0");
+  }
+
+  private boolean isStreamFile(String fileName) {
+    // if the timestamp in file name is "0", it is a streaming file
+    return fileName.endsWith(CarbonTablePath.CARBON_DATA_EXT) &&
+        CarbonTablePath.DataFileUtil.getTimeStampFromFileName(fileName).equals("0");
+  }
+
+  // return file path mapping to file object
+  LinkedHashMap<String, DataFile> getDataFiles() {
+    return dataFiles;
+  }
+
+  CarbonFile getTableStatusFile() {
+    return tableStatusFile;
+  }
+
+  CarbonFile getSchemaFile() {
+    return schemaFile;
+  }
+
+  int getNumDataFiles() {
+    return dataFiles.size();
+  }
+
+  void printBasicStats() {
+    if (dataFiles.size() == 0) {
+      System.out.println("no data file found");
+      return;
+    }
+    out.println("## Summary");
+    out.println(
+        String.format("total: %,d blocks, %,d shards, %,d blocklets, %,d pages, %,d rows, %s",
+            numBlock, numShard, numBlocklet, numPage, numRow, Strings.formatSize(totalDataSize)));
+    out.println(
+        String.format("avg: %s/block, %s/blocklet, %,d rows/block, %,d rows/blocklet",
+            Strings.formatSize((float) totalDataSize / numBlock),
+            Strings.formatSize((float) totalDataSize / numBlocklet),
+            numRow / numBlock,
+            numRow / numBlocklet));
+  }
+}

--- a/tools/cli/src/main/java/org/apache/carbondata/tool/ScanBenchmark.java
+++ b/tools/cli/src/main/java/org/apache/carbondata/tool/ScanBenchmark.java
@@ -38,7 +38,6 @@ import org.apache.carbondata.core.memory.MemoryException;
 import org.apache.carbondata.core.metadata.ColumnarFormatVersion;
 import org.apache.carbondata.core.metadata.blocklet.BlockletInfo;
 import org.apache.carbondata.core.metadata.blocklet.DataFileFooter;
-import org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema;
 import org.apache.carbondata.core.util.DataFileFooterConverterV3;
 import org.apache.carbondata.core.util.path.CarbonTablePath;
 import org.apache.carbondata.format.FileFooter3;
@@ -165,7 +164,8 @@ class ScanBenchmark implements Command {
   private MeasureColumnChunkReader measureColumnChunkReader;
 
   private AbstractRawColumnChunk readBlockletColumnChunkIO(
-      DataFileFooter footer, int blockletId, int columnIndex, boolean dimension) throws IOException {
+      DataFileFooter footer, int blockletId, int columnIndex, boolean dimension)
+      throws IOException {
     BlockletInfo blockletInfo = footer.getBlockletList().get(blockletId);
     if (dimension) {
       dimensionColumnChunkReader = CarbonDataReaderFactory.getInstance()

--- a/tools/cli/src/main/java/org/apache/carbondata/tool/ScanBenchmark.java
+++ b/tools/cli/src/main/java/org/apache/carbondata/tool/ScanBenchmark.java
@@ -1,0 +1,200 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.tool;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.carbondata.core.datastore.block.BlockletInfos;
+import org.apache.carbondata.core.datastore.block.TableBlockInfo;
+import org.apache.carbondata.core.datastore.chunk.AbstractRawColumnChunk;
+import org.apache.carbondata.core.datastore.chunk.DimensionColumnPage;
+import org.apache.carbondata.core.datastore.chunk.impl.DimensionRawColumnChunk;
+import org.apache.carbondata.core.datastore.chunk.impl.MeasureRawColumnChunk;
+import org.apache.carbondata.core.datastore.chunk.reader.CarbonDataReaderFactory;
+import org.apache.carbondata.core.datastore.chunk.reader.DimensionColumnChunkReader;
+import org.apache.carbondata.core.datastore.chunk.reader.MeasureColumnChunkReader;
+import org.apache.carbondata.core.datastore.impl.FileFactory;
+import org.apache.carbondata.core.datastore.page.ColumnPage;
+import org.apache.carbondata.core.memory.MemoryException;
+import org.apache.carbondata.core.metadata.ColumnarFormatVersion;
+import org.apache.carbondata.core.metadata.blocklet.BlockletInfo;
+import org.apache.carbondata.core.metadata.blocklet.DataFileFooter;
+import org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema;
+import org.apache.carbondata.core.util.DataFileFooterConverterV3;
+import org.apache.carbondata.core.util.path.CarbonTablePath;
+import org.apache.carbondata.format.FileFooter3;
+import org.apache.carbondata.format.FileHeader;
+
+import org.apache.commons.cli.CommandLine;
+
+class ScanBenchmark implements Command {
+
+  private String dataFolder;
+  private PrintStream out;
+  private DataFile file;
+
+  ScanBenchmark(String dataFolder, PrintStream out) {
+    this.dataFolder = dataFolder;
+    this.out = out;
+    this.file = new DataFile(FileFactory.getCarbonFile(dataFolder));
+  }
+
+  @Override
+  public void run(CommandLine line) throws IOException, MemoryException {
+    FileCollector collector = new FileCollector(out);
+    collector.collectFiles(dataFolder);
+    if (collector.getNumDataFiles() == 0) {
+      return;
+    }
+
+    out.println("\n## Benchmark");
+    Map<String, DataFile> dataFiles = collector.getDataFiles();
+    file = dataFiles.entrySet().iterator().next().getValue();
+    AtomicReference<FileHeader> fileHeaderRef = new AtomicReference<>();
+    AtomicReference<FileFooter3> fileFoorterRef = new AtomicReference<>();
+    AtomicReference<DataFileFooter> convertedFooterRef = new AtomicReference<>();
+
+    // benchmark read header and footer time
+    benchmarkOperation("ReadHeaderAndFooter", () -> {
+      fileHeaderRef.set(file.readHeader());
+      fileFoorterRef.set(file.readFooter());
+    });
+    FileHeader fileHeader = fileHeaderRef.get();
+    FileFooter3 fileFooter = fileFoorterRef.get();
+
+    // benchmark convert footer
+    benchmarkOperation("ConvertFooter", () -> {
+      convertFooter(fileHeader, fileFooter);
+    });
+
+    // benchmark read all meta and convert footer
+    benchmarkOperation("ReadAllMetaAndConvertFooter", () -> {
+      DataFileFooter footer = readAndConvertFooter(file);
+      convertedFooterRef.set(footer);
+    });
+
+    if (line.hasOption("c")) {
+      String columName = line.getOptionValue("c");
+      out.println("\nScan column '" + columName + "'");
+
+      DataFileFooter convertedFooter = convertedFooterRef.get();
+      AtomicReference<AbstractRawColumnChunk> columnChunk = new AtomicReference<>();
+      for (int i = 0; i < convertedFooter.getBlockletList().size(); i++) {
+        int blockletId = i;
+        benchmarkOperation(String.format("Blocklet#%d: ColumnChunkIO", blockletId), () -> {
+          columnChunk.set(readBlockletColumnChunkIO(convertedFooter, blockletId, columName));
+        });
+
+        if (dimensionColumnChunkReader != null) {
+          benchmarkOperation(String.format("Blocklet#%d: DecompressPage", blockletId), () -> {
+            for (int pageId = 0; pageId < convertedFooter.getBlockletList().size(); pageId++) {
+              decompressDimensionPages(columnChunk.get(),
+                  convertedFooter.getBlockletList().get(blockletId).getNumberOfPages());
+            }
+          });
+        } else {
+          benchmarkOperation("            DecompressPages", () -> {
+            for (int pageId = 0; pageId < convertedFooter.getBlockletList().size(); pageId++) {
+              decompressMeasurePages(columnChunk.get(),
+                  convertedFooter.getBlockletList().get(blockletId).getNumberOfPages());
+            }
+          });
+        }
+      }
+    }
+
+
+  }
+
+  interface Operation {
+    void run() throws IOException, MemoryException;
+  }
+
+  private void benchmarkOperation(String opName, Operation op) throws IOException, MemoryException {
+    long start, end;
+    start = System.nanoTime();
+    op.run();
+    end = System.nanoTime();
+    out.println(String.format("%s takes %,d us", opName, (end - start) / 1000));
+  }
+
+  private DataFileFooter readAndConvertFooter(DataFile file) throws IOException {
+    int numBlocklets = file.getNumBlocklet();
+    BlockletInfos blockletInfos = new BlockletInfos(numBlocklets, 0, numBlocklets);
+    String segmentId = CarbonTablePath.DataFileUtil.getSegmentNo(file.getFilePath());
+    TableBlockInfo blockInfo =
+        new TableBlockInfo(file.getFilePath(), file.getFooterOffset(),
+            segmentId, new String[]{"localhost"}, file.getFileSizeInBytes(),
+            blockletInfos, ColumnarFormatVersion.V3, new String[0]);
+
+    DataFileFooterConverterV3 converter = new DataFileFooterConverterV3();
+    return converter.readDataFileFooter(blockInfo);
+  }
+
+  private DataFileFooter convertFooter(FileHeader fileHeader, FileFooter3 fileFooter) {
+    DataFileFooterConverterV3 converter = new DataFileFooterConverterV3();
+    return converter.convertDataFileFooter(fileHeader, fileFooter);
+  }
+
+  private DimensionColumnChunkReader dimensionColumnChunkReader;
+  private MeasureColumnChunkReader measureColumnChunkReader;
+
+  private AbstractRawColumnChunk readBlockletColumnChunkIO(
+      DataFileFooter footer, int blockletId, String columnName) throws IOException {
+    BlockletInfo blockletInfo = footer.getBlockletList().get(blockletId);
+    int columnIndex = file.getColumnIndex(columnName);
+    ColumnSchema column = file.getColumn(columnName);
+    if (column.isDimensionColumn()) {
+      dimensionColumnChunkReader = CarbonDataReaderFactory.getInstance()
+          .getDimensionColumnChunkReader(ColumnarFormatVersion.V3, blockletInfo,
+              footer.getSegmentInfo().getColumnCardinality(), file.getFilePath(), false);
+      return dimensionColumnChunkReader.readRawDimensionChunk(file.getFileReader(), columnIndex);
+    } else {
+      columnIndex = columnIndex - file.numDimensions();
+      assert (columnIndex >= 0);
+      measureColumnChunkReader = CarbonDataReaderFactory.getInstance()
+          .getMeasureColumnChunkReader(ColumnarFormatVersion.V3, blockletInfo,
+              file.getFilePath(), false);
+      return measureColumnChunkReader.readRawMeasureChunk(file.getFileReader(), columnIndex);
+    }
+  }
+
+  private DimensionColumnPage[] decompressDimensionPages(
+      AbstractRawColumnChunk rawColumnChunk, int numPages) throws IOException, MemoryException {
+    DimensionColumnPage[] pages = new DimensionColumnPage[numPages];
+    for (int i = 0; i < pages.length; i++) {
+      pages[i] = dimensionColumnChunkReader.decodeColumnPage(
+          (DimensionRawColumnChunk) rawColumnChunk, i);
+    }
+    return pages;
+  }
+
+  private ColumnPage[] decompressMeasurePages(
+      AbstractRawColumnChunk rawColumnChunk, int numPages) throws IOException, MemoryException {
+    ColumnPage[] pages = new ColumnPage[numPages];
+    for (int i = 0; i < pages.length; i++) {
+      pages[i] = measureColumnChunkReader.decodeColumnPage(
+          (MeasureRawColumnChunk) rawColumnChunk, i);
+    }
+    return pages;
+  }
+
+}

--- a/tools/cli/src/test/java/org/apache/carbondata/tool/CarbonCliTest.java
+++ b/tools/cli/src/test/java/org/apache/carbondata/tool/CarbonCliTest.java
@@ -45,10 +45,10 @@ public class CarbonCliTest {
     fields[0] = new Field("name", DataTypes.STRING);
     fields[1] = new Field("age", DataTypes.INT);
 
-    TestUtil.writeFilesAndVerify(5000000, new Schema(fields), path, new String[]{"age"},
-        true, 3, 8, true);
-    TestUtil.writeFilesAndVerify(5000000, new Schema(fields), path, new String[]{"age"},
-        true, 3, 8, true);
+//    TestUtil.writeFilesAndVerify(5000000, new Schema(fields), path, new String[]{"name"},
+//        true, 3, 8, true);
+//    TestUtil.writeFilesAndVerify(5000000, new Schema(fields), path, new String[]{"name"},
+//        true, 3, 8, true);
   }
 
   @Test
@@ -69,7 +69,7 @@ public class CarbonCliTest {
   }
 
   @Test
-  public void testOutputIndividual() {
+  public void testSummaryOutputIndividual() {
     String[] args = {"-cmd", "summary", "-p", path};
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     PrintStream stream = new PrintStream(out);
@@ -142,9 +142,8 @@ public class CarbonCliTest {
   }
 
   @Test
-  public void testOutputAll() {
+  public void testSummaryOutputAll() {
     String[] args = {"-cmd", "summary", "-p", path, "-a", "-c", "age"};
-
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     PrintStream stream = new PrintStream(out);
     CarbonCli.run(args, stream);
@@ -189,6 +188,24 @@ public class CarbonCliTest {
         + "1    1      1.81KB     2.26MB     false      0            0.0B      79.60KB      46.4  61.9   \n"
         + "2    0      1.37KB     2.28MB     false      0            0.0B      106.11KB     61.9  80.5   \n"
         + "2    1      1.19KB     2.22MB     false      0            0.0B      119.55KB     80.5  100.0  "));
+  }
+
+  @Test
+  public void testBenchmark() {
+    String path = "/Users/jacky/code/spark-2.2.1-bin-hadoop2.7/carbonstore/tpchcarbon_base/lineitem";
+    String[] args = {"-cmd", "summary", "-p", path, "-a", "-c", "l_orderkey"};
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    PrintStream stream = new PrintStream(out);
+    CarbonCli.run(args, stream);
+    String output = new String(out.toByteArray());
+    System.out.println(output);
+
+    args = new String[]{"-cmd", "benchmark", "-p", path, "-c", "l_orderkey"};
+    out = new ByteArrayOutputStream();
+    stream = new PrintStream(out);
+    CarbonCli.run(args, stream);
+    output = new String(out.toByteArray());
+    System.out.println(output);
   }
 
   @After

--- a/tools/cli/src/test/java/org/apache/carbondata/tool/CarbonCliTest.java
+++ b/tools/cli/src/test/java/org/apache/carbondata/tool/CarbonCliTest.java
@@ -45,10 +45,10 @@ public class CarbonCliTest {
     fields[0] = new Field("name", DataTypes.STRING);
     fields[1] = new Field("age", DataTypes.INT);
 
-//    TestUtil.writeFilesAndVerify(5000000, new Schema(fields), path, new String[]{"name"},
-//        true, 3, 8, true);
-//    TestUtil.writeFilesAndVerify(5000000, new Schema(fields), path, new String[]{"name"},
-//        true, 3, 8, true);
+    TestUtil.writeFilesAndVerify(5000000, new Schema(fields), path, new String[]{"name"},
+        true, 3, 8, true);
+    TestUtil.writeFilesAndVerify(5000000, new Schema(fields), path, new String[]{"name"},
+        true, 3, 8, true);
   }
 
   @Test
@@ -79,20 +79,19 @@ public class CarbonCliTest {
         output.contains(
             "Input Folder: ./CarbonCliTest\n"
           + "## Summary\n"
-          + "total: 6 blocks, 2 shards, 12 blocklets, 314 pages, 10,000,000 rows, 30.72MB\n"
-          + "avg: 5.12MB/block, 2.56MB/blocklet, 1,666,666 rows/block, 833,333 rows/blocklet"));
+          + "total: 6 blocks, 2 shards, 14 blocklets, 314 pages, 10,000,000 rows, 32.26MB\n"
+          + "avg: 5.38MB/block, 2.30MB/blocklet, 1,666,666 rows/block, 714,285 rows/blocklet"));
 
     String[] args2 = {"-cmd", "summary", "-p", path, "-s"};
     out = new ByteArrayOutputStream();
     stream = new PrintStream(out);
     CarbonCli.run(args2, stream);
     output = new String(out.toByteArray());
-
     Assert.assertTrue(
         output.contains(
             "Column Name  Data Type  Column Type  SortColumn  Encoding          Ordinal  Id  \n"
-          + "age          INT        dimension    true        [INVERTED_INDEX]  1        NA  \n"
-          + "name         STRING     dimension    false       [INVERTED_INDEX]  0        NA  \n"));
+          + "name         STRING     dimension    true        [INVERTED_INDEX]  0        NA  \n"
+          + "age          INT        measure      false       []                1        NA  "));
 
     String[] args3 = {"-cmd", "summary", "-p", path, "-t"};
     out = new ByteArrayOutputStream();
@@ -113,32 +112,32 @@ public class CarbonCliTest {
     stream = new PrintStream(out);
     CarbonCli.run(args4, stream);
     output = new String(out.toByteArray());
-
     Assert.assertTrue(
         output.contains(
-            "BLK  BLKLT  NumPages  NumRows  Size    \n"
-          + "0    0      29        928,000  2.60MB  \n"
-          + "0    1      29        928,000  2.60MB  \n"
-          + "1    0      29        928,000  2.60MB  \n"
-          + "1    1      29        928,000  2.60MB  \n"
-          + "2    0      22        704,000  2.54MB  \n"
-          + "2    1      19        584,000  2.43MB  "));
+            "BLK  BLKLT  NumPages  NumRows  Size      \n"
+          + "0    0      25        800,000  2.58MB    \n"
+          + "0    1      25        800,000  2.58MB    \n"
+          + "1    0      25        800,000  2.58MB    \n"
+          + "1    1      25        800,000  2.58MB    \n"
+          + "2    0      25        800,000  2.58MB    \n"
+          + "2    1      25        800,000  2.58MB    \n"
+          + "2    2      7         200,000  660.74KB  "));
 
     String[] args5 = {"-cmd", "summary", "-p", path, "-c", "name"};
     out = new ByteArrayOutputStream();
     stream = new PrintStream(out);
     CarbonCli.run(args5, stream);
     output = new String(out.toByteArray());
-
     Assert.assertTrue(
         output.contains(
             "BLK  BLKLT  Meta Size  Data Size  LocalDict  DictEntries  DictSize  AvgPageSize  Min%    Max%    \n"
-          + "0    0      1.82KB     5.19MB     false      0            0.0B      11.96KB      robot0  robot9  \n"
-          + "0    1      1.82KB     2.60MB     false      0            0.0B      11.96KB      robot0  robot9  \n"
-          + "1    0      1.82KB     5.19MB     false      0            0.0B      11.96KB      robot0  robot9  \n"
-          + "1    1      1.82KB     2.60MB     false      0            0.0B      11.96KB      robot0  robot9  \n"
-          + "2    0      1.38KB     4.97MB     false      0            0.0B      11.92KB      robot0  robot9  \n"
-          + "2    1      1.19KB     2.43MB     false      0            0.0B      11.42KB      robot0  robot9  \n"));
+          + "0    0      1.72KB     295.89KB   false      0            0.0B      11.77KB      robot0  robot1  \n"
+          + "0    1      1.72KB     295.89KB   false      0            0.0B      11.77KB      robot1  robot3  \n"
+          + "1    0      1.72KB     295.89KB   false      0            0.0B      11.77KB      robot3  robot4  \n"
+          + "1    1      1.72KB     295.89KB   false      0            0.0B      11.77KB      robot4  robot6  \n"
+          + "2    0      1.72KB     295.89KB   false      0            0.0B      11.77KB      robot6  robot7  \n"
+          + "2    1      1.72KB     295.89KB   false      0            0.0B      11.77KB      robot8  robot9  \n"
+          + "2    2      492.0B     74.03KB    false      0            0.0B      10.51KB      robot9  robot9  "));
   }
 
   @Test
@@ -152,14 +151,14 @@ public class CarbonCliTest {
         output.contains(
             "Input Folder: ./CarbonCliTest\n"
           + "## Summary\n"
-          + "total: 6 blocks, 2 shards, 12 blocklets, 314 pages, 10,000,000 rows, 30.72MB\n"
-          + "avg: 5.12MB/block, 2.56MB/blocklet, 1,666,666 rows/block, 833,333 rows/blocklet"));
+          + "total: 6 blocks, 2 shards, 14 blocklets, 314 pages, 10,000,000 rows, 32.26MB\n"
+          + "avg: 5.38MB/block, 2.30MB/blocklet, 1,666,666 rows/block, 714,285 rows/blocklet\n"));
 
     Assert.assertTrue(
         output.contains(
             "Column Name  Data Type  Column Type  SortColumn  Encoding          Ordinal  Id  \n"
-          + "age          INT        dimension    true        [INVERTED_INDEX]  1        NA  \n"
-          + "name         STRING     dimension    false       [INVERTED_INDEX]  0        NA  \n"));
+          + "name         STRING     dimension    true        [INVERTED_INDEX]  0        NA  \n"
+          + "age          INT        measure      false       []                1        NA  \n"));
 
     Assert.assertTrue(
         output.contains(
@@ -171,41 +170,34 @@ public class CarbonCliTest {
 
     Assert.assertTrue(
         output.contains(
-            "BLK  BLKLT  NumPages  NumRows  Size    \n"
-          + "0    0      29        928,000  2.60MB  \n"
-          + "0    1      29        928,000  2.60MB  \n"
-          + "1    0      29        928,000  2.60MB  \n"
-          + "1    1      29        928,000  2.60MB  \n"
-          + "2    0      22        704,000  2.54MB  \n"
-          + "2    1      19        584,000  2.43MB  "));
+            "BLK  BLKLT  NumPages  NumRows  Size      \n"
+          + "0    0      25        800,000  2.58MB    \n"
+          + "0    1      25        800,000  2.58MB    \n"
+          + "1    0      25        800,000  2.58MB    \n"
+          + "1    1      25        800,000  2.58MB    \n"
+          + "2    0      25        800,000  2.58MB    \n"
+          + "2    1      25        800,000  2.58MB    \n"
+          + "2    2      7         200,000  660.74KB  "));
 
     Assert.assertTrue(
         output.contains(
           "BLK  BLKLT  Meta Size  Data Size  LocalDict  DictEntries  DictSize  AvgPageSize  Min%  Max%   \n"
-        + "0    0      1.81KB     2.26MB     false      0            0.0B      79.61KB      0.0   15.5   \n"
-        + "0    1      1.81KB     2.26MB     false      0            0.0B      79.60KB      15.5  30.9   \n"
-        + "1    0      1.81KB     2.26MB     false      0            0.0B      79.62KB      30.9  46.4   \n"
-        + "1    1      1.81KB     2.26MB     false      0            0.0B      79.60KB      46.4  61.9   \n"
-        + "2    0      1.37KB     2.28MB     false      0            0.0B      106.11KB     61.9  80.5   \n"
-        + "2    1      1.19KB     2.22MB     false      0            0.0B      119.55KB     80.5  100.0  "));
+        + "0    0      2.90KB     4.87MB     false      0            0.0B      93.76KB      0.0   100.0  \n"
+        + "0    1      2.90KB     2.29MB     false      0            0.0B      93.76KB      0.0   100.0  \n"
+        + "1    0      2.90KB     4.87MB     false      0            0.0B      93.76KB      0.0   100.0  \n"
+        + "1    1      2.90KB     2.29MB     false      0            0.0B      93.76KB      0.0   100.0  \n"
+        + "2    0      2.90KB     5.52MB     false      0            0.0B      93.76KB      0.0   100.0  \n"
+        + "2    1      2.90KB     2.94MB     false      0            0.0B      93.76KB      0.0   100.0  \n"
+        + "2    2      830.0B     586.81KB   false      0            0.0B      83.71KB      0.0   100.0 "));
   }
 
   @Test
   public void testBenchmark() {
-//    String path = "/Users/jacky/code/spark-2.2.1-bin-hadoop2.7/carbonstore/tpchcarbon_base/lineitem";
-    String path = "/Users/jacky/code/spark-2.2.1-bin-hadoop2.7/carbonstore/default/lineitem_32_256/";
-    String[] args = {"-cmd", "summary", "-p", path, "-a", "-c", "l_orderkey"};
+    String[] args = {"-cmd", "benchmark", "-p", path, "-a", "-c", "age"};
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     PrintStream stream = new PrintStream(out);
     CarbonCli.run(args, stream);
     String output = new String(out.toByteArray());
-    System.out.println(output);
-
-    args = new String[]{"-cmd", "benchmark", "-f", "/Users/jacky/code/spark-2.2.1-bin-hadoop2.7/carbonstore/default/lineitem_32_256/Fact/Part0/Segment_0/part-0-0_batchno0-0-0-1537635146902.carbondata", "-c", "l_orderkey"};
-    out = new ByteArrayOutputStream();
-    stream = new PrintStream(out);
-    CarbonCli.run(args, stream);
-    output = new String(out.toByteArray());
     System.out.println(output);
   }
 

--- a/tools/cli/src/test/java/org/apache/carbondata/tool/CarbonCliTest.java
+++ b/tools/cli/src/test/java/org/apache/carbondata/tool/CarbonCliTest.java
@@ -192,7 +192,8 @@ public class CarbonCliTest {
 
   @Test
   public void testBenchmark() {
-    String path = "/Users/jacky/code/spark-2.2.1-bin-hadoop2.7/carbonstore/tpchcarbon_base/lineitem";
+//    String path = "/Users/jacky/code/spark-2.2.1-bin-hadoop2.7/carbonstore/tpchcarbon_base/lineitem";
+    String path = "/Users/jacky/code/spark-2.2.1-bin-hadoop2.7/carbonstore/default/lineitem_32_256/";
     String[] args = {"-cmd", "summary", "-p", path, "-a", "-c", "l_orderkey"};
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     PrintStream stream = new PrintStream(out);
@@ -200,7 +201,7 @@ public class CarbonCliTest {
     String output = new String(out.toByteArray());
     System.out.println(output);
 
-    args = new String[]{"-cmd", "benchmark", "-p", path, "-c", "l_orderkey"};
+    args = new String[]{"-cmd", "benchmark", "-f", "/Users/jacky/code/spark-2.2.1-bin-hadoop2.7/carbonstore/default/lineitem_32_256/Fact/Part0/Segment_0/part-0-0_batchno0-0-0-1537635146902.carbondata", "-c", "l_orderkey"};
     out = new ByteArrayOutputStream();
     stream = new PrintStream(out);
     CarbonCli.run(args, stream);

--- a/tools/cli/src/test/java/org/apache/carbondata/tool/CarbonCliTest.java
+++ b/tools/cli/src/test/java/org/apache/carbondata/tool/CarbonCliTest.java
@@ -193,7 +193,7 @@ public class CarbonCliTest {
 
   @Test
   public void testBenchmark() {
-    String[] args = {"-cmd", "benchmark", "-p", path, "-a", "-c", "age"};
+    String[] args = {"-cmd", "benchmark", "-p", path, "-a", "-c", "name"};
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     PrintStream stream = new PrintStream(out);
     CarbonCli.run(args, stream);


### PR DESCRIPTION
A new command called "benchmark" is added in CarbonCli tool to output the scan performance of the specified file and column.
Example usage:
```
shell>java -jar carbondata-cli.jar org.apache.carbondata.CarbonCli -cmd benchmark -p hdfs://carbon1:9000/carbon.store/tpchcarbon_base/lineitem/ -a -c l_comment
```
will scan output the scan time of l_comment column in first file in the input folder and prints: (or using -f option to provide the data file instead of folder)
```
## Benchmark
ReadHeaderAndFooter takes 12,598 us
ConvertFooter takes 4,712 us
ReadAllMetaAndConvertFooter takes 8,039 us

Scan column 'l_comment'
Blocklet#0: ColumnChunkIO takes 222,609 us
Blocklet#0: DecompressPage takes 111,985 us
Blocklet#1: ColumnChunkIO takes 186,522 us
Blocklet#1: DecompressPage takes 89,132 us
Blocklet#2: ColumnChunkIO takes 209,129 us
Blocklet#2: DecompressPage takes 84,051 us
```

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
