### PR TITLE
[CARBONDATA-2447] Block update operation on range/list/hash partition table

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/partition/TestUpdateForPartitionTable.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/partition/TestUpdateForPartitionTable.scala
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.spark.testsuite.partition
+
+import org.apache.spark.sql.test.util.QueryTest
+import org.scalatest. BeforeAndAfterAll
+
+class TestUpdateForPartitionTable extends QueryTest with BeforeAndAfterAll {
+
+  override def beforeAll: Unit = {
+    dropTable
+
+    sql("create table test_range_partition_table (id int) partitioned by (name string) " +
+      "stored by 'carbondata' TBLPROPERTIES('PARTITION_TYPE' = 'RANGE','RANGE_INFO' = 'a,e,f')")
+    sql("create table test_hive_partition_table (id int) partitioned by (name string) " +
+      "stored by 'carbondata'")
+    sql("create table test_hash_partition_table (id int) partitioned by (name string) " +
+      "stored by 'carbondata' TBLPROPERTIES('PARTITION_TYPE' = 'HASH','NUM_PARTITIONS' = '2')")
+    sql("create table test_list_partition_table (id int) partitioned by (name string) " +
+      "stored by 'carbondata' TBLPROPERTIES('PARTITION_TYPE' = 'LIST','LIST_INFO' = 'a,e,f')")
+  }
+
+  def dropTable = {
+    sql("drop table if exists test_hash_partition_table")
+    sql("drop table if exists test_list_partition_table")
+    sql("drop table if exists test_range_partition_table")
+    sql("drop table if exists test_hive_partition_table")
+  }
+
+
+  test ("test update for unsupported partition table") {
+    val updateTables = Array(
+      "test_range_partition_table",
+      "test_list_partition_table",
+      "test_hash_partition_table")
+
+    updateTables.foreach(table => {
+      sql("insert into " + table + " select 1,'b' ")
+      val ex = intercept[UnsupportedOperationException] {
+        sql("update " + table + " set (name) = ('c') where id = 1").collect()
+      }
+      assertResult("Unsupported update operation for range/hash/list partition table")(ex.getMessage)
+    })
+
+  }
+
+  test ("test update for hive(standard) partition table") {
+
+    sql("insert into test_hive_partition_table select 1,'b' ")
+    sql("update test_hive_partition_table set (name) = ('c') where id = 1").collect()
+    assertResult(1)(sql("select * from test_hive_partition_table where name = 'c'").collect().length)
+  }
+
+  override def afterAll() : Unit = {
+    dropTable
+  }
+}

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/mutation/CarbonProjectForUpdateCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/mutation/CarbonProjectForUpdateCommand.scala
@@ -32,7 +32,7 @@ import org.apache.carbondata.core.datamap.Segment
 import org.apache.carbondata.core.exception.ConcurrentOperationException
 import org.apache.carbondata.core.features.TableOperation
 import org.apache.carbondata.core.locks.{CarbonLockFactory, CarbonLockUtil, LockUsage}
-import org.apache.carbondata.core.metadata.schema.table.CarbonTable
+import org.apache.carbondata.core.metadata.schema.partition.PartitionType
 import org.apache.carbondata.core.mutate.CarbonUpdateUtil
 import org.apache.carbondata.core.statusmanager.SegmentStatusManager
 import org.apache.carbondata.core.util.CarbonProperties
@@ -60,6 +60,13 @@ private[sql] case class CarbonProjectForUpdateCommand(
       return Seq.empty
     }
     val carbonTable = CarbonEnv.getCarbonTable(databaseNameOp, tableName)(sparkSession)
+    if (carbonTable.getPartitionInfo != null &&
+      (carbonTable.getPartitionInfo.getPartitionType == PartitionType.RANGE ||
+        carbonTable.getPartitionInfo.getPartitionType == PartitionType.HASH ||
+        carbonTable.getPartitionInfo.getPartitionType == PartitionType.LIST)) {
+      throw new UnsupportedOperationException("Unsupported update operation for range/" +
+        "hash/list partition table")
+    }
     setAuditTable(carbonTable)
     setAuditInfo(Map("plan" -> plan.simpleString))
     columns.foreach { col =>


### PR DESCRIPTION
[problem]
when update the data on range partition table, it will lost data or update failed , see the jira or new test case

[Cause]
Range partition table take taskNo in filename as partitionId, when update the taskNo is inscreasing ,the taskNo didn't changed with partitionId

[Solution]
(1) When query the range partition table, don't match the partitionid ---this method losses the meaning of partition
(2) Range partition table use directory or seperate part as partitionid  ---this is not necessary and suggest to use standard partition
(3) Range partition table doesn't support update opretion  ---this PR use this method

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [x] Testing done
       Add
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

