### PR TITLE
[HOTFIX]s3 lock file fix

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/S3CarbonFile.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/S3CarbonFile.java
@@ -107,8 +107,11 @@ public class S3CarbonFile extends HDFSCarbonFile {
         // create buffer
         byte[] byteStreamBuffer = new byte[count];
         int bytesRead = dataInputStream.read(byteStreamBuffer);
+        dataInputStream.close();
         stream = fileSystem.create(pt, true, bufferSize);
-        stream.write(byteStreamBuffer, 0, bytesRead);
+        if (bytesRead > 0) {
+          stream.write(byteStreamBuffer, 0, bytesRead);
+        }
       } else {
         stream = fileSystem.create(pt, true, bufferSize);
       }


### PR DESCRIPTION
### Why this PR?

When lock files is configured in S3 and load is run,  while acquiring the lock file, IndexOutOfBoundException will be thrown when tryong to acquire the outputStream and write into that stream. 

So if the file already exists, then we call `dataInputStream.available()` which will returns an estimate of the number of bytes that can be read from this input stream and we try to read that and put in byteStreamBuffer. This can be 0 also. So if zero no need to call write for `FSDataOutputStream`, it will throw the exception.


Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

