### PR TITLE
[CARBONDATA-2996] CarbonSchemaReader support read schema from folder path

### DIFF
--- a/docs/csdk-guide.md
+++ b/docs/csdk-guide.md
@@ -219,23 +219,28 @@ release the memory and destroy JVM.
 ```
 ```
     /**
-     * read Schema from Data File
+     * read schema from path,
+     * path can be folder path, carbonindex file path, and carbondata file path
+     * and will not check all files schema
      *
-     * @param path Data File path
-     * @return carbon schema object
+     * @param path file/folder path
+     * @return schema
      */
-    jobject readSchemaInDataFile(char *path);
+    jobject readSchema(char *path);
 ```
 ```
     /**
-     * read Schema from index File
+     *  read schema from path,
+     *  path can be folder path, carbonindex file path, and carbondata file path
+     *  and user can decide whether check all files schema
      *
-     * @param path index File path
-     * @return carbon schema object
+     * @param path carbon data path
+     * @param validateSchema whether check all files schema
+     * @return schema
      */
-    jobject readSchemaInIndexFile(char *path);
-
+    jobject readSchema(char *path, bool validateSchema);
 ```
+
 ###Schema
 ``` 
  /**

--- a/docs/sdk-guide.md
+++ b/docs/sdk-guide.md
@@ -727,6 +727,31 @@ Find example code at [CarbonReaderExample](https://github.com/apache/carbondata/
    */
   public static Schema readSchemaInIndexFile(String indexFilePath);
 ```
+```
+  /**
+   * read schema from path,
+   * path can be folder path,carbonindex file path, and carbondata file path
+   * and will not check all files schema
+   *
+   * @param path file/folder path
+   * @return schema
+   * @throws IOException
+   */
+  public static Schema readSchema(String path);
+```
+```
+  /**
+   * read schema from path,
+   * path can be folder path,carbonindex file path, and carbondata file path
+   * and user can decide whether check all files schema
+   *
+   * @param path             file/folder path
+   * @param validateSchema whether check all files schema
+   * @return schema
+   * @throws IOException
+   */
+  public static Schema readSchema(String path, boolean validateSchema);
+```
 
 ```
   /**

--- a/examples/spark2/src/main/java/org/apache/carbondata/examples/sdk/CarbonReaderExample.java
+++ b/examples/spark2/src/main/java/org/apache/carbondata/examples/sdk/CarbonReaderExample.java
@@ -96,7 +96,7 @@ public class CarbonReaderExample {
                 throw new RuntimeException("Carbon index file not exists.");
             }
             Schema schema = CarbonSchemaReader
-                .readSchemaInIndexFile(dataFiles[0].getAbsolutePath())
+                .readSchema(dataFiles[0].getAbsolutePath())
                 .asOriginOrder();
             // Transform the schema
             String[] strings = new String[schema.getFields().length];

--- a/store/CSDK/src/CarbonSchemaReader.cpp
+++ b/store/CSDK/src/CarbonSchemaReader.cpp
@@ -29,14 +29,14 @@ CarbonSchemaReader::CarbonSchemaReader(JNIEnv *env) {
     this->jniEnv = env;
 }
 
-jobject CarbonSchemaReader::readSchemaInDataFile(char *path) {
+jobject CarbonSchemaReader::readSchema(char *path) {
     if (path == NULL) {
         throw std::runtime_error("path parameter can't be NULL.");
     }
-    jmethodID methodID = jniEnv->GetStaticMethodID(carbonSchemaReaderClass, "readSchemaInDataFile",
-        "(Ljava/lang/String;)Lorg/apache/carbondata/sdk/file/Schema;");
+    jmethodID methodID = jniEnv->GetStaticMethodID(carbonSchemaReaderClass, "readSchema",
+                                                   "(Ljava/lang/String;)Lorg/apache/carbondata/sdk/file/Schema;");
     if (methodID == NULL) {
-        throw std::runtime_error("Can't find the method in java: readSchemaInDataFile");
+        throw std::runtime_error("Can't find the method in java: readSchema");
     }
     jstring jPath = jniEnv->NewStringUTF(path);
     jvalue args[1];
@@ -48,18 +48,19 @@ jobject CarbonSchemaReader::readSchemaInDataFile(char *path) {
     return result;
 }
 
-jobject CarbonSchemaReader::readSchemaInIndexFile(char *path) {
+jobject CarbonSchemaReader::readSchema(char *path, bool validateSchema) {
     if (path == NULL) {
         throw std::runtime_error("path parameter can't be NULL.");
     }
-    jmethodID methodID = jniEnv->GetStaticMethodID(carbonSchemaReaderClass, "readSchemaInIndexFile",
-        "(Ljava/lang/String;)Lorg/apache/carbondata/sdk/file/Schema;");
+    jmethodID methodID = jniEnv->GetStaticMethodID(carbonSchemaReaderClass, "readSchema",
+                                                   "(Ljava/lang/String;)Lorg/apache/carbondata/sdk/file/Schema;");
     if (methodID == NULL) {
-        throw std::runtime_error("Can't find the method in java: readSchemaInDataFile");
+        throw std::runtime_error("Can't find the method in java: readSchema");
     }
     jstring jPath = jniEnv->NewStringUTF(path);
-    jvalue args[1];
+    jvalue args[2];
     args[0].l = jPath;
+    args[1].z = validateSchema;
     jobject result = jniEnv->CallStaticObjectMethodA(carbonSchemaReaderClass, methodID, args);
     if (jniEnv->ExceptionCheck()) {
         throw jniEnv->ExceptionOccurred();

--- a/store/CSDK/src/CarbonSchemaReader.h
+++ b/store/CSDK/src/CarbonSchemaReader.h
@@ -40,19 +40,24 @@ public:
     CarbonSchemaReader(JNIEnv *env);
 
     /**
-     * read Schema from Data File
+     * read schema from path,
+     * path can be folder path, carbonindex file path, and carbondata file path
+     * and will not check all files schema
      *
-     * @param path Data File path
-     * @return carbon schema object
+     * @param path file/folder path
+     * @return schema
      */
