### PR TITLE
[CARBONDATA-3188] Create carbon table as hive understandable metastore table needed by Presto and Hive

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestCreateHiveTableWithCarbonDS.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestCreateHiveTableWithCarbonDS.scala
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.spark.testsuite.createTable
+
+import java.io.File
+
+import org.apache.hadoop.fs.Path
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.hive.CarbonSessionCatalog
+import org.apache.spark.sql.test.util.QueryTest
+import org.apache.spark.sql.{AnalysisException, CarbonEnv, CarbonSession}
+import org.apache.spark.util.SparkUtil
+import org.scalatest.BeforeAndAfterAll
+
+import org.apache.carbondata.core.constants.CarbonCommonConstants
+import org.apache.carbondata.core.util.CarbonProperties
+import org.apache.carbondata.hadoop.api.CarbonFileInputFormat
+
+class TestCreateHiveTableWithCarbonDS extends QueryTest with BeforeAndAfterAll {
+
+  override def beforeAll(): Unit = {
+    sql("DROP TABLE IF EXISTS source")
+  }
+
+  override def afterAll(): Unit = {
+    sql("DROP TABLE IF EXISTS source")
+  }
+
+  test("test create table and verify the hive table correctness with stored by") {
+    sql("DROP TABLE IF EXISTS source")
+    sql(
+      s"""
+         |CREATE TABLE source (key INT, value string, col1 double)
+         |STORED BY 'carbondata'
+     """.stripMargin)
+
+    verifyTable
+
+    sql("DROP TABLE IF EXISTS source")
+  }
+
+  private def verifyTable = {
+    val table = sqlContext.sparkSession.asInstanceOf[CarbonSession].sessionState.catalog.asInstanceOf[CarbonSessionCatalog].getClient().getTable("default", "source")
+    assert(table.schema.fields.length == 3)
+    if (SparkUtil.isSparkVersionEqualTo("2.2")) {
+      assert(table.storage.locationUri.get.equals(new Path(s"file:$storeLocation/source").toUri))
+    }
+    assert(table.storage.inputFormat.get.equals(classOf[CarbonFileInputFormat[_]].getName))
+  }
+
+  test("test create table and verify the hive table correctness with using carbondata") {
+    sql("DROP TABLE IF EXISTS source")
+    sql(
+      s"""
+         |CREATE TABLE source (key INT, value string, col1 double)
+         |using carbondata
+     """.stripMargin)
+
+    verifyTable
+
+
+    sql("DROP TABLE IF EXISTS source")
+  }
+
+  test("test create table and verify the hive table correctness with using carbon") {
+    sql("DROP TABLE IF EXISTS source")
+    sql(
+      s"""
+         |CREATE TABLE source (key INT, value string, col1 double)
+         |using carbon
+     """.stripMargin)
+
+    verifyTable
+
+
+    sql("DROP TABLE IF EXISTS source")
+  }
+
+}

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestCreateHiveTableWithCarbonDS.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestCreateHiveTableWithCarbonDS.scala
@@ -17,19 +17,14 @@
 
 package org.apache.carbondata.spark.testsuite.createTable
 
-import java.io.File
-
 import org.apache.hadoop.fs.Path
-import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.CarbonSession
 import org.apache.spark.sql.hive.CarbonSessionCatalog
 import org.apache.spark.sql.test.util.QueryTest
-import org.apache.spark.sql.{AnalysisException, CarbonEnv, CarbonSession}
 import org.apache.spark.util.SparkUtil
 import org.scalatest.BeforeAndAfterAll
 
