### PR TITLE
[CARBONDATA-2979] select count fails when carbondata file is written through SDK and read through sparkfileformat for complex datatype map(struct->array->map)

### DIFF
--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/AvroCarbonWriter.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/AvroCarbonWriter.java
@@ -625,7 +625,8 @@ public class AvroCarbonWriter extends CarbonWriter {
       case ARRAY:
         // recursively get the sub fields
         // array will have only one sub field.
-        DataType subType = getMappingDataTypeForCollectionRecord(childSchema.getElementType());
+        DataType subType =
+            getMappingDataTypeForCollectionRecord(fieldName, childSchema.getElementType());
         if (subType != null) {
           return (new StructField(fieldName, DataTypes.createArrayType(subType)));
         } else {
@@ -661,7 +662,8 @@ public class AvroCarbonWriter extends CarbonWriter {
     }
   }
 
-  private static DataType getMappingDataTypeForCollectionRecord(Schema childSchema) {
+  private static DataType getMappingDataTypeForCollectionRecord(String fieldName,
+      Schema childSchema) {
     LogicalType logicalType = childSchema.getLogicalType();
     switch (childSchema.getType()) {
       case BOOLEAN:
@@ -700,7 +702,7 @@ public class AvroCarbonWriter extends CarbonWriter {
         return DataTypes.FLOAT;
       case MAP:
         // recursively get the sub fields
-        StructField mapField = prepareSubFields("val", childSchema);
+        StructField mapField = prepareSubFields(fieldName, childSchema);
         if (mapField != null) {
           return mapField.getDataType();
         }
@@ -717,7 +719,8 @@ public class AvroCarbonWriter extends CarbonWriter {
         return DataTypes.createStructType(structSubFields);
       case ARRAY:
         // array will have only one sub field.
-        DataType subType = getMappingDataTypeForCollectionRecord(childSchema.getElementType());
+        DataType subType =
+            getMappingDataTypeForCollectionRecord(fieldName, childSchema.getElementType());
         if (subType != null) {
           return DataTypes.createArrayType(subType);
         } else {


### PR DESCRIPTION
**Problem**
Select query failed issue for map type when data is loaded using avro SDK and external table using carbon file format is used to query the data

**Analysis**
When data is loaded through Avro SDK which has a schema of type struct<array<map>>, fieldName was hard coded to "val" because of which during query the schema written in the file footer and schema inferred for the external table had a mismatch which lead to failure.

**Solution**
Instead of hard coding the field value as "val" use the given field name in the schema

 - [ ] Any interfaces changed?
No 
 - [ ] Any backward compatibility impacted?
 No
 - [ ] Document update required?
No
 - [ ] Testing done
UT Added
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA
