### PR TITLE
[WIP]

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/impl/AbstractPrimitiveDimColumnPage.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/impl/AbstractPrimitiveDimColumnPage.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.core.datastore.chunk.impl;
+
+import java.util.BitSet;
+
+import org.apache.carbondata.core.datastore.chunk.DimensionColumnPage;
+import org.apache.carbondata.core.datastore.page.ColumnPage;
+
+/**
+ * Abstract Class for handling Primitive data type Dimension column
+ */
+public abstract class AbstractPrimitiveDimColumnPage implements DimensionColumnPage {
+
+  /**
+   * column page which holds the actual data
+   */
+  protected ColumnPage columnPage;
+
+  /**
+   * inverted index store the actual position of the data
+   */
+  protected int[] invertedIndex;
+
+  /**
+   * reverse index store the position after sorting the data
+   */
+  protected int[] invertedIndexReverse;
+
+  /**
+   * boolean to check if data was exolictly sorted or not
+   */
+  protected boolean isExplictSorted;
+
+  /**
+   * null bitset represents cell with null value
+   */
+  protected BitSet nullBitset;
+
+  protected boolean isAllNullValues;
+
+  protected AbstractPrimitiveDimColumnPage(ColumnPage columnPage, int[] invertedIndex,
+      int[] invertedIndexReverse, int numberOfRows) {
+    this.columnPage = columnPage;
+    this.isExplictSorted = null != invertedIndex && invertedIndex.length > 0;
+    this.invertedIndex = invertedIndex;
+    this.invertedIndexReverse = invertedIndexReverse;
+    this.nullBitset = columnPage.getNullBits();
+    isAllNullValues = nullBitset.cardinality() == numberOfRows;
+  }
+
+  @Override public int fillRawData(int rowId, int offset, byte[] data) {
+    return 0;
+  }
+
+  @Override public int fillSurrogateKey(int rowId, int chunkIndex, int[] outputSurrogateKey) {
+    return 0;
+  }
+
+  @Override public boolean isAdaptiveEncoded() {
+    return true;
+  }
+
+  @Override public void freeMemory() {
+    if (null != columnPage) {
+      columnPage.freeMemory();
+      this.invertedIndexReverse = null;
+      this.invertedIndex = null;
+      columnPage = null;
+    }
+  }
+
+  @Override public boolean isNoDicitionaryColumn() {
+    return true;
+  }
+
+  @Override public boolean isExplicitSorted() {
+    return isExplictSorted;
+  }
+
+  @Override public int getInvertedIndex(int rowId) {
+    return invertedIndex[rowId];
+  }
+
+  @Override public int getInvertedReverseIndex(int rowId) {
+    return invertedIndexReverse[rowId];
+  }
+
+  /**
+   * to get the null bit sets in case of adaptive encoded page
+   */
+  @Override public BitSet getNullBits() {
+    return nullBitset;
+  }
+}

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/impl/BooleanTypeDimColumnPage.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/impl/BooleanTypeDimColumnPage.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.core.datastore.chunk.impl;
+
+import org.apache.carbondata.core.constants.CarbonCommonConstants;
+import org.apache.carbondata.core.datastore.page.ColumnPage;
+import org.apache.carbondata.core.scan.result.vector.CarbonColumnVector;
+import org.apache.carbondata.core.scan.result.vector.ColumnVectorInfo;
+import org.apache.carbondata.core.util.ByteUtil;
+
+/**
+ * Class responsible for processing boolean data type dimension column data
+ */
+public class BooleanTypeDimColumnPage extends AbstractPrimitiveDimColumnPage {
+  public BooleanTypeDimColumnPage(ColumnPage columnPage, int[] actualRowId,
+      int[] invertedIndexReverse, int numberOfRows) {
+    super(columnPage, actualRowId, invertedIndexReverse, numberOfRows);
+  }
+
+  @Override public int fillVector(ColumnVectorInfo[] vectorInfo, int chunkIndex) {
+    ColumnVectorInfo columnVectorInfo = vectorInfo[chunkIndex];
+    int offset = columnVectorInfo.offset;
+    int vectorOffset = columnVectorInfo.vectorOffset;
+    int len = columnVectorInfo.size + offset;
+    CarbonColumnVector vector = columnVectorInfo.vector;
+    if (isAllNullValues) {
+      for (int j = offset; j < len; j++) {
+        vector.putNull(vectorOffset++);
+      }
+    } else if (nullBitset.isEmpty()) {
+      for (int j = offset; j < len; j++) {
+        vector.putBoolean(vectorOffset++, getDataBasedOnActualRowId(j));
+      }
+    } else {
+      for (int j = offset; j < len; j++) {
+        if (nullBitset.get(j)) {
+          vector.putNull(vectorOffset++);
+        } else {
+          vector.putBoolean(vectorOffset++, getDataBasedOnActualRowId(j));
+        }
+      }
+    }
+    return chunkIndex + 1;
+  }
+
+  @Override
+  public int fillVector(int[] filteredRowId, ColumnVectorInfo[] vectorInfo, int chunkIndex) {
+    ColumnVectorInfo columnVectorInfo = vectorInfo[chunkIndex];
+    int offset = columnVectorInfo.offset;
+    int vectorOffset = columnVectorInfo.vectorOffset;
+    int len = columnVectorInfo.size + offset;
+    CarbonColumnVector vector = columnVectorInfo.vector;
+    if (isAllNullValues) {
+      for (int j = offset; j < len; j++) {
+        vector.putNull(vectorOffset++);
+      }
+    } else if (nullBitset.isEmpty()) {
+      for (int j = offset; j < len; j++) {
+        vector.putBoolean(vectorOffset++, getDataBasedOnActualRowId(filteredRowId[j]));
+      }
+    } else {
+      for (int j = offset; j < len; j++) {
+        int filteredIndex = filteredRowId[j];
+        if (nullBitset.get(filteredIndex)) {
+          vector.putNull(vectorOffset++);
+        } else {
+          vector.putBoolean(vectorOffset++, getDataBasedOnActualRowId(filteredIndex));
+        }
+      }
+    }
+    return chunkIndex + 1;
+  }
+
+  @Override public byte[] getChunkData(int rowId) {
+    if (nullBitset.get(rowId)) {
+      return CarbonCommonConstants.EMPTY_BYTE_ARRAY;
+    }
+    return ByteUtil.toBytes(getDataBasedOnActualRowId(rowId));
+  }
+
+  private boolean getDataBasedOnActualRowId(int rowId) {
+    if (isExplictSorted) {
+      return ByteUtil.toBoolean(columnPage.getByte(invertedIndexReverse[rowId]));
+    }
+    return ByteUtil.toBoolean(columnPage.getByte(rowId));
+  }
+
+  @Override public int compareTo(int rowId, byte[] compareValue) {
+    byte[] data;
+    int nullBitSetRowId = isExplictSorted ? invertedIndex[rowId] : rowId;
+    if (nullBitset.get(nullBitSetRowId)) {
+      data = CarbonCommonConstants.EMPTY_BYTE_ARRAY;
+    } else {
+      data = ByteUtil.toBytes(ByteUtil.toBoolean(columnPage.getByte(rowId)));
+    }
+    return ByteUtil.UnsafeComparer.INSTANCE.compareTo(data, compareValue);
+  }
+
+}

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/impl/ByteTypeDimColumnPage.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/impl/ByteTypeDimColumnPage.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.core.datastore.chunk.impl;
+
+import org.apache.carbondata.core.constants.CarbonCommonConstants;
+import org.apache.carbondata.core.datastore.page.ColumnPage;
+import org.apache.carbondata.core.scan.result.vector.CarbonColumnVector;
+import org.apache.carbondata.core.scan.result.vector.ColumnVectorInfo;
+import org.apache.carbondata.core.util.ByteUtil;
+
+/**
+ * Class responsible for processing byte data type dimension column data
+ */
+public class ByteTypeDimColumnPage extends AbstractPrimitiveDimColumnPage {
+
+  public ByteTypeDimColumnPage(ColumnPage columnPage, int[] actualRowId,
+      int[] invertedIndexReverse, int numberOfRows) {
+    super(columnPage, actualRowId, invertedIndexReverse, numberOfRows);
+  }
+
+  @Override public int fillVector(ColumnVectorInfo[] vectorInfo, int chunkIndex) {
+    ColumnVectorInfo columnVectorInfo = vectorInfo[chunkIndex];
+    int offset = columnVectorInfo.offset;
+    int vectorOffset = columnVectorInfo.vectorOffset;
+    int len = columnVectorInfo.size + offset;
+    CarbonColumnVector vector = columnVectorInfo.vector;
+    if (isAllNullValues) {
+      for (int j = offset; j < len; j++) {
+        vector.putNull(vectorOffset++);
+      }
+    } else if (nullBitset.isEmpty()) {
+      for (int j = offset; j < len; j++) {
+        vector.putByte(vectorOffset++, getDataBasedOnActualRowId(j));
+      }
+    } else {
+      for (int j = offset; j < len; j++) {
+        if (nullBitset.get(j)) {
+          vector.putNull(vectorOffset++);
+        } else {
+          vector.putByte(vectorOffset++, getDataBasedOnActualRowId(j));
+        }
+      }
+    }
+    return chunkIndex + 1;
+  }
+
+  @Override
+  public int fillVector(int[] filteredRowId, ColumnVectorInfo[] vectorInfo, int chunkIndex) {
+    ColumnVectorInfo columnVectorInfo = vectorInfo[chunkIndex];
+    int offset = columnVectorInfo.offset;
+    int vectorOffset = columnVectorInfo.vectorOffset;
+    int len = columnVectorInfo.size + offset;
+    CarbonColumnVector vector = columnVectorInfo.vector;
+    if (isAllNullValues) {
+      for (int j = offset; j < len; j++) {
+        vector.putNull(vectorOffset++);
+      }
+    } else if (nullBitset.isEmpty()) {
+      for (int j = offset; j < len; j++) {
+        vector.putByte(vectorOffset++, getDataBasedOnActualRowId(filteredRowId[j]));
+      }
+    } else {
+      for (int j = offset; j < len; j++) {
+        int filteredIndex = filteredRowId[j];
+        if (nullBitset.get(filteredIndex)) {
+          vector.putNull(vectorOffset++);
+        } else {
+          vector.putByte(vectorOffset++, getDataBasedOnActualRowId(filteredIndex));
+        }
+      }
+    }
+    return chunkIndex + 1;
+  }
+
+  @Override public byte[] getChunkData(int rowId) {
+    if (nullBitset.get(rowId)) {
+      return CarbonCommonConstants.EMPTY_BYTE_ARRAY;
+    }
+    return new byte[] { getDataBasedOnActualRowId(rowId) };
+  }
+
+  @Override public int compareTo(int rowId, byte[] compareValue) {
+    byte[] data;
+    int nullBitSetRowId = isExplictSorted ? invertedIndex[rowId] : rowId;
+    if (nullBitset.get(nullBitSetRowId)) {
+      data = CarbonCommonConstants.EMPTY_BYTE_ARRAY;
+    } else {
+      data = new byte[] { columnPage.getByte(rowId) };
+    }
+    return ByteUtil.UnsafeComparer.INSTANCE.compareTo(data, compareValue);
+  }
+
+  private byte getDataBasedOnActualRowId(int rowId) {
+    if (isExplictSorted) {
+      return columnPage.getByte(invertedIndexReverse[rowId]);
+    }
+    return columnPage.getByte(rowId);
+  }
+
+}

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/impl/IntTypeDimColumnPage.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/impl/IntTypeDimColumnPage.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.core.datastore.chunk.impl;
+
+import org.apache.carbondata.core.constants.CarbonCommonConstants;
+import org.apache.carbondata.core.datastore.page.ColumnPage;
+import org.apache.carbondata.core.metadata.datatype.DataType;
+import org.apache.carbondata.core.metadata.datatype.DataTypes;
+import org.apache.carbondata.core.scan.result.vector.CarbonColumnVector;
+import org.apache.carbondata.core.scan.result.vector.ColumnVectorInfo;
+import org.apache.carbondata.core.util.ByteUtil;
+
+/**
+ * Class responsible for processing int data type dimension column data
+ */
+public class IntTypeDimColumnPage extends AbstractPrimitiveDimColumnPage {
+
+  public IntTypeDimColumnPage(ColumnPage columnPage, int[] actualRowId,
+      int[] invertedIndexReverse, int numberOfRows) {
+    super(columnPage, actualRowId, invertedIndexReverse, numberOfRows);
+  }
+
+  @Override public int fillVector(ColumnVectorInfo[] vectorInfo, int chunkIndex) {
+    ColumnVectorInfo columnVectorInfo = vectorInfo[chunkIndex];
+    int offset = columnVectorInfo.offset;
+    int vectorOffset = columnVectorInfo.vectorOffset;
+    int len = columnVectorInfo.size + offset;
+    CarbonColumnVector vector = columnVectorInfo.vector;
+    DataType dataType = vector.getType();
+    if (isAllNullValues) {
+      for (int j = offset; j < len; j++) {
+        vector.putNull(vectorOffset++);
+      }
+    } else if (nullBitset.isEmpty()) {
+      for (int j = offset; j < len; j++) {
+        if (dataType == DataTypes.INT) {
+          vector.putInt(vectorOffset++, getDataBasedOnActualRowId(j));
+        } else {
+          vector.putLong(vectorOffset++, getDataBasedOnActualRowId(j));
+        }
+      }
+    } else {
+      for (int j = offset; j < len; j++) {
+        if (nullBitset.get(j)) {
+          vector.putNull(vectorOffset++);
+        } else {
+          if (dataType == DataTypes.INT) {
+            vector.putInt(vectorOffset++, getDataBasedOnActualRowId(j));
+          } else {
+            vector.putLong(vectorOffset++, getDataBasedOnActualRowId(j));
+          }
+        }
+      }
+    }
+    return chunkIndex + 1;
+  }
+
+  @Override
+  public int fillVector(int[] filteredRowId, ColumnVectorInfo[] vectorInfo, int chunkIndex) {
+    ColumnVectorInfo columnVectorInfo = vectorInfo[chunkIndex];
+    int offset = columnVectorInfo.offset;
+    int vectorOffset = columnVectorInfo.vectorOffset;
+    int len = columnVectorInfo.size + offset;
+    CarbonColumnVector vector = columnVectorInfo.vector;
+    DataType dataType = vector.getType();
+    if (isAllNullValues) {
+      for (int j = offset; j < len; j++) {
+        vector.putNull(vectorOffset++);
+      }
+    } else if (nullBitset.isEmpty()) {
+      for (int j = offset; j < len; j++) {
+        if (dataType == DataTypes.INT) {
+          vector.putInt(vectorOffset++, getDataBasedOnActualRowId(filteredRowId[j]));
+        } else {
+          vector.putLong(vectorOffset++, getDataBasedOnActualRowId(filteredRowId[j]));
+        }
+      }
+    } else {
+      for (int j = offset; j < len; j++) {
+        int filteredIndex = filteredRowId[j];
+        if (nullBitset.get(filteredIndex)) {
+          vector.putNull(vectorOffset++);
+        } else {
+          if (dataType == DataTypes.INT) {
+            vector.putInt(vectorOffset++, getDataBasedOnActualRowId(filteredIndex));
+          } else {
+            vector.putLong(vectorOffset++, getDataBasedOnActualRowId(filteredIndex));
+          }
+        }
+      }
+    }
+    return chunkIndex + 1;
+  }
+
+  @Override public byte[] getChunkData(int rowId) {
+    if (nullBitset.get(rowId)) {
+      return CarbonCommonConstants.EMPTY_BYTE_ARRAY;
+    }
+    if (isExplictSorted) {
+      rowId = invertedIndexReverse[rowId];
+    }
+    return ByteUtil.toXorBytes((int) columnPage.getLong(rowId));
+  }
+
+  @Override public int compareTo(int rowId, byte[] compareValue) {
+    byte[] data;
+    int nullBitSetRowId = isExplictSorted ? invertedIndex[rowId] : rowId;
+    if (nullBitset.get(nullBitSetRowId)) {
+      data = CarbonCommonConstants.EMPTY_BYTE_ARRAY;
+    } else {
+      data = ByteUtil.toXorBytes((int) columnPage.getLong(rowId));
+    }
+    return ByteUtil.UnsafeComparer.INSTANCE.compareTo(data, compareValue);
+  }
+
+  private int getDataBasedOnActualRowId(int rowId) {
+    if (isExplictSorted) {
+      return (int) columnPage.getLong(invertedIndexReverse[rowId]);
+    }
+    return (int) columnPage.getLong(rowId);
+  }
+}

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/impl/LongTypeDimColumnPage.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/impl/LongTypeDimColumnPage.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.core.datastore.chunk.impl;
+
+import org.apache.carbondata.core.constants.CarbonCommonConstants;
+import org.apache.carbondata.core.datastore.page.ColumnPage;
+import org.apache.carbondata.core.metadata.datatype.DataType;
+import org.apache.carbondata.core.metadata.datatype.DataTypes;
+import org.apache.carbondata.core.scan.result.vector.CarbonColumnVector;
+import org.apache.carbondata.core.scan.result.vector.ColumnVectorInfo;
+import org.apache.carbondata.core.util.ByteUtil;
+
+/**
+ * Class responsible for processing local dictionary data type dimension column data
+ */
+
+public class LongTypeDimColumnPage extends AbstractPrimitiveDimColumnPage {
+
+  public LongTypeDimColumnPage(ColumnPage columnPage, int[] actualRowId,
+      int[] invertedIndexReverse, int numberOfRows) {
+    super(columnPage, actualRowId, invertedIndexReverse, numberOfRows);
+  }
+
+  @Override public int fillVector(ColumnVectorInfo[] vectorInfo, int chunkIndex) {
+    ColumnVectorInfo columnVectorInfo = vectorInfo[chunkIndex];
+    int offset = columnVectorInfo.offset;
+    int vectorOffset = columnVectorInfo.vectorOffset;
+    int len = columnVectorInfo.size + offset;
+    CarbonColumnVector vector = columnVectorInfo.vector;
+    DataType type = vector.getType();
+    if (isAllNullValues) {
+      for (int j = offset; j < len; j++) {
+        vector.putNull(vectorOffset++);
+      }
+    } else if (nullBitset.isEmpty()) {
+      for (int j = offset; j < len; j++) {
+        vector.putLong(vectorOffset++, getDataBasedOnActualRowId(j, type));
+      }
+    } else {
+      for (int j = offset; j < len; j++) {
+        if (nullBitset.get(j)) {
+          vector.putNull(vectorOffset++);
+        } else {
+          vector.putLong(vectorOffset++, getDataBasedOnActualRowId(j, type));
+        }
+      }
+    }
+    return chunkIndex + 1;
+  }
+
+  @Override
+  public int fillVector(int[] filteredRowId, ColumnVectorInfo[] vectorInfo, int chunkIndex) {
+    ColumnVectorInfo columnVectorInfo = vectorInfo[chunkIndex];
+    int offset = columnVectorInfo.offset;
+    int vectorOffset = columnVectorInfo.vectorOffset;
+    int len = columnVectorInfo.size + offset;
+    CarbonColumnVector vector = columnVectorInfo.vector;
+    DataType type = vector.getType();
+    if (isAllNullValues) {
+      for (int j = offset; j < len; j++) {
+        vector.putNull(vectorOffset++);
+      }
+    } else if (nullBitset.isEmpty()) {
+      for (int j = offset; j < len; j++) {
+        vector.putLong(vectorOffset++, getDataBasedOnActualRowId(filteredRowId[j], type));
+      }
+    } else {
+      for (int j = offset; j < len; j++) {
+        int filteredIndex = filteredRowId[j];
+        if (nullBitset.get(filteredIndex)) {
+          vector.putNull(vectorOffset++);
+        } else {
+          vector.putLong(vectorOffset++, getDataBasedOnActualRowId(filteredIndex, type));
+        }
+      }
+    }
+    return chunkIndex + 1;
+  }
+
+  @Override public byte[] getChunkData(int rowId) {
+    if (nullBitset.get(rowId)) {
+      return CarbonCommonConstants.EMPTY_BYTE_ARRAY;
+    }
+    if (isExplictSorted) {
+      rowId = invertedIndexReverse[rowId];
+    }
+    return ByteUtil.toXorBytes(columnPage.getLong(rowId));
+  }
+
+  @Override public int compareTo(int rowId, byte[] compareValue) {
+    byte[] data;
+    int nullBitSetRowId = isExplictSorted ? invertedIndex[rowId] : rowId;
+    if (nullBitset.get(nullBitSetRowId)) {
+      data = CarbonCommonConstants.EMPTY_BYTE_ARRAY;
+    } else {
+      data = ByteUtil.toXorBytes(columnPage.getLong(rowId));
+    }
+    return ByteUtil.UnsafeComparer.INSTANCE.compareTo(data, compareValue);
+  }
+
+  private long getDataBasedOnActualRowId(int rowId, DataType dataType) {
+    if (isExplictSorted) {
+      rowId = invertedIndexReverse[rowId];
+    }
+    long value = columnPage.getLong(rowId);
+    if (dataType == DataTypes.TIMESTAMP) {
+      return value * 1000L;
+    }
+    return value;
+  }
+}

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/impl/ShortTypeDimColumnPage.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/impl/ShortTypeDimColumnPage.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.core.datastore.chunk.impl;
+
+import org.apache.carbondata.core.constants.CarbonCommonConstants;
+import org.apache.carbondata.core.datastore.page.ColumnPage;
+import org.apache.carbondata.core.scan.result.vector.CarbonColumnVector;
+import org.apache.carbondata.core.scan.result.vector.ColumnVectorInfo;
+import org.apache.carbondata.core.util.ByteUtil;
+
+/**
+ * Class responsible for processing short data type dimension column data
+ */
+
+public class ShortTypeDimColumnPage extends AbstractPrimitiveDimColumnPage {
+  public ShortTypeDimColumnPage(ColumnPage columnPage, int[] actualRowId,
+      int[] invertedIndexReverse, int numberOfRows) {
+    super(columnPage, actualRowId, invertedIndexReverse, numberOfRows);
+  }
+
+  @Override public int fillVector(ColumnVectorInfo[] vectorInfo, int chunkIndex) {
+    ColumnVectorInfo columnVectorInfo = vectorInfo[chunkIndex];
+    int offset = columnVectorInfo.offset;
+    int vectorOffset = columnVectorInfo.vectorOffset;
+    int len = columnVectorInfo.size + offset;
+    CarbonColumnVector vector = columnVectorInfo.vector;
+    if (isAllNullValues) {
+      for (int j = offset; j < len; j++) {
+        vector.putNull(vectorOffset++);
+      }
+    } else if (nullBitset.isEmpty()) {
+      for (int j = offset; j < len; j++) {
+        vector.putShort(vectorOffset++, getDataBasedOnActualRowId(j));
+      }
+    } else {
+      for (int j = offset; j < len; j++) {
+        if (nullBitset.get(j)) {
+          vector.putNull(vectorOffset++);
+        } else {
+          vector.putShort(vectorOffset++, getDataBasedOnActualRowId(j));
+        }
+      }
+    }
+    return chunkIndex + 1;
+  }
+
+  @Override
+  public int fillVector(int[] filteredRowId, ColumnVectorInfo[] vectorInfo, int chunkIndex) {
+    ColumnVectorInfo columnVectorInfo = vectorInfo[chunkIndex];
+    int offset = columnVectorInfo.offset;
+    int vectorOffset = columnVectorInfo.vectorOffset;
+    int len = columnVectorInfo.size + offset;
+    CarbonColumnVector vector = columnVectorInfo.vector;
+    if (isAllNullValues) {
+      for (int j = offset; j < len; j++) {
+        vector.putNull(vectorOffset++);
+      }
+    } else if (nullBitset.isEmpty()) {
+      for (int j = offset; j < len; j++) {
+        vector.putShort(vectorOffset++, getDataBasedOnActualRowId(filteredRowId[j]));
+      }
+    } else {
+      for (int j = offset; j < len; j++) {
+        int filteredIndex = filteredRowId[j];
+        if (nullBitset.get(filteredIndex)) {
+          vector.putNull(vectorOffset++);
+        } else {
+          vector.putShort(vectorOffset++, getDataBasedOnActualRowId(filteredIndex));
+        }
+      }
+    }
+    return chunkIndex + 1;
+  }
+
+  @Override public byte[] getChunkData(int rowId) {
+    if (nullBitset.get(rowId)) {
+      return CarbonCommonConstants.EMPTY_BYTE_ARRAY;
+    }
+    if (isExplictSorted) {
+      rowId = invertedIndexReverse[rowId];
+    }
+    return ByteUtil.toXorBytes((short) columnPage.getLong(rowId));
+  }
+
+  @Override public int compareTo(int rowId, byte[] compareValue) {
+    byte[] data;
+    int nullBitSetRowId = isExplictSorted ? invertedIndex[rowId] : rowId;
+    if (nullBitset.get(nullBitSetRowId)) {
+      data = CarbonCommonConstants.EMPTY_BYTE_ARRAY;
+    } else {
+      data = ByteUtil.toXorBytes((short) columnPage.getLong(rowId));
+    }
+    return ByteUtil.UnsafeComparer.INSTANCE.compareTo(data, compareValue);
+  }
+
+  private short getDataBasedOnActualRowId(int rowId) {
+    if (isExplictSorted) {
+      return (short) columnPage.getLong(invertedIndexReverse[rowId]);
+    }
+    return (short) columnPage.getLong(rowId);
+  }
+
+}

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/ColumnPageWrapper.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/ColumnPageWrapper.java
@@ -17,7 +17,6 @@
 
 package org.apache.carbondata.core.datastore.chunk.store;
 
