### PR TITLE
[HOTFIX] Exclude filter doesn't work in presto carbon in cluster

### DIFF
--- a/integration/presto/pom.xml
+++ b/integration/presto/pom.xml
@@ -169,10 +169,6 @@
           <artifactId>compress-lzf</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>org.roaringbitmap</groupId>
-          <artifactId>RoaringBitmap</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>com.thoughtworks.paranamer</groupId>
           <artifactId>paranamer</artifactId>
         </exclusion>

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/readers/SliceStreamReader.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/readers/SliceStreamReader.java
@@ -83,6 +83,7 @@ public class SliceStreamReader extends CarbonColumnVectorImpl implements PrestoV
     super.setDictionary(dictionary);
     if (dictionary == null) {
       dictionaryBlock = null;
+      this.isLocalDict = false;
       return;
     }
     boolean[] nulls = new boolean[dictionary.getDictionarySize()];
@@ -144,7 +145,6 @@ public class SliceStreamReader extends CarbonColumnVectorImpl implements PrestoV
 
   @Override public void reset() {
     builder = type.createBlockBuilder(null, batchSize);
-    this.isLocalDict = false;
   }
 
   @Override public void putInt(int rowId, int value) {


### PR DESCRIPTION
**problem1:** Exclude filter fails in cluster for presto carbon with exception.
```
java.lang.NoClassDefFoundError: org/roaringbitmap/RoaringBitmap
        at org.apache.carbondata.core.scan.filter.FilterUtil.prepareExcludeFilterMembers(FilterUtil.java:826)
        at org.apache.carbondata.core.scan.filter.FilterUtil.getDimColumnFilterInfoAfterApplyingCBO(FilterUtil.java:776)
        at org.apache.carbondata.core.scan.filter.FilterUtil.getFilterListForAllValues(FilterUtil.java:884)

```        
**cause:**  RoaringBitmap jar is not added in the dependency, hence it is not present in the presto snapshot folder.
**solution** : include RoaringBitmap in dependency.

**problem2:** Local dictionary reset was not proper in vector for presto slice reader.
**cause** : For each batch local dictionary was resetting. Instead of the actual place reset.
**solution** : reset local dictionary when dictionary is set to null.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed? NA
 
 - [ ] Any backward compatibility impacted? NA
 
 - [ ] Document update required? NA

 - [ ] Testing done. please find the report 
**Before:**
```
presto:default> select name from nbig where name < 'aj' limit 5;
Query 20190109_131447_00004_qhrfk failed: org/roaringbitmap/RoaringBitmap

```
**After:**

```
presto:default> select name from nbig where name < 'aj' limit 5;
  name  
--------
 208    
 150209 
 150210 
 150211 
 150212 
(5 rows)
```

 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. NA

