### PR TITLE
[HOTFIX] Fixed Query performance issue

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/scan/result/BlockletScannedResult.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/BlockletScannedResult.java
@@ -663,6 +663,12 @@ public abstract class BlockletScannedResult {
       return true;
     } else if (pageCounter < pageFilteredRowCount.length) {
       pageCounter++;
+      if (pageCounter >= pageFilteredRowCount.length) {
+        return false;
+      }
+      if (this.pageFilteredRowCount[pageCounter] == 0) {
+        return hasNext();
+      }
       fillDataChunks();
       rowCounter = 0;
       currentRow = -1;


### PR DESCRIPTION
### Problem
When some pages is giving 0 rows, then also BlockletScanResult is uncompressing all the pages. When compression is high and one blocklet contains more number of pages in this case page uncompression is taking more time and impacting query performance.

### Solution
Added check if number of record after filtering is 0 then no need to uncompress that page 

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