-
 import java.util.BitSet;
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
@@ -26,7 +25,6 @@ import org.apache.carbondata.core.datastore.chunk.DimensionColumnPage;
 import org.apache.carbondata.core.datastore.page.ColumnPage;
 import org.apache.carbondata.core.metadata.datatype.DataType;
 import org.apache.carbondata.core.metadata.datatype.DataTypes;
-import org.apache.carbondata.core.scan.executor.util.QueryUtil;
 import org.apache.carbondata.core.scan.result.vector.CarbonColumnVector;
 import org.apache.carbondata.core.scan.result.vector.CarbonDictionary;
 import org.apache.carbondata.core.scan.result.vector.ColumnVectorInfo;
@@ -43,21 +41,14 @@ public class ColumnPageWrapper implements DimensionColumnPage {
 
   private boolean isAdaptivePrimitivePage;
 
-  private int[] invertedIndex;
-
-  private int[] invertedReverseIndex;
-
-  private boolean isExplicitSorted;
+  private BitSet nullBitset;
 
   public ColumnPageWrapper(ColumnPage columnPage, CarbonDictionary localDictionary,
-      int[] invertedIndex, int[] invertedReverseIndex, boolean isAdaptivePrimitivePage,
-      boolean isExplicitSorted) {
+      boolean isAdaptivePrimitivePage) {
     this.columnPage = columnPage;
     this.localDictionary = localDictionary;
-    this.invertedIndex = invertedIndex;
-    this.invertedReverseIndex = invertedReverseIndex;
     this.isAdaptivePrimitivePage = isAdaptivePrimitivePage;
-    this.isExplicitSorted = isExplicitSorted;
+    this.nullBitset = columnPage.getNullBits();
   }
 
   @Override
@@ -72,15 +63,7 @@ public class ColumnPageWrapper implements DimensionColumnPage {
 
   @Override
   public int fillVector(ColumnVectorInfo[] vectorInfo, int chunkIndex) {
-    ColumnVectorInfo columnVectorInfo = vectorInfo[chunkIndex];
-    CarbonColumnVector vector = columnVectorInfo.vector;
-    int offset = columnVectorInfo.offset;
-    int vectorOffset = columnVectorInfo.vectorOffset;
-    int len = offset + columnVectorInfo.size;
-    for (int i = offset; i < len; i++) {
-      fillRow(i, vector, vectorOffset++);
-    }
-    return chunkIndex + 1;
+    throw new UnsupportedOperationException("Operation not supported for complex type");
   }
 
   /**
@@ -91,47 +74,21 @@ public class ColumnPageWrapper implements DimensionColumnPage {
    * @param vectorRow
    */
   private void fillRow(int rowId, CarbonColumnVector vector, int vectorRow) {
-    if (columnPage.getNullBits().get(rowId)
-        && columnPage.getColumnSpec().getColumnType() == ColumnType.COMPLEX_PRIMITIVE) {
-      // if this row is null, return default null represent in byte array
-      byte[] value = CarbonCommonConstants.MEMBER_DEFAULT_VAL_ARRAY;
-      QueryUtil.putDataToVector(vector, value, vectorRow, value.length);
-    } else if (columnPage.getNullBits().get(rowId)) {
-      // if this row is null, return default null represent in byte array
-      byte[] value = CarbonCommonConstants.EMPTY_BYTE_ARRAY;
-      QueryUtil.putDataToVector(vector, value, vectorRow, value.length);
-    } else {
-      if (isExplicitSorted) {
-        rowId = invertedReverseIndex[rowId];
-      }
-      QueryUtil.putDataToVector(vector, getActualData(rowId, true), vectorRow);
-    }
+    throw new UnsupportedOperationException("Operation not supported for complex type");
   }
 
   @Override
   public int fillVector(int[] filteredRowId, ColumnVectorInfo[] vectorInfo, int chunkIndex) {
-    ColumnVectorInfo columnVectorInfo = vectorInfo[chunkIndex];
-    CarbonColumnVector vector = columnVectorInfo.vector;
-    int offset = columnVectorInfo.offset;
-    int vectorOffset = columnVectorInfo.vectorOffset;
-    int len = offset + columnVectorInfo.size;
-    for (int i = offset; i < len; i++) {
-      fillRow(filteredRowId[i], vector, vectorOffset++);
-    }
-    return chunkIndex + 1;
+    throw new UnsupportedOperationException("Operation not supported for complex type");
   }
 
   @Override public byte[] getChunkData(int rowId) {
-    byte[] nullBitSet = getNullBitSet(rowId, columnPage.getColumnSpec().getColumnType());
-    if (nullBitSet != null) {
+    if (nullBitset.get(rowId)
+        && columnPage.getColumnSpec().getColumnType() == ColumnType.COMPLEX_PRIMITIVE) {
       // if this row is null, return default null represent in byte array
-      return nullBitSet;
-    } else {
-      if (isExplicitSorted()) {
-        rowId = getInvertedReverseIndex(rowId);
-      }
-      return getChunkDataInBytes(rowId);
+      return CarbonCommonConstants.MEMBER_DEFAULT_VAL_ARRAY;
     }
+    return getChunkDataInBytes(rowId);
   }
 
   private byte[] getChunkDataInBytes(int rowId) {
@@ -141,8 +98,7 @@ public class ColumnPageWrapper implements DimensionColumnPage {
     if (null != localDictionary) {
       return localDictionary
           .getDictionaryValue(CarbonUtil.getSurrogateInternal(columnPage.getBytes(rowId), 0, 3));
-    } else if ((columnType == ColumnType.COMPLEX_PRIMITIVE && isAdaptiveEncoded()) || (
-        columnType == ColumnType.PLAIN_VALUE && DataTypeUtil.isPrimitiveColumn(srcDataType))) {
+    } else if ((columnType == ColumnType.COMPLEX_PRIMITIVE && isAdaptivePrimitivePage)) {
       if (srcDataType == DataTypes.FLOAT) {
         float floatData = columnPage.getFloat(rowId);
         return ByteUtil.toXorBytes(floatData);
@@ -181,7 +137,7 @@ public class ColumnPageWrapper implements DimensionColumnPage {
       } else {
         throw new RuntimeException("unsupported type: " + targetDataType);
       }
-    } else if ((columnType == ColumnType.COMPLEX_PRIMITIVE && !isAdaptiveEncoded())) {
+    } else if ((columnType == ColumnType.COMPLEX_PRIMITIVE)) {
       if ((srcDataType == DataTypes.BYTE) || (srcDataType == DataTypes.BOOLEAN)) {
         byte[] out = new byte[1];
         out[0] = (columnPage.getByte(rowId));
@@ -291,39 +247,27 @@ public class ColumnPageWrapper implements DimensionColumnPage {
 
   @Override
   public int getInvertedIndex(int rowId) {
-    return invertedIndex[rowId];
+    throw new UnsupportedOperationException("Operation not supported for complex type");
   }
 
   @Override
   public int getInvertedReverseIndex(int rowId) {
-    return invertedReverseIndex[rowId];
+    throw new UnsupportedOperationException("Operation not supported for complex type");
   }
 
   @Override
   public boolean isNoDicitionaryColumn() {
-    return true;
+    return false;
   }
 
   @Override
   public boolean isExplicitSorted() {
-    return isExplicitSorted;
+    return false;
   }
 
   @Override
   public int compareTo(int rowId, byte[] compareValue) {
-    // rowId is the inverted index, but the null bitset is based on actual data
-    int nullBitSetRowId = rowId;
-    if (isExplicitSorted()) {
-      nullBitSetRowId = getInvertedReverseIndex(rowId);
-    }
-    byte[] nullBitSet = getNullBitSet(nullBitSetRowId, columnPage.getColumnSpec().getColumnType());
-    if (nullBitSet != null) {
-      // if this row is null, return default null represent in byte array
-      return ByteUtil.UnsafeComparer.INSTANCE.compareTo(nullBitSet, compareValue);
-    } else {
-      byte[] chunkData = this.getChunkDataInBytes(rowId);
-      return ByteUtil.UnsafeComparer.INSTANCE.compareTo(chunkData, compareValue);
-    }
+    throw new UnsupportedOperationException("Operation not supported for complex type");
   }
 
   @Override
@@ -335,11 +279,10 @@ public class ColumnPageWrapper implements DimensionColumnPage {
   }
 
   @Override public boolean isAdaptiveEncoded() {
-    return isAdaptivePrimitivePage;
+    throw new UnsupportedOperationException("Operation not supported for complex type");
   }
 
   @Override public BitSet getNullBits() {
     return columnPage.getNullBits();
   }
-
 }


### PR DESCRIPTION
### What changes are proposed in this PR
**Method In-lining Optimization**
JIT will inline any method if method size is less than 325 byte code size and if it is called more than 10K times(default value). If method is private or static it will be easier for JIT to inline as type safe check is not required, for protected/public method it will add a overhead of type check and because of this it will not behave as inline.
Because of above case some refactoring is done for primitive no dictionary data type columns. Earlier ColumnPageWrapper.java was handling query processing for all primitive no dictionary data type column now in This PR separate classes are created for each data type handling and all the HOT method is kept as private and protected methods are overridden and other methods are added in Super classes

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

