### PR TITLE
[CARBONDATA-3069][Compaction] Fix bugs in setting cores for compaction

### DIFF
--- a/processing/src/main/java/org/apache/carbondata/processing/store/CarbonFactDataHandlerModel.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/CarbonFactDataHandlerModel.java
@@ -312,7 +312,7 @@ public class CarbonFactDataHandlerModel {
     }
     carbonFactDataHandlerModel.dataMapWriterlistener = listener;
     carbonFactDataHandlerModel.writingCoresCount = configuration.getWritingCoresCount();
-    setNumberOfCores(carbonFactDataHandlerModel);
+    carbonFactDataHandlerModel.initNumberOfCores();
     carbonFactDataHandlerModel.setVarcharDimIdxInNoDict(varcharDimIdxInNoDict);
     return carbonFactDataHandlerModel;
   }
@@ -400,7 +400,7 @@ public class CarbonFactDataHandlerModel {
             loadModel.getSegmentId()),
         segmentProperties);
     carbonFactDataHandlerModel.dataMapWriterlistener = listener;
-    setNumberOfCores(carbonFactDataHandlerModel);
+    carbonFactDataHandlerModel.initNumberOfCores();
     carbonFactDataHandlerModel
         .setColumnLocalDictGenMap(CarbonUtil.getLocalDictionaryModel(carbonTable));
     carbonFactDataHandlerModel.setVarcharDimIdxInNoDict(varcharDimIdxInNoDict);
@@ -570,6 +570,7 @@ public class CarbonFactDataHandlerModel {
    */
   public void setCompactionFlow(boolean compactionFlow) {
     isCompactionFlow = compactionFlow;
+    initNumberOfCores();
   }
 
   /**
@@ -683,30 +684,30 @@ public class CarbonFactDataHandlerModel {
     this.columnLocalDictGenMap = columnLocalDictGenMap;
   }
 
-  private static void setNumberOfCores(CarbonFactDataHandlerModel model) {
+  private void initNumberOfCores() {
     // in compaction flow the measure with decimal type will come as spark decimal.
     // need to convert it to byte array.
-    if (model.isCompactionFlow()) {
+    if (this.isCompactionFlow()) {
       try {
-        model.numberOfCores = Integer.parseInt(CarbonProperties.getInstance()
+        this.numberOfCores = Integer.parseInt(CarbonProperties.getInstance()
             .getProperty(CarbonCommonConstants.NUM_CORES_COMPACTING,
                 CarbonCommonConstants.NUM_CORES_DEFAULT_VAL));
       } catch (NumberFormatException exc) {
         LOGGER.error("Configured value for property " + CarbonCommonConstants.NUM_CORES_COMPACTING
             + "is wrong.Falling back to the default value "
             + CarbonCommonConstants.NUM_CORES_DEFAULT_VAL);
-        model.numberOfCores = Integer.parseInt(CarbonCommonConstants.NUM_CORES_DEFAULT_VAL);
+        this.numberOfCores = Integer.parseInt(CarbonCommonConstants.NUM_CORES_DEFAULT_VAL);
       }
     } else {
-      model.numberOfCores = CarbonProperties.getInstance().getNumberOfCores();
+      this.numberOfCores = CarbonProperties.getInstance().getNumberOfCores();
     }
 
-    if (model.sortScope != null && model.sortScope.equals(SortScopeOptions.SortScope.GLOBAL_SORT)) {
-      model.numberOfCores = 1;
+    if (this.sortScope != null && this.sortScope.equals(SortScopeOptions.SortScope.GLOBAL_SORT)) {
+      this.numberOfCores = 1;
     }
     // Overriding it to the task specified cores.
-    if (model.getWritingCoresCount() > 0) {
-      model.numberOfCores = model.getWritingCoresCount();
+    if (this.getWritingCoresCount() > 0) {
+      this.numberOfCores = this.getWritingCoresCount();
     }
   }
 


### PR DESCRIPTION
Current implementation for setting cores for compaction is wrong. It
will set the cores first and then set the flow to compaction, which
causes that the number set is always from 'loading.cores' instead of
'compaction.cores'.
In this commit, we fix this bug by setting the cores again when the user
changes the flow to compaction.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 `Yes, only internal used interfaces has been changed`
 - [x] Any backward compatibility impacted?
 `NO`
 - [x] Document update required?
`NO`
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
`No, it only affects the intermediate procedure`
        - How it is tested? Please attach test report.
`Tested and verified in local machine`
        - Is it a performance related change? Please attach the performance test report.
`For users whose 'compaction.cores' is not equal to 'loading.cores', the performance of compaction may change`
        - Any additional information to help reviewers in testing this change.
`NA`
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
`NA`
