### PR TITLE
[CARBONDATA-3206] Fix some spell error in CarbonData

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/scan/complextypes/ArrayQueryType.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/complextypes/ArrayQueryType.java
@@ -33,8 +33,8 @@ public class ArrayQueryType extends ComplexQueryType implements GenericQueryType
 
   private GenericQueryType children;
 
-  public ArrayQueryType(String name, String parentname, int blockIndex) {
-    super(name, parentname, blockIndex);
+  public ArrayQueryType(String name, String parentName, int blockIndex) {
+    super(name, parentName, blockIndex);
   }
 
   @Override public void addChildren(GenericQueryType children) {

--- a/core/src/main/java/org/apache/carbondata/core/scan/complextypes/ArrayQueryType.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/complextypes/ArrayQueryType.java
@@ -38,7 +38,7 @@ public class ArrayQueryType extends ComplexQueryType implements GenericQueryType
   }
 
   @Override public void addChildren(GenericQueryType children) {
-    if (this.getName().equals(children.getParentname())) {
+    if (this.getName().equals(children.getParentName())) {
       this.children = children;
     } else {
       this.children.addChildren(children);
@@ -53,12 +53,12 @@ public class ArrayQueryType extends ComplexQueryType implements GenericQueryType
     this.name = name;
   }
 
-  @Override public String getParentname() {
-    return parentname;
+  @Override public String getParentName() {
+    return parentName;
   }
 
-  @Override public void setParentname(String parentname) {
-    this.parentname = parentname;
+  @Override public void setParentName(String parentName) {
+    this.parentName = parentName;
 
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/scan/complextypes/ComplexQueryType.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/complextypes/ComplexQueryType.java
@@ -26,13 +26,13 @@ import org.apache.carbondata.core.scan.processor.RawBlockletColumnChunks;
 public class ComplexQueryType {
   protected String name;
 
-  protected String parentname;
+  protected String parentName;
 
   protected int blockIndex;
 
-  public ComplexQueryType(String name, String parentname, int blockIndex) {
+  public ComplexQueryType(String name, String parentName, int blockIndex) {
     this.name = name;
-    this.parentname = parentname;
+    this.parentName = parentName;
     this.blockIndex = blockIndex;
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/scan/complextypes/MapQueryType.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/complextypes/MapQueryType.java
@@ -25,8 +25,8 @@ import org.apache.carbondata.core.util.DataTypeUtil;
  */
 public class MapQueryType extends ArrayQueryType {
 
-  public MapQueryType(String name, String parentname, int blockIndex) {
-    super(name, parentname, blockIndex);
+  public MapQueryType(String name, String parentName, int blockIndex) {
+    super(name, parentName, blockIndex);
   }
 
   /**

--- a/core/src/main/java/org/apache/carbondata/core/scan/complextypes/PrimitiveQueryType.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/complextypes/PrimitiveQueryType.java
@@ -40,7 +40,7 @@ import org.apache.carbondata.core.util.DataTypeUtil;
 public class PrimitiveQueryType extends ComplexQueryType implements GenericQueryType {
 
   private String name;
-  private String parentname;
+  private String parentName;
 
   private int keySize;
 
@@ -54,15 +54,15 @@ public class PrimitiveQueryType extends ComplexQueryType implements GenericQuery
 
   private DirectDictionaryGenerator directDictGenForDate;
 
-  public PrimitiveQueryType(String name, String parentname, int blockIndex,
+  public PrimitiveQueryType(String name, String parentName, int blockIndex,
       DataType dataType, int keySize,
       Dictionary dictionary, boolean isDirectDictionary) {
-    super(name, parentname, blockIndex);
+    super(name, parentName, blockIndex);
     this.dataType = dataType;
     this.keySize = keySize;
     this.dictionary = dictionary;
     this.name = name;
-    this.parentname = parentname;
+    this.parentName = parentName;
     this.isDirectDictionary = isDirectDictionary;
     this.isDictionary = (dictionary != null && !isDirectDictionary);
     this.directDictGenForDate =

--- a/core/src/main/java/org/apache/carbondata/core/scan/complextypes/PrimitiveQueryType.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/complextypes/PrimitiveQueryType.java
@@ -81,12 +81,12 @@ public class PrimitiveQueryType extends ComplexQueryType implements GenericQuery
     this.name = name;
   }
 
-  @Override public String getParentname() {
-    return parentname;
+  @Override public String getParentName() {
+    return parentName;
   }
 
-  @Override public void setParentname(String parentname) {
-    this.parentname = parentname;
+  @Override public void setParentName(String parentName) {
+    this.parentName = parentName;
 
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/scan/complextypes/StructQueryType.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/complextypes/StructQueryType.java
@@ -35,16 +35,16 @@ public class StructQueryType extends ComplexQueryType implements GenericQueryTyp
 
   private List<GenericQueryType> children = new ArrayList<GenericQueryType>();
   private String name;
-  private String parentname;
+  private String parentName;
 
-  public StructQueryType(String name, String parentname, int blockIndex) {
-    super(name, parentname, blockIndex);
+  public StructQueryType(String name, String parentName, int blockIndex) {
+    super(name, parentName, blockIndex);
     this.name = name;
-    this.parentname = parentname;
+    this.parentName = parentName;
   }
 
   @Override public void addChildren(GenericQueryType newChild) {
-    if (this.getName().equals(newChild.getParentname())) {
+    if (this.getName().equals(newChild.getParentName())) {
       this.children.add(newChild);
     } else {
       for (GenericQueryType child : this.children) {
@@ -62,12 +62,12 @@ public class StructQueryType extends ComplexQueryType implements GenericQueryTyp
     this.name = name;
   }
 
-  @Override public String getParentname() {
-    return parentname;
+  @Override public String getParentName() {
+    return parentName;
   }
 
-  @Override public void setParentname(String parentname) {
-    this.parentname = parentname;
+  @Override public void setParentName(String parentName) {
+    this.parentName = parentName;
 
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/GenericQueryType.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/GenericQueryType.java
@@ -33,9 +33,9 @@ public interface GenericQueryType {
 
   void setName(String name);
 
-  String getParentname();
+  String getParentName();
 
-  void setParentname(String parentname);
+  void setParentName(String parentName);
 
   void addChildren(GenericQueryType children);
 

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
@@ -597,9 +597,9 @@ public final class CarbonProperties {
         .getProperty(NUMBER_OF_COLUMN_TO_READ_IN_IO,
             CarbonV3DataFormatConstants.NUMBER_OF_COLUMN_TO_READ_IN_IO_DEFAULTVALUE);
     try {
-      short numberofColumnPerIO = Short.parseShort(numberOfColumnPerIOString);
-      if (numberofColumnPerIO < CarbonV3DataFormatConstants.NUMBER_OF_COLUMN_TO_READ_IN_IO_MIN
-          || numberofColumnPerIO > CarbonV3DataFormatConstants.NUMBER_OF_COLUMN_TO_READ_IN_IO_MAX) {
+      short numberOfColumnPerIO = Short.parseShort(numberOfColumnPerIOString);
+      if (numberOfColumnPerIO < CarbonV3DataFormatConstants.NUMBER_OF_COLUMN_TO_READ_IN_IO_MIN
+          || numberOfColumnPerIO > CarbonV3DataFormatConstants.NUMBER_OF_COLUMN_TO_READ_IN_IO_MAX) {
         LOGGER.info("The Number Of pages per blocklet column value \"" + numberOfColumnPerIOString
             + "\" is invalid. Using the default value \""
             + CarbonV3DataFormatConstants.NUMBER_OF_COLUMN_TO_READ_IN_IO_DEFAULTVALUE);

--- a/core/src/test/java/org/apache/carbondata/core/scan/complextypes/ArrayQueryTypeTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/scan/complextypes/ArrayQueryTypeTest.java
@@ -48,7 +48,7 @@ public class ArrayQueryTypeTest {
     ByteBuffer surrogateData = ByteBuffer.allocate(10);
     surrogateData.put(3, (byte) 1);
     arrayQueryType.setName("testName");
-    arrayQueryType.setParentname("testName");
+    arrayQueryType.setParentName("testName");
     arrayQueryType.addChildren(arrayQueryType);
     assertNotNull(arrayQueryType.getDataBasedOnDataType(surrogateData));
   }

--- a/core/src/test/java/org/apache/carbondata/core/scan/complextypes/StructQueryTypeTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/scan/complextypes/StructQueryTypeTest.java
@@ -52,7 +52,7 @@ public class StructQueryTypeTest {
 
   @Test public void testGetColsCount() {
     structQueryType.setName("testName");
-    structQueryType.setParentname("testName");
+    structQueryType.setParentName("testName");
     structQueryType.addChildren(arrayQueryType);
     new MockUp<ArrayQueryType>() {
       @Mock int getColsCount() {

--- a/processing/src/main/java/org/apache/carbondata/processing/datatypes/ArrayDataType.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/datatypes/ArrayDataType.java
@@ -55,7 +55,7 @@ public class ArrayDataType implements GenericDataType<ArrayObject> {
   /**
    * parent column name
    */
-  private String parentname;
+  private String parentName;
 
   /**
    * output array index
@@ -84,26 +84,26 @@ public class ArrayDataType implements GenericDataType<ArrayObject> {
   /**
    * constructor
    * @param name
-   * @param parentname
+   * @param parentName
    * @param columnId
    */
-  public ArrayDataType(String name, String parentname, String columnId) {
+  public ArrayDataType(String name, String parentName, String columnId) {
     this.name = name;
-    this.parentname = parentname;
+    this.parentName = parentName;
     this.columnId = columnId;
   }
 
   /**
    * constructor
    * @param name
-   * @param parentname
+   * @param parentName
    * @param columnId
    * @param isDictionaryColumn
    */
-  public ArrayDataType(String name, String parentname, String columnId,
+  public ArrayDataType(String name, String parentName, String columnId,
       Boolean isDictionaryColumn) {
     this.name = name;
-    this.parentname = parentname;
+    this.parentName = parentName;
     this.columnId = columnId;
     this.isDictionaryColumn = isDictionaryColumn;
   }
@@ -113,7 +113,7 @@ public class ArrayDataType implements GenericDataType<ArrayObject> {
    */
   @Override
   public void addChildren(GenericDataType children) {
-    if (this.getName().equals(children.getParentname())) {
+    if (this.getName().equals(children.getParentName())) {
       this.children = children;
     } else {
       this.children.addChildren(children);
@@ -140,8 +140,8 @@ public class ArrayDataType implements GenericDataType<ArrayObject> {
    * set parent name
    */
   @Override
-  public String getParentname() {
-    return parentname;
+  public String getParentName() {
+    return parentName;
   }
 
   /*

--- a/processing/src/main/java/org/apache/carbondata/processing/datatypes/GenericDataType.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/datatypes/GenericDataType.java
@@ -43,7 +43,7 @@ public interface GenericDataType<T> {
   /**
    * @return - columns parent name
    */
-  String getParentname();
+  String getParentName();
 
   /**
    * @param children - To add children dimension for parent complex type

--- a/processing/src/main/java/org/apache/carbondata/processing/datatypes/PrimitiveDataType.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/datatypes/PrimitiveDataType.java
@@ -83,7 +83,7 @@ public class PrimitiveDataType implements GenericDataType<Object> {
   /**
    * column parent name
    */
-  private String parentname;
+  private String parentName;
 
   /**
    * column unique id
@@ -111,7 +111,7 @@ public class PrimitiveDataType implements GenericDataType<Object> {
 
   private boolean isDictionary;
 
-  private String nullformat;
+  private String nullFormat;
 
   private boolean isDirectDictionary;
 
@@ -133,10 +133,10 @@ public class PrimitiveDataType implements GenericDataType<Object> {
   public PrimitiveDataType(String name, DataType dataType, String parentName, String columnId,
       boolean isDictionary, String nullFormat) {
     this.name = name;
-    this.parentname = parentName;
+    this.parentName = parentName;
     this.columnId = columnId;
     this.isDictionary = isDictionary;
-    this.nullformat = nullFormat;
+    this.nullFormat = nullFormat;
     this.dataType = dataType;
   }
 
@@ -157,11 +157,11 @@ public class PrimitiveDataType implements GenericDataType<Object> {
       DictionaryClient client, Boolean useOnePass, Map<Object, Integer> localCache,
       String nullFormat) {
     this.name = carbonColumn.getColName();
-    this.parentname = parentName;
+    this.parentName = parentName;
     this.columnId = columnId;
     this.carbonDimension = carbonDimension;
     this.isDictionary = isDictionaryDimension(carbonDimension);
-    this.nullformat = nullFormat;
+    this.nullFormat = nullFormat;
     this.dataType = carbonColumn.getDataType();
 
     DictionaryColumnUniqueIdentifier identifier =
@@ -250,8 +250,8 @@ public class PrimitiveDataType implements GenericDataType<Object> {
    * get column parent name
    */
   @Override
-  public String getParentname() {
-    return parentname;
+  public String getParentName() {
+    return parentName;
   }
 
   /*
@@ -330,7 +330,7 @@ public class PrimitiveDataType implements GenericDataType<Object> {
       // TODO have to refactor and place all the cases present in NonDictionaryFieldConverterImpl
       if (null == parsedValue && this.carbonDimension.getDataType() != DataTypes.STRING) {
         updateNullValue(dataOutputStream, logHolder);
-      } else if (null == parsedValue || parsedValue.equals(nullformat)) {
+      } else if (null == parsedValue || parsedValue.equals(nullFormat)) {
         updateNullValue(dataOutputStream, logHolder);
       } else {
         String dateFormat = null;
@@ -558,10 +558,10 @@ public class PrimitiveDataType implements GenericDataType<Object> {
     PrimitiveDataType dataType = new PrimitiveDataType(this.outputArrayIndex, 0);
     dataType.carbonDimension = this.carbonDimension;
     dataType.isDictionary = this.isDictionary;
-    dataType.parentname = this.parentname;
+    dataType.parentName = this.parentName;
     dataType.columnId = this.columnId;
     dataType.dictionaryGenerator = this.dictionaryGenerator;
-    dataType.nullformat = this.nullformat;
+    dataType.nullFormat = this.nullFormat;
     dataType.setKeySize(this.keySize);
     dataType.setSurrogateIndex(this.index);
     dataType.name = this.name;

--- a/processing/src/main/java/org/apache/carbondata/processing/datatypes/StructDataType.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/datatypes/StructDataType.java
@@ -48,7 +48,7 @@ public class StructDataType implements GenericDataType<StructObject> {
   /**
    * parent column name
    */
-  private String parentname;
+  private String parentName;
   /**
    * column unique id
    */
@@ -79,26 +79,26 @@ public class StructDataType implements GenericDataType<StructObject> {
   /**
    * constructor
    * @param name
-   * @param parentname
+   * @param parentName
    * @param columnId
    */
-  public StructDataType(String name, String parentname, String columnId) {
+  public StructDataType(String name, String parentName, String columnId) {
     this.name = name;
-    this.parentname = parentname;
+    this.parentName = parentName;
     this.columnId = columnId;
   }
 
   /**
    * constructor
    * @param name
-   * @param parentname
+   * @param parentName
    * @param columnId
    * @param isDictionaryColumn
    */
-  public StructDataType(String name, String parentname, String columnId,
+  public StructDataType(String name, String parentName, String columnId,
       Boolean isDictionaryColumn) {
     this.name = name;
-    this.parentname = parentname;
+    this.parentName = parentName;
     this.columnId = columnId;
     this.isDictionaryColumn = isDictionaryColumn;
   }
@@ -108,7 +108,7 @@ public class StructDataType implements GenericDataType<StructObject> {
    */
   @Override
   public void addChildren(GenericDataType newChild) {
-    if (this.getName().equals(newChild.getParentname())) {
+    if (this.getName().equals(newChild.getParentName())) {
       this.children.add(newChild);
     } else {
       for (GenericDataType child : this.children) {
@@ -130,8 +130,8 @@ public class StructDataType implements GenericDataType<StructObject> {
    * get parent column name
    */
   @Override
-  public String getParentname() {
-    return parentname;
+  public String getParentName() {
+    return parentName;
   }
 
   /*

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/converter/impl/MeasureFieldConverterImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/converter/impl/MeasureFieldConverterImpl.java
@@ -39,15 +39,15 @@ public class MeasureFieldConverterImpl implements FieldConverter {
 
   private int index;
 
-  private String nullformat;
+  private String nullFormat;
 
   private boolean isEmptyBadRecord;
 
   private DataField dataField;
 
-  public MeasureFieldConverterImpl(DataField dataField, String nullformat, int index,
+  public MeasureFieldConverterImpl(DataField dataField, String nullFormat, int index,
       boolean isEmptyBadRecord) {
-    this.nullformat = nullformat;
+    this.nullFormat = nullFormat;
     this.index = index;
     this.isEmptyBadRecord = isEmptyBadRecord;
     this.dataField = dataField;
@@ -88,7 +88,7 @@ public class MeasureFieldConverterImpl implements FieldConverter {
         logHolder.setReason(message);
       }
       return null;
-    } else if (literalValue.equals(nullformat)) {
+    } else if (literalValue.equals(nullFormat)) {
       return null;
     } else {
       try {

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/converter/impl/NonDictionaryFieldConverterImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/converter/impl/NonDictionaryFieldConverterImpl.java
@@ -34,7 +34,7 @@ public class NonDictionaryFieldConverterImpl implements FieldConverter {
 
   private int index;
 
-  private String nullformat;
+  private String nullFormat;
 
   private CarbonColumn column;
 
@@ -42,13 +42,13 @@ public class NonDictionaryFieldConverterImpl implements FieldConverter {
 
   private DataField dataField;
 
-  public NonDictionaryFieldConverterImpl(DataField dataField, String nullformat, int index,
+  public NonDictionaryFieldConverterImpl(DataField dataField, String nullFormat, int index,
       boolean isEmptyBadRecord) {
     this.dataField = dataField;
     this.dataType = dataField.getColumn().getDataType();
     this.column = dataField.getColumn();
     this.index = index;
-    this.nullformat = nullformat;
+    this.nullFormat = nullFormat;
     this.isEmptyBadRecord = isEmptyBadRecord;
   }
 
@@ -65,7 +65,7 @@ public class NonDictionaryFieldConverterImpl implements FieldConverter {
       logHolder.setReason(
           CarbonDataProcessorUtil.prepareFailureReason(column.getColName(), column.getDataType()));
       return getNullValue();
-    } else if (dimensionValue == null || dimensionValue.equals(nullformat)) {
+    } else if (dimensionValue == null || dimensionValue.equals(nullFormat)) {
       return getNullValue();
     } else {
       String dateFormat = null;

--- a/processing/src/main/java/org/apache/carbondata/processing/util/CarbonLoaderUtil.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/util/CarbonLoaderUtil.java
@@ -592,19 +592,19 @@ public final class CarbonLoaderUtil {
 
     // if enable to control the minimum amount of input data for each node
     if (BlockAssignmentStrategy.NODE_MIN_SIZE_FIRST == blockAssignmentStrategy) {
-      long iexpectedMinSizePerNode = 0;
+      long expectedMinSizePerNodeInt = 0;
       // validate the property load_min_size_inmb specified by the user
       if (CarbonUtil.validateValidIntType(expectedMinSizePerNode)) {
-        iexpectedMinSizePerNode = Integer.parseInt(expectedMinSizePerNode);
+        expectedMinSizePerNodeInt = Integer.parseInt(expectedMinSizePerNode);
       } else {
         LOGGER.warn("Invalid load_min_size_inmb value found: " + expectedMinSizePerNode
             + ", only int value greater than 0 is supported.");
-        iexpectedMinSizePerNode = Integer.parseInt(
+        expectedMinSizePerNodeInt = Integer.parseInt(
             CarbonCommonConstants.CARBON_LOAD_MIN_SIZE_INMB_DEFAULT);
       }
       // If the average expected size for each node greater than load min size,
       // then fall back to default strategy
-      if (iexpectedMinSizePerNode * 1024 * 1024 < sizePerNode) {
+      if (expectedMinSizePerNodeInt * 1024 * 1024 < sizePerNode) {
         if (CarbonProperties.getInstance().isLoadSkewedDataOptimizationEnabled()) {
           blockAssignmentStrategy = BlockAssignmentStrategy.BLOCK_SIZE_FIRST;
         } else {
@@ -613,7 +613,7 @@ public final class CarbonLoaderUtil {
         LOGGER.info("Specified minimum data size to load is less than the average size "
             + "for each node, fallback to default strategy" + blockAssignmentStrategy);
       } else {
-        sizePerNode = iexpectedMinSizePerNode;
+        sizePerNode = expectedMinSizePerNodeInt;
       }
     }
 


### PR DESCRIPTION
numberofColumnPerIO => numberOfColumnPerIO
iexpectedMinSizePerNode => expectedMinSizePerNodeInt
parentname => parentName
nullformat => nullFormat

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 
org.apache.carbondata.processing.datatypes.ArrayDataType
org.apache.carbondata.processing.datatypes.PrimitiveDataType
org.apache.carbondata.core.scan.complextypes.StructQueryType
org.apache.carbondata.core.scan.complextypes.ComplexQueryType
org.apache.carbondata.core.scan.complextypes.ArrayQueryType
org.apache.carbondata.core.scan.filter.GenericQueryType
parentname => parentName

 - [x] Any backward compatibility impacted?
    No
 - [x] Document update required?
    No
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
          No
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
    No
