### PR TITLE
[CARBONDATA-3090][Integration][Perf] optimizing the columnar vector filling  flow by removing unwanted filter check.

### DIFF
--- a/integration/presto/src/main/java/org/apache/carbondata/presto/CarbonColumnVectorWrapper.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/CarbonColumnVectorWrapper.java
@@ -29,43 +29,36 @@ public class CarbonColumnVectorWrapper implements CarbonColumnVector {
 
   private CarbonColumnVectorImpl columnVector;
 
-  private boolean[] filteredRows;
-
   private int counter;
 
   private boolean filteredRowsExist;
 
   private DataType blockDataType;
 
-  public CarbonColumnVectorWrapper(CarbonColumnVectorImpl columnVector, boolean[] filteredRows) {
+  public CarbonColumnVectorWrapper(CarbonColumnVectorImpl columnVector) {
     this.columnVector = columnVector;
-    this.filteredRows = filteredRows;
   }
 
-  @Override public void putBoolean(int rowId, boolean value) {
-    if (!filteredRows[rowId]) {
-      columnVector.putBoolean(counter++, value);
-    }
+  @Override
+  public void putBoolean(int rowId, boolean value) {
+    columnVector.putBoolean(counter++, value);
   }
 
-  @Override public void putFloat(int rowId, float value) {
-    if (!filteredRows[rowId]) {
-      columnVector.putFloat(counter++, value);
-    }
+  @Override
+  public void putFloat(int rowId, float value) {
+    columnVector.putFloat(counter++, value);
   }
 
-  @Override public void putShort(int rowId, short value) {
-    if (!filteredRows[rowId]) {
-      columnVector.putShort(counter++, value);
-    }
+  @Override
+  public void putShort(int rowId, short value) {
+    columnVector.putShort(counter++, value);
   }
 
-  @Override public void putShorts(int rowId, int count, short value) {
+  @Override
+  public void putShorts(int rowId, int count, short value) {
     if (filteredRowsExist) {
       for (int i = 0; i < count; i++) {
-        if (!filteredRows[rowId]) {
-          columnVector.putShort(counter++, value);
-        }
+        columnVector.putShort(counter++, value);
         rowId++;
       }
     } else {
@@ -73,18 +66,16 @@ public class CarbonColumnVectorWrapper implements CarbonColumnVector {
     }
   }
 
-  @Override public void putInt(int rowId, int value) {
-    if (!filteredRows[rowId]) {
-      columnVector.putInt(counter++, value);
-    }
+  @Override
+  public void putInt(int rowId, int value) {
+    columnVector.putInt(counter++, value);
   }
 
-  @Override public void putInts(int rowId, int count, int value) {
+  @Override
+  public void putInts(int rowId, int count, int value) {
     if (filteredRowsExist) {
       for (int i = 0; i < count; i++) {
-        if (!filteredRows[rowId]) {
-          columnVector.putInt(counter++, value);
-        }
+        columnVector.putInt(counter++, value);
         rowId++;
       }
     } else {
@@ -92,18 +83,16 @@ public class CarbonColumnVectorWrapper implements CarbonColumnVector {
     }
   }
 
-  @Override public void putLong(int rowId, long value) {
-    if (!filteredRows[rowId]) {
-      columnVector.putLong(counter++, value);
-    }
+  @Override
+  public void putLong(int rowId, long value) {
+    columnVector.putLong(counter++, value);
   }
 
-  @Override public void putLongs(int rowId, int count, long value) {
+  @Override
+  public void putLongs(int rowId, int count, long value) {
     if (filteredRowsExist) {
       for (int i = 0; i < count; i++) {
-        if (!filteredRows[rowId]) {
-          columnVector.putLong(counter++, value);
-        }
+        columnVector.putLong(counter++, value);
         rowId++;
       }
     } else {
@@ -111,33 +100,29 @@ public class CarbonColumnVectorWrapper implements CarbonColumnVector {
     }
   }
 
-  @Override public void putDecimal(int rowId, BigDecimal value, int precision) {
-    if (!filteredRows[rowId]) {
-      columnVector.putDecimal(counter++, value, precision);
-    }
+  @Override
+  public void putDecimal(int rowId, BigDecimal value, int precision) {
+    columnVector.putDecimal(counter++, value, precision);
   }
 
-  @Override public void putDecimals(int rowId, int count, BigDecimal value, int precision) {
+  @Override
+  public void putDecimals(int rowId, int count, BigDecimal value, int precision) {
     for (int i = 0; i < count; i++) {
-      if (!filteredRows[rowId]) {
-        columnVector.putDecimal(counter++, value, precision);
-      }
+      columnVector.putDecimal(counter++, value, precision);
       rowId++;
     }
   }
 
-  @Override public void putDouble(int rowId, double value) {
-    if (!filteredRows[rowId]) {
-      columnVector.putDouble(counter++, value);
-    }
+  @Override
+  public void putDouble(int rowId, double value) {
+    columnVector.putDouble(counter++, value);
   }
 
-  @Override public void putDoubles(int rowId, int count, double value) {
+  @Override
+  public void putDoubles(int rowId, int count, double value) {
     if (filteredRowsExist) {
       for (int i = 0; i < count; i++) {
-        if (!filteredRows[rowId]) {
-          columnVector.putDouble(counter++, value);
-        }
+        columnVector.putDouble(counter++, value);
         rowId++;
       }
     } else {
@@ -145,45 +130,39 @@ public class CarbonColumnVectorWrapper implements CarbonColumnVector {
     }
   }
 
-  @Override public void putByte(int rowId, byte value) {
-    if (!filteredRows[rowId]) {
-      columnVector.putByte(counter++, value);
-    }
+  @Override
+  public void putByte(int rowId, byte value) {
+    columnVector.putByte(counter++, value);
   }
 
-  @Override public void putByteArray(int rowId, byte[] value) {
-    if (!filteredRows[rowId]) {
-      columnVector.putByteArray(counter++, value);
-    }
+  @Override
+  public void putByteArray(int rowId, byte[] value) {
+    columnVector.putByteArray(counter++, value);
   }
 
-  @Override public void putBytes(int rowId, int count, byte[] value) {
+  @Override
+  public void putBytes(int rowId, int count, byte[] value) {
     for (int i = 0; i < count; i++) {
-      if (!filteredRows[rowId]) {
-        columnVector.putByteArray(counter++, value);
-      }
+      columnVector.putByteArray(counter++, value);
       rowId++;
     }
   }
 
-  @Override public void putByteArray(int rowId, int offset, int length, byte[] value) {
-    if (!filteredRows[rowId]) {
-      columnVector.putByteArray(counter++, offset, length, value);
-    }
+  @Override
+  public void putByteArray(int rowId, int offset, int length, byte[] value) {
+    columnVector.putByteArray(counter++, offset, length, value);
   }
 
-  @Override public void putNull(int rowId) {
-    if (!filteredRows[rowId]) {
-      columnVector.putNull(counter++);
-    }
+  @Override
+  public void putNull(int rowId) {
+    columnVector.putNull(counter++);
   }
 
-  @Override public void putNulls(int rowId, int count) {
+  @Override
+  public void putNulls(int rowId, int count) {
     if (filteredRowsExist) {
       for (int i = 0; i < count; i++) {
-        if (!filteredRows[rowId]) {
-          columnVector.putNull(counter++);
-        }
+        columnVector.putNull(counter++);
         rowId++;
       }
     } else {
@@ -191,33 +170,40 @@ public class CarbonColumnVectorWrapper implements CarbonColumnVector {
     }
   }
 
-  @Override public void putNotNull(int rowId) {
+  @Override
+  public void putNotNull(int rowId) {
 
   }
 
-  @Override public void putNotNull(int rowId, int count) {
+  @Override
+  public void putNotNull(int rowId, int count) {
 
   }
 
-  @Override public boolean isNull(int rowId) {
+  @Override
+  public boolean isNull(int rowId) {
     return columnVector.isNullAt(rowId);
   }
 
-  @Override public void putObject(int rowId, Object obj) {
+  @Override
+  public void putObject(int rowId, Object obj) {
     //TODO handle complex types
   }
 
-  @Override public Object getData(int rowId) {
+  @Override
+  public Object getData(int rowId) {
     //TODO handle complex types
     return null;
   }
 
-  @Override public void reset() {
+  @Override
+  public void reset() {
     counter = 0;
     filteredRowsExist = false;
   }
 
-  @Override public DataType getType() {
+  @Override
+  public DataType getType() {
     return columnVector.getType();
   }
 
@@ -231,77 +217,76 @@ public class CarbonColumnVectorWrapper implements CarbonColumnVector {
     this.blockDataType = blockDataType;
   }
 
-  @Override public void setFilteredRowsExist(boolean filteredRowsExist) {
+  @Override
+  public void setFilteredRowsExist(boolean filteredRowsExist) {
     this.filteredRowsExist = filteredRowsExist;
   }
 
-  @Override public void setDictionary(CarbonDictionary dictionary) {
+  @Override
+  public void setDictionary(CarbonDictionary dictionary) {
     this.columnVector.setDictionary(dictionary);
   }
 
-  @Override public boolean hasDictionary() {
+  @Override
+  public boolean hasDictionary() {
     return this.columnVector.hasDictionary();
   }
 
-  @Override public CarbonColumnVector getDictionaryVector() {
+  @Override
+  public CarbonColumnVector getDictionaryVector() {
     return this.columnVector;
   }
 
-  @Override public void putFloats(int rowId, int count, float[] src, int srcIndex) {
+  @Override
+  public void putFloats(int rowId, int count, float[] src, int srcIndex) {
     for (int i = srcIndex; i < count; i++) {
-      if (!filteredRows[rowId]) {
-        columnVector.putFloat(counter++, src[i]);
-      }
+      columnVector.putFloat(counter++, src[i]);
       rowId++;
     }
   }
 
-  @Override public void putShorts(int rowId, int count, short[] src, int srcIndex) {
+  @Override
+  public void putShorts(int rowId, int count, short[] src, int srcIndex) {
     for (int i = srcIndex; i < count; i++) {
-      if (!filteredRows[rowId]) {
-        columnVector.putShort(counter++, src[i]);
-      }
+      columnVector.putShort(counter++, src[i]);
       rowId++;
     }
   }
 
-  @Override public void putInts(int rowId, int count, int[] src, int srcIndex) {
+  @Override
+  public void putInts(int rowId, int count, int[] src, int srcIndex) {
     for (int i = srcIndex; i < count; i++) {
-      if (!filteredRows[rowId]) {
-        columnVector.putInt(counter++, src[i]);
-      }
+      columnVector.putInt(counter++, src[i]);
       rowId++;
     }
   }
 
-  @Override public void putLongs(int rowId, int count, long[] src, int srcIndex) {
+  @Override
+  public void putLongs(int rowId, int count, long[] src, int srcIndex) {
     for (int i = srcIndex; i < count; i++) {
-      if (!filteredRows[rowId]) {
-        columnVector.putLong(counter++, src[i]);
-      }
+      columnVector.putLong(counter++, src[i]);
       rowId++;
     }
   }
 
-  @Override public void putDoubles(int rowId, int count, double[] src, int srcIndex) {
+  @Override
+  public void putDoubles(int rowId, int count, double[] src, int srcIndex) {
     for (int i = srcIndex; i < count; i++) {
-      if (!filteredRows[rowId]) {
-        columnVector.putDouble(counter++, src[i]);
-      }
+      columnVector.putDouble(counter++, src[i]);
       rowId++;
     }
   }
 
-  @Override public void putBytes(int rowId, int count, byte[] src, int srcIndex) {
+  @Override
+  public void putBytes(int rowId, int count, byte[] src, int srcIndex) {
     for (int i = srcIndex; i < count; i++) {
-      if (!filteredRows[rowId]) {
-        columnVector.putByte(counter++, src[i]);
-      }
+      columnVector.putByte(counter++, src[i]);
       rowId++;
     }
   }
 
-  @Override public void setLazyPage(LazyPageLoader lazyPage) {
+  @Override
+  public void setLazyPage(LazyPageLoader lazyPage) {
     lazyPage.loadPage();
   }
 

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/PrestoCarbonVectorizedRecordReader.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/PrestoCarbonVectorizedRecordReader.java
@@ -218,7 +218,7 @@ class PrestoCarbonVectorizedRecordReader extends AbstractRecordReader<Object> {
     CarbonColumnVector[] vectors = new CarbonColumnVector[fields.length];
     boolean[] filteredRows = new boolean[columnarBatch.capacity()];
     for (int i = 0; i < fields.length; i++) {
-      vectors[i] = new CarbonColumnVectorWrapper(columnarBatch.column(i), filteredRows);
+      vectors[i] = new CarbonColumnVectorWrapper(columnarBatch.column(i));
     }
     carbonColumnarBatch = new CarbonColumnarBatch(vectors, columnarBatch.capacity(), filteredRows);
   }

--- a/integration/spark-datasource/src/main/scala/org/apache/carbondata/spark/vectorreader/ColumnarVectorWrapper.java
+++ b/integration/spark-datasource/src/main/scala/org/apache/carbondata/spark/vectorreader/ColumnarVectorWrapper.java
@@ -34,8 +34,6 @@ class ColumnarVectorWrapper implements CarbonColumnVector {
 
   private CarbonVectorProxy carbonVectorProxy;
 
-  private boolean[] filteredRows;
-
   private int counter;
 
   private int ordinal;
@@ -48,38 +46,29 @@ class ColumnarVectorWrapper implements CarbonColumnVector {
 
   private CarbonColumnVector dictionaryVector;
 
-  ColumnarVectorWrapper(CarbonVectorProxy writableColumnVector,
-      boolean[] filteredRows, int ordinal) {
+  ColumnarVectorWrapper(CarbonVectorProxy writableColumnVector, int ordinal) {
     this.sparkColumnVectorProxy = writableColumnVector.getColumnVector(ordinal);
-    this.filteredRows = filteredRows;
     this.carbonVectorProxy = writableColumnVector;
     this.ordinal = ordinal;
   }
 
   @Override public void putBoolean(int rowId, boolean value) {
-    if (!filteredRows[rowId]) {
       sparkColumnVectorProxy.putBoolean(counter++, value);
-    }
   }
 
   @Override public void putFloat(int rowId, float value) {
-    if (!filteredRows[rowId]) {
       sparkColumnVectorProxy.putFloat(counter++, value);
-    }
   }
 
   @Override public void putShort(int rowId, short value) {
-    if (!filteredRows[rowId]) {
       sparkColumnVectorProxy.putShort(counter++, value);
-    }
   }
 
-  @Override public void putShorts(int rowId, int count, short value) {
+  @Override
+  public void putShorts(int rowId, int count, short value) {
     if (filteredRowsExist) {
       for (int i = 0; i < count; i++) {
-        if (!filteredRows[rowId]) {
-          sparkColumnVectorProxy.putShort(counter++, value);
-        }
+        sparkColumnVectorProxy.putShort(counter++, value);
         rowId++;
       }
     } else {
@@ -88,21 +77,17 @@ class ColumnarVectorWrapper implements CarbonColumnVector {
   }
 
   @Override public void putInt(int rowId, int value) {
-    if (!filteredRows[rowId]) {
       if (isDictionary) {
         sparkColumnVectorProxy.putDictionaryInt(counter++, value);
       } else {
         sparkColumnVectorProxy.putInt(counter++, value);
       }
-    }
   }
 
   @Override public void putInts(int rowId, int count, int value) {
     if (filteredRowsExist) {
       for (int i = 0; i < count; i++) {
-        if (!filteredRows[rowId]) {
           sparkColumnVectorProxy.putInt(counter++, value);
-        }
         rowId++;
       }
     } else {
@@ -111,17 +96,13 @@ class ColumnarVectorWrapper implements CarbonColumnVector {
   }
 
   @Override public void putLong(int rowId, long value) {
-    if (!filteredRows[rowId]) {
       sparkColumnVectorProxy.putLong(counter++, value);
-    }
   }
 
   @Override public void putLongs(int rowId, int count, long value) {
     if (filteredRowsExist) {
       for (int i = 0; i < count; i++) {
-        if (!filteredRows[rowId]) {
           sparkColumnVectorProxy.putLong(counter++, value);
-        }
         rowId++;
       }
     } else {
@@ -130,34 +111,26 @@ class ColumnarVectorWrapper implements CarbonColumnVector {
   }
 
   @Override public void putDecimal(int rowId, BigDecimal value, int precision) {
-    if (!filteredRows[rowId]) {
       Decimal toDecimal = Decimal.apply(value);
       sparkColumnVectorProxy.putDecimal(counter++, toDecimal, precision);
-    }
   }
 
   @Override public void putDecimals(int rowId, int count, BigDecimal value, int precision) {
     Decimal decimal = Decimal.apply(value);
     for (int i = 0; i < count; i++) {
-      if (!filteredRows[rowId]) {
         sparkColumnVectorProxy.putDecimal(counter++, decimal, precision);
-      }
       rowId++;
     }
   }
 
   @Override public void putDouble(int rowId, double value) {
-    if (!filteredRows[rowId]) {
       sparkColumnVectorProxy.putDouble(counter++, value);
-    }
   }
 
   @Override public void putDoubles(int rowId, int count, double value) {
     if (filteredRowsExist) {
       for (int i = 0; i < count; i++) {
-        if (!filteredRows[rowId]) {
           sparkColumnVectorProxy.putDouble(counter++, value);
-        }
         rowId++;
       }
     } else {
@@ -166,44 +139,32 @@ class ColumnarVectorWrapper implements CarbonColumnVector {
   }
 
   @Override public void putByte(int rowId, byte value) {
-    if (!filteredRows[rowId]) {
       sparkColumnVectorProxy.putByte(counter++, value);
-    }
   }
 
   @Override public void putByteArray(int rowId, byte[] value) {
-    if (!filteredRows[rowId]) {
       sparkColumnVectorProxy.putByteArray(counter++, value, 0, value.length);
-    }
   }
 
   @Override public void putBytes(int rowId, int count, byte[] value) {
     for (int i = 0; i < count; i++) {
-      if (!filteredRows[rowId]) {
         sparkColumnVectorProxy.putByteArray(counter++, value);
-      }
       rowId++;
     }
   }
 
   @Override public void putByteArray(int rowId, int offset, int length, byte[] value) {
-    if (!filteredRows[rowId]) {
       sparkColumnVectorProxy.putByteArray(counter++, value, offset, length);
-    }
   }
 
   @Override public void putNull(int rowId) {
-    if (!filteredRows[rowId]) {
       sparkColumnVectorProxy.putNull(counter++);
-    }
   }
 
   @Override public void putNulls(int rowId, int count) {
     if (filteredRowsExist) {
       for (int i = 0; i < count; i++) {
-        if (!filteredRows[rowId]) {
           sparkColumnVectorProxy.putNull(counter++);
-        }
         rowId++;
       }
     } else {
@@ -212,17 +173,13 @@ class ColumnarVectorWrapper implements CarbonColumnVector {
   }
 
   @Override public void putNotNull(int rowId) {
-    if (!filteredRows[rowId]) {
       sparkColumnVectorProxy.putNotNull(counter++);
-    }
   }
 
   @Override public void putNotNull(int rowId, int count) {
     if (filteredRowsExist) {
       for (int i = 0; i < count; i++) {
-        if (!filteredRows[rowId]) {
           sparkColumnVectorProxy.putNotNull(counter++);
-        }
         rowId++;
       }
     } else {
@@ -281,7 +238,7 @@ class ColumnarVectorWrapper implements CarbonColumnVector {
 
   public void reserveDictionaryIds() {
     sparkColumnVectorProxy.reserveDictionaryIds(carbonVectorProxy.numRows());
-    dictionaryVector = new ColumnarVectorWrapper(carbonVectorProxy, filteredRows, ordinal);
+    dictionaryVector = new ColumnarVectorWrapper(carbonVectorProxy, ordinal);
     ((ColumnarVectorWrapper) dictionaryVector).isDictionary = true;
   }
 
@@ -289,56 +246,49 @@ class ColumnarVectorWrapper implements CarbonColumnVector {
     return dictionaryVector;
   }
 
-  @Override public void putFloats(int rowId, int count, float[] src, int srcIndex) {
+  @Override
+  public void putFloats(int rowId, int count, float[] src, int srcIndex) {
     for (int i = srcIndex; i < count; i++) {
-      if (!filteredRows[rowId]) {
-        sparkColumnVectorProxy.putFloat(counter++, src[i]);
-      }
+      sparkColumnVectorProxy.putFloat(counter++, src[i]);
       rowId++;
     }
   }
 
-  @Override public void putShorts(int rowId, int count, short[] src, int srcIndex) {
+  @Override
+  public void putShorts(int rowId, int count, short[] src, int srcIndex) {
     for (int i = srcIndex; i < count; i++) {
-      if (!filteredRows[rowId]) {
-        sparkColumnVectorProxy.putShort(counter++, src[i]);
-      }
+      sparkColumnVectorProxy.putShort(counter++, src[i]);
       rowId++;
     }
   }
 
-  @Override public void putInts(int rowId, int count, int[] src, int srcIndex) {
+  @Override
+  public void putInts(int rowId, int count, int[] src, int srcIndex) {
     for (int i = srcIndex; i < count; i++) {
-      if (!filteredRows[rowId]) {
-        sparkColumnVectorProxy.putInt(counter++, src[i]);
-      }
+      sparkColumnVectorProxy.putInt(counter++, src[i]);
       rowId++;
     }
   }
 
-  @Override public void putLongs(int rowId, int count, long[] src, int srcIndex) {
+  @Override
+  public void putLongs(int rowId, int count, long[] src, int srcIndex) {
     for (int i = srcIndex; i < count; i++) {
-      if (!filteredRows[rowId]) {
-        sparkColumnVectorProxy.putLong(counter++, src[i]);
-      }
+      sparkColumnVectorProxy.putLong(counter++, src[i]);
       rowId++;
     }
   }
 
   @Override public void putDoubles(int rowId, int count, double[] src, int srcIndex) {
     for (int i = srcIndex; i < count; i++) {
-      if (!filteredRows[rowId]) {
         sparkColumnVectorProxy.putDouble(counter++, src[i]);
-      }
       rowId++;
     }
   }
 
-  @Override public void putBytes(int rowId, int count, byte[] src, int srcIndex) {
+  @Override
+  public void putBytes(int rowId, int count, byte[] src, int srcIndex) {
     for (int i = srcIndex; i < count; i++) {
-      if (!filteredRows[rowId]) {
-        sparkColumnVectorProxy.putByte(counter++, src[i]);
-      }
+      sparkColumnVectorProxy.putByte(counter++, src[i]);
       rowId++;
     }
   }

--- a/integration/spark-datasource/src/main/scala/org/apache/carbondata/spark/vectorreader/VectorizedCarbonRecordReader.java
+++ b/integration/spark-datasource/src/main/scala/org/apache/carbondata/spark/vectorreader/VectorizedCarbonRecordReader.java
@@ -307,7 +307,7 @@ public class VectorizedCarbonRecordReader extends AbstractRecordReader<Object> {
     } else {
       filteredRows = new boolean[vectorProxy.numRows()];
       for (int i = 0; i < fields.length; i++) {
-        vectors[i] = new ColumnarVectorWrapper(vectorProxy, filteredRows, i);
+        vectors[i] = new ColumnarVectorWrapper(vectorProxy, i);
         if (isNoDictStringField[i]) {
           if (vectors[i] instanceof ColumnarVectorWrapper) {
             ((ColumnarVectorWrapper) vectors[i]).reserveDictionaryIds();


### PR DESCRIPTION
## What changes were proposed in this pull request?
optimizing the columnar vector filling flow by removing unwanted filter check, currently while filling  column vectors as part of vector reading flow in the carbon query,  while processing the batch of rows there is a filter condition check which will validate each row whether its part of filter, since the batch already has filtered rows r , the filter check is not useful while forming the ColunVector, 
 in the current flow the boolean filteredRows[] is never been set  once its initialized so always the values will be false.
As part of the optimization this redundant validation of filter check is been removed. This optimization can also improve the performance of queries which undergoes vectorized reading since this check for each  row processing will add overhead while query processing.

## How was this patch tested?
Existing Unit test.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 None
 - [ ] Any backward compatibility impacted?
 None
 - [ ] Document update required?
None
 - [ ] Testing done
        Please provide details on 
    Existing testcases can verify the impact.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

