### PR TITLE
[CARBONDATA-3108][CARBONDATA-3044] Fix the error of jvm will crash when CarbonRow use wrong index number in CSDK

### DIFF
--- a/store/CSDK/src/CarbonReader.cpp
+++ b/store/CSDK/src/CarbonReader.cpp
@@ -31,7 +31,7 @@ void CarbonReader::builder(JNIEnv *env, char *path, char *tableName) {
         throw std::runtime_error("tableName parameter can't be NULL.");
     }
     jniEnv = env;
-    jclass carbonReaderClass = env->FindClass("org/apache/carbondata/sdk/file/CarbonReader");
+    carbonReaderClass = env->FindClass("org/apache/carbondata/sdk/file/CarbonReader");
     if (carbonReaderClass == NULL) {
         throw std::runtime_error("Can't find the class in java: org/apache/carbondata/sdk/file/CarbonReader");
     }
@@ -56,7 +56,7 @@ void CarbonReader::builder(JNIEnv *env, char *path) {
         throw std::runtime_error("path parameter can't be NULL.");
     }
     jniEnv = env;
-    jclass carbonReaderClass = env->FindClass("org/apache/carbondata/sdk/file/CarbonReader");
+    carbonReaderClass = env->FindClass("org/apache/carbondata/sdk/file/CarbonReader");
     if (carbonReaderClass == NULL) {
         throw std::runtime_error("Can't find the class in java: org/apache/carbondata/sdk/file/CarbonReader");
     }
@@ -230,4 +230,7 @@ void CarbonReader::close() {
     if (jniEnv->ExceptionCheck()) {
         throw jniEnv->ExceptionOccurred();
     }
+    jniEnv->DeleteLocalRef(carbonReaderBuilderObject);
+    jniEnv->DeleteLocalRef(carbonReaderObject);
+    jniEnv->DeleteLocalRef(carbonReaderClass);
 }

--- a/store/CSDK/src/CarbonReader.h
+++ b/store/CSDK/src/CarbonReader.h
@@ -46,6 +46,11 @@ private:
     jobject carbonReaderObject = NULL;
 
     /**
+    * carbonReader class for reading data
+    */
+    jclass carbonReaderClass = NULL;
+
+    /**
      * Return true if carbonReaderBuilder Object isn't NULL
      * Throw exception if carbonReaderBuilder Object is NULL
      *

--- a/store/CSDK/src/CarbonRow.cpp
+++ b/store/CSDK/src/CarbonRow.cpp
@@ -87,6 +87,9 @@ CarbonRow::CarbonRow(JNIEnv *env) {
     if (getArrayId == NULL) {
         throw std::runtime_error("Can't find the method in java: getArray");
     }
+    if (jniEnv->ExceptionCheck()) {
+        throw jniEnv->ExceptionOccurred();
+    }
 }
 
 void CarbonRow::setCarbonRow(jobject data) {
@@ -114,7 +117,11 @@ short CarbonRow::getShort(int ordinal) {
     jvalue args[2];
     args[0].l = carbonRow;
     args[1].i = ordinal;
-    return jniEnv->CallStaticShortMethodA(rowUtilClass, getShortId, args);
+    short result = jniEnv->CallStaticShortMethodA(rowUtilClass, getShortId, args);
+    if (jniEnv->ExceptionCheck()) {
+        throw jniEnv->ExceptionOccurred();
+    }
+    return result;
 }
 
 int CarbonRow::getInt(int ordinal) {
@@ -123,7 +130,11 @@ int CarbonRow::getInt(int ordinal) {
     jvalue args[2];
     args[0].l = carbonRow;
     args[1].i = ordinal;
-    return jniEnv->CallStaticIntMethodA(rowUtilClass, getIntId, args);
+    int result = jniEnv->CallStaticIntMethodA(rowUtilClass, getIntId, args);
+    if (jniEnv->ExceptionCheck()) {
+        throw jniEnv->ExceptionOccurred();
+    }
+    return result;
 }
 
 long CarbonRow::getLong(int ordinal) {
@@ -132,7 +143,11 @@ long CarbonRow::getLong(int ordinal) {
     jvalue args[2];
     args[0].l = carbonRow;
     args[1].i = ordinal;
-    return jniEnv->CallStaticLongMethodA(rowUtilClass, getLongId, args);
+    long result = jniEnv->CallStaticLongMethodA(rowUtilClass, getLongId, args);
+    if (jniEnv->ExceptionCheck()) {
+        throw jniEnv->ExceptionOccurred();
+    }
+    return result;
 }
 
 double CarbonRow::getDouble(int ordinal) {
@@ -141,9 +156,12 @@ double CarbonRow::getDouble(int ordinal) {
     jvalue args[2];
     args[0].l = carbonRow;
     args[1].i = ordinal;
-    return jniEnv->CallStaticDoubleMethodA(rowUtilClass, getDoubleId, args);
+    double result = jniEnv->CallStaticDoubleMethodA(rowUtilClass, getDoubleId, args);
+    if (jniEnv->ExceptionCheck()) {
+        throw jniEnv->ExceptionOccurred();
+    }
+    return result;
 }
-
 
 float CarbonRow::getFloat(int ordinal) {
     checkCarbonRow();
@@ -151,7 +169,11 @@ float CarbonRow::getFloat(int ordinal) {
     jvalue args[2];
     args[0].l = carbonRow;
     args[1].i = ordinal;
-    return jniEnv->CallStaticFloatMethodA(rowUtilClass, getFloatId, args);
+    float result = jniEnv->CallStaticFloatMethodA(rowUtilClass, getFloatId, args);
+    if (jniEnv->ExceptionCheck()) {
+        throw jniEnv->ExceptionOccurred();
+    }
+    return result;
 }
 
 jboolean CarbonRow::getBoolean(int ordinal) {
@@ -160,7 +182,11 @@ jboolean CarbonRow::getBoolean(int ordinal) {
     jvalue args[2];
     args[0].l = carbonRow;
     args[1].i = ordinal;
-    return jniEnv->CallStaticBooleanMethodA(rowUtilClass, getBooleanId, args);
+    bool result = jniEnv->CallStaticBooleanMethodA(rowUtilClass, getBooleanId, args);
+    if (jniEnv->ExceptionCheck()) {
+        throw jniEnv->ExceptionOccurred();
+    }
+    return result;
 }
 
 char *CarbonRow::getString(int ordinal) {
@@ -170,6 +196,9 @@ char *CarbonRow::getString(int ordinal) {
     args[0].l = carbonRow;
     args[1].i = ordinal;
     jobject data = jniEnv->CallStaticObjectMethodA(rowUtilClass, getStringId, args);
+    if (jniEnv->ExceptionCheck()) {
+        throw jniEnv->ExceptionOccurred();
+    }
     char *str = (char *) jniEnv->GetStringUTFChars((jstring) data, JNI_FALSE);
     jniEnv->DeleteLocalRef(data);
     return str;
@@ -182,6 +211,9 @@ char *CarbonRow::getDecimal(int ordinal) {
     args[0].l = carbonRow;
     args[1].i = ordinal;
     jobject data = jniEnv->CallStaticObjectMethodA(rowUtilClass, getDecimalId, args);
+    if (jniEnv->ExceptionCheck()) {
+        throw jniEnv->ExceptionOccurred();
+    }
     char *str = (char *) jniEnv->GetStringUTFChars((jstring) data, JNI_FALSE);
     jniEnv->DeleteLocalRef(data);
     return str;
@@ -194,6 +226,9 @@ char *CarbonRow::getVarchar(int ordinal) {
     args[0].l = carbonRow;
     args[1].i = ordinal;
     jobject data = jniEnv->CallStaticObjectMethodA(rowUtilClass, getVarcharId, args);
+    if (jniEnv->ExceptionCheck()) {
+        throw jniEnv->ExceptionOccurred();
+    }
     char *str = (char *) jniEnv->GetStringUTFChars((jstring) data, JNI_FALSE);
     jniEnv->DeleteLocalRef(data);
     return str;
@@ -205,5 +240,14 @@ jobjectArray CarbonRow::getArray(int ordinal) {
     jvalue args[2];
     args[0].l = carbonRow;
     args[1].i = ordinal;
-    return (jobjectArray) jniEnv->CallStaticObjectMethodA(rowUtilClass, getArrayId, args);
+    jobjectArray result = (jobjectArray) jniEnv->CallStaticObjectMethodA(rowUtilClass, getArrayId, args);
+    if (jniEnv->ExceptionCheck()) {
+        throw jniEnv->ExceptionOccurred();
+    }
+    return result;
+}
+
+void CarbonRow::close() {
+    jniEnv->DeleteLocalRef(rowUtilClass);
+    jniEnv->DeleteLocalRef(carbonRow);
 }

--- a/store/CSDK/src/CarbonRow.h
+++ b/store/CSDK/src/CarbonRow.h
@@ -154,4 +154,10 @@ public:
      * @return jobjectArray data type data
      */
     jobjectArray getArray(int ordinal);
+
+    /**
+     * delete data and release
+     * @return
+     */
+    void close();
 };

--- a/store/CSDK/src/CarbonWriter.cpp
+++ b/store/CSDK/src/CarbonWriter.cpp
@@ -164,4 +164,7 @@ void CarbonWriter::close() {
     if (jniEnv->ExceptionCheck()) {
         throw jniEnv->ExceptionOccurred();
     }
+    jniEnv->DeleteLocalRef(carbonWriterBuilderObject);
+    jniEnv->DeleteLocalRef(carbonWriterObject);
+    jniEnv->DeleteLocalRef(carbonWriter);
 }

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/RowUtil.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/RowUtil.java
@@ -70,7 +70,12 @@ public class RowUtil implements Serializable {
    * @return array data type data
    */
   public static Object[] getArray(Object[] data, int ordinal) {
-    return (Object[]) data[ordinal];
+    Object object = data[ordinal];
+    if (object instanceof Object[]) {
+      return (Object[]) data[ordinal];
+    } else {
+      throw new IllegalArgumentException("It's not an array in ordinal of data.");
+    }
   }
 
   /**


### PR DESCRIPTION
This PR:
1. fix the error of jvm will crash when CarbonRow use wrong index number in CSDK
  including getString, getVarchar, getArray, getDecimal
2. delete/release the data after running
3. init the variable to NULL

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 No
 - [x] Any backward compatibility impacted?
 No
 - [x] Document update required?
No
 - [x] Testing done
     add
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
JIRA2951
