### PR TITLE
[CARBONDATA-3036] Cache Columns And Refresh Table Isuue Fix

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMap.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMap.java
@@ -116,7 +116,7 @@ public class BlockletDataMap extends BlockDataMap implements Serializable {
     String tempFilePath = null;
     DataMapRowImpl summaryRow = null;
     CarbonRowSchema[] schema = getFileFooterEntrySchema();
-    boolean[] summaryRowMinMaxFlag = new boolean[segmentProperties.getDimensions().size()];
+    boolean[] summaryRowMinMaxFlag = new boolean[segmentProperties.getColumnsValueSize().length];
     Arrays.fill(summaryRowMinMaxFlag, true);
     // Relative blocklet ID is the id assigned to a blocklet within a part file
     int relativeBlockletId = 0;
@@ -173,6 +173,9 @@ public class BlockletDataMap extends BlockDataMap implements Serializable {
       byte[][] maxValuesForColumnsToBeCached = BlockletDataMapUtil
           .getMinMaxForColumnsToBeCached(segmentProperties, minMaxCacheColumns,
               minMaxIndex.getMaxValues());
+      boolean[] minMaxFlagValuesForColumnsToBeCached = BlockletDataMapUtil
+          .getMinMaxFlagValuesForColumnsToBeCached(segmentProperties, minMaxCacheColumns,
+              fileFooter.getBlockletIndex().getMinMaxIndex().getIsMinMaxSet());
       row.setRow(addMinMax(schema[ordinal], minValuesForColumnsToBeCached), ordinal);
       // compute and set task level min values
       addTaskMinMaxValues(summaryRow, taskSummarySchema, taskMinMaxOrdinal,
@@ -201,9 +204,7 @@ public class BlockletDataMap extends BlockDataMap implements Serializable {
         // Store block size
         row.setLong(blockMetaInfo.getSize(), ordinal++);
         // add min max flag for all the dimension columns
-        addMinMaxFlagValues(row, schema[ordinal],
-            fileFooter.getBlockletIndex().getMinMaxIndex().getIsMinMaxSet(), ordinal,
-            segmentProperties.getDimensions().size());
+        addMinMaxFlagValues(row, schema[ordinal], minMaxFlagValuesForColumnsToBeCached, ordinal);
         ordinal++;
         // add blocklet info
         ByteArrayOutputStream stream = new ByteArrayOutputStream();

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/schema/SchemaGenerator.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/schema/SchemaGenerator.java
@@ -58,7 +58,7 @@ public class SchemaGenerator {
     indexSchemas.add(new CarbonRowSchema.FixedCarbonRowSchema(DataTypes.LONG));
     // for storing min max flag for each column which reflects whether min max for a column is
     // written in the metadata or not.
-    addMinMaxFlagSchema(indexSchemas, segmentProperties);
+    addMinMaxFlagSchema(segmentProperties, indexSchemas, minMaxCacheColumns);
     CarbonRowSchema[] schema = indexSchemas.toArray(new CarbonRowSchema[indexSchemas.size()]);
     return schema;
   }
@@ -90,7 +90,7 @@ public class SchemaGenerator {
     indexSchemas.add(new CarbonRowSchema.FixedCarbonRowSchema(DataTypes.LONG));
     // for storing min max flag for each column which reflects whether min max for a column is
     // written in the metadata or not.
-    addMinMaxFlagSchema(indexSchemas, segmentProperties);
+    addMinMaxFlagSchema(segmentProperties, indexSchemas, minMaxCacheColumns);
     //for blocklet info
     indexSchemas.add(new CarbonRowSchema.VariableCarbonRowSchema(DataTypes.BYTE_ARRAY));
     // for number of pages.
@@ -123,7 +123,7 @@ public class SchemaGenerator {
         .add(new CarbonRowSchema.VariableCarbonRowSchema(DataTypes.BYTE_ARRAY));
     // for storing min max flag for each column which reflects whether min max for a column is
     // written in the metadata or not.
-    addMinMaxFlagSchema(taskMinMaxSchemas, segmentProperties);
+    addMinMaxFlagSchema(segmentProperties, taskMinMaxSchemas, minMaxCacheColumns);
     // store path only in case of partition table or non transactional table
     if (filePathToBeStored) {
       // for storing file path
@@ -179,15 +179,18 @@ public class SchemaGenerator {
 
   /**
    * Method to add min max flag schema for all the dimensions
-   *
-   * @param indexSchemas
    * @param segmentProperties
+   * @param indexSchemas
+   * @param minMaxCacheColumns
    */
-  private static void addMinMaxFlagSchema(List<CarbonRowSchema> indexSchemas,
-      SegmentProperties segmentProperties) {
-    int totalDimensions = segmentProperties.getDimensions().size();
-    CarbonRowSchema[] minMaxFlagSchemas = new CarbonRowSchema[totalDimensions];
-    for (int i = 0; i < totalDimensions; i++) {
+  private static void addMinMaxFlagSchema(SegmentProperties segmentProperties,
+      List<CarbonRowSchema> indexSchemas, List<CarbonColumn> minMaxCacheColumns) {
+    int minMaxFlagLength = segmentProperties.getColumnsValueSize().length;
+    if (null != minMaxCacheColumns) {
+      minMaxFlagLength = minMaxCacheColumns.size();
+    }
+    CarbonRowSchema[] minMaxFlagSchemas = new CarbonRowSchema[minMaxFlagLength];
+    for (int i = 0; i < minMaxFlagLength; i++) {
       minMaxFlagSchemas[i] = new CarbonRowSchema.FixedCarbonRowSchema(DataTypes.BOOLEAN);
     }
     CarbonRowSchema structMinMaxFlagSchema =

--- a/core/src/main/java/org/apache/carbondata/core/util/BlockletDataMapUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/BlockletDataMapUtil.java
@@ -407,6 +407,29 @@ public class BlockletDataMapUtil {
   }
 
   /**
+   * Method to get the flag values for columns to be cached
+   *
+   * @param segmentProperties
+   * @param minMaxCacheColumns
+   * @param minMaxFlag
+   * @return
+   */
+  public static boolean[] getMinMaxFlagValuesForColumnsToBeCached(
+      SegmentProperties segmentProperties, List<CarbonColumn> minMaxCacheColumns,
+      boolean[] minMaxFlag) {
+    boolean[] minMaxFlagValuesForColumnsToBeCached = minMaxFlag;
+    if (null != minMaxCacheColumns) {
+      minMaxFlagValuesForColumnsToBeCached = new boolean[minMaxCacheColumns.size()];
+      int counter = 0;
+      for (CarbonColumn column : minMaxCacheColumns) {
+        minMaxFlagValuesForColumnsToBeCached[counter++] =
+            minMaxFlag[getColumnOrdinal(segmentProperties, column)];
+      }
+    }
+    return minMaxFlagValuesForColumnsToBeCached;
+  }
+
+  /**
    * compute the column ordinal as per data is stored
    *
    * @param segmentProperties

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/RefreshCarbonTableCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/RefreshCarbonTableCommand.scala
@@ -63,8 +63,8 @@ case class RefreshCarbonTableCommand(
     // then do the below steps
     // 2.2.1 validate that all the aggregate tables are copied at the store location.
     // 2.2.2 Register the aggregate tables
-    val tablePath = CarbonEnv.getTablePath(databaseNameOp, tableName)(sparkSession)
-    val identifier = AbsoluteTableIdentifier.from(tablePath, databaseName, tableName)
+    val tablePath = CarbonEnv.getTablePath(databaseNameOp, tableName.toLowerCase)(sparkSession)
+    val identifier = AbsoluteTableIdentifier.from(tablePath, databaseName, tableName.toLowerCase)
     // 2.1 check if the table already register with hive then ignore and continue with the next
     // schema
     if (!sparkSession.sessionState.catalog.listTables(databaseName)


### PR DESCRIPTION
Refresh Table Issue : Refresh Table command acting in case sensitive manner.
Cache Columns Issue : Results inconsistent when cache is set but min/max exceeds. Columns are dictionary excluded.

Fix 1 : Path for carbon file was been taken as whatever table name given in the query(Lowercase/Uppercase). Changed it to lowercase.
Fix 2 : MinMaxFlag array was not set according to the columns to be cached giving inconsistent results. Changed it according to the min/max values array for whatever columns given in Cache Columns only.

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [x] Testing done
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

