### PR TITLE
[CARBONDATA-3048] Added Lazy Loading For 2.2/2.1

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/LocalDictDimensionDataChunkStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/LocalDictDimensionDataChunkStore.java
@@ -17,11 +17,15 @@
 
 package org.apache.carbondata.core.datastore.chunk.store.impl;
 
+import java.util.BitSet;
+
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.datastore.chunk.store.DimensionDataChunkStore;
 import org.apache.carbondata.core.scan.result.vector.CarbonColumnVector;
 import org.apache.carbondata.core.scan.result.vector.CarbonDictionary;
 import org.apache.carbondata.core.scan.result.vector.ColumnVectorInfo;
+import org.apache.carbondata.core.scan.result.vector.impl.directread.ColumnarVectorWrapperDirectFactory;
+import org.apache.carbondata.core.scan.result.vector.impl.directread.ConvertableVector;
 import org.apache.carbondata.core.util.CarbonUtil;
 
 /**
@@ -61,16 +65,24 @@ public class LocalDictDimensionDataChunkStore implements DimensionDataChunkStore
       vector.setDictionary(dictionary);
       dictionary.setDictionaryUsed();
     }
+    BitSet nullBitset = new BitSet();
+    CarbonColumnVector dictionaryVector = ColumnarVectorWrapperDirectFactory
+        .getDirectVectorWrapperFactory(vector.getDictionaryVector(), invertedIndex, nullBitset,
+            vectorInfo.deletedRows, false, true);
+    vector = ColumnarVectorWrapperDirectFactory
+        .getDirectVectorWrapperFactory(vector, invertedIndex, nullBitset, vectorInfo.deletedRows,
+            false, false);
     for (int i = 0; i < rowsNum; i++) {
       int surrogate = CarbonUtil.getSurrogateInternal(data, i * columnValueSize, columnValueSize);
       if (surrogate == CarbonCommonConstants.MEMBER_DEFAULT_VAL_SURROGATE_KEY) {
         vector.putNull(i);
-        vector.getDictionaryVector().putNull(i);
+        dictionaryVector.putNull(i);
       } else {
-        vector.putNotNull(i);
-        vector.getDictionaryVector().putInt(i, surrogate);
+        dictionaryVector.putInt(i, surrogate);
       }
-
+    }
+    if (dictionaryVector instanceof ConvertableVector) {
+      ((ConvertableVector) dictionaryVector).convert();
     }
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/safe/SafeFixedLengthDimensionDataChunkStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/safe/SafeFixedLengthDimensionDataChunkStore.java
@@ -56,7 +56,7 @@ public class SafeFixedLengthDimensionDataChunkStore extends SafeAbsractDimension
     BitSet deletedRows = vectorInfo.deletedRows;
     BitSet nullBits = new BitSet(numOfRows);
     vector = ColumnarVectorWrapperDirectFactory
-        .getDirectVectorWrapperFactory(vector, invertedIndex, nullBits, deletedRows, false);
+        .getDirectVectorWrapperFactory(vector, invertedIndex, nullBits, deletedRows, false, false);
     fillVector(data, vectorInfo, vector);
     if (vector instanceof ConvertableVector) {
       ((ConvertableVector) vector).convert();

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/safe/SafeVariableLengthDimensionDataChunkStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/safe/SafeVariableLengthDimensionDataChunkStore.java
@@ -98,19 +98,14 @@ public abstract class SafeVariableLengthDimensionDataChunkStore
   @Override
   public void fillVector(int[] invertedIndex, int[] invertedIndexReverse, byte[] data,
       ColumnVectorInfo vectorInfo) {
-    this.invertedIndexReverse = invertedIndex;
-    int lengthSize = getLengthSize();
     CarbonColumnVector vector = vectorInfo.vector;
     DataType dt = vector.getType();
-    // creating a byte buffer which will wrap the length of the row
-    ByteBuffer buffer = ByteBuffer.wrap(data);
     AbstractNonDictionaryVectorFiller vectorFiller =
-        NonDictionaryVectorFillerFactory.getVectorFiller(dt, lengthSize, numberOfRows);
-    BitSet nullBits = new BitSet(numberOfRows);
+        NonDictionaryVectorFillerFactory.getVectorFiller(getLengthSize(), dt, numberOfRows);
     vector = ColumnarVectorWrapperDirectFactory
-        .getDirectVectorWrapperFactory(vector, invertedIndex, nullBits, vectorInfo.deletedRows,
-            false);
-    vectorFiller.fillVector(data, vector, buffer);
+        .getDirectVectorWrapperFactory(vector, invertedIndex, new BitSet(), vectorInfo.deletedRows,
+            false, false);
+    vectorFiller.fillVector(data, vector);
     if (vector instanceof ConvertableVector) {
       ((ConvertableVector) vector).convert();
     }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/adaptive/AdaptiveDeltaFloatingCodec.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/adaptive/AdaptiveDeltaFloatingCodec.java
@@ -252,7 +252,7 @@ public class AdaptiveDeltaFloatingCodec extends AdaptiveCodec {
       BitSet deletedRows = vectorInfo.deletedRows;
       DataType vectorDataType = vector.getType();
       vector = ColumnarVectorWrapperDirectFactory
-          .getDirectVectorWrapperFactory(vector, null, nullBits, deletedRows, true);
+          .getDirectVectorWrapperFactory(vector, null, nullBits, deletedRows, true, false);
       if (vectorDataType == DataTypes.FLOAT) {
         float floatFactor = factor.floatValue();
         if (pageDataType == DataTypes.BOOLEAN || pageDataType == DataTypes.BYTE) {

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/adaptive/AdaptiveDeltaIntegralCodec.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/adaptive/AdaptiveDeltaIntegralCodec.java
@@ -309,7 +309,7 @@ public class AdaptiveDeltaIntegralCodec extends AdaptiveCodec {
       BitSet deletedRows = vectorInfo.deletedRows;
       vector = ColumnarVectorWrapperDirectFactory
           .getDirectVectorWrapperFactory(vector, vectorInfo.invertedIndex, nullBits, deletedRows,
-              true);
+              true, false);
       fillVector(columnPage, vector, vectorDataType, pageDataType, pageSize, vectorInfo);
       if (deletedRows == null || deletedRows.isEmpty()) {
         for (int i = nullBits.nextSetBit(0); i >= 0; i = nullBits.nextSetBit(i + 1)) {

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/adaptive/AdaptiveFloatingCodec.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/adaptive/AdaptiveFloatingCodec.java
@@ -255,7 +255,7 @@ public class AdaptiveFloatingCodec extends AdaptiveCodec {
       BitSet deletedRows = vectorInfo.deletedRows;
       DataType vectorDataType = vector.getType();
       vector = ColumnarVectorWrapperDirectFactory
-          .getDirectVectorWrapperFactory(vector, null, nullBits, deletedRows, true);
+          .getDirectVectorWrapperFactory(vector, null, nullBits, deletedRows, true, false);
       if (vectorDataType == DataTypes.FLOAT) {
         if (pageDataType == DataTypes.BOOLEAN || pageDataType == DataTypes.BYTE) {
           byte[] byteData = columnPage.getBytePage();

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/adaptive/AdaptiveIntegralCodec.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/adaptive/AdaptiveIntegralCodec.java
@@ -282,7 +282,7 @@ public class AdaptiveIntegralCodec extends AdaptiveCodec {
       BitSet deletedRows = vectorInfo.deletedRows;
       vector = ColumnarVectorWrapperDirectFactory
           .getDirectVectorWrapperFactory(vector, vectorInfo.invertedIndex, nullBits, deletedRows,
-              true);
+              true, false);
       fillVector(columnPage, vector, vectorDataType, pageDataType, pageSize, vectorInfo);
       if (deletedRows == null || deletedRows.isEmpty()) {
         for (int i = nullBits.nextSetBit(0); i >= 0; i = nullBits.nextSetBit(i + 1)) {

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/adaptive/AdaptiveIntegralCodec.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/adaptive/AdaptiveIntegralCodec.java
@@ -369,7 +369,7 @@ public class AdaptiveIntegralCodec extends AdaptiveCodec {
           }
         } else if (DataTypes.isDecimal(vectorDataType)) {
           DecimalConverterFactory.DecimalConverter decimalConverter = vectorInfo.decimalConverter;
-          int[] shortIntData = ByteUtil.toIntArray(shortIntPage, pageSize);
+          int[] shortIntData = ByteUtil.toIntArrayFrom3Bytes(shortIntPage, pageSize);
           decimalConverter.fillVector(shortIntData, pageSize, vectorInfo, columnPage.getNullBits());
         } else {
           for (int i = 0; i < pageSize; i++) {

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/compress/DirectCompressCodec.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/compress/DirectCompressCodec.java
@@ -298,7 +298,7 @@ public class DirectCompressCodec implements ColumnPageCodec {
           }
         } else if (DataTypes.isDecimal(vectorDataType)) {
           DecimalConverterFactory.DecimalConverter decimalConverter = vectorInfo.decimalConverter;
-          int[] shortIntData = ByteUtil.toIntArray(shortIntPage, pageSize);
+          int[] shortIntData = ByteUtil.toIntArrayFrom3Bytes(shortIntPage, pageSize);
           decimalConverter.fillVector(shortIntData, pageSize, vectorInfo, columnPage.getNullBits());
         } else {
           for (int i = 0; i < pageSize; i++) {

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/compress/DirectCompressCodec.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/compress/DirectCompressCodec.java
@@ -212,7 +212,7 @@ public class DirectCompressCodec implements ColumnPageCodec {
       BitSet deletedRows = vectorInfo.deletedRows;
       vector = ColumnarVectorWrapperDirectFactory
           .getDirectVectorWrapperFactory(vector, vectorInfo.invertedIndex, nullBits, deletedRows,
-              true);
+              true, false);
       fillVector(columnPage, vector, vectorDataType, pageDataType, pageSize, vectorInfo);
       if (deletedRows == null || deletedRows.isEmpty()) {
         for (int i = nullBits.nextSetBit(0); i >= 0; i = nullBits.nextSetBit(i + 1)) {

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/vector/impl/directread/ColumnarVectorWrapperDirectFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/vector/impl/directread/ColumnarVectorWrapperDirectFactory.java
@@ -39,7 +39,8 @@ public final class ColumnarVectorWrapperDirectFactory {
    * @return wrapped CarbonColumnVector
    */
   public static CarbonColumnVector getDirectVectorWrapperFactory(CarbonColumnVector columnVector,
-      int[] invertedIndex, BitSet nullBitset, BitSet deletedRows, boolean isnullBitsExists) {
+      int[] invertedIndex, BitSet nullBitset, BitSet deletedRows, boolean isnullBitsExists,
+      boolean isDictVector) {
     if ((invertedIndex != null && invertedIndex.length > 0) && (deletedRows == null || deletedRows
         .isEmpty())) {
       return new ColumnarVectorWrapperDirectWithInvertedIndex(columnVector, invertedIndex,
@@ -50,7 +51,7 @@ public final class ColumnarVectorWrapperDirectFactory {
     } else if ((invertedIndex != null && invertedIndex.length > 0) && (deletedRows != null
         && !deletedRows.isEmpty())) {
       return new ColumnarVectorWrapperDirectWithDeleteDeltaAndInvertedIndex(columnVector,
-          deletedRows, invertedIndex, nullBitset, isnullBitsExists);
+          deletedRows, invertedIndex, nullBitset, isnullBitsExists, isDictVector);
     } else {
       return columnVector;
     }

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/vector/impl/directread/ColumnarVectorWrapperDirectWithDeleteDeltaAndInvertedIndex.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/vector/impl/directread/ColumnarVectorWrapperDirectWithDeleteDeltaAndInvertedIndex.java
@@ -55,9 +55,9 @@ class ColumnarVectorWrapperDirectWithDeleteDeltaAndInvertedIndex
    */
   public ColumnarVectorWrapperDirectWithDeleteDeltaAndInvertedIndex(
       CarbonColumnVector vectorWrapper, BitSet deletedRows, int[] invertedIndex, BitSet nullBits,
-      boolean isnullBitsExists) {
-    super(new CarbonColumnVectorImpl(invertedIndex.length, vectorWrapper.getType()), invertedIndex,
-        isnullBitsExists);
+      boolean isnullBitsExists, boolean isDictVector) {
+    super(new CarbonColumnVectorImpl(invertedIndex.length,
+        isDictVector ? DataTypes.INT : vectorWrapper.getType()), invertedIndex, isnullBitsExists);
     this.deletedRows = deletedRows;
     this.carbonColumnVector = vectorWrapper;
     this.nullBits = nullBits;
@@ -82,7 +82,7 @@ class ColumnarVectorWrapperDirectWithDeleteDeltaAndInvertedIndex
   public void convert() {
     if (columnVector instanceof CarbonColumnVectorImpl) {
       CarbonColumnVectorImpl localVector = (CarbonColumnVectorImpl) columnVector;
-      DataType dataType = carbonColumnVector.getType();
+      DataType dataType = columnVector.getType();
       int length = invertedIndex.length;
       int counter = 0;
       if (dataType == DataTypes.BOOLEAN || dataType == DataTypes.BYTE) {

--- a/core/src/main/java/org/apache/carbondata/core/util/ByteUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/ByteUtil.java
@@ -734,7 +734,7 @@ public final class ByteUtil {
     return Float.intBitsToFloat(toXorInt(value, offset, length));
   }
 
-  public static int[] toIntArray(byte[] data, int size) {
+  public static int[] toIntArrayFrom3Bytes(byte[] data, int size) {
     int[] ints = new int[size];
     for (int i = 0; i < ints.length; i++) {
       ints[i] = ByteUtil.valueOf3Bytes(data, i * 3);

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/detailquery/CastColumnTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/detailquery/CastColumnTestCase.scala
@@ -224,7 +224,7 @@ class CastColumnTestCase extends QueryTest with BeforeAndAfterAll {
 
   test("Dictionary INT In to implicit Int") {
     checkAnswer(
-      sql("select empno,empname,workgroupcategory from DICTIONARY_CARBON_1 where workgroupcategory in (1, 2)"),
+      sql("select empno,empname,workgroupcategory from DICTIONARY_CARBON_1 where workgroupcategory in ('1', '2')"),
       sql("select empno,empname,workgroupcategory from DICTIONARY_HIVE_1 where workgroupcategory in ('1', '2')")
     )
   }

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
@@ -90,7 +90,7 @@ class CarbonScanRDD[T: ClassTag](
   }
   private var vectorReader = false
 
-  private var directScan = false
+  private var directFill = false
 
   private val bucketedTable = tableInfo.getFactTable.getBucketingInfo
 
@@ -230,7 +230,7 @@ class CarbonScanRDD[T: ClassTag](
       statistic.addStatistics(QueryStatisticsConstants.BLOCK_ALLOCATION, System.currentTimeMillis)
       statisticRecorder.recordStatisticsForDriver(statistic, queryId)
       statistic = new QueryStatistic()
-      val carbonDistribution = if (directScan) {
+      val carbonDistribution = if (directFill) {
         CarbonCommonConstants.CARBON_TASK_DISTRIBUTION_MERGE_FILES
       } else {
         CarbonProperties.getInstance().getProperty(
@@ -443,7 +443,7 @@ class CarbonScanRDD[T: ClassTag](
         case _ =>
           // create record reader for CarbonData file format
           if (vectorReader) {
-            model.setDirectVectorFill(directScan)
+            model.setDirectVectorFill(directFill)
             val carbonRecordReader = createVectorizedCarbonRecordReader(model,
               inputMetricsStats,
               "true")
@@ -757,6 +757,6 @@ class CarbonScanRDD[T: ClassTag](
 
   // TODO find the better way set it.
   def setDirectScanSupport(isDirectScan: Boolean): Unit = {
-    directScan = isDirectScan
+    directFill = isDirectScan
   }
 }

--- a/integration/spark-datasource/src/main/scala/org/apache/carbondata/spark/vectorreader/ColumnarVectorWrapper.java
+++ b/integration/spark-datasource/src/main/scala/org/apache/carbondata/spark/vectorreader/ColumnarVectorWrapper.java
@@ -173,7 +173,7 @@ class ColumnarVectorWrapper implements CarbonColumnVector {
 
   @Override public void putByteArray(int rowId, byte[] value) {
     if (!filteredRows[rowId]) {
-      sparkColumnVectorProxy.putByteArray(counter++, value);
+      sparkColumnVectorProxy.putByteArray(counter++, value, 0, value.length);
     }
   }
 

--- a/integration/spark-datasource/src/main/scala/org/apache/carbondata/spark/vectorreader/ColumnarVectorWrapperDirect.java
+++ b/integration/spark-datasource/src/main/scala/org/apache/carbondata/spark/vectorreader/ColumnarVectorWrapperDirect.java
@@ -115,7 +115,7 @@ class ColumnarVectorWrapperDirect implements CarbonColumnVector {
   }
 
   @Override public void putByteArray(int rowId, byte[] value) {
-    sparkColumnVectorProxy.putByteArray(rowId, value);
+    sparkColumnVectorProxy.putByteArray(rowId, value, 0, value.length);
   }
 
   @Override


### PR DESCRIPTION
### Problem:

Currently in 2.2/2.1 For Direct fill Lazy loading is not added because of this when data is huge and number of columns are high query is taking more time Lazy to execute.

### Solution
**Add Lazy loading for 2.2 and 2.1** 


Fixed Local Dictionary test case failure when it is enabled

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

