### PR TITLE
[CARBONDATA-3025]Added CLI enhancements

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestNonTransactionalCarbonTable.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestNonTransactionalCarbonTable.scala
@@ -389,6 +389,10 @@ class TestNonTransactionalCarbonTable extends QueryTest with BeforeAndAfterAll {
          |'carbondata' LOCATION
          |'$writerPath' """.stripMargin)
 
+    val output = sql("show summary for table sdkOutputTable options('command'='-cmd,summary,-p,-a,-v,-c,age')").collect()
+
+    assert(output.toList.contains(Row("written_by                       Version         ")))
+
     checkExistence(sql("describe formatted sdkOutputTable"), true, "age,name")
 
     checkExistence(sql("describe formatted sdkOutputTable"), true, writerPath)

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
@@ -188,6 +188,7 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
   protected val STREAM = carbonKeyWord("STREAM")
   protected val STREAMS = carbonKeyWord("STREAMS")
   protected val STMPROPERTIES = carbonKeyWord("STMPROPERTIES")
+  protected val SUMMARY = carbonKeyWord("SUMMARY")
 
   protected val doubleQuotedString = "\"([^\"]+)\"".r
   protected val singleQuotedString = "'([^']+)'".r
@@ -1140,6 +1141,13 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
       case opt ~ optvalue => (opt.trim.toLowerCase(), optvalue)
       case _ => ("", "")
     }
+
+  protected lazy val summaryOptions: Parser[(String, String)] =
+    (stringLit <~ "=") ~ stringLit ^^ {
+      case opt ~ optvalue => (opt.trim.toLowerCase(), optvalue)
+      case _ => ("", "")
+    }
+
 
   protected lazy val partitions: Parser[(String, Option[String])] =
     (ident <~ "=".?) ~ stringLit.? ^^ {

--- a/integration/spark2/pom.xml
+++ b/integration/spark2/pom.xml
@@ -42,6 +42,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.carbondata</groupId>
+      <artifactId>carbondata-cli</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.carbondata</groupId>
       <artifactId>carbondata-store-sdk</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonShowSummaryCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonShowSummaryCommand.scala
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.command.management
+
+import java.util
+
+import scala.collection.JavaConverters._
+
+import org.apache.spark.sql.{CarbonEnv, Row, SparkSession}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
+import org.apache.spark.sql.execution.command.{Checker, DataCommand}
+import org.apache.spark.sql.types.StringType
+
+import org.apache.carbondata.tool.CarbonCli
+
+/**
+ * Show summary command class which is integrated to cli and sql support is provided via this class
+ * @param databaseNameOp
+ * @param tableName
+ * @param commandOptions
+ */
+case class CarbonShowSummaryCommand(
+    databaseNameOp: Option[String],
+    tableName: String,
+    commandOptions: Map[String, String])
+  extends DataCommand {
+
+  override def output: Seq[Attribute] = {
+      Seq(AttributeReference("Table Summary", StringType, nullable = false)())
+  }
+
+  override def processData(sparkSession: SparkSession): Seq[Row] = {
+    Checker.validateTableExists(databaseNameOp, tableName, sparkSession)
+    val carbonTable = CarbonEnv.getCarbonTable(databaseNameOp, tableName)(sparkSession)
+    val commandArgs: Seq[String] = commandOptions("command").split(",")
+    val finalCommands = commandArgs.collect {
+      case a if a.trim.equalsIgnoreCase("-p") =>
+        Seq(a, carbonTable.getTablePath)
+      case x => Seq(x.trim)
+    }.flatten
+    val summaryOutput = new util.ArrayList[String]()
+    CarbonCli.run(finalCommands.toArray, summaryOutput)
+    summaryOutput.asScala.map(x =>
+      Row(x)
+    )
+  }
+}

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSpark2SqlParser.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSpark2SqlParser.scala
@@ -78,7 +78,7 @@ class CarbonSpark2SqlParser extends CarbonDDLSqlParser {
 
   protected lazy val startCommand: Parser[LogicalPlan] =
     loadManagement | showLoads | alterTable | restructure | updateTable | deleteRecords |
-    alterPartition | datamapManagement | alterTableFinishStreaming | stream
+    alterPartition | datamapManagement | alterTableFinishStreaming | stream | cli
 
   protected lazy val loadManagement: Parser[LogicalPlan] =
     deleteLoadsByID | deleteLoadsByLoadDate | cleanFiles | loadDataNew
@@ -494,6 +494,23 @@ class CarbonSpark2SqlParser extends CarbonDDLSqlParser {
           convertDbNameToLowerCase(databaseName), tableName.toLowerCase(), limit,
           showHistory.isDefined)
     }
+
+
+  protected lazy val cli: Parser[LogicalPlan] =
+    (SHOW ~> SUMMARY ~> FOR ~> TABLE) ~> (ident <~ ".").? ~ ident ~
+    (OPTIONS ~> "(" ~> repsep(summaryOptions, ",") <~ ")").? <~
+    opt(";") ^^ {
+      case databaseName ~ tableName ~ commandList =>
+        var commandOptions: Map[String, String] = null
+        if (commandList.isDefined) {
+          commandOptions = commandList.getOrElse(List.empty[(String, String)]).toMap
+        }
+        CarbonShowSummaryCommand(
+          convertDbNameToLowerCase(databaseName),
+          tableName.toLowerCase(),
+          commandOptions.map { case (key, value) => key.toLowerCase -> value })
+    }
+
 
   protected lazy val alterTableModifyDataType: Parser[LogicalPlan] =
     ALTER ~> TABLE ~> (ident <~ ".").? ~ ident ~ CHANGE ~ ident ~ ident ~

--- a/tools/cli/src/main/java/org/apache/carbondata/tool/CarbonCli.java
+++ b/tools/cli/src/main/java/org/apache/carbondata/tool/CarbonCli.java
@@ -19,6 +19,8 @@ package org.apache.carbondata.tool;
 
 import java.io.IOException;
 import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.apache.carbondata.common.annotations.InterfaceAudience;
 import org.apache.carbondata.common.annotations.InterfaceStability;
@@ -39,6 +41,13 @@ import org.apache.commons.cli.PosixParser;
 @InterfaceAudience.User
 @InterfaceStability.Unstable
 public class CarbonCli {
+
+  // List to collect all the outputs of option details
+  private static List<String> outPuts;
+
+  // a boolean variable to decide whether to print the output in console or return the list,
+  // by default true, and it will be set to false if the cli is trigerred via sql command
+  private static boolean isPrintInConsole = true;
 
   private static Options buildOptions() {
     Option help = new Option("h", "help", false,"print this message");
@@ -64,7 +73,6 @@ public class CarbonCli {
     Option schema = new Option("s", "schema",false, "print the schema");
     Option segment = new Option("m", "showSegment", false, "print segment information");
     Option tblProperties = new Option("t", "tblProperties", false, "print table properties");
-    Option detail = new Option("b", "blocklet", false, "print blocklet size detail");
     Option columnMeta = new Option("k", "columnChunkMeta", false, "print column chunk meta");
     Option columnName = OptionBuilder
         .withArgName("column name")
@@ -73,6 +81,15 @@ public class CarbonCli {
         .withLongOpt("column")
         .create("c");
 
+    Option blockletDetail = OptionBuilder.withArgName("limitSize").hasOptionalArg()
+        .withDescription("print blocklet size detail").withLongOpt("limitSize")
+        .create("b");
+
+    Option blockLevelDetail = OptionBuilder.withArgName("blockDetail").hasArg()
+        .withDescription("print block details").withLongOpt("blockDetail")
+        .create("B");
+
+    Option version = new Option("v", "version", false, "print version details of carbondata file");
     Options options = new Options();
     options.addOption(help);
     options.addOption(path);
@@ -82,9 +99,11 @@ public class CarbonCli {
     options.addOption(schema);
     options.addOption(segment);
     options.addOption(tblProperties);
-    options.addOption(detail);
+    options.addOption(blockletDetail);
     options.addOption(columnMeta);
     options.addOption(columnName);
+    options.addOption(version);
+    options.addOption(blockLevelDetail);
     return options;
   }
 
@@ -92,7 +111,24 @@ public class CarbonCli {
     run(args, System.out);
   }
 
-  static void run(String[] args, PrintStream out) {
+  public static void run(String[] args, ArrayList<String> e) {
+    // this boolean to check whether to print in console or not
+    isPrintInConsole = false;
+    outPuts = e;
+    Options options = buildOptions();
+    CommandLineParser parser = new PosixParser();
+
+    CommandLine line;
+    try {
+      line = parser.parse(options, args);
+    } catch (ParseException exp) {
+      throw new RuntimeException("Parsing failed. Reason: " + exp.getMessage());
+    }
+
+    runCli(System.out, options, line);
+  }
+
+  public static void run(String[] args, PrintStream out) {
     Options options = buildOptions();
     CommandLineParser parser = new PosixParser();
 
@@ -104,6 +140,13 @@ public class CarbonCli {
       return;
     }
 
+    runCli(out, options, line);
+  }
+
+  private static void  runCli(PrintStream out, Options options, CommandLine line) {
+    if (outPuts == null) {
+      outPuts = new ArrayList<>();
+    }
     if (line.hasOption("h")) {
       printHelp(options);
       return;
@@ -113,22 +156,28 @@ public class CarbonCli {
     if (line.hasOption("p")) {
       path = line.getOptionValue("path");
     }
-    out.println("Input Folder: " + path);
+    outPuts.add("Input Folder: " + path);
 
     String cmd = line.getOptionValue("cmd");
     Command command;
     if (cmd.equalsIgnoreCase("summary")) {
-      command = new DataSummary(path, out);
+      command = new DataSummary(path, outPuts);
     } else if (cmd.equalsIgnoreCase("benchmark")) {
-      command = new ScanBenchmark(path, out);
+      command = new ScanBenchmark(path, outPuts);
     } else {
       out.println("command " + cmd + " is not supported");
+      outPuts.add("command " + cmd + " is not supported");
       printHelp(options);
       return;
     }
 
     try {
       command.run(line);
+      if (isPrintInConsole) {
+        for (String output : outPuts) {
+          out.println(output);
+        }
+      }
       out.flush();
     } catch (IOException | MemoryException e) {
       e.printStackTrace();

--- a/tools/cli/src/main/java/org/apache/carbondata/tool/DataFile.java
+++ b/tools/cli/src/main/java/org/apache/carbondata/tool/DataFile.java
@@ -317,6 +317,10 @@ class DataFile {
     // min/max stats of this column chunk
     byte[] min, max;
 
+    // to set whether min max is present for the column chunck, as we may not right min max after
+    // specific size
+    boolean isMinMaxPresent;
+
     // percentage of min/max comparing to min/max scope collected in all blocklets
     // they are set after calculation in DataSummary
     double minPercentage, maxPercentage;
@@ -335,6 +339,7 @@ class DataFile {
       this.column = column;
       min = index.min_max_index.min_values.get(columnIndex).array();
       max = index.min_max_index.max_values.get(columnIndex).array();
+      isMinMaxPresent = index.min_max_index.min_max_presence.get(columnIndex);
 
       // read the column chunk metadata: DataChunk3
       ByteBuffer buffer = fileReader.readByteBuffer(

--- a/tools/cli/src/main/java/org/apache/carbondata/tool/FileCollector.java
+++ b/tools/cli/src/main/java/org/apache/carbondata/tool/FileCollector.java
@@ -18,7 +18,6 @@
 package org.apache.carbondata.tool;
 
 import java.io.IOException;
-import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -43,16 +42,16 @@ class FileCollector {
   private long numPage;
   private long numRow;
   private long totalDataSize;
+  private List<String> outPuts;
 
   // file path mapping to file object
   private LinkedHashMap<String, DataFile> dataFiles = new LinkedHashMap<>();
   private CarbonFile tableStatusFile;
   private CarbonFile schemaFile;
 
-  private PrintStream out;
 
-  FileCollector(PrintStream out) {
-    this.out = out;
+  FileCollector(List<String> outPuts) {
+    this.outPuts = outPuts;
   }
 
   void collectFiles(String dataFolder) throws IOException {
@@ -73,8 +72,9 @@ class FileCollector {
       } else if (file.getName().startsWith(CarbonTablePath.SCHEMA_FILE)) {
         schemaFile = file;
       } else if (isStreamFile(file.getName())) {
-        out.println("WARN: input path contains streaming file, this tool does not support it yet, "
-            + "skipping it...");
+        outPuts.add(("WARN: input path contains streaming file, this tool does not support it yet, "
+            + "skipping it..."));
+
       }
     }
     unsortedFiles.sort((o1, o2) -> {
@@ -133,15 +133,16 @@ class FileCollector {
       System.out.println("no data file found");
       return;
     }
-    out.println("## Summary");
-    out.println(
-        String.format("total: %,d blocks, %,d shards, %,d blocklets, %,d pages, %,d rows, %s",
-            numBlock, numShard, numBlocklet, numPage, numRow, Strings.formatSize(totalDataSize)));
-    out.println(
-        String.format("avg: %s/block, %s/blocklet, %,d rows/block, %,d rows/blocklet",
-            Strings.formatSize((float) totalDataSize / numBlock),
-            Strings.formatSize((float) totalDataSize / numBlocklet),
-            numRow / numBlock,
-            numRow / numBlocklet));
+    outPuts.add("## Summary");
+    String format = String
+        .format("total: %,d blocks, %,d shards, %,d blocklets, %,d pages, %,d rows, %s", numBlock,
+            numShard, numBlocklet, numPage, numRow, Strings.formatSize(totalDataSize));
+    outPuts.add(format);
+
+    String format1 = String.format("avg: %s/block, %s/blocklet, %,d rows/block, %,d rows/blocklet",
+        Strings.formatSize((float) totalDataSize / numBlock),
+        Strings.formatSize((float) totalDataSize / numBlocklet), numRow / numBlock,
+        numRow / numBlocklet);
+    outPuts.add(format1);
   }
 }

--- a/tools/cli/src/main/java/org/apache/carbondata/tool/ShardPrinter.java
+++ b/tools/cli/src/main/java/org/apache/carbondata/tool/ShardPrinter.java
@@ -17,33 +17,35 @@
 
 package org.apache.carbondata.tool;
 
-import java.io.PrintStream;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 class ShardPrinter {
-  private Map<String, TablePrinter> shardPrinter = new HashMap<>();
+  private Map<String, TableFormatter> shardPrinter = new HashMap<>();
   private String[] header;
+  private List<String> outPuts;
 
-  ShardPrinter(String[] header) {
+  ShardPrinter(String[] header, List<String> outPuts) {
     this.header = header;
+    this.outPuts = outPuts;
   }
 
   void addRow(String shardName, String[] row) {
-    TablePrinter printer = shardPrinter.get(shardName);
-    if (printer == null) {
-      printer = new TablePrinter(header);
-      shardPrinter.put(shardName, printer);
+    TableFormatter tableFormatter = shardPrinter.get(shardName);
+    if (tableFormatter == null) {
+      tableFormatter = new TableFormatter(header, outPuts);
+      shardPrinter.put(shardName, tableFormatter);
     }
-    printer.addRow(row);
+    tableFormatter.addRow(row);
   }
 
-  void printFormatted(PrintStream out) {
+  void collectFormattedData() {
     int shardId = 1;
-    for (Map.Entry<String, TablePrinter> entry : shardPrinter.entrySet()) {
-      out.println(String.format("Shard #%d (%s)", shardId++, entry.getKey()));
-      entry.getValue().printFormatted(out);
-      out.println();
+    for (Map.Entry<String, TableFormatter> entry : shardPrinter.entrySet()) {
+      outPuts.add(String.format("Shard #%d (%s)", shardId++, entry.getKey()));
+      entry.getValue().printFormatted();
+      outPuts.add("");
     }
   }
 }

--- a/tools/cli/src/main/java/org/apache/carbondata/tool/TableFormatter.java
+++ b/tools/cli/src/main/java/org/apache/carbondata/tool/TableFormatter.java
@@ -17,26 +17,27 @@
 
 package org.apache.carbondata.tool;
 
-import java.io.PrintStream;
 import java.util.LinkedList;
 import java.util.List;
 
-class TablePrinter {
+class TableFormatter {
   private List<String[]> table = new LinkedList<>();
+  private List<String> outPuts;
 
   /**
    * create a new Table Printer
    * @param header table header
    */
-  TablePrinter(String[] header) {
+  TableFormatter(String[] header, List<String> outPuts) {
     this.table.add(header);
+    this.outPuts = outPuts;
   }
 
   void addRow(String[] row) {
     table.add(row);
   }
 
-  void printFormatted(PrintStream out) {
+  void printFormatted() {
     // calculate the max length of each output field in the table
     int padding = 2;
     int[] maxLength = new int[table.get(0).length];
@@ -47,13 +48,14 @@ class TablePrinter {
     }
 
     for (String[] row : table) {
+      StringBuilder outString = new StringBuilder();
       for (int i = 0; i < row.length; i++) {
-        out.print(row[i]);
+        outString.append(row[i]);
         for (int num = 0; num < maxLength[i] + padding - row[i].length(); num++) {
-          out.print(" ");
+          outString.append(" ");
         }
       }
-      out.println();
+      outPuts.add(outString.toString());
     }
   }
 }

--- a/tools/cli/src/test/java/org/apache/carbondata/tool/CarbonCliTest.java
+++ b/tools/cli/src/test/java/org/apache/carbondata/tool/CarbonCliTest.java
@@ -102,7 +102,7 @@ public class CarbonCliTest {
             "## Table Properties\n"
           + "schema file not found"));
 
-    String[] args4 = {"-cmd", "summary", "-p", path, "-b"};
+    String[] args4 = {"-cmd", "summary", "-p", path, "-b", "7"};
     out = new ByteArrayOutputStream();
     stream = new PrintStream(out);
     CarbonCli.run(args4, stream);
@@ -125,14 +125,64 @@ public class CarbonCliTest {
     output = new String(out.toByteArray());
     Assert.assertTrue(
         output.contains(
-            "BLK  BLKLT  Meta Size  Data Size  LocalDict  DictEntries  DictSize  AvgPageSize  Min%    Max%    \n"
-          + "0    0      1.81KB     295.98KB   false      0            0.0B      11.77KB      robot0  robot1  \n"
-          + "0    1      1.81KB     295.99KB   false      0            0.0B      11.77KB      robot1  robot3  \n"
-          + "1    0      1.81KB     295.98KB   false      0            0.0B      11.77KB      robot3  robot4  \n"
-          + "1    1      1.81KB     295.99KB   false      0            0.0B      11.77KB      robot4  robot6  \n"
-          + "2    0      1.81KB     295.98KB   false      0            0.0B      11.77KB      robot6  robot7  \n"
-          + "2    1      1.81KB     295.98KB   false      0            0.0B      11.77KB      robot8  robot9  \n"
-          + "2    2      519.0B     74.06KB    false      0            0.0B      10.51KB      robot9  robot9  "));
+            "BLK  BLKLT  Meta Size  Data Size  LocalDict  DictEntries  DictSize  AvgPageSize  Min%  Max%  Min     Max     \n"
+          + "0    0      1.81KB     295.98KB   false      0            0.0B      11.77KB      NA    NA    robot0  robot1  \n"
+          + "0    1      1.81KB     295.99KB   false      0            0.0B      11.77KB      NA    NA    robot1  robot3  \n"
+          + "1    0      1.81KB     295.98KB   false      0            0.0B      11.77KB      NA    NA    robot3  robot4  \n"
+          + "1    1      1.81KB     295.99KB   false      0            0.0B      11.77KB      NA    NA    robot4  robot6  \n"
+          + "2    0      1.81KB     295.98KB   false      0            0.0B      11.77KB      NA    NA    robot6  robot7  \n"
+          + "2    1      1.81KB     295.98KB   false      0            0.0B      11.77KB      NA    NA    robot8  robot9  \n"
+          + "2    2      519.0B     74.06KB    false      0            0.0B      10.51KB      NA    NA    robot9  robot9 "));
+  }
+
+  @Test
+  public void testSummaryOutputAll() {
+    String[] args = {"-cmd", "summary", "-p", path, "-a", "-c", "age"};
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    PrintStream stream = new PrintStream(out);
+    CarbonCli.run(args, stream);
+    String output = new String(out.toByteArray());
+    Assert.assertTrue(
+        output.contains(
+            "Input Folder: ./CarbonCliTest\n"
+          + "## Summary\n"
+          + "total: 6 blocks, 2 shards, 14 blocklets, 314 pages, 10,000,000 rows, 32.27MB\n"
+          + "avg: 5.38MB/block, 2.30MB/blocklet, 1,666,666 rows/block, 714,285 rows/blocklet\n"));
+
+    Assert.assertTrue(
+        output.contains(
+            "Column Name  Data Type  Column Type  SortColumn  Encoding          Ordinal  Id  \n"
+          + "name         STRING     dimension    true        [INVERTED_INDEX]  0        NA  \n"
+          + "age          INT        measure      false       []                1        NA  \n"));
+
+    Assert.assertTrue(
+        output.contains(
+            "## Table Properties\n"
+          + "schema file not found"));
+
+    Assert.assertTrue(
+        output.contains(
+            "BLK  BLKLT  NumPages  NumRows  Size    \n"
+            + "0    0      25        800,000  2.58MB  \n"
+            + "0    1      25        800,000  2.58MB  \n"
+            + "1    0      25        800,000  2.58MB  \n"
+            + "1    1      25        800,000  2.58MB"));
+
+    Assert.assertTrue(
+        output.contains(
+          "BLK  BLKLT  Meta Size  Data Size  LocalDict  DictEntries  DictSize  AvgPageSize  Min%  Max%   Min  Max      \n"
+        + "0    0      3.00KB     4.87MB     false      0            0.0B      93.76KB      0.0   100.0  0    2999990  \n"
+        + "0    1      3.00KB     2.29MB     false      0            0.0B      93.76KB      0.0   100.0  1    2999992  \n"
+        + "1    0      3.00KB     4.87MB     false      0            0.0B      93.76KB      0.0   100.0  3    2999993  \n"
+        + "1    1      3.00KB     2.29MB     false      0            0.0B      93.76KB      0.0   100.0  4    2999995  \n"
+        + "2    0      3.00KB     5.52MB     false      0            0.0B      93.76KB      0.0   100.0  6    2999997  \n"
+        + "2    1      3.00KB     2.94MB     false      0            0.0B      93.76KB      0.0   100.0  8    2999998  \n"
+        + "2    2      858.0B     586.84KB   false      0            0.0B      83.71KB      0.0   100.0  9    2999999 "));
+
+    Assert.assertTrue(output.contains(
+        "## version Details\n"
+            + "written_by  Version         \n"
+            + "TestUtil    1.6.0-SNAPSHOT"));
   }
 
   @Test


### PR DESCRIPTION

### Enhancement in CLI tool
1.  a new option called "`-v`" is added to get the written_by and version details in addition to existing options
2.  SQL support is added for CLI
		This is introduced so that user can get the details in beeline only and no need to execute separately. Currently the command is as below, based on comment we can change this DDL
		`Show summary for table <table_name> options('command'='-cmd,summary,-a,-p,-b');`
		
3.  when we get details for column statistics ,we will get the Min and Max percentage, if we add actual min and max values, then it will be helpful for the developer
```
BLK  BLKLT  Meta Size  Data Size  LocalDict  DictEntries DictSize  AvgPageSize  Min%  Max%  Min  Max      
0      0      2.90KB       4.87MB     false       0          0.0B     93.76KB    0.0  100.0  0    2999990  
0      1      2.90KB       2.29MB     false       0          0.0B     93.76KB    0.0  100.0  1    2999992  
1      0      2.90KB       4.87MB     false       0          0.0B     93.76KB    0.0  100.0  3    2999993  
1      1      2.90KB       2.29MB     false       0          0.0B     93.76KB    0.0  100.0  4    2999995  
2      0      2.90KB       5.52MB     false       0          0.0B     93.76KB    0.0  100.0  6    2999997  
2      1      2.90KB       2.94MB     false       0          0.0B     93.76KB    0.0  100.0  8    2999998  
2      2      830.0B       586.81KB   false       0          0.0B     83.71KB    0.0  100.0  9    2999999 

```		 
4.  Currently CLI tool get blocklet details for all the blockfiles, so if we have more number of carbondata files, then it will take lot of time to get the details,
	so limit is added to it, by default when we give option as "-b", only 4 outputs will be given, if we want more, we can pass the option value for b as limit number, 
	Example:   "`-b 30`"   =>>  Then limit will be increased to 30
	
5. one more is a new Option is added called "`-B`", which takes mandatory option value as a block path. This is added just to get the block detail like, number of blocklets, number of pages, rows and size

Example:  "`-B /home/ss/ss/part-0-0_batchno0-0-0-1539782855178.carbondata`"
			
```
##  Filtered Block Details for: part-0-0_batchno0-0-0-1539782855178.carbondata
	BLKT  NumPages  NumRows  Size
        0        4        20      10.0B
```
Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

