### PR TITLE
[CARBONDATA-2993] fix random NPE while concurrent loading

### DIFF
--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/AvroCarbonWriter.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/AvroCarbonWriter.java
@@ -520,7 +520,7 @@ public class AvroCarbonWriter extends CarbonWriter {
         // recursively get the sub fields
         ArrayList<StructField> arraySubField = new ArrayList<>();
         // array will have only one sub field.
-        StructField structField = prepareSubFields("val", childSchema.getElementType());
+        StructField structField = prepareSubFields(fieldName, childSchema.getElementType());
         if (structField != null) {
           arraySubField.add(structField);
           return new Field(fieldName, "array", arraySubField);


### PR DESCRIPTION
**Problem:** 
1. NPE is thrown from CarbonRDD during concurrent dataload.
This is due to configuration being extracted from broadcast variable and sometimes it gives null instead of hadoopconfiguration.
2. Array<Map> is throwing schema mismatch exception.

**Solution:** 
1. Keep Hadoop Conf as a transient class level variable for driver and extract from broadcast in executor.
2. In SDK write array child name was being hard coded as 'val'. Instead use the fieldName.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

