### PR TITLE
[CARBONDATA-3269] Fix ArrayIndexOutOfBoundsException of Range_Column when using KryoSerializer

### DIFF
--- a/integration/spark-common/src/main/scala/org/apache/spark/DataSkewRangePartitioner.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/DataSkewRangePartitioner.scala
@@ -202,7 +202,7 @@ class DataSkewRangePartitioner[K: Ordering : ClassTag, V](
     }
   }
 
-  private val skewPartitions: Int = if (skewCount == 0) {
+  private var skewPartitions: Int = if (skewCount == 0) {
     0
   } else {
     skewWeights.map(_ - 1).sum
@@ -307,6 +307,7 @@ class DataSkewRangePartitioner[K: Ordering : ClassTag, V](
         case js: JavaSerializer => out.defaultWriteObject()
         case _ =>
           out.writeInt(skewCount)
+          out.writeInt(skewPartitions)
           if (skewCount > 0) {
             out.writeObject(skewIndexes)
             out.writeObject(skewWeights)
@@ -332,6 +333,7 @@ class DataSkewRangePartitioner[K: Ordering : ClassTag, V](
         case js: JavaSerializer => in.defaultReadObject()
         case _ =>
           skewCount = in.readInt()
+          skewPartitions = in.readInt()
           if (skewCount > 0) {
             skewIndexes = in.readObject().asInstanceOf[Array[Int]]
             skewWeights = in.readObject().asInstanceOf[Array[Int]]


### PR DESCRIPTION
Fix ArrayIndexOutOfBoundsException of Range_Column when using KryoSerializer

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

