### PR TITLE
[CARBONDATA-3075] Select Filter fails for Legacy store if DirectVecorFill is enabled

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/scan/executor/impl/AbstractQueryExecutor.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/executor/impl/AbstractQueryExecutor.java
@@ -230,6 +230,11 @@ public abstract class AbstractQueryExecutor<E> implements QueryExecutor<E> {
           updateColumns(queryModel, fileFooter.getColumnInTable(), blockInfo.getFilePath());
           filePathToSegmentPropertiesMap.put(blockInfo.getFilePath(), segmentProperties);
         }
+        LOGGER.warn("Skipping Direct Vector Filling as it is not Supported "
+            + "for Legacy store prior to V3 store");
+        if (blockletDetailInfo.isLegacyStore()) {
+          queryModel.setDirectVectorFill(false);
+        }
         readAndFillBlockletInfo(tableBlockInfos, blockInfo,
             blockletDetailInfo, fileFooter, segmentProperties);
       } else {


### PR DESCRIPTION
**Why this PR?**
When **isDirectVectorFill** is set to true, Select filter fails in Legacy Store throwing UnsupportedOperationException

**Solution:**
Set **isDirectVectorFill** to false for Legacy store


 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

