### PR TITLE
[CARBONDATA-3088][Compaction] support prefetch for compaction

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/scan/result/iterator/RawResultIterator.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/iterator/RawResultIterator.java
@@ -16,12 +16,21 @@
  */
 package org.apache.carbondata.core.scan.result.iterator;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
 import org.apache.carbondata.common.CarbonIterator;
 import org.apache.carbondata.common.logging.LogServiceFactory;
+import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.datastore.block.SegmentProperties;
 import org.apache.carbondata.core.keygenerator.KeyGenException;
 import org.apache.carbondata.core.scan.result.RowBatch;
 import org.apache.carbondata.core.scan.wrappers.ByteArrayWrapper;
+import org.apache.carbondata.core.util.CarbonProperties;
 
 import org.apache.log4j.Logger;
 
@@ -40,12 +49,14 @@ public class RawResultIterator extends CarbonIterator<Object[]> {
    */
   private CarbonIterator<RowBatch> detailRawQueryResultIterator;
 
-  /**
-   * Counter to maintain the row counter.
-   */
-  private int counter = 0;
-
-  private Object[] currentConveretedRawRow = null;
+  private boolean prefetchEnabled;
+  private List<Object[]> currentBuffer;
+  private List<Object[]> backupBuffer;
+  private int currentIdxInBuffer;
+  private ExecutorService executorService;
+  private Future<Void> fetchFuture;
+  private Object[] currentRawRow = null;
+  private boolean isBackupFilled = false;
 
   /**
    * LOGGER
@@ -53,72 +64,126 @@ public class RawResultIterator extends CarbonIterator<Object[]> {
   private static final Logger LOGGER =
       LogServiceFactory.getLogService(RawResultIterator.class.getName());
 
-  /**
-   * batch of the result.
-   */
-  private RowBatch batch;
-
   public RawResultIterator(CarbonIterator<RowBatch> detailRawQueryResultIterator,
-      SegmentProperties sourceSegProperties, SegmentProperties destinationSegProperties) {
+      SegmentProperties sourceSegProperties, SegmentProperties destinationSegProperties,
+      boolean isStreamingHandoff) {
     this.detailRawQueryResultIterator = detailRawQueryResultIterator;
     this.sourceSegProperties = sourceSegProperties;
     this.destinationSegProperties = destinationSegProperties;
+    this.executorService = Executors.newFixedThreadPool(1);
+
+    if (!isStreamingHandoff) {
+      init();
+    }
+  }
+
+  private void init() {
+    this.prefetchEnabled = CarbonProperties.getInstance().getProperty(
+        CarbonCommonConstants.CARBON_COMPACTION_PREFETCH_ENABLE,
+        CarbonCommonConstants.CARBON_COMPACTION_PREFETCH_ENABLE_DEFAULT).equalsIgnoreCase("true");
+    try {
+      new RowsFetcher(false).call();
+      if (prefetchEnabled) {
+        this.fetchFuture = executorService.submit(new RowsFetcher(true));
+      }
+    } catch (Exception e) {
+      LOGGER.error("Error occurs while fetching records", e);
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * fetch rows
+   */
+  private final class RowsFetcher implements Callable<Void> {
+    private boolean isBackupFilling;
+
+    private RowsFetcher(boolean isBackupFilling) {
+      this.isBackupFilling = isBackupFilling;
+    }
+
+    @Override
+    public Void call() throws Exception {
+      if (isBackupFilling) {
+        backupBuffer = fetchRows();
+        isBackupFilled = true;
+      } else {
+        currentBuffer = fetchRows();
+      }
+      return null;
+    }
+  }
+
+  private List<Object[]> fetchRows() throws Exception {
+    List<Object[]> converted = new ArrayList<>();
+    if (detailRawQueryResultIterator.hasNext()) {
+      for (Object[] r : detailRawQueryResultIterator.next().getRows()) {
+        converted.add(convertRow(r));
+      }
+      return converted;
+    } else {
+      return new ArrayList<>();
+    }
+  }
+
+  private void fillDataFromPrefetch() {
+    try {
+      if (currentIdxInBuffer >= currentBuffer.size() && 0 != currentIdxInBuffer) {
+        if (prefetchEnabled) {
+          if (!isBackupFilled) {
+            fetchFuture.get();
+          }
+          // copy backup buffer to current buffer and fill backup buffer asyn
+          currentIdxInBuffer = 0;
+          currentBuffer.clear();
+          currentBuffer = backupBuffer;
+          isBackupFilled = false;
+          fetchFuture = executorService.submit(new RowsFetcher(true));
+        } else {
+          currentIdxInBuffer = 0;
+          new RowsFetcher(false).call();
+        }
+      }
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * populate a row with index counter increased
+   */
+  private void popRow() {
+    fillDataFromPrefetch();
+    currentRawRow = currentBuffer.get(currentIdxInBuffer);
+    currentIdxInBuffer++;
+  }
+
+  /**
+   * populate a row with index counter unchanged
+   */
+  private void pickRow() {
+    fillDataFromPrefetch();
+    currentRawRow = currentBuffer.get(currentIdxInBuffer);
   }
 
   @Override
   public boolean hasNext() {
-    if (null == batch || checkIfBatchIsProcessedCompletely(batch)) {
-      if (detailRawQueryResultIterator.hasNext()) {
-        batch = null;
-        batch = detailRawQueryResultIterator.next();
-        counter = 0; // batch changed so reset the counter.
-      } else {
-        return false;
-      }
-    }
-    if (!checkIfBatchIsProcessedCompletely(batch)) {
+    fillDataFromPrefetch();
+    if (currentIdxInBuffer < currentBuffer.size()) {
       return true;
-    } else {
-      return false;
     }
+
+    return false;
   }
 
   @Override
   public Object[] next() {
-    if (null == batch) { // for 1st time
-      batch = detailRawQueryResultIterator.next();
-    }
-    if (!checkIfBatchIsProcessedCompletely(batch)) {
-      try {
-        if (null != currentConveretedRawRow) {
-          counter++;
-          Object[] currentConveretedRawRowTemp = this.currentConveretedRawRow;
-          currentConveretedRawRow = null;
-          return currentConveretedRawRowTemp;
-        }
-        return convertRow(batch.getRawRow(counter++));
-      } catch (KeyGenException e) {
-        LOGGER.error(e.getMessage());
-        return null;
-      }
-    } else { // completed one batch.
-      batch = null;
-      batch = detailRawQueryResultIterator.next();
-      counter = 0;
-    }
     try {
-      if (null != currentConveretedRawRow) {
-        counter++;
-        Object[] currentConveretedRawRowTemp = this.currentConveretedRawRow;
-        currentConveretedRawRow = null;
-        return currentConveretedRawRowTemp;
-      }
-      return convertRow(batch.getRawRow(counter++));
-    } catch (KeyGenException e) {
-      LOGGER.error(e.getMessage());
-      return null;
+      popRow();
+      return this.currentRawRow;
+    } catch (Exception e) {
+      throw new RuntimeException(e);
     }
-
   }
 
   /**
@@ -126,17 +191,8 @@ public class RawResultIterator extends CarbonIterator<Object[]> {
    * @return
    */
   public Object[] fetchConverted() throws KeyGenException {
-    if (null != currentConveretedRawRow) {
-      return currentConveretedRawRow;
-    }
-    if (hasNext()) {
-      Object[] rawRow = batch.getRawRow(counter);
-      currentConveretedRawRow = convertRow(rawRow);
-      return currentConveretedRawRow;
-    }
-    else {
-      return null;
-    }
+    pickRow();
+    return this.currentRawRow;
   }
 
   private Object[] convertRow(Object[] rawRow) throws KeyGenException {
@@ -148,16 +204,9 @@ public class RawResultIterator extends CarbonIterator<Object[]> {
     return rawRow;
   }
 
-  /**
-   * To check if the batch is processed completely
-   * @param batch
-   * @return
-   */
-  private boolean checkIfBatchIsProcessedCompletely(RowBatch batch) {
-    if (counter < batch.getSize()) {
-      return false;
-    } else {
-      return true;
+  public void close() {
+    if (null != executorService) {
+      executorService.shutdownNow();
     }
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/iterator/RawResultIterator.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/iterator/RawResultIterator.java
@@ -120,10 +120,8 @@ public class RawResultIterator extends CarbonIterator<Object[]> {
       for (Object[] r : detailRawQueryResultIterator.next().getRows()) {
         converted.add(convertRow(r));
       }
-      return converted;
-    } else {
-      return new ArrayList<>();
     }
+    return converted;
   }
 
   private void fillDataFromPrefetch() {

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/StreamHandoffRDD.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/StreamHandoffRDD.scala
@@ -79,7 +79,7 @@ class HandoffPartition(
  */
 class StreamingRawResultIterator(
     recordReader: RecordReader[Void, Any]
-) extends RawResultIterator(null, null, null) {
+) extends RawResultIterator(null, null, null, false) {
 
   override def hasNext: Boolean = {
     recordReader.nextKeyValue()

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/StreamHandoffRDD.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/StreamHandoffRDD.scala
@@ -79,7 +79,7 @@ class HandoffPartition(
  */
 class StreamingRawResultIterator(
     recordReader: RecordReader[Void, Any]
-) extends RawResultIterator(null, null, null, false) {
+) extends RawResultIterator(null, null, null, true) {
 
   override def hasNext: Boolean = {
     recordReader.nextKeyValue()

--- a/processing/src/main/java/org/apache/carbondata/processing/merger/CarbonCompactionExecutor.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/merger/CarbonCompactionExecutor.java
@@ -136,7 +136,7 @@ public class CarbonCompactionExecutor {
         resultList.add(
             new RawResultIterator(executeBlockList(list, segmentId, task, configuration),
                 sourceSegProperties,
-                destinationSegProperties));
+                destinationSegProperties, false));
       }
     }
     return resultList;


### PR DESCRIPTION
Current compaction performance is low. By adding logs to observe the
compaction procedure, we found that in
`CarbonFactDataHandlerColumnar.addDataToStore(CarbonRow)`, it will wait
about 30ms before submitting a new TablePage producer. Since the method
`addDataToStore` is called in single thread, it will result the waiting
every 32000 records since it will collect 32000 records to form a
TablePage.

To reduce the waiting time, we can prepare the 32000 records ahead. This
can be achived using prefetch.

We will prepare two buffers, one will provide the records to the
downstream (`addDataToStore`) and the other one will prepare the records
asynchronously. The first is called working buffer and the second is
called backup buffer. Once working buffer is exhausted, the two buffers
will exchange their roles: the backup buffer will be the new working
buffer and the old working buffer will be the new backup buffer and it
will be filled asynchronously.

Two parameters are involved for this feature:

1. carbon.detail.batch.size: This is an existed parameter and the default
value is 100. This parameter controls the batch size of records that
return to the client. For normal query, it is OK to keep it as 100. But
for compaction, since all the records will be operated, we suggest you
to set it to a larger value such as 32000. (32000 is the max rows for a
table page that the down stream wants).

2. carbon.compaction.prefetch.enable: This is a new parameter and the
default value is `false` (We may change it to `true` later). This
parameter controls whether we will prefetch the records for compation.

By using this prefetch feature, we can enhance the performance for
compaction. More test results can be found in the PR description.

## Test1
3 huawei ecs instances as workers each with 16cores and 32GB. Spark executor use 12 cores and 24GB. Using 74GB LineItem in 100GB TPCH

| Code Branch | Inverted Index | Prefetch  |  Batch Size (default 100)  |  Load1/2/3 (s)  |  Compact 3 Loads (s) | Time Reduced  |  Perf Enhanced |
| ------------- | ---- | ---- | ------------------------ | --------- | ------------------- | ----------- | ----- |
| master@20181107 | TRUE  |  NA | 100 447.4/445.9/450.1 |  661.3 |  Baseline  |  Baseline |
| master@20181107 | TRUE  |  NA | 32000  |  441.5/454.4/456.8 |  641.2 |  3.0%  |  3.1% |
| PR2906@20181107 | TRUE  |  enable | 100 | 445.3/450.2/445.3  | 411.8  | 37.7%  | 60.6% |
| PR2906@20181107 | TRUE  |  enable | 32000   | 438.7/446.8/441.8  | 333.1  | 49.6%  | 98.5% |
| PR2906@20181107 | TRUE  |  disable | 100 |  458.1/459.4/450.9 |  659.5 |  0.3%  |  0.3% |
| PR2906@20181107 | TRUE  |  disable | 32000  |  472.0/446.8/457.1 |  654.5 |  1.0%  |  1.0% |
| master@20181120 | FALSE |  NA | 100 | 427.4/440.0/432.0  | 596.5  | 9.8%   | 10.9% |
| master@20181120 | FALSE |  NA | 32000  |  431.1/430.7/433.6 |  603.1 |  8.8%  |  9.7% |
| PR2906@20181120 | FALSE |  enable | 100 | 436.9/430.8/424.3  | 386.7  | 41.5%  | 71.0% |
| PR2906@20181120 | FALSE |  enable | 32000   4| 43.7/432.9/439.7   |306.0   |53.7%   |116.1% |
| PR2906@20181120 | FALSE |  disable | 100 |  448.1/437.1/436.4 |  611.0 |  7.6%  |  8.2% |
| PR2906@20181120 | FALSE |  disable | 32000   | 437.5/431.7/448.1  | 597.2  | 9.7%   | 10.7% |


## Test2

1 huawei RH2288 with 32 cores and 128GB. Spark executor use   30cores and 90GB. Using 7.3GB LineItem in 10GB TPCH

Code   Branch | Prefetch | Batch Size   (default 100) | Load1 (s) | Load2 (s) | Load3 (s) | Compact 3 Loads   (s) | Time Reduced | Perf Enhanced
-- | -- | -- | -- | -- | -- | -- | -- | --
master | NA | 100 | 147.4 | 142.3 | 144.6 | 201.4 | Baseline | Baseline
master | NA | 32000 | 140.8 | 138.7 | 141.6 | 196.2 | 2.6% | 2.7%
PR2906 | enable | 100 | 143.9 | 142.5 | 146.2 | 99.9 | 50.4% | 101.6%
PR2906 | enable | 32000 | 142.1 | 139.3 | 136.9 | 98.3 | 51.2% | 104.9%
PR2906 | disable | 100 | 146.7 | 137.4 | 139.6 | 200.6 | 0.4% | 0.4%
PR2906 | disable | 32000 | 145.2 | 145.0 | 139.7 | 195.7 | 2.8% | 2.9%

**Note**:
Prefetch: carbon.compaction.prefetch.enable
BatchSize: carbon.detail.batch.size 

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

