### PR TITLE
 [CARBONDATA-3003] Support read batch row in CSDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ CarbonData is built using Apache Maven, to [build CarbonData](https://github.com
  * [CarbonData Pre-aggregate DataMap](https://github.com/apache/carbondata/blob/master/docs/preaggregate-datamap-guide.md) 
  * [CarbonData Timeseries DataMap](https://github.com/apache/carbondata/blob/master/docs/timeseries-datamap-guide.md) 
 * [SDK Guide](https://github.com/apache/carbondata/blob/master/docs/sdk-guide.md) 
-* [CSDK Guide](https://github.com/apache/carbondata/blob/master/docs/csdk-guide.md)
+* [C++ SDK Guide](https://github.com/apache/carbondata/blob/master/docs/csdk-guide.md)
 * [Performance Tuning](https://github.com/apache/carbondata/blob/master/docs/performance-tuning.md) 
 * [S3 Storage](https://github.com/apache/carbondata/blob/master/docs/s3-guide.md) 
 * [Carbon as Spark's Datasource](https://github.com/apache/carbondata/blob/master/docs/carbon-as-spark-datasource-guide.md) 

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/RowBatch.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/RowBatch.java
@@ -100,4 +100,17 @@ public class RowBatch extends CarbonIterator<Object[]> {
     counter++;
     return row;
   }
+
+  /**
+   * read next batch
+   *
+   * @return rows
+   */
+  public List<Object[]> nextBatch() {
+    if (!hasNext()) {
+      throw new NoSuchElementException();
+    }
+    counter = counter + rows.size();
+    return rows;
+  }
 }

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/iterator/ChunkRowIterator.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/iterator/ChunkRowIterator.java
@@ -17,6 +17,8 @@
 
 package org.apache.carbondata.core.scan.result.iterator;
 
+import java.util.List;
+
 import org.apache.carbondata.common.CarbonIterator;
 import org.apache.carbondata.core.scan.result.RowBatch;
 
@@ -72,6 +74,15 @@ public class ChunkRowIterator extends CarbonIterator<Object[]> {
    */
   @Override public Object[] next() {
     return currentChunk.next();
+  }
+
+  /**
+   * read next batch
+   *
+   * @return list of batch result
+   */
+  public List<Object[]> nextBatch() {
+    return currentChunk.nextBatch();
   }
 
 }

--- a/docs/csdk-guide.md
+++ b/docs/csdk-guide.md
@@ -15,20 +15,20 @@
     limitations under the License.
 -->
 
-# CSDK Guide
+# C++ SDK Guide
 
-CarbonData CSDK provides C++ interface to write and read carbon file. 
-CSDK use JNI to invoke java SDK in C++ code.
+CarbonData C++ SDK provides C++ interface to write and read carbon file. 
+C++ SDK use JNI to invoke java SDK in C++ code.
 
 
-# CSDK Reader
-This CSDK reader reads CarbonData file and carbonindex file at a given path.
+# C++ SDK Reader
+This C++ SDK reader reads CarbonData file and carbonindex file at a given path.
 External client can make use of this reader to read CarbonData files in C++ 
 code and without CarbonSession.
 
 
 In the carbon jars package, there exist a carbondata-sdk.jar, 
-including SDK reader for CSDK.
+including SDK reader for C++ SDK.
 ## Quick example
 
 Please find example code at  [main.cpp](https://github.com/apache/carbondata/blob/master/store/CSDK/test/main.cpp) of CSDK module  
@@ -37,6 +37,8 @@ When users use C++ to read carbon files, users should init JVM first. Then users
 carbon reader and read data.There are some example code of read data from local disk  
 and read data from S3 at main.cpp of CSDK module.  Finally, users need to 
 release the memory and destroy JVM.
+
+C++ SDK support read batch row. User can set batch by using withBatch(int batch) before build, and read batch by using readNextBatchRow().
 
 ## API List
 ### CarbonReader
@@ -73,6 +75,14 @@ release the memory and destroy JVM.
      **/
     jobject withHadoopConf(int argc, char *argv[]);
 
+   /**
+     * set batch size
+     *
+     * @param batch batch size
+     * @return CarbonReaderBuilder object
+     */
+    void withBatch(int batch);
+
     /**
      * build carbonReader object for reading data
      * it support read data from load disk
@@ -95,6 +105,13 @@ release the memory and destroy JVM.
      jobject readNextRow();
 
     /**
+     * read Next Batch Row
+     *
+     * @return rows
+     */
+    jobjectArray readNextBatchRow();
+
+    /**
      * close the carbon reader
      *
      * @return  boolean value
@@ -103,13 +120,13 @@ release the memory and destroy JVM.
 
 ```
 
-# CSDK Writer
-This CSDK writer writes CarbonData file and carbonindex file at a given path. 
+# C++ SDK Writer
+This C++ SDK writer writes CarbonData file and carbonindex file at a given path. 
 External client can make use of this writer to write CarbonData files in C++ 
-code and without CarbonSession. CSDK already supports S3 and local disk.
+code and without CarbonSession. C++ SDK already supports S3 and local disk.
 
 In the carbon jars package, there exist a carbondata-sdk.jar, 
-including SDK writer for CSDK. 
+including SDK writer for C++ SDK. 
 
 ## Quick example
 Please find example code at  [main.cpp](https://github.com/apache/carbondata/blob/master/store/CSDK/test/main.cpp) of CSDK module  

--- a/docs/ddl-of-carbondata.md
+++ b/docs/ddl-of-carbondata.md
@@ -565,7 +565,7 @@ CarbonData DDL statements are documented here,which includes:
   ```
 
   Here writer path will have carbondata and index files.
-  This can be SDK output or CSDK output. Refer [SDK Guide](./sdk-guide.md) and [CSDK Guide](./csdk-guide.md). 
+  This can be SDK output or C++ SDK output. Refer [SDK Guide](./sdk-guide.md) and [C++ SDK Guide](./csdk-guide.md). 
 
   **Note:**
   1. Dropping of the external table should not delete the files present in the location.

--- a/docs/quick-start-guide.md
+++ b/docs/quick-start-guide.md
@@ -294,7 +294,7 @@ hdfs://<host_name>:port/user/hive/warehouse/carbon.store
 ## Installing and Configuring CarbonData on Presto
 
 **NOTE:** **CarbonData tables cannot be created nor loaded from Presto. User need to create CarbonData Table and load data into it
-either with [Spark](#installing-and-configuring-carbondata-to-run-locally-with-spark-shell) or [SDK](./sdk-guide.md) or [CSDK](./csdk-guide.md).
+either with [Spark](#installing-and-configuring-carbondata-to-run-locally-with-spark-shell) or [SDK](./sdk-guide.md) or [C++ SDK](./csdk-guide.md).
 Once the table is created,it can be queried from Presto.**
 
 

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/CarbonRecordReader.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/CarbonRecordReader.java
@@ -131,6 +131,20 @@ public class CarbonRecordReader<T> extends AbstractRecordReader<T> {
     return readSupport.readRow(carbonIterator.next());
   }
 
+  /**
+   * get batch result
+   *
+   * @return rows
+   */
+  public List<Object[]> getBatchValue() {
+    if (null != inputMetricsStats) {
+      inputMetricsStats.incrementRecordRead(1L);
+    }
+    List<Object[]> objects = ((ChunkRowIterator) carbonIterator).nextBatch();
+    rowCount += objects.size();
+    return objects;
+  }
+
   @Override public float getProgress() throws IOException, InterruptedException {
     // TODO : Implement it based on total number of rows it is going to retrieve.
     return 0;

--- a/store/CSDK/CMakeLists.txt
+++ b/store/CSDK/CMakeLists.txt
@@ -1,3 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 cmake_minimum_required(VERSION 2.8)
 project(CJDK)
 set(CMAKE_BUILD_TYPE Debug)

--- a/store/CSDK/src/CarbonReader.h
+++ b/store/CSDK/src/CarbonReader.h
@@ -30,6 +30,11 @@ private:
     jmethodID readNextRowID = NULL;
 
     /**
+     * readNextBatchRow jmethodID
+     */
+    jmethodID readNextBatchRowID = NULL;
+
+    /**
      * carbonReaderBuilder object for building carbonReader
      * it can configure some operation
      */
@@ -98,6 +103,19 @@ public:
     void withHadoopConf(char *key, char *value);
 
     /**
+     * set batch size
+     *
+     * @param batch batch size
+     * @return CarbonReaderBuilder object
+     */
+    void withBatch(int batch);
+
+    /**
+     * Configure Row Record Reader for reading.
+     */
+    void withRowRecordReader();
+
+    /**
      * build carbonReader object for reading data
      * it support read data from load disk
      *
@@ -117,6 +135,13 @@ public:
      * @return carbon Row object of one row
      */
     jobject readNextRow();
+
+    /**
+     * read Next Batch Row
+     *
+     * @return rows
+     */
+    jobjectArray readNextBatchRow();
 
     /**
      * close the carbon reader

--- a/store/CSDK/src/CarbonRow.cpp
+++ b/store/CSDK/src/CarbonRow.cpp
@@ -102,7 +102,14 @@ void CarbonRow::checkOrdinal(int ordinal) {
     }
 }
 
+void CarbonRow::checkCarbonRow() {
+    if (carbonRow == NULL) {
+        throw std::runtime_error("carbonRow is NULL! Please set carbonRow first..");
+    }
+}
+
 short CarbonRow::getShort(int ordinal) {
+    checkCarbonRow();
     checkOrdinal(ordinal);
     jvalue args[2];
     args[0].l = carbonRow;
@@ -111,6 +118,7 @@ short CarbonRow::getShort(int ordinal) {
 }
 
 int CarbonRow::getInt(int ordinal) {
+    checkCarbonRow();
     checkOrdinal(ordinal);
     jvalue args[2];
     args[0].l = carbonRow;
@@ -119,6 +127,7 @@ int CarbonRow::getInt(int ordinal) {
 }
 
 long CarbonRow::getLong(int ordinal) {
+    checkCarbonRow();
     checkOrdinal(ordinal);
     jvalue args[2];
     args[0].l = carbonRow;
@@ -127,6 +136,7 @@ long CarbonRow::getLong(int ordinal) {
 }
 
 double CarbonRow::getDouble(int ordinal) {
+    checkCarbonRow();
     checkOrdinal(ordinal);
     jvalue args[2];
     args[0].l = carbonRow;
@@ -136,6 +146,7 @@ double CarbonRow::getDouble(int ordinal) {
 
 
 float CarbonRow::getFloat(int ordinal) {
+    checkCarbonRow();
     checkOrdinal(ordinal);
     jvalue args[2];
     args[0].l = carbonRow;
@@ -144,6 +155,7 @@ float CarbonRow::getFloat(int ordinal) {
 }
 
 jboolean CarbonRow::getBoolean(int ordinal) {
+    checkCarbonRow();
     checkOrdinal(ordinal);
     jvalue args[2];
     args[0].l = carbonRow;
@@ -152,6 +164,7 @@ jboolean CarbonRow::getBoolean(int ordinal) {
 }
 
 char *CarbonRow::getString(int ordinal) {
+    checkCarbonRow();
     checkOrdinal(ordinal);
     jvalue args[2];
     args[0].l = carbonRow;
@@ -163,6 +176,7 @@ char *CarbonRow::getString(int ordinal) {
 }
 
 char *CarbonRow::getDecimal(int ordinal) {
+    checkCarbonRow();
     checkOrdinal(ordinal);
     jvalue args[2];
     args[0].l = carbonRow;
@@ -174,6 +188,7 @@ char *CarbonRow::getDecimal(int ordinal) {
 }
 
 char *CarbonRow::getVarchar(int ordinal) {
+    checkCarbonRow();
     checkOrdinal(ordinal);
     jvalue args[2];
     args[0].l = carbonRow;
@@ -185,6 +200,7 @@ char *CarbonRow::getVarchar(int ordinal) {
 }
 
 jobjectArray CarbonRow::getArray(int ordinal) {
+    checkCarbonRow();
     checkOrdinal(ordinal);
     jvalue args[2];
     args[0].l = carbonRow;

--- a/store/CSDK/src/CarbonRow.h
+++ b/store/CSDK/src/CarbonRow.h
@@ -38,7 +38,7 @@ private:
     /**
      * carbon row data
      */
-    jobject carbonRow;
+    jobject carbonRow = NULL;
 
     /**
      * check ordinal, ordinal can't be negative
@@ -46,6 +46,11 @@ private:
      * @param ordinal int value, the data index of carbon Row
      */
     void checkOrdinal(int ordinal);
+
+    /**
+     * check ordinal, ordinal can't be negative
+     */
+    void checkCarbonRow();
 
 public:
 

--- a/store/CSDK/test/main.cpp
+++ b/store/CSDK/test/main.cpp
@@ -15,10 +15,12 @@
  * limitations under the License.
  */
 
-#include <stdio.h>
-#include <jni.h>
-#include <stdlib.h>
 #include <iostream>
+#include <jni.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/time.h>
 #include <unistd.h>
 #include <sys/time.h>
 #include "../src/CarbonReader.h"
@@ -40,13 +42,15 @@ JavaVM *jvm;
 JNIEnv *initJVM() {
     JNIEnv *env;
     JavaVMInitArgs vm_args;
-    int parNum = 3;
+    int parNum = 2;
     int res;
     JavaVMOption options[parNum];
 
-    options[0].optionString = "-Djava.compiler=NONE";
-    options[1].optionString = "-Djava.class.path=../../sdk/target/carbondata-sdk.jar";
-    options[2].optionString = "-verbose:jni";
+    options[0].optionString = "-Djava.class.path=../../sdk/target/carbondata-sdk.jar";
+    options[1].optionString = "-verbose:jni";                // For debug and check the jni information
+    //    options[2].optionString = "-Xmx12000m";            // change the jvm max memory size
+    //    options[3].optionString = "-Xms5000m";             // change the jvm min memory size
+    //    options[4].optionString = "-Djava.compiler=NONE";  // forbidden JIT
     vm_args.version = JNI_VERSION_1_8;
     vm_args.nOptions = parNum;
     vm_args.options = options;
@@ -186,12 +190,12 @@ bool readSchemaInDataFile(JNIEnv *env, char *dataFilePath) {
  * @param env  jni env
  * @return
  */
-bool readFromLocalWithoutProjection(JNIEnv *env) {
+bool readFromLocalWithoutProjection(JNIEnv *env, char *path) {
     printf("\nRead data from local without projection:\n");
 
     CarbonReader carbonReaderClass;
     try {
-        carbonReaderClass.builder(env, "../../../../resources/carbondata");
+        carbonReaderClass.builder(env, path);
     } catch (runtime_error e) {
         printf("\nget exception fro builder and throw\n");
         throw e;
@@ -205,16 +209,189 @@ bool readFromLocalWithoutProjection(JNIEnv *env) {
 }
 
 /**
+ * test read data by readNextRow method
+ *
+ * @param env  jni env
+ */
+void testReadNextRow(JNIEnv *env, char *path, int printNum, char **argv, int argc, bool useVectorReader) {
+    printf("\nTest next Row Performance, useVectorReader is ");
+    printBoolean(useVectorReader);
+    printf("\n");
+
+    struct timeval start, build, startRead, endBatchRead, endRead;
+    gettimeofday(&start, NULL);
+
+    try {
+        CarbonReader carbonReaderClass;
+
+        carbonReaderClass.builder(env, path);
+        if (argc > 1) {
+            carbonReaderClass.withHadoopConf("fs.s3a.access.key", argv[1]);
+            carbonReaderClass.withHadoopConf("fs.s3a.secret.key", argv[2]);
+            carbonReaderClass.withHadoopConf("fs.s3a.endpoint", argv[3]);
+        }
+        if (!useVectorReader) {
+            carbonReaderClass.withRowRecordReader();
+        }
+        carbonReaderClass.build();
+
+        gettimeofday(&build, NULL);
+        int time = 1000000 * (build.tv_sec - start.tv_sec) + build.tv_usec - start.tv_usec;
+        double buildTime = time / 1000000.0;
+        printf("\n\nbuild time is: %lf s\n\n", time / 1000000.0);
+
+        CarbonRow carbonRow(env);
+        int i = 0;
+
+        gettimeofday(&startRead, NULL);
+        jobject row;
+        while (carbonReaderClass.hasNext()) {
+
+            row = carbonReaderClass.readNextRow();
+
+            i++;
+            if (i > 1 && i % printNum == 0) {
+                gettimeofday(&endBatchRead, NULL);
+
+                time = 1000000 * (endBatchRead.tv_sec - startRead.tv_sec) + endBatchRead.tv_usec - startRead.tv_usec;
+                printf("%d: time is %lf s, speed is %lf records/s  ", i, time / 1000000.0,
+                       printNum / (time / 1000000.0));
+
+                carbonRow.setCarbonRow(row);
+                printf("%s\t", carbonRow.getString(0));
+                printf("%s\t", carbonRow.getString(1));
+                printf("%s\t", carbonRow.getString(2));
+                printf("%s\t", carbonRow.getString(3));
+                printf("%ld\t", carbonRow.getLong(4));
+                printf("%ld\t", carbonRow.getLong(5));
+                printf("\n");
+
+                gettimeofday(&startRead, NULL);
+            }
+            env->DeleteLocalRef(row);
+        }
+
+        gettimeofday(&endRead, NULL);
+
+        time = 1000000 * (endRead.tv_sec - build.tv_sec) + endRead.tv_usec - build.tv_usec;
+        printf("total line is: %d,\t build time is: %lf s,\tread time is %lf s, average speed is %lf records/s  ",
+               i, buildTime, time / 1000000.0, i / (time / 1000000.0));
+        carbonReaderClass.close();
+    } catch (jthrowable) {
+        env->ExceptionDescribe();
+    }
+}
+
+/**
+ * test read data by readNextBatchRow method
+ *
+ * @param env  jni env
+ */
+void testReadNextBatchRow(JNIEnv *env, char *path, int batchSize, int printNum, char **argv, int argc,
+                          bool useVectorReader) {
+    printf("\n\nTest next Batch Row Performance:\n");
+    printBoolean(useVectorReader);
+    printf("\n");
+
+    struct timeval start, build, read;
+    gettimeofday(&start, NULL);
+
+    CarbonReader carbonReaderClass;
+
+    carbonReaderClass.builder(env, path);
+    if (argc > 1) {
+        carbonReaderClass.withHadoopConf("fs.s3a.access.key", argv[1]);
+        carbonReaderClass.withHadoopConf("fs.s3a.secret.key", argv[2]);
+        carbonReaderClass.withHadoopConf("fs.s3a.endpoint", argv[3]);
+    }
+    if (!useVectorReader) {
+        carbonReaderClass.withRowRecordReader();
+    }
+    carbonReaderClass.withBatch(batchSize);
+    try {
+        carbonReaderClass.build();
+    } catch (jthrowable e) {
+        env->ExceptionDescribe();
+    }
+
+    gettimeofday(&build, NULL);
+    int time = 1000000 * (build.tv_sec - start.tv_sec) + build.tv_usec - start.tv_usec;
+    double buildTime = time / 1000000.0;
+    printf("\n\nbuild time is: %lf s\n\n", time / 1000000.0);
+
+    CarbonRow carbonRow(env);
+    int i = 0;
+    struct timeval startHasNext, startReadNextBatchRow, endReadNextBatchRow, endRead;
+    gettimeofday(&startHasNext, NULL);
+
+    while (carbonReaderClass.hasNext()) {
+
+        gettimeofday(&startReadNextBatchRow, NULL);
+        jobjectArray batch = carbonReaderClass.readNextBatchRow();
+        if (env->ExceptionCheck()) {
+            env->ExceptionDescribe();
+        }
+        gettimeofday(&endReadNextBatchRow, NULL);
+
+        jsize length = env->GetArrayLength(batch);
+        if (i + length > printNum - 1) {
+            for (int j = 0; j < length; j++) {
+                i++;
+                jobject row = env->GetObjectArrayElement(batch, j);
+                carbonRow.setCarbonRow(row);
+                carbonRow.getString(0);
+                carbonRow.getString(1);
+                carbonRow.getString(2);
+                carbonRow.getString(3);
+                carbonRow.getLong(4);
+                carbonRow.getLong(5);
+                if (i > 1 && i % printNum == 0) {
+                    gettimeofday(&read, NULL);
+
+                    double hasNextTime = 1000000 * (startReadNextBatchRow.tv_sec - startHasNext.tv_sec) +
+                                         startReadNextBatchRow.tv_usec - startHasNext.tv_usec;
+
+                    double readNextBatchTime = 1000000 * (endReadNextBatchRow.tv_sec - startReadNextBatchRow.tv_sec) +
+                                               endReadNextBatchRow.tv_usec - startReadNextBatchRow.tv_usec;
+
+                    time = 1000000 * (read.tv_sec - startHasNext.tv_sec) + read.tv_usec - startHasNext.tv_usec;
+                    printf("%d: time is %lf s, speed is %lf records/s, hasNext time is %lf s,readNextBatchRow time is %lf s ",
+                           i, time / 1000000.0, printNum / (time / 1000000.0), hasNextTime / 1000000.0,
+                           readNextBatchTime / 1000000.0);
+                    gettimeofday(&startHasNext, NULL);
+                    printf("%s\t", carbonRow.getString(0));
+                    printf("%s\t", carbonRow.getString(1));
+                    printf("%s\t", carbonRow.getString(2));
+                    printf("%s\t", carbonRow.getString(3));
+                    printf("%ld\t", carbonRow.getLong(4));
+                    printf("%ld\t", carbonRow.getLong(5));
+                    printf("\n");
+                }
+                env->DeleteLocalRef(row);
+            }
+        } else {
+            i = i + length;
+        }
+        env->DeleteLocalRef(batch);
+    }
+    gettimeofday(&endRead, NULL);
+    time = 1000000 * (endRead.tv_sec - build.tv_sec) + endRead.tv_usec - build.tv_usec;
+    printf("total line is: %d,\t build time is: %lf s,\tread time is %lf s, average speed is %lf records/s  ",
+           i, buildTime, time / 1000000.0, i / (time / 1000000.0));
+    carbonReaderClass.close();
+}
+
+/**
  * test read data from local disk
  *
  * @param env  jni env
  * @return
  */
-bool readFromLocal(JNIEnv *env) {
+bool readFromLocalWithProjection(JNIEnv *env, char *path) {
     printf("\nRead data from local:\n");
 
     CarbonReader reader;
-    reader.builder(env, "../../../../resources/carbondata", "test");
+    reader.builder(env, path, "test");
 
     char *argv[12];
     argv[0] = "stringField";
@@ -271,6 +448,7 @@ bool tryCatchException(JNIEnv *env) {
         carbonReaderClass.build();
     } catch (jthrowable e) {
         env->ExceptionDescribe();
+        env->ExceptionClear();
     }
     printf("\nfinished handle exception\n");
 }
@@ -455,20 +633,35 @@ int main(int argc, char *argv[]) {
     char *S3WritePath = "s3a://sdk/WriterOutput/carbondata2";
     char *S3ReadPath = "s3a://sdk/WriterOutput/carbondata";
 
+    char *smallFilePath = "../../../../resources/carbondata";
+    char *path = "../../../../../../../Downloads/carbon-data-big/dir2";
+    char *S3Path = "s3a://sdk/ges/i400bs128";
+
     if (argc > 3) {
         // TODO: need support read schema from S3 in the future
         testWriteData(env, S3WritePath, 4, argv);
         readFromS3(env, S3ReadPath, argv);
+        testReadNextRow(env, S3Path, 100000, argv, 4, false);
+        testReadNextRow(env, S3Path, 100000, argv, 4, true);
+        testReadNextBatchRow(env, S3Path, 100000, 100000, argv, 4, false);
+        testReadNextBatchRow(env, S3Path, 100000, 100000, argv, 4, true);
     } else {
         tryCatchException(env);
         char *indexFilePath = argv[1];
         char *dataFilePath = argv[2];
         testCarbonProperties(env);
-        readFromLocalWithoutProjection(env);
         testWriteData(env, "./data", 1, argv);
-        readFromLocal(env);
         readSchemaInIndexFile(env, indexFilePath);
         readSchemaInDataFile(env, dataFilePath);
+        testWriteData(env, "./data", 1, argv);
+        readFromLocalWithoutProjection(env, smallFilePath);
+        readFromLocalWithProjection(env, smallFilePath);
+        int batch = 32000;
+        int printNum = 32000;
+        testReadNextRow(env, path, printNum, argv, 0, true);
+        testReadNextRow(env, path, printNum, argv, 0, false);
+        testReadNextBatchRow(env, path, batch, printNum, argv, 0, true);
+        testReadNextBatchRow(env, path, batch, printNum, argv, 0, false);
     }
     (jvm)->DestroyJavaVM();
 

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonReaderBuilder.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonReaderBuilder.java
@@ -24,12 +24,14 @@ import java.util.Objects;
 
 import org.apache.carbondata.common.annotations.InterfaceAudience;
 import org.apache.carbondata.common.annotations.InterfaceStability;
+import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.datamap.DataMapStoreManager;
 import org.apache.carbondata.core.datastore.impl.FileFactory;
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
 import org.apache.carbondata.core.scan.expression.Expression;
 import org.apache.carbondata.core.scan.model.ProjectionDimension;
 import org.apache.carbondata.core.scan.model.QueryModel;
+import org.apache.carbondata.core.util.CarbonProperties;
 import org.apache.carbondata.core.util.CarbonSessionInfo;
 import org.apache.carbondata.core.util.CarbonUtil;
 import org.apache.carbondata.core.util.ThreadLocalSessionInfo;
@@ -103,6 +105,19 @@ public class CarbonReaderBuilder {
     if (conf != null) {
       this.hadoopConf = conf;
     }
+    return this;
+  }
+
+  /**
+   * set read batch size before build
+   *
+   * @param batch batch size
+   * @return updated CarbonReaderBuilder
+   */
+  public CarbonReaderBuilder withBatch(int batch) {
+    CarbonProperties.getInstance()
+        .addProperty(CarbonCommonConstants.DETAIL_QUERY_BATCH_SIZE,
+            String.valueOf(batch));
     return this;
   }
 

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/RowUtil.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/RowUtil.java
@@ -119,8 +119,8 @@ public class RowUtil implements Serializable {
 
   /**
    * get varchar data type data by ordinal
-   * This is for CSDK
-   * JNI don't support varchar, so carbon convert varchar to string
+   * This is for C++ SDK
+   * JNI don't support varchar, so carbon convert decimal to string
    *
    * @param data carbon row data
    * @param ordinal the data index of Row
@@ -132,7 +132,7 @@ public class RowUtil implements Serializable {
 
   /**
    * get decimal data type data by ordinal
-   * This is for CSDK
+   * This is for C++ SDK
    * JNI don't support Decimal, so carbon convert decimal to string
    *
    * @param data carbon row data

--- a/store/sdk/src/test/java/org/apache/carbondata/sdk/file/CSVCarbonWriterTest.java
+++ b/store/sdk/src/test/java/org/apache/carbondata/sdk/file/CSVCarbonWriterTest.java
@@ -63,7 +63,9 @@ public class CSVCarbonWriterTest {
       assert (false);
     }
     CarbonProperties.getInstance()
-        .addProperty(CarbonCommonConstants.CARBON_SYSTEM_FOLDER_LOCATION, path);
+        .addProperty(CarbonCommonConstants.CARBON_SYSTEM_FOLDER_LOCATION, path)
+        .addProperty(CarbonCommonConstants.DETAIL_QUERY_BATCH_SIZE,
+            String.valueOf(CarbonCommonConstants.DETAIL_QUERY_BATCH_SIZE_DEFAULT));
     assert (TestUtil.cleanMdtFile());
   }
 


### PR DESCRIPTION
 [CARBONDATA-3003] Support read batch row in CSDK
    1. Support read batch rows in SDK
    2. Support read batch rows in CSDK
    3. improve CSDK read performance

For SDK batch read:
readNextBatchRow:
```
total lines is 200100000, build time is 10.434133262 s, 	total read time is 167.567157044 s, 	average speed is 1194148.0868321797records/s.
```
readNextRow:
```
total lines is 200100000, build time is 15.775965656 s, 	total read time is 183.312544655 s, 	average speed is 1091578.322567037records/s.
```
read batch row is faster 9.4% than readCarbonRow( one by one)

For CSDK:

Test next Row Performance: in local

```

Test next Row Performance:
build time is: 6.119777 s

100000: time is 0.278082 s, speed is 359606.159334 records/s  from_email10144phillip.allen@enron.com	to_email69149buck.buckner@honeywell.com	from_to	<5164240.1075855667637.JavaMail.evans@thyme>	1538015558000000	971703720000000	
200000: time is 0.301743 s, speed is 331407.853703 records/s  from_email10324veronica.espinoza@enron.com	to_email44094cynthia.franklin@enron.com	from_to	<14154714.1075858633174.JavaMail.evans@thyme>	1538015558000000	1003768608000000	
300000: time is 0.180397 s, speed is 554332.943452 records/s  from_email10545store-news@amazon.com	to_email59755pallen@enron.com	from_to	<5977904.1075858636257.JavaMail.evans@thyme>	1538015558000000	1004057196000000	
......
199800000: time is 0.144240 s, speed is 693288.962840 records/s  from_email99414kathie.grabstald@enron.com	to_email97812cowan'.'beth@enron.com	from_cc	<25801832.1075858634648.JavaMail.evans@thyme>	1538015558000000	1003926153000000	
199900000: time is 0.139121 s, speed is 718798.743540 records/s  from_email99622kathie.grabstald@enron.com	to_email39726jean.mrha@enron.com	from_to	<30070113.1075858637581.JavaMail.evans@thyme>	1538015558000000	1004364487000000	
200000000: time is 0.139053 s, speed is 719150.252062 records/s  from_email99837kathie.grabstald@enron.com	to_email40090e.taylor@enron.com	from_bcc	<20754442.1075858633286.JavaMail.evans@thyme>	1538015558000000	1003755042000000	
200100000: time is 0.140395 s, speed is 712276.078208 records/s  from_email999kathie.grabstald@enron.com	to_email23160christina.valdez@enron.com	from_cc	<20754442.1075858633286.JavaMail.evans@thyme>	1538015558000000	1003755042000000	
total line is: 200100000,	 build time is: 6.119777 s,	read time is 332.814506 s, average speed is 601235.812720 records/s  


```
Test next Batch Row Performance:

```
build time is: 6.459723 s

100000: time is 0.020954 s, speed is 4772358.499570 records/s, hasNext time is 0.000007 s,readNextBatchRow time is 0.010277 s from_email10144phillip.allen@enron.com	to_email69149buck.buckner@honeywell.com	from_to	<5164240.1075855667637.JavaMail.evans@thyme>	1538015558000000	971703720000000	
200000: time is 0.097710 s, speed is 1023436.700440 records/s, hasNext time is 0.084311 s,readNextBatchRow time is 0.002229 s from_email10324veronica.espinoza@enron.com	to_email44094cynthia.franklin@enron.com	from_to	<14154714.1075858633174.JavaMail.evans@thyme>	1538015558000000	1003768608000000	
300000: time is 0.106816 s, speed is 936189.334931 records/s, hasNext time is 0.097423 s,readNextBatchRow time is 0.000329 s from_email10545store-news@amazon.com	to_email59755pallen@enron.com	from_to	<5977904.1075858636257.JavaMail.evans@thyme>	1538015558000000	1004057196000000	
......
199900000: time is 0.081506 s, speed is 1226903.540844 records/s, hasNext time is 0.074667 s,readNextBatchRow time is 0.000244 s from_email99622kathie.grabstald@enron.com	to_email39726jean.mrha@enron.com	from_to	<30070113.1075858637581.JavaMail.evans@thyme>	1538015558000000	1004364487000000	
200000000: time is 0.081756 s, speed is 1223151.817604 records/s, hasNext time is 0.074859 s,readNextBatchRow time is 0.000248 s from_email99837kathie.grabstald@enron.com	to_email40090e.taylor@enron.com	from_bcc	<20754442.1075858633286.JavaMail.evans@thyme>	1538015558000000	1003755042000000	
200100000: time is 0.066725 s, speed is 1498688.647433 records/s, hasNext time is 0.059760 s,readNextBatchRow time is 0.000259 s from_email999kathie.grabstald@enron.com	to_email23160christina.valdez@enron.com	from_cc	<20754442.1075858633286.JavaMail.evans@thyme>	1538015558000000	1003755042000000	
total line is: 200100000,	 build time is: 6.459723 s,	read time is 222.737179 s, average speed is 898368.206414 records/s  [Dynamic-linking native method java.io.UnixFileSystem.delete0 ... JNI]

```

readNextBatchRow is faster 49.4% than readNextRow
Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 add interface
 - [x] Any backward compatibility impacted?
 No
 - [x] Document update required?
yes
 - [x] Testing done
  add test case in main.cpp and SDKReaderBenchmark
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
https://issues.apache.org/jira/browse/CARBONDATA-2951