-    jobject readSchemaInDataFile(char *path);
+    jobject readSchema(char *path);
 
     /**
-     * read Schema from index File
+     *  read schema from path,
+     *  path can be folder path, carbonindex file path, and carbondata file path
+     *  and user can decide whether check all files schema
      *
-     * @param path index File path
-     * @return carbon schema object
+     * @param path carbon data path
+     * @param validateSchema whether check all files schema
+     * @return schema
      */
-    jobject readSchemaInIndexFile(char *path);
+    jobject readSchema(char *path, bool validateSchema);
 
 };

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonSchemaReader.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonSchemaReader.java
@@ -26,6 +26,7 @@ import java.util.List;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.datastore.FileReader;
 import org.apache.carbondata.core.datastore.filesystem.CarbonFile;
+import org.apache.carbondata.core.datastore.filesystem.CarbonFileFilter;
 import org.apache.carbondata.core.datastore.impl.FileFactory;
 import org.apache.carbondata.core.metadata.converter.SchemaConverter;
 import org.apache.carbondata.core.metadata.converter.ThriftWrapperSchemaConverterImpl;
@@ -34,10 +35,12 @@ import org.apache.carbondata.core.reader.CarbonFooterReaderV3;
 import org.apache.carbondata.core.reader.CarbonHeaderReader;
 import org.apache.carbondata.core.reader.CarbonIndexFileReader;
 import org.apache.carbondata.core.util.CarbonUtil;
-import org.apache.carbondata.core.util.path.CarbonTablePath;
 import org.apache.carbondata.format.FileFooter3;
+import org.apache.carbondata.processing.loading.exception.CarbonDataLoadingException;
 
 import static org.apache.carbondata.core.util.CarbonUtil.thriftColumnSchemaToWrapperColumnSchema;
+import static org.apache.carbondata.core.util.path.CarbonTablePath.CARBON_DATA_EXT;
+import static org.apache.carbondata.core.util.path.CarbonTablePath.INDEX_FILE_EXT;
 
 /**
  * Schema reader for carbon files, including carbondata file, carbonindex file, and schema file
@@ -51,6 +54,7 @@ public class CarbonSchemaReader {
    * @return schema object
    * @throws IOException
    */
