### PR TITLE
[HOTFIX] Throw original exception in thread pool

### DIFF
--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/NewCarbonDataLoadRDD.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/NewCarbonDataLoadRDD.scala
@@ -156,6 +156,8 @@ class NewCarbonDataLoadRDD[K, V](
           logInfo("Bad Record Found")
         case e: Exception =>
           loadMetadataDetails.setSegmentStatus(SegmentStatus.LOAD_FAILURE)
+          executionErrors.failureCauses = FailureCauses.EXECUTOR_FAILURE
+          executionErrors.errorMsg = e.getMessage
           logInfo("DataLoad failure", e)
           LOGGER.error(e)
           throw e

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/PartitionDropper.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/PartitionDropper.scala
@@ -102,8 +102,8 @@ object PartitionDropper {
               Seq(partitionId, targetPartitionId).toList, dbName,
               tableName, partitionInfo)
           } catch {
-            case e: IOException => sys.error(s"Exception while delete original carbon files " +
-                                             e.getMessage)
+            case e: IOException =>
+              throw new IOException("Exception while delete original carbon files ", e)
           }
           Audit.log(logger, s"Drop Partition request completed for table " +
                        s"${ dbName }.${ tableName }")
@@ -111,7 +111,8 @@ object PartitionDropper {
                       s"${ dbName }.${ tableName }")
         }
       } catch {
-        case e: Exception => sys.error(s"Exception in dropping partition action: ${ e.getMessage }")
+        case e: Exception =>
+          throw new RuntimeException("Exception in dropping partition action", e)
       }
     } else {
       PartitionUtils.deleteOriginalCarbonFile(alterPartitionModel, absoluteTableIdentifier,

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/PartitionSplitter.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/PartitionSplitter.scala
@@ -87,8 +87,8 @@ object PartitionSplitter {
            deleteOriginalCarbonFile(alterPartitionModel, absoluteTableIdentifier,
              Seq(partitionId).toList, databaseName, tableName, partitionInfo)
        } catch {
-         case e: IOException => sys.error(s"Exception while delete original carbon files " +
-         e.getMessage)
+         case e: IOException =>
+           throw new IOException("Exception while delete original carbon files ", e)
        }
        Audit.log(logger, s"Add/Split Partition request completed for table " +
                     s"${ databaseName }.${ tableName }")


### PR DESCRIPTION
If there are exception occurs in the Callable.run in the thread pool, it should throw the original exception instead of throw a new one, which makes it hard for debugging.

 - [X] Any interfaces changed?
 No
 - [X] Any backward compatibility impacted?
 No
 - [X] Document update required?
No
 - [X] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
 rerun all test      
 - [X] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA
