### PR TITLE
[CARBONDATA-3142]Add timestamp with thread name which created by CarbonThreadFactory

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonThreadFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonThreadFactory.java
@@ -50,8 +50,7 @@ public class CarbonThreadFactory implements ThreadFactory {
     final Thread thread = defaultFactory.newThread(r);
     if (withTime) {
       thread.setName(name + "_" + System.currentTimeMillis());
-    }
-    else {
+    } else {
       thread.setName(name);
     }
     return thread;

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonThreadFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonThreadFactory.java
@@ -34,14 +34,26 @@ public class CarbonThreadFactory implements ThreadFactory {
    */
   private String name;
 
+  private boolean withTime = false;
+
   public CarbonThreadFactory(String name) {
     this.defaultFactory = Executors.defaultThreadFactory();
     this.name = name;
   }
 
+  public CarbonThreadFactory(String name, boolean withTime) {
+    this(name);
+    this.withTime = withTime;
+  }
+
   @Override public Thread newThread(Runnable r) {
     final Thread thread = defaultFactory.newThread(r);
-    thread.setName(name);
+    if (withTime) {
+      thread.setName(name + "_" + System.currentTimeMillis());
+    }
+    else {
+      thread.setName(name);
+    }
     return thread;
   }
 }

--- a/processing/src/main/java/org/apache/carbondata/processing/store/CarbonFactDataHandlerColumnar.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/CarbonFactDataHandlerColumnar.java
@@ -144,14 +144,14 @@ public class CarbonFactDataHandlerColumnar implements CarbonFactHandler {
     blockletProcessingCount = new AtomicInteger(0);
     producerExecutorService = Executors.newFixedThreadPool(model.getNumberOfCores(),
         new CarbonThreadFactory(
-            "ProducerPool:" + model.getTableName() + ", range: " + model
-                .getBucketId(), true));
+            String.format("ProducerPool:%s, range: %d",
+                model.getTableName(),model.getBucketId()), true));
     producerExecutorServiceTaskList =
         new ArrayList<>(CarbonCommonConstants.DEFAULT_COLLECTION_SIZE);
     LOGGER.debug("Initializing writer executors");
     consumerExecutorService = Executors.newFixedThreadPool(1, new CarbonThreadFactory(
-        "ConsumerPool:" + model.getTableName() + ", range: " + model
-            .getBucketId(), true));
+        String.format("ConsumerPool:%s, range: %d",
+                model.getTableName(),model.getBucketId()), true));
     consumerExecutorServiceTaskList = new ArrayList<>(1);
     semaphore = new Semaphore(numberOfCores);
     tablePageList = new TablePageList();

--- a/processing/src/main/java/org/apache/carbondata/processing/store/CarbonFactDataHandlerColumnar.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/CarbonFactDataHandlerColumnar.java
@@ -144,14 +144,14 @@ public class CarbonFactDataHandlerColumnar implements CarbonFactHandler {
     blockletProcessingCount = new AtomicInteger(0);
     producerExecutorService = Executors.newFixedThreadPool(model.getNumberOfCores(),
         new CarbonThreadFactory(
-            "ProducerPool_" + System.nanoTime() + ":" + model.getTableName() + ", range: " + model
-                .getBucketId()));
+            "ProducerPool:" + model.getTableName() + ", range: " + model
+                .getBucketId(), true));
     producerExecutorServiceTaskList =
         new ArrayList<>(CarbonCommonConstants.DEFAULT_COLLECTION_SIZE);
     LOGGER.debug("Initializing writer executors");
     consumerExecutorService = Executors.newFixedThreadPool(1, new CarbonThreadFactory(
-        "ConsumerPool_" + System.nanoTime() + ":" + model.getTableName() + ", range: " + model
-            .getBucketId()));
+        "ConsumerPool:" + model.getTableName() + ", range: " + model
+            .getBucketId(), true));
     consumerExecutorServiceTaskList = new ArrayList<>(1);
     semaphore = new Semaphore(numberOfCores);
     tablePageList = new TablePageList();


### PR DESCRIPTION
Add timestamp with thread name which created by CarbonThreadFactory
Because the names of threads created by CarbonThreadFactory are all the same, such as "ProducerPool_", this logs are confused,  we can't distinguish threads in the thread pool

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 [√] Any interfaces changed?
       No 
 [√ ] Any backward compatibility impacted?
       No
 [√] Document update required?
       No
 [√] Testing done
      Only change thread name, don't need add test cases        
 [√] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
      No
