### PR TITLE
[CARBONDATA-3113] Fixed Local Dictionary Query Performance and Added reusable buffer for direct flow

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/ReusableDataBuffer.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/ReusableDataBuffer.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.core.datastore;
+
+import org.apache.carbondata.common.annotations.InterfaceAudience;
+import org.apache.carbondata.common.annotations.InterfaceStability;
+
+/**
+ * class holds the reusable data buffer based on request it will resize.
+ * If request size is less it will return the same buffer, in case it is more
+ * it will resize and update the buffer
+ */
+@InterfaceAudience.Internal
+@InterfaceStability.Evolving
+public class ReusableDataBuffer {
+  /**
+   * reusable byte array
+   */
+  private byte[] dataBuffer;
+
+  /**
+   * current size of data buffer
+   */
+  private int size;
+
+  /**
+   * below method will be used to get the data buffer based on size
+   * If requested size is less it will return same buffer, if size is more
+   * it resize the buffer and return
+   * @param requestedSize
+   * @return databuffer
+   */
+  public byte[] getDataBuffer(int requestedSize) {
+    if (dataBuffer == null || requestedSize > size) {
+      this.size = requestedSize + ((requestedSize * 30) / 100);
+      dataBuffer = new byte[size];
+    }
+    return dataBuffer;
+  }
+}

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/impl/DimensionRawColumnChunk.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/impl/DimensionRawColumnChunk.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.datastore.FileReader;
+import org.apache.carbondata.core.datastore.ReusableDataBuffer;
 import org.apache.carbondata.core.datastore.chunk.AbstractRawColumnChunk;
 import org.apache.carbondata.core.datastore.chunk.DimensionColumnPage;
 import org.apache.carbondata.core.datastore.chunk.reader.DimensionColumnChunkReader;
