### PR TITLE
[CARBONDATA-3218] Fix schema refresh and wrong query result  issues in presto.

### DIFF
--- a/integration/presto/src/main/java/org/apache/carbondata/presto/CarbondataPageSourceProvider.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/CarbondataPageSourceProvider.java
@@ -230,10 +230,11 @@ public class CarbondataPageSourceProvider extends HivePageSourceProvider {
         .getCarbonCache(new SchemaTableName(carbonSplit.getDatabase(), carbonSplit.getTable()),
             carbonSplit.getSchema().getProperty("tablePath"), configuration);
     checkNotNull(tableCacheModel, "tableCacheModel should not be null");
-    checkNotNull(tableCacheModel.carbonTable, "tableCacheModel.carbonTable should not be null");
-    checkNotNull(tableCacheModel.carbonTable.getTableInfo(),
+    checkNotNull(tableCacheModel.getCarbonTable(),
+        "tableCacheModel.carbonTable should not be null");
+    checkNotNull(tableCacheModel.getCarbonTable().getTableInfo(),
         "tableCacheModel.carbonTable.tableInfo should not be null");
-    return tableCacheModel.carbonTable;
+    return tableCacheModel.getCarbonTable();
   }
 
 }

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/impl/CarbonTableCacheModel.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/impl/CarbonTableCacheModel.java
@@ -25,10 +25,35 @@ import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
  */
 public class CarbonTableCacheModel {
 
-  public CarbonTable carbonTable;
+  private long lastUpdatedTime;
 
-  public boolean isValid() {
-    return carbonTable != null;
+  private boolean isValid;
+
+  private CarbonTable carbonTable;
+
+  public CarbonTableCacheModel(long lastUpdatedTime, CarbonTable carbonTable) {
+    this.lastUpdatedTime = lastUpdatedTime;
+    this.carbonTable = carbonTable;
+    this.isValid = true;
   }
 
+  public void setCurrentSchemaTime(long currentSchemaTime) {
+    if (lastUpdatedTime != currentSchemaTime) {
+      isValid = false;
+    }
+    this.lastUpdatedTime = currentSchemaTime;
+  }
+
+  public CarbonTable getCarbonTable() {
+    return carbonTable;
+  }
+
+  public boolean isValid() {
+    return isValid;
+  }
+
+  public void setCarbonTable(CarbonTable carbonTable) {
+    this.carbonTable = carbonTable;
+    this.isValid = true;
+  }
 }

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/readers/BooleanStreamReader.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/readers/BooleanStreamReader.java
@@ -82,6 +82,12 @@ public class BooleanStreamReader extends CarbonColumnVectorImpl
     builder.appendNull();
   }
 
+  @Override public void putNulls(int rowId, int count) {
+    for (int i = 0; i < count; i++) {
+      builder.appendNull();
+    }
+  }
+
   @Override public void reset() {
     builder = type.createBlockBuilder(null, batchSize);
   }

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/readers/DecimalSliceStreamReader.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/readers/DecimalSliceStreamReader.java
@@ -89,6 +89,18 @@ public class DecimalSliceStreamReader extends CarbonColumnVectorImpl
     decimalBlockWriter(value);
   }
 
+  @Override public void putDecimals(int rowId, int count, BigDecimal value, int precision) {
+    for (int i = 0; i < count; i++) {
+      putDecimal(rowId++, value, precision);
+    }
+  }
+
+  @Override public void putNulls(int rowId, int count) {
+    for (int i = 0; i < count; i++) {
+      builder.appendNull();
+    }
+  }
+
   @Override public void putNull(int rowId) {
     builder.appendNull();
   }

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/readers/DoubleStreamReader.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/readers/DoubleStreamReader.java
@@ -70,8 +70,20 @@ public class DoubleStreamReader extends CarbonColumnVectorImpl implements Presto
     type.writeDouble(builder, value);
   }
 
+  @Override public void putDoubles(int rowId, int count, double value) {
+    for (int i = 0; i < count; i++) {
+      type.writeDouble(builder, value);
+    }
+  }
+
   @Override public void putNull(int rowId) {
     builder.appendNull();
+  }
+
+  @Override public void putNulls(int rowId, int count) {
+    for (int i = 0; i < count; i++) {
+      builder.appendNull();
+    }
   }
 
   @Override public void reset() {

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/readers/IntegerStreamReader.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/readers/IntegerStreamReader.java
@@ -68,8 +68,20 @@ public class IntegerStreamReader extends CarbonColumnVectorImpl
     }
   }
 
+  @Override public void putInts(int rowId, int count, int value) {
+    for (int i = 0; i < count; i++) {
+      putInt(rowId++, value);
+    }
+  }
+
   @Override public void putNull(int rowId) {
     builder.appendNull();
+  }
+
+  @Override public void putNulls(int rowId, int count) {
+    for (int i = 0; i < count; i++) {
+      builder.appendNull();
+    }
   }
 
   @Override public void reset() {

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/readers/LongStreamReader.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/readers/LongStreamReader.java
@@ -67,11 +67,23 @@ public class LongStreamReader extends CarbonColumnVectorImpl implements PrestoVe
     type.writeLong(builder, value);
   }
 
+  @Override public void putLongs(int rowId, int count, long value) {
+    for (int i = 0; i < count; i++) {
+      type.writeLong(builder, value);
+    }
+  }
+
   @Override public void putNull(int rowId) {
     builder.appendNull();
   }
 
   @Override public void reset() {
     builder = type.createBlockBuilder(null, batchSize);
+  }
+
+  @Override public void putNulls(int rowId, int count) {
+    for (int i = 0; i < count; i++) {
+      builder.appendNull();
+    }
   }
 }

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/readers/ObjectStreamReader.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/readers/ObjectStreamReader.java
@@ -62,4 +62,10 @@ public class ObjectStreamReader extends CarbonColumnVectorImpl implements Presto
     builder = type.createBlockBuilder(null, batchSize);
   }
 
+  @Override public void putNulls(int rowId, int count) {
+    for (int i = 0; i < count; i++) {
+      builder.appendNull();
+    }
+  }
+
 }

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/readers/ShortStreamReader.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/readers/ShortStreamReader.java
@@ -67,8 +67,20 @@ public class ShortStreamReader extends CarbonColumnVectorImpl implements PrestoV
     type.writeLong(builder, value);
   }
 
+  @Override public void putShorts(int rowId, int count, short value) {
+    for (int i = 0; i < count; i++) {
+      type.writeLong(builder, value);
+    }
+  }
+
   @Override public void putNull(int rowId) {
     builder.appendNull();
+  }
+
+  @Override public void putNulls(int rowId, int count) {
+    for (int i = 0; i < count; i++) {
+      builder.appendNull();
+    }
   }
 
   @Override public void reset() {

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/readers/SliceStreamReader.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/readers/SliceStreamReader.java
@@ -106,19 +106,37 @@ public class SliceStreamReader extends CarbonColumnVectorImpl implements PrestoV
     values[rowId] = value;
   }
 
+  @Override public void putInts(int rowId, int count, int value) {
+    for (int i = 0; i < count; i++) {
+      values[rowId++] = value;
+    }
+  }
+
   @Override public void putByteArray(int rowId, byte[] value) {
     type.writeSlice(builder, wrappedBuffer(value));
   }
 
   @Override public void putByteArray(int rowId, int offset, int length, byte[] value) {
-    byte[] byteArr = new byte[length];
-    System.arraycopy(value, offset, byteArr, 0, length);
-    type.writeSlice(builder, wrappedBuffer(byteArr));
+    type.writeSlice(builder, wrappedBuffer(value), offset, length);
+  }
+
+  @Override public void putByteArray(int rowId, int count, byte[] value) {
+    for (int i = 0; i < count; i++) {
+      type.writeSlice(builder, wrappedBuffer(value));
+    }
   }
 
   @Override public void putNull(int rowId) {
     if (dictionaryBlock == null) {
       builder.appendNull();
+    }
+  }
+
+  @Override public void putNulls(int rowId, int count) {
+    if (dictionaryBlock == null) {
+      for (int i = 0; i < count; ++i) {
+        builder.appendNull();
+      }
     }
   }
 

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/readers/TimestampStreamReader.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/readers/TimestampStreamReader.java
@@ -68,8 +68,20 @@ public class TimestampStreamReader extends CarbonColumnVectorImpl
     type.writeLong(builder, value / 1000);
   }
 
+  @Override public void putLongs(int rowId, int count, long value) {
+    for (int i = 0; i < count; i++) {
+      type.writeLong(builder, value / 1000);
+    }
+  }
+
   @Override public void putNull(int rowId) {
     builder.appendNull();
+  }
+
+  @Override public void putNulls(int rowId, int count) {
+    for (int i = 0; i < count; ++i) {
+      builder.appendNull();
+    }
   }
 
   @Override public void reset() {


### PR DESCRIPTION
Problem: 
Schema which is updated in spark is not reflecting in presto. which results in wrong query result in presto.

Solution:
Update the schema in presto whenever the schema changed in spark. And also override the putNulls method in all presto readers to work for null data scenarios.


Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

