### PR TITLE
[CARBONDATA-3247] Support to select all columns when creating MV datamap

### DIFF
--- a/datamap/mv/core/src/main/scala/org/apache/carbondata/mv/datamap/MVHelper.scala
+++ b/datamap/mv/core/src/main/scala/org/apache/carbondata/mv/datamap/MVHelper.scala
@@ -42,7 +42,7 @@ import org.apache.carbondata.core.datastore.impl.FileFactory
 import org.apache.carbondata.core.metadata.schema.datamap.DataMapClassProvider
 import org.apache.carbondata.core.metadata.schema.table.{CarbonTable, DataMapSchema, RelationIdentifier}
 import org.apache.carbondata.datamap.DataMapManager
-import org.apache.carbondata.mv.plans.modular.{GroupBy, Matchable, ModularPlan, Select}
+import org.apache.carbondata.mv.plans.modular._
 import org.apache.carbondata.mv.rewrite.{MVPlanWrapper, QueryRewrite, SummaryDatasetCatalog}
 import org.apache.carbondata.spark.util.CommonUtil
 
@@ -292,6 +292,7 @@ object MVHelper {
         g.child match {
           case s: Select =>
             isValidSelect(isValidExp, s)
+          case m: ModularRelation => isValidExp
         }
       case s: Select =>
         isValidSelect(true, s)

--- a/datamap/mv/core/src/main/scala/org/apache/carbondata/mv/rewrite/Navigator.scala
+++ b/datamap/mv/core/src/main/scala/org/apache/carbondata/mv/rewrite/Navigator.scala
@@ -194,6 +194,7 @@ private[mv] class Navigator(catalog: SummaryDatasetCatalog, session: MVSession) 
               return intersetJoinEdges.exists(j => j.left == rIndex && j.left == eIndex ||
                 j.right == rIndex && j.right == eIndex)
             }
+          case _ => false
         }
     }
     true

--- a/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/SelectAllColumnsSuite.scala
+++ b/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/SelectAllColumnsSuite.scala
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.mv.rewrite
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.execution.datasources.LogicalRelation
+import org.apache.spark.sql.test.util.QueryTest
+
+class SelectAllColumnsSuite extends QueryTest {
+
+  test ("table select all columns mv") {
+    sql("drop datamap if exists all_table_mv")
+    sql("drop table if exists all_table")
+    sql("create table all_table(name string, age int, height int)  stored by 'carbondata'")
+    sql("insert into all_table select 'tom',20,175")
+    sql("insert into all_table select 'tom',32,180")
+    sql("create datamap all_table_mv on table all_table using 'mv' as select avg(age),avg(height),name from all_table group by name")
+    sql("rebuild datamap all_table_mv")
+    checkAnswer(
+      sql("select avg(age),avg(height),name from all_table group by name"),
+      Seq(Row(26.0, 177.5, "tom")))
+    val frame = sql("select avg(age),avg(height),name from all_table group by name")
+    val analyzed = frame.queryExecution.analyzed
+    assert(verifyMVDataMap(analyzed, "all_table_mv"))
+    sql("drop table if exists all_table")
+  }
+
+  def verifyMVDataMap(logicalPlan: LogicalPlan, dataMapName: String): Boolean = {
+    val tables = logicalPlan collect {
+      case l: LogicalRelation => l.catalogTable.get
+    }
+    tables.exists(_.identifier.table.equalsIgnoreCase(dataMapName+"_table"))
+  }
+
+}

--- a/datamap/mv/plan/src/main/scala/org/apache/carbondata/mv/plans/modular/ModularPlan.scala
+++ b/datamap/mv/plan/src/main/scala/org/apache/carbondata/mv/plans/modular/ModularPlan.scala
@@ -125,6 +125,8 @@ abstract class ModularPlan
       case modular.Select(_, _, _, _, _, children, _, _, _, _)
         if children.forall(_.isInstanceOf[modular.LeafNode]) => true
 
+      case modular.GroupBy(_, _, _, _, modular.ModularRelation(_, _, _, _, _), _, _, _) => true
+
       case _ => false
     }
   }


### PR DESCRIPTION
[Problem]
"create table all_table(name string, age int, height int) stored by 'carbondata'"
"create datamap all_table_mv on table all_table using 'mv' as select avg(age),avg(height),name from all_table group by name"
throw UnsupportedOperationException("MV is not supported for this query")

[Cause]
ColumnPruning rule will not generate Project LogicalPlan when select all columns, So carbon can't generate SELECT node when transforming LogicalPlan to ModularPlan, then it can't create mv datamap

[Solution]
Add a executor rule to change the logical plan to support this scene

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [x] Testing done
        Add a new test case
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

