### PR TITLE
[CARBONDATA-3109] Support get length from CarbonRow in CSDK

### DIFF
--- a/store/CSDK/src/CarbonRow.cpp
+++ b/store/CSDK/src/CarbonRow.cpp
@@ -87,8 +87,15 @@ CarbonRow::CarbonRow(JNIEnv *env) {
     if (getArrayId == NULL) {
         throw std::runtime_error("Can't find the method in java: getArray");
     }
+
     if (jniEnv->ExceptionCheck()) {
         throw jniEnv->ExceptionOccurred();
+    }
+
+    getLengthId = jniEnv->GetStaticMethodID(rowUtilClass, "getLength",
+        "([Ljava/lang/Object;)I");
+    if (getLengthId == NULL) {
+        throw std::runtime_error("Can't find the method in java: getLength");
     }
 }
 
@@ -250,4 +257,11 @@ jobjectArray CarbonRow::getArray(int ordinal) {
 void CarbonRow::close() {
     jniEnv->DeleteLocalRef(rowUtilClass);
     jniEnv->DeleteLocalRef(carbonRow);
+}
+
+int CarbonRow::getLength() {
+    checkCarbonRow();
+    jvalue args[1];
+    args[0].l = carbonRow;
+    return jniEnv->CallStaticIntMethodA(rowUtilClass, getLengthId, args);
 }

--- a/store/CSDK/src/CarbonRow.h
+++ b/store/CSDK/src/CarbonRow.h
@@ -29,6 +29,7 @@ private:
     jmethodID getDecimalId = NULL;
     jmethodID getVarcharId = NULL;
     jmethodID getArrayId = NULL;
+    jmethodID getLengthId = NULL;
 
     /**
      * RowUtil Class for read data from Carbon Row
@@ -160,4 +161,12 @@ public:
      * @return
      */
     void close();
+
+    /*
+     * get length of data
+     *
+     * @param data carbon row data
+     * @return data length
+     */
+    int getLength();
 };

--- a/store/CSDK/test/main.cpp
+++ b/store/CSDK/test/main.cpp
@@ -160,6 +160,7 @@ void printResult(JNIEnv *env, CarbonReader reader) {
             printBoolean(carbonRow.getBoolean(9));
             printf("%s\t", carbonRow.getDecimal(10));
             printf("%f\t", carbonRow.getFloat(11));
+            printf("%d\t", carbonRow.getLength());
             printf("\n");
             env->DeleteLocalRef(row);
         }

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/RowUtil.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/RowUtil.java
@@ -148,4 +148,14 @@ public class RowUtil implements Serializable {
     return ((BigDecimal) data[ordinal]).toString();
   }
 
+  /**
+   * get length of data
+   *
+   * @param data carbon row data
+   * @return data length
+   */
+  public static int getLength(Object[] data) {
+    return data.length;
+  }
+
 }

--- a/store/sdk/src/test/java/org/apache/carbondata/sdk/file/CarbonReaderTest.java
+++ b/store/sdk/src/test/java/org/apache/carbondata/sdk/file/CarbonReaderTest.java
@@ -1655,6 +1655,7 @@ public class CarbonReaderTest extends TestCase {
         assert (arr[3].equals("Carbon"));
 
         assertEquals(RowUtil.getFloat(data, 11), (float) 1.23);
+        assertEquals(RowUtil.getLength(data), 12);
         i++;
       }
       reader.close();


### PR DESCRIPTION
When user want to read the data from carbonRow, user want to know the data length first, so we should support get length from CarbonRow in CSDK

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 add
 - [x] Any backward compatibility impacted?
 No
 - [x] Document update required?
No
 - [x] Testing done
     add
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
JIRA2951
