### PR TITLE
[CARBONDATA-3067] Add check for debug to avoid string concat

### DIFF
--- a/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomCoarseGrainDataMap.java
+++ b/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomCoarseGrainDataMap.java
@@ -185,7 +185,9 @@ public class BloomCoarseGrainDataMap extends CoarseGrainDataMap {
     }
     for (BloomQueryModel bloomQueryModel : bloomQueryModels) {
       Set<Blocklet> tempHitBlockletsResult = new HashSet<>();
-      LOGGER.debug("prune blocklet for query: " + bloomQueryModel);
+      if (LOGGER.isDebugEnabled()) {
+        LOGGER.debug("prune blocklet for query: " + bloomQueryModel);
+      }
       BloomCacheKeyValue.CacheKey cacheKey = new BloomCacheKeyValue.CacheKey(
           this.indexPath.toString(), bloomQueryModel.columnName);
       BloomCacheKeyValue.CacheValue cacheValue = cache.get(cacheKey);
@@ -205,12 +207,14 @@ public class BloomCoarseGrainDataMap extends CoarseGrainDataMap {
           }
         }
         if (scanRequired) {
-          LOGGER.debug(String.format("BloomCoarseGrainDataMap: Need to scan -> blocklet#%s",
-              String.valueOf(bloomFilter.getBlockletNo())));
+          if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug(String.format("BloomCoarseGrainDataMap: Need to scan -> blocklet#%s",
+                String.valueOf(bloomFilter.getBlockletNo())));
+          }
           Blocklet blocklet = new Blocklet(bloomFilter.getShardName(),
               String.valueOf(bloomFilter.getBlockletNo()));
           tempHitBlockletsResult.add(blocklet);
-        } else {
+        } else if (LOGGER.isDebugEnabled()) {
           LOGGER.debug(String.format("BloomCoarseGrainDataMap: Skip scan -> blocklet#%s",
               String.valueOf(bloomFilter.getBlockletNo())));
         }


### PR DESCRIPTION
For bloomfilter datamap, it will log debug for each blocklet. If the
data is huge, there maybe thousands of blocklet, so in this commit, we
will try to avoid necessary string concat if the debug level is not
enabled.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

