### PR TITLE
[CARBONDATA-3138] Fix random count mismatch with multi-thread block pruning

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/ColumnFilterInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/ColumnFilterInfo.java
@@ -107,19 +107,26 @@ public class ColumnFilterInfo implements Serializable {
   public Set<String> getImplicitDriverColumnFilterList() {
     // this list is required to be populated only n case of driver, so in executor this check will
     // avoid unnecessary loading of the driver filter list
-    if (null == implicitDriverColumnFilterList) {
-      populateBlockIdListForDriverBlockPruning();
+    if (implicitDriverColumnFilterList != null) {
+      return implicitDriverColumnFilterList;
+    }
+    synchronized (this) {
+      if (null == implicitDriverColumnFilterList) {
+        // populate only once. (can be called in multi-thread)
+        implicitDriverColumnFilterList = populateBlockIdListForDriverBlockPruning();
+      }
     }
     return implicitDriverColumnFilterList;
   }
 
-  private void populateBlockIdListForDriverBlockPruning() {
-    implicitDriverColumnFilterList = new HashSet<>(implicitColumnFilterList.size());
-    String blockId = null;
+  private Set<String> populateBlockIdListForDriverBlockPruning() {
+    Set<String> columnFilterList = new HashSet<>(implicitColumnFilterList.size());
+    String blockId;
     for (String blockletId : implicitColumnFilterList) {
       blockId =
           blockletId.substring(0, blockletId.lastIndexOf(CarbonCommonConstants.FILE_SEPARATOR));
-      implicitDriverColumnFilterList.add(blockId);
+      columnFilterList.add(blockId);
     }
+    return columnFilterList;
   }
 }


### PR DESCRIPTION
problem: Random count mismatch in query in multi-thread block-pruning scenario.

cause: Existing prune method not meant for multi-threading as synchronization was missing.
only in implicit filter scenario, while preparing the block ID list, synchronization was missing. Hence pruning was giving wrong result.

solution: synchronize the implicit filter preparation, as prune now called in multi-thread

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed? NA
 
 - [ ] Any backward compatibility impacted? NA
 
 - [ ] Document update required? NA

 - [ ] Testing done
   done with huge data       
 
- [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

