### PR TITLE
[CARBONDATA-3098] Fix for negative exponents value giving wrong results in Float datatype

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/adaptive/AdaptiveFloatingCodec.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/adaptive/AdaptiveFloatingCodec.java
@@ -167,19 +167,7 @@ public class AdaptiveFloatingCodec extends AdaptiveCodec {
 
     @Override
     public void encode(int rowId, float value) {
-      if (targetDataType == DataTypes.BYTE) {
-        encodedPage.putByte(rowId, (byte) (value * floatFactor));
-      } else if (targetDataType == DataTypes.SHORT) {
-        encodedPage.putShort(rowId, (short) (value * floatFactor));
-      } else if (targetDataType == DataTypes.SHORT_INT) {
-        encodedPage.putShortInt(rowId, (int) (value * floatFactor));
-      } else if (targetDataType == DataTypes.INT) {
-        encodedPage.putInt(rowId, (int) (value * floatFactor));
-      } else if (targetDataType == DataTypes.LONG) {
-        encodedPage.putLong(rowId, (long) (value * floatFactor));
-      } else {
-        throw new RuntimeException("internal error: " + debugInfo());
-      }
+      encode(rowId, (double) value);
     }
 
     @Override

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/statistics/PrimitivePageStatsCollector.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/statistics/PrimitivePageStatsCollector.java
@@ -253,19 +253,7 @@ public class PrimitivePageStatsCollector implements ColumnPageStatsCollector, Si
   }
 
   private int getDecimalCount(float value) {
-    int decimalPlaces = 0;
-    try {
-      String strValue = Float.valueOf(Math.abs(value)).toString();
-      int integerPlaces = strValue.indexOf('.');
-      if (-1 != integerPlaces) {
-        decimalPlaces = strValue.length() - integerPlaces - 1;
-      }
-    } catch (NumberFormatException e) {
-      if (!Double.isInfinite(value)) {
-        throw e;
-      }
-    }
-    return decimalPlaces;
+    return getDecimalCount((double) value);
   }
 
   @Override

--- a/integration/spark-datasource/src/test/scala/org/apache/spark/sql/carbondata/datasource/SparkCarbonDataSourceTest.scala
+++ b/integration/spark-datasource/src/test/scala/org/apache/spark/sql/carbondata/datasource/SparkCarbonDataSourceTest.scala
@@ -1310,6 +1310,21 @@ class SparkCarbonDataSourceTest extends FunSuite with BeforeAndAfterAll {
     checkAnswer(spark.sql("select * from t_carbn01b_hive"), spark.sql("select * from t_carbn01b"))
     spark.sql("drop table if exists t_carbn01b_hive")
     spark.sql(s"drop table if exists t_carbn01b")
+    }
+
+  test("Test Float value by having negative exponents") {
+    spark.sql("DROP TABLE IF EXISTS float_p")
+    spark.sql("DROP TABLE IF EXISTS float_c")
+    spark.sql("CREATE TABLE float_p(f float) using parquet")
+    spark.sql("CREATE TABLE float_c(f float) using carbon")
+    spark.sql("INSERT INTO float_p select \"1.4E-3\"")
+    spark.sql("INSERT INTO float_p select \"1.4E-38\"")
+    spark.sql("INSERT INTO float_c select \"1.4E-3\"")
+    spark.sql("INSERT INTO float_c select \"1.4E-38\"")
+    checkAnswer(spark.sql("SELECT * FROM float_p"),
+      spark.sql("SELECT * FROM float_c"))
+    spark.sql("DROP TABLE float_p")
+    spark.sql("DROP TABLE float_c")
   }
 
   override protected def beforeAll(): Unit = {


### PR DESCRIPTION
Problem: When the value of exponent is a negative number then the data is incorrect due to loss of precision of Floating point values and wrong calculation of the count of decimal points.

Solution: Handled floating point precision by converting it to double and counted the decimal count values as done in double datatype(using Big Decimal).

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [x] Testing done
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

