### PR TITLE
[WIP]Show load/insert/update/delete row number

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/iud/TestShowIUDRowCount.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/iud/TestShowIUDRowCount.scala
@@ -1,0 +1,60 @@
+package org.apache.carbondata.spark.testsuite.iud
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.test.util.QueryTest
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
+
+class TestShowIUDRowCount extends QueryTest with BeforeAndAfterEach with BeforeAndAfterAll {
+
+  override protected def beforeAll(): Unit = {
+    dropTable("iud_rows")
+  }
+
+  override protected def beforeEach(): Unit = {
+    dropTable("iud_rows")
+  }
+
+  override protected def afterEach(): Unit = {
+    dropTable("iud_rows")
+  }
+
+  test("Test show load row count") {
+    sql("""create table iud_rows (c1 string,c2 int,c3 string,c5 string)
+        |STORED BY 'org.apache.carbondata.format'""".stripMargin)
+    checkAnswer(
+      sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/IUD/dest.csv' INTO table iud_rows"""),
+      Seq(Row(5)))
+  }
+
+  test("Test show insert row count") {
+    sql("""create table iud_rows (c1 string,c2 int,c3 string,c5 string)
+          |STORED BY 'org.apache.carbondata.format'""".stripMargin)
+    checkAnswer(
+      sql(s"""INSERT INTO TABLE iud_rows VALUES('f',6,'ff','fff')"""),
+      Seq(Row(1)))
+  }
+
+  test("Test show update row count") {
+    sql("""create table iud_rows (c1 string,c2 int,c3 string,c5 string)
+          |STORED BY 'org.apache.carbondata.format'""".stripMargin)
+    sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/IUD/dest.csv' INTO table iud_rows""")
+    checkAnswer(
+      sql(s"""UPDATE iud_rows SET (c1)=('k') WHERE c2 = 4"""),
+      Seq(Row(1)))
+    checkAnswer(sql("SELECT c1 FROM iud_rows WHERE c2 = 4"), Seq(Row("k")))
+  }
+
+  test("Test show delete row count") {
+    sql("""create table iud_rows (c1 string,c2 int,c3 string,c5 string)
+          |STORED BY 'org.apache.carbondata.format'""".stripMargin)
+    sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/IUD/dest.csv' INTO table iud_rows""")
+    checkAnswer(
+      sql(s"""DELETE FROM iud_rows WHERE c2 = 4"""),
+      Seq(Row(1)))
+    checkAnswer(sql("SELECT count(*) FROM iud_rows"), Seq(Row(4)))
+  }
+
+  override protected def afterAll(): Unit = {
+    dropTable("iud_rows")
+  }
+}

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/KeyVal.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/KeyVal.scala
@@ -48,29 +48,30 @@ class RawValueImpl extends RawValue[Array[Any]] {
 }
 
 trait DataLoadResult[K, V] extends Serializable {
-  def getKey(key: String, value: (LoadMetadataDetails, ExecutionErrors)): (K, V)
+  def getKey(key: String, value: (LoadMetadataDetails, ExecutionErrors, Long)): (K, V)
 }
 
-class DataLoadResultImpl extends DataLoadResult[String, (LoadMetadataDetails, ExecutionErrors)] {
+class DataLoadResultImpl extends
+  DataLoadResult[String, (LoadMetadataDetails, ExecutionErrors, Long)] {
   override def getKey(key: String,
-      value: (LoadMetadataDetails, ExecutionErrors)): (String, (LoadMetadataDetails,
-    ExecutionErrors)) = {
+      value: (LoadMetadataDetails, ExecutionErrors, Long)): (String, (LoadMetadataDetails,
+    ExecutionErrors, Long)) = {
     (key, value)
   }
 }
 
 trait updateResult[K, V] extends Serializable {
   def getKey(key: String,
-             value: (LoadMetadataDetails, ExecutionErrors)):
+             value: (LoadMetadataDetails, ExecutionErrors, Long)):
   (K, V)
 }
 
 class updateResultImpl
-  extends updateResult[String, (LoadMetadataDetails, ExecutionErrors)] {
+  extends updateResult[String, (LoadMetadataDetails, ExecutionErrors, Long)] {
   override def getKey(key: String,
-                      value: (LoadMetadataDetails, ExecutionErrors)):
+                      value: (LoadMetadataDetails, ExecutionErrors, Long)):
   (String,
-    (LoadMetadataDetails, ExecutionErrors)) = {
+    (LoadMetadataDetails, ExecutionErrors, Long)) = {
     (key, value)
   }
 }

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/load/DataLoadProcessBuilderOnSpark.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/load/DataLoadProcessBuilderOnSpark.scala
@@ -47,7 +47,7 @@ object DataLoadProcessBuilderOnSpark {
       sparkSession: SparkSession,
       dataFrame: Option[DataFrame],
       model: CarbonLoadModel,
-      hadoopConf: Configuration): Array[(String, (LoadMetadataDetails, ExecutionErrors))] = {
+      hadoopConf: Configuration): Array[(String, (LoadMetadataDetails, ExecutionErrors, Long))] = {
     val originRDD = if (dataFrame.isDefined) {
       dataFrame.get.rdd
     } else {
@@ -147,13 +147,13 @@ object DataLoadProcessBuilderOnSpark {
       loadMetadataDetails.setSegmentStatus(SegmentStatus.LOAD_PARTIAL_SUCCESS)
       val executionErrors = new ExecutionErrors(FailureCauses.NONE, "")
       executionErrors.failureCauses = FailureCauses.BAD_RECORDS
-      Array((uniqueLoadStatusId, (loadMetadataDetails, executionErrors)))
+      Array((uniqueLoadStatusId, (loadMetadataDetails, executionErrors, writeStepRowCounter.value)))
     } else {
       val uniqueLoadStatusId = model.getTableName + CarbonCommonConstants.UNDERSCORE + "Success"
       val loadMetadataDetails = new LoadMetadataDetails()
       loadMetadataDetails.setSegmentStatus(SegmentStatus.SUCCESS)
       val executionErrors = new ExecutionErrors(FailureCauses.NONE, "")
-      Array((uniqueLoadStatusId, (loadMetadataDetails, executionErrors)))
+      Array((uniqueLoadStatusId, (loadMetadataDetails, executionErrors, writeStepRowCounter.value)))
     }
   }
 }

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/UpdateDataLoad.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/UpdateDataLoad.scala
@@ -40,7 +40,7 @@ object UpdateDataLoad {
       index: Long,
       iter: Iterator[Row],
       carbonLoadModel: CarbonLoadModel,
-      loadMetadataDetails: LoadMetadataDetails): Unit = {
+      loadMetadataDetails: LoadMetadataDetails): Long = {
     val LOGGER = LogServiceFactory.getLogService(this.getClass.getCanonicalName)
     try {
       val recordReaders = mutable.Buffer[CarbonIterator[Array[AnyRef]]]()
@@ -61,7 +61,7 @@ object UpdateDataLoad {
         executor.close()
         CommonUtil.clearUnsafeMemory(ThreadLocalTaskInfo.getCarbonTaskInfo.getTaskId)
       }
-      executor.execute(carbonLoadModel,
+      return executor.execute(carbonLoadModel,
         loader.storeLocation,
         recordReaders.toArray)
 

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonCatalystOperators.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonCatalystOperators.scala
@@ -25,6 +25,7 @@ import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression,
 import org.apache.spark.sql.catalyst.plans.logical.{UnaryNode, _}
 import org.apache.spark.sql.execution.datasources.LogicalRelation
 import org.apache.spark.sql.optimizer.CarbonDecoderRelation
+import org.apache.spark.sql.types.LongType
 
 import org.apache.carbondata.spark.CarbonAliasDecoderRelation
 
@@ -69,7 +70,8 @@ case class ProjectForUpdate(
     table: UnresolvedRelation,
     columns: List[String],
     children: Seq[LogicalPlan] ) extends LogicalPlan {
-  override def output: Seq[AttributeReference] = Seq.empty
+  override def output: Seq[AttributeReference] =
+    Seq(AttributeReference("Total Rows Updated", LongType, nullable = false)())
 }
 
 case class UpdateTable(
@@ -102,7 +104,8 @@ case class InsertIntoCarbonTable (table: CarbonDatasourceHadoopRelation,
     ifNotExists: Boolean)
   extends Command {
 
-    override def output: Seq[Attribute] = Seq.empty
+    override def output: Seq[Attribute] =
+      Seq(AttributeReference("Total Rows Inserted", LongType, nullable = false)())
 
     // This is the expected schema of the table prepared to be inserted into
     // including dynamic partition columns.

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonInsertIntoCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonInsertIntoCommand.scala
@@ -18,8 +18,10 @@
 package org.apache.spark.sql.execution.command.management
 
 import org.apache.spark.sql.{CarbonDatasourceHadoopRelation, Dataset, Row, SparkSession}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
 import org.apache.spark.sql.catalyst.plans.logical.{GlobalLimit, LogicalPlan}
 import org.apache.spark.sql.execution.command.{AtomicRunnableCommand, DataCommand}
+import org.apache.spark.sql.types.LongType
 import org.apache.spark.storage.StorageLevel
 
 import org.apache.carbondata.common.logging.{LogService, LogServiceFactory}
@@ -34,6 +36,10 @@ case class CarbonInsertIntoCommand(
   extends AtomicRunnableCommand {
 
   var loadCommand: CarbonLoadDataCommand = _
+
+  override def output: Seq[Attribute] = {
+    Seq(AttributeReference("Total Rows Inserted", LongType, nullable = false)())
+  }
 
   override def processMetadata(sparkSession: SparkSession): Seq[Row] = {
     setAuditTable(relation.carbonTable.getDatabaseName, relation.carbonTable.getTableName)

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonLoadDataCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonLoadDataCommand.scala
@@ -743,7 +743,7 @@ case class CarbonLoadDataCommand(
             attributes,
             sortScope,
             isDataFrame = true)
-        numberOfRowsLoaded = dataFrame.get.count()
+        numberOfRowsLoaded = rdd.count()
         partitionsLen = partitions
         persistedRDD = persistedRDDLocal
         transformedPlan

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/mutation/CarbonProjectForDeleteCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/mutation/CarbonProjectForDeleteCommand.scala
@@ -18,8 +18,10 @@
 package org.apache.spark.sql.execution.command.mutation
 
 import org.apache.spark.sql._
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.command._
+import org.apache.spark.sql.types.LongType
 
 import org.apache.carbondata.common.exceptions.sql.MalformedCarbonCommandException
 import org.apache.carbondata.common.logging.LogServiceFactory
@@ -41,6 +43,10 @@ private[sql] case class CarbonProjectForDeleteCommand(
     tableName: String,
     timestamp: String)
   extends DataCommand {
+
+  override def output: Seq[Attribute] = {
+    Seq(AttributeReference("Total Rows Deleted", LongType, nullable = false)())
+  }
 
   override def processData(sparkSession: SparkSession): Seq[Row] = {
     val LOGGER = LogServiceFactory.getLogService(this.getClass.getName)
@@ -135,7 +141,7 @@ private[sql] case class CarbonProjectForDeleteCommand(
         CarbonLockUtil.fileUnlock(metadataLock, LockUsage.METADATA_LOCK)
       }
     }
-    Seq.empty
+    Seq(Row(dataRdd.count()))
   }
 
   override protected def opName: String = "DELETE DATA"

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/DataLoadExecutor.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/DataLoadExecutor.java
@@ -40,7 +40,7 @@ public class DataLoadExecutor {
 
   private boolean isClosed;
 
-  public void execute(CarbonLoadModel loadModel, String[] storeLocation,
+  public long execute(CarbonLoadModel loadModel, String[] storeLocation,
       CarbonIterator<Object[]>[] inputIterators) throws Exception {
     try {
       loadProcessorStep =
@@ -54,6 +54,7 @@ public class DataLoadExecutor {
       if (CarbonBadRecordUtil.hasBadRecord(loadModel)) {
         LOGGER.error("Data Load is partially success for table " + loadModel.getTableName());
       }
+      return loadProcessorStep.rowCounter.get();
     } catch (CarbonDataLoadingException e) {
       if (e instanceof BadRecordFoundException) {
         throw new NoRetryException(e.getMessage());


### PR DESCRIPTION
1. Change output schema for load/insert/update/delete command to show proceeded row count
2. Get proceeded row count:
    - Load: sum up loaded row count from each executor
    - Insert: get from load result
    - Delete: it first fired a query. we can get the number by calling DataFrame.count()
    - Update: delete + load


Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

