### PR TITLE
[HOTFIX] Fixed data loading failure with safe column page

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -766,7 +766,7 @@ public final class CarbonCommonConstants {
   /**
    * default value of ENABLE_UNSAFE_COLUMN_PAGE
    */
-  public static final String ENABLE_UNSAFE_COLUMN_PAGE_DEFAULT = "false";
+  public static final String ENABLE_UNSAFE_COLUMN_PAGE_DEFAULT = "true";
 
   /**
    * to enable offheap sort

--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -766,7 +766,7 @@ public final class CarbonCommonConstants {
   /**
    * default value of ENABLE_UNSAFE_COLUMN_PAGE
    */
-  public static final String ENABLE_UNSAFE_COLUMN_PAGE_DEFAULT = "true";
+  public static final String ENABLE_UNSAFE_COLUMN_PAGE_DEFAULT = "false";
 
   /**
    * to enable offheap sort

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/SafeFixLengthColumnPage.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/SafeFixLengthColumnPage.java
@@ -41,6 +41,7 @@ public class SafeFixLengthColumnPage extends ColumnPage {
   private double[] doubleData;
   private byte[] shortIntData;
   private byte[][] fixedLengthdata;
+  private int totalLength;
 
   // total number of entries in array
   private int arrayElementCount = 0;
@@ -57,6 +58,7 @@ public class SafeFixLengthColumnPage extends ColumnPage {
     ensureArraySize(rowId, DataTypes.BYTE);
     byteData[rowId] = value;
     arrayElementCount++;
+    totalLength += DataTypes.BYTE.getSizeInBytes();
   }
 
   /**
@@ -67,6 +69,7 @@ public class SafeFixLengthColumnPage extends ColumnPage {
     ensureArraySize(rowId, DataTypes.SHORT);
     shortData[rowId] = value;
     arrayElementCount++;
+    totalLength += DataTypes.SHORT.getSizeInBytes();
   }
 
   /**
@@ -77,6 +80,7 @@ public class SafeFixLengthColumnPage extends ColumnPage {
     ensureArraySize(rowId, DataTypes.INT);
     intData[rowId] = value;
     arrayElementCount++;
+    totalLength += DataTypes.INT.getSizeInBytes();
   }
 
   /**
@@ -87,6 +91,7 @@ public class SafeFixLengthColumnPage extends ColumnPage {
     ensureArraySize(rowId, DataTypes.LONG);
     longData[rowId] = value;
     arrayElementCount++;
+    totalLength += DataTypes.LONG.getSizeInBytes();
   }
 
   /**
@@ -97,6 +102,7 @@ public class SafeFixLengthColumnPage extends ColumnPage {
     ensureArraySize(rowId, DataTypes.DOUBLE);
     doubleData[rowId] = value;
     arrayElementCount++;
+    totalLength += DataTypes.DOUBLE.getSizeInBytes();
   }
 
   /**
@@ -107,6 +113,7 @@ public class SafeFixLengthColumnPage extends ColumnPage {
     ensureArraySize(rowId, DataTypes.FLOAT);
     floatData[rowId] = value;
     arrayElementCount++;
+    totalLength += DataTypes.FLOAT.getSizeInBytes();
   }
 
   /**
@@ -117,6 +124,7 @@ public class SafeFixLengthColumnPage extends ColumnPage {
     ensureArraySize(rowId, DataTypes.BYTE_ARRAY);
     this.fixedLengthdata[rowId] = bytes;
     arrayElementCount++;
+    totalLength += bytes.length;
   }
 
   @Override
@@ -125,6 +133,7 @@ public class SafeFixLengthColumnPage extends ColumnPage {
     byte[] converted = ByteUtil.to3Bytes(value);
     System.arraycopy(converted, 0, shortIntData, rowId * 3, 3);
     arrayElementCount++;
+    totalLength += DataTypes.SHORT_INT.getSizeInBytes();
   }
 
   @Override
@@ -475,4 +484,8 @@ public class SafeFixLengthColumnPage extends ColumnPage {
     return arrayElementCount;
   }
 
+  @Override
+  public long getPageLengthInBytes() throws IOException {
+    return totalLength;
+  }
 }


### PR DESCRIPTION
### Note:
Currently In this PR I have disabling safe column page and local dictionary enable once all testcases passed i will revert.
### Problem: 
Data Loading is failing with safe column page.
### Root cause: 
This is because SafeFixedLengthColumnPage is not implementing getPageLengthInBytes because of this is it is going to default method and with local dictionary it is throwing exception
### Solution: 
Now added implementation getPageLengthInBytes in SafeFixedLengthColumnPage



 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

