### PR TITLE
[HOTFIX] Intializing the CSDK object reference to NULL

### DIFF
--- a/store/CSDK/src/CarbonProperties.h
+++ b/store/CSDK/src/CarbonProperties.h
@@ -22,17 +22,17 @@ private:
     /**
      * carbonProperties Class
      */
-    jclass carbonPropertiesClass;
+    jclass carbonPropertiesClass = NULL;
 
     /**
      * carbonProperties Object
      */
-    jobject carbonPropertiesObject;
+    jobject carbonPropertiesObject = NULL;
 public:
     /**
      * jni env
      */
-    JNIEnv *jniEnv;
+    JNIEnv *jniEnv = NULL;
 
     /**
      * Constructor of CarbonProperties

--- a/store/CSDK/src/CarbonReader.h
+++ b/store/CSDK/src/CarbonReader.h
@@ -38,12 +38,12 @@ private:
      * carbonReaderBuilder object for building carbonReader
      * it can configure some operation
      */
-    jobject carbonReaderBuilderObject;
+    jobject carbonReaderBuilderObject = NULL;
 
     /**
      * carbonReader object for reading data
      */
-    jobject carbonReaderObject;
+    jobject carbonReaderObject = NULL;
 
     /**
      * Return true if carbonReaderBuilder Object isn't NULL
@@ -65,7 +65,7 @@ public:
     /**
      * jni env
      */
-    JNIEnv *jniEnv;
+    JNIEnv *jniEnv = NULL;
 
     /**
      * create a CarbonReaderBuilder object for building carbonReader,

--- a/store/CSDK/src/CarbonRow.h
+++ b/store/CSDK/src/CarbonRow.h
@@ -19,21 +19,21 @@
 
 class CarbonRow {
 private:
-    jmethodID getShortId;
-    jmethodID getIntId;
-    jmethodID getLongId;
-    jmethodID getDoubleId;
-    jmethodID getFloatId;
-    jmethodID getBooleanId;
-    jmethodID getStringId;
-    jmethodID getDecimalId;
-    jmethodID getVarcharId;
-    jmethodID getArrayId;
+    jmethodID getShortId = NULL;
+    jmethodID getIntId = NULL;
+    jmethodID getLongId = NULL;
+    jmethodID getDoubleId = NULL;
+    jmethodID getFloatId = NULL;
+    jmethodID getBooleanId = NULL;
+    jmethodID getStringId = NULL;
+    jmethodID getDecimalId = NULL;
+    jmethodID getVarcharId = NULL;
+    jmethodID getArrayId = NULL;
 
     /**
      * RowUtil Class for read data from Carbon Row
      */
-    jclass rowUtilClass;
+    jclass rowUtilClass = NULL;
 
     /**
      * carbon row data
@@ -57,7 +57,7 @@ public:
     /**
      * jni env
      */
-    JNIEnv *jniEnv;
+    JNIEnv *jniEnv = NULL;
 
     /**
      * Constructor and express the carbon row result

--- a/store/CSDK/src/CarbonSchemaReader.h
+++ b/store/CSDK/src/CarbonSchemaReader.h
@@ -23,12 +23,12 @@ private:
     /**
      * jni env
      */
-    JNIEnv *jniEnv;
+    JNIEnv *jniEnv = NULL;
 
     /**
      * carbonSchemaReader Class for get method id and call method
      */
-    jclass carbonSchemaReaderClass;
+    jclass carbonSchemaReaderClass = NULL;
 
 public:
 

--- a/store/CSDK/src/CarbonWriter.h
+++ b/store/CSDK/src/CarbonWriter.h
@@ -22,7 +22,7 @@ private:
     /**
     * jni env
     */
-    JNIEnv *jniEnv;
+    JNIEnv *jniEnv = NULL;
 
     /**
      * carbonWriterBuilder object for building carbonWriter
@@ -33,12 +33,12 @@ private:
     /**
      * carbonWriter object for writing data
      */
-    jobject carbonWriterObject;
+    jobject carbonWriterObject = NULL;
 
     /**
      * carbon writer class
      */
-    jclass carbonWriter;
+    jclass carbonWriter = NULL;
 
     /**
      * write method id

--- a/store/CSDK/src/Schema.h
+++ b/store/CSDK/src/Schema.h
@@ -28,17 +28,17 @@ private:
     /**
      * jni env
      */
-    JNIEnv *jniEnv;
+    JNIEnv *jniEnv = NULL;
 
     /**
      * schema class for get method id
      */
-    jclass schemaClass;
+    jclass schemaClass = NULL;
 
     /**
      * carbon schema data
      */
-    jobject schema;
+    jobject schema = NULL;
 
     /**
      * check ordinal, ordinal can't be negative


### PR DESCRIPTION
Changes in this PR:

NULL intialization done to JObjects in CPP files of CSDK. This prevents seg fault when these objects are referenced without initilization .

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [NA] Any interfaces changed?
 
 - [NA] Any backward compatibility impacted?
 
 - [NA] Document update required?

 - [OK] Testing done using existing test cases
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ NA] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

