### PR TITLE
[CARBONDATA-3032] Remove carbon.blocklet.size from properties template

### DIFF
--- a/conf/carbon.properties.template
+++ b/conf/carbon.properties.template
@@ -68,8 +68,6 @@ carbon.major.compaction.size=1024
 #carbon.csv.read.buffersize.byte=1048576
 ##no of threads used for reading intermediate files for final merging.
 #carbon.merge.sort.reader.thread=3
-##Carbon blocklet size. Note: this configuration cannot be change once store is generated
-#carbon.blocklet.size=120000
 ##To disable/enable carbon block distribution
 #carbon.custom.block.distribution=false
 

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/reader/dimension/AbstractChunkReader.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/reader/dimension/AbstractChunkReader.java
@@ -54,7 +54,7 @@ public abstract class AbstractChunkReader implements DimensionColumnChunkReader 
    * this will be used to uncompress the
    * row id and rle chunk
    */
-  protected NumberCompressor numberComressor;
+  protected NumberCompressor numberCompressor;
 
   /**
    * number of element in each chunk
@@ -80,7 +80,7 @@ public abstract class AbstractChunkReader implements DimensionColumnChunkReader 
     } catch (NumberFormatException exception) {
       numberOfElement = Integer.parseInt(CarbonCommonConstants.BLOCKLET_SIZE_DEFAULT_VAL);
     }
-    this.numberComressor = new NumberCompressor(numberOfElement);
+    this.numberCompressor = new NumberCompressor(numberOfElement);
     this.numberOfRows = numberOfRows;
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/reader/dimension/v1/CompressedDimensionChunkFileBasedReaderV1.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/reader/dimension/v1/CompressedDimensionChunkFileBasedReaderV1.java
@@ -126,7 +126,7 @@ public class CompressedDimensionChunkFileBasedReaderV1 extends AbstractChunkRead
       }
       invertedIndexes = CarbonUtil
           .getUnCompressColumnIndex(dataChunk.getRowIdPageLength(),
-              columnIndexData, numberComressor, 0);
+              columnIndexData, numberCompressor, 0);
       // get the reverse index
       invertedIndexesReverse = CarbonUtil.getInvertedReverseIndex(invertedIndexes);
     }
@@ -141,7 +141,7 @@ public class CompressedDimensionChunkFileBasedReaderV1 extends AbstractChunkRead
             .readByteArray(filePath, dataChunk.getRlePageOffset(),
                 dataChunk.getRlePageLength());
       }
-      rlePage = numberComressor
+      rlePage = numberCompressor
           .unCompress(key, 0, dataChunk.getRlePageLength());
       // uncompress the data with rle indexes
       dataPage = UnBlockIndexer.uncompressData(dataPage, rlePage, eachColumnValueSize[blockIndex]);

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/reader/dimension/v2/CompressedDimensionChunkFileBasedReaderV2.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/reader/dimension/v2/CompressedDimensionChunkFileBasedReaderV2.java
@@ -156,7 +156,7 @@ public class CompressedDimensionChunkFileBasedReaderV2 extends AbstractChunkRead
       rawData.get(dataInv);
       invertedIndexes = CarbonUtil
           .getUnCompressColumnIndex(dimensionColumnChunk.rowid_page_length, dataInv,
-              numberComressor, 0);
+              numberCompressor, 0);
       copySourcePoint += dimensionColumnChunk.rowid_page_length;
       // get the reverse index
       invertedIndexesReverse = CarbonUtil.getInvertedReverseIndex(invertedIndexes);
@@ -167,7 +167,7 @@ public class CompressedDimensionChunkFileBasedReaderV2 extends AbstractChunkRead
       byte[] dataRle = new byte[dimensionColumnChunk.rle_page_length];
       rawData.position(copySourcePoint);
       rawData.get(dataRle);
-      rlePage = numberComressor.unCompress(dataRle, 0, dimensionColumnChunk.rle_page_length);
+      rlePage = numberCompressor.unCompress(dataRle, 0, dimensionColumnChunk.rle_page_length);
       // uncompress the data with rle indexes
       dataPage = UnBlockIndexer.uncompressData(dataPage, rlePage, eachColumnValueSize[blockIndex]);
     }

--- a/docs/sdk-guide.md
+++ b/docs/sdk-guide.md
@@ -25,7 +25,9 @@ CarbonData provides SDK to facilitate
 # SDK Writer
 
 In the carbon jars package, there exist a carbondata-store-sdk-x.x.x-SNAPSHOT.jar, including SDK writer and reader. 
-If you want to use SDK, it needs other carbon jar or you can use carbondata-sdk.jar.
+If user want to use SDK, it needs carbondata-core-x.x.x-SNAPSHOT.jar, carbondata-common-x.x.x-SNAPSHOT.jar, 
+carbondata-format-x.x.x-SNAPSHOT.jar, carbondata-hadoop-x.x.x-SNAPSHOT.jar and carbondata-processing-x.x.x-SNAPSHOT.jar.
+What's more, user can use carbondata-sdk.jar directly.
 
 This SDK writer, writes carbondata file and carbonindex file at a given path.
 External client can make use of this writer to convert other format data or live data to create carbondata and index files.

--- a/docs/sdk-guide.md
+++ b/docs/sdk-guide.md
@@ -25,9 +25,10 @@ CarbonData provides SDK to facilitate
 # SDK Writer
 
 In the carbon jars package, there exist a carbondata-store-sdk-x.x.x-SNAPSHOT.jar, including SDK writer and reader. 
-If user want to use SDK, it needs carbondata-core-x.x.x-SNAPSHOT.jar, carbondata-common-x.x.x-SNAPSHOT.jar, 
+If user want to use SDK, except carbondata-store-sdk-x.x.x-SNAPSHOT.jar, 
+it needs carbondata-core-x.x.x-SNAPSHOT.jar, carbondata-common-x.x.x-SNAPSHOT.jar, 
 carbondata-format-x.x.x-SNAPSHOT.jar, carbondata-hadoop-x.x.x-SNAPSHOT.jar and carbondata-processing-x.x.x-SNAPSHOT.jar.
-What's more, user can use carbondata-sdk.jar directly.
+What's more, user also can use carbondata-sdk.jar directly.
 
 This SDK writer, writes carbondata file and carbonindex file at a given path.
 External client can make use of this writer to convert other format data or live data to create carbondata and index files.

--- a/docs/sdk-guide.md
+++ b/docs/sdk-guide.md
@@ -24,7 +24,8 @@ CarbonData provides SDK to facilitate
 
 # SDK Writer
 
-In the carbon jars package, there exist a carbondata-store-sdk-x.x.x-SNAPSHOT.jar, including SDK writer and reader.
+In the carbon jars package, there exist a carbondata-store-sdk-x.x.x-SNAPSHOT.jar, including SDK writer and reader. 
+If you want to use SDK, it needs other carbon jar or you can use carbondata-sdk.jar.
 
 This SDK writer, writes carbondata file and carbonindex file at a given path.
 External client can make use of this writer to convert other format data or live data to create carbondata and index files.

--- a/processing/src/main/java/org/apache/carbondata/processing/store/CarbonDataWriterFactory.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/CarbonDataWriterFactory.java
@@ -51,8 +51,8 @@ class CarbonDataWriterFactory {
   /**
    * Below method will be used to get the writer instance based on version
    *
-   * @param version            writer version
-   * @param carbonDataWriterVo writer vo object
+   * @param version writer version
+   * @param model   CarbonFactDataHandlerModel object
    * @return writer instance
    */
   public CarbonFactDataWriter getFactDataWriter(final ColumnarFormatVersion version,


### PR DESCRIPTION
1.Remove carbon.blocklet.size from properties template, because carbon.blocklet.size is in V2, V3 use carbon.blockletgroup.size.in.mb or page size
2.change numberComressor to numberCompressor
3.optimize the annotation of method


 - [x] Any interfaces changed?
 No
 - [x] Any backward compatibility impacted?
 No
 - [x] Document update required?
No
 - [x] Testing done
      No
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
No
