### PR TITLE
[CARBONDATA-3231] Fix OOM exception when dictionary map size is too huge in case of varchar columns

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -2076,4 +2076,25 @@ public final class CarbonCommonConstants {
    */
   public static final String CARBON_QUERY_DATAMAP_BLOOM_CACHE_SIZE_DEFAULT_VAL = "512";
 
+  /**
+   * Used to set Max threshold size for local dictionanary after which fallback would be triggered.
+   *
+   * Currently this is an internal property not to be used by the user.
+   */
+  public static final String CARBON_LOCAL_DICTIONARY_MAX_SIZE_THRESHOLD =
+      "carbon.local.dictionary.max.size.threshold";
+
+  /**
+   * Max threshold for local dictionary in MB after which fallback should be triggered
+   */
+  public static final String CARBON_LOCAL_DICTIONARY_MAX_SIZE_THRESHOLD_DEFAULT = "2";
+
+  /**
+   * Max allowed limit for local dictionary threshold. If the user specifies the
+   */
+  public static final int CARBON_LOCAL_DICTIONARY_THRESHOLD_MAX_VALUE = 20;
+
+
+
+
 }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/DecoderBasedFallbackEncoder.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/DecoderBasedFallbackEncoder.java
@@ -57,10 +57,7 @@ public class DecoderBasedFallbackEncoder implements Callable<FallbackEncodedColu
     int pageSize =
         encodedColumnPage.getActualPage().getPageSize();
     int offset = 0;
-    int[] reverseInvertedIndex = new int[pageSize];
-    for (int i = 0; i < pageSize; i++) {
-      reverseInvertedIndex[i] = i;
-    }
+    int[] reverseInvertedIndex = null;
     int[] rlePage;
 
     // uncompress the encoded column page
@@ -109,11 +106,19 @@ public class DecoderBasedFallbackEncoder implements Callable<FallbackEncodedColu
 
     // get the actual data for each dictionary data and put the actual data in new page
     int rowId = 0;
-    for (int i = 0; i < pageSize; i++) {
-      int index = reverseInvertedIndex[i] * 3;
-      int keyArray = (int) keyGenerator.getKeyArray(bytes, index)[0];
-      actualDataColumnPage
-          .putBytes(rowId++, localDictionaryGenerator.getDictionaryKeyBasedOnValue(keyArray));
+    if (reverseInvertedIndex == null) {
+      for (int i = 0; i < pageSize; i++) {
+        int keyArray = (int) keyGenerator.getKeyArray(bytes, i * 3)[0];
+        actualDataColumnPage
+            .putBytes(rowId++, localDictionaryGenerator.getDictionaryKeyBasedOnValue(keyArray));
+      }
+    } else {
+      for (int i = 0; i < pageSize; i++) {
+        int index = reverseInvertedIndex[i] * 3;
+        int keyArray = (int) keyGenerator.getKeyArray(bytes, index)[0];
+        actualDataColumnPage
+            .putBytes(rowId++, localDictionaryGenerator.getDictionaryKeyBasedOnValue(keyArray));
+      }
     }
 
     // get column spec for existing column page

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
@@ -1491,6 +1491,37 @@ public final class CarbonProperties {
     }
   }
 
+  public int getMaxDictionaryThreshold() {
+    int localDictionaryMaxThreshold = Integer.parseInt(carbonProperties
+        .getProperty(CarbonCommonConstants.CARBON_LOCAL_DICTIONARY_MAX_SIZE_THRESHOLD,
+            CarbonCommonConstants.CARBON_LOCAL_DICTIONARY_MAX_SIZE_THRESHOLD_DEFAULT));
+    if (localDictionaryMaxThreshold
+        > CarbonCommonConstants.CARBON_LOCAL_DICTIONARY_THRESHOLD_MAX_VALUE) {
+      LOGGER.info(
+          "Configured value for " + CarbonCommonConstants.CARBON_LOCAL_DICTIONARY_MAX_SIZE_THRESHOLD
+              + "MB is more than the allowed limit: "
+              + CarbonCommonConstants.CARBON_LOCAL_DICTIONARY_THRESHOLD_MAX_VALUE
+              + "MB, therefore considering "
+              + CarbonCommonConstants.CARBON_LOCAL_DICTIONARY_MAX_SIZE_THRESHOLD_DEFAULT + "MB.");
+      localDictionaryMaxThreshold =
+          CarbonCommonConstants.CARBON_LOCAL_DICTIONARY_THRESHOLD_MAX_VALUE;
+    } else if (localDictionaryMaxThreshold < Integer
+        .parseInt(CarbonCommonConstants.CARBON_LOCAL_DICTIONARY_MAX_SIZE_THRESHOLD_DEFAULT)) {
+      LOGGER.info(
+          "Configured value for " + CarbonCommonConstants.CARBON_LOCAL_DICTIONARY_MAX_SIZE_THRESHOLD
+              + "MB is less than the required limit: "
+              + CarbonCommonConstants.CARBON_LOCAL_DICTIONARY_MAX_SIZE_THRESHOLD_DEFAULT
+              + "MB, therefore considering "
+              + CarbonCommonConstants.CARBON_LOCAL_DICTIONARY_MAX_SIZE_THRESHOLD_DEFAULT + "MB.");
+      localDictionaryMaxThreshold = Integer
+          .parseInt(CarbonCommonConstants.CARBON_LOCAL_DICTIONARY_MAX_SIZE_THRESHOLD_DEFAULT);
+    }
+    LOGGER.info(
+        "Configured value for " + CarbonCommonConstants.CARBON_LOCAL_DICTIONARY_MAX_SIZE_THRESHOLD
+            + ": " + localDictionaryMaxThreshold + "MB");
+    return localDictionaryMaxThreshold;
+  }
+
   /**
    * This method validates the allowed character limit for storing min/max for string type
    */

--- a/processing/src/main/java/org/apache/carbondata/processing/store/CarbonFactDataHandlerModel.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/CarbonFactDataHandlerModel.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
 
 import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
@@ -186,6 +187,8 @@ public class CarbonFactDataHandlerModel {
   private List<Integer> varcharDimIdxInNoDict;
 
   private String columnCompressor;
+
+  private ExecutorService fallBackExecutorService;
 
   /**
    * Create the model using @{@link CarbonDataLoadConfiguration}
@@ -777,6 +780,14 @@ public class CarbonFactDataHandlerModel {
 
   public void setNoDictAndComplexColumns(CarbonColumn[] noDictAndComplexColumns) {
     this.noDictAndComplexColumns = noDictAndComplexColumns;
+  }
+
+  public ExecutorService getFallBackExecutorService() {
+    return fallBackExecutorService;
+  }
+
+  public void setFallBackExecutorService(ExecutorService fallBackExecutorService) {
+    this.fallBackExecutorService = fallBackExecutorService;
   }
 }
 

--- a/processing/src/main/java/org/apache/carbondata/processing/store/writer/AbstractFactDataWriter.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/writer/AbstractFactDataWriter.java
@@ -205,8 +205,10 @@ public abstract class AbstractFactDataWriter implements CarbonFactDataWriter {
       if (model.getNumberOfCores() > 1) {
         numberOfCores = model.getNumberOfCores() / 2;
       }
-      fallbackExecutorService = Executors.newFixedThreadPool(numberOfCores, new CarbonThreadFactory(
-          "FallbackPool:" + model.getTableName() + ", range: " + model.getBucketId()));
+      fallbackExecutorService = model.getFallBackExecutorService() != null ?
+          model.getFallBackExecutorService() :
+          Executors.newFixedThreadPool(numberOfCores, new CarbonThreadFactory(
+              "FallbackPool:" + model.getTableName() + ", range: " + model.getBucketId(), true));
     }
   }
 


### PR DESCRIPTION
**Problem:** when using varchar column with email data the key for the dictionary map is very huge. When fallback happens the same data is kept in memory twice, which causes the application to throw OOM exception.

**Solution:** Add a check on the dictionary size so that fallback can be triggered to restrict the size of data we keep in memory.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

