### PR TITLE
[CARBONDATA-3235] Fix Rename-Fail & Datamap-creation-Fail

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/datamap/CarbonDropDataMapCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/datamap/CarbonDropDataMapCommand.scala
@@ -103,7 +103,7 @@ case class CarbonDropDataMapCommand(
             Some(childCarbonTable.get.getDatabaseName),
             childCarbonTable.get.getTableName,
             dropChildTable = true)
-          commandToRun.processMetadata(sparkSession)
+          commandToRun.run(sparkSession)
         }
         dropDataMapFromSystemFolder(sparkSession)
         return Seq.empty

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/schema/CarbonAlterTableRenameCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/schema/CarbonAlterTableRenameCommand.scala
@@ -87,6 +87,7 @@ private[sql] case class CarbonAlterTableRenameCommand(
 
     var timeStamp = 0L
     var carbonTable: CarbonTable = null
+    var hiveRenameSuccess = false
     // lock file path to release locks after operation
     var carbonTableLockFilePath: String = null
     try {
@@ -139,6 +140,7 @@ private[sql] case class CarbonAlterTableRenameCommand(
           oldIdentifier,
           newIdentifier,
         oldTableIdentifier.getTablePath)
+      hiveRenameSuccess = true
 
       metastore.updateTableSchemaForAlter(
         newTableIdentifier,
@@ -165,6 +167,12 @@ private[sql] case class CarbonAlterTableRenameCommand(
       case e: ConcurrentOperationException =>
         throw e
       case e: Exception =>
+        if (hiveRenameSuccess) {
+          sparkSession.sessionState.catalog.asInstanceOf[CarbonSessionCatalog].alterTableRename(
+            TableIdentifier(newTableName, Some(oldDatabaseName)),
+            TableIdentifier(oldTableName, Some(oldDatabaseName)),
+            carbonTable.getAbsoluteTableIdentifier.getTableName)
+        }
         if (carbonTable != null) {
           AlterTableUtil.revertRenameTableChanges(
             newTableName,
@@ -172,8 +180,9 @@ private[sql] case class CarbonAlterTableRenameCommand(
             timeStamp)(
             sparkSession)
         }
+        LOGGER.error(opName + " operation failed: ", e)
         throwMetadataException(oldDatabaseName, oldTableName,
-          s"Alter table rename table operation failed: ${e.getMessage}")
+          opName + " operation failed! Please check logs for details.")
     }
     Seq.empty
   }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/schema/CarbonAlterTableRenameCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/schema/CarbonAlterTableRenameCommand.scala
@@ -169,8 +169,8 @@ private[sql] case class CarbonAlterTableRenameCommand(
       case e: Exception =>
         if (hiveRenameSuccess) {
           sparkSession.sessionState.catalog.asInstanceOf[CarbonSessionCatalog].alterTableRename(
-            TableIdentifier(newTableName, Some(oldDatabaseName)),
-            TableIdentifier(oldTableName, Some(oldDatabaseName)),
+            newTableIdentifier,
+            oldTableIdentifier,
             carbonTable.getAbsoluteTableIdentifier.getTableName)
         }
         if (carbonTable != null) {
@@ -180,9 +180,8 @@ private[sql] case class CarbonAlterTableRenameCommand(
             timeStamp)(
             sparkSession)
         }
-        LOGGER.error(opName + " operation failed: ", e)
         throwMetadataException(oldDatabaseName, oldTableName,
-          opName + " operation failed! Please check logs for details.")
+          opName + " operation failed: " + e.getMessage)
     }
     Seq.empty
   }


### PR DESCRIPTION
Fixed 2 negative scenarios:

### 1. Alter Table Rename Table Fail
**Problem:** When tabe rename is success in hive, for failed in carbon data store, it would throw exception, but would not go back and undo rename in hive.

**Solution:** A flag to keep check if hive rename has already executed, and of the code breaks after hive rename is done, go back and undo the hive rename.

### 2. Create-Preagregate-Datamap Fail
**Problem:** When (preaggregate) datamap schema is written, but table updation is failed
* call CarbonDropDataMapCommand.processMetadata()
* call dropDataMapFromSystemFolder() -> this is  supposed to delete the folder on disk, but doesnt as the datamap is not yet updated in table, and throws NoSuchDataMapException

**Solution:** Call CarbonDropTableCommand.run() instead of CarbonDropTableCommand.processDatamap(). As CarbonDropTableCommand.processData() deletes actual folders from disk.
       
<br><br>
 - [x] Any interfaces changed?   --->   No
 - [ ] Any backward compatibility impacted?
 - [x] Document update required?   --->   No
 - [ ] Testing done 
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
