### PR TITLE
[CARBONDATA-2969]local dictioanry query fix for spark-2.3

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/localdictionary/LocalDictionarySupportLoadTableTest.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/localdictionary/LocalDictionarySupportLoadTableTest.scala
@@ -136,6 +136,20 @@ class LocalDictionarySupportLoadTableTest extends QueryTest with BeforeAndAfterA
     assert(checkForLocalDictionary(getDimRawChunk(2)))
   }
 
+  test("test local dictionary data validation") {
+    sql("drop table if exists local_query_enable")
+    sql("drop table if exists local_query_disable")
+    sql(
+      "CREATE TABLE local_query_enable(name string) STORED BY 'carbondata' tblproperties" +
+      "('local_dictionary_enable'='false','local_dictionary_include'='name')")
+    sql("load data inpath '" + file1 + "' into table local_query_enable OPTIONS('header'='false')")
+    sql(
+      "CREATE TABLE local_query_disable(name string) STORED BY 'carbondata' tblproperties" +
+      "('local_dictionary_enable'='true','local_dictionary_include'='name')")
+    sql("load data inpath '" + file1 + "' into table local_query_disable OPTIONS('header'='false')")
+    checkAnswer(sql("select name from local_query_enable"), sql("select name from local_query_disable"))
+  }
+
   test("test to validate local dictionary values"){
     sql("drop table if exists local2")
     sql("CREATE TABLE local2(name string) STORED BY 'carbondata' tblproperties('local_dictionary_enable'='true')")

--- a/integration/spark-datasource/src/main/scala/org/apache/carbondata/spark/vectorreader/ColumnarVectorWrapper.java
+++ b/integration/spark-datasource/src/main/scala/org/apache/carbondata/spark/vectorreader/ColumnarVectorWrapper.java
@@ -269,16 +269,7 @@ class ColumnarVectorWrapper implements CarbonColumnVector {
   }
 
   @Override public void setDictionary(CarbonDictionary dictionary) {
-    if (dictionary == null) {
-      sparkColumnVectorProxy.setDictionary(null, ordinal);
-    } else {
-      sparkColumnVectorProxy
-          .setDictionary(new CarbonDictionaryWrapper(Encoding.PLAIN, dictionary),ordinal);
-    }
-  }
-
-  private void  setDictionaryType(boolean type) {
-    this.isDictionary = type;
+      sparkColumnVectorProxy.setDictionary(dictionary, ordinal);
   }
 
   @Override public boolean hasDictionary() {

--- a/integration/spark-datasource/src/main/spark2.1andspark2.2/org/apache/spark/sql/CarbonDictionaryWrapper.java
+++ b/integration/spark-datasource/src/main/spark2.1andspark2.2/org/apache/spark/sql/CarbonDictionaryWrapper.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.carbondata.spark.vectorreader;
+package org.apache.spark.sql;
 
 import org.apache.carbondata.core.scan.result.vector.CarbonDictionary;
 

--- a/integration/spark-datasource/src/main/spark2.1andspark2.2/org/apache/spark/sql/CarbonVectorProxy.java
+++ b/integration/spark-datasource/src/main/spark2.1andspark2.2/org/apache/spark/sql/CarbonVectorProxy.java
@@ -18,7 +18,10 @@ package org.apache.spark.sql;
 
 import java.math.BigInteger;
 
+import org.apache.carbondata.core.scan.result.vector.CarbonDictionary;
+
 import org.apache.parquet.column.Dictionary;
+import org.apache.parquet.column.Encoding;
 import org.apache.spark.memory.MemoryMode;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.execution.vectorized.ColumnarBatch;
@@ -82,9 +85,10 @@ public class CarbonVectorProxy {
         return columnarBatch.capacity();
     }
 
-    public void setDictionary(Object dictionary, int ordinal) {
-        if (dictionary instanceof Dictionary) {
-            columnarBatch.column(ordinal).setDictionary((Dictionary) dictionary);
+    public void setDictionary(CarbonDictionary dictionary, int ordinal) {
+        if (null != dictionary) {
+            columnarBatch.column(ordinal)
+                .setDictionary(new CarbonDictionaryWrapper(Encoding.PLAIN, dictionary));
         } else {
             columnarBatch.column(ordinal).setDictionary(null);
         }

--- a/integration/spark-datasource/src/main/spark2.3plus/org/apache/spark/sql/CarbonDictionaryWrapper.java
+++ b/integration/spark-datasource/src/main/spark2.3plus/org/apache/spark/sql/CarbonDictionaryWrapper.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql;
+
+import org.apache.carbondata.core.scan.result.vector.CarbonDictionary;
+
+import org.apache.spark.sql.execution.vectorized.Dictionary;
+
+public class CarbonDictionaryWrapper implements Dictionary {
+
+  /**
+   * dictionary values
+   */
+  private byte[][] binaries;
+
+  CarbonDictionaryWrapper(CarbonDictionary dictionary) {
+    binaries = new byte[dictionary.getDictionarySize()][];
+    for (int i = 0; i < binaries.length; i++) {
+      binaries[i] = dictionary.getDictionaryValue(i);
+    }
+  }
+
+  @Override public int decodeToInt(int id) {
+    throw new UnsupportedOperationException("Dictionary encoding does not support int");
+  }
+
+  @Override public long decodeToLong(int id) {
+    throw new UnsupportedOperationException("Dictionary encoding does not support long");
+  }
+
+  @Override public float decodeToFloat(int id) {
+    throw new UnsupportedOperationException("Dictionary encoding does not support float");
+  }
+
+  @Override public double decodeToDouble(int id) {
+    throw new UnsupportedOperationException("Dictionary encoding does not support double");
+  }
+
+  @Override public byte[] decodeToBinary(int id) {
+    return binaries[id];
+  }
+}

--- a/integration/spark-datasource/src/main/spark2.3plus/org/apache/spark/sql/CarbonVectorProxy.java
+++ b/integration/spark-datasource/src/main/spark2.3plus/org/apache/spark/sql/CarbonVectorProxy.java
@@ -18,6 +18,8 @@ package org.apache.spark.sql;
 
 import java.math.BigInteger;
 
+import org.apache.carbondata.core.scan.result.vector.CarbonDictionary;
+
 import org.apache.spark.memory.MemoryMode;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.execution.vectorized.Dictionary;
@@ -262,9 +264,9 @@ public class CarbonVectorProxy {
         return columnVectors[ordinal].hasDictionary();
     }
 
-    public void setDictionary(Object dictionary, int ordinal) {
-        if (dictionary instanceof Dictionary) {
-            columnVectors[ordinal].setDictionary((Dictionary) dictionary);
+    public void setDictionary(CarbonDictionary dictionary, int ordinal) {
+        if (null != dictionary) {
+            columnVectors[ordinal].setDictionary(new CarbonDictionaryWrapper(dictionary));
         } else {
             columnVectors[ordinal].setDictionary(null);
         }


### PR DESCRIPTION
### Problem: 
Query on local dictionary column is giving empty data,this is because the Dictionary class is different in spark-2.2 and spark-2.3, so it fails for the instance of check and sets all the dictionary values as null and gives empty result.

### Solution: 
Create a new column vectory wrapper for spark-2.3 and handle in CarbonVectorProxy for the handling of setting dictionary values based on Dictionary object

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 NA
 - [x] Any backward compatibility impacted?
 NA
 - [x] Document update required?
NA
 - [x] Testing done
added UT
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA
