### PR TITLE
[CARBONDATA-3058] Fix some exception coding in data loading

### DIFF
--- a/processing/src/main/java/org/apache/carbondata/processing/loading/steps/CarbonRowDataWriterProcessorStepImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/steps/CarbonRowDataWriterProcessorStepImpl.java
@@ -212,7 +212,11 @@ public class CarbonRowDataWriterProcessorStepImpl extends AbstractDataLoadProces
     try {
       processingComplete(dataHandler);
     } catch (CarbonDataLoadingException e) {
-      exception = new CarbonDataWriterException(e.getMessage(), e);
+      // only assign when exception is null
+      // else it will erase original root cause
+      if (null == exception) {
+        exception = new CarbonDataWriterException(e.getMessage(), e);
+      }
     }
     CarbonTimeStatisticsFactory.getLoadStatisticsInstance()
         .recordDictionaryValue2MdkAdd2FileTime(CarbonTablePath.DEPRECATED_PATITION_ID,
@@ -308,7 +312,7 @@ public class CarbonRowDataWriterProcessorStepImpl extends AbstractDataLoadProces
       }
       writeCounter[iteratorIndex] += batch.getSize();
     } catch (Exception e) {
-      throw new CarbonDataLoadingException("unable to generate the mdkey", e);
+      throw new CarbonDataLoadingException(e);
     }
     rowCounter.getAndAdd(batch.getSize());
   }

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/steps/DataWriterBatchProcessorStepImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/steps/DataWriterBatchProcessorStepImpl.java
@@ -141,7 +141,9 @@ public class DataWriterBatchProcessorStepImpl extends AbstractDataLoadProcessorS
     try {
       processingComplete(dataHandler);
     } catch (Exception e) {
-      exception = new CarbonDataWriterException(e.getMessage(), e);
+      if (null == exception) {
+        exception = new CarbonDataWriterException(e.getMessage(), e);
+      }
     }
     CarbonTimeStatisticsFactory.getLoadStatisticsInstance()
         .recordDictionaryValue2MdkAdd2FileTime(CarbonTablePath.DEPRECATED_PATITION_ID,

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/steps/DataWriterProcessorStepImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/steps/DataWriterProcessorStepImpl.java
@@ -259,7 +259,7 @@ public class DataWriterProcessorStepImpl extends AbstractDataLoadProcessorStep {
       readCounter++;
       dataHandler.addDataToStore(row);
     } catch (Exception e) {
-      throw new CarbonDataLoadingException("unable to generate the mdkey", e);
+      throw new CarbonDataLoadingException(e);
     }
     rowCounter.getAndAdd(1);
   }


### PR DESCRIPTION
1. when exception occur in `dataHandler.finish();`, carbon does not proceed it immediately. Carbon keeps the exception and calls method to close the datahandler. But the exception would be overwrite if another exception occur when closing the dataHandler. This makes us lost the root cause.
Refer to `AbstractFactDataWriter.closeExecutorService()` and `CarbonFactDataWriterImplV3.closeWriter()`, we add null check before the second time assignment in `CarbonRowDataWriterProcessorStepImpl.finish()` and `DataWriterBatchProcessorStepImpl` to avoid exception overwrite.

2. remove irrelevant exception message "unable to generate the mdkey", use the exception itself directly. Message in the exception will be retrieved automatically when logging.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

