### PR TITLE
[CARBONDATA-2974] Fixed multiple expressions issue on datamap chooser and bloom datamap

### DIFF
--- a/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomCoarseGrainDataMap.java
+++ b/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomCoarseGrainDataMap.java
@@ -59,6 +59,7 @@ import org.apache.carbondata.core.scan.expression.LiteralExpression;
 import org.apache.carbondata.core.scan.expression.conditional.EqualToExpression;
 import org.apache.carbondata.core.scan.expression.conditional.InExpression;
 import org.apache.carbondata.core.scan.expression.conditional.ListExpression;
+import org.apache.carbondata.core.scan.expression.logical.AndExpression;
 import org.apache.carbondata.core.scan.filter.resolver.FilterResolverIntf;
 import org.apache.carbondata.core.util.CarbonProperties;
 import org.apache.carbondata.core.util.CarbonUtil;
@@ -264,11 +265,12 @@ public class BloomCoarseGrainDataMap extends CoarseGrainDataMap {
         LOGGER.warn(errorMsg);
         throw new RuntimeException(errorMsg);
       }
+    }  else if (expression instanceof AndExpression) {
+      queryModels.addAll(createQueryModel(((AndExpression) expression).getLeft()));
+      queryModels.addAll(createQueryModel(((AndExpression) expression).getRight()));
+      return queryModels;
     }
 
-    for (Expression child : expression.getChildren()) {
-      queryModels.addAll(createQueryModel(child));
-    }
     return queryModels;
   }
 


### PR DESCRIPTION
Problem: 
When datamap created on multiple columns and queried with multiple filter expressions then query is failing.
Solution:
It is failing because datamap chooser could not merge multiple expressions to single expression. And also bloom filter cannot support And expressions.


Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

