### PR TITLE
[CARBONDATA-2968] Single pass load fails 2nd time in Spark submit execution due to port binding error.

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/dictionary/server/NonSecureDictionaryServer.java
+++ b/core/src/main/java/org/apache/carbondata/core/dictionary/server/NonSecureDictionaryServer.java
@@ -109,6 +109,7 @@ public class NonSecureDictionaryServer extends AbstractDictionaryServer
         });
         bootstrap.childOption(ChannelOption.SO_KEEPALIVE, true);
         String hostToBind = findLocalIpAddress(LOGGER);
+        //iteratively listening to newports
         InetSocketAddress address = hostToBind == null ?
             new InetSocketAddress(newPort) :
             new InetSocketAddress(hostToBind, newPort);
@@ -119,7 +120,7 @@ public class NonSecureDictionaryServer extends AbstractDictionaryServer
         this.host = hostToBind;
         break;
       } catch (Exception e) {
-        LOGGER.error(e, "Dictionary Server Failed to bind to port:");
+        LOGGER.error(e, "Dictionary Server Failed to bind to port:" + newPort);
         if (i == 9) {
           throw new RuntimeException("Dictionary Server Could not bind to any port");
         }

--- a/integration/spark-common/src/main/java/org/apache/carbondata/spark/dictionary/server/SecureDictionaryServer.java
+++ b/integration/spark-common/src/main/java/org/apache/carbondata/spark/dictionary/server/SecureDictionaryServer.java
@@ -144,7 +144,8 @@ public class SecureDictionaryServer extends AbstractDictionaryServer implements 
             new SaslServerBootstrap(transportConf, securityManager);
         String host = findLocalIpAddress(LOGGER);
         //iteratively listening to newports
-        context.createServer(host, newPort, Lists.<TransportServerBootstrap>newArrayList(bootstrap));
+        context
+            .createServer(host, newPort, Lists.<TransportServerBootstrap>newArrayList(bootstrap));
         LOGGER.audit("Dictionary Server started, Time spent " + (System.currentTimeMillis() - start)
             + " Listening on port " + newPort);
         this.port = newPort;

--- a/integration/spark-common/src/main/java/org/apache/carbondata/spark/dictionary/server/SecureDictionaryServer.java
+++ b/integration/spark-common/src/main/java/org/apache/carbondata/spark/dictionary/server/SecureDictionaryServer.java
@@ -143,14 +143,15 @@ public class SecureDictionaryServer extends AbstractDictionaryServer implements 
         TransportServerBootstrap bootstrap =
             new SaslServerBootstrap(transportConf, securityManager);
         String host = findLocalIpAddress(LOGGER);
-        context.createServer(host, port, Lists.<TransportServerBootstrap>newArrayList(bootstrap));
+        //iteratively listening to newports
+        context.createServer(host, newPort, Lists.<TransportServerBootstrap>newArrayList(bootstrap));
         LOGGER.audit("Dictionary Server started, Time spent " + (System.currentTimeMillis() - start)
             + " Listening on port " + newPort);
         this.port = newPort;
         this.host = host;
         break;
       } catch (Exception e) {
-        LOGGER.error(e, "Dictionary Server Failed to bind to port:");
+        LOGGER.error(e, "Dictionary Server Failed to bind to port: " + newPort);
         if (i == 9) {
           throw new RuntimeException("Dictionary Server Could not bind to any port");
         }


### PR DESCRIPTION
Problem : In secure cluster setup, single pass load is failing in spark-submit after using the beeline.
Solution: It was happening because port was not getting updated and was not looking for the next empty port. port variable was not changing.So modified that part and added log to diplay the port number.

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [x] Testing done
         manually
   
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

