### PR TITLE
[WIP][CARBONDATA-3199]"show datamap" represents preaggregate datamap

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datamap/TestDataMapCommand.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datamap/TestDataMapCommand.scala
@@ -78,6 +78,15 @@ class TestDataMapCommand extends QueryTest with BeforeAndAfterAll {
     assert(dataMapSchemaList.get(0).getChildSchema.getTableName.equals("datamaptest_datamap3"))
   }
 
+  test("Test 'show datamap' bloomfilter and preaggregate") {
+    sql("drop table if exists maintable")
+    sql("create table maintable(name string, c_code int, price int) stored by 'carbondata'")
+    sql("create datamap ag1 on table maintable using 'preaggregate' as select name,sum(price) from maintable group by name")
+    sql("create datamap bloomfilter1 on table maintable using 'bloomfilter' DMPROPERTIES('INDEX_COLUMNS'='name')")
+    assert(sql("show datamap").collect().size == 2)
+    sql("drop table if exists maintable")
+  }
+
   test("check hivemetastore after drop datamap") {
     try {
       CarbonProperties.getInstance()

--- a/integration/spark2/src/main/java/org/apache/carbondata/datamap/PreAggregateDataMapProvider.java
+++ b/integration/spark2/src/main/java/org/apache/carbondata/datamap/PreAggregateDataMapProvider.java
@@ -32,9 +32,10 @@ import org.apache.carbondata.core.datamap.dev.DataMapFactory;
 import org.apache.carbondata.core.metadata.schema.datamap.DataMapProperty;
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
 import org.apache.carbondata.core.metadata.schema.table.DataMapSchema;
-
 import org.apache.carbondata.core.metadata.schema.table.RelationIdentifier;
+
 import org.apache.log4j.Logger;
+
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.execution.command.preaaggregate.PreAggregateTableHelper;
 import org.apache.spark.sql.execution.command.table.CarbonDropTableCommand;
@@ -115,7 +116,8 @@ public class PreAggregateDataMapProvider extends DataMapProvider {
     try {
       DataMapStoreManager.getInstance().dropDataMapSchema(getDataMapSchema().getDataMapName());
     } catch (IOException e) {
-      LOGGER.warn(String.format("DataMapStoreManager dropDataMapSchema fail! tableName:%s", tableName));
+      LOGGER.warn(String.format("DataMapStoreManager dropDataMapSchema fail! " +
+              "tableName:%s", tableName));
     }
   }
 


### PR DESCRIPTION
[Problem] "show datamap" command doesn't represents preaggregate datamap, it only represents bloom filter datamap

[Solution]PreAggregateDataMapProvider save datamap schema on hdfs or s3, so that CarbonDataMapShowCommand can get all datamap
 

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
saveDataMapSchema