### PR TITLE
[HOTFIX] Fixed S3 metrics issue.

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/AbstractDFSCarbonFile.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/AbstractDFSCarbonFile.java
@@ -327,8 +327,11 @@ public abstract class AbstractDFSCarbonFile implements CarbonFile {
       CompressionCodec codec = new CompressionCodecFactory(hadoopConf).getCodecByName(codecName);
       inputStream = codec.createInputStream(inputStream);
     }
-
-    return new DataInputStream(new BufferedInputStream(inputStream));
+    if (bufferSize <= 0 && inputStream instanceof FSDataInputStream) {
+      return (DataInputStream) inputStream;
+    } else {
+      return new DataInputStream(new BufferedInputStream(inputStream));
+    }
   }
 
   /**


### PR DESCRIPTION
Problem: When data read from s3 it shows the data read as more than the size of carbon data total size.
Reason: It happens because carbondata uses `dataInputStream.skip` but in s3 interface it cannot handle properly it reads in a loop and reads more data than required.
Solution: Use `FSDataInputStream.seek` instead of skip to fix this issue.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

