### PR TITLE
[CARBONDATA-3119] Fixed SDK Write for Complex Array Type when Array is Empty

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/complexType/TestComplexDataType.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/complexType/TestComplexDataType.scala
@@ -122,7 +122,7 @@ class TestComplexDataType extends QueryTest with BeforeAndAfterAll {
       .addProperty(CarbonCommonConstants.CARBON_BAD_RECORDS_ACTION, "FAIL")
     sql("drop table if exists table1")
     sql("create table table1 (person struct<detail:array<string>,age:int>) stored by 'carbondata'")
-    sql("insert into table1 values ('$1')")
+    sql("insert into table1 values ('\0011')")
     checkAnswer(sql("select person.detail[0] from table1"), Seq(Row("")))
     checkAnswer(sql("select person.age from table1"), Seq(Row(1)))
     sql("drop table if exists table1")

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/complexType/TestComplexDataType.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/complexType/TestComplexDataType.scala
@@ -105,6 +105,31 @@ class TestComplexDataType extends QueryTest with BeforeAndAfterAll {
       Seq(Row(1, "abc", Row(mutable.WrappedArray.make(Array("abc", "bcd"))), "bcd")))
   }
 
+  test("test Projection PushDown for Array - String type when Array is Empty") {
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.CARBON_BAD_RECORDS_ACTION, "FAIL")
+    sql("drop table if exists table1")
+    sql("create table table1 (detail array<string>) stored by 'carbondata'")
+    sql("insert into table1 values('')")
+    checkAnswer(sql("select detail[0] from table1"), Seq(Row("")))
+    sql("drop table if exists table1")
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.CARBON_BAD_RECORDS_ACTION, badRecordAction)
+  }
+
+  test("test Projection PushDown for Struct - Array type when Array is Empty") {
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.CARBON_BAD_RECORDS_ACTION, "FAIL")
+    sql("drop table if exists table1")
+    sql("create table table1 (person struct<detail:array<string>,age:int>) stored by 'carbondata'")
+    sql("insert into table1 values ('$1')")
+    checkAnswer(sql("select person.detail[0] from table1"), Seq(Row("")))
+    checkAnswer(sql("select person.age from table1"), Seq(Row(1)))
+    sql("drop table if exists table1")
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.CARBON_BAD_RECORDS_ACTION, badRecordAction)
+  }
+
   test("test Projection PushDown for Struct - Double type") {
     sql("DROP TABLE IF EXISTS table1")
     sql(

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/parser/impl/ArrayParserImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/parser/impl/ArrayParserImpl.java
@@ -58,7 +58,7 @@ public class ArrayParserImpl implements ComplexParser<ArrayObject> {
         }
       } else if (value.isEmpty()) {
         Object[] array = new Object[1];
-        array[0] = value;
+        array[0] = child.parse(value);
         return new ArrayObject(array);
       }
     }

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/parser/impl/ArrayParserImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/parser/impl/ArrayParserImpl.java
@@ -56,6 +56,10 @@ public class ArrayParserImpl implements ComplexParser<ArrayObject> {
           }
           return new ArrayObject(array);
         }
+      } else if (value.isEmpty()) {
+        Object[] array = new Object[1];
+        array[0] = value;
+        return new ArrayObject(array);
       }
     }
     return null;

--- a/store/sdk/src/test/java/org/apache/carbondata/sdk/file/CarbonReaderTest.java
+++ b/store/sdk/src/test/java/org/apache/carbondata/sdk/file/CarbonReaderTest.java
@@ -2074,6 +2074,8 @@ public class CarbonReaderTest extends TestCase {
 
   @Test
   public void testSdkWriteWhenArrayOfStringIsEmpty() throws IOException, InvalidLoadOptionException {
+    String badRecordAction =
+        CarbonProperties.getInstance().getProperty(CarbonCommonConstants.CARBON_BAD_RECORDS_ACTION);
     CarbonProperties.getInstance()
         .addProperty(CarbonCommonConstants.CARBON_BAD_RECORDS_ACTION, "FAIL");
 
@@ -2098,6 +2100,8 @@ public class CarbonReaderTest extends TestCase {
     CarbonWriter writer = builder.build();
     writer.write(rec);
     writer.close();
+    CarbonProperties.getInstance()
+        .addProperty(CarbonCommonConstants.CARBON_BAD_RECORDS_ACTION, badRecordAction);
   }
 
 }

--- a/store/sdk/src/test/java/org/apache/carbondata/sdk/file/CarbonReaderTest.java
+++ b/store/sdk/src/test/java/org/apache/carbondata/sdk/file/CarbonReaderTest.java
@@ -2072,4 +2072,32 @@ public class CarbonReaderTest extends TestCase {
     }
   }
 
+  @Test
+  public void testSdkWriteWhenArrayOfStringIsEmpty() throws IOException, InvalidLoadOptionException {
+    CarbonProperties.getInstance()
+        .addProperty(CarbonCommonConstants.CARBON_BAD_RECORDS_ACTION, "FAIL");
+
+    String path = "./testSdkWriteWhenArrayOfStringIsEmpty";
+    String[] rec = { "aaa", "bbb", "aaa@cdf.com", "", "", "mmm", "" };
+    Field[] fields = new Field[7];
+    fields[0] = new Field("stringField", DataTypes.STRING);
+    fields[1] = new Field("varcharField", DataTypes.VARCHAR);
+    fields[2] = new Field("stringField1", DataTypes.STRING);
+    fields[3] = new Field("arrayField", DataTypes.createArrayType(DataTypes.STRING));
+    fields[4] = new Field("arrayField1", DataTypes.createArrayType(DataTypes.STRING));
+    fields[5] = new Field("arrayField2", DataTypes.createArrayType(DataTypes.STRING));
+    fields[6] = new Field("varcharField1", DataTypes.VARCHAR);
+    Schema schema = new Schema(fields);
+    Map map = new HashMap();
+    map.put("complex_delimiter_level_1", "#");
+    map.put("bad_records_logger_enable", "TRUE");
+    map.put("bad_record_path", path + "/badrec");
+    CarbonWriterBuilder builder = CarbonWriter.builder().outputPath(path);
+    builder.withLoadOptions(map).withCsvInput(schema).enableLocalDictionary(false)
+        .writtenBy("CarbonReaderTest");
+    CarbonWriter writer = builder.build();
+    writer.write(rec);
+    writer.close();
+  }
+
 }


### PR DESCRIPTION
### What was the issue?
For SDK Write , it was going into bad record by returning null on passing empty array for Complex Type.
### What has been changed?
Added a check for empty array. This will return an empty array.

 - [ ] Any interfaces changed?
 NA
 - [ ] Any backward compatibility impacted?
 NA
 - [ ] Document update required?
NA
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
Test  case added
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA
