### PR TITLE
[CARBONDATA-3019] Add error log in catch block to avoid to abort the exception which is thrown from catch block when there is an exception thrown in finally block

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/util/comparator/Comparator.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/comparator/Comparator.java
@@ -70,7 +70,7 @@ public final class Comparator {
     } else if (dataType == DataTypes.BYTE) {
       return new ByteArraySerializableComparator();
     } else {
-      throw new IllegalArgumentException("Unsupported data type");
+      throw new IllegalArgumentException("Unsupported data type: " + dataType.getName());
     }
   }
 }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonLoadDataCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonLoadDataCommand.scala
@@ -347,7 +347,7 @@ case class CarbonLoadDataCommand(
           throw new RuntimeException(s"Dataload failure for $dbName.$tableName, ${ex.getMessage}")
         // In case of event related exception
         case preEventEx: PreEventException =>
-          LOGGER.error(preEventEx, s"Dataload failure for $dbName.$tableName")
+          LOGGER.error(s"Dataload failure for $dbName.$tableName", preEventEx)
           throw new AnalysisException(preEventEx.getMessage)
         case ex: Exception =>
           LOGGER.error(ex)

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonLoadDataCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonLoadDataCommand.scala
@@ -347,6 +347,7 @@ case class CarbonLoadDataCommand(
           throw new RuntimeException(s"Dataload failure for $dbName.$tableName, ${ex.getMessage}")
         // In case of event related exception
         case preEventEx: PreEventException =>
+          LOGGER.error(preEventEx, s"Dataload failure for $dbName.$tableName")
           throw new AnalysisException(preEventEx.getMessage)
         case ex: Exception =>
           LOGGER.error(ex)

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonDropTableCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonDropTableCommand.scala
@@ -146,12 +146,12 @@ case class CarbonDropTableCommand(
 
     } catch {
       case ex: NoSuchTableException =>
-        LOGGER.error(ex, ex.getLocalizedMessage)
+        LOGGER.error(ex.getLocalizedMessage, ex)
         if (!ifExistsSet) {
           throw ex
         }
       case ex: ConcurrentOperationException =>
-        LOGGER.error(ex, ex.getLocalizedMessage)
+        LOGGER.error(ex.getLocalizedMessage, ex)
         throw ex
       case ex: Exception =>
         val msg = s"Dropping table $dbName.$tableName failed: ${ex.getMessage}"

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonDropTableCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonDropTableCommand.scala
@@ -146,10 +146,12 @@ case class CarbonDropTableCommand(
 
     } catch {
       case ex: NoSuchTableException =>
+        LOGGER.error(ex, ex.getLocalizedMessage)
         if (!ifExistsSet) {
           throw ex
         }
       case ex: ConcurrentOperationException =>
+        LOGGER.error(ex, ex.getLocalizedMessage)
         throw ex
       case ex: Exception =>
         val msg = s"Dropping table $dbName.$tableName failed: ${ex.getMessage}"

--- a/processing/src/main/java/org/apache/carbondata/processing/merger/CompactionResultSortProcessor.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/merger/CompactionResultSortProcessor.java
@@ -173,7 +173,7 @@ public class CompactionResultSortProcessor extends AbstractResultProcessor {
       }
       isCompactionSuccess = true;
     } catch (Exception e) {
-      LOGGER.error(e, e.getLocalizedMessage());
+      LOGGER.error(e.getLocalizedMessage(), e);
       throw e;
     } finally {
       if (partitionSpec != null) {

--- a/processing/src/main/java/org/apache/carbondata/processing/merger/CompactionResultSortProcessor.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/merger/CompactionResultSortProcessor.java
@@ -173,6 +173,7 @@ public class CompactionResultSortProcessor extends AbstractResultProcessor {
       }
       isCompactionSuccess = true;
     } catch (Exception e) {
+      LOGGER.error(e, e.getLocalizedMessage());
       throw e;
     } finally {
       if (partitionSpec != null) {

--- a/processing/src/main/java/org/apache/carbondata/processing/merger/RowResultMergerProcessor.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/merger/RowResultMergerProcessor.java
@@ -171,7 +171,7 @@ public class RowResultMergerProcessor extends AbstractResultProcessor {
       mergeStatus = true;
     } catch (Exception e) {
       mergeStatus = false;
-      LOGGER.error(e, e.getLocalizedMessage());
+      LOGGER.error(e.getLocalizedMessage(), e);
       throw e;
     } finally {
       try {

--- a/processing/src/main/java/org/apache/carbondata/processing/merger/RowResultMergerProcessor.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/merger/RowResultMergerProcessor.java
@@ -171,6 +171,7 @@ public class RowResultMergerProcessor extends AbstractResultProcessor {
       mergeStatus = true;
     } catch (Exception e) {
       mergeStatus = false;
+      LOGGER.error(e, e.getLocalizedMessage());
       throw e;
     } finally {
       try {


### PR DESCRIPTION

1. Add error log in catch block to avoid to abort the exception which is thrown from catch block when there is an exception thrown in finally block.
2. enhance log output.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?  No
 
 - [ ] Any backward compatibility impacted?  No
 
 - [ ] Document update required?  No

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