@@ -72,7 +73,7 @@ public class DimensionRawColumnChunk extends AbstractRawColumnChunk {
     for (int i = 0; i < pagesCount; i++) {
       try {
         if (dataChunks[i] == null) {
-          dataChunks[i] = chunkReader.decodeColumnPage(this, i);
+          dataChunks[i] = chunkReader.decodeColumnPage(this, i, null);
         }
       } catch (IOException | MemoryException e) {
         throw new RuntimeException(e);
@@ -93,7 +94,7 @@ public class DimensionRawColumnChunk extends AbstractRawColumnChunk {
     }
     if (dataChunks[pageNumber] == null) {
       try {
-        dataChunks[pageNumber] = chunkReader.decodeColumnPage(this, pageNumber);
+        dataChunks[pageNumber] = chunkReader.decodeColumnPage(this, pageNumber, null);
       } catch (IOException | MemoryException e) {
         throw new RuntimeException(e);
       }
@@ -108,7 +109,8 @@ public class DimensionRawColumnChunk extends AbstractRawColumnChunk {
    * @param index
    * @return
    */
-  public DimensionColumnPage convertToDimColDataChunkWithOutCache(int index) {
+  public DimensionColumnPage convertToDimColDataChunkWithOutCache(int index,
+      ReusableDataBuffer reusableDataBuffer) {
     assert index < pagesCount;
     // in case of filter query filter column if filter column is decoded and stored.
     // then return the same
@@ -116,7 +118,7 @@ public class DimensionRawColumnChunk extends AbstractRawColumnChunk {
       return dataChunks[index];
     }
     try {
-      return chunkReader.decodeColumnPage(this, index);
+      return chunkReader.decodeColumnPage(this, index, reusableDataBuffer);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
@@ -129,10 +131,11 @@ public class DimensionRawColumnChunk extends AbstractRawColumnChunk {
    * @param pageNumber page number to decode and fill the vector
    * @param vectorInfo vector to be filled with column page
    */
-  public void convertToDimColDataChunkAndFillVector(int pageNumber, ColumnVectorInfo vectorInfo) {
+  public void convertToDimColDataChunkAndFillVector(int pageNumber, ColumnVectorInfo vectorInfo,
+      ReusableDataBuffer reusableDataBuffer) {
     assert pageNumber < pagesCount;
     try {
-      chunkReader.decodeColumnPageAndFillVector(this, pageNumber, vectorInfo);
+      chunkReader.decodeColumnPageAndFillVector(this, pageNumber, vectorInfo, reusableDataBuffer);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/impl/FixedLengthDimensionColumnPage.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/impl/FixedLengthDimensionColumnPage.java
@@ -39,14 +39,14 @@ public class FixedLengthDimensionColumnPage extends AbstractDimensionColumnPage 
    * @param columnValueSize      size of each column value
    */
   public FixedLengthDimensionColumnPage(byte[] dataChunk, int[] invertedIndex,
-      int[] invertedIndexReverse, int numberOfRows, int columnValueSize) {
+      int[] invertedIndexReverse, int numberOfRows, int columnValueSize, int dataLength) {
     boolean isExplicitSorted = isExplicitSorted(invertedIndex);
     long totalSize = isExplicitSorted ?
-        dataChunk.length + (2 * numberOfRows * CarbonCommonConstants.INT_SIZE_IN_BYTE) :
-        dataChunk.length;
+        dataLength + (2 * numberOfRows * CarbonCommonConstants.INT_SIZE_IN_BYTE) :
+        dataLength;
     dataChunkStore = DimensionChunkStoreFactory.INSTANCE
         .getDimensionChunkStore(columnValueSize, isExplicitSorted, numberOfRows, totalSize,
-            DimensionStoreType.FIXED_LENGTH, null, false);
+            DimensionStoreType.FIXED_LENGTH, null, false, dataLength);
     dataChunkStore.putArray(invertedIndex, invertedIndexReverse, dataChunk);
   }
 
@@ -62,14 +62,14 @@ public class FixedLengthDimensionColumnPage extends AbstractDimensionColumnPage 
    */
   public FixedLengthDimensionColumnPage(byte[] dataChunk, int[] invertedIndex,
       int[] invertedIndexReverse, int numberOfRows, int columnValueSize,
-      ColumnVectorInfo vectorInfo) {
+      ColumnVectorInfo vectorInfo, int dataLength) {
     boolean isExplicitSorted = isExplicitSorted(invertedIndex);
     long totalSize = isExplicitSorted ?
-        dataChunk.length + (2 * numberOfRows * CarbonCommonConstants.INT_SIZE_IN_BYTE) :
-        dataChunk.length;
+        dataLength + (2 * numberOfRows * CarbonCommonConstants.INT_SIZE_IN_BYTE) :
+        dataLength;
     dataChunkStore = DimensionChunkStoreFactory.INSTANCE
         .getDimensionChunkStore(columnValueSize, isExplicitSorted, numberOfRows, totalSize,
-            DimensionStoreType.FIXED_LENGTH, null, vectorInfo != null);
+            DimensionStoreType.FIXED_LENGTH, null, vectorInfo != null, dataLength);
     if (vectorInfo == null) {
       dataChunkStore.putArray(invertedIndex, invertedIndexReverse, dataChunk);
     } else {

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/impl/MeasureRawColumnChunk.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/impl/MeasureRawColumnChunk.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 
 import org.apache.carbondata.core.datastore.FileReader;
+import org.apache.carbondata.core.datastore.ReusableDataBuffer;
 import org.apache.carbondata.core.datastore.chunk.AbstractRawColumnChunk;
 import org.apache.carbondata.core.datastore.chunk.reader.MeasureColumnChunkReader;
 import org.apache.carbondata.core.datastore.page.ColumnPage;
@@ -56,7 +57,7 @@ public class MeasureRawColumnChunk extends AbstractRawColumnChunk {
     for (int i = 0; i < pagesCount; i++) {
       try {
         if (columnPages[i] == null) {
-          columnPages[i] = chunkReader.decodeColumnPage(this, i);
+          columnPages[i] = chunkReader.decodeColumnPage(this, i, null);
         }
       } catch (Exception e) {
         throw new RuntimeException(e);
@@ -77,7 +78,7 @@ public class MeasureRawColumnChunk extends AbstractRawColumnChunk {
 
     try {
       if (columnPages[pageNumber] == null) {
-        columnPages[pageNumber] = chunkReader.decodeColumnPage(this, pageNumber);
+        columnPages[pageNumber] = chunkReader.decodeColumnPage(this, pageNumber, null);
       }
     } catch (IOException | MemoryException e) {
       throw new RuntimeException(e);
@@ -92,7 +93,8 @@ public class MeasureRawColumnChunk extends AbstractRawColumnChunk {
    * @param index
    * @return
    */
-  public ColumnPage convertToColumnPageWithOutCache(int index) {
+  public ColumnPage convertToColumnPageWithOutCache(int index,
+      ReusableDataBuffer reusableDataBuffer) {
     assert index < pagesCount;
     // in case of filter query filter columns blocklet pages will uncompressed
     // so no need to decode again
@@ -100,7 +102,7 @@ public class MeasureRawColumnChunk extends AbstractRawColumnChunk {
       return columnPages[index];
     }
     try {
-      return chunkReader.decodeColumnPage(this, index);
+      return chunkReader.decodeColumnPage(this, index, reusableDataBuffer);
     } catch (IOException | MemoryException e) {
       throw new RuntimeException(e);
     }
@@ -113,10 +115,11 @@ public class MeasureRawColumnChunk extends AbstractRawColumnChunk {
    * @param pageNumber page number to decode and fill the vector
    * @param vectorInfo vector to be filled with column page
    */
-  public void convertToColumnPageAndFillVector(int pageNumber, ColumnVectorInfo vectorInfo) {
+  public void convertToColumnPageAndFillVector(int pageNumber, ColumnVectorInfo vectorInfo,
+      ReusableDataBuffer reusableDataBuffer) {
     assert pageNumber < pagesCount;
     try {
-      chunkReader.decodeColumnPageAndFillVector(this, pageNumber, vectorInfo);
+      chunkReader.decodeColumnPageAndFillVector(this, pageNumber, vectorInfo, reusableDataBuffer);
     } catch (IOException | MemoryException e) {
       throw new RuntimeException(e);
     }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/impl/VariableLengthDimensionColumnPage.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/impl/VariableLengthDimensionColumnPage.java
@@ -38,9 +38,9 @@ public class VariableLengthDimensionColumnPage extends AbstractDimensionColumnPa
    */
   public VariableLengthDimensionColumnPage(byte[] dataChunks, int[] invertedIndex,
       int[] invertedIndexReverse, int numberOfRows, DimensionStoreType dimStoreType,
-      CarbonDictionary dictionary) {
+      CarbonDictionary dictionary, int dataLength) {
     this(dataChunks, invertedIndex, invertedIndexReverse, numberOfRows, dimStoreType, dictionary,
-        null);
+        null, dataLength);
   }
 
   /**
@@ -54,28 +54,28 @@ public class VariableLengthDimensionColumnPage extends AbstractDimensionColumnPa
    */
   public VariableLengthDimensionColumnPage(byte[] dataChunks, int[] invertedIndex,
       int[] invertedIndexReverse, int numberOfRows, DimensionStoreType dimStoreType,
-      CarbonDictionary dictionary, ColumnVectorInfo vectorInfo) {
+      CarbonDictionary dictionary, ColumnVectorInfo vectorInfo, int dataLength) {
     boolean isExplicitSorted = isExplicitSorted(invertedIndex);
     long totalSize = 0;
     switch (dimStoreType) {
       case LOCAL_DICT:
         totalSize = null != invertedIndex ?
-            (dataChunks.length + (2 * numberOfRows * CarbonCommonConstants.INT_SIZE_IN_BYTE)) :
-            dataChunks.length;
+            (dataLength + (2 * numberOfRows * CarbonCommonConstants.INT_SIZE_IN_BYTE)) :
+            dataLength;
         break;
       case VARIABLE_INT_LENGTH:
       case VARIABLE_SHORT_LENGTH:
         totalSize = null != invertedIndex ?
-            (dataChunks.length + (2 * numberOfRows * CarbonCommonConstants.INT_SIZE_IN_BYTE) + (
+            (dataLength + (2 * numberOfRows * CarbonCommonConstants.INT_SIZE_IN_BYTE) + (
                 numberOfRows * CarbonCommonConstants.INT_SIZE_IN_BYTE)) :
-            (dataChunks.length + (numberOfRows * CarbonCommonConstants.INT_SIZE_IN_BYTE));
+            (dataLength + (numberOfRows * CarbonCommonConstants.INT_SIZE_IN_BYTE));
         break;
       default:
         throw new UnsupportedOperationException("Invalidate dimension store type");
     }
     dataChunkStore = DimensionChunkStoreFactory.INSTANCE
         .getDimensionChunkStore(0, isExplicitSorted, numberOfRows, totalSize, dimStoreType,
-            dictionary, vectorInfo != null);
+            dictionary, vectorInfo != null, dataLength);
     if (vectorInfo != null) {
       dataChunkStore.fillVector(invertedIndex, invertedIndexReverse, dataChunks, vectorInfo);
     } else {

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/reader/DimensionColumnChunkReader.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/reader/DimensionColumnChunkReader.java
@@ -19,6 +19,7 @@ package org.apache.carbondata.core.datastore.chunk.reader;
 import java.io.IOException;
 
 import org.apache.carbondata.core.datastore.FileReader;
+import org.apache.carbondata.core.datastore.ReusableDataBuffer;
 import org.apache.carbondata.core.datastore.chunk.DimensionColumnPage;
 import org.apache.carbondata.core.datastore.chunk.impl.DimensionRawColumnChunk;
 import org.apache.carbondata.core.memory.MemoryException;
@@ -60,11 +61,12 @@ public interface DimensionColumnChunkReader {
    * @throws IOException
    */
   DimensionColumnPage decodeColumnPage(DimensionRawColumnChunk dimensionRawColumnChunk,
-      int pageNumber) throws IOException, MemoryException;
+      int pageNumber, ReusableDataBuffer reusableDataBuffer) throws IOException, MemoryException;
 
   /**
    * Decodes the raw data chunk of given page number and fill the vector with decoded data.
    */
   void decodeColumnPageAndFillVector(DimensionRawColumnChunk dimensionRawColumnChunk,
-      int pageNumber, ColumnVectorInfo vectorInfo) throws IOException, MemoryException;
+      int pageNumber, ColumnVectorInfo vectorInfo, ReusableDataBuffer reusableDataBuffer)
+      throws IOException, MemoryException;
 }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/reader/MeasureColumnChunkReader.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/reader/MeasureColumnChunkReader.java
@@ -19,6 +19,7 @@ package org.apache.carbondata.core.datastore.chunk.reader;
 import java.io.IOException;
 
 import org.apache.carbondata.core.datastore.FileReader;
+import org.apache.carbondata.core.datastore.ReusableDataBuffer;
 import org.apache.carbondata.core.datastore.chunk.impl.MeasureRawColumnChunk;
 import org.apache.carbondata.core.datastore.page.ColumnPage;
 import org.apache.carbondata.core.memory.MemoryException;
@@ -56,13 +57,14 @@ public interface MeasureColumnChunkReader {
    * @return
    * @throws IOException
    */
-  ColumnPage decodeColumnPage(MeasureRawColumnChunk measureRawColumnChunk,
-      int pageNumber) throws IOException, MemoryException;
+  ColumnPage decodeColumnPage(MeasureRawColumnChunk measureRawColumnChunk, int pageNumber,
+      ReusableDataBuffer reusableDataBuffer) throws IOException, MemoryException;
 
   /**
    * Decode raw data and fill the vector
    */
-  void decodeColumnPageAndFillVector(MeasureRawColumnChunk measureRawColumnChunk,
-      int pageNumber, ColumnVectorInfo vectorInfo) throws IOException, MemoryException;
+  void decodeColumnPageAndFillVector(MeasureRawColumnChunk measureRawColumnChunk, int pageNumber,
+      ColumnVectorInfo vectorInfo, ReusableDataBuffer reusableDataBuffer)
+      throws IOException, MemoryException;
 
 }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/reader/dimension/AbstractChunkReader.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/reader/dimension/AbstractChunkReader.java
@@ -19,6 +19,7 @@ package org.apache.carbondata.core.datastore.chunk.reader.dimension;
 import java.io.IOException;
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
+import org.apache.carbondata.core.datastore.ReusableDataBuffer;
 import org.apache.carbondata.core.datastore.chunk.impl.DimensionRawColumnChunk;
 import org.apache.carbondata.core.datastore.chunk.reader.DimensionColumnChunkReader;
 import org.apache.carbondata.core.datastore.compression.Compressor;
@@ -86,7 +87,8 @@ public abstract class AbstractChunkReader implements DimensionColumnChunkReader 
 
   @Override
   public void decodeColumnPageAndFillVector(DimensionRawColumnChunk dimensionRawColumnChunk,
-      int pageNumber, ColumnVectorInfo vectorInfo) throws IOException, MemoryException {
+      int pageNumber, ColumnVectorInfo vectorInfo, ReusableDataBuffer reusableDataBuffer)
+      throws IOException, MemoryException {
     throw new UnsupportedOperationException(
         "This operation is not supported in this reader " + this.getClass().getName());
   }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/reader/dimension/v3/CompressedDimChunkFileBasedPageLevelReaderV3.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/reader/dimension/v3/CompressedDimChunkFileBasedPageLevelReaderV3.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 
 import org.apache.carbondata.core.datastore.FileReader;
+import org.apache.carbondata.core.datastore.ReusableDataBuffer;
 import org.apache.carbondata.core.datastore.chunk.DimensionColumnPage;
 import org.apache.carbondata.core.datastore.chunk.impl.DimensionRawColumnChunk;
 import org.apache.carbondata.core.datastore.compression.CompressorFactory;
@@ -140,7 +141,8 @@ public class CompressedDimChunkFileBasedPageLevelReaderV3
    * @return DimensionColumnDataChunk
    */
   @Override public DimensionColumnPage decodeColumnPage(
-      DimensionRawColumnChunk dimensionRawColumnChunk, int pageNumber)
+      DimensionRawColumnChunk dimensionRawColumnChunk, int pageNumber,
+      ReusableDataBuffer reusableDataBuffer)
       throws IOException, MemoryException {
     // data chunk of page
     DataChunk2 pageMetadata = null;
@@ -171,6 +173,7 @@ public class CompressedDimChunkFileBasedPageLevelReaderV3
     ByteBuffer rawData = dimensionRawColumnChunk.getFileReader()
         .readByteBuffer(filePath, offset, length);
 
-    return decodeDimension(dimensionRawColumnChunk, rawData, pageMetadata, 0, null);
+    return decodeDimension(dimensionRawColumnChunk, rawData, pageMetadata, 0, null,
+        reusableDataBuffer);
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/reader/measure/AbstractMeasureChunkReader.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/reader/measure/AbstractMeasureChunkReader.java
@@ -18,6 +18,7 @@ package org.apache.carbondata.core.datastore.chunk.reader.measure;
 
 import java.io.IOException;
 
+import org.apache.carbondata.core.datastore.ReusableDataBuffer;
 import org.apache.carbondata.core.datastore.chunk.impl.MeasureRawColumnChunk;
 import org.apache.carbondata.core.datastore.chunk.reader.MeasureColumnChunkReader;
 import org.apache.carbondata.core.datastore.compression.Compressor;
@@ -54,9 +55,9 @@ public abstract class AbstractMeasureChunkReader implements MeasureColumnChunkRe
     this.numberOfRows = numberOfRows;
   }
 
-  @Override
-  public void decodeColumnPageAndFillVector(MeasureRawColumnChunk measureRawColumnChunk,
-      int pageNumber, ColumnVectorInfo vectorInfo) throws IOException, MemoryException {
+  @Override public void decodeColumnPageAndFillVector(MeasureRawColumnChunk measureRawColumnChunk,
+      int pageNumber, ColumnVectorInfo vectorInfo, ReusableDataBuffer reusableDataBuffer)
+      throws IOException, MemoryException {
     throw new UnsupportedOperationException(
         "This operation is not supported in this class " + getClass().getName());
   }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/reader/measure/v1/CompressedMeasureChunkFileBasedReaderV1.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/reader/measure/v1/CompressedMeasureChunkFileBasedReaderV1.java
@@ -21,6 +21,7 @@ import java.nio.ByteBuffer;
 import java.util.List;
 
 import org.apache.carbondata.core.datastore.FileReader;
+import org.apache.carbondata.core.datastore.ReusableDataBuffer;
 import org.apache.carbondata.core.datastore.chunk.impl.MeasureRawColumnChunk;
 import org.apache.carbondata.core.datastore.chunk.reader.measure.AbstractMeasureChunkReader;
 import org.apache.carbondata.core.datastore.compression.CompressorFactory;
@@ -92,8 +93,8 @@ public class CompressedMeasureChunkFileBasedReaderV1 extends AbstractMeasureChun
   }
 
   @Override
-  public ColumnPage decodeColumnPage(MeasureRawColumnChunk measureRawColumnChunk,
-      int pageNumber) throws IOException, MemoryException {
+  public ColumnPage decodeColumnPage(MeasureRawColumnChunk measureRawColumnChunk, int pageNumber,
+      ReusableDataBuffer reusableDataBuffer) throws IOException, MemoryException {
     int blockIndex = measureRawColumnChunk.getColumnIndex();
     DataChunk dataChunk = measureColumnChunks.get(blockIndex);
     ValueEncoderMeta meta = dataChunk.getValueEncoderMeta().get(0);

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/reader/measure/v3/CompressedMeasureChunkFileBasedReaderV3.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/reader/measure/v3/CompressedMeasureChunkFileBasedReaderV3.java
@@ -22,6 +22,7 @@ import java.util.BitSet;
 import java.util.List;
 
 import org.apache.carbondata.core.datastore.FileReader;
+import org.apache.carbondata.core.datastore.ReusableDataBuffer;
 import org.apache.carbondata.core.datastore.chunk.impl.MeasureRawColumnChunk;
 import org.apache.carbondata.core.datastore.chunk.reader.measure.AbstractMeasureChunkReaderV2V3Format;
 import org.apache.carbondata.core.datastore.compression.CompressorFactory;
@@ -188,21 +189,20 @@ public class CompressedMeasureChunkFileBasedReaderV3 extends AbstractMeasureChun
    * @param pageNumber            number
    * @return DimensionColumnPage
    */
-  @Override
-  public ColumnPage decodeColumnPage(
-      MeasureRawColumnChunk rawColumnChunk, int pageNumber)
+  @Override public ColumnPage decodeColumnPage(MeasureRawColumnChunk rawColumnChunk, int pageNumber,
+      ReusableDataBuffer reusableDataBuffer)
       throws IOException, MemoryException {
-    return decodeColumnPage(rawColumnChunk, pageNumber, null);
+    return decodeColumnPage(rawColumnChunk, pageNumber, null, reusableDataBuffer);
   }
 
-  @Override
-  public void decodeColumnPageAndFillVector(MeasureRawColumnChunk measureRawColumnChunk,
-      int pageNumber, ColumnVectorInfo vectorInfo) throws IOException, MemoryException {
-    decodeColumnPage(measureRawColumnChunk, pageNumber, vectorInfo);
+  @Override public void decodeColumnPageAndFillVector(MeasureRawColumnChunk measureRawColumnChunk,
+      int pageNumber, ColumnVectorInfo vectorInfo, ReusableDataBuffer reusableDataBuffer)
+      throws IOException, MemoryException {
+    decodeColumnPage(measureRawColumnChunk, pageNumber, vectorInfo, reusableDataBuffer);
   }
 
-  private ColumnPage decodeColumnPage(
-      MeasureRawColumnChunk rawColumnChunk, int pageNumber, ColumnVectorInfo vectorInfo)
+  private ColumnPage decodeColumnPage(MeasureRawColumnChunk rawColumnChunk, int pageNumber,
+      ColumnVectorInfo vectorInfo, ReusableDataBuffer reusableDataBuffer)
       throws IOException, MemoryException {
     // data chunk of blocklet column
     DataChunk3 dataChunk3 = rawColumnChunk.getDataChunkV3();
@@ -219,7 +219,8 @@ public class CompressedMeasureChunkFileBasedReaderV3 extends AbstractMeasureChun
         dataChunk3.getPage_offset().get(pageNumber);
     BitSet nullBitSet = QueryUtil.getNullBitSet(pageMetadata.presence, this.compressor);
     ColumnPage decodedPage =
-        decodeMeasure(pageMetadata, rawColumnChunk.getRawData(), offset, vectorInfo, nullBitSet);
+        decodeMeasure(pageMetadata, rawColumnChunk.getRawData(), offset, vectorInfo, nullBitSet,
+            reusableDataBuffer);
     if (decodedPage == null) {
       return null;
     }
@@ -231,7 +232,8 @@ public class CompressedMeasureChunkFileBasedReaderV3 extends AbstractMeasureChun
    * Decode measure column page with page header and raw data starting from offset
    */
   protected ColumnPage decodeMeasure(DataChunk2 pageMetadata, ByteBuffer pageData, int offset,
-      ColumnVectorInfo vectorInfo, BitSet nullBitSet) throws MemoryException, IOException {
+      ColumnVectorInfo vectorInfo, BitSet nullBitSet, ReusableDataBuffer reusableDataBuffer)
+      throws MemoryException, IOException {
     List<Encoding> encodings = pageMetadata.getEncoders();
     org.apache.carbondata.core.metadata.encoder.Encoding.validateEncodingTypes(encodings);
     List<ByteBuffer> encoderMetas = pageMetadata.getEncoder_meta();
@@ -240,12 +242,12 @@ public class CompressedMeasureChunkFileBasedReaderV3 extends AbstractMeasureChun
     ColumnPageDecoder codec =
         encodingFactory.createDecoder(encodings, encoderMetas, compressorName, vectorInfo != null);
     if (vectorInfo != null) {
-      codec
-          .decodeAndFillVector(pageData.array(), offset, pageMetadata.data_page_length, vectorInfo,
-              nullBitSet, false, pageMetadata.numberOfRowsInpage);
+      codec.decodeAndFillVector(pageData.array(), offset, pageMetadata.data_page_length, vectorInfo,
+          nullBitSet, false, pageMetadata.numberOfRowsInpage, reusableDataBuffer);
       return null;
     } else {
-      return codec.decode(pageData.array(), offset, pageMetadata.data_page_length);
+      return codec
+          .decode(pageData.array(), offset, pageMetadata.data_page_length);
     }
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/reader/measure/v3/CompressedMsrChunkFileBasedPageLevelReaderV3.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/reader/measure/v3/CompressedMsrChunkFileBasedPageLevelReaderV3.java
@@ -22,6 +22,7 @@ import java.nio.ByteBuffer;
 import java.util.BitSet;
 
 import org.apache.carbondata.core.datastore.FileReader;
+import org.apache.carbondata.core.datastore.ReusableDataBuffer;
 import org.apache.carbondata.core.datastore.chunk.impl.MeasureRawColumnChunk;
 import org.apache.carbondata.core.datastore.compression.CompressorFactory;
 import org.apache.carbondata.core.datastore.page.ColumnPage;
@@ -135,7 +136,7 @@ public class CompressedMsrChunkFileBasedPageLevelReaderV3
    * @return DimensionColumnDataChunk
    */
   @Override public ColumnPage decodeColumnPage(
-      MeasureRawColumnChunk rawColumnPage, int pageNumber)
+      MeasureRawColumnChunk rawColumnPage, int pageNumber, ReusableDataBuffer reusableDataBuffer)
       throws IOException, MemoryException {
     // data chunk of blocklet column
     DataChunk3 dataChunk3 = rawColumnPage.getDataChunkV3();
@@ -153,7 +154,8 @@ public class CompressedMsrChunkFileBasedPageLevelReaderV3
         .readByteBuffer(filePath, offset, pageMetadata.data_page_length);
 
     BitSet nullBitSet = QueryUtil.getNullBitSet(pageMetadata.presence, this.compressor);
-    ColumnPage decodedPage = decodeMeasure(pageMetadata, buffer, 0, null, nullBitSet);
+    ColumnPage decodedPage =
+        decodeMeasure(pageMetadata, buffer, 0, null, nullBitSet, reusableDataBuffer);
     decodedPage.setNullBits(nullBitSet);
     return decodedPage;
   }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/DimensionChunkStoreFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/DimensionChunkStoreFactory.java
@@ -65,22 +65,22 @@ public class DimensionChunkStoreFactory {
    */
   public DimensionDataChunkStore getDimensionChunkStore(int columnValueSize,
       boolean isInvertedIndex, int numberOfRows, long totalSize, DimensionStoreType storeType,
-      CarbonDictionary dictionary, boolean fillDirectVector) {
+      CarbonDictionary dictionary, boolean fillDirectVector, int dataLength) {
     if (isUnsafe && !fillDirectVector) {
       switch (storeType) {
         case FIXED_LENGTH:
           return new UnsafeFixedLengthDimensionDataChunkStore(totalSize, columnValueSize,
-              isInvertedIndex, numberOfRows);
+              isInvertedIndex, numberOfRows, dataLength);
         case VARIABLE_SHORT_LENGTH:
           return new UnsafeVariableShortLengthDimensionDataChunkStore(totalSize, isInvertedIndex,
-              numberOfRows);
+              numberOfRows, dataLength);
         case VARIABLE_INT_LENGTH:
           return new UnsafeVariableIntLengthDimensionDataChunkStore(totalSize, isInvertedIndex,
-              numberOfRows);
+              numberOfRows, dataLength);
         case LOCAL_DICT:
           return new LocalDictDimensionDataChunkStore(
               new UnsafeFixedLengthDimensionDataChunkStore(totalSize, 3, isInvertedIndex,
-                  numberOfRows), dictionary);
+                  numberOfRows, dataLength), dictionary, dataLength);
         default:
           throw new UnsupportedOperationException("Invalid dimension store type");
       }
@@ -90,13 +90,15 @@ public class DimensionChunkStoreFactory {
           return new SafeFixedLengthDimensionDataChunkStore(isInvertedIndex, columnValueSize,
               numberOfRows);
         case VARIABLE_SHORT_LENGTH:
-          return new SafeVariableShortLengthDimensionDataChunkStore(isInvertedIndex, numberOfRows);
+          return new SafeVariableShortLengthDimensionDataChunkStore(isInvertedIndex, numberOfRows,
+              dataLength);
         case VARIABLE_INT_LENGTH:
-          return new SafeVariableIntLengthDimensionDataChunkStore(isInvertedIndex, numberOfRows);
+          return new SafeVariableIntLengthDimensionDataChunkStore(isInvertedIndex, numberOfRows,
+              dataLength);
         case LOCAL_DICT:
           return new LocalDictDimensionDataChunkStore(
               new SafeFixedLengthDimensionDataChunkStore(isInvertedIndex, 3, numberOfRows),
-              dictionary);
+              dictionary, dataLength);
         default:
           throw new UnsupportedOperationException("Invalid dimension store type");
       }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/safe/AbstractNonDictionaryVectorFiller.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/safe/AbstractNonDictionaryVectorFiller.java
@@ -44,15 +44,15 @@ public abstract class AbstractNonDictionaryVectorFiller {
 class NonDictionaryVectorFillerFactory {
 
   public static AbstractNonDictionaryVectorFiller getVectorFiller(int length, DataType type,
-      int numberOfRows) {
+      int numberOfRows, int actualDataLength) {
     if (type == DataTypes.STRING) {
       if (length > DataTypes.SHORT.getSizeInBytes()) {
-        return new LongStringVectorFiller(numberOfRows);
+        return new LongStringVectorFiller(numberOfRows, actualDataLength);
       } else {
-        return new StringVectorFiller(numberOfRows);
+        return new StringVectorFiller(numberOfRows, actualDataLength);
       }
     } else if (type == DataTypes.VARCHAR) {
-      return new LongStringVectorFiller(numberOfRows);
+      return new LongStringVectorFiller(numberOfRows, actualDataLength);
     } else if (type == DataTypes.TIMESTAMP) {
       return new TimeStampVectorFiller(numberOfRows);
     } else if (type == DataTypes.BOOLEAN) {
@@ -73,8 +73,11 @@ class NonDictionaryVectorFillerFactory {
 
 class StringVectorFiller extends AbstractNonDictionaryVectorFiller {
 
-  public StringVectorFiller(int numberOfRows) {
+  private int actualDataLength;
+
+  public StringVectorFiller(int numberOfRows, int actualDataLength) {
     super(numberOfRows);
+    this.actualDataLength = actualDataLength;
   }
 
   @Override
@@ -93,13 +96,17 @@ class StringVectorFiller extends AbstractNonDictionaryVectorFiller {
       }
       localOffset += length;
     }
-    vector.putAllByteArray(data, 0, data.length);
+    vector.putAllByteArray(data, 0, actualDataLength);
   }
 }
 
 class LongStringVectorFiller extends AbstractNonDictionaryVectorFiller {
-  public LongStringVectorFiller(int numberOfRows) {
+
+  private int actualDataLength;
+
+  public LongStringVectorFiller(int numberOfRows, int actualDataLength) {
     super(numberOfRows);
+    this.actualDataLength = actualDataLength;
   }
 
   @Override public void fillVector(byte[] data, CarbonColumnVector vector) {
@@ -135,7 +142,7 @@ class LongStringVectorFiller extends AbstractNonDictionaryVectorFiller {
         }
         localOffset += length;
       }
-      vector.putAllByteArray(data, 0, data.length);
+      vector.putAllByteArray(data, 0, actualDataLength);
     }
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/safe/SafeVariableIntLengthDimensionDataChunkStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/safe/SafeVariableIntLengthDimensionDataChunkStore.java
@@ -27,8 +27,9 @@ import org.apache.carbondata.core.constants.CarbonCommonConstants;
  */
 public class SafeVariableIntLengthDimensionDataChunkStore
     extends SafeVariableLengthDimensionDataChunkStore {
-  public SafeVariableIntLengthDimensionDataChunkStore(boolean isInvertedIndex, int numberOfRows) {
-    super(isInvertedIndex, numberOfRows);
+  public SafeVariableIntLengthDimensionDataChunkStore(boolean isInvertedIndex, int numberOfRows,
+      int dataLength) {
+    super(isInvertedIndex, numberOfRows, dataLength);
   }
 
   @Override

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/safe/SafeVariableShortLengthDimensionDataChunkStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/safe/SafeVariableShortLengthDimensionDataChunkStore.java
@@ -27,8 +27,9 @@ import org.apache.carbondata.core.constants.CarbonCommonConstants;
  */
 public class SafeVariableShortLengthDimensionDataChunkStore
     extends SafeVariableLengthDimensionDataChunkStore {
-  public SafeVariableShortLengthDimensionDataChunkStore(boolean isInvertedIndex, int numberOfRows) {
-    super(isInvertedIndex, numberOfRows);
+  public SafeVariableShortLengthDimensionDataChunkStore(boolean isInvertedIndex, int numberOfRows,
+      int dataLength) {
+    super(isInvertedIndex, numberOfRows, dataLength);
   }
 
   @Override protected int getLengthSize() {

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/unsafe/UnsafeAbstractDimensionDataChunkStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/unsafe/UnsafeAbstractDimensionDataChunkStore.java
@@ -73,13 +73,14 @@ public abstract class UnsafeAbstractDimensionDataChunkStore implements Dimension
    * @param numberOfRows   total number of rows
    */
   public UnsafeAbstractDimensionDataChunkStore(long totalSize, boolean isInvertedIdex,
-      int numberOfRows) {
+      int numberOfRows, int dataLength) {
     try {
       // allocating the data page
       this.dataPageMemoryBlock = UnsafeMemoryManager.allocateMemoryWithRetry(taskId, totalSize);
     } catch (MemoryException e) {
       throw new RuntimeException(e);
     }
+    this.dataLength = dataLength;
     this.isExplicitSorted = isInvertedIdex;
   }
 
@@ -93,7 +94,6 @@ public abstract class UnsafeAbstractDimensionDataChunkStore implements Dimension
   @Override public void putArray(final int[] invertedIndex, final int[] invertedIndexReverse,
       final byte[] data) {
     assert (!isMemoryOccupied);
-    this.dataLength = data.length;
     this.invertedIndexReverseOffset = dataLength;
     if (isExplicitSorted) {
       this.invertedIndexReverseOffset +=

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/unsafe/UnsafeFixedLengthDimensionDataChunkStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/unsafe/UnsafeFixedLengthDimensionDataChunkStore.java
@@ -40,8 +40,8 @@ public class UnsafeFixedLengthDimensionDataChunkStore
    * @param numberOfRows    total number of rows
    */
   public UnsafeFixedLengthDimensionDataChunkStore(long totalDataSize, int columnValueSize,
-      boolean isInvertedIdex, int numberOfRows) {
-    super(totalDataSize, isInvertedIdex, numberOfRows);
+      boolean isInvertedIdex, int numberOfRows, int dataLength) {
+    super(totalDataSize, isInvertedIdex, numberOfRows, dataLength);
     this.columnValueSize = columnValueSize;
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/unsafe/UnsafeVariableIntLengthDimensionDataChunkStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/unsafe/UnsafeVariableIntLengthDimensionDataChunkStore.java
@@ -28,8 +28,8 @@ import org.apache.carbondata.core.constants.CarbonCommonConstants;
 public class UnsafeVariableIntLengthDimensionDataChunkStore
     extends UnsafeVariableLengthDimensionDataChunkStore {
   public UnsafeVariableIntLengthDimensionDataChunkStore(long totalSize, boolean isInvertedIdex,
-      int numberOfRows) {
-    super(totalSize, isInvertedIdex, numberOfRows);
+      int numberOfRows, int dataLength) {
+    super(totalSize, isInvertedIdex, numberOfRows, dataLength);
   }
 
   @Override

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/unsafe/UnsafeVariableLengthDimensionDataChunkStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/unsafe/UnsafeVariableLengthDimensionDataChunkStore.java
@@ -50,8 +50,8 @@ public abstract class UnsafeVariableLengthDimensionDataChunkStore
   private byte[] value;
 
   public UnsafeVariableLengthDimensionDataChunkStore(long totalSize, boolean isInvertedIdex,
-      int numberOfRows) {
-    super(totalSize, isInvertedIdex, numberOfRows);
+      int numberOfRows, int dataLength) {
+    super(totalSize, isInvertedIdex, numberOfRows, dataLength);
     this.numberOfRows = numberOfRows;
     // initials size assigning to some random value
     this.value = new byte[20];
@@ -220,6 +220,7 @@ public abstract class UnsafeVariableLengthDimensionDataChunkStore
    */
   @Override
   public void fillRow(int rowId, CarbonColumnVector vector, int vectorRow) {
+    vector.setDictionary(null);
     // get the row id from reverse inverted index based on row id
     rowId = getRowId(rowId);
     // get the current row offset

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/unsafe/UnsafeVariableShortLengthDimensionDataChunkStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/unsafe/UnsafeVariableShortLengthDimensionDataChunkStore.java
@@ -28,8 +28,8 @@ import org.apache.carbondata.core.constants.CarbonCommonConstants;
 public class UnsafeVariableShortLengthDimensionDataChunkStore
     extends UnsafeVariableLengthDimensionDataChunkStore {
   public UnsafeVariableShortLengthDimensionDataChunkStore(long totalSize, boolean isInvertedIdex,
-      int numberOfRows) {
-    super(totalSize, isInvertedIdex, numberOfRows);
+      int numberOfRows, int dataLength) {
+    super(totalSize, isInvertedIdex, numberOfRows, dataLength);
   }
 
   @Override

--- a/core/src/main/java/org/apache/carbondata/core/datastore/columnar/UnBlockIndexer.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/columnar/UnBlockIndexer.java
@@ -54,7 +54,7 @@ public final class UnBlockIndexer {
     return indexes;
   }
 
-  public static byte[] uncompressData(byte[] data, int[] index, int keyLen) {
+  public static byte[] uncompressData(byte[] data, int[] index, int keyLen, int dataLength) {
     if (index.length < 1) {
       return data;
     }
@@ -67,7 +67,7 @@ public final class UnBlockIndexer {
     }
     byte[] uncompressedData = new byte[actualSize * keyLen];
     int picIndex = 0;
-    for (int i = 0; i < data.length; i += keyLen) {
+    for (int i = 0; i < dataLength; i += keyLen) {
       numberOfCopy = index[picIndex * 2 + 1];
       picIndex++;
       for (int j = 0; j < numberOfCopy; j++) {

--- a/core/src/main/java/org/apache/carbondata/core/datastore/compression/AbstractCompressor.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/compression/AbstractCompressor.java
@@ -119,5 +119,8 @@ public abstract class AbstractCompressor implements Compressor {
     throw new RuntimeException("Not implemented rawCompress for " + this.getName());
   }
 
+  @Override public boolean supportReusableBuffer() {
+    return false;
+  }
 
 }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/compression/Compressor.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/compression/Compressor.java
@@ -65,4 +65,10 @@ public interface Compressor {
    * @return true if it supports, otherwise return false
    */
   boolean supportUnsafe();
+
+  int unCompressedLength(byte[] data, int offset, int length);
+
+  int rawUncompress(byte[] data, int offset, int length, byte[] output);
+
+  boolean supportReusableBuffer();
 }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/compression/SnappyCompressor.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/compression/SnappyCompressor.java
@@ -210,4 +210,24 @@ public class SnappyCompressor extends AbstractCompressor {
   public boolean supportUnsafe() {
     return true;
   }
+
+  @Override public int unCompressedLength(byte[] data, int offset, int length) {
+    try {
+      return Snappy.uncompressedLength(data, offset, length);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override public int rawUncompress(byte[] data, int offset, int length, byte[] output) {
+    try {
+      return Snappy.rawUncompress(data, offset, length, output, 0);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override public boolean supportReusableBuffer() {
+    return true;
+  }
 }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/compression/ZstdCompressor.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/compression/ZstdCompressor.java
@@ -74,4 +74,12 @@ public class ZstdCompressor extends AbstractCompressor {
   public boolean supportUnsafe() {
     return false;
   }
+
+  @Override public int unCompressedLength(byte[] data, int offset, int length) {
+    throw new RuntimeException("Unsupported operation Exception");
+  }
+
+  @Override public int rawUncompress(byte[] data, int offset, int length, byte[] output) {
+    throw new RuntimeException("Unsupported operation Exception");
+  }
 }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/ColumnPage.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/ColumnPage.java
@@ -308,7 +308,8 @@ public abstract class ColumnPage {
 
   private static ColumnPage newDecimalPage(ColumnPageEncoderMeta meta,
       byte[] lvEncodedByteArray) throws MemoryException {
-    return VarLengthColumnPageBase.newDecimalColumnPage(meta, lvEncodedByteArray);
+    return VarLengthColumnPageBase
+        .newDecimalColumnPage(meta, lvEncodedByteArray, lvEncodedByteArray.length);
   }
 
   private static ColumnPage newLVBytesPage(TableSpec.ColumnSpec columnSpec,

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/DecoderBasedFallbackEncoder.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/DecoderBasedFallbackEncoder.java
@@ -88,7 +88,8 @@ public class DecoderBasedFallbackEncoder implements Callable<FallbackEncodedColu
           CarbonUtil.getIntArray(data, offset, encodedColumnPage.getPageMetadata().rle_page_length);
       // uncompress the data with rle indexes
       bytes = UnBlockIndexer
-          .uncompressData(bytes, rlePage, CarbonCommonConstants.LOCAL_DICT_ENCODED_BYTEARRAY_SIZE);
+          .uncompressData(bytes, rlePage, CarbonCommonConstants.LOCAL_DICT_ENCODED_BYTEARRAY_SIZE,
+              bytes.length);
     }
 
     // disable encoding using local dictionary

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/VarLengthColumnPageBase.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/VarLengthColumnPageBase.java
@@ -125,7 +125,7 @@ public abstract class VarLengthColumnPageBase extends ColumnPage {
    * Create a new column page for decimal page
    */
   public static ColumnPage newDecimalColumnPage(ColumnPageEncoderMeta meta,
-      byte[] lvEncodedBytes) throws MemoryException {
+      byte[] lvEncodedBytes, int actualDataLength) throws MemoryException {
     TableSpec.ColumnSpec columnSpec = meta.getColumnSpec();
     DecimalConverterFactory.DecimalConverter decimalConverter =
         DecimalConverterFactory.INSTANCE.getDecimalConverter(columnSpec.getPrecision(),
@@ -137,7 +137,7 @@ public abstract class VarLengthColumnPageBase extends ColumnPage {
           CarbonCommonConstants.INT_SIZE_IN_BYTE, meta.getCompressorName());
     } else {
       // Here the size is always fixed.
-      return getDecimalColumnPage(meta, lvEncodedBytes, size);
+      return getDecimalColumnPage(meta, lvEncodedBytes, size, actualDataLength);
     }
   }
 
@@ -160,7 +160,7 @@ public abstract class VarLengthColumnPageBase extends ColumnPage {
   }
 
   private static ColumnPage getDecimalColumnPage(ColumnPageEncoderMeta meta,
-      byte[] lvEncodedBytes, int size) throws MemoryException {
+      byte[] lvEncodedBytes, int size, int actualDataLength) throws MemoryException {
     TableSpec.ColumnSpec columnSpec = meta.getColumnSpec();
     String compressorName = meta.getCompressorName();
     TableSpec.ColumnSpec spec = TableSpec.ColumnSpec
@@ -171,7 +171,7 @@ public abstract class VarLengthColumnPageBase extends ColumnPage {
     int offset;
     int rowId = 0;
     int counter = 0;
-    for (offset = 0; offset < lvEncodedBytes.length; offset += size) {
+    for (offset = 0; offset < actualDataLength; offset += size) {
       rowOffset.putInt(counter, offset);
       rowId++;
       counter++;

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/ColumnPageDecoder.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/ColumnPageDecoder.java
@@ -20,6 +20,7 @@ package org.apache.carbondata.core.datastore.page.encoding;
 import java.io.IOException;
 import java.util.BitSet;
 
+import org.apache.carbondata.core.datastore.ReusableDataBuffer;
 import org.apache.carbondata.core.datastore.page.ColumnPage;
 import org.apache.carbondata.core.memory.MemoryException;
 import org.apache.carbondata.core.scan.result.vector.ColumnVectorInfo;
@@ -29,13 +30,15 @@ public interface ColumnPageDecoder {
   /**
    * Apply decoding algorithm on input byte array and return decoded column page
    */
-  ColumnPage decode(byte[] input, int offset, int length) throws MemoryException, IOException;
+  ColumnPage decode(byte[] input, int offset, int length)
+      throws MemoryException, IOException;
 
   /**
    *  Apply decoding algorithm on input byte array and fill the vector here.
    */
   void decodeAndFillVector(byte[] input, int offset, int length, ColumnVectorInfo vectorInfo,
-      BitSet nullBits, boolean isLVEncoded, int pageSize) throws MemoryException, IOException;
+      BitSet nullBits, boolean isLVEncoded, int pageSize, ReusableDataBuffer reusableDataBuffer)
+      throws MemoryException, IOException;
 
   ColumnPage decode(byte[] input, int offset, int length, boolean isLVEncoded)
       throws MemoryException, IOException;

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/adaptive/AdaptiveFloatingCodec.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/adaptive/AdaptiveFloatingCodec.java
@@ -23,6 +23,7 @@ import java.util.BitSet;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.carbondata.core.datastore.ReusableDataBuffer;
 import org.apache.carbondata.core.datastore.compression.Compressor;
 import org.apache.carbondata.core.datastore.compression.CompressorFactory;
 import org.apache.carbondata.core.datastore.page.ColumnPage;
@@ -111,26 +112,31 @@ public class AdaptiveFloatingCodec extends AdaptiveCodec {
   @Override
   public ColumnPageDecoder createDecoder(final ColumnPageEncoderMeta meta) {
     return new ColumnPageDecoder() {
-      @Override
-      public ColumnPage decode(byte[] input, int offset, int length)
+      @Override public ColumnPage decode(byte[] input, int offset, int length)
           throws MemoryException, IOException {
         ColumnPage page = ColumnPage.decompress(meta, input, offset, length, false);
         return LazyColumnPage.newPage(page, converter);
       }
 
-      @Override
-      public void decodeAndFillVector(byte[] input, int offset, int length,
-          ColumnVectorInfo vectorInfo, BitSet nullBits, boolean isLVEncoded, int pageSize)
+      @Override public void decodeAndFillVector(byte[] input, int offset, int length,
+          ColumnVectorInfo vectorInfo, BitSet nullBits, boolean isLVEncoded, int pageSize,
+          ReusableDataBuffer reusableDataBuffer)
           throws MemoryException, IOException {
         Compressor compressor =
             CompressorFactory.getInstance().getCompressor(meta.getCompressorName());
-        byte[] unCompressData = compressor.unCompressByte(input, offset, length);
+        byte[] unCompressData;
+        if (null != reusableDataBuffer && compressor.supportReusableBuffer()) {
+          int uncompressedLength = compressor.unCompressedLength(input, offset, length);
+          unCompressData = reusableDataBuffer.getDataBuffer(uncompressedLength);
+          compressor.rawUncompress(input, offset, length, unCompressData);
+        } else {
+          unCompressData = compressor.unCompressByte(input, offset, length);
+        }
         converter.decodeAndFillVector(unCompressData, vectorInfo, nullBits, meta.getStoreDataType(),
             pageSize);
       }
 
-      @Override
-      public ColumnPage decode(byte[] input, int offset, int length, boolean isLVEncoded)
+      @Override public ColumnPage decode(byte[] input, int offset, int length, boolean isLVEncoded)
           throws MemoryException, IOException {
         return decode(input, offset, length);
       }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/adaptive/AdaptiveIntegralCodec.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/adaptive/AdaptiveIntegralCodec.java
@@ -23,6 +23,7 @@ import java.util.BitSet;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.carbondata.core.datastore.ReusableDataBuffer;
 import org.apache.carbondata.core.datastore.TableSpec;
 import org.apache.carbondata.core.datastore.compression.Compressor;
 import org.apache.carbondata.core.datastore.compression.CompressorFactory;
@@ -107,8 +108,7 @@ public class AdaptiveIntegralCodec extends AdaptiveCodec {
   @Override
   public ColumnPageDecoder createDecoder(final ColumnPageEncoderMeta meta) {
     return new ColumnPageDecoder() {
-      @Override
-      public ColumnPage decode(byte[] input, int offset, int length)
+      @Override public ColumnPage decode(byte[] input, int offset, int length)
           throws MemoryException, IOException {
         ColumnPage page = null;
         if (DataTypes.isDecimal(meta.getSchemaDataType())) {
@@ -119,13 +119,19 @@ public class AdaptiveIntegralCodec extends AdaptiveCodec {
         return LazyColumnPage.newPage(page, converter);
       }
 
-      @Override
-      public void decodeAndFillVector(byte[] input, int offset, int length,
-          ColumnVectorInfo vectorInfo, BitSet nullBits, boolean isLVEncoded, int pageSize)
-          throws MemoryException, IOException {
+      @Override public void decodeAndFillVector(byte[] input, int offset, int length,
+          ColumnVectorInfo vectorInfo, BitSet nullBits, boolean isLVEncoded, int pageSize,
+          ReusableDataBuffer reusableDataBuffer) throws MemoryException, IOException {
         Compressor compressor =
             CompressorFactory.getInstance().getCompressor(meta.getCompressorName());
-        byte[] unCompressData = compressor.unCompressByte(input, offset, length);
+        byte[] unCompressData;
+        if (null != reusableDataBuffer && compressor.supportReusableBuffer()) {
+          int uncompressedLength = compressor.unCompressedLength(input, offset, length);
+          unCompressData = reusableDataBuffer.getDataBuffer(uncompressedLength);
+          compressor.rawUncompress(input, offset, length, unCompressData);
+        } else {
+          unCompressData = compressor.unCompressByte(input, offset, length);
+        }
         if (DataTypes.isDecimal(meta.getSchemaDataType())) {
           TableSpec.ColumnSpec columnSpec = meta.getColumnSpec();
           DecimalConverterFactory.DecimalConverter decimalConverter =

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/rle/RLECodec.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/rle/RLECodec.java
@@ -27,6 +27,7 @@ import java.util.BitSet;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.carbondata.core.datastore.ReusableDataBuffer;
 import org.apache.carbondata.core.datastore.TableSpec;
 import org.apache.carbondata.core.datastore.page.ColumnPage;
 import org.apache.carbondata.core.datastore.page.encoding.ColumnPageCodec;
@@ -295,8 +296,7 @@ public class RLECodec implements ColumnPageCodec {
       this.compressorName = compressorName;
     }
 
-    @Override
-    public ColumnPage decode(byte[] input, int offset, int length)
+    @Override public ColumnPage decode(byte[] input, int offset, int length)
         throws MemoryException, IOException {
       DataType dataType = columnSpec.getSchemaDataType();
       DataInputStream in = new DataInputStream(new ByteArrayInputStream(input, offset, length));
@@ -316,9 +316,9 @@ public class RLECodec implements ColumnPageCodec {
       return resultPage;
     }
 
-    @Override
-    public void decodeAndFillVector(byte[] input, int offset, int length,
-        ColumnVectorInfo vectorInfo, BitSet nullBits, boolean isLVEncoded, int pageSize)
+    @Override public void decodeAndFillVector(byte[] input, int offset, int length,
+        ColumnVectorInfo vectorInfo, BitSet nullBits, boolean isLVEncoded, int pageSize,
+        ReusableDataBuffer reusableDataBuffer)
         throws MemoryException, IOException {
       throw new UnsupportedOperationException("Not supposed to be called here");
     }

--- a/core/src/main/java/org/apache/carbondata/core/scan/executor/infos/BlockExecutionInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/executor/infos/BlockExecutionInfo.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import org.apache.carbondata.core.datastore.DataRefNode;
 import org.apache.carbondata.core.datastore.IndexKey;
+import org.apache.carbondata.core.datastore.ReusableDataBuffer;
 import org.apache.carbondata.core.datastore.block.AbstractIndex;
 import org.apache.carbondata.core.mutate.DeleteDeltaVo;
 import org.apache.carbondata.core.scan.filter.GenericQueryType;
@@ -220,6 +221,10 @@ public class BlockExecutionInfo {
    * It fills the vector directly from decoded column page with out any staging and conversions
    */
   private boolean isDirectVectorFill;
+
+  private ReusableDataBuffer[] dimensionResusableDataBuffer;
+
+  private ReusableDataBuffer[] measureResusableDataBuffer;
 
   /**
    * @param blockIndex the tableBlock to set
@@ -637,5 +642,21 @@ public class BlockExecutionInfo {
 
   public void setDirectVectorFill(boolean directVectorFill) {
     isDirectVectorFill = directVectorFill;
+  }
+
+  public ReusableDataBuffer[] getDimensionResusableDataBuffer() {
+    return dimensionResusableDataBuffer;
+  }
+
+  public void setDimensionResusableDataBuffer(ReusableDataBuffer[] dimensionResusableDataBuffer) {
+    this.dimensionResusableDataBuffer = dimensionResusableDataBuffer;
+  }
+
+  public ReusableDataBuffer[] getMeasureResusableDataBuffer() {
+    return measureResusableDataBuffer;
+  }
+
+  public void setMeasureResusableDataBuffer(ReusableDataBuffer[] measureResusableDataBuffer) {
+    this.measureResusableDataBuffer = measureResusableDataBuffer;
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/vector/CarbonDictionary.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/vector/CarbonDictionary.java
@@ -22,6 +22,10 @@ public interface CarbonDictionary  {
 
   int getDictionarySize();
 
+  boolean isDictionaryUsed();
+
+  void setDictionaryUsed();
+
   byte[] getDictionaryValue(int index);
 
   byte[][] getAllDictionaryValues();

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/vector/impl/CarbonDictionaryImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/vector/impl/CarbonDictionaryImpl.java
@@ -30,6 +30,8 @@ public class CarbonDictionaryImpl implements CarbonDictionary {
 
   private int actualSize;
 
+  private boolean isDictUsed;
+
   public CarbonDictionaryImpl(byte[][] dictionary, int actualSize) {
     this.dictionary = dictionary;
     this.actualSize = actualSize;
@@ -41,6 +43,14 @@ public class CarbonDictionaryImpl implements CarbonDictionary {
 
   @Override public int getDictionarySize() {
     return this.dictionary.length;
+  }
+
+  @Override public boolean isDictionaryUsed() {
+    return this.isDictUsed;
+  }
+
+  @Override public void setDictionaryUsed() {
+    this.isDictUsed = true;
   }
 
   @Override public byte[] getDictionaryValue(int index) {

--- a/core/src/main/java/org/apache/carbondata/core/scan/scanner/LazyPageLoader.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/scanner/LazyPageLoader.java
@@ -18,6 +18,7 @@ package org.apache.carbondata.core.scan.scanner;
 
 import java.io.IOException;
 
+import org.apache.carbondata.core.datastore.ReusableDataBuffer;
 import org.apache.carbondata.core.datastore.chunk.impl.DimensionRawColumnChunk;
 import org.apache.carbondata.core.datastore.chunk.impl.MeasureRawColumnChunk;
 import org.apache.carbondata.core.scan.result.vector.ColumnVectorInfo;
@@ -43,14 +44,17 @@ public class LazyPageLoader {
 
   private QueryStatisticsModel queryStatisticsModel;
 
+  private ReusableDataBuffer reusableDataBuffer;
+
   public LazyPageLoader(LazyBlockletLoader lazyBlockletLoader, int index, boolean isMeasure,
-      int pageNumber, ColumnVectorInfo vectorInfo) {
+      int pageNumber, ColumnVectorInfo vectorInfo, ReusableDataBuffer reusableDataBuffer) {
     this.lazyBlockletLoader = lazyBlockletLoader;
     this.lazyChunkWrapper = lazyBlockletLoader.getLazyChunkWrapper(index, isMeasure);
     this.isMeasure = isMeasure;
     this.pageNumber = pageNumber;
     this.vectorInfo = vectorInfo;
     this.queryStatisticsModel = lazyBlockletLoader.getQueryStatisticsModel();
+    this.reusableDataBuffer = reusableDataBuffer;
   }
 
   public void loadPage() {
@@ -64,10 +68,10 @@ public class LazyPageLoader {
     long startTime = System.currentTimeMillis();
     if (isMeasure) {
       ((MeasureRawColumnChunk) lazyChunkWrapper.getRawColumnChunk())
-          .convertToColumnPageAndFillVector(pageNumber, vectorInfo);
+          .convertToColumnPageAndFillVector(pageNumber, vectorInfo, reusableDataBuffer);
     } else {
       ((DimensionRawColumnChunk) lazyChunkWrapper.getRawColumnChunk())
-          .convertToDimColDataChunkAndFillVector(pageNumber, vectorInfo);
+          .convertToDimColDataChunkAndFillVector(pageNumber, vectorInfo, reusableDataBuffer);
     }
     if (queryStatisticsModel.isEnabled()) {
       QueryStatistic pageUncompressTime = queryStatisticsModel.getStatisticsTypeAndObjMap()

--- a/core/src/test/java/org/apache/carbondata/core/datastore/chunk/impl/FixedLengthDimensionDataChunkTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/datastore/chunk/impl/FixedLengthDimensionDataChunkTest.java
@@ -38,7 +38,8 @@ public class FixedLengthDimensionDataChunkTest {
 
     int invertedIndexReverse[] = { 1, 0, 5, 7, 8 };
     fixedLengthDimensionDataChunk =
-        new FixedLengthDimensionColumnPage(data, invertedIndex, invertedIndexReverse, 5, 4);
+        new FixedLengthDimensionColumnPage(data, invertedIndex, invertedIndexReverse, 5, 4,
+            data.length);
   }
 
   @Test public void fillChunkDataTest() {

--- a/core/src/test/java/org/apache/carbondata/core/scan/filter/executer/IncludeFilterExecuterImplTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/scan/filter/executer/IncludeFilterExecuterImplTest.java
@@ -184,7 +184,7 @@ public class IncludeFilterExecuterImplTest extends TestCase {
     dim.setFilterKeys(filterKeys);
 
     dimensionColumnDataChunk = new FixedLengthDimensionColumnPage(dataChunk, null, null,
-        dataChunkSize, dimColumnSize);
+        dataChunkSize, dimColumnSize, dataChunk.length);
 
     // repeat query and compare 2 result between old code and new optimized code
     for (int j = 0; j < queryTimes; j++) {
@@ -304,7 +304,7 @@ public class IncludeFilterExecuterImplTest extends TestCase {
     dim.setFilterKeys(filterKeys);
 
     dimensionColumnDataChunk = new FixedLengthDimensionColumnPage(dataChunk, null, null,
-        dataChunk.length / dimColumnSize, dimColumnSize);
+        dataChunk.length / dimColumnSize, dimColumnSize, dataChunk.length);
 
     // initial to run
     BitSet bitOld = this.setFilterdIndexToBitSetWithColumnIndexOld(dimensionColumnDataChunk, dataChunkSize, filterKeys);

--- a/core/src/test/java/org/apache/carbondata/core/util/CarbonUtilTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/util/CarbonUtilTest.java
@@ -247,7 +247,7 @@ public class CarbonUtilTest {
     byte[] dataChunks = { 5, 6, 7, 8, 9 };
     byte[] compareValues = { 7 };
     FixedLengthDimensionColumnPage fixedLengthDataChunk =
-        new FixedLengthDimensionColumnPage(dataChunks, null, null, 5, 1);
+        new FixedLengthDimensionColumnPage(dataChunks, null, null, 5, 1, dataChunks.length);
     int result = CarbonUtil.nextLesserValueToTarget(2, fixedLengthDataChunk, compareValues);
     assertEquals(result, 1);
   }
@@ -256,7 +256,7 @@ public class CarbonUtilTest {
     byte[] dataChunks = { 7, 7, 7, 8, 9 };
     byte[] compareValues = { 7 };
     FixedLengthDimensionColumnPage fixedLengthDataChunk =
-        new FixedLengthDimensionColumnPage(dataChunks, null, null, 5, 1);
+        new FixedLengthDimensionColumnPage(dataChunks, null, null, 5, 1, dataChunks.length);
     int result = CarbonUtil.nextLesserValueToTarget(2, fixedLengthDataChunk, compareValues);
     assertEquals(result, -1);
   }
@@ -265,7 +265,7 @@ public class CarbonUtilTest {
     byte[] dataChunks = { 5, 6, 7, 8, 9 };
     byte[] compareValues = { 7 };
     FixedLengthDimensionColumnPage fixedLengthDataChunk =
-        new FixedLengthDimensionColumnPage(dataChunks, null, null, 5, 1);
+        new FixedLengthDimensionColumnPage(dataChunks, null, null, 5, 1, dataChunks.length);
     int result = CarbonUtil.nextGreaterValueToTarget(2, fixedLengthDataChunk, compareValues, 5);
     assertEquals(result, 3);
   }
@@ -282,7 +282,7 @@ public class CarbonUtilTest {
     byte[] dataChunks = { 5, 6, 7, 7, 7 };
     byte[] compareValues = { 7 };
     FixedLengthDimensionColumnPage fixedLengthDataChunk =
-        new FixedLengthDimensionColumnPage(dataChunks, null, null, 5, 1);
+        new FixedLengthDimensionColumnPage(dataChunks, null, null, 5, 1, dataChunks.length);
     int result = CarbonUtil.nextGreaterValueToTarget(2, fixedLengthDataChunk, compareValues, 5);
     assertEquals(result, 5);
   }
@@ -772,7 +772,7 @@ public class CarbonUtilTest {
     byte[] dataChunks = { 10, 20, 30, 40, 50, 60 };
     byte[] compareValue = { 5 };
     FixedLengthDimensionColumnPage fixedLengthDimensionDataChunk =
-        new FixedLengthDimensionColumnPage(dataChunks, null, null, 6, 1);
+        new FixedLengthDimensionColumnPage(dataChunks, null, null, 6, 1, dataChunks.length);
     int result = CarbonUtil
         .getFirstIndexUsingBinarySearch(fixedLengthDimensionDataChunk, 1, 3, compareValue, false);
     assertEquals(-2, result);
@@ -782,7 +782,7 @@ public class CarbonUtilTest {
     byte[] dataChunks = { 10, 20, 30, 40, 50, 60 };
     byte[] compareValue = { 30 };
     FixedLengthDimensionColumnPage fixedLengthDimensionDataChunk =
-        new FixedLengthDimensionColumnPage(dataChunks, null, null, 6, 1);
+        new FixedLengthDimensionColumnPage(dataChunks, null, null, 6, 1, dataChunks.length);
     int result = CarbonUtil
         .getFirstIndexUsingBinarySearch(fixedLengthDimensionDataChunk, 1, 3, compareValue, false);
     assertEquals(2, result);
@@ -792,7 +792,7 @@ public class CarbonUtilTest {
     byte[] dataChunks = { 10, 10, 10, 40, 50, 60 };
     byte[] compareValue = { 10 };
     FixedLengthDimensionColumnPage fixedLengthDimensionDataChunk =
-        new FixedLengthDimensionColumnPage(dataChunks, null, null, 6, 1);
+        new FixedLengthDimensionColumnPage(dataChunks, null, null, 6, 1, dataChunks.length);
     int result = CarbonUtil
         .getFirstIndexUsingBinarySearch(fixedLengthDimensionDataChunk, 1, 3, compareValue, false);
     assertEquals(0, result);
@@ -802,7 +802,7 @@ public class CarbonUtilTest {
     byte[] dataChunks = { 10, 10, 10, 40, 50, 60 };
     byte[] compareValue = { 10 };
     FixedLengthDimensionColumnPage fixedLengthDimensionDataChunk =
-        new FixedLengthDimensionColumnPage(dataChunks, null, null, 6, 1);
+        new FixedLengthDimensionColumnPage(dataChunks, null, null, 6, 1, dataChunks.length);
     int result = CarbonUtil
         .getFirstIndexUsingBinarySearch(fixedLengthDimensionDataChunk, 1, 3, compareValue, true);
     assertEquals(2, result);
@@ -819,7 +819,7 @@ public class CarbonUtilTest {
     dataChunk = "abbcccddddeffgggh".getBytes();
     byte[][] dataArr = new byte[dataChunk.length / keyWord.length][keyWord.length];
     fixedLengthDimensionDataChunk = new FixedLengthDimensionColumnPage(dataChunk, null, null,
-        dataChunk.length / keyWord.length, keyWord.length);
+        dataChunk.length / keyWord.length, keyWord.length, dataChunk.length);
 
     for (int ii = 0; ii < dataChunk.length / keyWord.length; ii++) {
       dataArr[ii] = fixedLengthDimensionDataChunk.getChunkData(ii);
@@ -851,7 +851,7 @@ public class CarbonUtilTest {
 
     dataChunk = "ab".getBytes();
     fixedLengthDimensionDataChunk = new FixedLengthDimensionColumnPage(dataChunk, null, null,
-        dataChunk.length / keyWord.length, keyWord.length);
+        dataChunk.length / keyWord.length, keyWord.length, dataChunk.length);
 
     keyWord[0] = Byte.valueOf("97");
     range = CarbonUtil.getRangeIndexUsingBinarySearch(fixedLengthDimensionDataChunk, 0, dataChunk.length - 1, keyWord);
@@ -865,7 +865,7 @@ public class CarbonUtilTest {
 
     dataChunk = "aabb".getBytes();
     fixedLengthDimensionDataChunk = new FixedLengthDimensionColumnPage(dataChunk, null, null,
-        dataChunk.length / keyWord.length, keyWord.length);
+        dataChunk.length / keyWord.length, keyWord.length, dataChunk.length);
 
     keyWord[0] = Byte.valueOf("97");
     range = CarbonUtil.getRangeIndexUsingBinarySearch(fixedLengthDimensionDataChunk, 0, dataChunk.length - 1, keyWord);
@@ -879,7 +879,7 @@ public class CarbonUtilTest {
 
     dataChunk = "a".getBytes();
     fixedLengthDimensionDataChunk = new FixedLengthDimensionColumnPage(dataChunk, null, null,
-        dataChunk.length / keyWord.length, keyWord.length);
+        dataChunk.length / keyWord.length, keyWord.length, dataChunk.length);
 
     keyWord[0] = Byte.valueOf("97");
     range = CarbonUtil.getRangeIndexUsingBinarySearch(fixedLengthDimensionDataChunk, 0, dataChunk.length - 1, keyWord);
@@ -888,7 +888,7 @@ public class CarbonUtilTest {
 
     dataChunk = "aa".getBytes();
     fixedLengthDimensionDataChunk = new FixedLengthDimensionColumnPage(dataChunk, null, null,
-        dataChunk.length / keyWord.length, keyWord.length);
+        dataChunk.length / keyWord.length, keyWord.length, dataChunk.length);
 
     keyWord[0] = Byte.valueOf("97");
     range = CarbonUtil.getRangeIndexUsingBinarySearch(fixedLengthDimensionDataChunk, 0, dataChunk.length - 1, keyWord);
@@ -897,7 +897,7 @@ public class CarbonUtilTest {
 
     dataChunk = "aabbbbbbbbbbcc".getBytes();
     fixedLengthDimensionDataChunk = new FixedLengthDimensionColumnPage(dataChunk, null, null,
-        dataChunk.length / keyWord.length, keyWord.length);
+        dataChunk.length / keyWord.length, keyWord.length, dataChunk.length);
     keyWord[0] = Byte.valueOf("98");
     range = CarbonUtil.getRangeIndexUsingBinarySearch(fixedLengthDimensionDataChunk, 0, dataChunk.length - 1, keyWord);
     assertEquals(2, range[0]);
@@ -917,7 +917,7 @@ public class CarbonUtilTest {
     byte[][] dataArr = new byte[dataChunk.length / keyWord.length][keyWord.length];
 
     fixedLengthDimensionDataChunk = new FixedLengthDimensionColumnPage(dataChunk, null, null,
-        dataChunk.length / keyWord.length, keyWord.length);
+        dataChunk.length / keyWord.length, keyWord.length, dataChunk.length);
 
     for (int ii = 0; ii < dataChunk.length / keyWord.length; ii++) {
       dataArr[ii] = fixedLengthDimensionDataChunk.getChunkData(ii);
@@ -959,7 +959,7 @@ public class CarbonUtilTest {
     byte[][] dataArr = new byte[dataChunk.length / keyWord.length][keyWord.length];
 
     fixedLengthDimensionDataChunk = new FixedLengthDimensionColumnPage(dataChunk, null, null,
-        dataChunk.length / keyWord.length, keyWord.length);
+        dataChunk.length / keyWord.length, keyWord.length, dataChunk.length);
 
     for (int ii = 0; ii < dataChunk.length / keyWord.length; ii++) {
       dataArr[ii] = fixedLengthDimensionDataChunk.getChunkData(ii);

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/dataload/TestLoadDataWithCompression.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/dataload/TestLoadDataWithCompression.scala
@@ -147,6 +147,21 @@ class CustomizeCompressor extends Compressor {
   override def supportUnsafe(): Boolean = {
     false
   }
+
+  override def unCompressedLength(data: Array[Byte],
+      offset: Int,
+      length: Int): Int = {
+    throw new RuntimeException("Unsupported operation Exception")
+  }
+
+  override def rawUncompress(data: Array[Byte],
+      offset: Int,
+      length: Int,
+      output: Array[Byte]): Int = {
+    throw new RuntimeException("Unsupported operation Exception")
+  }
+
+  override def supportReusableBuffer(): Boolean = false
 }
 
 class TestLoadDataWithCompression extends QueryTest with BeforeAndAfterEach with BeforeAndAfterAll {

--- a/integration/spark-datasource/src/main/scala/org/apache/carbondata/spark/vectorreader/VectorizedCarbonRecordReader.java
+++ b/integration/spark-datasource/src/main/scala/org/apache/carbondata/spark/vectorreader/VectorizedCarbonRecordReader.java
@@ -365,7 +365,6 @@ public class VectorizedCarbonRecordReader extends AbstractRecordReader<Object> {
       for (int i = 0; i < isNoDictStringField.length; i++) {
         if (isNoDictStringField[i]) {
           vectorProxy.resetDictionaryIds(i);
-          vectorProxy.column(i).setDictionary(null);
         }
       }
     }

--- a/tools/cli/src/main/java/org/apache/carbondata/tool/ScanBenchmark.java
+++ b/tools/cli/src/main/java/org/apache/carbondata/tool/ScanBenchmark.java
@@ -205,7 +205,7 @@ class ScanBenchmark implements Command {
     DimensionColumnPage[] pages = new DimensionColumnPage[numPages];
     for (int i = 0; i < pages.length; i++) {
       pages[i] = dimensionColumnChunkReader.decodeColumnPage(
-          (DimensionRawColumnChunk) rawColumnChunk, i);
+          (DimensionRawColumnChunk) rawColumnChunk, i, null);
     }
     return pages;
   }
@@ -215,7 +215,7 @@ class ScanBenchmark implements Command {
     ColumnPage[] pages = new ColumnPage[numPages];
     for (int i = 0; i < pages.length; i++) {
       pages[i] = measureColumnChunkReader.decodeColumnPage(
-          (MeasureRawColumnChunk) rawColumnChunk, i);
+          (MeasureRawColumnChunk) rawColumnChunk, i, null);
     }
     return pages;
   }


### PR DESCRIPTION
Following optimizations done in the PR.

1. Added reusable buffer for direct flow
In query for each page each column it is creating a byte array, when number of columns are high it is causing lots of minor gc and degrading query performance, as each page is getting uncompressed one by one we can use same buffer for all the columns and based on requested size it will resize.

2. Fixed Local Dictionary performance issue.
Reverted back #2895 and fixed NPE issue by setting null for local dictionary to vector In safe and Unsafe VariableLengthDataChunkStore

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

