### PR TITLE
[CARBONDATA-3025]Added DDL support for cli and added more info in carbon file footer

### DIFF
--- a/format/src/main/thrift/carbondata.thrift
+++ b/format/src/main/thrift/carbondata.thrift
@@ -206,6 +206,8 @@ struct FileFooter3{
     4: optional list<BlockletInfo3> blocklet_info_list3;	// Information about blocklets of all columns in this file for V3 format
     5: optional dictionary.ColumnDictionaryChunk dictionary; // Blocklet local dictionary
     6: optional bool is_sort; // True if the data is sorted in this file, it is used for compaction to decide whether to use merge sort or not
+    7: optional string written_by; // written by is used to write who wrote the file, it can be LOAD, or SDK etc
+    8: optional string version; // version in which this carbondata file is written
 }
 
 /**

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestNonTransactionalCarbonTable.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestNonTransactionalCarbonTable.scala
@@ -139,13 +139,15 @@ class TestNonTransactionalCarbonTable extends QueryTest with BeforeAndAfterAll {
             .sortBy(sortColumns.toArray)
             .uniqueIdentifier(
               System.currentTimeMillis).withBlockSize(2).withLoadOptions(options)
-            .withCsvInput(Schema.parseJson(schema)).build()
+            .withCsvInput(Schema.parseJson(schema))
+            .writtenBy("SDK").build()
         } else {
           builder.outputPath(writerPath)
             .sortBy(sortColumns.toArray)
             .uniqueIdentifier(
               System.currentTimeMillis).withBlockSize(2)
-            .withCsvInput(Schema.parseJson(schema)).build()
+            .withCsvInput(Schema.parseJson(schema))
+            .writtenBy("SDK").build()
         }
       var i = 0
       while (i < rows) {
@@ -180,7 +182,8 @@ class TestNonTransactionalCarbonTable extends QueryTest with BeforeAndAfterAll {
       val writer =
         builder.outputPath(writerPath)
           .uniqueIdentifier(System.currentTimeMillis()).withBlockSize(2).sortBy(sortColumns)
-          .withCsvInput(new Schema(fields)).build()
+          .withCsvInput(new Schema(fields))
+          .writtenBy("SDK").build()
       var i = 0
       while (i < rows) {
         writer.write(Array[String]("true", String.valueOf(i), String.valueOf(i.toDouble / 2)))
@@ -212,7 +215,8 @@ class TestNonTransactionalCarbonTable extends QueryTest with BeforeAndAfterAll {
           .sortBy(sortColumns.toArray)
           .uniqueIdentifier(
             123).withBlockSize(2)
-          .withCsvInput(Schema.parseJson(schema)).build()
+          .withCsvInput(Schema.parseJson(schema))
+          .writtenBy("SDK").build()
       var i = 0
       while (i < rows) {
         writer.write(Array[String]("robot" + i, String.valueOf(i), String.valueOf(i.toDouble / 2)))
@@ -389,6 +393,8 @@ class TestNonTransactionalCarbonTable extends QueryTest with BeforeAndAfterAll {
       s"""CREATE EXTERNAL TABLE sdkOutputTable STORED BY
          |'carbondata' LOCATION
          |'$writerPath' """.stripMargin)
+
+    sql("show summary for table sdkOutputTable options('command'='-cmd,summary,-p,-a,-v,-c,age')").show(1000,false)
 
     checkExistence(sql("describe formatted sdkOutputTable"), true, "age,name")
 
@@ -986,7 +992,7 @@ class TestNonTransactionalCarbonTable extends QueryTest with BeforeAndAfterAll {
     val builder: CarbonWriterBuilder = CarbonWriter.builder.outputPath(writerPath)
       .withLoadOptions(options)
 
-    val writer: CarbonWriter = builder.withCsvInput(new Schema(fields)).build()
+    val writer: CarbonWriter = builder.withCsvInput(new Schema(fields)).writtenBy("SDK").build()
     writer.write(Array("babu","1","02-01-2002","02-01-2002 01:01:00"))
     writer.close()
 
@@ -1111,7 +1117,7 @@ class TestNonTransactionalCarbonTable extends QueryTest with BeforeAndAfterAll {
     try {
       val writer = CarbonWriter.builder
         .outputPath(writerPath)
-        .uniqueIdentifier(System.currentTimeMillis()).withAvroInput(nn).build()
+        .uniqueIdentifier(System.currentTimeMillis()).withAvroInput(nn).writtenBy("SDK").build()
       var i = 0
       while (i < rows) {
         writer.write(record)
@@ -2085,7 +2091,7 @@ class TestNonTransactionalCarbonTable extends QueryTest with BeforeAndAfterAll {
 
     assert(intercept[RuntimeException] {
       val writer = CarbonWriter.builder.sortBy(Array("name", "id"))
-        .outputPath(writerPath).withAvroInput(nn).build()
+        .outputPath(writerPath).withAvroInput(nn).writtenBy("SDK").build()
       writer.write(record)
       writer.close()
     }.getMessage.toLowerCase.contains("column: name specified in sort columns"))
@@ -2125,7 +2131,7 @@ class TestNonTransactionalCarbonTable extends QueryTest with BeforeAndAfterAll {
     val record = testUtil.jsonToAvro(json1, schema1)
 
     val writer = CarbonWriter.builder
-      .outputPath(writerPath).withAvroInput(nn).build()
+      .outputPath(writerPath).withAvroInput(nn).writtenBy("SDK").build()
     writer.write(record)
     writer.close()
   }
@@ -2163,7 +2169,7 @@ class TestNonTransactionalCarbonTable extends QueryTest with BeforeAndAfterAll {
     val record = testUtil.jsonToAvro(json1, schema1)
 
     val writer = CarbonWriter.builder.sortBy(Array("id"))
-      .outputPath(writerPath).withAvroInput(nn).build()
+      .outputPath(writerPath).withAvroInput(nn).writtenBy("SDK").build()
     writer.write(record)
     writer.close()
   }
@@ -2207,7 +2213,7 @@ class TestNonTransactionalCarbonTable extends QueryTest with BeforeAndAfterAll {
     val record = testUtil.jsonToAvro(json1, schema)
 
     val writer = CarbonWriter.builder
-      .outputPath(writerPath).withAvroInput(nn).build()
+      .outputPath(writerPath).withAvroInput(nn).writtenBy("SDK").build()
     writer.write(record)
     writer.close()
   }
@@ -2247,7 +2253,7 @@ class TestNonTransactionalCarbonTable extends QueryTest with BeforeAndAfterAll {
     val record = testUtil.jsonToAvro(json1, schema1)
 
     val writer = CarbonWriter.builder
-      .outputPath(writerPath).withAvroInput(nn).build()
+      .outputPath(writerPath).withAvroInput(nn).writtenBy("SDK").build()
     writer.write(record)
     writer.close()
     sql(
@@ -2293,7 +2299,7 @@ class TestNonTransactionalCarbonTable extends QueryTest with BeforeAndAfterAll {
     val record = testUtil.jsonToAvro(json1, schema1)
 
     val writer = CarbonWriter.builder
-      .outputPath(writerPath).withAvroInput(nn).build()
+      .outputPath(writerPath).withAvroInput(nn).writtenBy("SDK").build()
     writer.write(record)
     writer.close()
     sql(
@@ -2340,7 +2346,7 @@ class TestNonTransactionalCarbonTable extends QueryTest with BeforeAndAfterAll {
 
 
     val writer = CarbonWriter.builder
-      .outputPath(writerPath).withAvroInput(nn).build()
+      .outputPath(writerPath).withAvroInput(nn).writtenBy("SDK").build()
     writer.write(record)
     writer.close()
     sql(
@@ -2360,7 +2366,7 @@ class TestNonTransactionalCarbonTable extends QueryTest with BeforeAndAfterAll {
     val writer: CarbonWriter = CarbonWriter.builder
       .outputPath(writerPath)
       .withTableProperties(options)
-      .withCsvInput(new Schema(fields)).build()
+      .withCsvInput(new Schema(fields)).writtenBy("SDK").build()
     writer.write(Array("carbon", "1"))
     writer.write(Array("hydrogen", "10"))
     writer.write(Array("boron", "4"))
@@ -2378,7 +2384,7 @@ class TestNonTransactionalCarbonTable extends QueryTest with BeforeAndAfterAll {
     // write local sort data
     val writer1: CarbonWriter = CarbonWriter.builder
       .outputPath(writerPath)
-      .withCsvInput(new Schema(fields)).build()
+      .withCsvInput(new Schema(fields)).writtenBy("SDK").build()
     writer1.write(Array("carbon", "1"))
     writer1.write(Array("hydrogen", "10"))
     writer1.write(Array("boron", "4"))
@@ -2395,6 +2401,7 @@ class TestNonTransactionalCarbonTable extends QueryTest with BeforeAndAfterAll {
     val builder = CarbonWriter.builder
       .sortBy(Array[String]("name")).withBlockSize(12).enableLocalDictionary(true)
       .uniqueIdentifier(System.currentTimeMillis).taskNo(System.nanoTime).outputPath(writerPath)
+      .writtenBy("SDK")
     generateCarbonData(builder)
     assert(FileFactory.getCarbonFile(writerPath).exists())
     assert(testUtil.checkForLocalDictionary(testUtil.getDimRawChunk(0,writerPath)))
@@ -2420,6 +2427,7 @@ class TestNonTransactionalCarbonTable extends QueryTest with BeforeAndAfterAll {
     val builder = CarbonWriter.builder
       .withTableProperties(tablePropertiesMap)
       .uniqueIdentifier(System.currentTimeMillis).taskNo(System.nanoTime).outputPath(writerPath)
+      .writtenBy("SDK")
     generateCarbonData(builder)
     assert(FileFactory.getCarbonFile(writerPath).exists())
     assert(testUtil.checkForLocalDictionary(testUtil.getDimRawChunk(0,writerPath)))
@@ -2441,6 +2449,7 @@ class TestNonTransactionalCarbonTable extends QueryTest with BeforeAndAfterAll {
       .sortBy(Array[String]("name")).withBlockSize(12).enableLocalDictionary(true)
       .localDictionaryThreshold(5)
       .uniqueIdentifier(System.currentTimeMillis).taskNo(System.nanoTime).outputPath(writerPath)
+      .writtenBy("SDK")
     generateCarbonData(builder)
     assert(FileFactory.getCarbonFile(writerPath).exists())
     assert(!testUtil.checkForLocalDictionary(testUtil.getDimRawChunk(0,writerPath)))
@@ -2462,6 +2471,7 @@ class TestNonTransactionalCarbonTable extends QueryTest with BeforeAndAfterAll {
       .sortBy(Array[String]("name")).withBlockSize(12).enableLocalDictionary(true)
       .localDictionaryThreshold(200)
       .uniqueIdentifier(System.currentTimeMillis).taskNo(System.nanoTime).outputPath(writerPath)
+      .writtenBy("SDK")
     generateCarbonData(builder)
     assert(FileFactory.getCarbonFile(writerPath).exists())
     assert(testUtil.checkForLocalDictionary(testUtil.getDimRawChunk(0,writerPath)))

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
@@ -188,6 +188,7 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
   protected val STREAM = carbonKeyWord("STREAM")
   protected val STREAMS = carbonKeyWord("STREAMS")
   protected val STMPROPERTIES = carbonKeyWord("STMPROPERTIES")
+  protected val SUMMARY = carbonKeyWord("SUMMARY")
 
   protected val doubleQuotedString = "\"([^\"]+)\"".r
   protected val singleQuotedString = "'([^']+)'".r
@@ -1140,6 +1141,13 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
       case opt ~ optvalue => (opt.trim.toLowerCase(), optvalue)
       case _ => ("", "")
     }
+
+  protected lazy val summaryOptions: Parser[(String, String)] =
+    (stringLit <~ "=") ~ stringLit ^^ {
+      case opt ~ optvalue => (opt.trim.toLowerCase(), optvalue)
+      case _ => ("", "")
+    }
+
 
   protected lazy val partitions: Parser[(String, Option[String])] =
     (ident <~ "=".?) ~ stringLit.? ^^ {

--- a/integration/spark2/pom.xml
+++ b/integration/spark2/pom.xml
@@ -42,6 +42,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.carbondata</groupId>
+      <artifactId>carbondata-cli</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.carbondata</groupId>
       <artifactId>carbondata-store-sdk</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonLoadDataCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonLoadDataCommand.scala
@@ -212,6 +212,7 @@ case class CarbonLoadDataCommand(
         .getOrElse(CarbonCommonConstants.COMPRESSOR,
           CompressorFactory.getInstance().getCompressor.getName)
       carbonLoadModel.setColumnCompressor(columnCompressor)
+      carbonLoadModel.setAppName(sparkSession.sparkContext.getConf.get("spark.app.name"))
 
       val javaPartition = mutable.Map[String, String]()
       partition.foreach { case (k, v) =>

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonShowSummaryCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonShowSummaryCommand.scala
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.command.management
+
+import java.util
+
+import scala.collection.JavaConverters._
+
+import org.apache.spark.sql.{CarbonEnv, Row, SparkSession}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
+import org.apache.spark.sql.execution.command.{Checker, DataCommand}
+import org.apache.spark.sql.types.StringType
+
+import org.apache.carbondata.common.exceptions.sql.MalformedCarbonCommandException
+import org.apache.carbondata.tool.CarbonCli
+
+case class CarbonShowSummaryCommand(
+    databaseNameOp: Option[String],
+    tableName: String,
+    commandOptions: Map[String, String])
+  extends DataCommand {
+
+  override def output: Seq[Attribute] = {
+      Seq(AttributeReference("Table Summary", StringType, nullable = false)())
+  }
+
+  override def processData(sparkSession: SparkSession): Seq[Row] = {
+    Checker.validateTableExists(databaseNameOp, tableName, sparkSession)
+    val carbonTable = CarbonEnv.getCarbonTable(databaseNameOp, tableName)(sparkSession)
+    val commandArgs: Seq[String] = commandOptions("command").split(",")
+    val finalCommands = commandArgs.collect {
+      case a if a.trim.equalsIgnoreCase("-p") =>
+        Seq(a, carbonTable.getTablePath)
+      case x => Seq(x.trim)
+    }.flatten
+    val summaryOutput = new util.ArrayList[String]()
+    CarbonCli.run(finalCommands.toArray, summaryOutput)
+    summaryOutput.asScala.map(x =>
+      Row(x)
+    )
+  }
+}

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/CarbonDataLoadConfiguration.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/CarbonDataLoadConfiguration.java
@@ -127,6 +127,10 @@ public class CarbonDataLoadConfiguration {
    */
   private String columnCompressor;
 
