### PR TITLE
[CARBONDATA-3187] Supported Global Dictionary For Map

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestCreateDDLForComplexMapType.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestCreateDDLForComplexMapType.scala
@@ -226,22 +226,22 @@ class TestCreateDDLForComplexMapType extends QueryTest with BeforeAndAfterAll {
       Row(Map(1 -> "Nalla", 2 -> "", 3 -> "Gupta", 4 -> "Kumar"))))
   }
 
-  // Support this for Map type
+  // Global Dictionary for Map type
   test("Test Load data in map with dictionary include") {
     sql("DROP TABLE IF EXISTS carbon")
     sql(
       s"""
          | CREATE TABLE carbon(
-         | mapField map<int,STRING>
+         | mapField map<STRING,STRING>
          | )
          | STORED BY 'carbondata'
          | TBLPROPERTIES('DICTIONARY_INCLUDE'='mapField')
          | """
         .stripMargin)
-    sql("insert into carbon values('1\002Nalla\0012\002Singh\0013\002Gupta')")
+    sql("insert into carbon values('vi\002Nalla\001sh\002Singh\001al\002Gupta')")
     sql("select * from carbon").show(false)
-    //checkAnswer(sql("select * from carbon"), Seq(
-    //Row(Map(1 -> "Nalla", 2 -> "Singh", 3 -> "Gupta", 4 -> "Kumar"))))
+    checkAnswer(sql("select * from carbon"), Seq(
+      Row(Map("vi" -> "Nalla", "sh" -> "Singh", "al" -> "Gupta"))))
   }
 
   test("Test Load data in map with partition columns") {

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/GlobalDictionaryUtil.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/GlobalDictionaryUtil.scala
@@ -182,7 +182,7 @@ object GlobalDictionaryUtil {
       case None =>
         None
       case Some(dim) =>
-        if (DataTypes.isArrayType(dim.getDataType)) {
+        if (DataTypes.isArrayType(dim.getDataType) || DataTypes.isMapType(dim.getDataType)) {
           val arrDim = ArrayParser(dim, format)
           generateParserForChildrenDimension(dim, format, mapColumnValuesWithId, arrDim)
           Some(arrDim)


### PR DESCRIPTION
Problem: Global Dictionary was not working for Map datatype and giving Null values.

Solution:Added the case for Global Dictionary to be created in case the datatype is Complex Map.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

