### PR TITLE
[CARBONDATA-3042] Column Schema objects are present in Driver and Executor even after dropping table

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/metadata/CarbonMetadata.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/CarbonMetadata.java
@@ -69,9 +69,8 @@ public final class CarbonMetadata {
 
   /**
    * Below method will be used to set the carbon table
-   * This method will be used in executor side as driver will always have
-   * updated table so from driver during query execution and data loading
-   * we just need to add the table
+   * Note: Use this method only in driver as clean up in Executor is not handled
+   *       if this table is added to executor
    *
    * @param carbonTable
    */

--- a/core/src/main/java/org/apache/carbondata/core/statusmanager/SegmentStatusManager.java
+++ b/core/src/main/java/org/apache/carbondata/core/statusmanager/SegmentStatusManager.java
@@ -1001,9 +1001,9 @@ public class SegmentStatusManager {
             CarbonLockUtil.fileUnlock(carbonTableStatusLock, LockUsage.TABLE_STATUS_LOCK);
           }
           if (updationCompletionStatus) {
-            DeleteLoadFolders.physicalFactAndMeasureMetadataDeletion(
-                identifier, carbonTable.getMetadataPath(),
-                newAddedLoadHistoryList, isForceDeletion, partitionSpecs);
+            DeleteLoadFolders
+                .physicalFactAndMeasureMetadataDeletion(carbonTable, newAddedLoadHistoryList,
+                    isForceDeletion, partitionSpecs);
           }
         }
       }

--- a/core/src/main/java/org/apache/carbondata/core/util/DeleteLoadFolders.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/DeleteLoadFolders.java
@@ -66,22 +66,19 @@ public final class DeleteLoadFolders {
     return CarbonTablePath.getSegmentPath(identifier.getTablePath(), segmentId);
   }
 
