### PR TITLE
[CARBONDATA-3134] fixed null values when cachelevel is set as blocklet

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/column/ColumnSchema.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/column/ColumnSchema.java
@@ -297,6 +297,10 @@ public class ColumnSchema implements Serializable, Writable {
     return result;
   }
 
+  public int strictHashCode() {
+    return hashCode() + columnUniqueId.hashCode() + encodingList.hashCode();
+  }
+
   /**
    * Overridden equals method for columnSchema
    */

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/standardpartition/StandardPartitionTableQueryTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/standardpartition/StandardPartitionTableQueryTestCase.scala
@@ -440,7 +440,7 @@ test("Creation of partition table should fail if the colname in table schema and
   test("validate data in partition table after dropping and adding a column") {
     sql("drop table if exists par")
     sql("create table par(name string) partitioned by (age double) stored by " +
-              "'carbondata'")
+              "'carbondata' TBLPROPERTIES('cache_level'='blocklet')")
     sql(s"load data local inpath '$resourcesPath/uniqwithoutheader.csv' into table par options" +
         s"('header'='false')")
     sql("alter table par drop columns(name)")


### PR DESCRIPTION
**Problem:**
For each blocklet an object of SegmentPropertiesAndSchemaHolder is created to store the schema used for query. This object is created only if no other blocklet has the same schema. To check the schema we are comparing List<ColumnSchema>, as the equals method in ColumnSchema does not check for columnUniqueId therefore this check is failing and the new restructured blocklet is using the schema of the old blocklet. Due to this the newly added column is being ignored as the old blocklet schema specifies that the column is delete(alter drop).

**Solution:**
Instead of checking the equality through equals and hashcode, write a new implementation for both and check based on columnUniqueId.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

