### PR TITLE
[HOTFIX] Improve log message in CarbonWriterBuilder

### DIFF
--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonWriterBuilder.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonWriterBuilder.java
@@ -443,7 +443,7 @@ public class CarbonWriterBuilder {
     }
     if (this.writtenByApp == null || this.writtenByApp.isEmpty()) {
       throw new RuntimeException(
-          "'writtenBy' must be set when writting carbon files, use writtenBy() API to " 
+          "'writtenBy' must be set when writting carbon files, use writtenBy() API to "
               + "set it, it can be the application name which using the SDK");
     }
     CarbonLoadModel loadModel = buildLoadModel(schema);

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonWriterBuilder.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonWriterBuilder.java
@@ -444,7 +444,7 @@ public class CarbonWriterBuilder {
     if (this.writtenByApp == null || this.writtenByApp.isEmpty()) {
       throw new RuntimeException(
           "'writtenBy' must be set when writting carbon files, use writtenBy() API to "
-              + "set it, it can be the application name which using the SDK");
+              + "set it, it can be the name of the application which is using the SDK");
     }
     CarbonLoadModel loadModel = buildLoadModel(schema);
     loadModel.setSdkWriterCores(numOfThreads);

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonWriterBuilder.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonWriterBuilder.java
@@ -438,13 +438,13 @@ public class CarbonWriterBuilder {
     Objects.requireNonNull(path, "path should not be null");
     if (this.writerType == null) {
       throw new IOException(
-          "Writer type is not set, use withCsvInput() or withAvroInput() or withJsonInput()  "
+          "'writerType' must be set, use withCsvInput() or withAvroInput() or withJsonInput()  "
               + "API based on input");
     }
     if (this.writtenByApp == null || this.writtenByApp.isEmpty()) {
       throw new RuntimeException(
-          "AppName is not set, please use writtenBy() API to set the App Name"
-              + "which is using SDK");
+          "'writtenBy' must be set when writting carbon files, use writtenBy() API to " 
+              + "set it, it can be the application name which using the SDK");
     }
     CarbonLoadModel loadModel = buildLoadModel(schema);
     loadModel.setSdkWriterCores(numOfThreads);

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonWriterBuilder.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonWriterBuilder.java
@@ -443,7 +443,7 @@ public class CarbonWriterBuilder {
     }
     if (this.writtenByApp == null || this.writtenByApp.isEmpty()) {
       throw new RuntimeException(
-          "'writtenBy' must be set when writting carbon files, use writtenBy() API to "
+          "'writtenBy' must be set when writing carbon files, use writtenBy() API to "
               + "set it, it can be the name of the application which is using the SDK");
     }
     CarbonLoadModel loadModel = buildLoadModel(schema);


### PR DESCRIPTION
In master the log message is not proper: 
`AppName is not set, please use writtenBy() API to set the App Namewhich is using SDK`

This PR improves log message in CarbonWriterBuilder

 - [X] Any interfaces changed?
 No
 - [X] Any backward compatibility impacted?
 No
 - [X] Document update required?
No
 - [X] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
 rerun all test      
 - [X] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA