### PR TITLE
[CARBONDATA-3222]Fix dataload failure after creation of preaggregate datamap on main table with long_string_columns

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/preaaggregate/PreAggregateTableHelper.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/preaaggregate/PreAggregateTableHelper.scala
@@ -110,7 +110,29 @@ case class PreAggregateTableHelper(
     // Datamap table name and columns are automatically added prefix with parent table name
     // in carbon. For convenient, users can type column names same as the ones in select statement
     // when config dmproperties, and here we update column names with prefix.
-    val longStringColumn = tableProperties.get(CarbonCommonConstants.LONG_STRING_COLUMNS)
+    // If longStringColumn is not present in dm properties then we take long_string_columns from
+    // the parent table.
+    var longStringColumn = tableProperties.get(CarbonCommonConstants.LONG_STRING_COLUMNS)
+    if (longStringColumn.isEmpty) {
+      val longStringColumnInParents = parentTable.getTableInfo.getFactTable.getTableProperties
+        .asScala
+        .getOrElse(CarbonCommonConstants.LONG_STRING_COLUMNS, "").split(",").map(_.trim)
+      val varcharDatamapFields = scala.collection.mutable.ArrayBuffer.empty[String]
+      fieldRelationMap foreach (fields => {
+        val aggFunc = fields._2.aggregateFunction
+        val relationList = fields._2.columnTableRelationList
+        // check if columns present in datamap are long_string_col in parent table. If they are
+        // long_string_columns in parent, make them long_string_columns in datamap
+        if (aggFunc.isEmpty && relationList.size == 1 && longStringColumnInParents
+          .contains(relationList.head.head.parentColumnName)) {
+          varcharDatamapFields += relationList.head.head.parentColumnName
+        }
+      })
+      if (!varcharDatamapFields.isEmpty) {
+        longStringColumn = Option(varcharDatamapFields.mkString(","))
+      }
+    }
+
     if (longStringColumn != None) {
       val fieldNames = fields.map(_.column)
       val newLongStringColumn = longStringColumn.get.split(",").map(_.trim).map{ colName =>


### PR DESCRIPTION
This PR is to Fix dataload failure after creation of preaggregate datamap on main table with long_string_columns.

Dataload is gettling failed because child table properties are not getting modified according to the parent table for long_string_columns.
This occurs only when long_string_columns is not specified in dmproperties for preaggregate datamap but the datamap was getting created and data load was failing. This PR is to avoid the dataload failure in this scenario.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [x] Testing done
        added a testcase
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

