### PR TITLE
[CARBONDATA-3270] MV support groupby columns don't need be existed in the projection

### DIFF
--- a/datamap/mv/core/src/main/scala/org/apache/carbondata/mv/datamap/MVDataMapProvider.scala
+++ b/datamap/mv/core/src/main/scala/org/apache/carbondata/mv/datamap/MVDataMapProvider.scala
@@ -33,6 +33,7 @@ import org.apache.carbondata.core.datamap.{DataMapCatalog, DataMapProvider, Data
 import org.apache.carbondata.core.datamap.dev.{DataMap, DataMapFactory}
 import org.apache.carbondata.core.indexstore.Blocklet
 import org.apache.carbondata.core.metadata.schema.table.{CarbonTable, DataMapSchema}
+import org.apache.carbondata.mv.plans.util.MVSQLOptimizer
 import org.apache.carbondata.mv.rewrite.{SummaryDataset, SummaryDatasetCatalog}
 
 @InterfaceAudience.Internal
@@ -89,7 +90,7 @@ class MVDataMapProvider(
         }
       val updatedQuery = new CarbonSpark2SqlParser().addPreAggFunction(ctasQuery)
       val queryPlan = SparkSQLUtil.execute(
-        sparkSession.sql(updatedQuery).queryExecution.analyzed,
+        MVSQLOptimizer.execute(sparkSession.sql(updatedQuery).queryExecution.analyzed),
         sparkSession).drop("preAgg")
       val header = logicalPlan.output.map(_.name).mkString(",")
       val loadCommand = CarbonLoadDataCommand(

--- a/datamap/mv/core/src/main/scala/org/apache/carbondata/mv/rewrite/Navigator.scala
+++ b/datamap/mv/core/src/main/scala/org/apache/carbondata/mv/rewrite/Navigator.scala
@@ -17,11 +17,12 @@
 
 package org.apache.carbondata.mv.rewrite
 
-import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeMap, AttributeSet}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeMap}
 
 import org.apache.carbondata.mv.expressions.modular._
 import org.apache.carbondata.mv.plans.modular.{GroupBy, ModularPlan, Select}
 import org.apache.carbondata.mv.plans.modular
+import org.apache.carbondata.mv.plans.util.MVSQLOptimizer
 import org.apache.carbondata.mv.session.MVSession
 
 private[mv] class Navigator(catalog: SummaryDatasetCatalog, session: MVSession) {
@@ -49,8 +50,8 @@ private[mv] class Navigator(catalog: SummaryDatasetCatalog, session: MVSession) 
         else {
           val compensation =
             (for { dataset <- catalog.lookupFeasibleSummaryDatasets(currentFragment).toStream
-                   subsumer <- session.sessionState.modularizer.modularize(
-                     session.sessionState.optimizer.execute(dataset.plan)).map(_.semiHarmonized)
+                   subsumer <- session.sessionState.modularizer.modularize(MVSQLOptimizer.execute(
+                     session.sessionState.optimizer.execute(dataset.plan))).map(_.semiHarmonized)
                    subsumee <- unifySubsumee(currentFragment)
                    comp <- subsume(
                      unifySubsumer2(

--- a/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/MVCreateTestCase.scala
+++ b/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/MVCreateTestCase.scala
@@ -826,19 +826,16 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     sql("drop datamap if exists mv_unional")
   }
 
-  test("jira carbondata-2533") {
-
+  test("jira carbondata-2533 and jira carbondata-3270") {
     sql("drop datamap if exists MV_exp")
-    intercept[UnsupportedOperationException] {
-      sql(
-        "create datamap MV_exp using 'mv' as select sum(case when deptno=11 and (utilization=92) then salary else 0 end) as t from fact_table1 group by empname")
+    sql(
+      "create datamap MV_exp using 'mv' as select sum(case when deptno=11 and (utilization=92) then salary else 0 end) as t from fact_table1 group by empname")
 
-      sql("rebuild datamap MV_exp")
-      val frame = sql(
-        "select sum(case when deptno=11 and (utilization=92) then salary else 0 end) as t from fact_table1 group by empname")
-      val analyzed = frame.queryExecution.analyzed
-      assert(verifyMVDataMap(analyzed, "MV_exp"))
-    }
+    sql("rebuild datamap MV_exp")
+    val frame = sql(
+      "select sum(case when deptno=11 and (utilization=92) then salary else 0 end) as t from fact_table1 group by empname")
+    val analyzed = frame.queryExecution.analyzed
+    assert(verifyMVDataMap(analyzed, "MV_exp"))
     sql("drop datamap if exists MV_exp")
   }
 

--- a/datamap/mv/plan/src/main/scala/org/apache/carbondata/mv/plans/util/MVAddGroupByColsToProjection.scala
+++ b/datamap/mv/plan/src/main/scala/org/apache/carbondata/mv/plans/util/MVAddGroupByColsToProjection.scala
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.mv.plans.util
+
+import org.apache.spark.sql.catalyst.expressions.{Alias, NamedExpression}
+import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, LogicalPlan}
+import org.apache.spark.sql.catalyst.rules.Rule
+
+// mv sql add the group column to projection list
+// when projection list do not contain
+object MVAddGroupByColsToProjection extends Rule[LogicalPlan]{
+
+  override def apply(plan: LogicalPlan): LogicalPlan = {
+    plan match {
+      case agg : Aggregate =>
+        var newAgg : Option[Aggregate] = None
+        if (agg.groupingExpressions.nonEmpty) {
+          agg.groupingExpressions.foreach(groupExp => {
+            if (!agg.aggregateExpressions.exists {
+              case alias: Alias => alias.semanticEquals(groupExp) ||
+                alias.child.semanticEquals(groupExp)
+              case other => other.semanticEquals(groupExp)
+            }) {
+              newAgg = Some(agg.copy(aggregateExpressions =
+                agg.aggregateExpressions :+ groupExp.asInstanceOf[NamedExpression]))
+            }
+          })
+        }
+        newAgg.getOrElse(plan)
+      case _ => plan
+    }
+  }
+}

--- a/datamap/mv/plan/src/main/scala/org/apache/carbondata/mv/plans/util/MVSQLOptimizer.scala
+++ b/datamap/mv/plan/src/main/scala/org/apache/carbondata/mv/plans/util/MVSQLOptimizer.scala
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.mv.plans.util
+
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.rules.RuleExecutor
+
+// used to optimize the mv sql
+object MVSQLOptimizer extends RuleExecutor[LogicalPlan] {
+  override protected def batches: Seq[MVSQLOptimizer.Batch] = {
+    Batch("Add projection", Once, MVAddGroupByColsToProjection) :: Nil
+  }
+}


### PR DESCRIPTION
【Problem】
this sql throws UnsupportedOperationException("Group by columns must be present in project columns")
`create table mv_groupby_main(name string,height int,age int) stored by 'carbondata';
create datamap mv_groupby_main_mv using 'mv' as select sum(height) from mv_groupby_main group by age;`


[JIRA-CARBONDATA-2533](https://issues.apache.org/jira/browse/CARBONDATA-2533)
JIRA-2533's modification is not suitable

【Sulution】
modify the MV SQL logic plan to add the groupby columns to projection

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

