### PR TITLE
[HOTFIX] Fix ArrayOutOfBound exception when duplicate measure in projection column

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/scan/executor/impl/AbstractQueryExecutor.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/executor/impl/AbstractQueryExecutor.java
@@ -549,12 +549,9 @@ public abstract class AbstractQueryExecutor<E> implements QueryExecutor<E> {
     int[] dimensionChunkIndexes = QueryUtil.getDimensionChunkIndexes(projectDimensions,
         segmentProperties.getDimensionOrdinalToChunkMapping(),
         currentBlockFilterDimensions, allProjectionListDimensionIdexes);
-    int reusableBufferSize = segmentProperties.getDimensionOrdinalToChunkMapping().size()
-        < projectDimensions.size() ?
-        projectDimensions.size() :
-        segmentProperties.getDimensionOrdinalToChunkMapping().size();
-    ReusableDataBuffer[] dimensionBuffer =
-        new ReusableDataBuffer[reusableBufferSize];
+    int reusableBufferSize = Math.max(segmentProperties.getDimensionOrdinalToChunkMapping().size(),
+        projectDimensions.size());
+    ReusableDataBuffer[] dimensionBuffer = new ReusableDataBuffer[reusableBufferSize];
     for (int i = 0; i < dimensionBuffer.length; i++) {
       dimensionBuffer[i] = new ReusableDataBuffer();
     }
@@ -583,8 +580,9 @@ public abstract class AbstractQueryExecutor<E> implements QueryExecutor<E> {
         currentBlockQueryMeasures, expressionMeasures,
         segmentProperties.getMeasuresOrdinalToChunkMapping(), filterMeasures,
         allProjectionListMeasureIndexes);
-    ReusableDataBuffer[] measureBuffer =
-        new ReusableDataBuffer[segmentProperties.getMeasuresOrdinalToChunkMapping().size()];
+    reusableBufferSize = Math.max(segmentProperties.getMeasuresOrdinalToChunkMapping().size(),
+        allProjectionListMeasureIndexes.size());
+    ReusableDataBuffer[] measureBuffer = new ReusableDataBuffer[reusableBufferSize];
     for (int i = 0; i < measureBuffer.length; i++) {
       measureBuffer[i] = new ReusableDataBuffer();
     }

--- a/store/sdk/src/test/java/org/apache/carbondata/sdk/file/CarbonReaderTest.java
+++ b/store/sdk/src/test/java/org/apache/carbondata/sdk/file/CarbonReaderTest.java
@@ -575,7 +575,7 @@ public class CarbonReaderTest extends TestCase {
 
     CarbonReader reader = CarbonReader
         .builder(path, "_temp")
-        .projection(new String[]{"name", "name", "age", "name"})
+        .projection(new String[]{"name", "age", "age", "name"})
         .build();
 
     // expected output after sorting
@@ -591,7 +591,7 @@ public class CarbonReaderTest extends TestCase {
       Object[] row = (Object[]) reader.readNextRow();
       // Default sort column is applied for dimensions. So, need  to validate accordingly
       Assert.assertEquals(name[i], row[0]);
-      Assert.assertEquals(name[i], row[1]);
+      Assert.assertEquals(age[i], row[1]);
       Assert.assertEquals(age[i], row[2]);
       Assert.assertEquals(name[i], row[3]);
       i++;


### PR DESCRIPTION
problem: ArrayOutOfBound exception when duplicate measure in the projection column

cause: In query executor, when the reusable buffer is formed. It was considering only the unique values. Need to consider all the projections.

solution: consider all the projections, while forming a reusable buffer.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed? NA
 
 - [ ] Any backward compatibility impacted? NA
 
 - [ ] Document update required? NA

 - [ ] Testing done
        yes, updated UT.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.  NA

