### PR TITLE
[CARBONDATA-3268] Fix for query on Varchar Columns showing Null in Presto

### DIFF
--- a/integration/presto/src/main/java/org/apache/carbondata/presto/CarbonVectorBatch.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/CarbonVectorBatch.java
@@ -95,7 +95,7 @@ public class CarbonVectorBatch {
       return new FloatStreamReader(batchSize, field.getDataType(), dictionary);
     } else if (dataType == DataTypes.BYTE) {
       return new ByteStreamReader(batchSize, field.getDataType(), dictionary);
-    } else if (dataType == DataTypes.STRING) {
+    } else if (dataType == DataTypes.STRING || dataType == DataTypes.VARCHAR) {
       return new SliceStreamReader(batchSize, field.getDataType(), dictionary);
     } else if (DataTypes.isDecimal(dataType)) {
       if (dataType instanceof DecimalType) {


### PR DESCRIPTION
Problem: Select query on Varchar columns shows null in Presto as it was going to ObjectStreamReader instead of SliceStreamReader. 

Solution: Handled the scenario by adding a check for Varchar while creating StreamReader.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed? -> NO
 
 - [x] Any backward compatibility impacted? -> NO
 
 - [x] Document update required? -> NO

 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