+  @Deprecated
   public static Schema readSchemaInSchemaFile(String schemaFilePath) throws IOException {
     org.apache.carbondata.format.TableInfo tableInfo = CarbonUtil.readSchemaFile(schemaFilePath);
     SchemaConverter schemaConverter = new ThriftWrapperSchemaConverterImpl();
@@ -62,13 +66,121 @@ public class CarbonSchemaReader {
   }
 
   /**
-   * Read carbondata file and return the schema
+   * get carbondata/carbonindex file in path
    *
-   * @param dataFilePath complete path including carbondata file name
+   * @param path carbon file path
+   * @return CarbonFile array
+   */
+  private static CarbonFile[] getCarbonFile(String path, final String extension)
+      throws IOException {
+    String dataFilePath = path;
+    if (!(dataFilePath.contains(extension))) {
+      CarbonFile[] carbonFiles = FileFactory
+          .getCarbonFile(path)
+          .listFiles(new CarbonFileFilter() {
+            @Override
+            public boolean accept(CarbonFile file) {
+              if (file == null) {
+                return false;
+              }
+              return file.getName().endsWith(extension);
+            }
+          });
+      if (carbonFiles == null || carbonFiles.length < 1) {
+        throw new IOException("Carbon file not exists.");
+      }
+      return carbonFiles;
+    }
+    return null;
+  }
+
+  /**
+   * read schema from path,
+   * path can be folder path, carbonindex file path, and carbondata file path
+   * and will not check all files schema
+   *
+   * @param path file/folder path
+   * @return schema
+   * @throws IOException
+   */
+  public static Schema readSchema(String path) throws IOException {
+    return readSchema(path, false);
+  }
+
+  /**
+   * read schema from path,
+   * path can be folder path, carbonindex file path, and carbondata file path
+   * and user can decide whether check all files schema
+   *
+   * @param path             file/folder path
+   * @param validateSchema whether check all files schema
+   * @return schema
+   * @throws IOException
+   */
+  public static Schema readSchema(String path, boolean validateSchema) throws IOException {
+    if (path.endsWith(INDEX_FILE_EXT)) {
+      return readSchemaFromIndexFile(path);
+    } else if (path.endsWith(CARBON_DATA_EXT)) {
+      return readSchemaFromDataFile(path);
+    } else if (validateSchema) {
+      CarbonFile[] carbonIndexFiles = getCarbonFile(path, INDEX_FILE_EXT);
+      Schema schema;
+      if (carbonIndexFiles != null && carbonIndexFiles.length != 0) {
+        schema = readSchemaFromIndexFile(carbonIndexFiles[0].getAbsolutePath());
+        for (int i = 1; i < carbonIndexFiles.length; i++) {
+          Schema schema2 = readSchemaFromIndexFile(carbonIndexFiles[i].getAbsolutePath());
+          if (schema != schema2) {
+            throw new CarbonDataLoadingException("Schema is different between different files.");
+          }
+        }
+        CarbonFile[] carbonDataFiles = getCarbonFile(path, CARBON_DATA_EXT);
+        for (int i = 0; i < carbonDataFiles.length; i++) {
+          Schema schema2 = readSchemaFromDataFile(carbonDataFiles[i].getAbsolutePath());
+          if (!schema.equals(schema2)) {
+            throw new CarbonDataLoadingException("Schema is different between different files.");
+          }
+        }
+        return schema;
+      } else {
+        throw new CarbonDataLoadingException("No carbonindex file in this path.");
+      }
+    } else {
+      String indexFilePath = getCarbonFile(path, INDEX_FILE_EXT)[0].getAbsolutePath();
+      if (indexFilePath != null) {
+        return readSchemaFromIndexFile(indexFilePath);
+      } else {
+        String dataFilePath = getCarbonFile(path, CARBON_DATA_EXT)[0].getAbsolutePath();
+        if (dataFilePath == null) {
+          throw new CarbonDataLoadingException("No carbonindex and carbondata file in the path");
+        } else {
+          return readSchemaFromDataFile(dataFilePath);
+        }
+      }
+    }
+  }
+
+  /**
+   * Read carbondata file and return the schema
+   * This interface will be removed,
+   * please use readSchema instead of this interface
+   *
+   * @param dataFilePath carbondata file store path
    * @return Schema object
    * @throws IOException
    */
+  @Deprecated
   public static Schema readSchemaInDataFile(String dataFilePath) throws IOException {
+    return readSchema(dataFilePath, false);
+  }
+
+  /**
+   * Read schema from carbondata file
+   *
+   * @param dataFilePath carbondata file path
+   * @return carbon data schema
+   * @throws IOException
+   */
+  public static Schema readSchemaFromDataFile(String dataFilePath) throws IOException {
     CarbonHeaderReader reader = new CarbonHeaderReader(dataFilePath);
     List<ColumnSchema> columnSchemaList = new ArrayList<ColumnSchema>();
     List<ColumnSchema> schemaList = reader.readSchema();
@@ -82,40 +194,30 @@ public class CarbonSchemaReader {
   }
 
   /**
-   * This method return the version details in formatted string by reading from carbondata file
-   * @param dataFilePath
-   * @return
-   * @throws IOException
-   */
-  public static String getVersionDetails(String dataFilePath) throws IOException {
-    long fileSize =
-        FileFactory.getCarbonFile(dataFilePath, FileFactory.getFileType(dataFilePath)).getSize();
-    FileReader fileReader = FileFactory.getFileHolder(FileFactory.getFileType(dataFilePath));
-    ByteBuffer buffer =
-        fileReader.readByteBuffer(FileFactory.getUpdatedFilePath(dataFilePath), fileSize - 8, 8);
-    fileReader.finish();
-    CarbonFooterReaderV3 footerReader = new CarbonFooterReaderV3(dataFilePath, buffer.getLong());
-    FileFooter3 footer = footerReader.readFooterVersion3();
-    if (null != footer.getExtra_info()) {
-      return footer.getExtra_info().get(CarbonCommonConstants.CARBON_WRITTEN_BY_FOOTER_INFO)
-          + " in version: " + footer.getExtra_info()
-          .get(CarbonCommonConstants.CARBON_WRITTEN_VERSION);
-    } else {
-      return "Version Details are not found in carbondata file";
-    }
-  }
-
-  /**
    * Read carbonindex file and return the schema
+   * This interface will be removed,
+   * please use readSchema instead of this interface
    *
    * @param indexFilePath complete path including index file name
    * @return schema object
    * @throws IOException
    */
+  @Deprecated
   public static Schema readSchemaInIndexFile(String indexFilePath) throws IOException {
+    return readSchema(indexFilePath, false);
+  }
+
+  /**
+   * Read schema from carbonindex file
+   *
+   * @param indexFilePath carbonindex file path
+   * @return carbon data Schema
+   * @throws IOException
+   */
+  private static Schema readSchemaFromIndexFile(String indexFilePath) throws IOException {
     CarbonFile indexFile =
         FileFactory.getCarbonFile(indexFilePath, FileFactory.getFileType(indexFilePath));
-    if (!indexFile.getName().endsWith(CarbonTablePath.INDEX_FILE_EXT)) {
+    if (!indexFile.getName().endsWith(INDEX_FILE_EXT)) {
       throw new IOException("Not an index file name");
     }
     // read schema from the first index file
@@ -144,4 +246,28 @@ public class CarbonSchemaReader {
     }
   }
 
+  /**
+   * This method return the version details in formatted string by reading from carbondata file
+   *
+   * @param dataFilePath
+   * @return
+   * @throws IOException
+   */
+  public static String getVersionDetails(String dataFilePath) throws IOException {
+    long fileSize =
+        FileFactory.getCarbonFile(dataFilePath, FileFactory.getFileType(dataFilePath)).getSize();
+    FileReader fileReader = FileFactory.getFileHolder(FileFactory.getFileType(dataFilePath));
+    ByteBuffer buffer =
+        fileReader.readByteBuffer(FileFactory.getUpdatedFilePath(dataFilePath), fileSize - 8, 8);
+    fileReader.finish();
+    CarbonFooterReaderV3 footerReader = new CarbonFooterReaderV3(dataFilePath, buffer.getLong());
+    FileFooter3 footer = footerReader.readFooterVersion3();
+    if (null != footer.getExtra_info()) {
+      return footer.getExtra_info().get(CarbonCommonConstants.CARBON_WRITTEN_BY_FOOTER_INFO)
+          + " in version: " + footer.getExtra_info()
+          .get(CarbonCommonConstants.CARBON_WRITTEN_VERSION);
+    } else {
+      return "Version Details are not found in carbondata file";
+    }
+  }
 }

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonSchemaReader.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonSchemaReader.java
@@ -74,7 +74,7 @@ public class CarbonSchemaReader {
   private static CarbonFile[] getCarbonFile(String path, final String extension)
       throws IOException {
     String dataFilePath = path;
-    if (!(dataFilePath.contains(extension))) {
+    if (!(dataFilePath.endsWith(extension))) {
       CarbonFile[] carbonFiles = FileFactory
           .getCarbonFile(path)
           .listFiles(new CarbonFileFilter() {
@@ -90,8 +90,10 @@ public class CarbonSchemaReader {
         throw new IOException("Carbon file not exists.");
       }
       return carbonFiles;
+    } else {
+      throw new CarbonDataLoadingException("Please ensure path "
+          + path + " end with " + extension);
     }
-    return null;
   }
 
   /**
@@ -129,7 +131,7 @@ public class CarbonSchemaReader {
         schema = readSchemaFromIndexFile(carbonIndexFiles[0].getAbsolutePath());
         for (int i = 1; i < carbonIndexFiles.length; i++) {
           Schema schema2 = readSchemaFromIndexFile(carbonIndexFiles[i].getAbsolutePath());
-          if (schema != schema2) {
+          if (!schema.equals(schema2)) {
             throw new CarbonDataLoadingException("Schema is different between different files.");
           }
         }
@@ -146,16 +148,7 @@ public class CarbonSchemaReader {
       }
     } else {
       String indexFilePath = getCarbonFile(path, INDEX_FILE_EXT)[0].getAbsolutePath();
-      if (indexFilePath != null) {
-        return readSchemaFromIndexFile(indexFilePath);
-      } else {
-        String dataFilePath = getCarbonFile(path, CARBON_DATA_EXT)[0].getAbsolutePath();
-        if (dataFilePath == null) {
-          throw new CarbonDataLoadingException("No carbonindex and carbondata file in the path");
-        } else {
-          return readSchemaFromDataFile(dataFilePath);
-        }
-      }
+      return readSchemaFromIndexFile(indexFilePath);
     }
   }
 

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/Field.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/Field.java
@@ -291,4 +291,25 @@ public class Field {
       return new StructField(fieldName, dataType);
     }
   }
+
+  @Override
+  public int hashCode() {
+    return super.hashCode();
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj instanceof Field) {
+      Field field = (Field) obj;
+      if ((!this.getDataType().equals(field.getDataType()))
+          || (!this.getFieldName().equals(field.getFieldName()))
+          || (!(this.getSchemaOrdinal() == (field.getSchemaOrdinal())))
+          ) {
+        return false;
+      }
+    } else {
+      return false;
+    }
+    return true;
+  }
 }

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/Schema.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/Schema.java
@@ -151,4 +151,24 @@ public class Schema {
     });
     return this;
   }
+
+  @Override
+  public int hashCode() {
+    return super.hashCode();
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj instanceof Schema) {
+      Schema schema = (Schema) obj;
+      for (int i = 0; i < this.fields.length; i++) {
+        if (!(schema.fields)[i].equals((this.fields)[i])) {
+          return false;
+        }
+      }
+    } else {
+      return false;
+    }
+    return true;
+  }
 }

--- a/store/sdk/src/test/java/org/apache/carbondata/sdk/file/CarbonReaderTest.java
+++ b/store/sdk/src/test/java/org/apache/carbondata/sdk/file/CarbonReaderTest.java
@@ -777,7 +777,7 @@ public class CarbonReaderTest extends TestCase {
     });
     Assert.assertTrue(dataFiles != null);
     Assert.assertTrue(dataFiles.length > 0);
-    Schema schema = CarbonSchemaReader.readSchemaInDataFile(dataFiles[0].getAbsolutePath());
+    Schema schema = CarbonSchemaReader.readSchema(dataFiles[0].getAbsolutePath());
     Assert.assertTrue(schema.getFields().length == 2);
     Assert.assertEquals("name", (schema.getFields())[0].getFieldName());
     Assert.assertEquals("age", (schema.getFields())[1].getFieldName());
@@ -1021,7 +1021,7 @@ public class CarbonReaderTest extends TestCase {
       }
     });
 
-    Schema schema = CarbonSchemaReader.readSchemaInDataFile(dataFiles2[0].getAbsolutePath());
+    Schema schema = CarbonSchemaReader.readSchema(dataFiles2[0].getAbsolutePath());
 
     // sort the schema
     Arrays.sort(schema.getFields(), new Comparator<Field>() {
@@ -1140,7 +1140,7 @@ public class CarbonReaderTest extends TestCase {
       }
     });
 
-    Schema schema = CarbonSchemaReader.readSchemaInIndexFile(dataFiles2[0].getAbsolutePath()).asOriginOrder();
+    Schema schema = CarbonSchemaReader.readSchema(dataFiles2[0].getAbsolutePath()).asOriginOrder();
     // Transform the schema
     String[] strings = new String[schema.getFields().length];
     for (int i = 0; i < schema.getFields().length; i++) {
@@ -1355,7 +1355,7 @@ public class CarbonReaderTest extends TestCase {
       }
     });
 
-    Schema schema = CarbonSchemaReader.readSchemaInIndexFile(dataFiles2[0].getAbsolutePath()).asOriginOrder();
+    Schema schema = CarbonSchemaReader.readSchema(dataFiles2[0].getAbsolutePath()).asOriginOrder();
 
     for (int i = 0; i < schema.getFields().length; i++) {
       System.out.println((schema.getFields())[i].getFieldName() + "\t" + schema.getFields()[i].getSchemaOrdinal());
@@ -1518,10 +1518,10 @@ public class CarbonReaderTest extends TestCase {
         }
       });
       if (dataFiles == null || dataFiles.length < 1) {
-        throw new RuntimeException("Carbon index file not exists.");
+        throw new RuntimeException("Carbon data file not exists.");
       }
       Schema schema = CarbonSchemaReader
-          .readSchemaInDataFile(dataFiles[0].getAbsolutePath())
+          .readSchema(dataFiles[0].getAbsolutePath())
           .asOriginOrder();
       // Transform the schema
       String[] strings = new String[schema.getFields().length];
@@ -1613,7 +1613,7 @@ public class CarbonReaderTest extends TestCase {
         throw new RuntimeException("Carbon index file not exists.");
       }
       Schema schema = CarbonSchemaReader
-          .readSchemaInIndexFile(dataFiles[0].getAbsolutePath())
+          .readSchema(dataFiles[0].getAbsolutePath())
           .asOriginOrder();
       // Transform the schema
       int count = 0;

--- a/store/sdk/src/test/java/org/apache/carbondata/sdk/file/CarbonSchemaReaderTest.java
+++ b/store/sdk/src/test/java/org/apache/carbondata/sdk/file/CarbonSchemaReaderTest.java
@@ -110,8 +110,8 @@ public class CarbonSchemaReaderTest extends TestCase {
       assertEquals(schema.getFieldsLength(), 12);
       checkSchema(schema);
     } catch (Throwable e) {
-      Assert.fail();
       e.printStackTrace();
+      Assert.fail();
     }
   }
 
@@ -123,8 +123,8 @@ public class CarbonSchemaReaderTest extends TestCase {
           .asOriginOrder();
       checkSchema(schema);
     } catch (Throwable e) {
-      Assert.fail();
       e.printStackTrace();
+      Assert.fail();
     }
   }
 
@@ -185,8 +185,8 @@ public class CarbonSchemaReaderTest extends TestCase {
       assertEquals(schema.getFieldsLength(), 12);
       checkSchema(schema);
     } catch (Throwable e) {
-      Assert.fail();
       e.printStackTrace();
+      Assert.fail();
     }
   }
 
@@ -194,12 +194,12 @@ public class CarbonSchemaReaderTest extends TestCase {
   public void testReadSchemaAndCheckFilesSchema() {
     try {
       Schema schema = CarbonSchemaReader
-          .readSchema(path, false)
+          .readSchema(path, true)
           .asOriginOrder();
       checkSchema(schema);
     } catch (Throwable e) {
-      Assert.fail();
       e.printStackTrace();
+      Assert.fail();
     }
   }
 
@@ -231,8 +231,8 @@ public class CarbonSchemaReaderTest extends TestCase {
             .equalsIgnoreCase("Schema is different between different files."));
       }
     } catch (Throwable e) {
-      Assert.fail();
       e.printStackTrace();
+      Assert.fail();
     }
   }
 


### PR DESCRIPTION
[CARBONDATA-2996] CarbonSchemaReader support read schema from folder path
    1.Deprecated readSchemaInIndexFile and readSchemaInDataFile, unify them to readSchema
    2.Deprecated readSchemaInSchemaFile
    3.readSchema support read schema from folder path,carbonindex file, and carbondata file. and user can decide whether check all files schema


Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 No
 - [x] Any backward compatibility impacted?
 No
 - [x] Document update required?
No
 - [x] Testing done
    add test case
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
https://issues.apache.org/jira/browse/CARBONDATA-2951
