### PR TITLE
[CARBONDATA-3202]update the schema to session catalog after add column, drop column and column rename

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/metadata/converter/ThriftWrapperSchemaConverterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/converter/ThriftWrapperSchemaConverterImpl.java
@@ -548,6 +548,7 @@ public class ThriftWrapperSchemaConverterImpl implements SchemaConverter {
       if (sortColumns != null) {
         wrapperColumnSchema.setSortColumn(true);
       }
+      wrapperColumnSchema.setColumnProperties(externalColumnSchema.getColumnProperties());
     }
     wrapperColumnSchema.setFunction(externalColumnSchema.getAggregate_function());
     List<org.apache.carbondata.format.ParentColumnTableRelation> parentColumnTableRelation =

--- a/integration/spark2/src/main/commonTo2.2And2.3/org/apache/spark/sql/hive/CarbonInMemorySessionState.scala
+++ b/integration/spark2/src/main/commonTo2.2And2.3/org/apache/spark/sql/hive/CarbonInMemorySessionState.scala
@@ -35,6 +35,7 @@ import org.apache.spark.sql.parser.CarbonSparkSqlParser
 import org.apache.spark.sql.types.{StructField, StructType}
 import org.apache.spark.sql.{CarbonEnv, SparkSession}
 
+import org.apache.carbondata.core.metadata.schema.table.column.{ColumnSchema => ColumnSchema}
 import org.apache.carbondata.core.util.CarbonUtil
 import org.apache.carbondata.core.util.path.CarbonTablePath
 import org.apache.carbondata.format.TableInfo
@@ -79,15 +80,13 @@ class InMemorySessionCatalog(
 
   override def alterTable(tableIdentifier: TableIdentifier,
       schemaParts: String,
-      cols: Option[Seq[org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema]])
-  : Unit = {
+      cols: Option[Seq[ColumnSchema]]): Unit = {
     // NOt Required in case of In-memory catalog
   }
 
   override def alterAddColumns(tableIdentifier: TableIdentifier,
       schemaParts: String,
-      newColumns: Option[Seq[org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema]])
-  : Unit = {
+      newColumns: Option[Seq[ColumnSchema]]): Unit = {
     val catalogTable = sparkSession.sessionState.catalog.getTableMetadata(tableIdentifier)
     val structType = catalogTable.schema
     var newStructType = structType
@@ -101,8 +100,7 @@ class InMemorySessionCatalog(
 
   override def alterDropColumns(tableIdentifier: TableIdentifier,
       schemaParts: String,
-      dropCols: Option[Seq[org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema]])
-  : Unit = {
+      dropCols: Option[Seq[ColumnSchema]]): Unit = {
     val catalogTable = sparkSession.sessionState.catalog.getTableMetadata(tableIdentifier)
     val fields = catalogTable.schema.fields.filterNot { field =>
       dropCols.get.exists { col =>
@@ -112,10 +110,9 @@ class InMemorySessionCatalog(
     alterSchema(new StructType(fields), catalogTable, tableIdentifier)
   }
 
-  override def alterColumnChangeDataType(tableIdentifier: TableIdentifier,
+  override def alterColumnChangeDataTypeOrRename(tableIdentifier: TableIdentifier,
       schemaParts: String,
-      columns: Option[Seq[org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema]])
-  : Unit = {
+      columns: Option[Seq[ColumnSchema]]): Unit = {
     val catalogTable = sparkSession.sessionState.catalog.getTableMetadata(tableIdentifier)
     val a = catalogTable.schema.fields.flatMap { field =>
       columns.get.map { col =>

--- a/integration/spark2/src/main/commonTo2.2And2.3/org/apache/spark/sql/hive/CarbonSessionState.scala
+++ b/integration/spark2/src/main/commonTo2.2And2.3/org/apache/spark/sql/hive/CarbonSessionState.scala
@@ -34,6 +34,7 @@ import org.apache.spark.sql.internal.{SQLConf, SessionState}
 import org.apache.spark.sql.optimizer.{CarbonIUDRule, CarbonLateDecodeRule, CarbonUDFTransformRule}
 import org.apache.spark.sql.parser.CarbonSparkSqlParser
 
+import org.apache.carbondata.core.metadata.schema.table.column.{ColumnSchema => ColumnSchema}
 import org.apache.carbondata.spark.util.CarbonScalaUtil
 
 /**
@@ -105,47 +106,37 @@ class CarbonHiveSessionCatalog(
       .asInstanceOf[HiveExternalCatalog].client
   }
 
-  def alterTableRename(oldTableIdentifier: TableIdentifier,
-      newTableIdentifier: TableIdentifier,
-      newTablePath: String): Unit = {
-    getClient().runSqlHive(
-      s"ALTER TABLE ${ oldTableIdentifier.database.get }.${ oldTableIdentifier.table } " +
-      s"RENAME TO ${ oldTableIdentifier.database.get }.${ newTableIdentifier.table }")
-    getClient().runSqlHive(
-      s"ALTER TABLE ${ oldTableIdentifier.database.get }.${ newTableIdentifier.table} " +
-      s"SET SERDEPROPERTIES" +
-      s"('tableName'='${ newTableIdentifier.table }', " +
-      s"'dbName'='${ oldTableIdentifier.database.get }', 'tablePath'='${ newTablePath }')")
-  }
-
-  override def alterTable(tableIdentifier: TableIdentifier,
-      schemaParts: String,
-      cols: Option[Seq[org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema]])
-  : Unit = {
-    getClient()
-      .runSqlHive(s"ALTER TABLE ${tableIdentifier.database.get}.${ tableIdentifier.table } " +
-                  s"SET TBLPROPERTIES(${ schemaParts })")
-  }
-
   override def alterAddColumns(tableIdentifier: TableIdentifier,
       schemaParts: String,
-      cols: Option[Seq[org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema]])
-  : Unit = {
+      cols: Option[Seq[ColumnSchema]]): Unit = {
     alterTable(tableIdentifier, schemaParts, cols)
+    CarbonSessionUtil
+      .alterExternalCatalogForTableWithUpdatedSchema(tableIdentifier,
+        cols,
+        schemaParts,
+        sparkSession)
   }
 
   override def alterDropColumns(tableIdentifier: TableIdentifier,
       schemaParts: String,
-      cols: Option[Seq[org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema]])
-  : Unit = {
+      cols: Option[Seq[ColumnSchema]]): Unit = {
     alterTable(tableIdentifier, schemaParts, cols)
+    CarbonSessionUtil
+      .alterExternalCatalogForTableWithUpdatedSchema(tableIdentifier,
+        cols,
+        schemaParts,
+        sparkSession)
   }
 
-  override def alterColumnChangeDataType(tableIdentifier: TableIdentifier,
+  override def alterColumnChangeDataTypeOrRename(tableIdentifier: TableIdentifier,
       schemaParts: String,
-      cols: Option[Seq[org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema]])
-  : Unit = {
+      cols: Option[Seq[ColumnSchema]]): Unit = {
     alterTable(tableIdentifier, schemaParts, cols)
+    CarbonSessionUtil
+      .alterExternalCatalogForTableWithUpdatedSchema(tableIdentifier,
+        cols,
+        schemaParts,
+        sparkSession)
   }
 
   override def createPartitions(

--- a/integration/spark2/src/main/commonTo2.2And2.3/org/apache/spark/sql/hive/CarbonSessionState.scala
+++ b/integration/spark2/src/main/commonTo2.2And2.3/org/apache/spark/sql/hive/CarbonSessionState.scala
@@ -109,26 +109,30 @@ class CarbonHiveSessionCatalog(
   override def alterAddColumns(tableIdentifier: TableIdentifier,
       schemaParts: String,
       cols: Option[Seq[ColumnSchema]]): Unit = {
-    alterTable(tableIdentifier, schemaParts, cols)
-    CarbonSessionUtil
-      .alterExternalCatalogForTableWithUpdatedSchema(tableIdentifier,
-        cols,
-        schemaParts,
-        sparkSession)
+    updateCatalogTableForAlter(tableIdentifier, schemaParts, cols)
   }
 
   override def alterDropColumns(tableIdentifier: TableIdentifier,
       schemaParts: String,
       cols: Option[Seq[ColumnSchema]]): Unit = {
-    alterTable(tableIdentifier, schemaParts, cols)
-    CarbonSessionUtil
-      .alterExternalCatalogForTableWithUpdatedSchema(tableIdentifier,
-        cols,
-        schemaParts,
-        sparkSession)
+    updateCatalogTableForAlter(tableIdentifier, schemaParts, cols)
   }
 
   override def alterColumnChangeDataTypeOrRename(tableIdentifier: TableIdentifier,
+      schemaParts: String,
+      cols: Option[Seq[ColumnSchema]]): Unit = {
+    updateCatalogTableForAlter(tableIdentifier, schemaParts, cols)
+  }
+
+  /**
+   * This method alters table to set serde properties and updates the catalog table with new updated
+   * schema for all the alter operations like add column, drop column, change datatype or rename
+   * column
+   * @param tableIdentifier
+   * @param schemaParts
+   * @param cols
+   */
+  private def updateCatalogTableForAlter(tableIdentifier: TableIdentifier,
       schemaParts: String,
       cols: Option[Seq[ColumnSchema]]): Unit = {
     alterTable(tableIdentifier, schemaParts, cols)

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/schema/CarbonAlterTableColRenameDataTypeChangeCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/schema/CarbonAlterTableColRenameDataTypeChangeCommand.scala
@@ -269,14 +269,10 @@ private[sql] case class CarbonAlterTableColRenameDataTypeChangeCommand(
     // get the carbon column in schema order
     val carbonColumns = carbonTable.getCreateOrderColumn(carbonTable.getTableName).asScala
       .collect { case carbonColumn if !carbonColumn.isInvisible => carbonColumn.getColumnSchema }
-    // get the schema ordinal of the column for which the datatype changed or column is renamed
-    var schemaOrdinal: Int = 0
-    carbonColumns.foreach { carbonColumn =>
-      if (carbonColumn.getColumnName.equalsIgnoreCase(oldCarbonColumn.getColName)) {
-        schemaOrdinal = carbonColumns.indexOf(carbonColumn)
-      }
-    }
-    // update the schema changed column at the specific index in carbonColumns based on schemaorder
+    // get the schema ordinal of the column for which the dataType changed or column is renamed
+    val schemaOrdinal = carbonColumns.indexOf(carbonColumns
+      .filter { column => column.getColumnName.equalsIgnoreCase(oldCarbonColumn.getColName) }.head)
+    // update the schema changed column at the specific index in carbonColumns based on schema order
     carbonColumns
       .update(schemaOrdinal, schemaConverter.fromExternalToWrapperColumnSchema(addColumnSchema))
     val (tableIdentifier, schemaParts) = AlterTableUtil.updateSchemaInfo(

--- a/integration/spark2/src/main/scala/org/apache/spark/util/AlterTableUtil.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/util/AlterTableUtil.scala
@@ -107,13 +107,8 @@ object AlterTableUtil {
    */
   def updateSchemaInfo(carbonTable: CarbonTable,
       schemaEvolutionEntry: SchemaEvolutionEntry = null,
-      thriftTable: TableInfo,
-      cols: Option[Seq[org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema]] =
-      None)
-    (sparkSession: SparkSession):
-    (TableIdentifier,
-      String,
-      Option[Seq[org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema]]) = {
+      thriftTable: TableInfo)
+    (sparkSession: SparkSession): (TableIdentifier, String) = {
     val dbName = carbonTable.getDatabaseName
     val tableName = carbonTable.getTableName
     CarbonEnv.getInstance(sparkSession).carbonMetaStore
@@ -127,7 +122,7 @@ object AlterTableUtil {
     val schema = CarbonEnv.getInstance(sparkSession).carbonMetaStore
       .lookupRelation(tableIdentifier)(sparkSession).schema.json
     val schemaParts = prepareSchemaJsonForAlterTable(sparkSession.sparkContext.getConf, schema)
-    (tableIdentifier, schemaParts, cols)
+    (tableIdentifier, schemaParts)
   }
 
   /**
@@ -403,11 +398,10 @@ object AlterTableUtil {
         // check if duplicate columns are present in both local dictionary include and exclude
         CarbonScalaUtil.validateDuplicateLocalDictIncludeExcludeColmns(tblPropertiesMap)
       }
-      val (tableIdentifier, schemParts, cols: Option[Seq[org.apache.carbondata.core.metadata
-      .schema.table.column.ColumnSchema]]) = updateSchemaInfo(
+      val (tableIdentifier, schemParts) = updateSchemaInfo(
         carbonTable = carbonTable,
         thriftTable = thriftTable)(sparkSession)
-      catalog.alterTable(tableIdentifier, schemParts, cols)
+      catalog.alterTable(tableIdentifier, schemParts, None)
       sparkSession.catalog.refreshTable(tableIdentifier.quotedString)
       // check and clear the block/blocklet cache
       checkAndClearBlockletCache(carbonTable,

--- a/integration/spark2/src/main/spark2.1/org/apache/spark/sql/hive/CarbonSessionState.scala
+++ b/integration/spark2/src/main/spark2.1/org/apache/spark/sql/hive/CarbonSessionState.scala
@@ -40,6 +40,7 @@ import org.apache.spark.sql.{CarbonDatasourceHadoopRelation, CarbonEnv, Experime
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.datamap.DataMapStoreManager
 import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier
+import org.apache.carbondata.core.metadata.schema.table.column.{ColumnSchema => ColumnSchema}
 import org.apache.carbondata.core.util.CarbonProperties
 import org.apache.carbondata.spark.util.CarbonScalaUtil
 
@@ -85,45 +86,23 @@ class CarbonHiveSessionCatalog(
     carbonEnv
   }
 
-  def alterTableRename(oldTableIdentifier: TableIdentifier,
-      newTableIdentifier: TableIdentifier,
-      newTablePath: String): Unit = {
-    getClient().runSqlHive(
-      s"ALTER TABLE ${ oldTableIdentifier.database.get }.${ oldTableIdentifier.table }" +
-      s" RENAME TO ${ oldTableIdentifier.database.get }.${ newTableIdentifier.table }")
-    getClient().runSqlHive(
-      s"ALTER TABLE ${ oldTableIdentifier.database.get }.${ newTableIdentifier.table }" +
-      s" SET SERDEPROPERTIES" +
-      s"('tableName'='${ newTableIdentifier.table }', " +
-      s"'dbName'='${ oldTableIdentifier.database.get }', 'tablePath'='${ newTablePath }')")
-  }
-
-  def alterTable(tableIdentifier: TableIdentifier,
-      schemaParts: String,
-      cols: Option[Seq[org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema]])
-  : Unit = {
-    getClient()
-      .runSqlHive(s"ALTER TABLE ${tableIdentifier.database.get}.${tableIdentifier.table } " +
-                  s"SET TBLPROPERTIES(${ schemaParts })")
-  }
-
   def alterAddColumns(tableIdentifier: TableIdentifier,
       schemaParts: String,
-      cols: Option[Seq[org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema]])
+      cols: Option[Seq[ColumnSchema]])
   : Unit = {
     alterTable(tableIdentifier, schemaParts, cols)
   }
 
   def alterDropColumns(tableIdentifier: TableIdentifier,
       schemaParts: String,
-      cols: Option[Seq[org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema]])
+      cols: Option[Seq[ColumnSchema]])
   : Unit = {
     alterTable(tableIdentifier, schemaParts, cols)
   }
 
-  def alterColumnChangeDataType(tableIdentifier: TableIdentifier,
+  def alterColumnChangeDataTypeOrRename(tableIdentifier: TableIdentifier,
       schemaParts: String,
-      cols: Option[Seq[org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema]])
+      cols: Option[Seq[ColumnSchema]])
   : Unit = {
     alterTable(tableIdentifier, schemaParts, cols)
   }

--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/restructure/AlterTableRevertTestCase.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/restructure/AlterTableRevertTestCase.scala
@@ -22,7 +22,6 @@ import java.io.File
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.common.util.Spark2QueryTest
 import org.apache.spark.sql.test.TestQueryExecutor
-import org.apache.spark.util.AlterTableUtil
 import org.scalatest.BeforeAndAfterAll
 
 import org.apache.carbondata.core.metadata.CarbonMetadata

--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/restructure/vectorreader/AlterTableColumnRenameTestCase.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/restructure/vectorreader/AlterTableColumnRenameTestCase.scala
@@ -307,6 +307,14 @@ class AlterTableColumnRenameTestCase extends Spark2QueryTest with BeforeAndAfter
     sql("drop table if exists biginttable")
   }
 
+  test("test column comment after column rename") {
+    dropTable()
+    createTable()
+    checkExistence(sql("describe formatted rename"), true, "This column has comment ")
+    sql("alter table rename change deptno classno bigint")
+    checkExistence(sql("describe formatted rename"), true, "This column has comment ")
+  }
+
   override def afterAll(): Unit = {
     dropTable()
   }
@@ -335,7 +343,8 @@ class AlterTableColumnRenameTestCase extends Spark2QueryTest with BeforeAndAfter
   def createTable(): Unit = {
     sql(
       "CREATE TABLE rename (empno int, empname String, designation String, doj Timestamp, " +
-      "workgroupcategory int, workgroupcategoryname String, deptno int, deptname String, " +
+      "workgroupcategory int, workgroupcategoryname String, deptno int comment \"This column " +
+      "has comment\", deptname String, " +
       "projectcode int, projectjoindate Timestamp, projectenddate Timestamp,attendance int," +
       "utilization int,salary int) STORED BY 'org.apache.carbondata.format'")
   }


### PR DESCRIPTION
### Why this PR?

**Problem:**
1. For alter table rename, once we change the table name in carbon, we fire alter table rename DDL using hive client. But for add, drop and column rename Spark does not support there features, but hive supports. so after rename, or add or drop column, the new updated schema is not updated in catalog.
2. after column rename column comment is not getting copied to renamed column

**Solution:**
1. We can directly call the spark API **alterTableDataSchema** by passing the updated schema, which in turn updates the shema in sessioncatalog. Since this API is supported from spark2.1 onward, codes changes will be for spark 2.2 and spark2.3, behavior with spark2.1 remains the same.
2. while updating the catalog schema, if column has comment, put in column metadata

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 YES
 - [x] Any backward compatibility impacted?
 NA
 - [x] Document update required?
NA
 - [x] Testing done
tested in three node cluster for various spark versions
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA
