### PR TITLE
[HOTFIX] Fix the compile error when profile is hadoop-2.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -508,7 +508,6 @@
       <id>hadoop-2.8</id>
       <properties>
         <hadoop.version>2.8.3</hadoop.version>
-        <!--<httpclient.version>4.5.2</httpclient.version>-->
       </properties>
     </profile>
     <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -508,7 +508,7 @@
       <id>hadoop-2.8</id>
       <properties>
         <hadoop.version>2.8.3</hadoop.version>
-        <httpclient.version>4.5.2</httpclient.version>
+        <!--<httpclient.version>4.5.2</httpclient.version>-->
       </properties>
     </profile>
     <profile>


### PR DESCRIPTION
remove the version setting:<httpclient.version>4.5.2</httpclient.version> 
because Linux compiler cannot pass,....

Error message org.apache.carbondata -hive:jar:1.5.2 - the
SNAPSHOT:Failure to find org).apache httpcomponents: httpcore:jar:4.5.2
in http://maven.aliyun.com/nexus/content/groups/public/

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

