### PR TITLE
[CARBONDATA-2980][BloomDataMap] Fix bug in clearing bloomindex cache when recreating table and datamap

### DIFF
--- a/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomCoarseGrainDataMapFactory.java
+++ b/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomCoarseGrainDataMapFactory.java
@@ -235,13 +235,13 @@ public class BloomCoarseGrainDataMapFactory extends DataMapFactory<CoarseGrainDa
       } else if (carbonFile.getName().equals(BloomIndexFileStore.MERGE_INPROGRESS_FILE)) {
         mergeShardInprogress = true;
       } else if (carbonFile.isDirectory()) {
-        shardPaths.add(carbonFile.getAbsolutePath());
+        shardPaths.add(FileFactory.getPath(carbonFile.getAbsolutePath()).toString());
       }
     }
     if (mergeShardFile != null && !mergeShardInprogress) {
       // should only get one shard path if mergeShard is generated successfully
       shardPaths.clear();
-      shardPaths.add(mergeShardFile.getAbsolutePath());
+      shardPaths.add(FileFactory.getPath(mergeShardFile.getAbsolutePath()).toString());
     }
     return shardPaths;
   }
@@ -349,6 +349,7 @@ public class BloomCoarseGrainDataMapFactory extends DataMapFactory<CoarseGrainDa
             FileFactory.getFileType(datamapPath));
         CarbonUtil.deleteFoldersAndFilesSilent(file);
       }
+      clear(segment);
     } catch (InterruptedException ex) {
       throw new IOException("Failed to delete datamap for segment_" + segment.getSegmentNo());
     }


### PR DESCRIPTION
clear bloomindex cache when we drop bloomfilter datamap, otherwise
after dropping and recreating the table and datamap, query will give wrong result due to the stale
cache.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

