### PR TITLE
[CARBONDATA-2595] Reformat the output of command 'desc formatted table_name'

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/dataload/TestNoInvertedIndexLoadAndQuery.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/dataload/TestNoInvertedIndexLoadAndQuery.scala
@@ -279,7 +279,7 @@ class TestNoInvertedIndexLoadAndQuery extends QueryTest with BeforeAndAfterAll {
         """
            describe formatted indexFormat
         """),
-      true,"NOINVERTEDINDEX")
+      true,"NO_INVERTED_INDEX")
   }
 
   test("filter query on dictionary and no inverted index column where all values are null"){

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/alterTable/TestAlterTableWithColumnMetCacheAndCacheLevelProperty.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/alterTable/TestAlterTableWithColumnMetCacheAndCacheLevelProperty.scala
@@ -17,7 +17,7 @@
 
 package org.apache.carbondata.spark.testsuite.alterTable
 
-import org.apache.spark.sql.CarbonEnv
+import org.apache.spark.sql.{CarbonEnv, Row}
 import org.apache.spark.sql.test.util.QueryTest
 import org.scalatest.BeforeAndAfterAll
 
@@ -110,19 +110,23 @@ class TestAlterTableWithColumnMetCacheAndCacheLevelProperty extends QueryTest wi
 
   test("validate unsetting of column_meta_cache when column_meta_cache is already set - alter_column_meta_cache_11") {
     sql("Alter table alter_column_meta_cache SET TBLPROPERTIES('column_meta_cache'='c2,c3')")
-    var descResult = sql("describe formatted alter_column_meta_cache")
-    checkExistence(descResult, true, "COLUMN_META_CACHE")
+    checkAnswer(sql("describe formatted alter_column_meta_cache")
+      .selectExpr("trim(data_type)").where("trim(col_name) = 'COLUMN_META_CACHE'"),
+      Seq(Row("c2,c3")))
     sql("Alter table alter_column_meta_cache UNSET TBLPROPERTIES('column_meta_cache')")
-    descResult = sql("describe formatted alter_column_meta_cache")
-    checkExistence(descResult, false, "COLUMN_META_CACHE")
+    checkAnswer(sql("describe formatted alter_column_meta_cache")
+      .selectExpr("trim(data_type)").where("trim(col_name) = 'COLUMN_META_CACHE'"),
+      Seq(Row("")))
   }
 
   test("validate unsetting of column_meta_cache when column_meta_cache is not already set - alter_column_meta_cache_12") {
-    var descResult = sql("describe formatted alter_column_meta_cache")
-    checkExistence(descResult, false, "COLUMN_META_CACHE")
+    checkAnswer(sql("describe formatted alter_column_meta_cache")
+      .selectExpr("trim(data_type)").where("trim(col_name) = 'COLUMN_META_CACHE'"),
+      Seq(Row("")))
     sql("Alter table alter_column_meta_cache UNSET TBLPROPERTIES('column_meta_cache')")
-    descResult = sql("describe formatted alter_column_meta_cache")
-    checkExistence(descResult, false, "COLUMN_META_CACHE")
+    checkAnswer(sql("describe formatted alter_column_meta_cache")
+      .selectExpr("trim(data_type)").where("trim(col_name) = 'COLUMN_META_CACHE'"),
+      Seq(Row("")))
   }
 
   test("validate cache_level with only empty spaces - ALTER_CACHE_LEVEL_01") {

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestCreateTableWithColumnComment.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestCreateTableWithColumnComment.scala
@@ -42,7 +42,7 @@ class TestCreateTableWithColumnComment extends QueryTest with BeforeAndAfterAll 
     sql(
       "create table defaultComment(id int, name string) " +
       "stored by 'carbondata'")
-    checkExistence(sql("describe formatted defaultComment"), true, "null")
+    checkExistence(sql("describe formatted defaultComment"), false, "null")
   }
 
   override def afterAll {

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestCreateTableWithColumnMetCacheAndCacheLevelProperty.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestCreateTableWithColumnMetCacheAndCacheLevelProperty.scala
@@ -19,7 +19,7 @@ package org.apache.carbondata.spark.testsuite.createTable
 
 import scala.collection.JavaConverters._
 
-import org.apache.spark.sql.CarbonEnv
+import org.apache.spark.sql.{CarbonEnv, Row}
 import org.apache.spark.sql.test.util.QueryTest
 import org.scalatest.BeforeAndAfterAll
 
@@ -115,8 +115,9 @@ class TestCreateTableWithColumnMetCacheAndCacheLevelProperty extends QueryTest w
   test("validate describe formatted command to display column_meta_cache when column_meta_cache is not set - COLUMN_META_CACHE_11") {
     sql("drop table if exists column_meta_cache")
     sql("create table column_meta_cache(c1 String, c2 String, c3 int, c4 double) stored by 'carbondata'")
-    val descResult = sql("describe formatted column_meta_cache")
-    checkExistence(descResult, false, "COLUMN_META_CACHE")
+    checkAnswer(sql("describe formatted column_meta_cache")
+      .selectExpr("trim(data_type)").where("trim(col_name) = 'COLUMN_META_CACHE'"),
+      Seq(Row("")))
   }
 
   test("validate column_meta_cache after column drop - COLUMN_META_CACHE_12") {

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestCreateTableWithCompactionOptions.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestCreateTableWithCompactionOptions.scala
@@ -68,15 +68,15 @@ class TestCreateTableWithCompactionOptions extends QueryTest with BeforeAndAfter
       .collect().map(r => (r.getString(0).trim, r.getString(1).trim)).toMap
 
     assert(tableOptions.contains("MAJOR_COMPACTION_SIZE"))
-    assert(tableOptions.getOrElse("MAJOR_COMPACTION_SIZE","").equals("10240"))
+    assert(tableOptions.getOrElse("MAJOR_COMPACTION_SIZE", "").equals("10240 MB"))
     assert(tableOptions.contains("AUTO_LOAD_MERGE"))
-    assert(tableOptions.getOrElse("AUTO_LOAD_MERGE","").equals("true"))
+    assert(tableOptions.getOrElse("AUTO_LOAD_MERGE", "").equals("true"))
     assert(tableOptions.contains("COMPACTION_LEVEL_THRESHOLD"))
-    assert(tableOptions.getOrElse("COMPACTION_LEVEL_THRESHOLD","").equals("5,6"))
+    assert(tableOptions.getOrElse("COMPACTION_LEVEL_THRESHOLD", "").equals("5,6"))
     assert(tableOptions.contains("COMPACTION_PRESERVE_SEGMENTS"))
-    assert(tableOptions.getOrElse("COMPACTION_PRESERVE_SEGMENTS","").equals("10"))
+    assert(tableOptions.getOrElse("COMPACTION_PRESERVE_SEGMENTS", "").equals("10"))
     assert(tableOptions.contains("ALLOWED_COMPACTION_DAYS"))
-    assert(tableOptions.getOrElse("ALLOWED_COMPACTION_DAYS","").equals("5"))
+    assert(tableOptions.getOrElse("ALLOWED_COMPACTION_DAYS", "").equals("5"))
   }
 
   test("test create table with invalid major compaction size") {
@@ -188,11 +188,16 @@ class TestCreateTableWithCompactionOptions extends QueryTest with BeforeAndAfter
     val tableOptions = sql(s"DESCRIBE FORMATTED $tableWithoutCompactionOptions")
       .collect().map(r => (r.getString(0).trim, r.getString(1).trim)).toMap
 
-    assert(!tableOptions.contains("MAJOR_COMPACTION_SIZE"))
-    assert(!tableOptions.contains("AUTO_LOAD_MERGE"))
-    assert(!tableOptions.contains("COMPACTION_LEVEL_THRESHOLD"))
-    assert(!tableOptions.contains("COMPACTION_PRESERVE_SEGMENTS"))
-    assert(!tableOptions.contains("ALLOWED_COMPACTION_DAYS"))
+    assert(tableOptions.contains("MAJOR_COMPACTION_SIZE"))
+    assert(tableOptions.getOrElse("MAJOR_COMPACTION_SIZE", "").equals("1024 MB"))
+    assert(tableOptions.contains("AUTO_LOAD_MERGE"))
+    assert(tableOptions.getOrElse("AUTO_LOAD_MERGE", "").equals("false"))
+    assert(tableOptions.contains("COMPACTION_LEVEL_THRESHOLD"))
+    assert(tableOptions.getOrElse("COMPACTION_LEVEL_THRESHOLD", "").equals("4,3"))
+    assert(tableOptions.contains("COMPACTION_PRESERVE_SEGMENTS"))
+    assert(tableOptions.getOrElse("COMPACTION_PRESERVE_SEGMENTS", "").equals("0"))
+    assert(tableOptions.contains("ALLOWED_COMPACTION_DAYS"))
+    assert(tableOptions.getOrElse("ALLOWED_COMPACTION_DAYS", "").equals("0"))
   }
 
 }

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestNonTransactionalCarbonTable.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestNonTransactionalCarbonTable.scala
@@ -403,9 +403,9 @@ class TestNonTransactionalCarbonTable extends QueryTest with BeforeAndAfterAll {
          |'carbondata' LOCATION
          |'$writerPath' """.stripMargin)
 
-    checkExistence(sql("describe formatted sdkOutputTable"), true, "SORT_COLUMNS                        age")
-    checkExistence(sql("describe formatted sdkOutputTable"), false, "SORT_COLUMNS                        name,age")
-    checkExistence(sql("describe formatted sdkOutputTable"), false, "SORT_COLUMNS                        age,name")
+    checkExistence(sql("describe formatted sdkOutputTable"), true, "SORT_COLUMNS                            age")
+    checkExistence(sql("describe formatted sdkOutputTable"), false, "SORT_COLUMNS                            name,age")
+    checkExistence(sql("describe formatted sdkOutputTable"), false, "SORT_COLUMNS                            age,name")
     buildTestDataSingleFile()
     assert(new File(writerPath).exists())
     sql("DROP TABLE IF EXISTS sdkOutputTable")
@@ -415,7 +415,7 @@ class TestNonTransactionalCarbonTable extends QueryTest with BeforeAndAfterAll {
          |'carbondata' LOCATION
          |'$writerPath' """.stripMargin)
 
-    checkExistence(sql("describe formatted sdkOutputTable"), true, "SORT_COLUMNS                        name")
+    checkExistence(sql("describe formatted sdkOutputTable"), true, "SORT_COLUMNS                            name")
 
     buildTestDataWithSortColumns(List())
     assert(new File(writerPath).exists())
@@ -427,7 +427,7 @@ class TestNonTransactionalCarbonTable extends QueryTest with BeforeAndAfterAll {
          |'carbondata' LOCATION
          |'$writerPath' """.stripMargin)
 
-    checkExistence(sql("describe formatted sdkOutputTable"),false,"SORT_COLUMNS                        name")
+    checkExistence(sql("describe formatted sdkOutputTable"),false,"SORT_COLUMNS                            name")
     sql("select * from sdkOutputTable").show()
 
     sql("DROP TABLE sdkOutputTable")
@@ -879,7 +879,7 @@ class TestNonTransactionalCarbonTable extends QueryTest with BeforeAndAfterAll {
 
     // test the default sort column behavior in Nontransactional table
     checkExistence(sql("describe formatted sdkOutputTable"), true,
-      "SORT_COLUMNS                        name")
+      "SORT_COLUMNS                            name")
 
     sql("DROP TABLE sdkOutputTable")
     // drop table should not delete the files

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/describeTable/TestDescribeTable.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/describeTable/TestDescribeTable.scala
@@ -57,7 +57,7 @@ class TestDescribeTable extends QueryTest with BeforeAndAfterAll {
         "SORT_COLUMNS", "DICTIONARY_INCLUDE", "NO_INVERTED_INDEX", "Streaming", "CACHE_LEVEL",
         "COLUMN_META_CACHE", "AUTO_LOAD_MERGE", "COMPACTION_LEVEL_THRESHOLD",
         "COMPACTION_PRESERVE_SEGMENTS", "ALLOWED_COMPACTION_DAYS", "MAJOR_COMPACTION_SIZE",
-        "FLAT_FOLDER", "LONG_STRING_COLUMNS", "Local Dictionary Enabled", "ExternalTable")
+        "FLAT_FOLDER", "LONG_STRING_COLUMNS", "Local Dictionary Enabled", "External Table")
     val resultRow: Seq[Row] = resultCol map(propName => Row(f"$propName%-40s"))
     checkAnswer(sql("desc formatted DESC1").select("col_name"), resultRow)
     assert(sql("desc formatted desc1").count() == 34)

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/describeTable/TestDescribeTable.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/describeTable/TestDescribeTable.scala
@@ -50,11 +50,17 @@ class TestDescribeTable extends QueryTest with BeforeAndAfterAll {
 
   test("test describe formatted table desc1") {
 
-    val resultCol = Seq("", "", "##Detailed Column property", "##Detailed Table Information", "ADAPTIVE", "CARBON Store Path", "Comment", "Database Name", "Last Update Time",
-    "SORT_COLUMNS", "SORT_SCOPE", "CACHE_LEVEL", "Streaming", "Table Block Size", "Local Dictionary Enabled","Table Data Size", "Table Index Size", "Table Name", "dec2col1", "dec2col2", "dec2col3", "dec2col4")
-    val resultRow: Seq[Row] = resultCol map(propName => Row(f"$propName%-36s"))
+    val resultCol = Seq("dec2col1", "dec2col2", "dec2col3", "dec2col4", "",
+        "### PROPERTY", "", "## Table Basic Information", "Database Name", "Table Name",
+        "Table Path", "Comment", "Table Data Size", "Table Index Size", "Last Update Time", "",
+        "## Detailed Table Properties Information", "Table Block Size", "SORT_SCOPE",
+        "SORT_COLUMNS", "DICTIONARY_INCLUDE", "NO_INVERTED_INDEX", "Streaming", "CACHE_LEVEL",
+        "COLUMN_META_CACHE", "AUTO_LOAD_MERGE", "COMPACTION_LEVEL_THRESHOLD",
+        "COMPACTION_PRESERVE_SEGMENTS", "ALLOWED_COMPACTION_DAYS", "MAJOR_COMPACTION_SIZE",
+        "FLAT_FOLDER", "LONG_STRING_COLUMNS", "Local Dictionary Enabled", "ExternalTable")
+    val resultRow: Seq[Row] = resultCol map(propName => Row(f"$propName%-40s"))
     checkAnswer(sql("desc formatted DESC1").select("col_name"), resultRow)
-    assert(sql("desc formatted desc1").count() == 22)
+    assert(sql("desc formatted desc1").count() == 34)
   }
 
   test("test describe formatted for partition table") {

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/sql/commands/StoredAsCarbondataSuite.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/sql/commands/StoredAsCarbondataSuite.scala
@@ -61,7 +61,7 @@ class StoredAsCarbondataSuite extends QueryTest with BeforeAndAfterEach {
       .filter(row => row.getString(0).contains(CarbonCommonConstants.TABLE_DATA_SIZE) ||
         row.getString(0).contains(CarbonCommonConstants.TABLE_INDEX_SIZE))
     assert(res3.length == 2)
-    res3.foreach(row => assert(row.getString(1).trim.toLong > 0))
+    res3.foreach(row => assert(!row.getString(1).trim.equals("0.0B")))
   }
 
   test("CARBONDATA-2262: Don't Support the syntax of 'STORED AS 'carbondata''") {

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/sql/commands/UsingCarbondataSuite.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/sql/commands/UsingCarbondataSuite.scala
@@ -70,7 +70,7 @@ class UsingCarbondataSuite extends QueryTest with BeforeAndAfterEach {
       .filter(row => row.getString(0).contains(CarbonCommonConstants.TABLE_DATA_SIZE) ||
         row.getString(0).contains(CarbonCommonConstants.TABLE_INDEX_SIZE))
     assert(res3.length == 2)
-    res3.foreach(row => assert(row.getString(1).trim.toLong > 0))
+    res3.foreach(row => assert(!row.getString(1).trim.equals("0.0B")))
   }
 
   test("CARBONDATA-2396 Support Create Table As Select with 'using carbondata'") {

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonDescribeFormattedCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonDescribeFormattedCommand.scala
@@ -186,7 +186,8 @@ private[sql] case class CarbonDescribeFormattedCommand(
             }
           }
           results ++=
-            Seq(("Local Dictionary Exclude", getDictColumnString(builder.toString().split(",")), ""))
+            Seq(("Local Dictionary Exclude",
+                getDictColumnString(builder.toString().split(",")), ""))
         }
       }
     } else {

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonDescribeFormattedCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonDescribeFormattedCommand.scala
@@ -26,12 +26,10 @@ import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.execution.SparkPlan
 import org.apache.spark.sql.execution.command.MetadataCommand
 import org.apache.spark.sql.hive.CarbonRelation
-import org.codehaus.jackson.map.ObjectMapper
 
+import org.apache.carbondata.common.Strings
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.metadata.datatype.DataTypes
-import org.apache.carbondata.core.metadata.encoder.Encoding
-import org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema
 import org.apache.carbondata.core.util.CarbonUtil
 
 private[sql] case class CarbonDescribeFormattedCommand(
@@ -44,89 +42,121 @@ private[sql] case class CarbonDescribeFormattedCommand(
   override def processMetadata(sparkSession: SparkSession): Seq[Row] = {
     val relation = CarbonEnv.getInstance(sparkSession).carbonMetastore
       .lookupRelation(tblIdentifier)(sparkSession).asInstanceOf[CarbonRelation]
-    val mapper = new ObjectMapper()
-    val colProps = StringBuilder.newBuilder
-    val dims = relation.metaData.dims.map(x => x.toLowerCase)
-    var results: Seq[(String, String, String)] = child.schema.fields.map { field =>
-      val fieldName = field.name.toLowerCase
-      val colComment = field.getComment().getOrElse("null")
-      val comment = if (dims.contains(fieldName)) {
-        val dimension = relation.metaData.carbonTable.getDimensionByName(
-          relation.carbonTable.getTableName, fieldName)
-        if (null != dimension.getColumnProperties && !dimension.getColumnProperties.isEmpty) {
-          colProps.append(fieldName).append(".")
-            .append(mapper.writeValueAsString(dimension.getColumnProperties))
-            .append(",")
-        }
-        if (dimension.hasEncoding(Encoding.DICTIONARY) &&
-            !dimension.hasEncoding(Encoding.DIRECT_DICTIONARY)) {
-          "DICTIONARY, KEY COLUMN" + (if (dimension.hasEncoding(Encoding.INVERTED_INDEX)) {
-            "".concat(",").concat(colComment)
-          } else {
-            ",NOINVERTEDINDEX".concat(",").concat(colComment)
-          })
-        } else {
-          "KEY COLUMN" + (if (dimension.hasEncoding(Encoding.INVERTED_INDEX)) {
-            "".concat(",").concat(colComment)
-          } else {
-            ",NOINVERTEDINDEX".concat(",").concat(colComment)
-          })
-        }
-      } else {
-        "MEASURE".concat(",").concat(colComment)
-      }
-
-      (field.name, field.dataType.simpleString, comment)
-    }
-    val colPropStr = if (colProps.toString().trim().length() > 0) {
-      // drops additional comma at end
-      colProps.toString().dropRight(1)
-    } else {
-      colProps.toString()
-    }
     val carbonTable = relation.carbonTable
-    results ++= Seq(("", "", ""), ("##Detailed Table Information", "", ""))
-    results ++= Seq(("Database Name", relation.carbonTable.getDatabaseName, "")
-    )
-    results ++= Seq(("Table Name", relation.carbonTable.getTableName, ""))
-    results ++= Seq(("CARBON Store Path ", carbonTable.getTablePath, ""))
-
     val tblProps = carbonTable.getTableInfo.getFactTable.getTableProperties
 
-    // Carbon table support table comment
-    val tableComment = tblProps.asScala.getOrElse(CarbonCommonConstants.TABLE_COMMENT, "")
-    results ++= Seq(("Comment", tableComment, ""))
-    results ++= Seq(("Table Block Size ", carbonTable.getBlockSizeInMB + " MB", ""))
-    val dataIndexSize = CarbonUtil.calculateDataIndexSize(carbonTable, false)
-    if (!dataIndexSize.isEmpty) {
-      results ++= Seq((CarbonCommonConstants.TABLE_DATA_SIZE,
-        dataIndexSize.get(CarbonCommonConstants.CARBON_TOTAL_DATA_SIZE).toString, ""))
-      results ++= Seq((CarbonCommonConstants.TABLE_INDEX_SIZE,
-        dataIndexSize.get(CarbonCommonConstants.CARBON_TOTAL_INDEX_SIZE).toString, ""))
-      results ++= Seq((CarbonCommonConstants.LAST_UPDATE_TIME,
-        dataIndexSize.get(CarbonCommonConstants.LAST_UPDATE_TIME).toString, ""))
+    // Table Schema Information
+    var results: Seq[(String, String, String)] = child.schema.fields.map { field =>
+      (field.name, field.dataType.simpleString, field.getComment().getOrElse(""))
     }
 
+    results ++= Seq(("", "", ""), ("### PROPERTY", "VALUE", "DEFAULT_VALUE"))
+
+    // Table Basic Information
+    results ++= Seq(("", "", ""), ("## Table Basic Information", "", ""))
+    results ++= Seq(("Database Name", carbonTable.getDatabaseName, ""))
+    results ++= Seq(("Table Name", carbonTable.getTableName, ""))
+    results ++= Seq(("Table Path", carbonTable.getTablePath, ""))
+
+    // Carbon table support table comment
+    results ++= Seq(("Comment",
+        tblProps.asScala.getOrElse(CarbonCommonConstants.TABLE_COMMENT, ""), ""))
+
+    val dataIndexSize = CarbonUtil.calculateDataIndexSize(carbonTable, false)
+    var tableDataSizeStr = "0B"
+    var tableIndexSizeStr = "0B"
+    var lastUpdateTimeStr = "NA"
+    if (!dataIndexSize.isEmpty) {
+      val tableDataSize =
+        dataIndexSize.get(CarbonCommonConstants.CARBON_TOTAL_DATA_SIZE).toLong
+      tableDataSizeStr = Strings.formatSize(tableDataSize)
+      val tableIndexSize =
+        dataIndexSize.get(CarbonCommonConstants.CARBON_TOTAL_INDEX_SIZE).toLong
+      tableIndexSizeStr = Strings.formatSize(tableIndexSize)
+      val lastUpdateTime = dataIndexSize.get(CarbonCommonConstants.LAST_UPDATE_TIME).toLong
+      lastUpdateTimeStr = if (lastUpdateTime > 0L) {
+        new java.sql.Timestamp(lastUpdateTime).toString()
+      } else {
+        "NA"
+      }
+    }
+    results ++= Seq((CarbonCommonConstants.TABLE_DATA_SIZE, tableDataSizeStr, ""))
+    results ++= Seq((CarbonCommonConstants.TABLE_INDEX_SIZE, tableIndexSizeStr, ""))
+    results ++= Seq((CarbonCommonConstants.LAST_UPDATE_TIME, lastUpdateTimeStr, ""))
+
+    // Detailed Table Properties Information
+    results ++= Seq(("", "", ""), ("## Detailed Table Properties Information", "", ""))
+    results ++= Seq(("Table Block Size", carbonTable.getBlockSizeInMB + " MB",
+        CarbonCommonConstants.BLOCK_SIZE_DEFAULT_VAL + " MB"))
     results ++= Seq(("SORT_SCOPE", tblProps.asScala.getOrElse("sort_scope", CarbonCommonConstants
       .LOAD_SORT_SCOPE_DEFAULT), tblProps.asScala.getOrElse("sort_scope", CarbonCommonConstants
       .LOAD_SORT_SCOPE_DEFAULT)))
+    results ++= Seq(("SORT_COLUMNS", carbonTable.getSortColumns(
+      carbonTable.getTableName).asScala
+      .map(column => column).mkString(","), ""))
+    results ++= Seq(("DICTIONARY_INCLUDE",
+      tblProps.asScala.getOrElse(CarbonCommonConstants.DICTIONARY_INCLUDE, ""), ""))
+    results ++= Seq(("NO_INVERTED_INDEX",
+      tblProps.asScala.getOrElse(CarbonCommonConstants.NO_INVERTED_INDEX, ""), ""))
+    results ++= Seq(("Streaming", tblProps.asScala.getOrElse("streaming", "false"), "false"))
     // add Cache Level property
     results ++= Seq(("CACHE_LEVEL", tblProps.asScala.getOrElse(CarbonCommonConstants.CACHE_LEVEL,
-      CarbonCommonConstants.CACHE_LEVEL_DEFAULT_VALUE), ""))
-    val isStreaming = tblProps.asScala.getOrElse("streaming", "false")
-    results ++= Seq(("Streaming", isStreaming, ""))
+      CarbonCommonConstants.CACHE_LEVEL_DEFAULT_VALUE),
+      CarbonCommonConstants.CACHE_LEVEL_DEFAULT_VALUE))
+    // add columns configured in column meta cache
+    results ++=
+      Seq(("COLUMN_META_CACHE",
+          tblProps.asScala.getOrElse(CarbonCommonConstants.COLUMN_META_CACHE, ""), ""))
+
+    // show table level compaction options
+    results ++= Seq((CarbonCommonConstants.TABLE_AUTO_LOAD_MERGE.toUpperCase,
+      tblProps.asScala.getOrElse(CarbonCommonConstants.TABLE_AUTO_LOAD_MERGE,
+          CarbonCommonConstants.DEFAULT_ENABLE_AUTO_LOAD_MERGE),
+          CarbonCommonConstants.DEFAULT_ENABLE_AUTO_LOAD_MERGE))
+    results ++= Seq((CarbonCommonConstants.TABLE_COMPACTION_LEVEL_THRESHOLD.toUpperCase,
+      tblProps.asScala.getOrElse(CarbonCommonConstants.TABLE_COMPACTION_LEVEL_THRESHOLD,
+          CarbonCommonConstants.DEFAULT_SEGMENT_LEVEL_THRESHOLD),
+          CarbonCommonConstants.DEFAULT_SEGMENT_LEVEL_THRESHOLD))
+    results ++= Seq((CarbonCommonConstants.TABLE_COMPACTION_PRESERVE_SEGMENTS.toUpperCase,
+      tblProps.asScala.getOrElse(CarbonCommonConstants.TABLE_COMPACTION_PRESERVE_SEGMENTS,
+          CarbonCommonConstants.DEFAULT_PRESERVE_LATEST_SEGMENTS_NUMBER),
+          CarbonCommonConstants.DEFAULT_PRESERVE_LATEST_SEGMENTS_NUMBER))
+    results ++= Seq((CarbonCommonConstants.TABLE_ALLOWED_COMPACTION_DAYS.toUpperCase,
+      tblProps.asScala.getOrElse(CarbonCommonConstants.TABLE_ALLOWED_COMPACTION_DAYS,
+          CarbonCommonConstants.DEFAULT_DAYS_ALLOWED_TO_COMPACT),
+          CarbonCommonConstants.DEFAULT_DAYS_ALLOWED_TO_COMPACT))
+    results ++= Seq((CarbonCommonConstants.TABLE_MAJOR_COMPACTION_SIZE.toUpperCase,
+      tblProps.asScala.getOrElse(CarbonCommonConstants.TABLE_MAJOR_COMPACTION_SIZE,
+          CarbonCommonConstants.DEFAULT_CARBON_MAJOR_COMPACTION_SIZE) + " MB",
+          CarbonCommonConstants.DEFAULT_CARBON_MAJOR_COMPACTION_SIZE + " MB"))
+
+    results ++= Seq((CarbonCommonConstants.FLAT_FOLDER.toUpperCase,
+      tblProps.asScala.getOrElse(CarbonCommonConstants.FLAT_FOLDER,
+          CarbonCommonConstants.DEFAULT_FLAT_FOLDER),
+          CarbonCommonConstants.DEFAULT_FLAT_FOLDER))
 
     // longstring related info
-    if (tblProps.containsKey(CarbonCommonConstants.LONG_STRING_COLUMNS)) {
-      results ++= Seq((CarbonCommonConstants.LONG_STRING_COLUMNS.toUpperCase,
-        tblProps.get(CarbonCommonConstants.LONG_STRING_COLUMNS), ""))
+    results ++= Seq((CarbonCommonConstants.LONG_STRING_COLUMNS.toUpperCase,
+      tblProps.asScala.getOrElse(CarbonCommonConstants.LONG_STRING_COLUMNS, ""), ""))
+
+    /**
+     * return the string which has all comma separated columns
+     * @param localDictColumns
+     * @return
+     */
+    def getDictColumnString(localDictColumns: Array[String]): String = {
+      val dictColumns: StringBuilder = new StringBuilder
+      localDictColumns.foreach(column => dictColumns.append(column.trim).append(","))
+      dictColumns.toString().patch(dictColumns.toString().lastIndexOf(","), "", 1)
     }
 
+    // local dictionary properties
     var isLocalDictEnabled = tblProps.asScala
       .get(CarbonCommonConstants.LOCAL_DICTIONARY_ENABLE)
     if (isLocalDictEnabled.isDefined) {
       val localDictEnabled = isLocalDictEnabled.get.split(",") { 0 }
-      results ++= Seq(("Local Dictionary Enabled", localDictEnabled, ""))
+      results ++= Seq(("Local Dictionary Enabled", localDictEnabled,
+          CarbonCommonConstants.LOCAL_DICTIONARY_ENABLE_DEFAULT))
       // if local dictionary is enabled, then only show other properties of local dictionary
       if (localDictEnabled.toBoolean) {
         var localDictThreshold = tblProps.asScala
@@ -143,7 +173,7 @@ private[sql] case class CarbonDescribeFormattedCommand(
           }
         }
         results ++=
-        Seq(("Local Dictionary Include", getDictColumnString(builder.toString().split(",")), ""))
+          Seq(("Local Dictionary Include", getDictColumnString(builder.toString().split(",")), ""))
         if (tblProps.asScala
           .get(CarbonCommonConstants.LOCAL_DICTIONARY_EXCLUDE).isDefined) {
           val columns = carbonTable.getTableInfo.getFactTable.getListOfColumns.asScala
@@ -156,89 +186,40 @@ private[sql] case class CarbonDescribeFormattedCommand(
             }
           }
           results ++=
-          Seq(("Local Dictionary Exclude", getDictColumnString(builder.toString().split(",")), ""))
+            Seq(("Local Dictionary Exclude", getDictColumnString(builder.toString().split(",")), ""))
         }
       }
     } else {
       results ++=
-      Seq(("Local Dictionary Enabled", CarbonCommonConstants.LOCAL_DICTIONARY_ENABLE_DEFAULT, ""))
+        Seq(("Local Dictionary Enabled", CarbonCommonConstants.LOCAL_DICTIONARY_ENABLE_DEFAULT,
+          CarbonCommonConstants.LOCAL_DICTIONARY_ENABLE_DEFAULT))
     }
 
-    /**
-     * return the string which has all comma separated columns
-     * @param localDictColumns
-     * @return
-     */
-    def getDictColumnString(localDictColumns: Array[String]): String = {
-      val dictColumns: StringBuilder = new StringBuilder
-      localDictColumns.foreach(column => dictColumns.append(column.trim).append(","))
-      dictColumns.toString().patch(dictColumns.toString().lastIndexOf(","), "", 1)
+    val isExternalTable = tblProps.asScala.getOrElse("_external", "false").toBoolean
+    results ++= Seq(("External Table", isExternalTable.toString(), "false"))
+    // Location Path
+    if (isExternalTable) {
+      results ++= Seq(("External Path", carbonTable.getTablePath, ""))
     }
 
-
-    // show table level compaction options
-    if (tblProps.containsKey(CarbonCommonConstants.TABLE_MAJOR_COMPACTION_SIZE)) {
-      results ++= Seq((CarbonCommonConstants.TABLE_MAJOR_COMPACTION_SIZE.toUpperCase
-        , tblProps.get(CarbonCommonConstants.TABLE_MAJOR_COMPACTION_SIZE),
-        CarbonCommonConstants.DEFAULT_CARBON_MAJOR_COMPACTION_SIZE))
-    }
-    if (tblProps.containsKey(CarbonCommonConstants.TABLE_AUTO_LOAD_MERGE)) {
-      results ++= Seq((CarbonCommonConstants.TABLE_AUTO_LOAD_MERGE.toUpperCase,
-        tblProps.get(CarbonCommonConstants.TABLE_AUTO_LOAD_MERGE),
-        CarbonCommonConstants.DEFAULT_ENABLE_AUTO_LOAD_MERGE))
-    }
-    if (tblProps.containsKey(CarbonCommonConstants.TABLE_COMPACTION_LEVEL_THRESHOLD)) {
-      results ++= Seq((CarbonCommonConstants.TABLE_COMPACTION_LEVEL_THRESHOLD.toUpperCase,
-        tblProps.get(CarbonCommonConstants.TABLE_COMPACTION_LEVEL_THRESHOLD),
-        CarbonCommonConstants.DEFAULT_SEGMENT_LEVEL_THRESHOLD))
-    }
-    if (tblProps.containsKey(CarbonCommonConstants.TABLE_COMPACTION_PRESERVE_SEGMENTS)) {
-      results ++= Seq((CarbonCommonConstants.TABLE_COMPACTION_PRESERVE_SEGMENTS.toUpperCase,
-        tblProps.get(CarbonCommonConstants.TABLE_COMPACTION_PRESERVE_SEGMENTS),
-        CarbonCommonConstants.DEFAULT_PRESERVE_LATEST_SEGMENTS_NUMBER))
-    }
-    if (tblProps.containsKey(CarbonCommonConstants.TABLE_ALLOWED_COMPACTION_DAYS)) {
-      results ++= Seq((CarbonCommonConstants.TABLE_ALLOWED_COMPACTION_DAYS.toUpperCase,
-        tblProps.get(CarbonCommonConstants.TABLE_ALLOWED_COMPACTION_DAYS),
-        CarbonCommonConstants.DEFAULT_DAYS_ALLOWED_TO_COMPACT))
-    }
-    if (tblProps.containsKey(CarbonCommonConstants.FLAT_FOLDER)) {
-      results ++= Seq((CarbonCommonConstants.FLAT_FOLDER.toUpperCase,
-        tblProps.get(CarbonCommonConstants.FLAT_FOLDER),
-        CarbonCommonConstants.DEFAULT_FLAT_FOLDER))
-    }
-
-    results ++= Seq(("", "", ""), ("##Detailed Column property", "", ""))
-    if (colPropStr.length() > 0) {
-      results ++= Seq((colPropStr, "", ""))
-    } else {
-      results ++= Seq(("ADAPTIVE", "", ""))
-    }
-    results ++= Seq(("SORT_COLUMNS", relation.metaData.carbonTable.getSortColumns(
-      relation.carbonTable.getTableName).asScala
-      .map(column => column).mkString(","), ""))
-    // add columns configured in column meta cache
-    if (null != tblProps.get(CarbonCommonConstants.COLUMN_META_CACHE)) {
-      results ++=
-      Seq(("COLUMN_META_CACHE", carbonTable.getMinMaxCachedColumnsInCreateOrder().asScala
-        .map(col => col).mkString(","), ""))
-    }
+    // Partition Information
     if (carbonTable.getPartitionInfo(carbonTable.getTableName) != null) {
-      results ++=
-      Seq(("#Partition Information", "", ""),
-        ("#col_name", "data_type", "comment"))
-      results ++= carbonTable.getPartitionInfo(carbonTable.getTableName)
-        .getColumnSchemaList.asScala.map {
-        col => (col.getColumnName, col.getDataType.getName, "NULL")
-      }
+      results ++= Seq(("", "", ""), ("## Partition Information", "", ""))
       results ++= Seq(("Partition Type", carbonTable.getPartitionInfo(carbonTable.getTableName)
         .getPartitionType.toString, ""))
+      results ++= Seq(("", "", ""), ("# partition_col", "data_type", "comment"))
+      results ++= carbonTable.getPartitionInfo(carbonTable.getTableName)
+        .getColumnSchemaList.asScala.map {
+        col => (col.getColumnName, col.getDataType.getName, "")
+      }
     }
+
+    // Detailed Partition Information
     if (partitionSpec.nonEmpty) {
       val partitions = sparkSession.sessionState.catalog.getPartition(tblIdentifier, partitionSpec)
       results ++=
       Seq(("", "", ""),
-        ("##Detailed Partition Information", "", ""),
+        ("## Detailed Partition Information", "", ""),
         ("Partition Value:", partitions.spec.values.mkString("[", ",", "]"), ""),
         ("Database:", tblIdentifier.database.getOrElse(sparkSession.catalog.currentDatabase), ""),
         ("Table:", tblIdentifier.table, ""))
@@ -247,11 +228,12 @@ private[sql] case class CarbonDescribeFormattedCommand(
       }
       results ++= Seq(("Partition Parameters:", partitions.parameters.mkString(", "), ""))
     }
+
     results.map {
       case (name, dataType, null) =>
-        Row(f"$name%-36s", f"$dataType%-80s", null)
+        Row(f"$name%-40s", f"$dataType%-120s", null)
       case (name, dataType, comment) =>
-        Row(f"$name%-36s", f"$dataType%-80s", f"$comment%-72s")
+        Row(f"$name%-40s", f"$dataType%-120s", f"$comment%-60s")
     }
   }
 }

--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/restructure/vectorreader/AddColumnTestCases.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/restructure/vectorreader/AddColumnTestCases.scala
@@ -641,7 +641,9 @@ class AddColumnTestCases extends Spark2QueryTest with BeforeAndAfterAll {
       """)
 
     sql("alter table NO_INVERTED_CARBON add columns(col1 string,col2 string) tblproperties('NO_INVERTED_INDEX'='col2')")
-    checkExistenceCount(sql("desc formatted NO_INVERTED_CARBON"),2,"NOINVERTEDINDEX")
+    checkAnswer(sql("desc formatted NO_INVERTED_CARBON")
+        .selectExpr("trim(data_type)").where("trim(col_name) = 'NO_INVERTED_INDEX'"),
+        Seq(Row("city,col2")))
   }
 
   test("test if adding column in pre-aggregate table throws exception") {

--- a/integration/spark2/src/test/scala/org/apache/spark/sql/GetDataSizeAndIndexSizeTest.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/sql/GetDataSizeAndIndexSizeTest.scala
@@ -59,7 +59,7 @@ class GetDataSizeAndIndexSizeTest extends QueryTest with BeforeAndAfterAll {
       .filter(row => row.getString(0).contains(CarbonCommonConstants.TABLE_DATA_SIZE) ||
       row.getString(0).contains(CarbonCommonConstants.TABLE_INDEX_SIZE))
     assert(res1.length == 2)
-    res1.foreach(row => assert(row.getString(1).trim.toLong > 0))
+    res1.foreach(row => assert(!row.getString(1).trim.equals("0.0B")))
   }
 
   test("get data size and index size after major compaction") {
@@ -73,7 +73,7 @@ class GetDataSizeAndIndexSizeTest extends QueryTest with BeforeAndAfterAll {
       .filter(row => row.getString(0).contains(CarbonCommonConstants.TABLE_DATA_SIZE) ||
         row.getString(0).contains(CarbonCommonConstants.TABLE_INDEX_SIZE))
     assert(res2.length == 2)
-    res2.foreach(row => assert(row.getString(1).trim.toLong > 0))
+    res2.foreach(row => assert(!row.getString(1).trim.equals("0.0B")))
   }
 
   test("get data size and index size after minor compaction") {
@@ -91,7 +91,7 @@ class GetDataSizeAndIndexSizeTest extends QueryTest with BeforeAndAfterAll {
       .filter(row => row.getString(0).contains(CarbonCommonConstants.TABLE_DATA_SIZE) ||
         row.getString(0).contains(CarbonCommonConstants.TABLE_INDEX_SIZE))
     assert(res3.length == 2)
-    res3.foreach(row => assert(row.getString(1).trim.toLong > 0))
+    res3.foreach(row => assert(!row.getString(1).trim.equals("0.0B")))
   }
 
   test("get data size and index size after insert into") {
@@ -105,7 +105,7 @@ class GetDataSizeAndIndexSizeTest extends QueryTest with BeforeAndAfterAll {
       .filter(row => row.getString(0).contains(CarbonCommonConstants.TABLE_DATA_SIZE) ||
         row.getString(0).contains(CarbonCommonConstants.TABLE_INDEX_SIZE))
     assert(res4.length == 2)
-    res4.foreach(row => assert(row.getString(1).trim.toLong > 0))
+    res4.foreach(row => assert(!row.getString(1).equals("0.0B")))
   }
 
   test("get data size and index size after insert overwrite") {
@@ -119,7 +119,7 @@ class GetDataSizeAndIndexSizeTest extends QueryTest with BeforeAndAfterAll {
       .filter(row => row.getString(0).contains(CarbonCommonConstants.TABLE_DATA_SIZE) ||
         row.getString(0).contains(CarbonCommonConstants.TABLE_INDEX_SIZE))
     assert(res5.length == 2)
-    res5.foreach(row => assert(row.getString(1).trim.toLong > 0))
+    res5.foreach(row => assert(!row.getString(1).trim.equals("0.0B")))
   }
 
   test("get data size and index size for empty table") {
@@ -128,7 +128,7 @@ class GetDataSizeAndIndexSizeTest extends QueryTest with BeforeAndAfterAll {
       .filter(row => row.getString(0).contains(CarbonCommonConstants.TABLE_DATA_SIZE) ||
         row.getString(0).contains(CarbonCommonConstants.TABLE_INDEX_SIZE))
     assert(res6.length == 2)
-    res6.foreach(row => assert(row.getString(1).trim.toLong == 0))
+    res6.foreach(row => assert(row.getString(1).trim.equals("0.0B")))
   }
 
   test("get last update time for empty table") {
@@ -136,7 +136,7 @@ class GetDataSizeAndIndexSizeTest extends QueryTest with BeforeAndAfterAll {
     val res7 = sql("DESCRIBE FORMATTED tableSize9").collect()
       .filter(row => row.getString(0).contains(CarbonCommonConstants.LAST_UPDATE_TIME))
     assert(res7.length == 1)
-    res7.foreach(row => assert(row.getString(1).trim.toLong == 0))
+    res7.foreach(row => assert(row.getString(1).trim.equals("NA")))
   }
 
   test("get last update time for unempty table") {
@@ -146,7 +146,7 @@ class GetDataSizeAndIndexSizeTest extends QueryTest with BeforeAndAfterAll {
     val res8 = sql("DESCRIBE FORMATTED tableSize10").collect()
       .filter(row => row.getString(0).contains(CarbonCommonConstants.LAST_UPDATE_TIME))
     assert(res8.length == 1)
-    res8.foreach(row => assert(row.getString(1).trim.toLong > 0))
+    res8.foreach(row => assert(!row.getString(1).trim.equals("NA")))
   }
 
   test("index and datasize for update scenario") {
@@ -160,13 +160,13 @@ class GetDataSizeAndIndexSizeTest extends QueryTest with BeforeAndAfterAll {
       .filter(row => row.getString(0).contains(CarbonCommonConstants.TABLE_DATA_SIZE) ||
                      row.getString(0).contains(CarbonCommonConstants.TABLE_INDEX_SIZE))
     assert(res9.length == 2)
-    res9.foreach(row => assert(row.getString(1).trim.toLong > 0))
+    res9.foreach(row => assert(!row.getString(1).trim.equals("0.0B")))
     sql("update tableSize11 set (empno) = (234)").show()
     val res10 = sql("DESCRIBE FORMATTED tableSize11").collect()
       .filter(row => row.getString(0).contains(CarbonCommonConstants.TABLE_DATA_SIZE) ||
                      row.getString(0).contains(CarbonCommonConstants.TABLE_INDEX_SIZE))
     assert(res10.length == 2)
-    res10.foreach(row => assert(row.getString(1).trim.toLong > 0))
+    res10.foreach(row => assert(!row.getString(1).trim.equals("0.0B")))
   }
 
 }


### PR DESCRIPTION
According to the discussion in [topic](http://apache-carbondata-dev-mailing-list-archive.1130556.n5.nabble.com/Change-the-comment-content-for-column-when-execute-command-desc-formatted-table-name-td46848.html) , reformat the output of command 'desc formatted table_name'.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed? No
 
 - [ ] Any backward compatibility impacted? No
 
 - [ ] Document update required? No

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

