### PR TITLE
[CARBONDATA-2998] Refresh column schema for old store(before V3) for SORT_COLUMNS option

### DIFF
--- a/processing/src/main/java/org/apache/carbondata/processing/merger/CompactionResultSortProcessor.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/merger/CompactionResultSortProcessor.java
@@ -413,12 +413,12 @@ public class CompactionResultSortProcessor extends AbstractResultProcessor {
     isVarcharDimMapping = new boolean[dimensions.size()];
     int i = 0;
     for (CarbonDimension dimension : dimensions) {
+      if (dimension.isSortColumn()) {
+        sortColumnMapping[i] = true;
+      }
       if (CarbonUtil.hasEncoding(dimension.getEncoder(), Encoding.DICTIONARY)) {
         i++;
         continue;
-      }
-      if (dimension.isSortColumn()) {
-        sortColumnMapping[i] = true;
       }
       noDictionaryColMapping[i] = true;
       if (dimension.getColumnSchema().getDataType() == DataTypes.VARCHAR) {


### PR DESCRIPTION
**Problem:**
For old store, store before V3, SORT_COLUMN option is not set in ColumnSchema, but considered as SORT_COLUMNS. So, while refreshing the table it will try to read from the thrift and make it as no sort column in ColumnSchema as it is not set before.

**Solution:**
While refreshing the table, check for the SORT_COLUMN property in the table properties and if nothing is set, then by default take all the dimension columns as SORT_COLUMNS.

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
               
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

