### PR TITLE
[CARBONDATA-3227] Fix some spell errors in the project

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/complexType/TestComplexDataType.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/complexType/TestComplexDataType.scala
@@ -846,7 +846,7 @@ class TestComplexDataType extends QueryTest with BeforeAndAfterAll {
       "'carbondata' tblproperties('dictionary_exclude'='a.b')"))
     assertResult(
       "DICTIONARY_EXCLUDE column: a.b does not exist in table or unsupported for complex child " +
-      "column. Please check create table statement.")(
+      "column. Please check the create table statement.")(
       structException.getMessage)
     sql("DROP TABLE IF EXISTS table1")
     val arrayException = intercept[MalformedCarbonCommandException](
@@ -856,7 +856,7 @@ class TestComplexDataType extends QueryTest with BeforeAndAfterAll {
         "'carbondata' tblproperties('dictionary_exclude'='a[0]')"))
     assertResult(
       "DICTIONARY_EXCLUDE column: a[0] does not exist in table or unsupported for complex child " +
-      "column. Please check create table statement.")(
+      "column. Please check the create table statement.")(
       arrayException.getMessage)
   }
 
@@ -870,7 +870,7 @@ class TestComplexDataType extends QueryTest with BeforeAndAfterAll {
         "'carbondata' tblproperties('dictionary_include'='a.b')"))
     assertResult(
       "DICTIONARY_INCLUDE column: a.b does not exist in table or unsupported for complex child " +
-      "column. Please check create table statement.")(
+      "column. Please check the create table statement.")(
       structException.getMessage)
     sql("DROP TABLE IF EXISTS table1")
     val arrayException = intercept[MalformedCarbonCommandException](
@@ -880,7 +880,7 @@ class TestComplexDataType extends QueryTest with BeforeAndAfterAll {
         "'carbondata' tblproperties('dictionary_include'='a[0]')"))
     assertResult(
       "DICTIONARY_INCLUDE column: a[0] does not exist in table or unsupported for complex child " +
-      "column. Please check create table statement.")(
+      "column. Please check the create table statement.")(
       arrayException.getMessage)
   }
 

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestLoadDataWithMalformedCarbonCommandException.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestLoadDataWithMalformedCarbonCommandException.scala
@@ -86,7 +86,7 @@ class TestLoadDataWithMalformedCarbonCommandException extends QueryTest with Bef
     assert(e.getMessage
       .equals(
         "DICTIONARY_EXCLUDE column: ccc does not exist in table or unsupported for complex child " +
-        "column. Please check create table statement."))
+        "column. Please check the create table statement."))
   }
 
   test("test load data with dictionary include columns which no exist in table.") {
@@ -96,7 +96,7 @@ class TestLoadDataWithMalformedCarbonCommandException extends QueryTest with Bef
     assert(e.getMessage
       .equals(
         "DICTIONARY_INCLUDE column: aaa does not exist in table or unsupported for complex child " +
-        "column. Please check create table statement."))
+        "column. Please check the create table statement."))
   }
 
   test("test load data with dictionary include is same with dictionary exclude") {
@@ -104,7 +104,7 @@ class TestLoadDataWithMalformedCarbonCommandException extends QueryTest with Bef
       buildTableWithSameDictExcludeAndInclude()
     }
     assert(e.getMessage.equals("DICTIONARY_EXCLUDE can not contain the same column: country " +
-      "with DICTIONARY_INCLUDE. Please check create table statement."))
+      "with DICTIONARY_INCLUDE. Please check the create table statement."))
   }
 
   test("test load data with invalid option") {
@@ -139,6 +139,6 @@ class TestLoadDataWithMalformedCarbonCommandException extends QueryTest with Bef
       buildTableWithSameDictExcludeAndIncludeWithSpaces()
     }
     assert(e.getMessage.equals("DICTIONARY_EXCLUDE can not contain the same column: country " +
-      "with DICTIONARY_INCLUDE. Please check create table statement."))
+      "with DICTIONARY_INCLUDE. Please check the create table statement."))
   }
 }

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/CarbonScalaUtil.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/CarbonScalaUtil.scala
@@ -85,7 +85,7 @@ object CarbonScalaUtil {
       dataType: DataType,
       timeStampFormat: SimpleDateFormat,
       dateFormat: SimpleDateFormat): String = {
-    val defaultValue = value != null && value.equalsIgnoreCase(hivedefaultpartition)
+    val defaultValue = value != null && value.equalsIgnoreCase(hiveDefaultPartition)
     try {
       dataType match {
         case TimestampType if timeStampFormat != null =>
@@ -236,7 +236,7 @@ object CarbonScalaUtil {
     }
   }
 
-  private val hivedefaultpartition = "__HIVE_DEFAULT_PARTITION__"
+  private val hiveDefaultPartition = "__HIVE_DEFAULT_PARTITION__"
 
   /**
    * Update partition values as per the right date and time format
@@ -248,20 +248,20 @@ object CarbonScalaUtil {
     val cacheProvider: CacheProvider = CacheProvider.getInstance
     val forwardDictionaryCache: Cache[DictionaryColumnUniqueIdentifier, Dictionary] =
       cacheProvider.createCache(CacheType.FORWARD_DICTIONARY)
-    partitionSpec.map { case (col, pvalue) =>
+    partitionSpec.map { case (col, pValue) =>
       // replace special string with empty value.
-      val value = if (pvalue == null) {
-        hivedefaultpartition
-      } else if (pvalue.equals(CarbonCommonConstants.MEMBER_DEFAULT_VAL)) {
+      val value = if (pValue == null) {
+        hiveDefaultPartition
+      } else if (pValue.equals(CarbonCommonConstants.MEMBER_DEFAULT_VAL)) {
         ""
       } else {
-        pvalue
+        pValue
       }
       val carbonColumn = table.getColumnByName(table.getTableName, col.toLowerCase)
       val dataType =
         CarbonSparkDataSourceUtil.convertCarbonToSparkDataType(carbonColumn.getDataType)
       try {
-        if (value.equals(hivedefaultpartition)) {
+        if (value.equals(hiveDefaultPartition)) {
           (col, value)
         } else {
           val convertedString =
@@ -271,7 +271,7 @@ object CarbonScalaUtil {
               forwardDictionaryCache,
               table)
           if (convertedString == null) {
-            (col, hivedefaultpartition)
+            (col, hiveDefaultPartition)
           } else {
             (col, convertedString)
           }
@@ -518,11 +518,11 @@ object CarbonScalaUtil {
         if (dictIncludeColumns.exists(x => x.equalsIgnoreCase(distCol.trim))) {
           val commonColumn = (dictIncludeColumns ++ localDictColumns)
             .diff((dictIncludeColumns ++ localDictColumns).distinct).distinct
-          val errormsg = "LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE column: " +
+          val errorMsg = "LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE column: " +
                          commonColumn.mkString(",") +
                          " specified in Dictionary include. Local Dictionary will not be " +
                          "generated for Dictionary include columns. Please check the DDL."
-          throw new MalformedCarbonCommandException(errormsg)
+          throw new MalformedCarbonCommandException(errorMsg)
         }
       }
     }
@@ -633,9 +633,9 @@ object CarbonScalaUtil {
     // check if the column specified exists in table schema
     localDictColumns.foreach { distCol =>
       if (!fields.exists(x => x.column.equalsIgnoreCase(distCol.trim))) {
-        val errormsg = "LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE column: " + distCol.trim +
+        val errorMsg = "LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE column: " + distCol.trim +
                        " does not exist in table. Please check the DDL."
-        throw new MalformedCarbonCommandException(errormsg)
+        throw new MalformedCarbonCommandException(errorMsg)
       }
     }
 
@@ -648,12 +648,12 @@ object CarbonScalaUtil {
                      !x.dataType.get.equalsIgnoreCase("STRUCT") &&
                      !x.dataType.get.equalsIgnoreCase("MAP") &&
                      !x.dataType.get.equalsIgnoreCase("ARRAY"))) {
-        val errormsg = "LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE column: " +
+        val errorMsg = "LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE column: " +
                        dictColm.trim +
                        " is not a string/complex/varchar datatype column. LOCAL_DICTIONARY_COLUMN" +
                        " should be no dictionary string/complex/varchar datatype column." +
                        "Please check the DDL."
-        throw new MalformedCarbonCommandException(errormsg)
+        throw new MalformedCarbonCommandException(errorMsg)
       }
     }
 

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
@@ -668,9 +668,9 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
         tableProperties(CarbonCommonConstants.NO_INVERTED_INDEX).split(',').map(_.trim)
       noInvertedIdxColsProps.foreach { noInvertedIdxColProp =>
         if (!fields.exists(x => x.column.equalsIgnoreCase(noInvertedIdxColProp))) {
-          val errormsg = "NO_INVERTED_INDEX column: " + noInvertedIdxColProp +
+          val errorMsg = "NO_INVERTED_INDEX column: " + noInvertedIdxColProp +
                          " does not exist in table. Please check create table statement."
-          throw new MalformedCarbonCommandException(errormsg)
+          throw new MalformedCarbonCommandException(errorMsg)
         }
       }
     }
@@ -697,9 +697,9 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
         tableProperties(CarbonCommonConstants.INVERTED_INDEX).split(',').map(_.trim)
       invertedIdxColsProps.foreach { invertedIdxColProp =>
         if (!fields.exists(x => x.column.equalsIgnoreCase(invertedIdxColProp))) {
-          val errormsg = "INVERTED_INDEX column: " + invertedIdxColProp +
+          val errorMsg = "INVERTED_INDEX column: " + invertedIdxColProp +
                          " does not exist in table. Please check create table statement."
-          throw new MalformedCarbonCommandException(errormsg)
+          throw new MalformedCarbonCommandException(errorMsg)
         }
       }
     }
@@ -759,15 +759,15 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
 
       sortKey.foreach { column =>
         if (!fields.exists(x => x.column.equalsIgnoreCase(column))) {
-          val errormsg = "sort_columns: " + column +
+          val errorMsg = "sort_columns: " + column +
             " does not exist in table. Please check create table statement."
-          throw new MalformedCarbonCommandException(errormsg)
+          throw new MalformedCarbonCommandException(errorMsg)
         } else {
           val dataType = fields.find(x =>
             x.column.equalsIgnoreCase(column)).get.dataType.get
           if (isDataTypeSupportedForSortColumn(dataType)) {
-            val errormsg = s"sort_columns is unsupported for $dataType datatype column: " + column
-            throw new MalformedCarbonCommandException(errormsg)
+            val errorMsg = s"sort_columns is unsupported for $dataType datatype column: " + column
+            throw new MalformedCarbonCommandException(errorMsg)
           }
           if (varcharCols.exists(x => x.equalsIgnoreCase(column))) {
             throw new MalformedCarbonCommandException(
@@ -796,10 +796,10 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
       dictExcludeCols
         .foreach { dictExcludeCol =>
           if (!fields.exists(x => x.column.equalsIgnoreCase(dictExcludeCol))) {
-            val errormsg = "DICTIONARY_EXCLUDE column: " + dictExcludeCol +
+            val errorMsg = "DICTIONARY_EXCLUDE column: " + dictExcludeCol +
                            " does not exist in table or unsupported for complex child column. " +
                            "Please check create table statement."
-            throw new MalformedCarbonCommandException(errormsg)
+            throw new MalformedCarbonCommandException(errorMsg)
           } else {
             val dataType = fields.find(x =>
               x.column.equalsIgnoreCase(dictExcludeCol)).get.dataType.get
@@ -821,10 +821,10 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
         tableProperties(CarbonCommonConstants.DICTIONARY_INCLUDE).split(",").map(_.trim)
       dictIncludeCols.foreach { distIncludeCol =>
         if (!fields.exists(x => x.column.equalsIgnoreCase(distIncludeCol.trim))) {
-          val errormsg = "DICTIONARY_INCLUDE column: " + distIncludeCol.trim +
+          val errorMsg = "DICTIONARY_INCLUDE column: " + distIncludeCol.trim +
                          " does not exist in table or unsupported for complex child column. " +
                          "Please check create table statement."
-          throw new MalformedCarbonCommandException(errormsg)
+          throw new MalformedCarbonCommandException(errorMsg)
         }
         if (varcharCols.exists(x => x.equalsIgnoreCase(distIncludeCol.trim))) {
           throw new MalformedCarbonCommandException(
@@ -837,9 +837,9 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
     // include cols should not contain exclude cols
     dictExcludeCols.foreach { dicExcludeCol =>
       if (dictIncludeCols.exists(x => x.equalsIgnoreCase(dicExcludeCol))) {
-        val errormsg = "DICTIONARY_EXCLUDE can not contain the same column: " + dicExcludeCol +
+        val errorMsg = "DICTIONARY_EXCLUDE can not contain the same column: " + dicExcludeCol +
                        " with DICTIONARY_INCLUDE. Please check create table statement."
-        throw new MalformedCarbonCommandException(errormsg)
+        throw new MalformedCarbonCommandException(errorMsg)
       }
     }
 
@@ -855,7 +855,7 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
                  !dictIncludeCols.exists(x => x.equalsIgnoreCase(field.column))) {
         noDictionaryDims :+= field.column
         dimFields += field
-      } else if (isDetectAsDimentionDatatype(field.dataType.get)) {
+      } else if (isDetectAsDimentionDataType(field.dataType.get)) {
         dimFields += field
         // consider all String cols as noDicitonaryDims by default
         if (DataTypes.STRING.getName.equalsIgnoreCase(field.dataType.get)) {
@@ -922,7 +922,7 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
    *
    * @param dimensionDatatype
    */
-  def isDetectAsDimentionDatatype(dimensionDatatype: String): Boolean = {
+  def isDetectAsDimentionDataType(dimensionDatatype: String): Boolean = {
     val dimensionType = Array("string", "array", "struct", "map", "timestamp", "date", "char")
     dimensionType.exists(x => dimensionDatatype.toLowerCase.contains(x))
   }
@@ -1138,8 +1138,8 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
 
     // Validate ESCAPECHAR length
     if (options.exists(_._1.equalsIgnoreCase("ESCAPECHAR"))) {
-      val escapechar: String = options.get("escapechar").get.head._2
-      if (escapechar.length > 1 && !CarbonLoaderUtil.isValidEscapeSequence(escapechar)) {
+      val escapeChar: String = options.get("escapechar").get.head._2
+      if (escapeChar.length > 1 && !CarbonLoaderUtil.isValidEscapeSequence(escapeChar)) {
         throw new MalformedCarbonCommandException("ESCAPECHAR cannot be more than one character.")
       }
     }
@@ -1192,7 +1192,7 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
 
     // check for duplicate options
     val duplicateOptions = options filter {
-      case (_, optionlist) => optionlist.size > 1
+      case (_, optionList) => optionList.size > 1
     }
     val duplicates = StringBuilder.newBuilder
     if (duplicateOptions.nonEmpty) {

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
@@ -514,7 +514,7 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
     if (!nullColumnErr.isEmpty) {
       val errMsg = s"long_string_columns: ${
         nullColumnErr.mkString(",")
-      } does not exist in table. Please check create table statement."
+      } does not exist in table. Please check the create table statement."
       throw new MalformedCarbonCommandException(errMsg)
     }
 
@@ -529,7 +529,7 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
     if (!dataTypeErr.isEmpty) {
       val errMsg = s"long_string_columns: ${
         dataTypeErr.mkString(",")
-      } ,its data type is not string. Please check create table statement."
+      } ,its data type is not string. Please check the create table statement."
       throw new MalformedCarbonCommandException(errMsg)
     }
   }
