### PR TITLE
[HOTFIX] Avoid adding empty table property

### DIFF
--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchemaCommon.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchemaCommon.scala
@@ -839,12 +839,16 @@ class TableNewProcessor(cm: TableModel) {
       x => tablePropertiesMap.put(x._1, x._2)
     }
     // Add table comment to table properties
-    tablePropertiesMap.put("comment", cm.tableComment.getOrElse(""))
+    if (cm.tableComment.nonEmpty) {
+      tablePropertiesMap.put("comment", cm.tableComment.get)
+    }
     val badRecordsPath = getBadRecordsPath(tablePropertiesMap,
       cm.tableName,
       tableSchema.getTableId,
       cm.databaseNameOp.getOrElse("default"))
-    tablePropertiesMap.put("bad_records_path", badRecordsPath)
+    if (badRecordsPath.nonEmpty) {
+      tablePropertiesMap.put("bad_records_path", badRecordsPath.get)
+    }
     tableSchema.setTableProperties(tablePropertiesMap)
     if (cm.bucketFields.isDefined) {
       val bucketCols = cm.bucketFields.get.bucketColumns.map { b =>
@@ -896,14 +900,13 @@ class TableNewProcessor(cm: TableModel) {
   private def getBadRecordsPath(tablePropertiesMap: util.HashMap[String, String],
       tableName: String,
       tableId: String,
-      databaseName: String): String = {
-    val badRecordsPath = tablePropertiesMap.asScala
-      .getOrElse("bad_records_path", CarbonCommonConstants.CARBON_BADRECORDS_LOC_DEFAULT_VAL)
-    if (badRecordsPath == null || badRecordsPath.isEmpty) {
-      CarbonCommonConstants.CARBON_BADRECORDS_LOC_DEFAULT_VAL
+      databaseName: String): Option[String] = {
+    val badRecordsPath = tablePropertiesMap.asScala.get("bad_records_path")
+    if (badRecordsPath.nonEmpty) {
+      Some(badRecordsPath + CarbonCommonConstants.FILE_SEPARATOR + databaseName +
+      CarbonCommonConstants.FILE_SEPARATOR + s"${tableName}_$tableId")
     } else {
-      badRecordsPath + CarbonCommonConstants.FILE_SEPARATOR + databaseName +
-      CarbonCommonConstants.FILE_SEPARATOR + s"${tableName}_$tableId"
+      None
     }
   }
 


### PR DESCRIPTION
When using CarbonCli to print table property of the table, it prints:
```
## Table Properties
Property Name              Property Value                                                     
'sort_columns'             'l_shipdate,l_returnflag,l_shipmode,l_receiptdate,l_shipinstruct'  
'table_blocksize'          '256'                                                              
'no_inverted_index'        'l_shipdate,l_returnflag,l_shipmode,l_receiptdate,l_shipinstruct'  
'comment'                  ''                                                                 
'bad_records_path'         ''                                                                 
'local_dictionary_enable'  'true'  
```
As shown, there are some empty properties written, this PR remove these empty properties

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
