### PR TITLE
[CARBONDATA-2563][CATALYST] Explain query with Order by operator is fired Spark Job which is increase explain query time even though isQueryStatisticsEnabled is false

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/profiler/ExplainCollector.java
+++ b/core/src/main/java/org/apache/carbondata/core/profiler/ExplainCollector.java
@@ -171,7 +171,12 @@ public class ExplainCollector {
   }
 
   public static String getFormatedOutput() {
-    return get().toString();
+    if(null!=get()) {
+      return get().toString();
+    }
+    else {
+      return null;
+    }
   }
 
   @Override

--- a/core/src/main/java/org/apache/carbondata/core/profiler/ExplainCollector.java
+++ b/core/src/main/java/org/apache/carbondata/core/profiler/ExplainCollector.java
@@ -171,10 +171,9 @@ public class ExplainCollector {
   }
 
   public static String getFormatedOutput() {
-    if(null!=get()) {
+    if (null != get()) {
       return get().toString();
-    }
-    else {
+    } else {
       return null;
     }
   }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonExplainCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonExplainCommand.scala
@@ -47,15 +47,15 @@ case class CarbonExplainCommand(
   }
 
   private def collectProfiler(sparkSession: SparkSession): Seq[Row] = {
-    val queryExecution =
-      sparkSession.sessionState.executePlan(child.asInstanceOf[ExplainCommand].logicalPlan)
     try {
       ExplainCollector.setup()
       if (ExplainCollector.enabled()) {
+        val queryExecution =
+          sparkSession.sessionState.executePlan(child.asInstanceOf[ExplainCommand].logicalPlan)
         queryExecution.toRdd.partitions
         // For count(*) queries the explain collector will be disabled, so profiler
         // informations not required in such scenarios.
-        if(null==ExplainCollector.getFormatedOutput) {
+        if (null == ExplainCollector.getFormatedOutput) {
           Seq.empty
         }
         Seq(Row("== CarbonData Profiler ==\n" + ExplainCollector.getFormatedOutput))

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonExplainCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonExplainCommand.scala
@@ -51,8 +51,8 @@ case class CarbonExplainCommand(
       sparkSession.sessionState.executePlan(child.asInstanceOf[ExplainCommand].logicalPlan)
     try {
       ExplainCollector.setup()
-      queryExecution.toRdd.partitions
       if (ExplainCollector.enabled()) {
+        queryExecution.toRdd.partitions
         Seq(Row("== CarbonData Profiler ==\n" + ExplainCollector.getFormatedOutput))
       } else {
         Seq.empty

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonExplainCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonExplainCommand.scala
@@ -53,6 +53,11 @@ case class CarbonExplainCommand(
       ExplainCollector.setup()
       if (ExplainCollector.enabled()) {
         queryExecution.toRdd.partitions
+        // For count(*) queries the explain collector will be disabled, so profiler
+        // informations not required in such scenarios.
+        if(null==ExplainCollector.getFormatedOutput) {
+          Seq.empty
+        }
         Seq(Row("== CarbonData Profiler ==\n" + ExplainCollector.getFormatedOutput))
       } else {
         Seq.empty


### PR DESCRIPTION
## What changes were proposed in this pull request?
Even though isQueryStatisticsEnabled is false which means user doesnt wants to see statistics for explain command, still the engine tries to fetch the paritions information
which causes a job execution in case of order by query, this is mainly because spark engine does sampling for defifning certain range within paritions  for sorting process.

As part of solution the explain command process shall fetch the parition info only if isQueryStatisticsEnabled  true.

## How was this patch tested?
Manual testing.

Before fix
![image](https://user-images.githubusercontent.com/12999161/49452212-c0075b80-f806-11e8-903b-d47369c6f0d7.png)

After fix
![explain](https://user-images.githubusercontent.com/12999161/49452265-de6d5700-f806-11e8-8154-bc86a04db073.PNG)



