### PR TITLE
[CARBONDATA-3021][Streaming] Fix unsupported data type exception for streaming

### DIFF
--- a/streaming/src/main/java/org/apache/carbondata/streaming/index/StreamFileIndex.java
+++ b/streaming/src/main/java/org/apache/carbondata/streaming/index/StreamFileIndex.java
@@ -21,7 +21,6 @@ import java.io.Serializable;
 
 import org.apache.carbondata.common.annotations.InterfaceAudience;
 import org.apache.carbondata.core.metadata.blocklet.index.BlockletMinMaxIndex;
-import org.apache.carbondata.core.metadata.datatype.DataType;
 
 @InterfaceAudience.Internal
 public class StreamFileIndex implements Serializable {
@@ -34,8 +33,6 @@ public class StreamFileIndex implements Serializable {
   private BlockletMinMaxIndex minMaxIndex;
 
   private long rowCount;
-
-  private DataType[] msrDataTypes;
 
   public StreamFileIndex(String fileName, BlockletMinMaxIndex minMaxIndex, long rowCount) {
     this.fileName = fileName;
@@ -67,11 +64,4 @@ public class StreamFileIndex implements Serializable {
     this.rowCount = rowCount;
   }
 
-  public DataType[] getMsrDataTypes() {
-    return msrDataTypes;
-  }
-
-  public void setMsrDataTypes(DataType[] msrDataTypes) {
-    this.msrDataTypes = msrDataTypes;
-  }
 }


### PR DESCRIPTION
Background:
when spark uses Kryo serialization, streaming app throws the exception "Unsupported data type".
Root cause: 
1.  collect the data type list to driver side from executor side.  
2.  when using Kryo, datatype single instances are not working.
Solution:
don't collect measure data type list from executor side to avoid serialization.

 - [x] Any interfaces changed?
 no
 - [x] Any backward compatibility impacted?
 no
 - [x] Document update required?
 no
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
 use old test case to test it.      
 
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
small
