### PR TITLE
[HOXFIX] Upgrade spark integration version to  2.3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -608,13 +608,12 @@
     <profile>
       <id>spark-2.3</id>
       <properties>
-        <spark.version>2.3.1</spark.version>
+        <spark.version>2.3.2</spark.version>
         <scala.binary.version>2.11</scala.binary.version>
         <scala.version>2.11.8</scala.version>
       </properties>
       <modules>
         <module>integration/spark2</module>
-        <module>integration/hive</module>
         <module>integration/presto</module>
         <module>streaming</module>
         <module>examples/spark2</module>


### PR DESCRIPTION
1. Upgrade spark integration version to  2.3.2
2. Currently, hive integration module is not supported along with spark 2.3.2, so remove it in pom.