@@ -669,7 +669,7 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
       noInvertedIdxColsProps.foreach { noInvertedIdxColProp =>
         if (!fields.exists(x => x.column.equalsIgnoreCase(noInvertedIdxColProp))) {
           val errorMsg = "NO_INVERTED_INDEX column: " + noInvertedIdxColProp +
-                         " does not exist in table. Please check create table statement."
+                         " does not exist in table. Please check the create table statement."
           throw new MalformedCarbonCommandException(errorMsg)
         }
       }
@@ -698,7 +698,7 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
       invertedIdxColsProps.foreach { invertedIdxColProp =>
         if (!fields.exists(x => x.column.equalsIgnoreCase(invertedIdxColProp))) {
           val errorMsg = "INVERTED_INDEX column: " + invertedIdxColProp +
-                         " does not exist in table. Please check create table statement."
+                         " does not exist in table. Please check the create table statement."
           throw new MalformedCarbonCommandException(errorMsg)
         }
       }
@@ -760,7 +760,7 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
       sortKey.foreach { column =>
         if (!fields.exists(x => x.column.equalsIgnoreCase(column))) {
           val errorMsg = "sort_columns: " + column +
-            " does not exist in table. Please check create table statement."
+            " does not exist in table. Please check the create table statement."
           throw new MalformedCarbonCommandException(errorMsg)
         } else {
           val dataType = fields.find(x =>
@@ -798,7 +798,7 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
           if (!fields.exists(x => x.column.equalsIgnoreCase(dictExcludeCol))) {
             val errorMsg = "DICTIONARY_EXCLUDE column: " + dictExcludeCol +
                            " does not exist in table or unsupported for complex child column. " +
-                           "Please check create table statement."
+                           "Please check the create table statement."
             throw new MalformedCarbonCommandException(errorMsg)
           } else {
             val dataType = fields.find(x =>
@@ -823,7 +823,7 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
         if (!fields.exists(x => x.column.equalsIgnoreCase(distIncludeCol.trim))) {
           val errorMsg = "DICTIONARY_INCLUDE column: " + distIncludeCol.trim +
                          " does not exist in table or unsupported for complex child column. " +
-                         "Please check create table statement."
+                         "Please check the create table statement."
           throw new MalformedCarbonCommandException(errorMsg)
         }
         if (varcharCols.exists(x => x.equalsIgnoreCase(distIncludeCol.trim))) {
@@ -838,7 +838,7 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
     dictExcludeCols.foreach { dicExcludeCol =>
       if (dictIncludeCols.exists(x => x.equalsIgnoreCase(dicExcludeCol))) {
         val errorMsg = "DICTIONARY_EXCLUDE can not contain the same column: " + dicExcludeCol +
-                       " with DICTIONARY_INCLUDE. Please check create table statement."
+                       " with DICTIONARY_INCLUDE. Please check the create table statement."
         throw new MalformedCarbonCommandException(errorMsg)
       }
     }

--- a/integration/spark2/src/main/scala/org/apache/spark/util/AlterTableUtil.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/util/AlterTableUtil.scala
@@ -703,9 +703,9 @@ object AlterTableUtil {
     // check if the column specified exists in table schema
     localDictColumns.foreach { distCol =>
       if (!allColumns.exists(x => x.getColumnName.equalsIgnoreCase(distCol.trim))) {
-        val errormsg = "LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE column: " + distCol.trim +
+        val errorMsg = "LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE column: " + distCol.trim +
                        " does not exist in table. Please check the DDL."
-        throw new MalformedCarbonCommandException(errormsg)
+        throw new MalformedCarbonCommandException(errorMsg)
       }
     }
 


### PR DESCRIPTION
Correct scala variable name in three files：
carbondata\integration\spark-common\src\main\scala\org\apache\spark\sql\catalyst\CarbonDDLSqlParser.scala
carbondata\integration\spark-common\src\main\scala\org\apache\carbondata\spark\util\CarbonScalaUtil.scala
carbondata\integration\spark2\src\main\scala\org\apache\spark\util\AlterTableUtil.scala 

Change variable name from
escapechar -> escapeChar
optionlist -> optionList
hivedefaultpartition -> hiveDefaultPartition
pvalue -> pValue
errormsg -> errorMsg
isDetectAsDimentionDatatype -> isDetectAsDimentionDataType


Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
   No
 - [x] Any backward compatibility impacted?
   No
 - [x] Document update required?
   No
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
    No   
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
    No