### PR TITLE
[HOTFIX] Fixed NPE during query with Local Dictionary

### DIFF
--- a/integration/spark-datasource/src/main/spark2.1andspark2.2/org/apache/spark/sql/CarbonVectorProxy.java
+++ b/integration/spark-datasource/src/main/spark2.1andspark2.2/org/apache/spark/sql/CarbonVectorProxy.java
@@ -311,6 +311,7 @@ public class CarbonVectorProxy {
         vector.setDictionary(dictionaryWrapper);
         this.dictionary = dictionaryWrapper;
       } else {
+        this.dictionary = null;
         vector.setDictionary(null);
       }
     }


### PR DESCRIPTION
**Problem:**
Query is failing with NPE when some blocklet encoded with local dictionary and some without local dictionary.
**Root Cause:** 
This is coming because in carbonvectorProxy setDictionary with null it is not setting the dictionary to null because of this it is treated like a local dictionary column but column is not encoded with dictionary.
**Solution:**
Set dictionary to null
 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