+  private String appName;
+
+  private String version;
+
   public CarbonDataLoadConfiguration() {
   }
 
@@ -459,5 +463,21 @@ public class CarbonDataLoadConfiguration {
 
   public void setColumnCompressor(String columnCompressor) {
     this.columnCompressor = columnCompressor;
+  }
+
+  public String getAppName() {
+    return appName;
+  }
+
+  public void setAppName(String appName) {
+    this.appName = appName;
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  public void setVersion(String version) {
+    this.version = version;
   }
 }

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/DataLoadProcessBuilder.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/DataLoadProcessBuilder.java
@@ -26,6 +26,7 @@ import org.apache.carbondata.common.logging.LogService;
 import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.constants.CarbonLoadOptionConstants;
+import org.apache.carbondata.core.constants.CarbonVersionConstants;
 import org.apache.carbondata.core.datastore.TableSpec;
 import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
 import org.apache.carbondata.core.metadata.CarbonMetadata;
@@ -315,6 +316,8 @@ public final class DataLoadProcessBuilder {
       configuration.setWritingCoresCount(loadModel.getSdkWriterCores());
     }
     configuration.setColumnCompressor(loadModel.getColumnCompressor());
+    configuration.setAppName(loadModel.getAppName());
+    configuration.setVersion(CarbonVersionConstants.CARBONDATA_VERSION);
     return configuration;
   }
 

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/model/CarbonLoadModel.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/model/CarbonLoadModel.java
@@ -73,6 +73,8 @@ public class CarbonLoadModel implements Serializable {
 
   private String blocksID;
 
+  private String appName;
+
   /**
    * Map from carbon dimension to pre defined dict file path
    */
@@ -479,6 +481,7 @@ public class CarbonLoadModel implements Serializable {
     copy.parentTablePath = parentTablePath;
     copy.sdkWriterCores = sdkWriterCores;
     copy.columnCompressor = columnCompressor;
+    copy.appName = appName;
     return copy;
   }
 
@@ -536,6 +539,7 @@ public class CarbonLoadModel implements Serializable {
     copyObj.parentTablePath = parentTablePath;
     copyObj.sdkWriterCores = sdkWriterCores;
     copyObj.columnCompressor = columnCompressor;
+    copyObj.appName = appName;
     return copyObj;
   }
 
@@ -936,4 +940,13 @@ public class CarbonLoadModel implements Serializable {
   public void setColumnCompressor(String columnCompressor) {
     this.columnCompressor = columnCompressor;
   }
+
+  public String getAppName() {
+    return appName;
+  }
+
+  public void setAppName(String appName) {
+    this.appName = appName;
+  }
+
 }

--- a/processing/src/main/java/org/apache/carbondata/processing/store/CarbonFactDataHandlerModel.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/CarbonFactDataHandlerModel.java
@@ -187,6 +187,10 @@ public class CarbonFactDataHandlerModel {
 
   private String columnCompressor;
 
+  private String appName;
+
+  private String version;
+
   /**
    * Create the model using @{@link CarbonDataLoadConfiguration}
    */
@@ -313,6 +317,8 @@ public class CarbonFactDataHandlerModel {
     }
     carbonFactDataHandlerModel.dataMapWriterlistener = listener;
     carbonFactDataHandlerModel.writingCoresCount = configuration.getWritingCoresCount();
+    carbonFactDataHandlerModel.appName = configuration.getAppName();
+    carbonFactDataHandlerModel.version = configuration.getVersion();
     setNumberOfCores(carbonFactDataHandlerModel);
     carbonFactDataHandlerModel.setVarcharDimIdxInNoDict(varcharDimIdxInNoDict);
     return carbonFactDataHandlerModel;
@@ -738,5 +744,14 @@ public class CarbonFactDataHandlerModel {
   public void setNoDictAndComplexColumns(CarbonColumn[] noDictAndComplexColumns) {
     this.noDictAndComplexColumns = noDictAndComplexColumns;
   }
+
+  public String getAppName() {
+    return appName;
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
 }
 

--- a/processing/src/main/java/org/apache/carbondata/processing/store/writer/v3/CarbonFactDataWriterImplV3.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/writer/v3/CarbonFactDataWriterImplV3.java
@@ -102,6 +102,8 @@ public class CarbonFactDataWriterImplV3 extends AbstractFactDataWriter {
           .convertFileFooterVersion3(blockletMetadata, blockletIndex, localCardinality,
               thriftColumnSchemaList.size());
       convertFileMeta.setIs_sort(isSorted);
+      convertFileMeta.setWritten_by(model.getAppName());
+      convertFileMeta.setVersion(model.getVersion());
       // fill the carbon index details
       fillBlockIndexInfoDetails(convertFileMeta.getNum_rows(), carbonDataFileName, currentPosition);
       // write the footer

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonSchemaReader.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonSchemaReader.java
@@ -19,18 +19,22 @@ package org.apache.carbondata.sdk.file;
 
 import java.io.DataInputStream;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.carbondata.core.datastore.FileReader;
 import org.apache.carbondata.core.datastore.filesystem.CarbonFile;
 import org.apache.carbondata.core.datastore.impl.FileFactory;
 import org.apache.carbondata.core.metadata.converter.SchemaConverter;
 import org.apache.carbondata.core.metadata.converter.ThriftWrapperSchemaConverterImpl;
 import org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema;
+import org.apache.carbondata.core.reader.CarbonFooterReaderV3;
 import org.apache.carbondata.core.reader.CarbonHeaderReader;
 import org.apache.carbondata.core.reader.CarbonIndexFileReader;
 import org.apache.carbondata.core.util.CarbonUtil;
 import org.apache.carbondata.core.util.path.CarbonTablePath;
+import org.apache.carbondata.format.FileFooter3;
 
 import static org.apache.carbondata.core.util.CarbonUtil.thriftColumnSchemaToWrapperColumnSchema;
 
@@ -74,6 +78,17 @@ public class CarbonSchemaReader {
       }
     }
     return new Schema(columnSchemaList);
+  }
+
+  public static String getVersionDetails(String dataFilePath) throws IOException {
+    long fileSize =
+        FileFactory.getCarbonFile(dataFilePath, FileFactory.getFileType(dataFilePath)).getSize();
+    FileReader fileReader = FileFactory.getFileHolder(FileFactory.getFileType(dataFilePath));
+    ByteBuffer buffer =
+        fileReader.readByteBuffer(FileFactory.getUpdatedFilePath(dataFilePath), fileSize - 8, 8);
+    CarbonFooterReaderV3 footerReader = new CarbonFooterReaderV3(dataFilePath, buffer.getLong());
+    FileFooter3 footer = footerReader.readFooterVersion3();
+    return footer.getWritten_by() + " in version: " + footer.getVersion();
   }
 
   /**

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonWriterBuilder.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonWriterBuilder.java
@@ -65,6 +65,7 @@ public class CarbonWriterBuilder {
   private boolean isLocalDictionaryEnabled;
   private short numOfThreads;
   private Configuration hadoopConf;
+  private String writtenByApp;
   private enum WRITER_TYPE {
     CSV, AVRO, JSON
   }
@@ -293,6 +294,15 @@ public class CarbonWriterBuilder {
   }
 
   /**
+   * @param appName appName which is writing the carbondata files
+   * @return
+   */
+  public CarbonWriterBuilder writtenBy(String appName) {
+    this.writtenByApp = appName;
+    return this;
+  }
+
+  /**
    * @param enableLocalDictionary enable local dictionary  , default is false
    * @return updated CarbonWriterBuilder
    */
@@ -371,8 +381,14 @@ public class CarbonWriterBuilder {
           "Writer type is not set, use withCsvInput() or withAvroInput() or withJsonInput()  "
               + "API based on input");
     }
+    if (this.writtenByApp == null) {
+      throw new RuntimeException(
+          "AppName is not set, please use writtenBy() API to set the App Name"
+              + "which is using SDK");
+    }
     CarbonLoadModel loadModel = buildLoadModel(schema);
     loadModel.setSdkWriterCores(numOfThreads);
+    loadModel.setAppName(writtenByApp);
     if (hadoopConf == null) {
       hadoopConf = FileFactory.getConfiguration();
     }

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/TestUtil.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/TestUtil.java
@@ -120,7 +120,7 @@ public class TestUtil {
         builder = builder.withBlockSize(blockSize);
       }
 
-      CarbonWriter writer = builder.withCsvInput(schema).build();
+      CarbonWriter writer = builder.withCsvInput(schema).writtenBy("SDK").build();
 
       for (int i = 0; i < rows; i++) {
         writer.write(new String[]{

--- a/tools/cli/src/main/java/org/apache/carbondata/tool/DataSummary.java
+++ b/tools/cli/src/main/java/org/apache/carbondata/tool/DataSummary.java
@@ -17,9 +17,11 @@
 
 package org.apache.carbondata.tool;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.charset.Charset;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -36,6 +38,7 @@ import org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema;
 import org.apache.carbondata.core.reader.CarbonHeaderReader;
 import org.apache.carbondata.core.statusmanager.LoadMetadataDetails;
 import org.apache.carbondata.core.statusmanager.SegmentStatusManager;
+import org.apache.carbondata.core.util.ByteUtil;
 import org.apache.carbondata.core.util.CarbonUtil;
 import org.apache.carbondata.format.BlockletInfo3;
 import org.apache.carbondata.format.DataChunk2;
@@ -44,9 +47,9 @@ import org.apache.carbondata.format.FileFooter3;
 import org.apache.carbondata.format.FileHeader;
 import org.apache.carbondata.format.TableInfo;
 
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.DEFAULT_CHARSET;
-
 import org.apache.commons.cli.CommandLine;
+
+import static org.apache.carbondata.core.constants.CarbonCommonConstants.DEFAULT_CHARSET;
 
 /**
  * Data Summary command implementation for {@link CarbonCli}
@@ -54,18 +57,20 @@ import org.apache.commons.cli.CommandLine;
 class DataSummary implements Command {
   private String dataFolder;
   private PrintStream out;
+  private ArrayList<String> outPuts;
 
   // file path mapping to file object
   private LinkedHashMap<String, DataFile> dataFiles;
 
-  DataSummary(String dataFolder, PrintStream out) {
+  DataSummary(String dataFolder, PrintStream out, ArrayList<String> outPuts) {
     this.dataFolder = dataFolder;
     this.out = out;
+    this.outPuts = outPuts;
   }
 
   @Override
   public void run(CommandLine line) throws IOException, MemoryException {
-    FileCollector collector = new FileCollector(out);
+    FileCollector collector = new FileCollector(out, outPuts);
     collector.collectFiles(dataFolder);
     collector.printBasicStats();
     if (collector.getNumDataFiles() == 0) {
@@ -88,7 +93,19 @@ class DataSummary implements Command {
       printTableProperties(collector.getSchemaFile());
     }
     if (line.hasOption("b") || printAll) {
-      printBlockletDetail();
+      String limitSize = line.getOptionValue("b");
+      if (limitSize == null) {
+        // by default we can limit the output to two shards and user can increase this limit
+        limitSize = "2";
+      }
+      printBlockletDetail(Integer.parseInt(limitSize));
+    }
+    if (line.hasOption("v") || printAll) {
+      printVersionDetails();
+    }
+    if (line.hasOption("B")) {
+      String blockFileName = line.getOptionValue("B");
+      printBlockDetails(blockFileName);
     }
     if (line.hasOption("c")) {
       String columName = line.getOptionValue("c");
@@ -101,17 +118,17 @@ class DataSummary implements Command {
 
   private void printSchema(DataFile dataFile) throws IOException {
     CarbonFile file = FileFactory.getCarbonFile(dataFile.getFilePath());
-    out.println();
-    out.println("## Schema");
-    out.println(String.format("schema in %s", file.getName()));
+    outPuts.add("");
+    outPuts.add("## Schema");
+    outPuts.add(String.format("schema in %s", file.getName()));
     CarbonHeaderReader reader = new CarbonHeaderReader(file.getPath());
     FileHeader header = reader.readHeader();
-    out.println("version: V" + header.version);
-    out.println("timestamp: " + new java.sql.Timestamp(header.time_stamp));
+    outPuts.add("version: V" + header.version);
+    outPuts.add("timestamp: " + new java.sql.Timestamp(header.time_stamp));
     List<ColumnSchema> columns = reader.readSchema();
     TablePrinter printer = new TablePrinter(
         new String[]{"Column Name", "Data Type", "Column Type",
-            "SortColumn", "Encoding", "Ordinal", "Id"});
+            "SortColumn", "Encoding", "Ordinal", "Id"}, outPuts);
     for (ColumnSchema column : columns) {
       String shortColumnId = "NA";
       if (column.getColumnUniqueId() != null && column.getColumnUniqueId().length() > 4) {
@@ -128,19 +145,19 @@ class DataSummary implements Command {
           shortColumnId
       });
     }
-    printer.printFormatted(out);
+    printer.printFormatted();
   }
 
   private void printSegments(CarbonFile tableStatusFile) throws IOException {
-    out.println();
-    out.println("## Segment");
+    outPuts.add("");
+    outPuts.add("## Segment");
     if (tableStatusFile != null) {
       // first collect all information in memory then print a formatted table
       LoadMetadataDetails[] segments =
           SegmentStatusManager.readTableStatusFile(tableStatusFile.getPath());
       TablePrinter printer = new TablePrinter(
           new String[]{"SegmentID", "Status", "Load Start", "Load End",
-              "Merged To", "Format", "Data Size", "Index Size"});
+              "Merged To", "Format", "Data Size", "Index Size"}, outPuts);
       for (LoadMetadataDetails segment : segments) {
         String dataSize, indexSize;
         if (segment.getDataSize() == null) {
@@ -164,39 +181,38 @@ class DataSummary implements Command {
             indexSize}
         );
       }
-      printer.printFormatted(out);
+      printer.printFormatted();
     } else {
-      out.println("table status file not found");
+      outPuts.add("table status file not found");
     }
   }
 
   private void printTableProperties(CarbonFile schemaFile) throws IOException {
-    out.println();
-    out.println("## Table Properties");
+    outPuts.add("");
+    outPuts.add("## Table Properties");
     if (schemaFile != null) {
       TableInfo thriftTableInfo = CarbonUtil.readSchemaFile(schemaFile.getPath());
       Map<String, String> tblProperties = thriftTableInfo.fact_table.tableProperties;
       TablePrinter printer = new TablePrinter(
-          new String[]{"Property Name", "Property Value"});
+          new String[]{"Property Name", "Property Value"}, outPuts);
       for (Map.Entry<String, String> entry : tblProperties.entrySet()) {
         printer.addRow(new String[] {
             String.format("'%s'", entry.getKey()),
             String.format("'%s'", entry.getValue())
         });
       }
-      printer.printFormatted(out);
+      printer.printFormatted();
     } else {
-      out.println("schema file not found");
+      outPuts.add("schema file not found");
     }
   }
 
-  private void printBlockletDetail() {
-    out.println();
-    out.println("## Block Detail");
+  private void printBlockletDetail(int limitSize) {
+    outPuts.add("");
+    outPuts.add("## Block Detail");
 
-    ShardPrinter printer = new ShardPrinter(new String[]{
-        "BLK", "BLKLT", "NumPages", "NumRows", "Size"
-    });
+    ShardPrinter printer =
+        new ShardPrinter(new String[] { "BLK", "BLKLT", "NumPages", "NumRows", "Size" }, outPuts);
 
     for (Map.Entry<String, DataFile> entry : dataFiles.entrySet()) {
       DataFile file = entry.getValue();
@@ -211,8 +227,46 @@ class DataSummary implements Command {
             Strings.formatSize(file.getBlockletSizeInBytes(blockletId))
         });
       }
+      limitSize--;
+      if (limitSize == 0) {
+        break;
+      }
     }
     printer.printFormatted(out);
+  }
+
+  private void printBlockDetails(String blockFilePath) throws IOException {
+    outPuts.add("");
+    outPuts.add("## Filtered Block Details for: " + blockFilePath
+        .substring(blockFilePath.lastIndexOf(File.separator) + 1, blockFilePath.length()));
+    TablePrinter printer =
+        new TablePrinter(new String[] { "BLKLT", "NumPages", "NumRows", "Size" }, outPuts);
+    CarbonFile datafile = FileFactory.getCarbonFile(blockFilePath);
+    DataFile dataFile = new DataFile(datafile);
+    dataFile.collectAllMeta();
+    FileFooter3 footer = dataFile.getFooter();
+    for (int blockletId = 0; blockletId < footer.blocklet_info_list3.size(); blockletId++) {
+      BlockletInfo3 blocklet = footer.blocklet_info_list3.get(blockletId);
+      printer.addRow(new String[]{
+          String.valueOf(blockletId),
+          String.format("%,d", blocklet.number_number_of_pages),
+          String.format("%,d", blocklet.num_rows),
+          Strings.formatSize(dataFile.getBlockletSizeInBytes(blockletId))
+      });
+    }
+    printer.printFormatted();
+  }
+
+  private void printVersionDetails() {
+    outPuts.add("");
+    outPuts.add("## version Details");
+    DataFile file = dataFiles.entrySet().iterator().next().getValue();
+    FileFooter3 footer = file.getFooter();
+    TablePrinter printer = new TablePrinter(
+        new String[]{"written_by", "Version"}, outPuts);
+    printer.addRow(new String[]{String.format("%s", footer.written_by),
+        String.format("%s", footer.version)});
+    printer.printFormatted();
   }
 
   private int getColumnIndex(String columnName) {
@@ -226,25 +280,31 @@ class DataSummary implements Command {
   private boolean collected = false;
 
   private void printColumnStats(String columnName) throws IOException, MemoryException {
-    out.println();
-    out.println("## Column Statistics for '" + columnName + "'");
+    outPuts.add("");
+    outPuts.add("## Column Statistics for '" + columnName + "'");
     collectStats(columnName);
 
     int columnIndex = getColumnIndex(columnName);
     String[] header = new String[]{"BLK", "BLKLT", "Meta Size", "Data Size",
-        "LocalDict", "DictEntries", "DictSize", "AvgPageSize", "Min%", "Max%"};
+        "LocalDict", "DictEntries", "DictSize", "AvgPageSize", "Min%", "Max%", "Min", "Max"};
 
-    ShardPrinter printer = new ShardPrinter(header);
+    ShardPrinter printer = new ShardPrinter(header, outPuts);
     for (Map.Entry<String, DataFile> entry : dataFiles.entrySet()) {
       DataFile file = entry.getValue();
       for (DataFile.Blocklet blocklet : file.getAllBlocklets()) {
-        String min, max;
+        String min, max, minPercent, maxPercent;
         if (blocklet.getColumnChunk().getDataType() == DataTypes.STRING) {
+          minPercent = "NA";
+          maxPercent = "NA";
           min = new String(blocklet.getColumnChunk().min, Charset.forName(DEFAULT_CHARSET));
           max = new String(blocklet.getColumnChunk().max, Charset.forName(DEFAULT_CHARSET));
         } else {
-          min = String.format("%.1f", blocklet.getColumnChunk().getMinPercentage() * 100);
-          max = String.format("%.1f", blocklet.getColumnChunk().getMaxPercentage() * 100);
+          minPercent = String.format("%.1f", blocklet.getColumnChunk().getMinPercentage() * 100);
+          maxPercent = String.format("%.1f", blocklet.getColumnChunk().getMaxPercentage() * 100);
+          min = String.valueOf(ByteUtil
+              .toLong(blocklet.getColumnChunk().min, 0, blocklet.getColumnChunk().min.length));
+          max = String.valueOf(ByteUtil
+              .toLong(blocklet.getColumnChunk().max, 0, blocklet.getColumnChunk().max.length));
         }
         printer.addRow(
             blocklet.getShardName(),
@@ -257,6 +317,8 @@ class DataSummary implements Command {
                 String.valueOf(blocklet.getColumnChunk().blockletDictionaryEntries),
                 Strings.formatSize(blocklet.getColumnChunk().blocketletDictionarySize),
                 Strings.formatSize(blocklet.getColumnChunk().avgPageLengthInBytes),
+                minPercent,
+                maxPercent,
                 min,
                 max}
         );
@@ -276,9 +338,9 @@ class DataSummary implements Command {
   }
 
   private void printColumnChunkMeta(String columnName) throws IOException, MemoryException {
-    out.println();
     DataFile file = dataFiles.entrySet().iterator().next().getValue();
-    out.println("## Page Meta for column '" + columnName + "' in file " + file.getFilePath());
+    outPuts.add("");
+    outPuts.add("## Page Meta for column '" + columnName + "' in file " + file.getFilePath());
     collectStats(columnName);
     for (int i = 0; i < file.getAllBlocklets().size(); i++) {
       DataFile.Blocklet blocklet = file.getAllBlocklets().get(i);

--- a/tools/cli/src/main/java/org/apache/carbondata/tool/FileCollector.java
+++ b/tools/cli/src/main/java/org/apache/carbondata/tool/FileCollector.java
@@ -43,6 +43,7 @@ class FileCollector {
   private long numPage;
   private long numRow;
   private long totalDataSize;
+  private ArrayList<String> outPuts;
 
   // file path mapping to file object
   private LinkedHashMap<String, DataFile> dataFiles = new LinkedHashMap<>();
@@ -51,8 +52,9 @@ class FileCollector {
 
   private PrintStream out;
 
-  FileCollector(PrintStream out) {
+  FileCollector(PrintStream out, ArrayList<String> outPuts) {
     this.out = out;
+    this.outPuts = outPuts;
   }
 
   void collectFiles(String dataFolder) throws IOException {
@@ -73,8 +75,9 @@ class FileCollector {
       } else if (file.getName().startsWith(CarbonTablePath.SCHEMA_FILE)) {
         schemaFile = file;
       } else if (isStreamFile(file.getName())) {
-        out.println("WARN: input path contains streaming file, this tool does not support it yet, "
-            + "skipping it...");
+        outPuts.add(("WARN: input path contains streaming file, this tool does not support it yet, "
+            + "skipping it..."));
+
       }
     }
     unsortedFiles.sort((o1, o2) -> {
@@ -133,15 +136,16 @@ class FileCollector {
       System.out.println("no data file found");
       return;
     }
-    out.println("## Summary");
-    out.println(
-        String.format("total: %,d blocks, %,d shards, %,d blocklets, %,d pages, %,d rows, %s",
-            numBlock, numShard, numBlocklet, numPage, numRow, Strings.formatSize(totalDataSize)));
-    out.println(
-        String.format("avg: %s/block, %s/blocklet, %,d rows/block, %,d rows/blocklet",
-            Strings.formatSize((float) totalDataSize / numBlock),
-            Strings.formatSize((float) totalDataSize / numBlocklet),
-            numRow / numBlock,
-            numRow / numBlocklet));
+    outPuts.add("## Summary");
+    String format = String
+        .format("total: %,d blocks, %,d shards, %,d blocklets, %,d pages, %,d rows, %s", numBlock,
+            numShard, numBlocklet, numPage, numRow, Strings.formatSize(totalDataSize));
+    outPuts.add(format);
+
+    String format1 = String.format("avg: %s/block, %s/blocklet, %,d rows/block, %,d rows/blocklet",
+        Strings.formatSize((float) totalDataSize / numBlock),
+        Strings.formatSize((float) totalDataSize / numBlocklet), numRow / numBlock,
+        numRow / numBlocklet);
+    outPuts.add(format1);
   }
 }

--- a/tools/cli/src/main/java/org/apache/carbondata/tool/ScanBenchmark.java
+++ b/tools/cli/src/main/java/org/apache/carbondata/tool/ScanBenchmark.java
@@ -19,6 +19,7 @@ package org.apache.carbondata.tool;
 
 import java.io.IOException;
 import java.io.PrintStream;
+import java.util.ArrayList;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -50,10 +51,12 @@ class ScanBenchmark implements Command {
   private String dataFolder;
   private PrintStream out;
   private DataFile file;
+  private ArrayList<String> outPuts;
 
-  ScanBenchmark(String dataFolder, PrintStream out) {
+  ScanBenchmark(String dataFolder, PrintStream out, ArrayList<String> outPuts) {
     this.dataFolder = dataFolder;
     this.out = out;
+    this.outPuts = outPuts;
   }
 
   @Override
@@ -62,7 +65,7 @@ class ScanBenchmark implements Command {
       String filePath = line.getOptionValue("f");
       file = new DataFile(FileFactory.getCarbonFile(filePath));
     } else {
-      FileCollector collector = new FileCollector(out);
+      FileCollector collector = new FileCollector(out, outPuts);
       collector.collectFiles(dataFolder);
       if (collector.getNumDataFiles() == 0) {
         return;
@@ -71,7 +74,7 @@ class ScanBenchmark implements Command {
       file = dataFiles.entrySet().iterator().next().getValue();
     }
 
-    out.println("\n## Benchmark");
+    outPuts.add("\n## Benchmark");
     AtomicReference<FileHeader> fileHeaderRef = new AtomicReference<>();
     AtomicReference<FileFooter3> fileFoorterRef = new AtomicReference<>();
     AtomicReference<DataFileFooter> convertedFooterRef = new AtomicReference<>();
@@ -97,7 +100,7 @@ class ScanBenchmark implements Command {
 
     if (line.hasOption("c")) {
       String columnName = line.getOptionValue("c");
-      out.println("\nScan column '" + columnName + "'");
+      outPuts.add("\nScan column '" + columnName + "'");
 
       DataFileFooter footer = convertedFooterRef.get();
       AtomicReference<AbstractRawColumnChunk> columnChunk = new AtomicReference<>();
@@ -105,7 +108,7 @@ class ScanBenchmark implements Command {
       boolean dimension = file.getColumn(columnName).isDimensionColumn();
       for (int i = 0; i < footer.getBlockletList().size(); i++) {
         int blockletId = i;
-        out.println(String.format("Blocklet#%d: total size %s, %,d pages, %,d rows",
+        outPuts.add(String.format("Blocklet#%d: total size %s, %,d pages, %,d rows",
             blockletId,
             Strings.formatSize(file.getColumnDataSizeInBytes(blockletId, columnIndex)),
             footer.getBlockletList().get(blockletId).getNumberOfPages(),
@@ -139,7 +142,7 @@ class ScanBenchmark implements Command {
     start = System.nanoTime();
     op.run();
     end = System.nanoTime();
-    out.println(String.format("%s takes %,d us", opName, (end - start) / 1000));
+    outPuts.add(String.format("%s takes %,d us", opName, (end - start) / 1000));
   }
 
   private DataFileFooter readAndConvertFooter(DataFile file) throws IOException {

--- a/tools/cli/src/main/java/org/apache/carbondata/tool/ShardPrinter.java
+++ b/tools/cli/src/main/java/org/apache/carbondata/tool/ShardPrinter.java
@@ -18,21 +18,24 @@
 package org.apache.carbondata.tool;
 
 import java.io.PrintStream;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
 class ShardPrinter {
   private Map<String, TablePrinter> shardPrinter = new HashMap<>();
   private String[] header;
+  private ArrayList<String> outPuts;
 
-  ShardPrinter(String[] header) {
+  ShardPrinter(String[] header, ArrayList<String> outPuts) {
     this.header = header;
+    this.outPuts = outPuts;
   }
 
   void addRow(String shardName, String[] row) {
     TablePrinter printer = shardPrinter.get(shardName);
     if (printer == null) {
-      printer = new TablePrinter(header);
+      printer = new TablePrinter(header, outPuts);
       shardPrinter.put(shardName, printer);
     }
     printer.addRow(row);
@@ -41,9 +44,9 @@ class ShardPrinter {
   void printFormatted(PrintStream out) {
     int shardId = 1;
     for (Map.Entry<String, TablePrinter> entry : shardPrinter.entrySet()) {
-      out.println(String.format("Shard #%d (%s)", shardId++, entry.getKey()));
-      entry.getValue().printFormatted(out);
-      out.println();
+      outPuts.add(String.format("Shard #%d (%s)", shardId++, entry.getKey()));
+      entry.getValue().printFormatted();
+      outPuts.add("");
     }
   }
 }

--- a/tools/cli/src/main/java/org/apache/carbondata/tool/TablePrinter.java
+++ b/tools/cli/src/main/java/org/apache/carbondata/tool/TablePrinter.java
@@ -17,26 +17,28 @@
 
 package org.apache.carbondata.tool;
 
-import java.io.PrintStream;
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 
 class TablePrinter {
   private List<String[]> table = new LinkedList<>();
+  private ArrayList<String> outPuts;
 
   /**
    * create a new Table Printer
    * @param header table header
    */
-  TablePrinter(String[] header) {
+  TablePrinter(String[] header, ArrayList<String> outPuts) {
     this.table.add(header);
+    this.outPuts = outPuts;
   }
 
   void addRow(String[] row) {
     table.add(row);
   }
 
-  void printFormatted(PrintStream out) {
+  void printFormatted() {
     // calculate the max length of each output field in the table
     int padding = 2;
     int[] maxLength = new int[table.get(0).length];
@@ -47,13 +49,14 @@ class TablePrinter {
     }
 
     for (String[] row : table) {
+      StringBuilder outString = new StringBuilder();
       for (int i = 0; i < row.length; i++) {
-        out.print(row[i]);
+        outString.append(row[i]);
         for (int num = 0; num < maxLength[i] + padding - row[i].length(); num++) {
-          out.print(" ");
+          outString.append(" ");
         }
       }
-      out.println();
+      outPuts.add(outString.toString());
     }
   }
 }

--- a/tools/cli/src/test/java/org/apache/carbondata/tool/CarbonCliTest.java
+++ b/tools/cli/src/test/java/org/apache/carbondata/tool/CarbonCliTest.java
@@ -102,7 +102,7 @@ public class CarbonCliTest {
             "## Table Properties\n"
           + "schema file not found"));
 
-    String[] args4 = {"-cmd", "summary", "-p", path, "-b"};
+    String[] args4 = {"-cmd", "summary", "-p", path, "-b", "7"};
     out = new ByteArrayOutputStream();
     stream = new PrintStream(out);
     CarbonCli.run(args4, stream);
@@ -125,14 +125,14 @@ public class CarbonCliTest {
     output = new String(out.toByteArray());
     Assert.assertTrue(
         output.contains(
-            "BLK  BLKLT  Meta Size  Data Size  LocalDict  DictEntries  DictSize  AvgPageSize  Min%    Max%    \n"
-          + "0    0      1.72KB     295.89KB   false      0            0.0B      11.77KB      robot0  robot1  \n"
-          + "0    1      1.72KB     295.89KB   false      0            0.0B      11.77KB      robot1  robot3  \n"
-          + "1    0      1.72KB     295.89KB   false      0            0.0B      11.77KB      robot3  robot4  \n"
-          + "1    1      1.72KB     295.89KB   false      0            0.0B      11.77KB      robot4  robot6  \n"
-          + "2    0      1.72KB     295.89KB   false      0            0.0B      11.77KB      robot6  robot7  \n"
-          + "2    1      1.72KB     295.89KB   false      0            0.0B      11.77KB      robot8  robot9  \n"
-          + "2    2      492.0B     74.03KB    false      0            0.0B      10.51KB      robot9  robot9  "));
+            "BLK  BLKLT  Meta Size  Data Size  LocalDict  DictEntries  DictSize  AvgPageSize  Min%  Max%  Min     Max     \n"
+          + "0    0      1.72KB     295.89KB   false      0            0.0B      11.77KB      NA    NA    robot0  robot1  \n"
+          + "0    1      1.72KB     295.89KB   false      0            0.0B      11.77KB      NA    NA    robot1  robot3  \n"
+          + "1    0      1.72KB     295.89KB   false      0            0.0B      11.77KB      NA    NA    robot3  robot4  \n"
+          + "1    1      1.72KB     295.89KB   false      0            0.0B      11.77KB      NA    NA    robot4  robot6  \n"
+          + "2    0      1.72KB     295.89KB   false      0            0.0B      11.77KB      NA    NA    robot6  robot7  \n"
+          + "2    1      1.72KB     295.89KB   false      0            0.0B      11.77KB      NA    NA    robot8  robot9  \n"
+          + "2    2      492.0B     74.03KB    false      0            0.0B      10.51KB      NA    NA    robot9  robot9  "));
   }
 
   @Test
@@ -166,21 +166,23 @@ public class CarbonCliTest {
           + "0    0      25        800,000  2.58MB    \n"
           + "0    1      25        800,000  2.58MB    \n"
           + "1    0      25        800,000  2.58MB    \n"
-          + "1    1      25        800,000  2.58MB    \n"
-          + "2    0      25        800,000  2.58MB    \n"
-          + "2    1      25        800,000  2.58MB    \n"
-          + "2    2      7         200,000  660.74KB  "));
+          + "1    1      25        800,000  2.58MB    "));
 
     Assert.assertTrue(
         output.contains(
-          "BLK  BLKLT  Meta Size  Data Size  LocalDict  DictEntries  DictSize  AvgPageSize  Min%  Max%   \n"
-        + "0    0      2.90KB     4.87MB     false      0            0.0B      93.76KB      0.0   100.0  \n"
-        + "0    1      2.90KB     2.29MB     false      0            0.0B      93.76KB      0.0   100.0  \n"
-        + "1    0      2.90KB     4.87MB     false      0            0.0B      93.76KB      0.0   100.0  \n"
-        + "1    1      2.90KB     2.29MB     false      0            0.0B      93.76KB      0.0   100.0  \n"
-        + "2    0      2.90KB     5.52MB     false      0            0.0B      93.76KB      0.0   100.0  \n"
-        + "2    1      2.90KB     2.94MB     false      0            0.0B      93.76KB      0.0   100.0  \n"
-        + "2    2      830.0B     586.81KB   false      0            0.0B      83.71KB      0.0   100.0 "));
+          "BLK  BLKLT  Meta Size  Data Size  LocalDict  DictEntries  DictSize  AvgPageSize  Min%  Max%   Min  Max      \n"
+        + "0    0      2.90KB     4.87MB     false      0            0.0B      93.76KB      0.0   100.0  0    2999990  \n"
+        + "0    1      2.90KB     2.29MB     false      0            0.0B      93.76KB      0.0   100.0  1    2999992  \n"
+        + "1    0      2.90KB     4.87MB     false      0            0.0B      93.76KB      0.0   100.0  3    2999993  \n"
+        + "1    1      2.90KB     2.29MB     false      0            0.0B      93.76KB      0.0   100.0  4    2999995  \n"
+        + "2    0      2.90KB     5.52MB     false      0            0.0B      93.76KB      0.0   100.0  6    2999997  \n"
+        + "2    1      2.90KB     2.94MB     false      0            0.0B      93.76KB      0.0   100.0  8    2999998  \n"
+        + "2    2      830.0B     586.81KB   false      0            0.0B      83.71KB      0.0   100.0  9    2999999 "));
+
+    Assert.assertTrue(output.contains(
+        "## version Details \n"
+      + "written_by  Version       \n"
+      + "SDK         1.5.0-SNAPSHOT "));
   }
 
   @Test


