### PR TITLE
[CARBONDATA-3096] Wrong records size on the input metrics

### DIFF
--- a/integration/spark-datasource/src/main/scala/org/apache/carbondata/spark/vectorreader/VectorizedCarbonRecordReader.java
+++ b/integration/spark-datasource/src/main/scala/org/apache/carbondata/spark/vectorreader/VectorizedCarbonRecordReader.java
@@ -161,8 +161,8 @@ public class VectorizedCarbonRecordReader extends AbstractRecordReader<Object> {
 
   @Override
   public void close() throws IOException {
-    logStatistics(rowCount, queryModel.getStatisticsRecorder());
     if (vectorProxy != null) {
+      logStatistics(rowCount, queryModel.getStatisticsRecorder());
       vectorProxy.close();
       vectorProxy = null;
     }
@@ -198,7 +198,7 @@ public class VectorizedCarbonRecordReader extends AbstractRecordReader<Object> {
   @Override
   public Object getCurrentValue() throws IOException, InterruptedException {
     if (returnColumnarBatch) {
-      int value = vectorProxy.numRows();
+      int value = carbonColumnarBatch.getActualSize();
       rowCount += value;
       if (inputMetricsStats != null) {
         inputMetricsStats.incrementRecordRead((long) value);


### PR DESCRIPTION
(1) Scanned record result size is taking from the default batch size. It should be taken from the records scanned.

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [x] Testing done
        Manual Testing
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

