### PR TITLE
[CARBONDATA-3282] set hadoop conf to thread local for file factory usage in presto carbon 

### DIFF
--- a/docs/presto-guide.md
+++ b/docs/presto-guide.md
@@ -280,3 +280,8 @@ carbondata files.
   ```
   Replace the hostname, port and schema name with your own.
 
+### Supported features of presto carbon
+Presto carbon supports only reading the carbon table which is written by spark carbon or carbon SDK. 
+During reading, it supports the non-distributed datamaps like block datamap and bloom datamap.
+It doesn't support MV datamap and Pre-aggregate datamap as it needs query plan to be changed and presto does not allow it.
+Also Presto carbon supports streaming segment read from streaming table created by spark.

--- a/docs/presto-guide.md
+++ b/docs/presto-guide.md
@@ -281,7 +281,7 @@ carbondata files.
   Replace the hostname, port and schema name with your own.
 
 ### Supported features of presto carbon
-Presto carbon supports only reading the carbon table which is written by spark carbon or carbon SDK. 
+Presto carbon only supports reading the carbon table which is written by spark carbon or carbon SDK. 
 During reading, it supports the non-distributed datamaps like block datamap and bloom datamap.
 It doesn't support MV datamap and Pre-aggregate datamap as it needs query plan to be changed and presto does not allow it.
 Also Presto carbon supports streaming segment read from streaming table created by spark.

--- a/integration/presto/pom.xml
+++ b/integration/presto/pom.xml
@@ -551,6 +551,11 @@
       <artifactId>httpclient</artifactId>
       <version>4.5.5</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.carbondata</groupId>
+      <artifactId>carbondata-bloom</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/CarbondataSplitManager.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/CarbondataSplitManager.java
@@ -30,6 +30,7 @@ import org.apache.carbondata.core.stats.QueryStatistic;
 import org.apache.carbondata.core.stats.QueryStatisticsConstants;
 import org.apache.carbondata.core.stats.QueryStatisticsRecorder;
 import org.apache.carbondata.core.util.CarbonTimeStatisticsFactory;
+import org.apache.carbondata.core.util.ThreadLocalSessionInfo;
 import org.apache.carbondata.presto.impl.CarbonLocalMultiBlockSplit;
 import org.apache.carbondata.presto.impl.CarbonTableCacheModel;
 import org.apache.carbondata.presto.impl.CarbonTableReader;
@@ -117,6 +118,8 @@ public class CarbondataSplitManager extends HiveSplitManager {
         new HdfsEnvironment.HdfsContext(session, schemaTableName.getSchemaName(),
             schemaTableName.getTableName()), new Path(location));
     configuration = carbonTableReader.updateS3Properties(configuration);
+    // set the hadoop configuration to thread local, so that FileFactory can use it.
+    ThreadLocalSessionInfo.setConfigurationToCurrentThread(configuration);
     CarbonTableCacheModel cache =
         carbonTableReader.getCarbonCache(schemaTableName, location, configuration);
     Expression filters = PrestoFilterUtil.parseFilterExpression(predicate);


### PR DESCRIPTION
[HOTFIX] set hadoop conf to thread local for file factory usage in presto carbon. 
and Added bloom dependency in presto.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed? NA
 
 - [ ] Any backward compatibility impacted? NA
 
 - [ ] Document update required? NA

 - [ ] Testing done. yes. tested in cluster
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.  NA