-import org.apache.carbondata.core.constants.CarbonCommonConstants
-import org.apache.carbondata.core.util.CarbonProperties
-import org.apache.carbondata.hadoop.api.CarbonFileInputFormat
+import org.apache.carbondata.hadoop.api.CarbonTableInputFormat
 
 class TestCreateHiveTableWithCarbonDS extends QueryTest with BeforeAndAfterAll {
 
@@ -46,7 +41,7 @@ class TestCreateHiveTableWithCarbonDS extends QueryTest with BeforeAndAfterAll {
     sql(
       s"""
          |CREATE TABLE source (key INT, value string, col1 double)
-         |STORED BY 'carbondata'
+         |STORED AS carbondata
      """.stripMargin)
 
     verifyTable
@@ -56,11 +51,11 @@ class TestCreateHiveTableWithCarbonDS extends QueryTest with BeforeAndAfterAll {
 
   private def verifyTable = {
     val table = sqlContext.sparkSession.asInstanceOf[CarbonSession].sessionState.catalog.asInstanceOf[CarbonSessionCatalog].getClient().getTable("default", "source")
-    assert(table.schema.fields.length == 3)
+    assertResult(table.schema.fields.length)(3)
     if (SparkUtil.isSparkVersionEqualTo("2.2")) {
-      assert(table.storage.locationUri.get.equals(new Path(s"file:$storeLocation/source").toUri))
+      assertResult(table.storage.locationUri.get)(new Path(s"file:$storeLocation/source").toUri)
     }
-    assert(table.storage.inputFormat.get.equals(classOf[CarbonFileInputFormat[_]].getName))
+    assertResult(table.storage.inputFormat.get)(classOf[CarbonTableInputFormat[_]].getName)
   }
 
   test("test create table and verify the hive table correctness with using carbondata") {
@@ -70,10 +65,7 @@ class TestCreateHiveTableWithCarbonDS extends QueryTest with BeforeAndAfterAll {
          |CREATE TABLE source (key INT, value string, col1 double)
          |using carbondata
      """.stripMargin)
-
     verifyTable
-
-
     sql("DROP TABLE IF EXISTS source")
   }
 
@@ -84,10 +76,7 @@ class TestCreateHiveTableWithCarbonDS extends QueryTest with BeforeAndAfterAll {
          |CREATE TABLE source (key INT, value string, col1 double)
          |using carbon
      """.stripMargin)
-
     verifyTable
-
-
     sql("DROP TABLE IF EXISTS source")
   }
 

--- a/integration/spark-common/src/main/scala/org/apache/spark/util/CarbonReflectionUtils.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/util/CarbonReflectionUtils.scala
@@ -40,6 +40,7 @@ import org.apache.spark.sql.sources.{BaseRelation, Filter}
 import org.apache.spark.sql.types.StructField
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants
+import org.apache.carbondata.hadoop.api.{CarbonTableInputFormat, CarbonTableOutputFormat}
 
 /**
  * Reflection APIs
@@ -347,14 +348,14 @@ object CarbonReflectionUtils {
     val updatedSerdeMap =
       serdeMap ++ Map[String, HiveSerDe](
         ("org.apache.spark.sql.carbonsource", HiveSerDe(Some(
-          "org.apache.carbondata.hadoop.api.CarbonFileInputFormat"),
-          Some("org.apache.carbondata.hadoop.api.CarbonTableOutputFormat"))),
+          classOf[CarbonTableInputFormat[_]].getName),
+          Some(classOf[CarbonTableOutputFormat].getName))),
         ("carbon", HiveSerDe(Some(
-          "org.apache.carbondata.hadoop.api.CarbonFileInputFormat"),
-          Some("org.apache.carbondata.hadoop.api.CarbonTableOutputFormat"))),
+          classOf[CarbonTableInputFormat[_]].getName),
+          Some(classOf[CarbonTableOutputFormat].getName))),
         ("carbondata", HiveSerDe(Some(
-          "org.apache.carbondata.hadoop.api.CarbonFileInputFormat"),
-          Some("org.apache.carbondata.hadoop.api.CarbonTableOutputFormat"))))
+          classOf[CarbonTableInputFormat[_]].getName),
+          Some(classOf[CarbonTableOutputFormat].getName))))
     instanceMirror.reflectField(field).set(updatedSerdeMap)
   }
 }

--- a/integration/spark-common/src/main/scala/org/apache/spark/util/CarbonReflectionUtils.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/util/CarbonReflectionUtils.scala
@@ -35,6 +35,7 @@ import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.execution.{RowDataSourceScanExec, SparkPlan}
 import org.apache.spark.sql.execution.command.RunnableCommand
 import org.apache.spark.sql.execution.datasources.{DataSource, LogicalRelation}
+import org.apache.spark.sql.internal.HiveSerDe
 import org.apache.spark.sql.sources.{BaseRelation, Filter}
 import org.apache.spark.sql.types.StructField
 
@@ -330,5 +331,30 @@ object CarbonReflectionUtils {
     val ctor = clazz.getDeclaredConstructors.head
     ctor.setAccessible(true)
     (ctor.newInstance(conArgs: _*), clazz)
+  }
+
+  /**
+   * It is a hack to update the carbon input, output format information to #HiveSerDe
+   */
+  def updateCarbonSerdeInfo(): Unit = {
+    val currentMirror = scala.reflect.runtime.currentMirror
+    val instanceMirror = currentMirror.reflect(HiveSerDe)
+    val field = currentMirror.staticClass(HiveSerDe.getClass.getName).
+      toType.members.find { p =>
+      !p.isMethod && p.name.toString.equals("serdeMap")
+    }.get.asTerm
+    val serdeMap = instanceMirror.reflectField(field).get.asInstanceOf[Map[String, HiveSerDe]]
+    val updatedSerdeMap =
+      serdeMap ++ Map[String, HiveSerDe](
+        ("org.apache.spark.sql.carbonsource", HiveSerDe(Some(
+          "org.apache.carbondata.hadoop.api.CarbonFileInputFormat"),
+          Some("org.apache.carbondata.hadoop.api.CarbonTableOutputFormat"))),
+        ("carbon", HiveSerDe(Some(
+          "org.apache.carbondata.hadoop.api.CarbonFileInputFormat"),
+          Some("org.apache.carbondata.hadoop.api.CarbonTableOutputFormat"))),
+        ("carbondata", HiveSerDe(Some(
+          "org.apache.carbondata.hadoop.api.CarbonFileInputFormat"),
+          Some("org.apache.carbondata.hadoop.api.CarbonTableOutputFormat"))))
+    instanceMirror.reflectField(field).set(updatedSerdeMap)
   }
 }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSession.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonSession.scala
@@ -180,6 +180,7 @@ object CarbonSession {
         getValue("options", builder).asInstanceOf[scala.collection.mutable.HashMap[String, String]]
       val userSuppliedContext: Option[SparkContext] =
         getValue("userSuppliedContext", builder).asInstanceOf[Option[SparkContext]]
+      CarbonReflectionUtils.updateCarbonSerdeInfo()
 
       if (StringUtils.isNotBlank(metaStorePath)) {
         val hadoopConf = new Configuration()


### PR DESCRIPTION
Problem:
Current carbon table created in spark creates the hive table internally but it does not have much information like schema, input/output format and location details. So other execution engines like Presto and Hive cannot read the table.

Reason:
Spark always checks in HiveSerde static map whether it is a hive supported table or not, since carbon is not registered to that map it cannot create hive understandable table. It justs creates a table without schema and location and adds its own schema as part of properties.

Solution:
Add the carbon details also to HiveSerde static map so that it can create Hive understandable table.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

