### PR TITLE
[CARBONDATA-3261] support float and byte data type reading from presto carbon

### DIFF
--- a/integration/presto/src/main/java/org/apache/carbondata/presto/CarbonVectorBatch.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/CarbonVectorBatch.java
@@ -28,8 +28,10 @@ import org.apache.carbondata.core.metadata.datatype.DecimalType;
 import org.apache.carbondata.core.metadata.datatype.StructField;
 import org.apache.carbondata.core.scan.result.vector.impl.CarbonColumnVectorImpl;
 import org.apache.carbondata.presto.readers.BooleanStreamReader;
+import org.apache.carbondata.presto.readers.ByteStreamReader;
 import org.apache.carbondata.presto.readers.DecimalSliceStreamReader;
 import org.apache.carbondata.presto.readers.DoubleStreamReader;
+import org.apache.carbondata.presto.readers.FloatStreamReader;
 import org.apache.carbondata.presto.readers.IntegerStreamReader;
 import org.apache.carbondata.presto.readers.LongStreamReader;
 import org.apache.carbondata.presto.readers.ObjectStreamReader;
@@ -89,6 +91,10 @@ public class CarbonVectorBatch {
       return new LongStreamReader(batchSize, field.getDataType(), dictionary);
     } else if (dataType == DataTypes.DOUBLE) {
       return new DoubleStreamReader(batchSize, field.getDataType(), dictionary);
+    } else if (dataType == DataTypes.FLOAT) {
+      return new FloatStreamReader(batchSize, field.getDataType(), dictionary);
+    } else if (dataType == DataTypes.BYTE) {
+      return new ByteStreamReader(batchSize, field.getDataType(), dictionary);
     } else if (dataType == DataTypes.STRING) {
       return new SliceStreamReader(batchSize, field.getDataType(), dictionary);
     } else if (DataTypes.isDecimal(dataType)) {

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/PrestoCarbonVectorizedRecordReader.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/PrestoCarbonVectorizedRecordReader.java
@@ -26,7 +26,6 @@ import org.apache.carbondata.core.cache.dictionary.Dictionary;
 import org.apache.carbondata.core.datastore.block.TableBlockInfo;
 import org.apache.carbondata.core.keygenerator.directdictionary.DirectDictionaryGenerator;
 import org.apache.carbondata.core.keygenerator.directdictionary.DirectDictionaryKeyGeneratorFactory;
-import org.apache.carbondata.core.metadata.datatype.DataType;
 import org.apache.carbondata.core.metadata.datatype.DataTypes;
 import org.apache.carbondata.core.metadata.datatype.StructField;
 import org.apache.carbondata.core.metadata.encoder.Encoding;
@@ -201,17 +200,8 @@ class PrestoCarbonVectorizedRecordReader extends AbstractRecordReader<Object> {
     }
 
     for (ProjectionMeasure msr : queryMeasures) {
-      DataType dataType = msr.getMeasure().getDataType();
-      if (dataType == DataTypes.BOOLEAN || dataType == DataTypes.SHORT || dataType == DataTypes.INT
-          || dataType == DataTypes.LONG) {
-        fields[msr.getOrdinal()] =
-            new StructField(msr.getColumnName(), msr.getMeasure().getDataType());
-      } else if (DataTypes.isDecimal(dataType)) {
-        fields[msr.getOrdinal()] =
-            new StructField(msr.getColumnName(), msr.getMeasure().getDataType());
-      } else {
-        fields[msr.getOrdinal()] = new StructField(msr.getColumnName(), DataTypes.DOUBLE);
-      }
+      fields[msr.getOrdinal()] =
+          new StructField(msr.getColumnName(), msr.getMeasure().getDataType());
     }
 
     columnarBatch =

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/readers/ByteStreamReader.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/readers/ByteStreamReader.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.presto.readers;
+
+import org.apache.carbondata.core.cache.dictionary.Dictionary;
+import org.apache.carbondata.core.metadata.datatype.DataType;
+import org.apache.carbondata.core.metadata.datatype.DataTypes;
+import org.apache.carbondata.core.scan.result.vector.impl.CarbonColumnVectorImpl;
+import org.apache.carbondata.core.util.DataTypeUtil;
+
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.type.AbstractType;
+import com.facebook.presto.spi.type.TinyintType;
+
+/**
+ * Class for Reading the Byte(tiny int) value and setting it in Block
+ */
+public class ByteStreamReader extends CarbonColumnVectorImpl implements PrestoVectorBlockBuilder {
+
+  protected int batchSize;
+
+  protected AbstractType type = TinyintType.TINYINT;
+
+  protected BlockBuilder builder;
+
+  private Dictionary dictionary;
+
+
+  public ByteStreamReader(int batchSize, DataType dataType, Dictionary dictionary) {
+    super(batchSize, dataType);
+    this.batchSize = batchSize;
+    this.builder = type.createBlockBuilder(null, batchSize);
+    this.dictionary = dictionary;
+  }
+
+  @Override public Block buildBlock() {
+    return builder.build();
+  }
+
+  @Override public void setBatchSize(int batchSize) {
+    this.batchSize = batchSize;
+  }
+
+  @Override public void putInt(int rowId, int value) {
+    Object data = DataTypeUtil
+        .getDataBasedOnDataType(dictionary.getDictionaryValueForKey(value), DataTypes.BYTE);
+    if (data != null) {
+      type.writeLong(builder, (byte) data);
+    } else {
+      builder.appendNull();
+    }
+  }
+
+  @Override public void putByte(int rowId, byte value) {
+    type.writeLong(builder, value);
+  }
+
+  @Override public void putBytes(int rowId, int count, byte[] src, int srcIndex) {
+    for (int i = srcIndex; i < count; i++) {
+      type.writeLong(builder, src[i]);
+    }
+  }
+
+  @Override public void putNull(int rowId) {
+    builder.appendNull();
+  }
+
+  @Override public void putNulls(int rowId, int count) {
+    for (int i = 0; i < count; i++) {
+      builder.appendNull();
+    }
+  }
+
+  @Override public void reset() {
+    builder = type.createBlockBuilder(null, batchSize);
+  }
+
+  @Override public void putObject(int rowId, Object value) {
+    if (value == null) {
+      putNull(rowId);
+    } else {
+      if (dictionary == null) {
+        putByte(rowId, (byte) value);
+      } else {
+        putInt(rowId, (int) value);
+      }
+    }
+  }
+}

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/readers/FloatStreamReader.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/readers/FloatStreamReader.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.presto.readers;
+
+import org.apache.carbondata.core.cache.dictionary.Dictionary;
+import org.apache.carbondata.core.metadata.datatype.DataType;
+import org.apache.carbondata.core.metadata.datatype.DataTypes;
+import org.apache.carbondata.core.scan.result.vector.impl.CarbonColumnVectorImpl;
+import org.apache.carbondata.core.util.DataTypeUtil;
+
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+import com.facebook.presto.spi.type.AbstractType;
+import com.facebook.presto.spi.type.RealType;
+
+/**
+ * Class for Reading the Float(real) value and setting it in Block
+ */
+public class FloatStreamReader extends CarbonColumnVectorImpl implements PrestoVectorBlockBuilder {
+
+  protected int batchSize;
+
+  protected AbstractType type = RealType.REAL;
+
+  protected BlockBuilder builder;
+
+  private Dictionary dictionary;
+
+
+  public FloatStreamReader(int batchSize, DataType dataType, Dictionary dictionary) {
+    super(batchSize, dataType);
+    this.batchSize = batchSize;
+    this.builder = type.createBlockBuilder(null, batchSize);
+    this.dictionary = dictionary;
+  }
+
+  @Override public Block buildBlock() {
+    return builder.build();
+  }
+
+  @Override public void setBatchSize(int batchSize) {
+    this.batchSize = batchSize;
+  }
+
+  @Override public void putInt(int rowId, int value) {
+    Object data = DataTypeUtil
+        .getDataBasedOnDataType(dictionary.getDictionaryValueForKey(value), DataTypes.FLOAT);
+    if (data != null) {
+      type.writeLong(builder, (long)Float.floatToRawIntBits((float)data));
+    } else {
+      builder.appendNull();
+    }
+  }
+
+  @Override public void putFloat(int rowId, float value) {
+    type.writeLong(builder, (long)Float.floatToRawIntBits(value));
+  }
+
+  @Override public void putFloats(int rowId, int count, float[] src, int srcIndex) {
+    for (int i = srcIndex; i < count; i++) {
+      type.writeLong(builder, (long)Float.floatToRawIntBits(src[i]));
+    }
+  }
+
+  @Override public void putNull(int rowId) {
+    builder.appendNull();
+  }
+
+  @Override public void putNulls(int rowId, int count) {
+    for (int i = 0; i < count; i++) {
+      builder.appendNull();
+    }
+  }
+
+  @Override public void reset() {
+    builder = type.createBlockBuilder(null, batchSize);
+  }
+
+  @Override public void putObject(int rowId, Object value) {
+    if (value == null) {
+      putNull(rowId);
+    } else {
+      if (dictionary == null) {
+        putFloat(rowId, (float) value);
+      } else {
+        putInt(rowId, (int) value);
+      }
+    }
+  }
+}


### PR DESCRIPTION
[CARBONDATA-3261] support float and byte data type reading from presto

**problem:** support float and byte reading from presto

**cause:** currently float and byte cannot be read in presto due to code issue. It was going as double data type. Hence array out of bound issue used to come as float/byte read from double stream reader.

**solution:** Implement a new stream reader for float and byte.
Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed? NA
 
 - [ ] Any backward compatibility impacted? NA
 
 - [ ] Document update required? NA

 - [ ] Testing done. Added UT.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. NA
