### PR TITLE
[CARBONDATA-3174] Fix trailing space issue with varchar column for SDK

### DIFF
--- a/integration/spark-datasource/src/test/scala/org/apache/spark/sql/carbondata/datasource/TestCreateTableUsingSparkCarbonFileFormat.scala
+++ b/integration/spark-datasource/src/test/scala/org/apache/spark/sql/carbondata/datasource/TestCreateTableUsingSparkCarbonFileFormat.scala
@@ -428,7 +428,7 @@ class TestCreateTableUsingSparkCarbonFileFormat extends FunSuite with BeforeAndA
     val schema = new StringBuilder()
       .append("[ \n")
       .append("   {\"name\":\"string\"},\n")
-      .append("   {\"address\":\"varchar\"},\n")
+      .append("   {\"  address    \":\"varchar\"},\n")
       .append("   {\"age\":\"int\"},\n")
       .append("   {\"note\":\"varchar\"}\n")
       .append("]")

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonWriterBuilder.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonWriterBuilder.java
@@ -99,7 +99,7 @@ public class CarbonWriterBuilder {
   public CarbonWriterBuilder sortBy(String[] sortColumns) {
     if (sortColumns != null) {
       for (int i = 0; i < sortColumns.length; i++) {
-        sortColumns[i] = sortColumns[i].toLowerCase();
+        sortColumns[i] = sortColumns[i].toLowerCase().trim();
       }
     }
     this.sortColumns = sortColumns;
@@ -116,7 +116,7 @@ public class CarbonWriterBuilder {
   public CarbonWriterBuilder invertedIndexFor(String[] invertedIndexColumns) {
     if (invertedIndexColumns != null) {
       for (int i = 0; i < invertedIndexColumns.length; i++) {
-        invertedIndexColumns[i] = invertedIndexColumns[i].toLowerCase();
+        invertedIndexColumns[i] = invertedIndexColumns[i].toLowerCase().trim();
       }
     }
     this.invertedIndexColumns = invertedIndexColumns;
@@ -747,7 +747,6 @@ public class CarbonWriterBuilder {
     Field[] fields =  schema.getFields();
     for (int i = 0; i < fields.length; i++) {
       if (fields[i] != null) {
-        fields[i].updateNameToLowerCase();
         if (longStringColumns != null) {
           /* Also update the string type to varchar */
           if (longStringColumns.contains(fields[i].getFieldName())) {

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/Field.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/Field.java
@@ -55,7 +55,7 @@ public class Field {
    * @param type datatype of field, specified in strings.
    */
   public Field(String name, String type) {
-    this.name = name;
+    this.name = name.toLowerCase().trim();
     if (type.equalsIgnoreCase("string")) {
       this.type = DataTypes.STRING;
     } else if (type.equalsIgnoreCase("varchar")) {
@@ -90,7 +90,7 @@ public class Field {
   }
 
   public Field(String name, String type, List<StructField> fields) {
-    this.name = name;
+    this.name = name.toLowerCase().trim();
     this.children = fields;
     if (type.equalsIgnoreCase("string")) {
       this.type = DataTypes.STRING;
@@ -126,13 +126,13 @@ public class Field {
 
 
   public Field(String name, DataType type, List<StructField> fields) {
-    this.name = name;
+    this.name = name.toLowerCase().trim();
     this.type = type;
     this.children = fields;
   }
 
   public Field(String name, DataType type) {
-    this.name = name;
+    this.name = name.toLowerCase().trim();
     this.type = type;
     initComplexTypeChildren();
   }
@@ -143,7 +143,7 @@ public class Field {
    * @param columnSchema ColumnSchema, Store the information about the column meta data
    */
   public Field(ColumnSchema columnSchema) {
-    this.name = columnSchema.getColumnName();
+    this.name = columnSchema.getColumnName().toLowerCase().trim();
     this.type = columnSchema.getDataType();
     children = new LinkedList<>();
     schemaOrdinal = columnSchema.getSchemaOrdinal();
@@ -222,11 +222,6 @@ public class Field {
   /* for SDK, change string type to varchar by default for parent columns */
   public void updateDataTypeToVarchar() {
     this.type = DataTypes.VARCHAR;
-  }
-
-  /*can use to change the case of the schema */
-  public void updateNameToLowerCase() {
-    this.name = name.toLowerCase();
   }
 
   private void initComplexTypeChildren() {


### PR DESCRIPTION
What was the issue?
After doing SDK Write, Select * was failing for 'long_string_columns' with trailing space.

What has been changed?
Removed the trailing space in ColumnName. 

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [x] Testing done
            Added a test case.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

