### PR TITLE
[CARBONDATA-2982] CarbonSchemaReader support array<string>

### DIFF
--- a/examples/spark2/src/main/java/org/apache/carbondata/examples/sdk/CarbonReaderExample.java
+++ b/examples/spark2/src/main/java/org/apache/carbondata/examples/sdk/CarbonReaderExample.java
@@ -108,7 +108,7 @@ public class CarbonReaderExample {
                 .projection(strings)
                 .build();
 
-            System.out.println("\nData:");
+            System.out.println("\nFirst:");
             long day = 24L * 3600 * 1000;
             int i = 0;
             while (reader.hasNext()) {
@@ -125,7 +125,6 @@ public class CarbonReaderExample {
                 System.out.println();
                 i++;
             }
-            System.out.println("\nFinished");
             reader.close();
 
             // Read data
@@ -133,7 +132,7 @@ public class CarbonReaderExample {
                 .builder(path, "_temp")
                 .build();
 
-            System.out.println("\nData:");
+            System.out.println("\nSecond:");
             i = 0;
             while (reader2.hasNext()) {
                 Object[] row = (Object[]) reader2.readNextRow();
@@ -148,7 +147,6 @@ public class CarbonReaderExample {
                     row[5], row[6], row[7], row[8], row[9], row[10]));
                 i++;
             }
-            System.out.println("\nFinished");
             reader2.close();
             FileUtils.deleteDirectory(new File(path));
         } catch (Throwable e) {

--- a/examples/spark2/src/main/java/org/apache/carbondata/examples/sdk/CarbonReaderExample.java
+++ b/examples/spark2/src/main/java/org/apache/carbondata/examples/sdk/CarbonReaderExample.java
@@ -108,7 +108,7 @@ public class CarbonReaderExample {
                 .projection(strings)
                 .build();
 
-            System.out.println("\nFirst:");
+            System.out.println("\nData:");
             long day = 24L * 3600 * 1000;
             int i = 0;
             while (reader.hasNext()) {
@@ -122,6 +122,8 @@ public class CarbonReaderExample {
                 for (int j = 0; j < arr.length; j++) {
                     System.out.print(arr[j] + " ");
                 }
+                assert (arr[0].equals("Hello"));
+                assert (arr[3].equals("Carbon"));
                 System.out.println();
                 i++;
             }
@@ -132,7 +134,7 @@ public class CarbonReaderExample {
                 .builder(path, "_temp")
                 .build();
 
-            System.out.println("\nSecond:");
+            System.out.println("\nData:");
             i = 0;
             while (reader2.hasNext()) {
                 Object[] row = (Object[]) reader2.readNextRow();

--- a/examples/spark2/src/test/scala/org/apache/carbondata/examplesCI/RunExamples.scala
+++ b/examples/spark2/src/test/scala/org/apache/carbondata/examplesCI/RunExamples.scala
@@ -23,6 +23,7 @@ import org.scalatest.BeforeAndAfterAll
 import org.apache.carbondata.examples._
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.util.CarbonProperties
+import org.apache.carbondata.examples.sdk.CarbonReaderExample
 
 /**
  * Test suite for examples
@@ -112,5 +113,9 @@ class RunExamples extends QueryTest with BeforeAndAfterAll {
 
   test("ExternalTableExample") {
     ExternalTableExample.exampleBody(spark)
+  }
+
+  test("CarbonReaderExample") {
+    CarbonReaderExample.main(null)
   }
 }

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonSchemaReader.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonSchemaReader.java
@@ -65,7 +65,15 @@ public class CarbonSchemaReader {
    */
   public static Schema readSchemaInDataFile(String dataFilePath) throws IOException {
     CarbonHeaderReader reader = new CarbonHeaderReader(dataFilePath);
-    return new Schema(reader.readSchema());
+    List<ColumnSchema> columnSchemaList = new ArrayList<ColumnSchema>();
+    List<ColumnSchema> schemaList = reader.readSchema();
+    for (int i = 0; i < schemaList.size(); i++) {
+      ColumnSchema columnSchema = schemaList.get(i);
+      if (!(columnSchema.getColumnName().contains("."))) {
+        columnSchemaList.add(columnSchema);
+      }
+    }
+    return new Schema(columnSchemaList);
   }
 
   /**
@@ -97,7 +105,9 @@ public class CarbonSchemaReader {
       List<org.apache.carbondata.format.ColumnSchema> table_columns =
           readIndexHeader.getTable_columns();
       for (org.apache.carbondata.format.ColumnSchema columnSchema : table_columns) {
-        columnSchemaList.add(thriftColumnSchemaToWrapperColumnSchema(columnSchema));
+        if (!(columnSchema.column_name.contains("."))) {
+          columnSchemaList.add(thriftColumnSchemaToWrapperColumnSchema(columnSchema));
+        }
       }
       return new Schema(columnSchemaList);
     } finally {

--- a/store/sdk/src/test/java/org/apache/carbondata/sdk/file/CarbonReaderTest.java
+++ b/store/sdk/src/test/java/org/apache/carbondata/sdk/file/CarbonReaderTest.java
@@ -1505,29 +1505,21 @@ public class CarbonReaderTest extends TestCase {
           .projection(strings)
           .build();
 
-      System.out.println("\nData:");
-      long day = 24L * 3600 * 1000;
       int i = 0;
       while (reader.hasNext()) {
         Object[] row = (Object[]) reader.readNextRow();
-        System.out.println(String.format("%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t",
-            i, row[0], row[1], row[2], row[3], row[4], row[5],
-            new Date((day * ((int) row[6]))), new Timestamp((long) row[7] / 1000),
-            row[8], row[9]
-        ));
+        assert (row[0].equals("robot" + i));
+        assert (row[2].equals(i));
+        assert (row[6].equals(17957));
         Object[] arr = (Object[]) row[10];
-        for (int j = 0; j < arr.length; j++) {
-          System.out.print(arr[j] + " ");
-        }
-        System.out.println();
+        assert (arr[0].equals("Hello"));
+        assert (arr[3].equals("Carbon"));
         i++;
       }
-      System.out.println("\nFinished");
       reader.close();
       FileUtils.deleteDirectory(new File(path));
     } catch (Throwable e) {
       e.printStackTrace();
-      System.out.println(e.getMessage());
     }
   }
 }


### PR DESCRIPTION
This PR fix the issue and change :
org.apache.carbondata.sdk.file.CarbonSchemaReader#readSchemaInDataFile
org.apache.carbondata.sdk.file.CarbonSchemaReader#readSchemaInIndexFile

This PR remove child schema

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 No
 - [x] Any backward compatibility impacted?
 No
 - [x] Document update required?
No
 - [x] Testing done
     add test code
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
No