### PR TITLE
[CARBONDATA-3140]Block create like table command in carbon

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/memory/UnsafeMemoryManager.java
+++ b/core/src/main/java/org/apache/carbondata/core/memory/UnsafeMemoryManager.java
@@ -129,7 +129,7 @@ public class UnsafeMemoryManager {
       memoryBlock = MemoryAllocator.HEAP.allocate(memoryRequested);
       if (LOGGER.isDebugEnabled()) {
         LOGGER.debug(String
-            .format("Creating onheap working Memory block (%d) with size: ", memoryBlock.size()));
+            .format("Creating onheap working Memory block with size: (%d)", memoryBlock.size()));
       }
     }
     return memoryBlock;

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestCreateTableIfNotExists.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestCreateTableIfNotExists.scala
@@ -20,11 +20,15 @@ package org.apache.carbondata.spark.testsuite.createTable
 import org.apache.spark.sql.test.util.QueryTest
 import org.scalatest.BeforeAndAfterAll
 
+import org.apache.carbondata.common.exceptions.sql.MalformedCarbonCommandException
+
 class TestCreateTableIfNotExists extends QueryTest with BeforeAndAfterAll {
 
   override def beforeAll {
     sql("use default")
     sql("drop table if exists test")
+    sql("drop table if exists sourceTable")
+    sql("drop table if exists targetTable")
   }
 
   test("test create table if not exists") {
@@ -39,9 +43,19 @@ class TestCreateTableIfNotExists extends QueryTest with BeforeAndAfterAll {
     }
   }
 
+  test("test blocking of create table like command") {
+    sql("create table sourceTable(name string) stored by 'carbondata'")
+    val exception = intercept[MalformedCarbonCommandException] {
+      sql("create table targetTable like sourceTable")
+    }
+    assert(exception.getMessage.contains("Operation not allowed, when source table is carbon table"))
+  }
+
   override def afterAll {
     sql("use default")
     sql("drop table if exists test")
+    sql("drop table if exists sourceTable")
+    sql("drop table if exists targetTable")
   }
 
 }


### PR DESCRIPTION
### Why this PR?
when like table is created using carbon table as source table, and the new table is dropped, it deletes the source table in spark-2.1 and works fine in other. Blocking the create like command for carbon table


Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

