### PR TITLE
[CARBONDATA-3068] fixed cannot load data from hdfs files without hdfs prefix

### DIFF
--- a/integration/spark-common/src/main/scala/org/apache/spark/util/FileUtils.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/util/FileUtils.scala
@@ -75,7 +75,7 @@ object FileUtils {
       val filePaths = inputPath.split(",")
       for (i <- 0 until filePaths.size) {
         val filePath = CarbonUtil.checkAndAppendHDFSUrl(filePaths(i))
-        val carbonFile = FileFactory.getCarbonFile(filePaths(i), hadoopConf)
+        val carbonFile = FileFactory.getCarbonFile(filePath, hadoopConf)
         if (!carbonFile.exists()) {
           throw new DataLoadingException(
             s"The input file does not exist: ${CarbonUtil.removeAKSK(filePaths(i))}" )


### PR DESCRIPTION
sql:
LOAD DATA INPATH '/tmp/test.csv' INTO TABLE test OPTIONS('QUOTECHAR'='"','TIMESTAMPFORMAT'='yyyy/MM/dd HH:mm:ss');
error:
org.apache.carbondata.processing.exception.DataLoadingException: The input file does not exist: /tmp/test.csv (state=,code=0)
but the file "test.csv" is in hdfs path, and hadoop conf "core-site.xml" has the property:
<property>
  <name>fs.defaultFS</name>
  <value>hdfs://master:9000</value>
</property>

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
        no
 - [x] Any backward compatibility impacted?
        no
 - [x] Document update required?
        no
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       yes
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
        NA
