### PR TITLE
[CARBONDATA-3267]Fixed Range Sort OOM Issue 

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/memory/IntPointerBuffer.java
+++ b/core/src/main/java/org/apache/carbondata/core/memory/IntPointerBuffer.java
@@ -75,17 +75,17 @@ public class IntPointerBuffer {
   }
 
   public void loadToUnsafe() {
-    try {
-      pointerMemoryBlock =
-          UnsafeSortMemoryManager.allocateMemoryWithRetry(this.taskId, pointerBlock.length * 4);
+    pointerMemoryBlock =
+        UnsafeSortMemoryManager.INSTANCE.allocateMemory(this.taskId, pointerBlock.length * 4);
+    // pointerMemoryBlock it means sort storage memory manager does not have space to loaf pointer
+    // buffer in that case use pointerBlock
+    if (null != pointerMemoryBlock) {
       for (int i = 0; i < pointerBlock.length; i++) {
         CarbonUnsafe.getUnsafe()
             .putInt(pointerMemoryBlock.getBaseObject(), pointerMemoryBlock.getBaseOffset() + i * 4,
                 pointerBlock[i]);
       }
       pointerBlock = null;
-    } catch (MemoryException e) {
-      LOGGER.warn("Not enough memory for allocating pointer buffer, sorting in heap");
     }
   }
 

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/sort/impl/UnsafeParallelReadMergeSorterImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/sort/impl/UnsafeParallelReadMergeSorterImpl.java
@@ -85,9 +85,7 @@ public class UnsafeParallelReadMergeSorterImpl extends AbstractMergeSorter {
     } catch (Exception e) {
       throw new CarbonDataLoadingException(e);
     }
-    // setting the number of cores to 1 in case of range sort
-    int numberOfCores = sortParameters.isRangeSort() ? 1 : iterators.length;
-    this.executorService = Executors.newFixedThreadPool(numberOfCores,
+    this.executorService = Executors.newFixedThreadPool(iterators.length,
         new CarbonThreadFactory("UnsafeParallelSorterPool:" + sortParameters.getTableName()));
     this.threadStatusObserver = new ThreadStatusObserver(executorService);
 

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/sort/impl/UnsafeParallelReadMergeSorterImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/sort/impl/UnsafeParallelReadMergeSorterImpl.java
@@ -85,7 +85,9 @@ public class UnsafeParallelReadMergeSorterImpl extends AbstractMergeSorter {
     } catch (Exception e) {
       throw new CarbonDataLoadingException(e);
     }
-    this.executorService = Executors.newFixedThreadPool(iterators.length,
+    // setting the number of cores to 1 in case of range sort
+    int numberOfCores = sortParameters.isRangeSort() ? 1 : iterators.length;
+    this.executorService = Executors.newFixedThreadPool(numberOfCores,
         new CarbonThreadFactory("UnsafeParallelSorterPool:" + sortParameters.getTableName()));
     this.threadStatusObserver = new ThreadStatusObserver(executorService);
 

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/sort/unsafe/UnsafeCarbonRowPage.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/sort/unsafe/UnsafeCarbonRowPage.java
@@ -42,8 +42,6 @@ public class UnsafeCarbonRowPage {
 
   private MemoryBlock dataBlock;
 
-  private boolean saveToDisk;
-
   private MemoryManagerType managerType;
 
   private String taskId;
@@ -53,10 +51,9 @@ public class UnsafeCarbonRowPage {
   private boolean convertNoSortFields;
 
   public UnsafeCarbonRowPage(TableFieldStat tableFieldStat, MemoryBlock memoryBlock,
-      boolean saveToDisk, String taskId) {
+      String taskId) {
     this.tableFieldStat = tableFieldStat;
     this.sortStepRowHandler = new SortStepRowHandler(tableFieldStat);
-    this.saveToDisk = saveToDisk;
     this.taskId = taskId;
     buffer = new IntPointerBuffer(this.taskId);
     this.dataBlock = memoryBlock;
@@ -124,10 +121,6 @@ public class UnsafeCarbonRowPage {
         UnsafeSortMemoryManager.INSTANCE.freeMemory(taskId, dataBlock);
         buffer.freeMemory();
     }
-  }
-
-  public boolean isSaveToDisk() {
-    return saveToDisk;
   }
 
   public IntPointerBuffer getBuffer() {

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/sort/unsafe/merger/UnsafeIntermediateMerger.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/sort/unsafe/merger/UnsafeIntermediateMerger.java
@@ -140,7 +140,7 @@ public class UnsafeIntermediateMerger {
     mergerTask.add(executorService.submit(merger));
   }
 
-  public void tryTriggerInmemoryMerging(boolean spillDisk)
+  public void tryTriggerInMemoryMerging(boolean spillDisk)
       throws CarbonSortKeyAndGroupByException {
     List<UnsafeCarbonRowPage> pages2Merge = new ArrayList<>();
     int totalRows2Merge = 0;
@@ -170,7 +170,7 @@ public class UnsafeIntermediateMerger {
 
   public void startInmemoryMergingIfPossible() throws CarbonSortKeyAndGroupByException {
     if (rowPages.size() >= parameters.getNumberOfIntermediateFileToBeMerged()) {
-      tryTriggerInmemoryMerging(false);
+      tryTriggerInMemoryMerging(false);
     }
   }
 

--- a/processing/src/main/java/org/apache/carbondata/processing/sort/sortdata/SortParameters.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/sort/sortdata/SortParameters.java
@@ -144,8 +144,6 @@ public class SortParameters implements Serializable {
    */
   private CarbonTable carbonTable;
 
-  private boolean isRangeSort;
-
   public SortParameters getCopy() {
     SortParameters parameters = new SortParameters();
     parameters.tempFileLocation = tempFileLocation;
@@ -180,7 +178,6 @@ public class SortParameters implements Serializable {
     parameters.batchSortSizeinMb = batchSortSizeinMb;
     parameters.rangeId = rangeId;
     parameters.carbonTable = carbonTable;
-    parameters.isRangeSort = isRangeSort;
     return parameters;
   }
 
@@ -444,9 +441,6 @@ public class SortParameters implements Serializable {
 
     parameters.setTempFileLocation(sortTempDirs);
     LOGGER.info("temp file location: " + StringUtils.join(parameters.getTempFileLocation(), ","));
-
-    parameters
-        .setIsRangeSort(configuration.getTableSpec().getCarbonTable().getRangeColumn() != null);
     int numberOfCores = 1;
     // In case of loading from partition we should use the cores specified by it
     if (configuration.getWritingCoresCount() > 0) {
@@ -490,13 +484,6 @@ public class SortParameters implements Serializable {
     this.rangeId = rangeId;
   }
 
-  public boolean isRangeSort() {
-    return isRangeSort;
-  }
-
-  public void setIsRangeSort(boolean isRangeSort) {
-    this.isRangeSort = isRangeSort;
-  }
   public static SortParameters createSortParameters(CarbonTable carbonTable, String databaseName,
       String tableName, int dimColCount, int complexDimColCount, int measureColCount,
       int noDictionaryCount, String segmentId, String taskNo, boolean[] noDictionaryColMaping,

--- a/processing/src/main/java/org/apache/carbondata/processing/sort/sortdata/SortParameters.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/sort/sortdata/SortParameters.java
@@ -144,6 +144,8 @@ public class SortParameters implements Serializable {
    */
   private CarbonTable carbonTable;
 
+  private boolean isRangeSort;
+
   public SortParameters getCopy() {
     SortParameters parameters = new SortParameters();
     parameters.tempFileLocation = tempFileLocation;
@@ -178,6 +180,7 @@ public class SortParameters implements Serializable {
     parameters.batchSortSizeinMb = batchSortSizeinMb;
     parameters.rangeId = rangeId;
     parameters.carbonTable = carbonTable;
+    parameters.isRangeSort = isRangeSort;
     return parameters;
   }
 
@@ -442,6 +445,8 @@ public class SortParameters implements Serializable {
     parameters.setTempFileLocation(sortTempDirs);
     LOGGER.info("temp file location: " + StringUtils.join(parameters.getTempFileLocation(), ","));
 
+    parameters
+        .setIsRangeSort(configuration.getTableSpec().getCarbonTable().getRangeColumn() != null);
     int numberOfCores = 1;
     // In case of loading from partition we should use the cores specified by it
     if (configuration.getWritingCoresCount() > 0) {
@@ -485,6 +490,13 @@ public class SortParameters implements Serializable {
     this.rangeId = rangeId;
   }
 
+  public boolean isRangeSort() {
+    return isRangeSort;
+  }
+
+  public void setIsRangeSort(boolean isRangeSort) {
+    this.isRangeSort = isRangeSort;
+  }
   public static SortParameters createSortParameters(CarbonTable carbonTable, String databaseName,
       String tableName, int dimColCount, int complexDimColCount, int measureColCount,
       int noDictionaryCount, String segmentId, String taskNo, boolean[] noDictionaryColMaping,


### PR DESCRIPTION

### Problem:
Range sort is failing with OOM.
### Root cause:
This is because UnsafeSortStorageMemory is not able to control the off heap memory because of this when huge data is loaded it OOM exception is coming fron UnsafeMemoryAllocator.allocate.
### Solution:
Added code code to control Sort Storage memory. After sorting the rows if memory is available then only add sorted records to sort storage memory otherwise write to disk

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

