### PR TITLE
[HOTFIX][DataLoad]fix task assignment issue using NODE_MIN_SIZE_FIRST block assignment strategy

### DIFF
--- a/processing/src/main/java/org/apache/carbondata/processing/util/CarbonLoaderUtil.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/util/CarbonLoaderUtil.java
@@ -609,6 +609,14 @@ public final class CarbonLoaderUtil {
           blockAssignmentStrategy = BlockAssignmentStrategy.BLOCK_SIZE_FIRST;
         } else {
           blockAssignmentStrategy = BlockAssignmentStrategy.BLOCK_NUM_FIRST;
+          // fall back to BLOCK_NUM_FIRST strategy need to reset
+          // the average expected size for each node
+          if (numOfNodes == 0) {
+            sizePerNode = 1;
+          } else {
+            sizePerNode = blockInfos.size() / numOfNodes;
+            sizePerNode = sizePerNode <= 0 ? 1 : sizePerNode;
+          }
         }
         LOGGER.info("Specified minimum data size to load is less than the average size "
             + "for each node, fallback to default strategy" + blockAssignmentStrategy);


### PR DESCRIPTION
This PR sloves the problem of incorrect assignment of tasks if specified minimum data size to load is less than the average size for each node.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 NA
 - [ ] Any backward compatibility impacted?
 NA
 - [ ] Document update required?
NA
 - [ ] Testing done
 Test OK in local env
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA
