### PR TITLE
[CARBONDATA-3212] Fixed NegativeArraySizeException while querying in specific scenario

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/LocalDictColumnPage.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/LocalDictColumnPage.java
@@ -140,6 +140,9 @@ public class LocalDictColumnPage extends ColumnPage {
     } else {
       actualDataColumnPage.putBytes(rowId, bytes);
     }
+    if (pageSize <= rowId) {
+      pageSize = rowId + 1;
+    }
   }
 
   @Override public void disableLocalDictEncoding() {


### PR DESCRIPTION
### What was the issue?
In Local Dictionary, page size was not getting updated for complex children columns. So during fallback, new page was being created with less records giving NegativeArraySizeException while querying data.

### What has been changed?
Updated the page size in Local Dictionary.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

