### PR TITLE
[HOTFIX] Fix SDV test case failure after PR #2645

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestCreateExternalTable.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestCreateExternalTable.scala
@@ -101,7 +101,7 @@ class TestCreateExternalTable extends QueryTest with BeforeAndAfterAll {
            |LOCATION '$storeLocation/origin'
      """.stripMargin)
     }
-    assert(ex.message.contains("Schema may not be specified for external table"))
+    assert(ex.message.contains("Schema must not be specified for external table"))
 
     sql("DROP TABLE IF EXISTS source")
 

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSparkSqlParserUtil.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSparkSqlParserUtil.scala
@@ -123,6 +123,13 @@ object CarbonSparkSqlParserUtil {
     if (partitionFields.nonEmpty && options.isStreaming) {
       operationNotAllowed("Streaming is not allowed on partitioned table", partitionColumns)
     }
+
+    if (external && fields.isEmpty && tableProperties.nonEmpty) {
+      // as fields are always zero for external table, cannot validate table properties.
+      operationNotAllowed(
+        "table properties are not supported for external table", tablePropertyList)
+    }
+
     // validate tblProperties
     val bucketFields = parser.getBucketFields(tableProperties, fields, options)
     var isTransactionalTable: Boolean = true
@@ -132,7 +139,7 @@ object CarbonSparkSqlParserUtil {
         // user provided schema for this external table, this is not allow currently
         // see CARBONDATA-2866
         operationNotAllowed(
-          "Schema may not be specified for external table", columns)
+          "Schema must not be specified for external table", columns)
       }
       if (partitionByStructFields.nonEmpty) {
         operationNotAllowed(


### PR DESCRIPTION
**Changes:
1) #2645 has blocked the schema for external table. But SDV test cases were not updated. Hence updated the test cases
2) table properties was not blocked for external table, so even when a valid table property is passed, validation of table properties will fail for external table, as fields (schema) will be null.
Hence blocked this with proper error message**  

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed? NA
 
 - [ ] Any backward compatibility impacted? NA
 
 - [ ] Document update required? NA

 - [ ] Testing done
        yes, SDV test case is modified and locally ran       

 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 