### PR TITLE
[CARBONDATA-3084]dataload failure fix when float value exceeds the limit

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/primitiveTypes/FloatDataTypeTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/primitiveTypes/FloatDataTypeTestCase.scala
@@ -26,6 +26,8 @@ import org.scalatest.BeforeAndAfterAll
 class FloatDataTypeTestCase extends QueryTest with BeforeAndAfterAll {
 
   override def beforeAll {
+    sql("DROP TABLE IF EXISTS datatype_float_hive")
+    sql("DROP TABLE IF EXISTS datatype_float_byte")
     sql("DROP TABLE IF EXISTS tfloat")
     sql("""
            CREATE TABLE IF NOT EXISTS tfloat
@@ -57,7 +59,19 @@ class FloatDataTypeTestCase extends QueryTest with BeforeAndAfterAll {
       Seq(Row(24.56)))
   }
 
+  test("test when float range exceeds") {
+    sql("create table datatype_float_hive(f float, b byte)")
+    sql("insert into datatype_float_hive select 1.7976931348623157E308,-127")
+    sql("create table datatype_float_byte(f float, b byte) using carbon")
+    sql("insert into datatype_float_byte select 1.7976931348623157E308,-127")
+    checkAnswer(
+      sql("SELECT f FROM datatype_float_byte"),
+      sql("SELECT f FROM datatype_float_hive"))
+  }
+
   override def afterAll {
     sql("DROP TABLE IF EXISTS tfloat")
+    sql("DROP TABLE IF EXISTS datatype_float_byte")
+    sql("DROP TABLE IF EXISTS datatype_float_hive")
   }
 }


### PR DESCRIPTION
### Problem:
when the float value exceeds the range and we try to insert that data, data load fails.

### Analysis:
when the value exceeds the range, the max is set as `Infinity`, so the decimal count of that value will be 0, so when decimal count is zero we go for CodecByAlgorithmForIntegral, so it fails

### Solution:
when the value exceeds, and decimal count is zero , source datatype is float, then select DirectCompressCodec

### How this tested:
test cases are added to validate the load and data

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

