### PR TITLE
[HOTFIX][Streaming] Avoid throwing NPE during deleting the streaming lock file

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonAlterTableCompactionCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonAlterTableCompactionCommand.scala
@@ -334,8 +334,12 @@ case class CarbonAlterTableCompactionCommand(
     val streamingLock = CarbonLockFactory.getCarbonLockObj(
       carbonTable.getTableInfo.getOrCreateAbsoluteTableIdentifier,
       LockUsage.STREAMING_LOCK)
-    if (!FileFactory.getCarbonFile(streamingLock.getLockFilePath).delete()) {
-       LOGGER.warn("failed to delete lock file: " + streamingLock.getLockFilePath)
+    val lockFile =
+      FileFactory.getCarbonFile(streamingLock.getLockFilePath, FileFactory.getConfiguration)
+    if (lockFile.exists()) {
+      if (!lockFile.delete()) {
+        LOGGER.warn("failed to delete lock file: " + streamingLock.getLockFilePath)
+      }
     }
     try {
       if (streamingLock.lockWithRetries()) {

--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/TestStreamingTableOperation.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/TestStreamingTableOperation.scala
@@ -1506,6 +1506,9 @@ class TestStreamingTableOperation extends QueryTest with BeforeAndAfterAll {
   }
 
   test("auto hand off, close and reopen streaming table") {
+    sql("alter table streaming.stream_table_reopen compact 'close_streaming'")
+    sql("ALTER TABLE streaming.stream_table_reopen SET TBLPROPERTIES('streaming'='true')")
+
     executeStreamingIngest(
       tableName = "stream_table_reopen",
       batchNums = 2,


### PR DESCRIPTION
We should check whether the lock file is exists or not before deleting it.
If the lock file is exists, need to delete it.
If the lock file is not exists, no need to do anything.

 - [x] Any interfaces changed?
 no
 - [x] Any backward compatibility impacted?
 no
 - [x] Document update required?
no
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
           add unit test
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
small changes
