### PR TITLE
[CARBONDATA-3000] Provide C++ interface for writing carbon data in CSDK

### DIFF
--- a/docs/csdk-guide.md
+++ b/docs/csdk-guide.md
@@ -35,7 +35,7 @@ Please find example code at  [main.cpp](https://github.com/apache/carbondata/blo
 
 When users use C++ to read carbon files, users should init JVM first. Then users create 
 carbon reader and read data.There are some example code of read data from local disk  
-and read data from S3 at main.cpp of CSDK module.  Finally, Finally, users need to 
+and read data from S3 at main.cpp of CSDK module.  Finally, users need to 
 release the memory and destroy JVM.
 
 ## API List
@@ -100,4 +100,91 @@ release the memory and destroy JVM.
      */
     jboolean close();
 
+```
+
+# CSDK Writer
+This CSDK writer writes CarbonData file and carbonindex file at a given path. 
+External client can make use of this writer to write CarbonData files in C++ 
+code and without CarbonSession. CSDK already supports S3 and local disk.
+
+In the carbon jars package, there exist a carbondata-sdk.jar, 
+including SDK writer for CSDK. 
+
+## Quick example
+Please find example code at  [main.cpp](https://github.com/apache/carbondata/blob/master/store/CSDK/test/main.cpp) of CSDK module  
+
+When users use C++ to write carbon files, users should init JVM first. Then users create 
+carbon writer and write data.There are some example code of write data to local disk  
+and write data to S3 at main.cpp of CSDK module.  Finally, users need to 
+release the memory and destroy JVM.
+
+## API List
+
+```
+    /**
+     * create a CarbonWriterBuilder object for building carbonWriter,
+     * CarbonWriterBuilder object  can configure different parameter
+     *
+     * @param env JNIEnv
+     * @return CarbonWriterBuilder object
+     */
+    void builder(JNIEnv *env);
+```
+```
+    /**
+     * Sets the output path of the writer builder
+     *
+     * @param path is the absolute path where output files are written
+     * This method must be called when building CarbonWriterBuilder
+     * @return updated CarbonWriterBuilder
+     */
+    void outputPath(char *path);
+```
+```
+    /**
+     * configure the schema with json style schema
+     *
+     * @param jsonSchema json style schema
+     * @return updated CarbonWriterBuilder
+     */
+    void withCsvInput(char *jsonSchema);
+```
+```
+    /**
+    * configure parameter, including ak,sk and endpoint
+    *
+    * @param key key word
+    * @param value value
+    * @return CarbonWriterBuilder object
+    */
+    void withHadoopConf(char *key, char *value);
+```
+```
+    /**
+     * @param appName appName which is writing the carbondata files
+     */
+    void writtenBy(char *appName);
+```
+```
+    /**
+     * build carbonWriter object for writing data
+     * it support write data from load disk
+     *
+     * @return carbonWriter object
+     */
+    void build();
+```
+```
+    /**
+     * Write an object to the file, the format of the object depends on the
+     * implementation.
+     * Note: This API is not thread safe
+     */
+    void write(jobject obj);
+```
+```
+    /**
+     * close the carbon Writer
+     */
+    void close();
 ```

--- a/docs/ddl-of-carbondata.md
+++ b/docs/ddl-of-carbondata.md
@@ -550,7 +550,7 @@ CarbonData DDL statements are documented here,which includes:
   ```
 
   Here writer path will have carbondata and index files.
-  This can be SDK output. Refer [SDK Guide](./sdk-guide.md). 
+  This can be SDK output or CSDK output. Refer [SDK Guide](./sdk-guide.md) and [CSDK Guide](./csdk-guide.md). 
 
   **Note:**
   1. Dropping of the external table should not delete the files present in the location.

--- a/docs/quick-start-guide.md
+++ b/docs/quick-start-guide.md
@@ -294,7 +294,7 @@ hdfs://<host_name>:port/user/hive/warehouse/carbon.store
 ## Installing and Configuring CarbonData on Presto
 
 **NOTE:** **CarbonData tables cannot be created nor loaded from Presto. User need to create CarbonData Table and load data into it
-either with [Spark](#installing-and-configuring-carbondata-to-run-locally-with-spark-shell) or [SDK](./sdk-guide.md).
+either with [Spark](#installing-and-configuring-carbondata-to-run-locally-with-spark-shell) or [SDK](./sdk-guide.md) or [CSDK](./csdk-guide.md).
 Once the table is created,it can be queried from Presto.**
 
 

--- a/examples/spark2/src/main/java/org/apache/carbondata/examples/sdk/SDKS3Example.java
+++ b/examples/spark2/src/main/java/org/apache/carbondata/examples/sdk/SDKS3Example.java
@@ -62,7 +62,7 @@ public class SDKS3Example {
             num = Integer.parseInt(args[4]);
         }
 
-        Configuration conf = new Configuration(false);
+        Configuration conf = new Configuration(true);
         conf.set(Constants.ACCESS_KEY, args[0]);
         conf.set(Constants.SECRET_KEY, args[1]);
         conf.set(Constants.ENDPOINT, args[2]);
@@ -70,8 +70,13 @@ public class SDKS3Example {
         Field[] fields = new Field[2];
         fields[0] = new Field("name", DataTypes.STRING);
         fields[1] = new Field("age", DataTypes.INT);
-        CarbonWriterBuilder builder = CarbonWriter.builder().outputPath(path).withHadoopConf(conf);
-        CarbonWriter writer = builder.withCsvInput(new Schema(fields)).build();
+        CarbonWriter writer = CarbonWriter
+            .builder()
+            .outputPath(path)
+            .withHadoopConf(conf)
+            .withCsvInput(new Schema(fields))
+            .writtenBy("SDKS3Example")
+            .build();
 
         for (int i = 0; i < num; i++) {
             writer.write(new String[]{"robot" + (i % 10), String.valueOf(i)});

--- a/store/CSDK/CMakeLists.txt
+++ b/store/CSDK/CMakeLists.txt
@@ -8,7 +8,7 @@ find_package(JNI REQUIRED)
 include_directories(${JNI_INCLUDE_DIRS})
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-set(SOURCE_FILES src/CarbonReader.cpp src/CarbonReader.h test/main.cpp src/CarbonRow.h src/CarbonRow.cpp)
+set(SOURCE_FILES src/CarbonReader.cpp src/CarbonReader.h test/main.cpp src/CarbonRow.h src/CarbonRow.cpp src/CarbonWriter.h  src/CarbonWriter.cpp)
 
 add_executable(CJDK ${SOURCE_FILES})
 get_filename_component(JAVA_JVM_LIBRARY_DIR ${JAVA_JVM_LIBRARY} DIRECTORY)

--- a/store/CSDK/src/CarbonReader.cpp
+++ b/store/CSDK/src/CarbonReader.cpp
@@ -71,6 +71,12 @@ void CarbonReader::builder(JNIEnv *env, char *path) {
     carbonReaderBuilderObject = env->CallStaticObjectMethodA(carbonReaderClass, carbonReaderBuilderID, args);
 }
 
+bool CarbonReader::checkBuilder() {
+    if (carbonReaderBuilderObject == NULL) {
+        throw std::runtime_error("carbonReaderBuilder Object can't be NULL. Please call builder method first.");
+    }
+}
+
 void CarbonReader::projection(int argc, char *argv[]) {
     if (argc < 0) {
         throw std::runtime_error("argc parameter can't be negative.");
@@ -78,6 +84,7 @@ void CarbonReader::projection(int argc, char *argv[]) {
     if (argv == NULL) {
         throw std::runtime_error("argv parameter can't be NULL.");
     }
+    checkBuilder();
     jclass carbonReaderBuilderClass = jniEnv->GetObjectClass(carbonReaderBuilderObject);
     jmethodID buildID = jniEnv->GetMethodID(carbonReaderBuilderClass, "projection",
         "([Ljava/lang/String;)Lorg/apache/carbondata/sdk/file/CarbonReaderBuilder;");
@@ -106,6 +113,7 @@ void CarbonReader::withHadoopConf(char *key, char *value) {
     if (value == NULL) {
         throw std::runtime_error("value parameter can't be NULL.");
     }
+    checkBuilder();
     jclass carbonReaderBuilderClass = jniEnv->GetObjectClass(carbonReaderBuilderObject);
     jmethodID id = jniEnv->GetMethodID(carbonReaderBuilderClass, "withHadoopConf",
         "(Ljava/lang/String;Ljava/lang/String;)Lorg/apache/carbondata/sdk/file/CarbonReaderBuilder;");
@@ -119,6 +127,7 @@ void CarbonReader::withHadoopConf(char *key, char *value) {
 }
 
 jobject CarbonReader::build() {
+    checkBuilder();
     jclass carbonReaderBuilderClass = jniEnv->GetObjectClass(carbonReaderBuilderObject);
     jmethodID buildID = jniEnv->GetMethodID(carbonReaderBuilderClass, "build",
         "()Lorg/apache/carbondata/sdk/file/CarbonReader;");
@@ -132,7 +141,14 @@ jobject CarbonReader::build() {
     return carbonReaderObject;
 }
 
+bool CarbonReader::checkReader() {
+    if (carbonReaderObject == NULL) {
+        throw std::runtime_error("carbonReader Object is NULL, Please call build first.");
+    }
+}
+
 jboolean CarbonReader::hasNext() {
+    checkReader();
     if (hasNextID == NULL) {
         jclass carbonReader = jniEnv->GetObjectClass(carbonReaderObject);
         hasNextID = jniEnv->GetMethodID(carbonReader, "hasNext", "()Z");
@@ -148,6 +164,7 @@ jboolean CarbonReader::hasNext() {
 }
 
 jobject CarbonReader::readNextRow() {
+    checkReader();
     if (readNextRowID == NULL) {
         jclass carbonReader = jniEnv->GetObjectClass(carbonReaderObject);
         readNextRowID = jniEnv->GetMethodID(carbonReader, "readNextRow",
@@ -164,6 +181,7 @@ jobject CarbonReader::readNextRow() {
 }
 
 void CarbonReader::close() {
+    checkReader();
     jclass carbonReader = jniEnv->GetObjectClass(carbonReaderObject);
     jmethodID closeID = jniEnv->GetMethodID(carbonReader, "close", "()V");
     if (closeID == NULL) {

--- a/store/CSDK/src/CarbonReader.h
+++ b/store/CSDK/src/CarbonReader.h
@@ -41,14 +41,16 @@ private:
     jobject carbonReaderObject;
 
     /**
-     * check whether has called builder
+     * Return true if carbonReaderBuilder Object isn't NULL
+     * Throw exception if carbonReaderBuilder Object is NULL
      *
      * @return true or throw exception
      */
     bool checkBuilder();
 
     /**
-     * check reader and whether has called build
+     * Return true if carbonReader Object isn't NULL
+     * Throw exception if carbonReader Object is NULL
      *
      * @return true or throw exception
      */

--- a/store/CSDK/src/CarbonReader.h
+++ b/store/CSDK/src/CarbonReader.h
@@ -40,6 +40,19 @@ private:
      */
     jobject carbonReaderObject;
 
+    /**
+     * check whether has called builder
+     *
+     * @return true or throw exception
+     */
+    bool checkBuilder();
+
+    /**
+     * check reader and whether has called build
+     *
+     * @return true or throw exception
+     */
+    bool checkReader();
 public:
 
     /**

--- a/store/CSDK/src/CarbonWriter.cpp
+++ b/store/CSDK/src/CarbonWriter.cpp
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdexcept>
+#include "CarbonWriter.h"
+
+void CarbonWriter::builder(JNIEnv *env) {
+    if (env == NULL) {
+        throw std::runtime_error("JNIEnv parameter can't be NULL.");
+    }
+    jniEnv = env;
+    carbonWriter = env->FindClass("org/apache/carbondata/sdk/file/CarbonWriter");
+    if (carbonWriter == NULL) {
+        throw std::runtime_error("Can't find the class in java: org/apache/carbondata/sdk/file/CarbonWriter");
+    }
+    jmethodID carbonWriterBuilderID = env->GetStaticMethodID(carbonWriter, "builder",
+        "()Lorg/apache/carbondata/sdk/file/CarbonWriterBuilder;");
+    if (carbonWriterBuilderID == NULL) {
+        throw std::runtime_error("Can't find the method in java: carbonWriterBuilder");
+    }
+    carbonWriterBuilderObject = env->CallStaticObjectMethod(carbonWriter, carbonWriterBuilderID);
+}
+
+bool CarbonWriter::checkBuilder() {
+    if (carbonWriterBuilderObject == NULL) {
+        throw std::runtime_error("carbonWriterBuilder Object can't be NULL. Please call builder method first.");
+    }
+}
+
+void CarbonWriter::outputPath(char *path) {
+    if (path == NULL) {
+        throw std::runtime_error("path parameter can't be NULL.");
+    }
+    checkBuilder();
+    jclass carbonWriterBuilderClass = jniEnv->GetObjectClass(carbonWriterBuilderObject);
+    jmethodID methodID = jniEnv->GetMethodID(carbonWriterBuilderClass, "outputPath",
+        "(Ljava/lang/String;)Lorg/apache/carbondata/sdk/file/CarbonWriterBuilder;");
+    if (methodID == NULL) {
+        throw std::runtime_error("Can't find the method in java: outputPath");
+    }
+    jstring jPath = jniEnv->NewStringUTF(path);
+    jvalue args[1];
+    args[0].l = jPath;
+    carbonWriterBuilderObject = jniEnv->CallObjectMethodA(carbonWriterBuilderObject, methodID, args);
+}
+
+void CarbonWriter::withCsvInput(char *jsonSchema) {
+    if (jsonSchema == NULL) {
+        throw std::runtime_error("jsonSchema parameter can't be NULL.");
+    }
+    checkBuilder();
+    jclass carbonWriterBuilderClass = jniEnv->GetObjectClass(carbonWriterBuilderObject);
+    jmethodID methodID = jniEnv->GetMethodID(carbonWriterBuilderClass, "withCsvInput",
+        "(Ljava/lang/String;)Lorg/apache/carbondata/sdk/file/CarbonWriterBuilder;");
+    if (methodID == NULL) {
+        throw std::runtime_error("Can't find the method in java: withCsvInput");
+    }
+    jstring jPath = jniEnv->NewStringUTF(jsonSchema);
+    jvalue args[1];
+    args[0].l = jPath;
+    carbonWriterBuilderObject = jniEnv->CallObjectMethodA(carbonWriterBuilderObject, methodID, args);
+    if (jniEnv->ExceptionCheck()) {
+        throw jniEnv->ExceptionOccurred();
+    }
+};
+
+void CarbonWriter::withHadoopConf(char *key, char *value) {
+    if (key == NULL) {
+        throw std::runtime_error("key parameter can't be NULL.");
+    }
+    if (value == NULL) {
+        throw std::runtime_error("value parameter can't be NULL.");
+    }
+    checkBuilder();
+    jclass carbonWriterBuilderClass = jniEnv->GetObjectClass(carbonWriterBuilderObject);
+    jmethodID methodID = jniEnv->GetMethodID(carbonWriterBuilderClass, "withHadoopConf",
+        "(Ljava/lang/String;Ljava/lang/String;)Lorg/apache/carbondata/sdk/file/CarbonWriterBuilder;");
+    if (methodID == NULL) {
+        throw std::runtime_error("Can't find the method in java: withHadoopConf");
+    }
+    jvalue args[2];
+    args[0].l = jniEnv->NewStringUTF(key);
+    args[1].l = jniEnv->NewStringUTF(value);
+    carbonWriterBuilderObject = jniEnv->CallObjectMethodA(carbonWriterBuilderObject, methodID, args);
+}
+
+void CarbonWriter::writtenBy(char *appName) {
+    checkBuilder();
+    jclass carbonWriterBuilderClass = jniEnv->GetObjectClass(carbonWriterBuilderObject);
+    jmethodID methodID = jniEnv->GetMethodID(carbonWriterBuilderClass, "writtenBy",
+        "(Ljava/lang/String;)Lorg/apache/carbondata/sdk/file/CarbonWriterBuilder;");
+    if (methodID == NULL) {
+        throw std::runtime_error("Can't find the method in java: writtenBy");
+    }
+    jvalue args[1];
+    args[0].l = jniEnv->NewStringUTF(appName);
+    carbonWriterBuilderObject = jniEnv->CallObjectMethodA(carbonWriterBuilderObject, methodID, args);
+}
+
+void CarbonWriter::build() {
+    checkBuilder();
+
+    // If not add this, it will throw java.io.IOException: No FileSystem for scheme: file
+    withHadoopConf("fs.file.impl", "org.apache.hadoop.fs.LocalFileSystem");
+
+    jclass carbonWriterBuilderClass = jniEnv->GetObjectClass(carbonWriterBuilderObject);
+    jmethodID methodID = jniEnv->GetMethodID(carbonWriterBuilderClass, "build",
+        "()Lorg/apache/carbondata/sdk/file/CarbonWriter;");
+    if (methodID == NULL) {
+        throw std::runtime_error("Can't find the method in java: build");
+    }
+    carbonWriterObject = jniEnv->CallObjectMethod(carbonWriterBuilderObject, methodID);
+
+    if (jniEnv->ExceptionCheck()) {
+        throw jniEnv->ExceptionOccurred();
+    }
+}
+
+bool CarbonWriter::checkWriter() {
+    if (carbonWriterObject == NULL) {
+        throw std::runtime_error("carbonWriter Object is NULL, Please call build first.");
+    }
+}
+
+void CarbonWriter::write(jobject obj) {
+    checkWriter();
+    if (writeID == NULL) {
+        carbonWriter = jniEnv->GetObjectClass(carbonWriterObject);
+        writeID = jniEnv->GetMethodID(carbonWriter, "write", "(Ljava/lang/Object;)V");
+        if (writeID == NULL) {
+            throw std::runtime_error("Can't find the method in java: write");
+        }
+    }
+    jvalue args[1];
+    args[0].l = obj;
+    jniEnv->CallBooleanMethodA(carbonWriterObject, writeID, args);
+    if (jniEnv->ExceptionCheck()) {
+        throw jniEnv->ExceptionOccurred();
+    }
+};
+
+void CarbonWriter::close() {
+    checkWriter();
+    jclass carbonWriter = jniEnv->GetObjectClass(carbonWriterObject);
+    jmethodID methodID = jniEnv->GetMethodID(carbonWriter, "close", "()V");
+    if (methodID == NULL) {
+        throw std::runtime_error("Can't find the method in java: close");
+    }
+    jniEnv->CallBooleanMethod(carbonWriterObject, methodID);
+    if (jniEnv->ExceptionCheck()) {
+        throw jniEnv->ExceptionOccurred();
+    }
+}

--- a/store/CSDK/src/CarbonWriter.h
+++ b/store/CSDK/src/CarbonWriter.h
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <jni.h>
+
+class CarbonWriter {
+private:
+    /**
+    * jni env
+    */
+    JNIEnv *jniEnv;
+
+    /**
+     * carbonWriterBuilder object for building carbonWriter
+     * it can configure some operation
+     */
+    jobject carbonWriterBuilderObject = NULL;
+
+    /**
+     * carbonWriter object for writing data
+     */
+    jobject carbonWriterObject;
+
+    /**
+     * carbon writer class
+     */
+    jclass carbonWriter;
+
+    /**
+     * write method id
+     */
+    jmethodID writeID = NULL;
+
+    /**
+     * check whether has called builder
+     *
+     * @return true or throw exception
+     */
+    bool checkBuilder();
+
+    /**
+     * check writer whether has called build
+     *
+     * @return true or throw exception
+     */
+    bool checkWriter();
+public:
+    /**
+     * create a CarbonWriterBuilder object for building carbonWriter,
+     * CarbonWriterBuilder object  can configure different parameter
+     *
+     * @param env JNIEnv
+     * @return CarbonWriterBuilder object
+     */
+    void builder(JNIEnv *env);
+
+    /**
+     * Sets the output path of the writer builder
+     *
+     * @param path is the absolute path where output files are written
+     * This method must be called when building CarbonWriterBuilder
+     * @return updated CarbonWriterBuilder
+     */
+    void outputPath(char *path);
+
+    /**
+     * configure the schema with json style schema
+     *
+     * @param jsonSchema json style schema
+     * @return updated CarbonWriterBuilder
+     */
+    void withCsvInput(char *jsonSchema);
+
+    /**
+    * configure parameter, including ak,sk and endpoint
+    *
+    * @param key key word
+    * @param value value
+    * @return CarbonWriterBuilder object
+    */
+    void withHadoopConf(char *key, char *value);
+
+    /**
+     * @param appName appName which is writing the carbondata files
+     */
+    void writtenBy(char *appName);
+
+    /**
+     * build carbonWriter object for writing data
+     * it support write data from load disk
+     *
+     * @return carbonWriter object
+     */
+    void build();
+
+    /**
+     * Write an object to the file, the format of the object depends on the
+     * implementation.
+     * Note: This API is not thread safe
+     */
+    void write(jobject obj);
+
+    /**
+     * close the carbon Writer
+     */
+    void close();
+};
+
+

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonWriterBuilder.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonWriterBuilder.java
@@ -269,6 +269,21 @@ public class CarbonWriterBuilder {
   }
 
   /**
+   * configure hadoop configuration with key value
+   *
+   * @param key   key word
+   * @param value value
+   * @return this object
+   */
+  public CarbonWriterBuilder withHadoopConf(String key, String value) {
+    if (this.hadoopConf == null) {
+      this.hadoopConf = new Configuration(true);
+    }
+    this.hadoopConf.set(key, value);
+    return this;
+  }
+
+  /**
    * To set the carbondata file size in MB between 1MB-2048MB
    * @param blockSize is size in MB between 1MB to 2048 MB
    * default value is 1024 MB
@@ -337,6 +352,19 @@ public class CarbonWriterBuilder {
   public CarbonWriterBuilder withCsvInput(Schema schema) {
     Objects.requireNonNull(schema, "schema should not be null");
     this.schema = schema;
+    this.writerType = WRITER_TYPE.CSV;
+    return this;
+  }
+
+  /**
+   * to build a {@link CarbonWriter}, which accepts row in CSV format
+   *
+   * @param jsonSchema json Schema string
+   * @return CarbonWriterBuilder
+   */
+  public CarbonWriterBuilder withCsvInput(String jsonSchema) {
+    Objects.requireNonNull(jsonSchema, "schema should not be null");
+    this.schema = Schema.parseJson(jsonSchema);
     this.writerType = WRITER_TYPE.CSV;
     return this;
   }

--- a/store/sdk/src/main/resources/log4j.properties
+++ b/store/sdk/src/main/resources/log4j.properties
@@ -1,0 +1,11 @@
+# Root logger option
+log4j.rootLogger=INFO,stdout
+
+
+# Redirect log messages to console
+log4j.appender.debug=org.apache.log4j.RollingFileAppender
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
+

--- a/store/sdk/src/test/java/org/apache/carbondata/sdk/file/CSVCarbonWriterTest.java
+++ b/store/sdk/src/test/java/org/apache/carbondata/sdk/file/CSVCarbonWriterTest.java
@@ -105,6 +105,37 @@ public class CSVCarbonWriterTest {
   }
 
   @Test
+  public void testWriteFilesBuildWithJsonSchema() throws IOException, InvalidLoadOptionException, InterruptedException {
+    String path = "./testWriteFilesJsonSchema";
+    FileUtils.deleteDirectory(new File(path));
+
+    String schema = "[{name:string},{age:int},{height:double}]";
+    CarbonWriterBuilder builder = CarbonWriter
+        .builder()
+        .outputPath(path)
+        .withCsvInput(schema)
+        .writtenBy("testWriteFilesBuildWithJsonSchema");
+
+    CarbonWriter writer = builder.build();
+    for (int i = 0; i < 10; i++) {
+      writer.write(new String[]{
+          "robot" + (i % 10), String.valueOf(i % 3000000), String.valueOf((double) i / 2)});
+    }
+    writer.close();
+
+    CarbonReader carbonReader = CarbonReader.builder(path).build();
+    int i = 0;
+    while (carbonReader.hasNext()) {
+      Object[] row = (Object[]) carbonReader.readNextRow();
+      Assert.assertEquals(row[0], "robot" + i % 10);
+      System.out.println();
+      i++;
+    }
+    carbonReader.close();
+    FileUtils.deleteDirectory(new File(path));
+  }
+
+  @Test
   public void testAllPrimitiveDataType() throws IOException {
     // TODO: write all data type and read by CarbonRecordReader to verify the content
     String path = "./testWriteFiles";


### PR DESCRIPTION
[CARBONDATA-3000] Provide C++ interface for writing carbon data in CSDK
    1.suport string, short, int, long, double, float, array<string>, boolean data type
    2.provide builder, build, write, close interface
    3.support write data to S3
    4. add log for SDK and CSDK
Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 add C++interface
 - [x] Any backward compatibility impacted?
 No
 - [x] Document update required?
Yes
 - [x] Testing done
       add some test case
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
https://issues.apache.org/jira/browse/CARBONDATA-2951