### PR TITLE
[CARBONDATA-3197][BloomDataMap] Include bloomindex merging in loading/compaction/datamap rebuild transaction

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datamap/DataMapStoreManager.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/DataMapStoreManager.java
@@ -36,6 +36,7 @@ import org.apache.carbondata.core.indexstore.SegmentPropertiesFetcher;
 import org.apache.carbondata.core.indexstore.blockletindex.BlockletDataMapFactory;
 import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
 import org.apache.carbondata.core.metadata.CarbonMetadata;
+import org.apache.carbondata.core.metadata.schema.datamap.DataMapClassProvider;
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
 import org.apache.carbondata.core.metadata.schema.table.DataMapSchema;
 import org.apache.carbondata.core.metadata.schema.table.DataMapSchemaStorageProvider;
@@ -139,6 +140,25 @@ public final class DataMapStoreManager {
             .equals(carbonTable.getTableId())) {
           dataMaps.add(getDataMap(carbonTable, dataMapSchema));
         }
+      }
+    }
+    return dataMaps;
+  }
+
+  /**
+   * It gives datamaps of specific provider with flag to skip lazy datamap.
+   *
+   * @return
+   */
+  public List<TableDataMap> getAllDataMap(CarbonTable carbonTable, DataMapClassProvider provider,
+                                          boolean skipLazy) throws IOException {
+    List<TableDataMap> allDataMaps = getAllDataMap(carbonTable);
+    List<TableDataMap> dataMaps = new ArrayList<>();
+    for (TableDataMap dataMap : allDataMaps) {
+      DataMapSchema dataMapSchema = dataMap.getDataMapSchema();
+      if (dataMapSchema.getProviderName().equalsIgnoreCase(provider.getShortName())
+            && !(skipLazy && dataMapSchema.isLazy())) {
+        dataMaps.add(dataMap);
       }
     }
     return dataMaps;

--- a/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomCoarseGrainDataMapFactory.java
+++ b/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomCoarseGrainDataMapFactory.java
@@ -243,7 +243,10 @@ public class BloomCoarseGrainDataMapFactory extends DataMapFactory<CoarseGrainDa
         shardPaths.add(FileFactory.getPath(carbonFile.getAbsolutePath()).toString());
       }
     }
-    if (mergeShardFile != null && !mergeShardInprogress) {
+    if (mergeShardInprogress) {
+      LOGGER.warn(String.format("Bloom index file is merging for datamap=%s, segment=%s",
+          dataMapName, segmentId));
+    } else if (mergeShardFile != null) {
       // should only get one shard path if mergeShard is generated successfully
       shardPaths.clear();
       shardPaths.add(FileFactory.getPath(mergeShardFile.getAbsolutePath()).toString());

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
@@ -184,6 +184,9 @@ object CarbonEnv {
       .addListener(classOf[LoadTablePostExecutionEvent], new MergeIndexEventListener)
       .addListener(classOf[AlterTableCompactionPostEvent], new MergeIndexEventListener)
       .addListener(classOf[AlterTableMergeIndexEvent], new MergeIndexEventListener)
+      .addListener(classOf[LoadTablePreStatusUpdateEvent], new MergeBloomIndexEventListener)
+      .addListener(classOf[AlterTableCompactionPreStatusUpdateEvent],
+        new MergeBloomIndexEventListener)
       .addListener(classOf[BuildDataMapPostExecutionEvent], new MergeBloomIndexEventListener)
   }
 

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/events/MergeBloomIndexEventListener.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/events/MergeBloomIndexEventListener.scala
@@ -24,59 +24,88 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
 
 import org.apache.carbondata.common.logging.LogServiceFactory
-import org.apache.carbondata.core.datamap.DataMapStoreManager
+import org.apache.carbondata.core.datamap.{DataMapStoreManager, TableDataMap}
 import org.apache.carbondata.core.metadata.schema.datamap.DataMapClassProvider
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable
 import org.apache.carbondata.datamap.CarbonMergeBloomIndexFilesRDD
 import org.apache.carbondata.events._
+import org.apache.carbondata.processing.loading.events.LoadEvents.LoadTablePreStatusUpdateEvent
+import org.apache.carbondata.processing.merger.CarbonDataMergerUtil
 
 class MergeBloomIndexEventListener extends OperationEventListener with Logging {
   val LOGGER = LogServiceFactory.getLogService(this.getClass.getCanonicalName)
 
   override def onEvent(event: Event, operationContext: OperationContext): Unit = {
+    val sparkSession = SparkSession.getActiveSession.get
     event match {
+      case loadPreStatusUpdateEvent: LoadTablePreStatusUpdateEvent =>
+        LOGGER.info("LoadTablePreStatusUpdateEvent called for bloom index merging")
+        // For loading process, segment can not be accessed at this time
+        val loadModel = loadPreStatusUpdateEvent.getCarbonLoadModel
+        val carbonTable = loadModel.getCarbonDataLoadSchema.getCarbonTable
+        val segmentId = loadModel.getSegmentId
+
+        // filter out bloom datamap, skip lazy datamap
+        val bloomDatamaps = DataMapStoreManager.getInstance()
+          .getAllDataMap(carbonTable, DataMapClassProvider.BLOOMFILTER, true).asScala.toList
+
+        mergeBloomIndex(sparkSession, carbonTable, bloomDatamaps, Seq(segmentId))
+
+      case compactPreStatusUpdateEvent: AlterTableCompactionPreStatusUpdateEvent =>
+        LOGGER.info("AlterTableCompactionPreStatusUpdateEvent called for bloom index merging")
+        // For compact process, segment can not be accessed at this time
+        val carbonTable = compactPreStatusUpdateEvent.carbonTable
+        val mergedLoadName = compactPreStatusUpdateEvent.mergedLoadName
+        val segmentId = CarbonDataMergerUtil.getLoadNumberFromLoadName(mergedLoadName)
+
+        // filter out bloom datamap, skip lazy datamap
+        val bloomDatamaps = DataMapStoreManager.getInstance()
+          .getAllDataMap(carbonTable, DataMapClassProvider.BLOOMFILTER, true).asScala.toList
+
+        mergeBloomIndex(sparkSession, carbonTable, bloomDatamaps, Seq(segmentId))
+
       case datamapPostEvent: BuildDataMapPostExecutionEvent =>
-        LOGGER.info("Load post status event-listener called for merge bloom index")
+        LOGGER.info("BuildDataMapPostExecutionEvent called for bloom index merging")
+        // For rebuild datamap process, datamap is disabled when rebuilding
+        if (!datamapPostEvent.isFromRebuild || null == datamapPostEvent.dmName) {
+          // ignore datamapPostEvent from loading and compaction for bloom index merging
+          // they use LoadTablePreStatusUpdateEvent and AlterTableCompactionPreStatusUpdateEvent
+          LOGGER.info("Ignore BuildDataMapPostExecutionEvent from loading and compaction")
+          return
+        }
+
         val carbonTableIdentifier = datamapPostEvent.identifier
         val carbonTable = DataMapStoreManager.getInstance().getCarbonTable(carbonTableIdentifier)
-        val tableDataMaps = DataMapStoreManager.getInstance().getAllDataMap(carbonTable)
-        val sparkSession = SparkSession.getActiveSession.get
 
-        // filter out bloom datamap
-        var bloomDatamaps = tableDataMaps.asScala.filter(
-          _.getDataMapSchema.getProviderName.equalsIgnoreCase(
-            DataMapClassProvider.BLOOMFILTER.getShortName))
-
-        if (datamapPostEvent.isFromRebuild) {
-          if (null != datamapPostEvent.dmName) {
-            // for rebuild process
-            bloomDatamaps = bloomDatamaps.filter(
-              _.getDataMapSchema.getDataMapName.equalsIgnoreCase(datamapPostEvent.dmName))
-          }
-        } else {
-          // for load process, skip lazy datamap
-          bloomDatamaps = bloomDatamaps.filter(!_.getDataMapSchema.isLazy)
-        }
+        // filter out current rebuilt bloom datamap
+        val bloomDatamaps = DataMapStoreManager.getInstance()
+          .getAllDataMap(carbonTable, DataMapClassProvider.BLOOMFILTER, false).asScala
+          .filter(_.getDataMapSchema.getDataMapName.equalsIgnoreCase(datamapPostEvent.dmName))
+          .toList
 
         val segmentIds = datamapPostEvent.segmentIdList
-        if (bloomDatamaps.size > 0 && segmentIds.size > 0) {
-          // we extract bloom datamap name and index columns here
-          // because TableDataMap is not serializable
-          val bloomDMnames = ListBuffer.empty[String]
-          val bloomIndexColumns = ListBuffer.empty[Seq[String]]
-          bloomDatamaps.foreach( dm => {
-            bloomDMnames += dm.getDataMapSchema.getDataMapName
-            bloomIndexColumns += dm.getDataMapSchema.getIndexColumns.map(_.trim.toLowerCase)
-          })
-          new CarbonMergeBloomIndexFilesRDD(sparkSession, carbonTable,
-            segmentIds, bloomDMnames, bloomIndexColumns).collect()
-        }
+        mergeBloomIndex(sparkSession, carbonTable, bloomDatamaps, segmentIds)
     }
   }
 
 
-  private def clearBloomCache(carbonTable: CarbonTable, segmentIds: Seq[String]): Unit = {
-    DataMapStoreManager.getInstance.clearDataMaps(carbonTable.getTableUniqueName)
+  private def mergeBloomIndex(sparkSession: SparkSession, carbonTable: CarbonTable,
+      bloomDatamaps: List[TableDataMap], segmentIds: Seq[String]) = {
+    if (bloomDatamaps.nonEmpty && segmentIds.nonEmpty) {
+      // we extract bloom datamap name and index columns here
+      // because TableDataMap is not serializable
+      val bloomDMnames = ListBuffer.empty[String]
+      val bloomIndexColumns = ListBuffer.empty[Seq[String]]
+      bloomDatamaps.foreach(dm => {
+        bloomDMnames += dm.getDataMapSchema.getDataMapName
+        bloomIndexColumns += dm.getDataMapSchema.getIndexColumns.map(_.trim.toLowerCase)
+      })
+      LOGGER.info(
+        String.format("Start to merge bloom index file for table %s. Datamaps=%s, SegmentIds=%s",
+          carbonTable.getTableName, bloomDMnames.mkString("|"), segmentIds.mkString("|") ))
+      new CarbonMergeBloomIndexFilesRDD(sparkSession, carbonTable,
+        segmentIds, bloomDMnames, bloomIndexColumns).collect()
+      LOGGER.info("Finish merging bloom index file for table " + carbonTable.getTableName)
+    }
   }
-
 }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/datamap/CarbonDataMapRebuildCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/datamap/CarbonDataMapRebuildCommand.scala
@@ -67,6 +67,9 @@ case class CarbonDataMapRebuildCommand(
 
     setAuditTable(table)
 
+    // Disable the datamap before rebuild
+    DataMapStatusManager.disableDataMap(dataMapName)
+
     val provider = DataMapManager.get().getDataMapProvider(table, schema, sparkSession)
     provider.rebuild()
 


### PR DESCRIPTION
**Problem**
Currently carbon allows to query when bloom index files are merging, but this will cause problems when the index files state change from multiple shards to merged shard.

Timeline to explain problem:
- load data for table with bloom datamap, data is loaded, bloom index files are generated along loading, bloom index file merging is under action
- query fired
- `BloomCoarseGrainDataMapFactory.getAllShardPaths` found multiple shards, and bloom index file merging in progress, so `BloomCoarseGrainDataMap` with detailed shard name created
- bloom index file merging done, folders with detailed shard name are deleted
- Exception will occur when `BloomCoarseGrainDataMap` wants to read bloom index file from  folders with detailed shard name to prune

**Analyse**
Root cause is that we allow query on datamap which is not in stable state. one solution is to disable datamap when merging bloom index file,  but this will affect all the segments many times. Another solution is to take the bloom index files merging as part of loading, such that query can not access unstable bloom index files until it is ready

**Solution**
Change the events to watch for `MergeBloomIndexEventListener`, do the merging staff before segment status is updated for access

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

