### PR TITLE
[CARBONDATA-3186]Avoid creating empty carbondata file when all the records are bad record with action redirect.

### DIFF
--- a/integration/presto/src/main/java/org/apache/carbondata/presto/impl/CarbonTableReader.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/impl/CarbonTableReader.java
@@ -288,8 +288,8 @@ public class CarbonTableReader {
     }
     if (isKeyExists) {
       CarbonTableCacheModel carbonTableCacheModel = carbonCache.get().get(schemaTableName);
-      if (carbonTableCacheModel != null
-          && carbonTableCacheModel.carbonTable.getTableInfo() != null) {
+      if (carbonTableCacheModel != null && carbonTableCacheModel.carbonTable.getTableInfo() != null
+          && carbonTableCacheModel.carbonTable.isTransactionalTable()) {
         Long latestTime = FileFactory.getCarbonFile(CarbonTablePath
             .getSchemaFilePath(carbonCache.get().get(schemaTableName).carbonTable.getTablePath()))
             .getLastModifiedTime();

--- a/processing/src/main/java/org/apache/carbondata/processing/store/writer/AbstractFactDataWriter.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/writer/AbstractFactDataWriter.java
@@ -273,15 +273,7 @@ public abstract class AbstractFactDataWriter implements CarbonFactDataWriter {
     if (!enableDirectlyWriteDataToStorePath) {
       try {
         if (currentFileSize == 0) {
-          FileFactory
-              .deleteFile(carbonDataFileTempPath, FileFactory.getFileType(carbonDataFileTempPath));
-          if (blockIndexInfoList.size() > 0 && blockIndexInfoList.get(blockIndexInfoList.size() - 1)
-              .getFileName().equals(carbonDataFileName)) {
-            // no need add this entry in index file
-            blockIndexInfoList.remove(blockIndexInfoList.size() - 1);
-            // TODO: currently there is no implementation for notifyDataMapBlockEnd(),
-            // hence no impact, once implementation is done. Need to undo it in this case.
-          }
+          handleEmptyDataFile(carbonDataFileTempPath);
         } else {
           if (copyInCurrentThread) {
             CarbonUtil.copyCarbonDataFileToCarbonStorePath(carbonDataFileTempPath,
@@ -299,17 +291,22 @@ public abstract class AbstractFactDataWriter implements CarbonFactDataWriter {
     } else {
       if (currentFileSize == 0) {
         try {
-          FileFactory.deleteFile(carbonDataFileStorePath,
-              FileFactory.getFileType(carbonDataFileStorePath));
+          handleEmptyDataFile(carbonDataFileStorePath);
         } catch (IOException e) {
           LOGGER.error(e);
         }
-        if (blockIndexInfoList.size() > 0 && blockIndexInfoList.get(blockIndexInfoList.size() - 1)
-            .getFileName().equals(carbonDataFileName)) {
-          // no need add this entry in index file
-          blockIndexInfoList.remove(blockIndexInfoList.size() - 1);
-        }
       }
+    }
+  }
+
+  private void handleEmptyDataFile(String filePath) throws IOException {
+    FileFactory.deleteFile(filePath, FileFactory.getFileType(filePath));
+    if (blockIndexInfoList.size() > 0 && blockIndexInfoList.get(blockIndexInfoList.size() - 1)
+        .getFileName().equals(carbonDataFileName)) {
+      // no need add this entry in index file
+      blockIndexInfoList.remove(blockIndexInfoList.size() - 1);
+      // TODO: currently there is no implementation for notifyDataMapBlockEnd(),
+      // hence no impact, once implementation is done. Need to undo it in this case.
     }
   }
 


### PR DESCRIPTION
**problem:** In the no_sort flow, writer will be open as there is no blocking sort step. 
So, when all the record goes as bad record with redirect in converted step.
writer is closing the empty .carbondata file. 
when this empty carbondata file is queried , we get multiple issues including NPE.

**solution:** When the file size is 0 bytes. do the following
a) If one data and one index file -- delete carbondata file and avoid index file creation
b) If multiple data and one index file (with few data file is full of bad recod) -- delete carbondata files, remove them from blockIndexInfoList, so index file not will not have that info of empty carbon files
c) In case direct write to store path is enable. need to delete data file from there and avoid writing index file with that carbondata in info.

[HOTFIX] Presto NPE when non-transactional table is cached for s3a/HDFS. 
cause: for non-transactional table, schema must not be read. 

solution: use inferred schema, instead of checking schema file.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed? NA
 
 - [ ] Any backward compatibility impacted? NA
 
 - [ ] Document update required? NA

 - [ ] Testing done
Added UT       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.  NA

