### PR TITLE
[CARBONDATA-3157] Added lazy load and direct vector fill support to Presto

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/safe/AbstractNonDictionaryVectorFiller.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/safe/AbstractNonDictionaryVectorFiller.java
@@ -84,12 +84,14 @@ class StringVectorFiller extends AbstractNonDictionaryVectorFiller {
   @Override
   public void fillVector(byte[] data, CarbonColumnVector vector) {
     // start position will be used to store the current data position
-    boolean invertedIndex = vector instanceof ColumnarVectorWrapperDirectWithInvertedIndex
+    boolean addSequential = vector instanceof ColumnarVectorWrapperDirectWithInvertedIndex
         || vector instanceof SequentialFill;
 
     int localOffset = 0;
     ByteUtil.UnsafeComparer comparator = ByteUtil.UnsafeComparer.INSTANCE;
-    if (invertedIndex) {
+    // In case of inverted index and sequential fill, add data to vector sequentially instead of
+    // adding offsets and data separately.
+    if (addSequential) {
       for (int i = 0; i < numberOfRows; i++) {
         int length = (((data[localOffset] & 0xFF) << 8) | (data[localOffset + 1] & 0xFF));
         localOffset += 2;

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/adaptive/AdaptiveDeltaFloatingCodec.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/adaptive/AdaptiveDeltaFloatingCodec.java
@@ -40,6 +40,7 @@ import org.apache.carbondata.core.metadata.datatype.DataTypes;
 import org.apache.carbondata.core.scan.result.vector.CarbonColumnVector;
 import org.apache.carbondata.core.scan.result.vector.ColumnVectorInfo;
 import org.apache.carbondata.core.scan.result.vector.impl.directread.ColumnarVectorWrapperDirectFactory;
+import org.apache.carbondata.core.scan.result.vector.impl.directread.SequentialFill;
 import org.apache.carbondata.core.util.ByteUtil;
 import org.apache.carbondata.format.DataChunk2;
 import org.apache.carbondata.format.Encoding;
@@ -316,7 +317,8 @@ public class AdaptiveDeltaFloatingCodec extends AdaptiveCodec {
         }
       }
 
-      if (deletedRows == null || deletedRows.isEmpty()) {
+      if ((deletedRows == null || deletedRows.isEmpty())
+          && !(vectorInfo.vector instanceof SequentialFill)) {
         for (int i = nullBits.nextSetBit(0); i >= 0; i = nullBits.nextSetBit(i + 1)) {
           vector.putNull(i);
         }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/adaptive/AdaptiveDeltaIntegralCodec.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/adaptive/AdaptiveDeltaIntegralCodec.java
@@ -43,6 +43,7 @@ import org.apache.carbondata.core.scan.result.vector.CarbonColumnVector;
 import org.apache.carbondata.core.scan.result.vector.ColumnVectorInfo;
 import org.apache.carbondata.core.scan.result.vector.impl.directread.ColumnarVectorWrapperDirectFactory;
 import org.apache.carbondata.core.scan.result.vector.impl.directread.ConvertableVector;
+import org.apache.carbondata.core.scan.result.vector.impl.directread.SequentialFill;
 import org.apache.carbondata.core.util.ByteUtil;
 import org.apache.carbondata.format.DataChunk2;
 import org.apache.carbondata.format.Encoding;
@@ -318,7 +319,8 @@ public class AdaptiveDeltaIntegralCodec extends AdaptiveCodec {
           .getDirectVectorWrapperFactory(vector, vectorInfo.invertedIndex, nullBits, deletedRows,
               true, false);
       fillVector(pageData, vector, vectorDataType, pageDataType, pageSize, vectorInfo);
-      if (deletedRows == null || deletedRows.isEmpty()) {
+      if ((deletedRows == null || deletedRows.isEmpty())
+          && !(vectorInfo.vector instanceof SequentialFill)) {
         for (int i = nullBits.nextSetBit(0); i >= 0; i = nullBits.nextSetBit(i + 1)) {
           vector.putNull(i);
         }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/adaptive/AdaptiveFloatingCodec.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/adaptive/AdaptiveFloatingCodec.java
@@ -39,6 +39,7 @@ import org.apache.carbondata.core.metadata.datatype.DataTypes;
 import org.apache.carbondata.core.scan.result.vector.CarbonColumnVector;
 import org.apache.carbondata.core.scan.result.vector.ColumnVectorInfo;
 import org.apache.carbondata.core.scan.result.vector.impl.directread.ColumnarVectorWrapperDirectFactory;
+import org.apache.carbondata.core.scan.result.vector.impl.directread.SequentialFill;
 import org.apache.carbondata.core.util.ByteUtil;
 import org.apache.carbondata.format.DataChunk2;
 import org.apache.carbondata.format.Encoding;
@@ -302,7 +303,8 @@ public class AdaptiveFloatingCodec extends AdaptiveCodec {
         }
       }
 
-      if (deletedRows == null || deletedRows.isEmpty()) {
+      if ((deletedRows == null || deletedRows.isEmpty())
+          && !(vectorInfo.vector instanceof SequentialFill)) {
         for (int i = nullBits.nextSetBit(0); i >= 0; i = nullBits.nextSetBit(i + 1)) {
           vector.putNull(i);
         }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/adaptive/AdaptiveIntegralCodec.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/adaptive/AdaptiveIntegralCodec.java
@@ -42,6 +42,7 @@ import org.apache.carbondata.core.scan.result.vector.CarbonColumnVector;
 import org.apache.carbondata.core.scan.result.vector.ColumnVectorInfo;
 import org.apache.carbondata.core.scan.result.vector.impl.directread.ColumnarVectorWrapperDirectFactory;
 import org.apache.carbondata.core.scan.result.vector.impl.directread.ConvertableVector;
+import org.apache.carbondata.core.scan.result.vector.impl.directread.SequentialFill;
 import org.apache.carbondata.core.util.ByteUtil;
 import org.apache.carbondata.format.DataChunk2;
 import org.apache.carbondata.format.Encoding;
@@ -291,7 +292,8 @@ public class AdaptiveIntegralCodec extends AdaptiveCodec {
           .getDirectVectorWrapperFactory(vector, vectorInfo.invertedIndex, nullBits, deletedRows,
               true, false);
       fillVector(pageData, vector, vectorDataType, pageDataType, pageSize, vectorInfo, nullBits);
-      if (deletedRows == null || deletedRows.isEmpty()) {
+      if ((deletedRows == null || deletedRows.isEmpty())
+          && !(vectorInfo.vector instanceof SequentialFill)) {
         for (int i = nullBits.nextSetBit(0); i >= 0; i = nullBits.nextSetBit(i + 1)) {
           vector.putNull(i);
         }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/compress/DirectCompressCodec.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/compress/DirectCompressCodec.java
@@ -43,6 +43,7 @@ import org.apache.carbondata.core.scan.result.vector.CarbonColumnVector;
 import org.apache.carbondata.core.scan.result.vector.ColumnVectorInfo;
 import org.apache.carbondata.core.scan.result.vector.impl.directread.ColumnarVectorWrapperDirectFactory;
 import org.apache.carbondata.core.scan.result.vector.impl.directread.ConvertableVector;
+import org.apache.carbondata.core.scan.result.vector.impl.directread.SequentialFill;
 import org.apache.carbondata.core.util.ByteUtil;
 import org.apache.carbondata.format.Encoding;
 
@@ -239,7 +240,8 @@ public class DirectCompressCodec implements ColumnPageCodec {
           .getDirectVectorWrapperFactory(vector, vectorInfo.invertedIndex, nullBits, deletedRows,
               true, false);
       fillVector(pageData, vector, vectorDataType, pageDataType, pageSize, vectorInfo, nullBits);
-      if (deletedRows == null || deletedRows.isEmpty()) {
+      if ((deletedRows == null || deletedRows.isEmpty())
+          && !(vectorInfo.vector instanceof SequentialFill)) {
         for (int i = nullBits.nextSetBit(0); i >= 0; i = nullBits.nextSetBit(i + 1)) {
           vector.putNull(i);
         }

--- a/core/src/main/java/org/apache/carbondata/core/scan/collector/impl/RestructureBasedVectorResultCollector.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/collector/impl/RestructureBasedVectorResultCollector.java
@@ -204,7 +204,8 @@ public class RestructureBasedVectorResultCollector extends DictionaryBasedVector
       } else if (dataType == DataTypes.LONG || dataType == DataTypes.TIMESTAMP) {
         vector.putLongs(columnVectorInfo.vectorOffset, columnVectorInfo.size, (long) defaultValue);
       } else {
-        vector.putBytes(columnVectorInfo.vectorOffset, columnVectorInfo.size, (byte[])defaultValue);
+        vector.putByteArray(columnVectorInfo.vectorOffset, columnVectorInfo.size,
+            (byte[]) defaultValue);
       }
     } else {
       vector.putNulls(columnVectorInfo.vectorOffset, columnVectorInfo.size);

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/vector/CarbonColumnVector.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/vector/CarbonColumnVector.java
@@ -68,7 +68,7 @@ public interface CarbonColumnVector {
 
   void putByte(int rowId, byte value);
 
-  void putBytes(int rowId, int count, byte[] value);
+  void putByteArray(int rowId, int count, byte[] value);
 
   void putBytes(int rowId, int count, byte[] src, int srcIndex);
 

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/vector/impl/CarbonColumnVectorImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/vector/impl/CarbonColumnVectorImpl.java
@@ -167,7 +167,7 @@ public class CarbonColumnVectorImpl implements CarbonColumnVector {
     byteArr[rowId] = value;
   }
 
-  @Override public void putBytes(int rowId, int count, byte[] value) {
+  @Override public void putByteArray(int rowId, int count, byte[] value) {
     for (int i = 0; i < count; ++i) {
       bytes[i + rowId] = value;
     }

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/vector/impl/directread/AbstractCarbonColumnarVector.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/vector/impl/directread/AbstractCarbonColumnarVector.java
@@ -59,7 +59,7 @@ public abstract class AbstractCarbonColumnarVector
   }
 
   @Override
-  public void putBytes(int rowId, int count, byte[] value) {
+  public void putByteArray(int rowId, int count, byte[] value) {
     throw new UnsupportedOperationException("Not allowed from here " + getClass().getName());
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/vector/impl/directread/SequentialFill.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/vector/impl/directread/SequentialFill.java
@@ -19,10 +19,15 @@ package org.apache.carbondata.core.scan.result.vector.impl.directread;
 
 import java.util.BitSet;
 
+import org.apache.carbondata.common.annotations.InterfaceAudience;
+import org.apache.carbondata.common.annotations.InterfaceStability;
+
 /**
  * It is sort of a marker interface to let execution engine know that it is appendable/sequential
  * data adding vector. It means we cannot add random rowids to it.
  */
+@InterfaceStability.Evolving
+@InterfaceAudience.Internal
 public interface SequentialFill {
 
   /**

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/vector/impl/directread/SequentialFill.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/vector/impl/directread/SequentialFill.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.core.scan.result.vector.impl.directread;
+
+import java.util.BitSet;
+
+/**
+ * It is sort of a marker interface to let execution engine know that it is appendable/sequential
+ * data adding vector. It means we cannot add random rowids to it.
+ */
+public interface SequentialFill {
+
+  /**
+   * Set the null bitset
+   * @param nullBits
+   */
+  void setNullBits(BitSet nullBits);
+}

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/CarbonColumnVectorWrapper.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/CarbonColumnVectorWrapper.java
@@ -157,7 +157,7 @@ public class CarbonColumnVectorWrapper implements CarbonColumnVector {
     }
   }
 
-  @Override public void putBytes(int rowId, int count, byte[] value) {
+  @Override public void putByteArray(int rowId, int count, byte[] value) {
     for (int i = 0; i < count; i++) {
       if (!filteredRows[rowId]) {
         columnVector.putByteArray(counter++, value);

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/CarbonVectorBatch.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/CarbonVectorBatch.java
@@ -21,6 +21,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.apache.carbondata.core.cache.dictionary.Dictionary;
+import org.apache.carbondata.core.constants.CarbonV3DataFormatConstants;
 import org.apache.carbondata.core.metadata.datatype.DataType;
 import org.apache.carbondata.core.metadata.datatype.DataTypes;
 import org.apache.carbondata.core.metadata.datatype.DecimalType;
@@ -68,8 +69,13 @@ public class CarbonVectorBatch {
   }
 
   public static CarbonVectorBatch allocate(StructField[] schema,
-      CarbonDictionaryDecodeReadSupport readSupport) {
-    return new CarbonVectorBatch(schema, readSupport, DEFAULT_BATCH_SIZE);
+      CarbonDictionaryDecodeReadSupport readSupport, boolean isDirectFill) {
+    if (isDirectFill) {
+      return new CarbonVectorBatch(schema, readSupport,
+          CarbonV3DataFormatConstants.NUMBER_OF_ROWS_PER_BLOCKLET_COLUMN_PAGE_DEFAULT);
+    } else {
+      return new CarbonVectorBatch(schema, readSupport,DEFAULT_BATCH_SIZE);
+    }
   }
 
   private CarbonColumnVectorImpl createDirectStreamReader(int batchSize, DataType dataType,

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/CarbondataPageSource.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/CarbondataPageSource.java
@@ -161,6 +161,7 @@ class CarbondataPageSource implements ConnectorPageSource {
       }
       checkState(batchId == expectedBatchId);
       try {
+        vectorReader.getColumnarBatch().column(columnIndex).loadPage();
         PrestoVectorBlockBuilder blockBuilder =
             (PrestoVectorBlockBuilder) vectorReader.getColumnarBatch().column(columnIndex);
         blockBuilder.setBatchSize(lazyBlock.getPositionCount());

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/CarbondataPageSourceProvider.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/CarbondataPageSourceProvider.java
@@ -100,6 +100,11 @@ public class CarbondataPageSourceProvider implements ConnectorPageSourceProvider
     checkArgument(carbondataSplit.getConnectorId().equals(connectorId),
         "split is not for this connector");
     QueryModel queryModel = createQueryModel(carbondataSplit, columns);
+    if (carbonTableReader.config.getPushRowFilter() == null ||
+        carbonTableReader.config.getPushRowFilter().equalsIgnoreCase("false")) {
+      queryModel.setDirectVectorFill(true);
+      queryModel.setPreFetchData(false);
+    }
     QueryExecutor queryExecutor =
         QueryExecutorFactory.getQueryExecutor(queryModel, new Configuration());
     try {

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/ColumnarVectorWrapperDirect.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/ColumnarVectorWrapperDirect.java
@@ -30,14 +30,15 @@ import org.apache.carbondata.core.scan.scanner.LazyPageLoader;
 /**
  * Fills the vector directly with out considering any deleted rows.
  */
-class ColumnarVectorWrapperDirect implements CarbonColumnVector,SequentialFill {
-
-
+class ColumnarVectorWrapperDirect implements CarbonColumnVector, SequentialFill {
   /**
    * It is adapter class of complete ColumnarBatch.
    */
   protected CarbonColumnVectorImpl columnVector;
 
+  /**
+   * It is current block file datatype used for alter table scenarios when datatype changes.
+   */
   private DataType blockDataType;
 
   private CarbonColumnVector dictionaryVector;
@@ -79,14 +80,7 @@ class ColumnarVectorWrapperDirect implements CarbonColumnVector,SequentialFill {
   }
 
   @Override public void putShorts(int rowId, int count, short value) {
-    for (int i = 0; i < count; i++) {
-      if (nullBitset.get(rowId)) {
-        columnVector.putNull(rowId);
-      } else {
-        columnVector.putShort(rowId, value);
-      }
-      rowId++;
-    }
+    columnVector.putShorts(rowId, count, value);
 
   }
 
@@ -154,14 +148,9 @@ class ColumnarVectorWrapperDirect implements CarbonColumnVector,SequentialFill {
   }
 
   @Override
-  public void putBytes(int rowId, int count, byte[] value) {
+  public void putByteArray(int rowId, int count, byte[] value) {
     for (int i = 0; i < count; i++) {
-      if (nullBitset.get(rowId)) {
-        columnVector.putNull(rowId);
-      } else {
-        columnVector.putByteArray(rowId, value);
-      }
-      rowId++;
+      columnVector.putByteArray(rowId++, value);
     }
   }
 
@@ -193,12 +182,13 @@ class ColumnarVectorWrapperDirect implements CarbonColumnVector,SequentialFill {
   }
 
   @Override public void putObject(int rowId, Object obj) {
-    //TODO handle complex types
+    throw new UnsupportedOperationException(
+        "Not supported this opeartion from " + this.getClass().getName());
   }
 
   @Override public Object getData(int rowId) {
-    //TODO handle complex types
-    return null;
+    throw new UnsupportedOperationException(
+        "Not supported this opeartion from " + this.getClass().getName());
   }
 
   @Override public void reset() {
@@ -237,7 +227,7 @@ class ColumnarVectorWrapperDirect implements CarbonColumnVector,SequentialFill {
   }
 
   @Override public void setFilteredRowsExist(boolean filteredRowsExist) {
-
+    // Leave it, as it does not need to do anything here.
   }
 
   @Override public void putFloats(int rowId, int count, float[] src, int srcIndex) {

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/ColumnarVectorWrapperDirect.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/ColumnarVectorWrapperDirect.java
@@ -1,0 +1,320 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.presto;
+
+import java.math.BigDecimal;
+import java.util.BitSet;
+
+import org.apache.carbondata.core.metadata.datatype.DataType;
+import org.apache.carbondata.core.scan.result.vector.CarbonColumnVector;
+import org.apache.carbondata.core.scan.result.vector.CarbonDictionary;
+import org.apache.carbondata.core.scan.result.vector.impl.CarbonColumnVectorImpl;
+import org.apache.carbondata.core.scan.result.vector.impl.directread.SequentialFill;
+import org.apache.carbondata.core.scan.scanner.LazyPageLoader;
+
+/**
+ * Fills the vector directly with out considering any deleted rows.
+ */
+class ColumnarVectorWrapperDirect implements CarbonColumnVector,SequentialFill {
+
+
+  /**
+   * It is adapter class of complete ColumnarBatch.
+   */
+  protected CarbonColumnVectorImpl columnVector;
+
+  private DataType blockDataType;
+
+  private CarbonColumnVector dictionaryVector;
+
+  private BitSet nullBitset;
+
+  ColumnarVectorWrapperDirect(CarbonColumnVectorImpl columnVector) {
+    this.columnVector = columnVector;
+    this.dictionaryVector = columnVector.getDictionaryVector();
+    this.nullBitset = new BitSet();
+  }
+
+  @Override public void setNullBits(BitSet nullBits) {
+    this.nullBitset = nullBits;
+  }
+
+  @Override public void putBoolean(int rowId, boolean value) {
+    if (nullBitset.get(rowId)) {
+      columnVector.putNull(rowId);
+    } else {
+      columnVector.putBoolean(rowId, value);
+    }
+  }
+
+  @Override public void putFloat(int rowId, float value) {
+    if (nullBitset.get(rowId)) {
+      columnVector.putNull(rowId);
+    } else {
+      columnVector.putFloat(rowId, value);
+    }
+  }
+
+  @Override public void putShort(int rowId, short value) {
+    if (nullBitset.get(rowId)) {
+      columnVector.putNull(rowId);
+    } else {
+      columnVector.putShort(rowId, value);
+    }
+  }
+
+  @Override public void putShorts(int rowId, int count, short value) {
+    for (int i = 0; i < count; i++) {
+      if (nullBitset.get(rowId)) {
+        columnVector.putNull(rowId);
+      } else {
+        columnVector.putShort(rowId, value);
+      }
+      rowId++;
+    }
+
+  }
+
+  @Override public void putInt(int rowId, int value) {
+    if (nullBitset.get(rowId)) {
+      columnVector.putNull(rowId);
+    } else {
+      columnVector.putInt(rowId, value);
+    }
+  }
+
+  @Override public void putInts(int rowId, int count, int value) {
+    columnVector.putInts(rowId, count, value);
+  }
+
+  @Override public void putLong(int rowId, long value) {
+    if (nullBitset.get(rowId)) {
+      columnVector.putNull(rowId);
+    } else {
+      columnVector.putLong(rowId, value);
+    }
+  }
+
+  @Override public void putLongs(int rowId, int count, long value) {
+    columnVector.putLongs(rowId, count, value);
+  }
+
+  @Override public void putDecimal(int rowId, BigDecimal value, int precision) {
+    if (nullBitset.get(rowId)) {
+      columnVector.putNull(rowId);
+    } else {
+      columnVector.putDecimal(rowId, value, precision);
+    }
+  }
+
+  @Override public void putDecimals(int rowId, int count, BigDecimal value, int precision) {
+    for (int i = 0; i < count; i++) {
+      if (nullBitset.get(rowId)) {
+        columnVector.putNull(rowId);
+      } else {
+        columnVector.putDecimal(rowId, value, precision);
+      }
+      rowId++;
+    }
+  }
+
+  @Override public void putDouble(int rowId, double value) {
+    if (nullBitset.get(rowId)) {
+      columnVector.putNull(rowId);
+    } else {
+      columnVector.putDouble(rowId, value);
+    }
+  }
+
+  @Override public void putDoubles(int rowId, int count, double value) {
+    columnVector.putDoubles(rowId, count, value);
+  }
+
+  @Override public void putByteArray(int rowId, byte[] value) {
+    if (nullBitset.get(rowId)) {
+      columnVector.putNull(rowId);
+    } else {
+      columnVector.putByteArray(rowId, value);
+    }
+  }
+
+  @Override
+  public void putBytes(int rowId, int count, byte[] value) {
+    for (int i = 0; i < count; i++) {
+      if (nullBitset.get(rowId)) {
+        columnVector.putNull(rowId);
+      } else {
+        columnVector.putByteArray(rowId, value);
+      }
+      rowId++;
+    }
+  }
+
+  @Override public void putByteArray(int rowId, int offset, int length, byte[] value) {
+    if (nullBitset.get(rowId)) {
+      columnVector.putNull(rowId);
+    } else {
+      columnVector.putByteArray(rowId, offset, length, value);
+    }
+  }
+
+  @Override public void putNull(int rowId) {
+    columnVector.putNull(rowId);
+  }
+
+  @Override public void putNulls(int rowId, int count) {
+    columnVector.putNulls(rowId, count);
+  }
+
+  @Override public void putNotNull(int rowId) {
+    columnVector.putNotNull(rowId);
+  }
+
+  @Override public void putNotNull(int rowId, int count) {
+  }
+
+  @Override public boolean isNull(int rowId) {
+    return columnVector.isNullAt(rowId);
+  }
+
+  @Override public void putObject(int rowId, Object obj) {
+    //TODO handle complex types
+  }
+
+  @Override public Object getData(int rowId) {
+    //TODO handle complex types
+    return null;
+  }
+
+  @Override public void reset() {
+    if (null != dictionaryVector) {
+      dictionaryVector.reset();
+    }
+  }
+
+  @Override public DataType getType() {
+    return columnVector.getType();
+  }
+
+  @Override public DataType getBlockDataType() {
+    return blockDataType;
+  }
+
+  @Override public void setBlockDataType(DataType blockDataType) {
+    this.blockDataType = blockDataType;
+  }
+
+  @Override public void setDictionary(CarbonDictionary dictionary) {
+    columnVector.setDictionary(dictionary);
+  }
+
+  @Override public boolean hasDictionary() {
+    return columnVector.hasDictionary();
+  }
+
+
+  @Override public CarbonColumnVector getDictionaryVector() {
+    return dictionaryVector;
+  }
+
+  @Override public void putByte(int rowId, byte value) {
+    columnVector.putByte(rowId, value);
+  }
+
+  @Override public void setFilteredRowsExist(boolean filteredRowsExist) {
+
+  }
+
+  @Override public void putFloats(int rowId, int count, float[] src, int srcIndex) {
+    for (int i = 0; i < count; i++) {
+      if (nullBitset.get(rowId)) {
+        columnVector.putNull(rowId);
+      } else {
+        columnVector.putFloat(rowId, src[i]);
+      }
+      rowId++;
+    }
+  }
+
+  @Override public void putShorts(int rowId, int count, short[] src, int srcIndex) {
+    for (int i = 0; i < count; i++) {
+      if (nullBitset.get(rowId)) {
+        columnVector.putNull(rowId);
+      } else {
+        columnVector.putShort(rowId, src[i]);
+      }
+      rowId++;
+    }
+  }
+
+  @Override public void putInts(int rowId, int count, int[] src, int srcIndex) {
+    for (int i = 0; i < count; i++) {
+      if (nullBitset.get(rowId)) {
+        columnVector.putNull(rowId);
+      } else {
+        columnVector.putInt(rowId, src[i]);
+      }
+      rowId++;
+    }
+  }
+
+  @Override public void putLongs(int rowId, int count, long[] src, int srcIndex) {
+    for (int i = 0; i < count; i++) {
+      if (nullBitset.get(rowId)) {
+        columnVector.putNull(rowId);
+      } else {
+        columnVector.putLong(rowId, src[i]);
+      }
+      rowId++;
+    }
+  }
+
+  @Override public void putDoubles(int rowId, int count, double[] src, int srcIndex) {
+    for (int i = 0; i < count; i++) {
+      if (nullBitset.get(rowId)) {
+        columnVector.putNull(rowId);
+      } else {
+        columnVector.putDouble(rowId, src[i]);
+      }
+      rowId++;
+    }
+  }
+
+  @Override public void putBytes(int rowId, int count, byte[] src, int srcIndex) {
+    for (int i = 0; i < count; i++) {
+      if (nullBitset.get(rowId)) {
+        columnVector.putNull(rowId);
+      } else {
+        columnVector.putByte(rowId, src[i]);
+      }
+      rowId++;
+    }
+  }
+
+  @Override public void setLazyPage(LazyPageLoader lazyPage) {
+    columnVector.setLazyPage(lazyPage);
+  }
+
+  @Override public void putArray(int rowId, int offset, int length) {
+    columnVector.putArray(rowId, offset, length);
+  }
+
+  @Override public void putAllByteArray(byte[] data, int offset, int length) {
+    columnVector.putAllByteArray(data, offset, length);
+  }
+}

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/PrestoCarbonVectorizedRecordReader.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/PrestoCarbonVectorizedRecordReader.java
@@ -214,11 +214,16 @@ class PrestoCarbonVectorizedRecordReader extends AbstractRecordReader<Object> {
       }
     }
 
-    columnarBatch = CarbonVectorBatch.allocate(fields, readSupport);
+    columnarBatch =
+        CarbonVectorBatch.allocate(fields, readSupport, queryModel.isDirectVectorFill());
     CarbonColumnVector[] vectors = new CarbonColumnVector[fields.length];
     boolean[] filteredRows = new boolean[columnarBatch.capacity()];
     for (int i = 0; i < fields.length; i++) {
-      vectors[i] = new CarbonColumnVectorWrapper(columnarBatch.column(i), filteredRows);
+      if (queryModel.isDirectVectorFill()) {
+        vectors[i] = new ColumnarVectorWrapperDirect(columnarBatch.column(i));
+      } else {
+        vectors[i] = new CarbonColumnVectorWrapper(columnarBatch.column(i), filteredRows);
+      }
     }
     carbonColumnarBatch = new CarbonColumnarBatch(vectors, columnarBatch.capacity(), filteredRows);
   }

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/impl/CarbonTableConfig.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/impl/CarbonTableConfig.java
@@ -43,6 +43,7 @@ public class CarbonTableConfig {
   private String s3N_acesssKey;
   private String s3N_secretKey;
   private String endPoint;
+  private String pushRowFilter;
 
 
   @NotNull public String getDbPath() {
@@ -194,5 +195,14 @@ public class CarbonTableConfig {
   public CarbonTableConfig setS3EndPoint(String endPoint) {
     this.endPoint = endPoint;
     return this;
+  }
+
+  public String getPushRowFilter() {
+    return pushRowFilter;
+  }
+
+  @Config("carbon.push.rowfilters.for.vector")
+  public void setPushRowFilter(String pushRowFilter) {
+    this.pushRowFilter = pushRowFilter;
   }
 }

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/impl/CarbonTableReader.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/impl/CarbonTableReader.java
@@ -412,7 +412,7 @@ public class CarbonTableReader {
     List<CarbonLocalMultiBlockSplit> multiBlockSplitList = new ArrayList<>();
     CarbonTable carbonTable = tableCacheModel.carbonTable;
     TableInfo tableInfo = tableCacheModel.carbonTable.getTableInfo();
-    Configuration config = FileFactory.getConfiguration();
+    Configuration config = new Configuration();
     config.set(CarbonTableInputFormat.INPUT_SEGMENT_NUMBERS, "");
     String carbonTablePath = carbonTable.getAbsoluteTableIdentifier().getTablePath();
     config.set(CarbonTableInputFormat.INPUT_DIR, carbonTablePath);

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/readers/BooleanStreamReader.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/readers/BooleanStreamReader.java
@@ -68,12 +68,6 @@ public class BooleanStreamReader extends CarbonColumnVectorImpl
     type.writeBoolean(builder, value == 1);
   }
 
-  @Override public void putBytes(int rowId, int count, byte[] value) {
-    for (int i = 0; i < count; i++) {
-      type.writeBoolean(builder, value[i] == 1);
-    }
-  }
-
   @Override public void putBytes(int rowId, int count, byte[] src, int srcIndex) {
     for (int i = 0; i < count; i++) {
       type.writeBoolean(builder, src[srcIndex++] == 1);

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/readers/BooleanStreamReader.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/readers/BooleanStreamReader.java
@@ -64,6 +64,22 @@ public class BooleanStreamReader extends CarbonColumnVectorImpl
     }
   }
 
+  @Override public void putByte(int rowId, byte value) {
+    type.writeBoolean(builder, value == 1);
+  }
+
+  @Override public void putBytes(int rowId, int count, byte[] value) {
+    for (int i = 0; i < count; i++) {
+      type.writeBoolean(builder, value[i] == 1);
+    }
+  }
+
+  @Override public void putBytes(int rowId, int count, byte[] src, int srcIndex) {
+    for (int i = 0; i < count; i++) {
+      type.writeBoolean(builder, src[srcIndex++] == 1);
+    }
+  }
+
   @Override public void putBoolean(int rowId, boolean value) {
     type.writeBoolean(builder, value);
   }

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/readers/SliceStreamReader.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/readers/SliceStreamReader.java
@@ -80,8 +80,8 @@ public class SliceStreamReader extends CarbonColumnVectorImpl implements PrestoV
     int[] dictOffsets = new int[dictionary.getDictionarySize() + 1];
     int size = 0;
     for (int i = 0; i < dictionary.getDictionarySize(); i++) {
+      dictOffsets[i] = size;
       if (dictionary.getDictionaryValue(i) != null) {
-        dictOffsets[i] = size;
         size += dictionary.getDictionaryValue(i).length;
       }
     }

--- a/integration/spark-datasource/src/main/scala/org/apache/carbondata/spark/vectorreader/ColumnarVectorWrapper.java
+++ b/integration/spark-datasource/src/main/scala/org/apache/carbondata/spark/vectorreader/ColumnarVectorWrapper.java
@@ -177,7 +177,7 @@ class ColumnarVectorWrapper implements CarbonColumnVector {
     }
   }
 
-  @Override public void putBytes(int rowId, int count, byte[] value) {
+  @Override public void putByteArray(int rowId, int count, byte[] value) {
     for (int i = 0; i < count; i++) {
       if (!filteredRows[rowId]) {
         sparkColumnVectorProxy.putByteArray(counter++, value);

--- a/integration/spark-datasource/src/main/scala/org/apache/carbondata/spark/vectorreader/ColumnarVectorWrapperDirect.java
+++ b/integration/spark-datasource/src/main/scala/org/apache/carbondata/spark/vectorreader/ColumnarVectorWrapperDirect.java
@@ -119,7 +119,7 @@ class ColumnarVectorWrapperDirect implements CarbonColumnVector {
   }
 
   @Override
-  public void putBytes(int rowId, int count, byte[] value) {
+  public void putByteArray(int rowId, int count, byte[] value) {
     for (int i = 0; i < count; i++) {
       sparkColumnVectorProxy.putByteArray(rowId, value);
       rowId++;


### PR DESCRIPTION
This PR is on top of https://github.com/apache/carbondata/pull/2972

To improve the scan performance, integrate lazy loading and direct fil vector features to Carbon Presto Integration.

This PR also fixes the query fail in case of multiple table join and filters

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

