### PR TITLE
[CARBONDATA-3235] Fixed Alter Table Rename

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/schema/CarbonAlterTableRenameCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/schema/CarbonAlterTableRenameCommand.scala
@@ -169,9 +169,9 @@ private[sql] case class CarbonAlterTableRenameCommand(
       case e: Exception =>
         if (hiveRenameSuccess) {
           sparkSession.sessionState.catalog.asInstanceOf[CarbonSessionCatalog].alterTableRename(
-            newTableIdentifier,
-            oldTableIdentifier,
-            carbonTable.getAbsoluteTableIdentifier.getTableName)
+            TableIdentifier(newTableName, Some(oldDatabaseName)),
+            TableIdentifier(oldTableName, Some(oldDatabaseName)),
+            carbonTable.getAbsoluteTableIdentifier.getTablePath)
         }
         if (carbonTable != null) {
           AlterTableUtil.revertRenameTableChanges(


### PR DESCRIPTION
Fixed a mistake in [PR-2996](https://github.com/apache/carbondata/pull/2996). 

Fixed negative scenario: **Alter Table Rename Table Fail**

Problem: _When tabe rename is success in hive, for failed in carbon data store, it would throw exception, but would not go back and undo rename in hive._

Solution: _A flag to keep check if hive rename has already executed, and of the code breaks after hive rename is done, go back and undo the hive rename._


 - [x] Any interfaces changed?   ->  No
 - [x] Any backward compatibility impacted?  -> No
 - [x] Document update required?  ->  No
 - [x] Testing done  ->  Yes
