### PR TITLE
[CARBONDATA-3165]Protection of Bloom Null Exception

### DIFF
--- a/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomCoarseGrainDataMap.java
+++ b/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomCoarseGrainDataMap.java
@@ -175,6 +175,10 @@ public class BloomCoarseGrainDataMap extends CoarseGrainDataMap {
       // null is different from empty here. Empty means after pruning, no blocklet need to scan.
       return null;
     }
+    if (filteredShard.isEmpty()) {
+      LOGGER.info("Bloom filtered shards is empty");
+      return new ArrayList<>();
+    }
 
     List<BloomQueryModel> bloomQueryModels;
     try {
@@ -226,6 +230,12 @@ public class BloomCoarseGrainDataMap extends CoarseGrainDataMap {
           hitBlocklets.retainAll(tempHitBlockletsResult);
         }
       }
+    }
+    if (hitBlocklets == null) {
+      LOGGER.warn(String.format("HitBlocklets is null int bloom filter prune method! " +
+              "bloomQueryModels size is %d, filterShards size if %d",
+              bloomQueryModels.size(), filteredShard.size()));
+      return null;
     }
     return new ArrayList<>(hitBlocklets);
   }


### PR DESCRIPTION
Problem：
24274.0 (TID 664711) | org.apache.spark.internal.Logging$class.logError(Logging.scala:91)
java.lang.NullPointerException
        at java.util.ArrayList.<init>(ArrayList.java:177)
        at org.apache.carbondata.datamap.bloom.BloomCoarseGrainDataMap.prune(BloomCoarseGrainDataMap.java:230)
        at org.apache.carbondata.core.datamap.TableDataMap.prune(TableDataMap.java:379)
        at org.apache.carbondata.core.datamap.DistributableDataMapFormat$1.initialize(DistributableDataMapFormat.java:108)
        at org.apache.carbondata.spark.rdd.DataMapPruneRDD.internalCompute(SparkDataMapJob.scala:77)
        at org.apache.carbondata.spark.rdd.CarbonRDD.compute(CarbonRDD.scala:82)
        at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:324)
        at org.apache.spark.rdd.RDD.iterator(RDD.scala:288)
        at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:87)
        at org.apache.spark.scheduler.Task.run(Task.scala:99)
        at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:325)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)

Solution：
when filteredShard is empty, return arraylist<>(), and protect null exception of other scenes

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        protection of null exception, existing test cases are fine
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

