### PR TITLE
[CARBONDATA-3026] clear expired property that may cause GC problem

### DIFF
--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableOutputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableOutputFormat.java
@@ -267,9 +267,6 @@ public class CarbonTableOutputFormat extends FileOutputFormat<NullWritable, Obje
             iterator.closeWriter(true);
           }
           dataLoadExecutor.close();
-          // clean up the folders and files created locally for data load operation
-          TableProcessingOperations.deleteLocalDataLoadFolderLocation(loadModel, false, false);
-
           throw new RuntimeException(e);
         } finally {
           ThreadLocalSessionInfo.unsetAll();

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/TableProcessingOperations.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/TableProcessingOperations.java
@@ -146,6 +146,7 @@ public class TableProcessingOperations {
         }
       });
     } finally {
+      CarbonProperties.getInstance().removeProperty(tempLocationKey);
       if (null != localFolderDeletionService) {
         localFolderDeletionService.shutdown();
       }


### PR DESCRIPTION
During data loading, we will write some temp files (sort temp
files and temp fact data files) in some locations. In currently
implementation, we will add the locations to the CarbonProperties and
associated it with a special key that refers to the data loading.

After data loading, the temp locations are cleared, but the added
property is still remain in the CarbonProperties and never to be cleared.

This will cause the CarbonProperties object growing bigger and bigger
and lead to OOM problems if the thrift-server is a long time running
service. A local test shows that after adding different properties for
11 Million times, the OOM happens.

In this commit, I clear the property for the locations when we clear the
locations.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 `NO`
 - [x] Any backward compatibility impacted?
  `NO`
 - [x] Document update required?
 `NO`
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
`NO`
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
`NO`
        - Any additional information to help reviewers in testing this change.
`NO`
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
`NA`
