### PR TITLE
[HOTFIX] Fix select query on varchar column with large data fails with jvm crash

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -1387,6 +1387,13 @@ public final class CarbonCommonConstants {
   public static final int CARBON_DYNAMIC_ALLOCATION_SCHEDULER_THREAD_SLEEP_TIME = 250;
 
   /**
+   * We increment the requested page size by 30% only if the requested size is less than 10MB.
+   * Otherwise we take the original requested page size.This parameter will be used till the
+   * size based page implementation comes in carbon.
+   */
+  public static final int REQUESTED_PAGE_SIZE_MAX = 10485760;
+
+  /**
    * It allows queries on hive metastore directly along with filter information, otherwise first
    * fetches all partitions from hive and apply filters on it.
    */

--- a/core/src/main/java/org/apache/carbondata/core/datastore/ReusableDataBuffer.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/ReusableDataBuffer.java
@@ -19,6 +19,7 @@ package org.apache.carbondata.core.datastore;
 
 import org.apache.carbondata.common.annotations.InterfaceAudience;
 import org.apache.carbondata.common.annotations.InterfaceStability;
+import org.apache.carbondata.core.constants.CarbonCommonConstants;
 
 /**
  * class holds the reusable data buffer based on request it will resize.
@@ -47,7 +48,13 @@ public class ReusableDataBuffer {
    */
   public byte[] getDataBuffer(int requestedSize) {
     if (dataBuffer == null || requestedSize > size) {
-      this.size = requestedSize + ((requestedSize * 30) / 100);
+      // increase by 30% only if the requestedSize less than 10 MB
+      // otherwise take the original requestedSize.
+      if (requestedSize < CarbonCommonConstants.REQUESTED_PAGE_SIZE_MAX) {
+        this.size = requestedSize + ((requestedSize * 30) / 100);
+      } else {
+        this.size = requestedSize;
+      }
       dataBuffer = new byte[size];
     }
     return dataBuffer;


### PR DESCRIPTION
**Problem** : When select query fired on varchar column having large data it results in JVM crash because when when we increase the ReusableBuffer by 30% the new size gets gets reduced because requestSize * 30 gets out of range for int which gives a negative value and the total size gets reduced.

**Solution** : While assigning the size to ByteBuffer we first check if total size less than the requested size then we pass requested size to to the ByteBuffer. 

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed? - No
 
 - [x] Any backward compatibility impacted? - No
 
 - [x] Document update required? - No

 - [x] Testing done 
       manually tested
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

