### PR TITLE
[CARBONDATA-3002] Fix some spell error and remove the data after test case finished running

### DIFF
--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/CarbonRecordReader.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/CarbonRecordReader.java
@@ -117,7 +117,7 @@ public class CarbonRecordReader<T> extends AbstractRecordReader<T> {
   }
 
   @Override public float getProgress() throws IOException, InterruptedException {
-    // TODO : Implement it based on total number of rows it is going to retrive.
+    // TODO : Implement it based on total number of rows it is going to retrieve.
     return 0;
   }
 

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/PrestoCarbonVectorizedRecordReader.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/PrestoCarbonVectorizedRecordReader.java
@@ -169,7 +169,7 @@ class PrestoCarbonVectorizedRecordReader extends AbstractRecordReader<Object> {
   }
 
   @Override public float getProgress() throws IOException, InterruptedException {
-    // TODO : Implement it based on total number of rows it is going to retrive.
+    // TODO : Implement it based on total number of rows it is going to retrieve.
     return 0;
   }
 

--- a/integration/spark-datasource/src/main/scala/org/apache/carbondata/spark/vectorreader/VectorizedCarbonRecordReader.java
+++ b/integration/spark-datasource/src/main/scala/org/apache/carbondata/spark/vectorreader/VectorizedCarbonRecordReader.java
@@ -215,7 +215,7 @@ public class VectorizedCarbonRecordReader extends AbstractRecordReader<Object> {
 
   @Override
   public float getProgress() throws IOException, InterruptedException {
-    // TODO : Implement it based on total number of rows it is going to retrive.
+    // TODO : Implement it based on total number of rows it is going to retrieve.
     return 0;
   }
 

--- a/integration/spark2/src/test/scala/org/apache/carbondata/spark/testsuite/partition/TestAlterPartitionTable.scala
+++ b/integration/spark2/src/test/scala/org/apache/carbondata/spark/testsuite/partition/TestAlterPartitionTable.scala
@@ -889,6 +889,8 @@ class TestAlterPartitionTable extends QueryTest with BeforeAndAfterAll {
   }
 
   override def afterAll = {
+    sql("DROP TABLE IF EXISTS carbondb.carbontable")
+    sql("DROP DATABASE IF EXISTS carbondb")
     dropTable
     CarbonProperties.getInstance()
     .addProperty(CarbonCommonConstants.CARBON_DATE_FORMAT, "yyyy-MM-dd")

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonReader.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonReader.java
@@ -18,9 +18,8 @@
 package org.apache.carbondata.sdk.file;
 
 import java.io.IOException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
 import java.util.List;
+import java.util.UUID;
 
 import org.apache.carbondata.common.annotations.InterfaceAudience;
 import org.apache.carbondata.common.annotations.InterfaceStability;
@@ -140,8 +139,8 @@ public class CarbonReader<T> {
    * @return CarbonReaderBuilder object
    */
   public static CarbonReaderBuilder builder(String tablePath) {
-    String time = new SimpleDateFormat("yyyyMMddHHmmssSSS").format(new Date());
-    String tableName = "UnknownTable" + time;
+    UUID uuid = UUID.randomUUID();
+    String tableName = "UnknownTable" + uuid;
     return builder(tablePath, tableName);
   }
 


### PR DESCRIPTION
[CARBONDATA-3002] Fix some spell error and remove the data after test case finished running

1. fix spell error:retrive to retrieve.   
2.remove the data after test case finished running, by delete table and database.   
3.change dummy table with UUID, avoid erri when there are multiple carbonreader.   

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 No
 - [x] Any backward compatibility impacted?
 No
 - [x] Document update required?
No
 - [x] Testing done
      no need 
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
No
