### PR TITLE
[CARBONDATA-2967] Fixed NPE for preaggregate queries

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/RelationIdentifier.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/RelationIdentifier.java
@@ -32,6 +32,8 @@ public class RelationIdentifier implements Serializable, Writable {
 
   private String tableId;
 
+  private String tablePath = "";
+
   public RelationIdentifier(String databaseName, String tableName, String tableId) {
     this.databaseName = databaseName;
     this.tableName = tableName;
@@ -50,16 +52,26 @@ public class RelationIdentifier implements Serializable, Writable {
     return tableId;
   }
 
+  public String getTablePath() {
+    return tablePath;
+  }
+
+  public void setTablePath(String tablePath) {
+    this.tablePath = tablePath;
+  }
+
   @Override public void write(DataOutput out) throws IOException {
     out.writeUTF(databaseName);
     out.writeUTF(tableName);
     out.writeUTF(tableId);
+    out.writeUTF(tablePath);
   }
 
   @Override public void readFields(DataInput in) throws IOException {
     this.databaseName = in.readUTF();
     this.tableName = in.readUTF();
     this.tableId = in.readUTF();
+    this.tablePath = in.readUTF();
   }
 
   @Override public boolean equals(Object o) {

--- a/core/src/main/java/org/apache/carbondata/core/scan/executor/util/QueryUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/executor/util/QueryUtil.java
@@ -393,12 +393,6 @@ public class QueryUtil {
 
   public static AbsoluteTableIdentifier getTableIdentifierForColumn(
       CarbonDimension carbonDimension) {
-    RelationIdentifier parentRelationIdentifier =
-        carbonDimension.getColumnSchema().getParentColumnTableRelations().get(0)
-            .getRelationIdentifier();
-    String parentTablePath = CarbonMetadata.getInstance()
-        .getCarbonTable(parentRelationIdentifier.getDatabaseName(),
-            parentRelationIdentifier.getTableName()).getTablePath();
     RelationIdentifier relation = carbonDimension.getColumnSchema()
         .getParentColumnTableRelations()
         .get(0)
@@ -406,8 +400,8 @@ public class QueryUtil {
     String parentTableName = relation.getTableName();
     String parentDatabaseName = relation.getDatabaseName();
     String parentTableId = relation.getTableId();
-    return AbsoluteTableIdentifier.from(parentTablePath, parentDatabaseName, parentTableName,
-        parentTableId);
+    return AbsoluteTableIdentifier.from(relation.getTablePath(), parentDatabaseName,
+        parentTableName, parentTableId);
   }
 
   /**

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonDatasourceHadoopRelation.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonDatasourceHadoopRelation.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql
 
+import scala.collection.JavaConverters._
 import scala.collection.mutable.{ArrayBuffer, ListBuffer}
 import scala.util.control.Breaks._
 
@@ -35,6 +36,7 @@ import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.indexstore.PartitionSpec
 import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable
+import org.apache.carbondata.core.metadata.schema.table.column.CarbonDimension
 import org.apache.carbondata.core.scan.expression.Expression
 import org.apache.carbondata.core.scan.expression.logical.AndExpression
 import org.apache.carbondata.hadoop.CarbonProjection
@@ -79,6 +81,16 @@ case class CarbonDatasourceHadoopRelation(
     }.reduceOption(new AndExpression(_, _))
 
     val projection = new CarbonProjection
+
+    if (carbonTable.isChildDataMap) {
+      val parentTableIdentifier = carbonTable.getTableInfo.getParentRelationIdentifiers.get(0)
+      val path = CarbonEnv.getCarbonTable(Some(parentTableIdentifier.getDatabaseName),
+        parentTableIdentifier.getTableName)(sparkSession).getTablePath
+      for (carbonDimension: CarbonDimension <- carbonTable.getAllDimensions.asScala) {
+        carbonDimension.getColumnSchema.getParentColumnTableRelations.get(0)
+          .getRelationIdentifier.setTablePath(path)
+      }
+    }
 
     // As Filter pushdown for Complex datatype is not supported, if filter is applied on complex
     // column, then Projection pushdown on Complex Columns will not take effect. Hence, check if


### PR DESCRIPTION
**Problem:**
Preaggregate select queries require table path of parent table to access dictionary files. Therefore in executor CarbonMetadata class was used to get parent table object.  As CarbonMetadata class is only meant to be used in driver and is not filled with carbontable objects for select queries therefore the query was throwing NPE.

**Solution:**
Pass parent table path from driver to executor by adding a new variable in RelationIdentifier. This will not be written to thrift, instead will be used to carry tablePath property from driver to executor.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

