### PR TITLE
[HOTFIX] Handle Lazy loading with inverted index for ColumnarVectorWrapperDirectWithInvertedIndex

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/scan/result/vector/impl/directread/ColumnarVectorWrapperDirectWithInvertedIndex.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/vector/impl/directread/ColumnarVectorWrapperDirectWithInvertedIndex.java
@@ -19,6 +19,7 @@ package org.apache.carbondata.core.scan.result.vector.impl.directread;
 
 import java.math.BigDecimal;
 
+import org.apache.carbondata.core.metadata.datatype.DataType;
 import org.apache.carbondata.core.scan.result.vector.CarbonColumnVector;
 
 /**
@@ -140,5 +141,10 @@ class ColumnarVectorWrapperDirectWithInvertedIndex extends AbstractCarbonColumna
     for (int i = srcIndex; i < count; i++) {
       columnVector.putByte(invertedIndex[rowId++], src[i]);
     }
+  }
+
+  @Override
+  public DataType getBlockDataType() {
+    return columnVector.getBlockDataType();
   }
 }


### PR DESCRIPTION
when the lazy loading with an inverted index, 
getBlockDataType() was not implemented for ColumnarVectorWrapperDirectWithInvertedIndex.
So, Added implementation.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed? NA
 
 - [ ] Any backward compatibility impacted? NA
 
 - [ ] Document update required? NA

 - [ ] Testing done
yes.       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. NA

