### PR TITLE
[CARBONDATA-3121] Improvement of CarbonReader build time

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/scan/result/iterator/ChunkRowIterator.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/iterator/ChunkRowIterator.java
@@ -39,9 +39,6 @@ public class ChunkRowIterator extends CarbonIterator<Object[]> {
 
   public ChunkRowIterator(CarbonIterator<RowBatch> iterator) {
     this.iterator = iterator;
-    if (iterator.hasNext()) {
-      currentChunk = iterator.next();
-    }
   }
 
   /**
@@ -52,17 +49,11 @@ public class ChunkRowIterator extends CarbonIterator<Object[]> {
    * @return {@code true} if the iteration has more elements
    */
   @Override public boolean hasNext() {
-    if (null != currentChunk) {
-      if ((currentChunk.hasNext())) {
-        return true;
-      } else if (!currentChunk.hasNext()) {
-        while (iterator.hasNext()) {
-          currentChunk = iterator.next();
-          if (currentChunk != null && currentChunk.hasNext()) {
-            return true;
-          }
-        }
-      }
+    if (currentChunk != null && currentChunk.hasNext()) {
+      return true;
+    } else if (iterator != null && iterator.hasNext()) {
+      currentChunk = iterator.next();
+      return hasNext();
     }
     return false;
   }


### PR DESCRIPTION
CarbonReader builder is taking huge time.

**Reason**
Initialization of ChunkRowIterator is triggering actual I/O operation, and thus huge build time.

**Solution**
remove CarbonIterator.hasNext() and CarbonIterator.next() from build.


The following tables are the build times of CarbonReader.

**Before**

| DETAIL_QUERY_BATCH_SIZE | 4000 | 50000 |
| -- | -- | -- |
| With Vector Reader | 1870 ms | 1867 ms |
| Without Vector Reader	| 12961 ms | 28539 ms |


**After**

| DETAIL_QUERY_BATCH_SIZE | 4000 | 50000 |
| -- | -- | -- |
| With Vector Reader	| 1238 ms	| 1279 ms	|
| Without Vector Reader	| 1878 ms	| 1913 ms	|


This test was done on a 3 node cluster in spark-shell. The exact code for computing the above build times is:
```scala
import org.apache.carbondata.sdk.file._

val startTime = System.currentTimeMillis
val reader = CarbonReader
	.builder("hdfs://hacluster/carbonfiles", "t1")
	.withBatch(50000)
	.build
println(s"Time to build: ${System.currentTimeMillis - startTime}")
reader.close

```

 - [x] Any interfaces changed?
     No 
 - [x] Any backward compatibility impacted?
       No
 - [x] Document update required?
        No
 - [x] Testing done
      Yes
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 