### PR TITLE
[CARBONDATA-2990] Fixed JVM crash when rebuilding bloom datamap.

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/memory/HeapMemoryAllocator.java
+++ b/core/src/main/java/org/apache/carbondata/core/memory/HeapMemoryAllocator.java
@@ -71,7 +71,8 @@ public class HeapMemoryAllocator implements MemoryAllocator {
             final long[] array = arrayReference.get();
             if (array != null) {
               assert (array.length * 8L >= size);
-              MemoryBlock memory = new MemoryBlock(array, CarbonUnsafe.LONG_ARRAY_OFFSET, size);
+              MemoryBlock memory =
+                  new MemoryBlock(array, CarbonUnsafe.LONG_ARRAY_OFFSET, size, MemoryType.ONHEAP);
               // reuse this MemoryBlock
               memory.setFreedStatus(false);
               return memory;
@@ -82,7 +83,7 @@ public class HeapMemoryAllocator implements MemoryAllocator {
       }
     }
     long[] array = new long[numWords];
-    return new MemoryBlock(array, CarbonUnsafe.LONG_ARRAY_OFFSET, size);
+    return new MemoryBlock(array, CarbonUnsafe.LONG_ARRAY_OFFSET, size, MemoryType.ONHEAP);
   }
 
   @Override public void free(MemoryBlock memory) {

--- a/core/src/main/java/org/apache/carbondata/core/memory/MemoryBlock.java
+++ b/core/src/main/java/org/apache/carbondata/core/memory/MemoryBlock.java
@@ -31,12 +31,18 @@ public class MemoryBlock extends MemoryLocation {
   /**
    * whether freed or not
    */
-  private boolean isFreed = false;
+  private boolean isFreed;
 
-  public MemoryBlock(@Nullable Object obj, long offset, long length) {
+  /**
+   * Whether it is offheap or onheap memory type
+   */
+  private MemoryType memoryType;
+
+  public MemoryBlock(@Nullable Object obj, long offset, long length, MemoryType memoryType) {
     super(obj, offset);
     this.length = length;
     this.isFreed = false;
+    this.memoryType = memoryType;
   }
 
   /**
@@ -52,5 +58,9 @@ public class MemoryBlock extends MemoryLocation {
 
   public void setFreedStatus(boolean freedStatus) {
     this.isFreed = freedStatus;
+  }
+
+  public MemoryType getMemoryType() {
+    return memoryType;
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/memory/MemoryType.java
+++ b/core/src/main/java/org/apache/carbondata/core/memory/MemoryType.java
@@ -17,25 +17,7 @@
 
 package org.apache.carbondata.core.memory;
 
-/**
- * Code ported from Apache Spark {org.apache.spark.unsafe.memory} package
- * A simple {@link MemoryAllocator} that uses {@code Unsafe} to allocate off-heap memory.
- */
-public class UnsafeMemoryAllocator implements MemoryAllocator {
+public enum MemoryType {
 
-  @Override
-  public MemoryBlock allocate(long size) throws OutOfMemoryError {
-    long address = CarbonUnsafe.getUnsafe().allocateMemory(size);
-    // initializing memory with zero
-    CarbonUnsafe.getUnsafe().setMemory(null, address, size, (byte) 0);
-    return new MemoryBlock(null, address, size, MemoryType.OFFHEAP);
-  }
-
-  @Override
-  public void free(MemoryBlock memory) {
-    assert (memory.obj == null) :
-      "baseObject not null; are you trying to use the off-heap allocator to free on-heap memory?";
-    CarbonUnsafe.getUnsafe().freeMemory(memory.offset);
-    memory.setFreedStatus(true);
-  }
+  OFFHEAP, ONHEAP;
 }

--- a/core/src/main/java/org/apache/carbondata/core/memory/UnsafeMemoryManager.java
+++ b/core/src/main/java/org/apache/carbondata/core/memory/UnsafeMemoryManager.java
@@ -216,8 +216,6 @@ public class UnsafeMemoryManager {
     switch (memoryType) {
       case ONHEAP:
         return MemoryAllocator.HEAP;
-      case OFFHEAP:
-        return MemoryAllocator.UNSAFE;
       default:
         return MemoryAllocator.UNSAFE;
     }

--- a/core/src/main/java/org/apache/carbondata/core/memory/UnsafeMemoryManager.java
+++ b/core/src/main/java/org/apache/carbondata/core/memory/UnsafeMemoryManager.java
@@ -68,9 +68,9 @@ public class UnsafeMemoryManager {
       LOGGER.info("Invalid memory size value: " + defaultWorkingMemorySize);
     }
     long takenSize = size;
-    MemoryAllocator allocator;
+    MemoryType memoryType;
     if (offHeap) {
-      allocator = MemoryAllocator.UNSAFE;
+      memoryType = MemoryType.OFFHEAP;
       long defaultSize = Long.parseLong(CarbonCommonConstants.UNSAFE_WORKING_MEMORY_IN_MB_DEFAULT);
       if (takenSize < defaultSize) {
         takenSize = defaultSize;
@@ -86,9 +86,9 @@ public class UnsafeMemoryManager {
           takenSize = maxMemory;
         }
       }
-      allocator = MemoryAllocator.HEAP;
+      memoryType = MemoryType.ONHEAP;
     }
-    INSTANCE = new UnsafeMemoryManager(takenSize, allocator);
+    INSTANCE = new UnsafeMemoryManager(takenSize, memoryType);
     taskIdToMemoryBlockMap = new HashMap<>();
   }
 
@@ -98,19 +98,19 @@ public class UnsafeMemoryManager {
 
   private long memoryUsed;
 
-  private MemoryAllocator allocator;
+  private MemoryType memoryType;
 
-  private UnsafeMemoryManager(long totalMemory, MemoryAllocator allocator) {
+  private UnsafeMemoryManager(long totalMemory, MemoryType memoryType) {
     this.totalMemory = totalMemory;
-    this.allocator = allocator;
+    this.memoryType = memoryType;
     LOGGER
-        .info("Working Memory manager is created with size " + totalMemory + " with " + allocator);
+        .info("Working Memory manager is created with size " + totalMemory + " with " + memoryType);
   }
 
-  private synchronized MemoryBlock allocateMemory(MemoryAllocator memoryAllocator, long taskId,
+  private synchronized MemoryBlock allocateMemory(MemoryType memoryType, long taskId,
       long memoryRequested) {
     if (memoryUsed + memoryRequested <= totalMemory) {
-      MemoryBlock allocate = memoryAllocator.allocate(memoryRequested);
+      MemoryBlock allocate = getMemoryAllocator(memoryType).allocate(memoryRequested);
       memoryUsed += allocate.size();
       Set<MemoryBlock> listOfMemoryBlock = taskIdToMemoryBlockMap.get(taskId);
       if (null == listOfMemoryBlock) {
@@ -129,16 +129,11 @@ public class UnsafeMemoryManager {
   }
 
   public synchronized void freeMemory(long taskId, MemoryBlock memoryBlock) {
-    freeMemory(allocator, taskId, memoryBlock);
-  }
-
-  public synchronized void freeMemory(MemoryAllocator memoryAllocator, long taskId,
-      MemoryBlock memoryBlock) {
     if (taskIdToMemoryBlockMap.containsKey(taskId)) {
       taskIdToMemoryBlockMap.get(taskId).remove(memoryBlock);
     }
     if (!memoryBlock.isFreedStatus()) {
-      memoryAllocator.free(memoryBlock);
+      getMemoryAllocator(memoryBlock.getMemoryType()).free(memoryBlock);
       memoryUsed -= memoryBlock.size();
       memoryUsed = memoryUsed < 0 ? 0 : memoryUsed;
       if (LOGGER.isDebugEnabled()) {
@@ -160,7 +155,7 @@ public class UnsafeMemoryManager {
         memoryBlock = iterator.next();
         if (!memoryBlock.isFreedStatus()) {
           occuppiedMemory += memoryBlock.size();
-          allocator.free(memoryBlock);
+          getMemoryAllocator(memoryBlock.getMemoryType()).free(memoryBlock);
         }
       }
     }
@@ -188,15 +183,15 @@ public class UnsafeMemoryManager {
    */
   public static MemoryBlock allocateMemoryWithRetry(long taskId, long size)
       throws MemoryException {
-    return allocateMemoryWithRetry(INSTANCE.allocator, taskId, size);
+    return allocateMemoryWithRetry(INSTANCE.memoryType, taskId, size);
   }
 
-  public static MemoryBlock allocateMemoryWithRetry(MemoryAllocator memoryAllocator, long taskId,
+  public static MemoryBlock allocateMemoryWithRetry(MemoryType memoryType, long taskId,
       long size) throws MemoryException {
     MemoryBlock baseBlock = null;
     int tries = 0;
     while (tries < 300) {
-      baseBlock = INSTANCE.allocateMemory(memoryAllocator, taskId, size);
+      baseBlock = INSTANCE.allocateMemory(memoryType, taskId, size);
       if (baseBlock == null) {
         try {
           LOGGER.info("Memory is not available, retry after 500 millis");
@@ -215,6 +210,17 @@ public class UnsafeMemoryManager {
           "Not enough memory. please increase carbon.unsafe.working.memory.in.mb");
     }
     return baseBlock;
+  }
+
+  private MemoryAllocator getMemoryAllocator(MemoryType memoryType) {
+    switch (memoryType) {
+      case ONHEAP:
+        return MemoryAllocator.HEAP;
+      case OFFHEAP:
+        return MemoryAllocator.UNSAFE;
+      default:
+        return MemoryAllocator.UNSAFE;
+    }
   }
 
   public static boolean isOffHeap() {


### PR DESCRIPTION
Problem: while rebuilding the datamap it access the datamap store so it builds datamap and store in unsafe onheap storage. But while closing the reader it frees all memory acquired during that task. Since acquired memory is onheap but releasing the memory with offheap allocator it crashes the jvm.

Solution: Maintain the type of memory acquired in the memory block itself and get the allocator as per the memory type and release it.


Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

