### PR TITLE
[CARBONDATA-3004][32k] Fix bugs in writing dataframe to carbon with longstring

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/longstring/VarcharDataTypesBasicTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/longstring/VarcharDataTypesBasicTestCase.scala
@@ -405,6 +405,28 @@ class VarcharDataTypesBasicTestCase extends QueryTest with BeforeAndAfterEach wi
     checkQuery()
   }
 
+  test("write from dataframe with long_string datatype whose order of fields is not the same as that in table") {
+    sql(
+      s"""
+         | CREATE TABLE if not exists $longStringTable(
+         | id INT, name STRING, description STRING, address STRING, note STRING
+         | ) STORED BY 'carbondata'
+         | TBLPROPERTIES('LONG_STRING_COLUMNS'='description, note', 'dictionary_include'='name', 'sort_columns'='id')
+         |""".
+        stripMargin)
+
+    prepareDF()
+    // the order of fields in dataframe is different from that in create table
+    longStringDF.select("note", "address", "description", "name", "id")
+      .write
+      .format("carbondata")
+      .option("tableName", longStringTable)
+      .mode(SaveMode.Append)
+      .save()
+
+    checkQuery()
+  }
+
   test("desc table shows long_string_columns property") {
     sql(
       s"""


### PR DESCRIPTION
Currently while writing dataframe to carbon table, we need to parse the
rows in dataframe. For string columns, we need to judge whether it is a
long string column or not. In current implementation, the judgement is
position based which means that the order of fields in dataframe should
be the same as that in create table. In this PR, we fix this bug.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 `NO`
 - [x] Any backward compatibility impacted?
 `NO`
 - [x] Document update required?
 `NO`
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
`Added tests for this`
        - How it is tested? Please attach test report.
 `Tested in local`
        - Is it a performance related change? Please attach the performance test report.
`NO`
        - Any additional information to help reviewers in testing this change.
`NA`
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
`NA`
