### PR TITLE
[CARBONDATA-3060]Improve the command for cli and fixed other issues

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/column/ColumnSchema.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/column/ColumnSchema.java
@@ -571,4 +571,13 @@ public class ColumnSchema implements Serializable, Writable {
     }
     this.isLocalDictColumn = in.readBoolean();
   }
+
+  /**
+   * returns whether column is complex column based on column name for child column
+   * @return
+   */
+  public boolean isComplexColumn() {
+    return this.getColumnName()
+        .contains(".val") || this.getColumnName().contains(".");
+  }
 }

--- a/examples/spark2/src/main/java/org/apache/carbondata/examples/sdk/CarbonReaderExample.java
+++ b/examples/spark2/src/main/java/org/apache/carbondata/examples/sdk/CarbonReaderExample.java
@@ -61,7 +61,9 @@ public class CarbonReaderExample {
             CarbonWriter writer = CarbonWriter.builder()
                 .outputPath(path)
                 .withLoadOptions(map)
-                .withCsvInput(new Schema(fields)).writtenBy("CarbonReaderExample").build();
+                .withCsvInput(new Schema(fields))
+                .writtenBy("CarbonReaderExample")
+                .build();
 
             for (int i = 0; i < 10; i++) {
                 String[] row2 = new String[]{

--- a/examples/spark2/src/main/java/org/apache/carbondata/examples/sdk/CarbonReaderExample.java
+++ b/examples/spark2/src/main/java/org/apache/carbondata/examples/sdk/CarbonReaderExample.java
@@ -61,7 +61,7 @@ public class CarbonReaderExample {
             CarbonWriter writer = CarbonWriter.builder()
                 .outputPath(path)
                 .withLoadOptions(map)
-                .withCsvInput(new Schema(fields)).build();
+                .withCsvInput(new Schema(fields)).writtenBy("CarbonReaderExample").build();
 
             for (int i = 0; i < 10; i++) {
                 String[] row2 = new String[]{

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestNonTransactionalCarbonTable.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestNonTransactionalCarbonTable.scala
@@ -389,7 +389,7 @@ class TestNonTransactionalCarbonTable extends QueryTest with BeforeAndAfterAll {
          |'carbondata' LOCATION
          |'$writerPath' """.stripMargin)
 
-    val output = sql("show summary for table sdkOutputTable options('command'='-cmd,summary,-p,-a,-v,-c,age')").collect()
+    val output = sql("Carboncli for table sdkOutputTable options('-cmd summary -a -v -c age')").collect()
 
     assert(output.toList.contains(Row("written_by                       Version         ")))
 

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
@@ -188,7 +188,7 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
   protected val STREAM = carbonKeyWord("STREAM")
   protected val STREAMS = carbonKeyWord("STREAMS")
   protected val STMPROPERTIES = carbonKeyWord("STMPROPERTIES")
-  protected val SUMMARY = carbonKeyWord("SUMMARY")
+  protected val CARBONCLI = carbonKeyWord("CARBONCLI")
 
   protected val doubleQuotedString = "\"([^\"]+)\"".r
   protected val singleQuotedString = "'([^']+)'".r
@@ -1145,10 +1145,10 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
       case _ => ("", "")
     }
 
-  protected lazy val summaryOptions: Parser[(String, String)] =
-    (stringLit <~ "=") ~ stringLit ^^ {
-      case opt ~ optvalue => (opt.trim.toLowerCase(), optvalue)
-      case _ => ("", "")
+  protected lazy val commandOptions: Parser[String] =
+    stringLit ^^ {
+      case optValue => optValue
+      case _ => ""
     }
 
 

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonCliCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonCliCommand.scala
@@ -29,28 +29,28 @@ import org.apache.spark.sql.types.StringType
 import org.apache.carbondata.tool.CarbonCli
 
 /**
- * Show summary command class which is integrated to cli and sql support is provided via this class
+ * CarbonCLi command class which is integrated to cli and sql support is provided via this class
  * @param databaseNameOp
  * @param tableName
  * @param commandOptions
  */
-case class CarbonShowSummaryCommand(
+case class CarbonCliCommand(
     databaseNameOp: Option[String],
     tableName: String,
-    commandOptions: Map[String, String])
+    commandOptions: String)
   extends DataCommand {
 
   override def output: Seq[Attribute] = {
-      Seq(AttributeReference("Table Summary", StringType, nullable = false)())
+      Seq(AttributeReference("CarbonCli", StringType, nullable = false)())
   }
 
   override def processData(sparkSession: SparkSession): Seq[Row] = {
     Checker.validateTableExists(databaseNameOp, tableName, sparkSession)
     val carbonTable = CarbonEnv.getCarbonTable(databaseNameOp, tableName)(sparkSession)
-    val commandArgs: Seq[String] = commandOptions("command").split(",")
+    val commandArgs: Seq[String] = commandOptions.split("\\s+")
     val finalCommands = commandArgs.collect {
-      case a if a.trim.equalsIgnoreCase("-p") =>
-        Seq(a, carbonTable.getTablePath)
+      case a if a.trim.equalsIgnoreCase("summary") || a.trim.equalsIgnoreCase("benchmark") =>
+        Seq(a, "-p", carbonTable.getTablePath)
       case x => Seq(x.trim)
     }.flatten
     val summaryOutput = new util.ArrayList[String]()

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSpark2SqlParser.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSpark2SqlParser.scala
@@ -497,18 +497,18 @@ class CarbonSpark2SqlParser extends CarbonDDLSqlParser {
 
 
   protected lazy val cli: Parser[LogicalPlan] =
-    (SHOW ~> SUMMARY ~> FOR ~> TABLE) ~> (ident <~ ".").? ~ ident ~
-    (OPTIONS ~> "(" ~> repsep(summaryOptions, ",") <~ ")").? <~
+    (CARBONCLI ~> FOR ~> TABLE) ~> (ident <~ ".").? ~ ident ~
+    (OPTIONS ~> "(" ~> commandOptions <~ ")").? <~
     opt(";") ^^ {
       case databaseName ~ tableName ~ commandList =>
-        var commandOptions: Map[String, String] = null
+        var commandOptions: String = null
         if (commandList.isDefined) {
-          commandOptions = commandList.getOrElse(List.empty[(String, String)]).toMap
+          commandOptions = commandList.get
         }
-        CarbonShowSummaryCommand(
+        CarbonCliCommand(
           convertDbNameToLowerCase(databaseName),
           tableName.toLowerCase(),
-          commandOptions.map { case (key, value) => key.toLowerCase -> value })
+          commandOptions)
     }
 
 

--- a/tools/cli/src/main/java/org/apache/carbondata/tool/CarbonCli.java
+++ b/tools/cli/src/main/java/org/apache/carbondata/tool/CarbonCli.java
@@ -19,6 +19,8 @@ package org.apache.carbondata.tool;
 
 import java.io.IOException;
 import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -148,7 +150,10 @@ public class CarbonCli {
       outPuts = new ArrayList<>();
     }
     if (line.hasOption("h")) {
-      printHelp(options);
+      collectHelpInfo(options);
+      for (String output : outPuts) {
+        out.println(output);
+      }
       return;
     }
 
@@ -167,7 +172,10 @@ public class CarbonCli {
     } else {
       out.println("command " + cmd + " is not supported");
       outPuts.add("command " + cmd + " is not supported");
-      printHelp(options);
+      collectHelpInfo(options);
+      for (String output : outPuts) {
+        out.println(output);
+      }
       return;
     }
 
@@ -186,9 +194,14 @@ public class CarbonCli {
     }
   }
 
-  private static void printHelp(Options options) {
+  private static void collectHelpInfo(Options options) {
     HelpFormatter formatter = new HelpFormatter();
-    formatter.printHelp("CarbonCli", options);
+    StringWriter stringWriter = new StringWriter();
+    PrintWriter printWriter = new PrintWriter(stringWriter);
+    formatter.printHelp(printWriter, formatter.getWidth(), "CarbonCli", null, options,
+        formatter.getLeftPadding(), formatter.getDescPadding(), null, false);
+    printWriter.flush();
+    outPuts.add(stringWriter.toString());
   }
 
 }

--- a/tools/cli/src/main/java/org/apache/carbondata/tool/DataFile.java
+++ b/tools/cli/src/main/java/org/apache/carbondata/tool/DataFile.java
@@ -33,6 +33,7 @@ import org.apache.carbondata.core.datastore.impl.FileFactory;
 import org.apache.carbondata.core.memory.MemoryException;
 import org.apache.carbondata.core.metadata.datatype.DataType;
 import org.apache.carbondata.core.metadata.datatype.DataTypes;
+import org.apache.carbondata.core.metadata.encoder.Encoding;
 import org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema;
 import org.apache.carbondata.core.reader.CarbonFooterReaderV3;
 import org.apache.carbondata.core.reader.CarbonHeaderReader;
@@ -446,7 +447,8 @@ class DataFile {
      * @return result
      */
     private double computePercentage(byte[] data, byte[] min, byte[] max, ColumnSchema column) {
-      if (column.getDataType() == DataTypes.STRING) {
+      if (column.getDataType() == DataTypes.STRING || column.getDataType() == DataTypes.BOOLEAN
+          || column.hasEncoding(Encoding.DICTIONARY)) {
         // for string, we do not calculate
         return 0;
       } else if (DataTypes.isDecimal(column.getDataType())) {
@@ -456,7 +458,16 @@ class DataFile {
         return dataValue.divide(factorValue).doubleValue();
       }
       double dataValue, minValue, factorValue;
-      if (column.getDataType() == DataTypes.SHORT) {
+      if (columnChunk.column.isDimensionColumn() && DataTypeUtil
+          .isPrimitiveColumn(columnChunk.column.getDataType())) {
+        minValue = Double.valueOf(String.valueOf(
+            DataTypeUtil.getDataBasedOnDataTypeForNoDictionaryColumn(min, column.getDataType())));
+        dataValue = Double.valueOf(String.valueOf(
+            DataTypeUtil.getDataBasedOnDataTypeForNoDictionaryColumn(data, column.getDataType())));
+        factorValue = Double.valueOf(String.valueOf(
+            DataTypeUtil.getDataBasedOnDataTypeForNoDictionaryColumn(max, column.getDataType())))
+            - minValue;
+      } else if (column.getDataType() == DataTypes.SHORT) {
         minValue = ByteUtil.toShort(min, 0);
         dataValue = ByteUtil.toShort(data, 0) - minValue;
         factorValue = ByteUtil.toShort(max, 0) - ByteUtil.toShort(min, 0);

--- a/tools/cli/src/main/java/org/apache/carbondata/tool/DataFile.java
+++ b/tools/cli/src/main/java/org/apache/carbondata/tool/DataFile.java
@@ -448,7 +448,7 @@ class DataFile {
      */
     private double computePercentage(byte[] data, byte[] min, byte[] max, ColumnSchema column) {
       if (column.getDataType() == DataTypes.STRING || column.getDataType() == DataTypes.BOOLEAN
-          || column.hasEncoding(Encoding.DICTIONARY)) {
+          || column.hasEncoding(Encoding.DICTIONARY) || column.getDataType().isComplexType()) {
         // for string, we do not calculate
         return 0;
       } else if (DataTypes.isDecimal(column.getDataType())) {
@@ -458,8 +458,8 @@ class DataFile {
         return dataValue.divide(factorValue).doubleValue();
       }
       double dataValue, minValue, factorValue;
-      if (columnChunk.column.isDimensionColumn() && DataTypeUtil
-          .isPrimitiveColumn(columnChunk.column.getDataType())) {
+      if (columnChunk.column.isDimensionColumn() &&
+          DataTypeUtil.isPrimitiveColumn(columnChunk.column.getDataType())) {
         minValue = Double.valueOf(String.valueOf(
             DataTypeUtil.getDataBasedOnDataTypeForNoDictionaryColumn(min, column.getDataType())));
         dataValue = Double.valueOf(String.valueOf(


### PR DESCRIPTION
### Changes proposed in this PR:

**1. improve the syntax for CLI DDL, now the command can be given as** 
`CarbonCli for table <table_name> options('-cmd summary/benchmark    -a  -s  -v  -c <column_name> -m')`

the options will take one string, which is basically a command, which user can directly paste into command promt and run as java command
Now user no nned to give -P also, internally when above commad is run we take table path into consideration in command line arguments

**2. other issues are fixed in this PR are**
1. when numeric columns are included in dictionary
2. timestamp column's min and max details
3. help command was not working in beeline
4. for all the complex columns, like parent and child columns, min and max will be given as "NA"




Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

