### PR TITLE
[CARBONDATA-2970]lock object creation fix for viewFS

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/locks/CarbonLockFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/locks/CarbonLockFactory.java
@@ -71,7 +71,8 @@ public class CarbonLockFactory {
       lockTypeConfigured = CarbonCommonConstants.CARBON_LOCK_TYPE_S3;
       return new S3FileLock(absoluteLockPath,
           lockFile);
-    } else if (absoluteLockPath.startsWith(CarbonCommonConstants.HDFSURL_PREFIX)) {
+    } else if (absoluteLockPath.startsWith(CarbonCommonConstants.HDFSURL_PREFIX) || absoluteLockPath
+        .startsWith(CarbonCommonConstants.VIEWFSURL_PREFIX)) {
       lockTypeConfigured = CarbonCommonConstants.CARBON_LOCK_TYPE_HDFS;
       return new HdfsFileLock(absoluteLockPath, lockFile);
     } else {


### PR DESCRIPTION
### Problem
when default fs is set to ViewFS then the drop table and load fails with exception saying failed to get lock like meta.lock, tablestatus.lock. This is because when getting locktypeObject  we wre not checking for viewfs and we are returning it as local file system and failes while acquiring

### Solution
Check for viewFS also when trying to get the lock object 

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 NA
 - [x] Any backward compatibility impacted?
 NA
 - [x] Document update required?
NA
 - [X] Testing done
tested on three node cluster where defaultfs is set to viewFS
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [X] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
na