### PR DESCRIPTION
### **Changes Proposed in this PR:**

1. Add more info to carbon file footer, like `written_by` (which will be spark application_name) in case of insert into and load command. To read this info one can use CLI
   For SDK this API will be exposed to write this info in footer and one API will exposed to read this info from SDK.
   
2. footer will have information about in which `version` of carbon the file is written, which will be helpful for getting details, for comaptibility etc

Enhancement in CLI tool
3.  a new option called "`-v`" is added to get the written_by and version details in addition to existing options
4.  SQL support is added for CLI
		This is introduced so that user can get the details in beeline only and no need to execute separately. Currently the command is as below, based on comment we can change this DDL
		`Show summary for table <table_name> options('command'='-cmd,summary,-a,-p,-b');`
		
5.  when we get details for column statistics ,we will get the Min and Max percentage, if we add actual min and max values, then it will be helpful for the developer
```
BLK  BLKLT  Meta Size  Data Size  LocalDict  DictEntries DictSize  AvgPageSize  Min%  Max%  Min  Max      
0      0      2.90KB       4.87MB     false       0          0.0B     93.76KB    0.0  100.0  0    2999990  
0      1      2.90KB       2.29MB     false       0          0.0B     93.76KB    0.0  100.0  1    2999992  
1      0      2.90KB       4.87MB     false       0          0.0B     93.76KB    0.0  100.0  3    2999993  
1      1      2.90KB       2.29MB     false       0          0.0B     93.76KB    0.0  100.0  4    2999995  
2      0      2.90KB       5.52MB     false       0          0.0B     93.76KB    0.0  100.0  6    2999997  
2      1      2.90KB       2.94MB     false       0          0.0B     93.76KB    0.0  100.0  8    2999998  
2      2      830.0B       586.81KB   false       0          0.0B     83.71KB    0.0  100.0  9    2999999 

```		 
6.  Currently CLI tool get blocklet details for all the blockfiles, so if we have more number of carbondata files, then it will take lot of time to get the details,
	so limit is added to it, by default when we give option as "-b", only 4 outputs will be given, if we want more, we can pass the option value for b as limit number, 
	Example:   "`-b 30`"   =>>  Then limit will be increased to 30
	
7. one more is a new Option is added called "`-B`", which takes mandatory option value as a block path. This is added just to get the block detail like, number of blocklets, number of pages, rows and size

Example:  "`-B /home/ss/ss/part-0-0_batchno0-0-0-1539782855178.carbondata`"
			
```
##  Filtered Block Details for: part-0-0_batchno0-0-0-1539782855178.carbondata
	BLKT  NumPages  NumRows  Size
        0        4        20      10.0B
```

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 NA
 - [x] Any backward compatibility impacted?
 Need o handle
 - [x] Document update required?
Yes, will be raised in separate PR
 - [x] Testing done
UTs are added
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA


