### PR TITLE
[CARBONDATA-3102] Fix NoClassDefFoundError when use thriftServer and beeline to read/write data from/to S3

### DIFF
--- a/examples/spark2/src/main/scala/org/apache/carbondata/benchmark/SimpleQueryBenchmark.scala
+++ b/examples/spark2/src/main/scala/org/apache/carbondata/benchmark/SimpleQueryBenchmark.scala
@@ -273,7 +273,7 @@ object SimpleQueryBenchmark {
     }
   }
 
-  // run testcases and print comparison result
+  // run test cases and print comparison result
   private def runTest(spark: SparkSession, table1: String, table2: String): Unit = {
     val formatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
     val date = new Date

--- a/examples/spark2/src/main/scala/org/apache/carbondata/examples/S3Example.scala
+++ b/examples/spark2/src/main/scala/org/apache/carbondata/examples/S3Example.scala
@@ -157,8 +157,8 @@ object S3Example {
   }
 
   def getSparkMaster(args: Array[String]): String = {
-      if (args.length == 5) args(4)
-      else if (args(3).contains("spark:") || args(3).contains("mesos:")) args(3)
-      else "local"
-    }
+    if (args.length == 5) args(4)
+    else if (args(3).contains("spark:") || args(3).contains("mesos:")) args(3)
+    else "local"
+  }
 }

--- a/integration/hive/pom.xml
+++ b/integration/hive/pom.xml
@@ -87,12 +87,12 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.3.4</version>
+            <version>${httpclient.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
-            <version>4.3-alpha1</version>
+            <version>${httpcore.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>

--- a/integration/presto/pom.xml
+++ b/integration/presto/pom.xml
@@ -540,7 +540,7 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpcore</artifactId>
-      <version>4.2</version>
+      <version>${httpcore.version}</version>
     </dependency>
   </dependencies>
 

--- a/integration/spark2/pom.xml
+++ b/integration/spark2/pom.xml
@@ -135,6 +135,11 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>${httpclient.version}</version>
+    </dependency>
+    <dependency>
       <groupId>net.java.dev.jets3t</groupId>
       <artifactId>jets3t</artifactId>
       <version>0.9.0</version>

--- a/integration/spark2/src/main/scala/org/apache/carbondata/spark/thriftserver/CarbonThriftServer.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/spark/thriftserver/CarbonThriftServer.scala
@@ -50,6 +50,7 @@ object CarbonThriftServer {
 
     val builder = SparkSession
       .builder()
+      .master(getSparkMaster(args))
       .config(sparkConf)
       .appName("Carbon Thrift Server(uses CarbonSession)")
       .enableHiveSupport()
@@ -113,4 +114,9 @@ object CarbonThriftServer {
     else ""
   }
 
+  def getSparkMaster(args: Array[String]): String = {
+    if (args.length == 5) args(4)
+    else if (args(3).contains("spark:") || args(3).contains("mesos:")) args(3)
+    else "local"
+  }
 }

--- a/integration/spark2/src/main/scala/org/apache/carbondata/spark/thriftserver/CarbonThriftServer.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/spark/thriftserver/CarbonThriftServer.scala
@@ -48,9 +48,13 @@ object CarbonThriftServer {
       System.exit(0)
     }
 
+    val master = Option(System.getProperty("spark.master"))
+      .orElse(sys.env.get("MASTER"))
+      .orElse(Option("local[8]"))
+
     val builder = SparkSession
       .builder()
-      .master(getSparkMaster(args))
+      .master(master.get)
       .config(sparkConf)
       .appName("Carbon Thrift Server(uses CarbonSession)")
       .enableHiveSupport()
@@ -114,9 +118,4 @@ object CarbonThriftServer {
     else ""
   }
 
-  def getSparkMaster(args: Array[String]): String = {
-    if (args.length == 5) args(4)
-    else if (args(3).contains("spark:") || args(3).contains("mesos:")) args(3)
-    else "local"
-  }
 }

--- a/integration/spark2/src/main/scala/org/apache/carbondata/spark/thriftserver/CarbonThriftServer.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/spark/thriftserver/CarbonThriftServer.scala
@@ -48,13 +48,8 @@ object CarbonThriftServer {
       System.exit(0)
     }
 
-    val master = Option(System.getProperty("spark.master"))
-      .orElse(sys.env.get("MASTER"))
-      .orElse(Option("local[8]"))
-
     val builder = SparkSession
       .builder()
-      .master(master.get)
       .config(sparkConf)
       .appName("Carbon Thrift Server(uses CarbonSession)")
       .enableHiveSupport()

--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,7 @@
     <snappy.version>1.1.2.6</snappy.version>
     <hadoop.version>2.7.2</hadoop.version>
     <httpclient.version>4.2.5</httpclient.version>
+    <httpcore.version>${httpclient.version}</httpcore.version>
     <scala.binary.version>2.11</scala.binary.version>
     <scala.version>2.11.8</scala.version>
     <hadoop.deps.scope>compile</hadoop.deps.scope>


### PR DESCRIPTION
When I run the carbonThriftServer and use beeline to read/write data from/to S3, it throw  NoClassDefFoundError:
`0: jdbc:hive2://127.0.0.1:10000> create table xubo6 stored by 'carbondata' location 's3a://xubo6/xubo3';
Error: java.lang.NoClassDefFoundError: org/apache/http/pool/ConnPoolControl (state=,code=0)`

Reproduce step in local:

1. start carbonThriftServer with s3 store path, ak,sk,endpoint.  

2.use beeline to connect:
` localhost:spark xubo$ ./bin/beeline -u jdbc:hive2://127.0.0.1:10000`

3. run sql
`create table xubo6 stored by 'carbondata' location 's3a://xubo6/xubo3';`
Exception:
`
0: jdbc:hive2://127.0.0.1:10000> create table xubo6 stored by 'carbondata' location 's3a://xubo6/xubo3';
Error: java.lang.NoClassDefFoundError: org/apache/http/pool/ConnPoolControl (state=,code=0)
`


 When I run in cluster, also has this problem before.

This PR fix NoClassDefFoundError when use thriftServer and beeline 

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 No
 - [x] Any backward compatibility impacted?
 No
 - [x] Document update required?
No
 - [x] Testing done
    No
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
No