-  public static void physicalFactAndMeasureMetadataDeletion(
-      AbsoluteTableIdentifier absoluteTableIdentifier,
-      String metadataPath,
+  public static void physicalFactAndMeasureMetadataDeletion(CarbonTable carbonTable,
       LoadMetadataDetails[] newAddedLoadHistoryList,
       boolean isForceDelete,
       List<PartitionSpec> specs) {
-    LoadMetadataDetails[] currentDetails = SegmentStatusManager.readLoadMetadata(metadataPath);
-    physicalFactAndMeasureMetadataDeletion(
-        absoluteTableIdentifier,
+    LoadMetadataDetails[] currentDetails =
+        SegmentStatusManager.readLoadMetadata(carbonTable.getMetadataPath());
+    physicalFactAndMeasureMetadataDeletion(carbonTable,
         currentDetails,
         isForceDelete,
         specs,
         currentDetails);
     if (newAddedLoadHistoryList != null && newAddedLoadHistoryList.length > 0) {
-      physicalFactAndMeasureMetadataDeletion(
-          absoluteTableIdentifier,
+      physicalFactAndMeasureMetadataDeletion(carbonTable,
           newAddedLoadHistoryList,
           isForceDelete,
           specs,
@@ -91,17 +88,15 @@ public final class DeleteLoadFolders {
 
   /**
    * Delete the invalid data physically from table.
-   * @param absoluteTableIdentifier table identifier
+   * @param carbonTable table
    * @param loadDetails Load details which need clean up
    * @param isForceDelete is Force delete requested by user
    * @param specs Partition specs
    * @param currLoadDetails Current table status load details which are required for update manager.
    */
-  private static void physicalFactAndMeasureMetadataDeletion(
-      AbsoluteTableIdentifier absoluteTableIdentifier, LoadMetadataDetails[] loadDetails,
-      boolean isForceDelete, List<PartitionSpec> specs, LoadMetadataDetails[] currLoadDetails) {
-    CarbonTable carbonTable = DataMapStoreManager.getInstance().getCarbonTable(
-        absoluteTableIdentifier);
+  private static void physicalFactAndMeasureMetadataDeletion(CarbonTable carbonTable,
+      LoadMetadataDetails[] loadDetails, boolean isForceDelete, List<PartitionSpec> specs,
+      LoadMetadataDetails[] currLoadDetails) {
     List<TableDataMap> indexDataMaps = new ArrayList<>();
     try {
       for (TableDataMap dataMap : DataMapStoreManager.getInstance().getAllDataMap(carbonTable)) {
@@ -112,7 +107,8 @@ public final class DeleteLoadFolders {
     } catch (IOException e) {
       LOGGER.warn(String.format(
           "Failed to get datamaps for %s.%s, therefore the datamap files could not be cleaned.",
-          absoluteTableIdentifier.getDatabaseName(), absoluteTableIdentifier.getTableName()));
+          carbonTable.getAbsoluteTableIdentifier().getDatabaseName(),
+          carbonTable.getAbsoluteTableIdentifier().getTableName()));
     }
     SegmentUpdateStatusManager updateStatusManager =
         new SegmentUpdateStatusManager(carbonTable, currLoadDetails);
@@ -120,12 +116,11 @@ public final class DeleteLoadFolders {
       if (checkIfLoadCanBeDeletedPhysically(oneLoad, isForceDelete)) {
         try {
           if (oneLoad.getSegmentFile() != null) {
-            SegmentFileStore.deleteSegment(
-                absoluteTableIdentifier.getTablePath(),
+            SegmentFileStore.deleteSegment(carbonTable.getAbsoluteTableIdentifier().getTablePath(),
                 new Segment(oneLoad.getLoadName(), oneLoad.getSegmentFile()),
                 specs, updateStatusManager);
           } else {
-            String path = getSegmentPath(absoluteTableIdentifier, oneLoad);
+            String path = getSegmentPath(carbonTable.getAbsoluteTableIdentifier(), oneLoad);
             boolean status = false;
             if (FileFactory.isFileExist(path, FileFactory.getFileType(path))) {
               CarbonFile file = FileFactory.getCarbonFile(path, FileFactory.getFileType(path));

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/AlterTableLoadPartitionRDD.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/AlterTableLoadPartitionRDD.scala
@@ -62,13 +62,11 @@ class AlterTableLoadPartitionRDD[K, V](alterPartitionModel: AlterPartitionModel,
       val partitionId: Int = partitionInfo.getPartitionId(split.index)
       carbonLoadModel.setTaskNo(String.valueOf(partitionId))
       carbonLoadModel.setSegmentId(segmentId)
-      CarbonMetadata.getInstance().addCarbonTable(
-        carbonLoadModel.getCarbonDataLoadSchema.getCarbonTable)
 
       CommonUtil.setTempStoreLocation(split.index, carbonLoadModel,
         isCompactionFlow = false, isAltPartitionFlow = true)
       val tempStoreLoc: Array[String] = CarbonDataProcessorUtil.getLocalDataFolderLocation(
-        databaseName, factTableName, carbonLoadModel.getTaskNo, segmentId, false, true)
+        carbonTable, carbonLoadModel.getTaskNo, segmentId, false, true)
 
       val loadStatus: Boolean = if (rows.isEmpty) {
         LOGGER.info("After repartition this split, NO target rows to write back.")

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonMergerRDD.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonMergerRDD.scala
@@ -86,7 +86,6 @@ class CarbonMergerRDD[K, V](
     val LOGGER = LogServiceFactory.getLogService(this.getClass.getName)
     val iter = new Iterator[(K, V)] {
       val carbonTable = carbonLoadModel.getCarbonDataLoadSchema.getCarbonTable
-      CarbonMetadata.getInstance().addCarbonTable(carbonTable)
       val carbonSparkPartition = theSplit.asInstanceOf[CarbonSparkPartition]
       if (carbonTable.isPartitionTable) {
         carbonLoadModel.setTaskNo(String.valueOf(carbonSparkPartition.partitionId))
@@ -198,7 +197,7 @@ class CarbonMergerRDD[K, V](
         }
 
         val tempStoreLoc = CarbonDataProcessorUtil.getLocalDataFolderLocation(
-          databaseName, factTableName, carbonLoadModel.getTaskNo, mergeNumber, true, false)
+          carbonTable, carbonLoadModel.getTaskNo, mergeNumber, true, false)
 
         if (restructuredBlockExists) {
           LOGGER.info("CompactionResultSortProcessor flow is selected")

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/StreamHandoffRDD.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/StreamHandoffRDD.scala
@@ -117,7 +117,6 @@ class StreamHandoffRDD[K, V](
     carbonLoadModel.setTaskNo("" + split.index)
     val carbonTable = carbonLoadModel.getCarbonDataLoadSchema.getCarbonTable
     DataTypeUtil.setDataTypeConverter(new SparkDataTypeConverterImpl)
-    CarbonMetadata.getInstance().addCarbonTable(carbonTable)
     // the input iterator is using raw row
     val iteratorList = prepareInputIterator(split, carbonTable)
 

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonDictionaryDecoder.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonDictionaryDecoder.scala
@@ -279,11 +279,6 @@ case class CarbonDictionaryDecoder(
               if (null != carbonDimension.getColumnSchema.getParentColumnTableRelations &&
                   !carbonDimension
                     .getColumnSchema.getParentColumnTableRelations.isEmpty) {
-                val parentRelationIdentifier = carbonDimension.getColumnSchema
-                  .getParentColumnTableRelations.get(0).getRelationIdentifier
-                val parentTablePath = CarbonMetadata.getInstance()
-                  .getCarbonTable(parentRelationIdentifier.getDatabaseName,
-                    parentRelationIdentifier.getTableName).getTablePath
                 (QueryUtil
                   .getTableIdentifierForColumn(carbonDimension),
                   new ColumnIdentifier(carbonDimension.getColumnSchema

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonFileMetastore.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonFileMetastore.scala
@@ -491,7 +491,6 @@ class CarbonFileMetastore extends CarbonMetaStore {
       // in the other beeline need to update.
       checkSchemasModifiedTimeAndReloadTable(TableIdentifier(tableName, Some(dbName)))
 
-      removeTableFromMetadata(dbName, tableName)
       CarbonHiveMetadataUtil.invalidateAndDropTable(dbName, tableName, sparkSession)
       updateSchemasUpdatedTime(touchSchemaFileSystemTime())
       // discard cached table info in cachedDataSourceTables
@@ -499,6 +498,7 @@ class CarbonFileMetastore extends CarbonMetaStore {
       sparkSession.sessionState.catalog.refreshTable(tableIdentifier)
       DataMapStoreManager.getInstance().clearDataMaps(absoluteTableIdentifier)
       SegmentPropertiesAndSchemaHolder.getInstance().invalidate(absoluteTableIdentifier)
+      removeTableFromMetadata(dbName, tableName)
     } else {
       if (!isTransactionalCarbonTable(absoluteTableIdentifier)) {
         removeTableFromMetadata(dbName, tableName)
@@ -508,6 +508,7 @@ class CarbonFileMetastore extends CarbonMetaStore {
         sparkSession.sessionState.catalog.refreshTable(tableIdentifier)
         DataMapStoreManager.getInstance().clearDataMaps(absoluteTableIdentifier)
         SegmentPropertiesAndSchemaHolder.getInstance().invalidate(absoluteTableIdentifier)
+        removeTableFromMetadata(dbName, tableName)
       }
     }
   }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonHiveMetaStore.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonHiveMetaStore.scala
@@ -79,13 +79,13 @@ class CarbonHiveMetaStore extends CarbonFileMetastore {
       ManageDictionaryAndBTree.clearBTreeAndDictionaryLRUCache(carbonTable)
     }
     checkSchemasModifiedTimeAndReloadTable(TableIdentifier(tableName, Some(dbName)))
-    removeTableFromMetadata(dbName, tableName)
     CarbonHiveMetadataUtil.invalidateAndDropTable(dbName, tableName, sparkSession)
     // discard cached table info in cachedDataSourceTables
     val tableIdentifier = TableIdentifier(tableName, Option(dbName))
     sparkSession.sessionState.catalog.refreshTable(tableIdentifier)
     DataMapStoreManager.getInstance().clearDataMaps(absoluteTableIdentifier)
     SegmentPropertiesAndSchemaHolder.getInstance().invalidate(absoluteTableIdentifier)
+    removeTableFromMetadata(dbName, tableName)
   }
 
   override def checkSchemasModifiedTimeAndReloadTable(tableIdentifier: TableIdentifier): Boolean = {

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/DataLoadProcessBuilder.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/DataLoadProcessBuilder.java
@@ -27,7 +27,6 @@ import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.constants.CarbonLoadOptionConstants;
 import org.apache.carbondata.core.datastore.TableSpec;
 import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
-import org.apache.carbondata.core.metadata.CarbonMetadata;
 import org.apache.carbondata.core.metadata.datatype.DataTypes;
 import org.apache.carbondata.core.metadata.schema.SortColumnRangeInfo;
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
@@ -249,7 +248,6 @@ public final class DataLoadProcessBuilder {
     configuration.setDataLoadProperty(CarbonLoadOptionConstants.CARBON_OPTIONS_BAD_RECORD_PATH,
         loadModel.getBadRecordsLocation());
 
-    CarbonMetadata.getInstance().addCarbonTable(carbonTable);
     List<CarbonDimension> dimensions =
         carbonTable.getDimensionByTableName(carbonTable.getTableName());
     List<CarbonMeasure> measures =

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/sort/impl/ParallelReadMergeSorterImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/sort/impl/ParallelReadMergeSorterImpl.java
@@ -71,11 +71,10 @@ public class ParallelReadMergeSorterImpl extends AbstractMergeSorter {
   public void initialize(SortParameters sortParameters) {
     this.sortParameters = sortParameters;
     intermediateFileMerger = new SortIntermediateFileMerger(sortParameters);
-    String[] storeLocations =
-        CarbonDataProcessorUtil.getLocalDataFolderLocation(
-            sortParameters.getDatabaseName(), sortParameters.getTableName(),
-            String.valueOf(sortParameters.getTaskNo()), sortParameters.getSegmentId(),
-            false, false);
+    String[] storeLocations = CarbonDataProcessorUtil
+        .getLocalDataFolderLocation(sortParameters.getCarbonTable(),
+            String.valueOf(sortParameters.getTaskNo()), sortParameters.getSegmentId(), false,
+            false);
     // Set the data file location
     String[] dataFolderLocations = CarbonDataProcessorUtil.arrayAppend(storeLocations,
         File.separator, CarbonCommonConstants.SORT_TEMP_FILE_LOCATION);

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/sort/impl/ParallelReadMergeSorterWithColumnRangeImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/sort/impl/ParallelReadMergeSorterWithColumnRangeImpl.java
@@ -148,7 +148,7 @@ public class ParallelReadMergeSorterWithColumnRangeImpl extends AbstractMergeSor
 
   private SingleThreadFinalSortFilesMerger getFinalMerger(SortParameters sortParameters) {
     String[] storeLocation = CarbonDataProcessorUtil
-        .getLocalDataFolderLocation(sortParameters.getDatabaseName(), sortParameters.getTableName(),
+        .getLocalDataFolderLocation(sortParameters.getCarbonTable(),
             String.valueOf(sortParameters.getTaskNo()),
             sortParameters.getSegmentId() + "", false, false);
     // Set the data file location
@@ -188,9 +188,9 @@ public class ParallelReadMergeSorterWithColumnRangeImpl extends AbstractMergeSor
 
   private void setTempLocation(SortParameters parameters) {
     String[] carbonDataDirectoryPath = CarbonDataProcessorUtil
-        .getLocalDataFolderLocation(parameters.getDatabaseName(),
-            parameters.getTableName(), parameters.getTaskNo(),
-            parameters.getSegmentId(), false, false);
+        .getLocalDataFolderLocation(parameters.getCarbonTable(), parameters.getTaskNo(),
+            parameters.getSegmentId(),
+            false, false);
     String[] tmpLocs = CarbonDataProcessorUtil.arrayAppend(carbonDataDirectoryPath, File.separator,
         CarbonCommonConstants.SORT_TEMP_FILE_LOCATION);
     parameters.setTempFileLocation(tmpLocs);

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/sort/impl/UnsafeBatchParallelReadMergeSorterImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/sort/impl/UnsafeBatchParallelReadMergeSorterImpl.java
@@ -232,9 +232,9 @@ public class UnsafeBatchParallelReadMergeSorterImpl extends AbstractMergeSorter 
     }
 
     private void setTempLocation(SortParameters parameters) {
-      String[] carbonDataDirectoryPath = CarbonDataProcessorUtil.getLocalDataFolderLocation(
-          parameters.getDatabaseName(), parameters.getTableName(), parameters.getTaskNo(),
-          parameters.getSegmentId(), false, false);
+      String[] carbonDataDirectoryPath = CarbonDataProcessorUtil
+          .getLocalDataFolderLocation(parameters.getCarbonTable(), parameters.getTaskNo(),
+              parameters.getSegmentId(), false, false);
       String[] tempDirs = CarbonDataProcessorUtil.arrayAppend(carbonDataDirectoryPath,
           File.separator, CarbonCommonConstants.SORT_TEMP_FILE_LOCATION);
       parameters.setTempFileLocation(tempDirs);

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/sort/impl/UnsafeParallelReadMergeSorterWithColumnRangeImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/sort/impl/UnsafeParallelReadMergeSorterWithColumnRangeImpl.java
@@ -143,9 +143,9 @@ public class UnsafeParallelReadMergeSorterWithColumnRangeImpl extends AbstractMe
 
   private UnsafeSingleThreadFinalSortFilesMerger getFinalMerger(SortParameters sortParameters) {
     String[] storeLocation = CarbonDataProcessorUtil
-        .getLocalDataFolderLocation(sortParameters.getDatabaseName(), sortParameters.getTableName(),
-            String.valueOf(sortParameters.getTaskNo()),
-            sortParameters.getSegmentId() + "", false, false);
+        .getLocalDataFolderLocation(sortParameters.getCarbonTable(),
+            String.valueOf(sortParameters.getTaskNo()), sortParameters.getSegmentId() + "", false,
+            false);
     // Set the data file location
     String[] dataFolderLocation = CarbonDataProcessorUtil.arrayAppend(storeLocation,
         File.separator, CarbonCommonConstants.SORT_TEMP_FILE_LOCATION);
@@ -182,9 +182,8 @@ public class UnsafeParallelReadMergeSorterWithColumnRangeImpl extends AbstractMe
 
   private void setTempLocation(SortParameters parameters) {
     String[] carbonDataDirectoryPath = CarbonDataProcessorUtil
-        .getLocalDataFolderLocation(parameters.getDatabaseName(), parameters.getTableName(),
-            parameters.getTaskNo(), parameters.getSegmentId(),
-            false, false);
+        .getLocalDataFolderLocation(parameters.getCarbonTable(), parameters.getTaskNo(),
+            parameters.getSegmentId(), false, false);
     String[] tmpLoc = CarbonDataProcessorUtil.arrayAppend(carbonDataDirectoryPath, File.separator,
         CarbonCommonConstants.SORT_TEMP_FILE_LOCATION);
     LOGGER.warn("set temp location: " + StringUtils.join(tmpLoc, ", "));

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/steps/CarbonRowDataWriterProcessorStepImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/steps/CarbonRowDataWriterProcessorStepImpl.java
@@ -100,13 +100,10 @@ public class CarbonRowDataWriterProcessorStepImpl extends AbstractDataLoadProces
     child.initialize();
   }
 
-  private String[] getStoreLocation(CarbonTableIdentifier tableIdentifier) {
-    String[] storeLocation = CarbonDataProcessorUtil.getLocalDataFolderLocation(
-        tableIdentifier.getDatabaseName(),
-        tableIdentifier.getTableName(),
-        String.valueOf(configuration.getTaskNo()), configuration.getSegmentId(),
-        false,
-        false);
+  private String[] getStoreLocation() {
+    String[] storeLocation = CarbonDataProcessorUtil
+        .getLocalDataFolderLocation(this.configuration.getTableSpec().getCarbonTable(),
+            String.valueOf(configuration.getTaskNo()), configuration.getSegmentId(), false, false);
     CarbonDataProcessorUtil.createLocations(storeLocation);
     return storeLocation;
   }
@@ -161,7 +158,7 @@ public class CarbonRowDataWriterProcessorStepImpl extends AbstractDataLoadProces
   }
 
   private void doExecute(Iterator<CarbonRowBatch> iterator, int iteratorIndex) throws IOException {
-    String[] storeLocation = getStoreLocation(tableIdentifier);
+    String[] storeLocation = getStoreLocation();
     DataMapWriterListener listener = getDataMapWriterListener(0);
     CarbonFactDataHandlerModel model = CarbonFactDataHandlerModel.createCarbonFactDataHandlerModel(
         configuration, storeLocation, 0, iteratorIndex, listener);

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/steps/DataConverterProcessorStepImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/steps/DataConverterProcessorStepImpl.java
@@ -136,15 +136,13 @@ public class DataConverterProcessorStepImpl extends AbstractDataLoadProcessorSte
     Arrays.sort(convertedSortColumnRanges,
         new RawRowComparator(sortColumnRangeInfo.getSortColumnIndex(),
             sortColumnRangeInfo.getIsSortColumnNoDict(), CarbonDataProcessorUtil
-            .getNoDictDataTypes(configuration.getTableIdentifier().getDatabaseName(),
-                configuration.getTableIdentifier().getTableName())));
+            .getNoDictDataTypes(configuration.getTableSpec().getCarbonTable())));
 
     // range partitioner to dispatch rows by sort columns
     this.partitioner = new RangePartitionerImpl(convertedSortColumnRanges,
         new RawRowComparator(sortColumnRangeInfo.getSortColumnIndex(),
             sortColumnRangeInfo.getIsSortColumnNoDict(), CarbonDataProcessorUtil
-            .getNoDictDataTypes(configuration.getTableIdentifier().getDatabaseName(),
-                configuration.getTableIdentifier().getTableName())));
+            .getNoDictDataTypes(configuration.getTableSpec().getCarbonTable())));
   }
 
   // only convert sort column fields

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/steps/DataWriterBatchProcessorStepImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/steps/DataWriterBatchProcessorStepImpl.java
@@ -67,11 +67,10 @@ public class DataWriterBatchProcessorStepImpl extends AbstractDataLoadProcessorS
     child.initialize();
   }
 
-  private String[] getStoreLocation(CarbonTableIdentifier tableIdentifier) {
-    return CarbonDataProcessorUtil.getLocalDataFolderLocation(
-        tableIdentifier.getDatabaseName(), tableIdentifier.getTableName(),
-        String.valueOf(configuration.getTaskNo()),
-        configuration.getSegmentId(), false, false);
+  private String[] getStoreLocation() {
+    return CarbonDataProcessorUtil
+        .getLocalDataFolderLocation(configuration.getTableSpec().getCarbonTable(),
+            String.valueOf(configuration.getTaskNo()), configuration.getSegmentId(), false, false);
   }
 
   @Override public Iterator<CarbonRowBatch>[] execute() throws CarbonDataLoadingException {
@@ -84,7 +83,7 @@ public class DataWriterBatchProcessorStepImpl extends AbstractDataLoadProcessorS
           .recordDictionaryValue2MdkAdd2FileTime(CarbonTablePath.DEPRECATED_PATITION_ID,
               System.currentTimeMillis());
       int i = 0;
-      String[] storeLocation = getStoreLocation(tableIdentifier);
+      String[] storeLocation = getStoreLocation();
       CarbonDataProcessorUtil.createLocations(storeLocation);
       for (Iterator<CarbonRowBatch> iterator : iterators) {
         int k = 0;

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/steps/DataWriterProcessorStepImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/steps/DataWriterProcessorStepImpl.java
@@ -89,19 +89,16 @@ public class DataWriterProcessorStepImpl extends AbstractDataLoadProcessorStep {
     this.carbonFactHandlers = new CopyOnWriteArrayList<>();
   }
 
-  private String[] getStoreLocation(CarbonTableIdentifier tableIdentifier) {
+  private String[] getStoreLocation() {
     String[] storeLocation = CarbonDataProcessorUtil
-        .getLocalDataFolderLocation(tableIdentifier.getDatabaseName(),
-            tableIdentifier.getTableName(), String.valueOf(configuration.getTaskNo()),
-            configuration.getSegmentId(), false, false);
+        .getLocalDataFolderLocation(configuration.getTableSpec().getCarbonTable(),
+            String.valueOf(configuration.getTaskNo()), configuration.getSegmentId(), false, false);
     CarbonDataProcessorUtil.createLocations(storeLocation);
     return storeLocation;
   }
 
   public CarbonFactDataHandlerModel getDataHandlerModel() {
-    CarbonTableIdentifier tableIdentifier =
-        configuration.getTableIdentifier().getCarbonTableIdentifier();
-    String[] storeLocation = getStoreLocation(tableIdentifier);
+    String[] storeLocation = getStoreLocation();
     listener = getDataMapWriterListener(0);
     CarbonFactDataHandlerModel carbonFactDataHandlerModel = CarbonFactDataHandlerModel
         .createCarbonFactDataHandlerModel(configuration, storeLocation, 0, 0, listener);
@@ -170,14 +167,13 @@ public class DataWriterProcessorStepImpl extends AbstractDataLoadProcessorStep {
     @Override public Void call() throws Exception {
       LOGGER.info("Process writer forward for table " + tableIdentifier.getTableName()
           + ", range: " + rangeId);
-      processRange(insideRangeIterator, tableIdentifier, rangeId);
+      processRange(insideRangeIterator, rangeId);
       return null;
     }
   }
 
-  private void processRange(Iterator<CarbonRowBatch> insideRangeIterator,
-      CarbonTableIdentifier tableIdentifier, int rangeId) {
-    String[] storeLocation = getStoreLocation(tableIdentifier);
+  private void processRange(Iterator<CarbonRowBatch> insideRangeIterator, int rangeId) {
+    String[] storeLocation = getStoreLocation();
 
     listener = getDataMapWriterListener(rangeId);
     CarbonFactDataHandlerModel model = CarbonFactDataHandlerModel

--- a/processing/src/main/java/org/apache/carbondata/processing/merger/CompactionResultSortProcessor.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/merger/CompactionResultSortProcessor.java
@@ -463,7 +463,7 @@ public class CompactionResultSortProcessor extends AbstractResultProcessor {
    */
   private void initializeFinalThreadMergerForMergeSort() {
     boolean[] noDictionarySortColumnMapping = CarbonDataProcessorUtil
-        .getNoDictSortColMapping(carbonTable.getDatabaseName(), carbonTable.getTableName());
+        .getNoDictSortColMapping(carbonTable);
     sortParameters.setNoDictionarySortColumn(noDictionarySortColumnMapping);
     String[] sortTempFileLocation = CarbonDataProcessorUtil.arrayAppend(tempStoreLocation,
         CarbonCommonConstants.FILE_SEPARATOR, CarbonCommonConstants.SORT_TEMP_FILE_LOCATION);
@@ -482,7 +482,7 @@ public class CompactionResultSortProcessor extends AbstractResultProcessor {
               + carbonLoadModel.getFactTimeStamp() + ".tmp";
     } else {
       carbonStoreLocation = CarbonDataProcessorUtil
-          .createCarbonStoreLocation(carbonLoadModel.getDatabaseName(), tableName,
+          .createCarbonStoreLocation(carbonLoadModel.getCarbonDataLoadSchema().getCarbonTable(),
               carbonLoadModel.getSegmentId());
     }
     CarbonFactDataHandlerModel carbonFactDataHandlerModel = CarbonFactDataHandlerModel

--- a/processing/src/main/java/org/apache/carbondata/processing/merger/RowResultMergerProcessor.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/merger/RowResultMergerProcessor.java
@@ -81,8 +81,9 @@ public class RowResultMergerProcessor extends AbstractResultProcessor {
           partitionSpec.getLocation().toString() + CarbonCommonConstants.FILE_SEPARATOR + loadModel
               .getFactTimeStamp() + ".tmp";
     } else {
-      carbonStoreLocation = CarbonDataProcessorUtil.createCarbonStoreLocation(
-          loadModel.getDatabaseName(), tableName, loadModel.getSegmentId());
+      carbonStoreLocation = CarbonDataProcessorUtil
+          .createCarbonStoreLocation(loadModel.getCarbonDataLoadSchema().getCarbonTable(),
+              loadModel.getSegmentId());
     }
     CarbonFactDataHandlerModel carbonFactDataHandlerModel = CarbonFactDataHandlerModel
         .getCarbonFactDataHandlerModel(loadModel, carbonTable, segProp, tableName,

--- a/processing/src/main/java/org/apache/carbondata/processing/partition/spliter/RowResultProcessor.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/partition/spliter/RowResultProcessor.java
@@ -50,8 +50,9 @@ public class RowResultProcessor {
     CarbonDataProcessorUtil.createLocations(tempStoreLocation);
     this.segmentProperties = segProp;
     String tableName = carbonTable.getTableName();
-    String carbonStoreLocation = CarbonDataProcessorUtil.createCarbonStoreLocation(
-        loadModel.getDatabaseName(), tableName, loadModel.getSegmentId());
+    String carbonStoreLocation = CarbonDataProcessorUtil
+        .createCarbonStoreLocation(loadModel.getCarbonDataLoadSchema().getCarbonTable(),
+            loadModel.getSegmentId());
     CarbonFactDataHandlerModel carbonFactDataHandlerModel =
         CarbonFactDataHandlerModel.getCarbonFactDataHandlerModel(loadModel, carbonTable,
             segProp, tableName, tempStoreLocation, carbonStoreLocation);

--- a/processing/src/main/java/org/apache/carbondata/processing/store/CarbonFactDataHandlerModel.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/CarbonFactDataHandlerModel.java
@@ -30,7 +30,6 @@ import org.apache.carbondata.core.datastore.block.SegmentProperties;
 import org.apache.carbondata.core.keygenerator.KeyGenerator;
 import org.apache.carbondata.core.localdictionary.generator.LocalDictionaryGenerator;
 import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
-import org.apache.carbondata.core.metadata.CarbonMetadata;
 import org.apache.carbondata.core.metadata.CarbonTableIdentifier;
 import org.apache.carbondata.core.metadata.datatype.DataType;
 import org.apache.carbondata.core.metadata.datatype.DataTypes;
@@ -205,8 +204,7 @@ public class CarbonFactDataHandlerModel {
         }
       }
     }
-    CarbonTable carbonTable = CarbonMetadata.getInstance().getCarbonTable(
-        identifier.getDatabaseName(), identifier.getTableName());
+    CarbonTable carbonTable = configuration.getTableSpec().getCarbonTable();
 
     List<ColumnSchema> wrapperColumnSchema = CarbonUtil
         .getColumnSchemaList(carbonTable.getDimensionByTableName(identifier.getTableName()),

--- a/processing/src/main/java/org/apache/carbondata/processing/util/CarbonDataProcessorUtil.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/util/CarbonDataProcessorUtil.java
@@ -33,7 +33,6 @@ import org.apache.carbondata.common.CarbonIterator;
 import org.apache.carbondata.common.constants.LoggerAction;
 import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
-import org.apache.carbondata.core.metadata.CarbonMetadata;
 import org.apache.carbondata.core.metadata.datatype.DataType;
 import org.apache.carbondata.core.metadata.datatype.DataTypes;
 import org.apache.carbondata.core.metadata.encoder.Encoding;
@@ -135,25 +134,6 @@ public final class CarbonDataProcessorUtil {
       localDataFolderLocArray[i] = carbonDataDirectoryPath + File.separator + taskId;
     }
     return localDataFolderLocArray;
-  }
-
-  /**
-   * This method will form the local data folder store location
-   *
-   * @param databaseName
-   * @param tableName
-   * @param taskId
-   * @param segmentId
-   * @param isCompactionFlow
-   * @param isAltPartitionFlow
-   * @return
-   */
-  public static String[] getLocalDataFolderLocation(String databaseName, String tableName,
-      String taskId, String segmentId, boolean isCompactionFlow,
-      boolean isAltPartitionFlow) {
-    CarbonTable carbonTable = CarbonMetadata.getInstance().getCarbonTable(databaseName, tableName);
-    return getLocalDataFolderLocation(carbonTable, taskId,
-        segmentId, isCompactionFlow, isAltPartitionFlow);
   }
 
   /**
@@ -413,14 +393,12 @@ public final class CarbonDataProcessorUtil {
     return columnNames;
   }
 
-  public static DataType[] getMeasureDataType(int measureCount, String databaseName,
-      String tableName) {
+  public static DataType[] getMeasureDataType(int measureCount, CarbonTable carbonTable) {
     DataType[] type = new DataType[measureCount];
     for (int i = 0; i < type.length; i++) {
       type[i] = DataTypes.DOUBLE;
     }
-    CarbonTable carbonTable = CarbonMetadata.getInstance().getCarbonTable(databaseName, tableName);
-    List<CarbonMeasure> measures = carbonTable.getMeasureByTableName(tableName);
+    List<CarbonMeasure> measures = carbonTable.getMeasureByTableName(carbonTable.getTableName());
     for (int i = 0; i < type.length; i++) {
       type[i] = measures.get(i).getDataType();
     }
@@ -430,13 +408,12 @@ public final class CarbonDataProcessorUtil {
   /**
    * Get the no dictionary data types on the table
    *
-   * @param databaseName
-   * @param tableName
+   * @param carbonTable
    * @return
    */
-  public static DataType[] getNoDictDataTypes(String databaseName, String tableName) {
-    CarbonTable carbonTable = CarbonMetadata.getInstance().getCarbonTable(databaseName, tableName);
-    List<CarbonDimension> dimensions = carbonTable.getDimensionByTableName(tableName);
+  public static DataType[] getNoDictDataTypes(CarbonTable carbonTable) {
+    List<CarbonDimension> dimensions =
+        carbonTable.getDimensionByTableName(carbonTable.getTableName());
     List<DataType> type = new ArrayList<>();
     for (int i = 0; i < dimensions.size(); i++) {
       if (dimensions.get(i).isSortColumn() && !dimensions.get(i).hasEncoding(Encoding.DICTIONARY)) {
@@ -449,13 +426,12 @@ public final class CarbonDataProcessorUtil {
   /**
    * Get the no dictionary sort column mapping of the table
    *
-   * @param databaseName
-   * @param tableName
+   * @param carbonTable
    * @return
    */
-  public static boolean[] getNoDictSortColMapping(String databaseName, String tableName) {
-    CarbonTable carbonTable = CarbonMetadata.getInstance().getCarbonTable(databaseName, tableName);
-    List<CarbonDimension> dimensions = carbonTable.getDimensionByTableName(tableName);
+  public static boolean[] getNoDictSortColMapping(CarbonTable carbonTable) {
+    List<CarbonDimension> dimensions =
+        carbonTable.getDimensionByTableName(carbonTable.getTableName());
     List<Boolean> noDicSortColMap = new ArrayList<>();
     for (int i = 0; i < dimensions.size(); i++) {
       if (dimensions.get(i).isSortColumn()) {
@@ -477,14 +453,12 @@ public final class CarbonDataProcessorUtil {
   /**
    * Get the data types of the no dictionary sort columns
    *
-   * @param databaseName
-   * @param tableName
+   * @param carbonTable
    * @return
    */
-  public static Map<String, DataType[]> getNoDictSortAndNoSortDataTypes(String databaseName,
-      String tableName) {
-    CarbonTable carbonTable = CarbonMetadata.getInstance().getCarbonTable(databaseName, tableName);
-    List<CarbonDimension> dimensions = carbonTable.getDimensionByTableName(tableName);
+  public static Map<String, DataType[]> getNoDictSortAndNoSortDataTypes(CarbonTable carbonTable) {
+    List<CarbonDimension> dimensions =
+        carbonTable.getDimensionByTableName(carbonTable.getTableName());
     List<DataType> noDictSortType = new ArrayList<>();
     List<DataType> noDictNoSortType = new ArrayList<>();
     for (int i = 0; i < dimensions.size(); i++) {
@@ -509,9 +483,7 @@ public final class CarbonDataProcessorUtil {
    *
    * @return data directory path
    */
-  public static String createCarbonStoreLocation(String databaseName, String tableName,
-      String segmentId) {
-    CarbonTable carbonTable = CarbonMetadata.getInstance().getCarbonTable(databaseName, tableName);
+  public static String createCarbonStoreLocation(CarbonTable carbonTable, String segmentId) {
     return CarbonTablePath.getSegmentPath(carbonTable.getTablePath(), segmentId);
   }
 


### PR DESCRIPTION
**Problem:**
Column Schema objects are present in Driver and Executor even after dropping table.

**Solution:**
In Driver:
After dropping table, remove entry of tableInfo from CarbonMetaDataInstance.
In Executor:
Remove usage of CarbonMetaDataInstance object and instead pass CarbonTable Object itself

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

