### PR TITLE
[CARBONDATA-3081] Fixed NPE for boolean type column with null value

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/metadata/datatype/DecimalType.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/datatype/DecimalType.java
@@ -23,7 +23,7 @@ public class DecimalType extends DataType {
   private int scale;
 
   // create a decimal type object with specified precision and scale
-  public DecimalType(int precision, int scale) {
+  DecimalType(int precision, int scale) {
     super(DataTypes.DECIMAL_TYPE_ID, 8, "DECIMAL", -1);
     this.precision = precision;
     this.scale = scale;

--- a/store/sdk/src/test/java/org/apache/carbondata/sdk/file/CarbonReaderTest.java
+++ b/store/sdk/src/test/java/org/apache/carbondata/sdk/file/CarbonReaderTest.java
@@ -2025,4 +2025,53 @@ public class CarbonReaderTest extends TestCase {
     }
   }
 
+  @Test
+  public void testReadingNullValues() {
+    String path = "./testWriteFiles";
+    try {
+      FileUtils.deleteDirectory(new File(path));
+
+      Field[] fields = new Field[2];
+      fields[0] = new Field("stringField", DataTypes.STRING);
+      fields[1] = new Field("booleanField", DataTypes.BOOLEAN);
+      CarbonWriter writer = CarbonWriter.builder()
+          .outputPath(path)
+          .withCsvInput(new Schema(fields))
+          .writtenBy("CarbonReaderTest")
+          .build();
+
+      for (int i = 0; i < 2; i++) {
+        String[] row2 = new String[]{
+            "robot" + (i % 10),
+            "",
+        };
+        writer.write(row2);
+      }
+      writer.close();
+
+      // Read data
+      CarbonReader reader = CarbonReader
+          .builder(path, "_temp")
+          .build();
+
+      int i = 0;
+      while (reader.hasNext()) {
+        reader.readNextRow();
+        i++;
+      }
+      assert (i == 2);
+      reader.close();
+    } catch (Throwable e) {
+      e.printStackTrace();
+      Assert.fail(e.getMessage());
+    } finally {
+      try {
+        FileUtils.deleteDirectory(new File(path));
+      } catch (IOException e) {
+        e.printStackTrace();
+        Assert.fail(e.getMessage());
+      }
+    }
+  }
+
 }


### PR DESCRIPTION
**Problem:** NPE thrown when boolean type column has null values.

**Solution:** check for null values before converting byte to boolean.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

