### PR TITLE
[HOTFIX] Fix NPE in spark, when same vector reads files with local dictionary and without local dictionary

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/LocalDictDimensionDataChunkStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/LocalDictDimensionDataChunkStore.java
@@ -61,10 +61,7 @@ public class LocalDictDimensionDataChunkStore implements DimensionDataChunkStore
     int columnValueSize = dimensionDataChunkStore.getColumnValueSize();
     int rowsNum = data.length / columnValueSize;
     CarbonColumnVector vector = vectorInfo.vector;
-    if (!dictionary.isDictionaryUsed()) {
-      vector.setDictionary(dictionary);
-      dictionary.setDictionaryUsed();
-    }
+    vector.setDictionary(dictionary);
     BitSet nullBitset = new BitSet();
     CarbonColumnVector dictionaryVector = ColumnarVectorWrapperDirectFactory
         .getDirectVectorWrapperFactory(vector.getDictionaryVector(), invertedIndex, nullBitset,
@@ -91,10 +88,7 @@ public class LocalDictDimensionDataChunkStore implements DimensionDataChunkStore
   }
 
   @Override public void fillRow(int rowId, CarbonColumnVector vector, int vectorRow) {
-    if (!dictionary.isDictionaryUsed()) {
-      vector.setDictionary(dictionary);
-      dictionary.setDictionaryUsed();
-    }
+    vector.setDictionary(dictionary);
     int surrogate = dimensionDataChunkStore.getSurrogate(rowId);
     if (surrogate == CarbonCommonConstants.MEMBER_DEFAULT_VAL_SURROGATE_KEY) {
       vector.putNull(vectorRow);

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/vector/CarbonDictionary.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/vector/CarbonDictionary.java
@@ -22,10 +22,6 @@ public interface CarbonDictionary  {
 
   int getDictionarySize();
 
-  boolean isDictionaryUsed();
-
-  void setDictionaryUsed();
-
   byte[] getDictionaryValue(int index);
 
   byte[][] getAllDictionaryValues();

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/vector/impl/CarbonDictionaryImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/vector/impl/CarbonDictionaryImpl.java
@@ -24,8 +24,6 @@ public class CarbonDictionaryImpl implements CarbonDictionary {
 
   private int actualSize;
 
-  private boolean isDictUsed;
-
   public CarbonDictionaryImpl(byte[][] dictionary, int actualSize) {
     this.dictionary = dictionary;
     this.actualSize = actualSize;
@@ -37,14 +35,6 @@ public class CarbonDictionaryImpl implements CarbonDictionary {
 
   @Override public int getDictionarySize() {
     return this.dictionary.length;
-  }
-
-  @Override public boolean isDictionaryUsed() {
-    return this.isDictUsed;
-  }
-
-  @Override public void setDictionaryUsed() {
-    this.isDictUsed = true;
   }
 
   @Override public byte[] getDictionaryValue(int index) {

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonFileInputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonFileInputFormat.java
@@ -199,7 +199,7 @@ public class CarbonFileInputFormat<T> extends CarbonInputFormat<T> implements Se
     try {
       carbonFiles = FileFactory.getCarbonFile(tablePath).listFiles(true, new CarbonFileFilter() {
         @Override public boolean accept(CarbonFile file) {
-          return file.getName().contains(CarbonTablePath.CARBON_DATA_EXT);
+          return file.getName().endsWith(CarbonTablePath.CARBON_DATA_EXT);
         }
       });
     } catch (IOException e) {

--- a/integration/spark-datasource/src/main/scala/org/apache/carbondata/spark/vectorreader/VectorizedCarbonRecordReader.java
+++ b/integration/spark-datasource/src/main/scala/org/apache/carbondata/spark/vectorreader/VectorizedCarbonRecordReader.java
@@ -336,6 +336,7 @@ public class VectorizedCarbonRecordReader extends AbstractRecordReader<Object> {
       for (int i = 0; i < isNoDictStringField.length; i++) {
         if (isNoDictStringField[i]) {
           vectorProxy.resetDictionaryIds(i);
+          vectorProxy.column(i).setDictionary(null);
         }
       }
     }


### PR DESCRIPTION
problem: NPE in spark, when same vector reads files with local dictionary and without local dictionary

cause: when two carbondata files are present, one with local dictionary and one without local dictionary. If same vector is used to read this files [can happen if task is launched to group of files]. If  local dictionary files are found first, dictionary is set for that vector. But it was never reset for another file reading.

solution: reset dictionary once batch is processed,set only for local dictionary batch processing. 


Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed? NA
 
 - [ ] Any backward compatibility impacted? NA
 
 - [ ] Document update required? NA

 - [ ] Testing done
yes, cluster testing done.       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.  NA

