### PR TITLE
[CARBONDATA-3181][BloomDataMap] Fix access field error for BitSet in bloom filter

### DIFF
--- a/datamap/bloom/src/main/java/org/apache/hadoop/util/bloom/CarbonBloomFilter.java
+++ b/datamap/bloom/src/main/java/org/apache/hadoop/util/bloom/CarbonBloomFilter.java
@@ -49,27 +49,23 @@ public class CarbonBloomFilter extends BloomFilter {
 
   @Override
   public boolean membershipTest(Key key) {
-    if (key == null) {
-      throw new NullPointerException("key cannot be null");
-    }
-
-    int[] h = hash.hash(key);
-    hash.clear();
     if (compress) {
       // If it is compressed check in roaring bitmap
+      if (key == null) {
+        throw new NullPointerException("key cannot be null");
+      }
+      int[] h = hash.hash(key);
+      hash.clear();
       for (int i = 0; i < nbHash; i++) {
         if (!bitmap.contains(h[i])) {
           return false;
         }
       }
+      return true;
     } else {
-      for (int i = 0; i < nbHash; i++) {
-        if (!bits.get(h[i])) {
-          return false;
-        }
-      }
+      // call super method to avoid IllegalAccessError for `bits` field
+      return super.membershipTest(key);
     }
-    return true;
   }
 
   @Override


### PR DESCRIPTION
**Problem**
java.lang.IllegalAccessError is thrown when query on bloom filter without compress on CarbonThriftServer. Detailed log is pasted at bottom.

**Analyse**
similar problem was occur when get/set BitSet in CarbonBloomFilter, it uses reflection to solve. We can do it like this. 
Since we have set the BitSet already, another easier way is to call super class method to avoid accessing it from CarbonBloomFilter

**Solution**
if bloom filter is not compressed, call super method to test membership

---
*Log*
```
18/12/19 11:16:07 ERROR thriftserver.SparkExecuteStatementOperation: Error executing query, currentState RUNNING,
java.lang.IllegalAccessError: tried to access field org.apache.hadoop.util.bloom.BloomFilter.bits from class org.apache.hadoop.util.bloom.CarbonBloomFilter
        at org.apache.hadoop.util.bloom.CarbonBloomFilter.membershipTest(CarbonBloomFilter.java:70)
        at org.apache.carbondata.datamap.bloom.BloomCoarseGrainDataMap.prune(BloomCoarseGrainDataMap.java:202)
        at org.apache.carbondata.core.datamap.TableDataMap.pruneWithFilter(TableDataMap.java:185)
        at org.apache.carbondata.core.datamap.TableDataMap.prune(TableDataMap.java:160)
        at org.apache.carbondata.core.datamap.dev.expr.DataMapExprWrapperImpl.prune(DataMapExprWrapperImpl.java:53)
        at org.apache.carbondata.hadoop.api.CarbonInputFormat.getPrunedBlocklets(CarbonInputFormat.java:517)
        at org.apache.carbondata.hadoop.api.CarbonInputFormat.getDataBlocksOfSegment(CarbonInputFormat.java:412)
        at org.apache.carbondata.hadoop.api.CarbonTableInputFormat.getSplits(CarbonTableInputFormat.java:529)
        at org.apache.carbondata.hadoop.api.CarbonTableInputFormat.getSplits(CarbonTableInputFormat.java:220)
        at org.apache.carbondata.spark.rdd.CarbonScanRDD.internalGetPartitions(CarbonScanRDD.scala:127)
        at org.apache.carbondata.spark.rdd.CarbonRDD.getPartitions(CarbonRDD.scala:66)
        at org.apache.spark.rdd.RDD$$anonfun$partitions$2.apply(RDD.scala:252)
        at org.apache.spark.rdd.RDD$$anonfun$partitions$2.apply(RDD.scala:250)
```

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

