### PR TITLE
[CARBONDATA-3229]Validate the true/false for all boolean parameters

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonLoadOptionConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonLoadOptionConstants.java
@@ -30,7 +30,7 @@ public final class CarbonLoadOptionConstants {
   public static final String CARBON_OPTIONS_BAD_RECORDS_LOGGER_ENABLE =
       "carbon.options.bad.records.logger.enable";
 
-  public static String CARBON_OPTIONS_BAD_RECORDS_LOGGER_ENABLE_DEFAULT = "false";
+  public static final String CARBON_OPTIONS_BAD_RECORDS_LOGGER_ENABLE_DEFAULT = "false";
 
   /**
    * property to pass the bad records action

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
@@ -23,10 +23,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.text.SimpleDateFormat;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.carbondata.common.logging.LogServiceFactory;
@@ -37,40 +34,9 @@ import org.apache.carbondata.core.datastore.impl.FileFactory;
 import org.apache.carbondata.core.metadata.ColumnarFormatVersion;
 import org.apache.carbondata.core.util.annotations.CarbonProperty;
 
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.BLOCKLET_SIZE;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_CUSTOM_BLOCK_DISTRIBUTION;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_DATA_FILE_VERSION;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_DATE_FORMAT;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_DYNAMIC_ALLOCATION_SCHEDULER_TIMEOUT;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_MINMAX_ALLOWED_BYTE_COUNT;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_PREFETCH_BUFFERSIZE;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_SCHEDULER_MIN_REGISTERED_RESOURCES_RATIO;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_SCHEDULER_MIN_REGISTERED_RESOURCES_RATIO_DEFAULT;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_SCHEDULER_MIN_REGISTERED_RESOURCES_RATIO_MAX;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_SCHEDULER_MIN_REGISTERED_RESOURCES_RATIO_MIN;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_SORT_FILE_WRITE_BUFFER_SIZE;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_TASK_DISTRIBUTION;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_TASK_DISTRIBUTION_BLOCK;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_TASK_DISTRIBUTION_BLOCKLET;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_TASK_DISTRIBUTION_CUSTOM;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_TASK_DISTRIBUTION_MERGE_FILES;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.CSV_READ_BUFFER_SIZE;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.DETAIL_QUERY_BATCH_SIZE;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.DETAIL_QUERY_BATCH_SIZE_DEFAULT;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.DETAIL_QUERY_BATCH_SIZE_MAX;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.DETAIL_QUERY_BATCH_SIZE_MIN;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.ENABLE_AUTO_HANDOFF;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.ENABLE_OFFHEAP_SORT;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.ENABLE_UNSAFE_SORT;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.ENABLE_VECTOR_READER;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.HANDOFF_SIZE;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.LOCK_TYPE;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.SORT_INTERMEDIATE_FILES_LIMIT;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.SORT_SIZE;
-import static org.apache.carbondata.core.constants.CarbonLoadOptionConstants.CARBON_LOAD_SORT_MEMORY_SPILL_PERCENTAGE;
-import static org.apache.carbondata.core.constants.CarbonV3DataFormatConstants.BLOCKLET_SIZE_IN_MB;
-import static org.apache.carbondata.core.constants.CarbonV3DataFormatConstants.NUMBER_OF_COLUMN_TO_READ_IN_IO;
+import static org.apache.carbondata.core.constants.CarbonCommonConstants.*;
+import static org.apache.carbondata.core.constants.CarbonLoadOptionConstants.*;
+import static org.apache.carbondata.core.constants.CarbonV3DataFormatConstants.*;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.log4j.Logger;
@@ -98,6 +64,11 @@ public final class CarbonProperties {
    * It is purely for testing
    */
   private Map<String, String> addedProperty = new ConcurrentHashMap<>();
+
+  /**
+   * Boolean type properties default value
+   */
+  Map<String, String> booleanProperties = new ConcurrentHashMap<>();
 
   /**
    * Private constructor this will call load properties method to load all the
@@ -201,6 +172,10 @@ public final class CarbonProperties {
         break;
       // TODO : Validation for carbon.lock.type should be handled for addProperty flow
       default:
+        //Validate boolean type options
+        if (booleanProperties.keySet().contains(key)) {
+          validateBooleanProperty(key);
+        }
         // none
     }
   }
@@ -264,6 +239,7 @@ public final class CarbonProperties {
     validateSortMemorySpillPercentage();
     validateStringCharacterLimit();
     validateDetailQueryBatchSize();
+    validateBooleanProperties();
   }
 
   /**
@@ -511,6 +487,85 @@ public final class CarbonProperties {
     }
   }
 
+  private void initBooleanProperties() {
+    booleanProperties.put(ENABLE_XXHASH,
+            ENABLE_XXHASH_DEFAULT);
+    booleanProperties.put(LOCAL_DICTIONARY_DECODER_BASED_FALLBACK,
+            LOCAL_DICTIONARY_DECODER_BASED_FALLBACK);
+    booleanProperties.put(DATA_MANAGEMENT_DRIVER,
+            DATA_MANAGEMENT_DRIVER_DEFAULT);
+    booleanProperties.put(CARBON_SECURE_DICTIONARY_SERVER,
+            CARBON_SECURE_DICTIONARY_SERVER_DEFAULT);
+    booleanProperties.put(ENABLE_CALCULATE_SIZE,
+            DEFAULT_ENABLE_CALCULATE_SIZE);
+    booleanProperties.put(CARBON_MERGE_INDEX_IN_SEGMENT,
+            CARBON_MERGE_INDEX_IN_SEGMENT_DEFAULT);
+    booleanProperties.put(LOCAL_DICTIONARY_ENABLE,
+            LOCAL_DICTIONARY_ENABLE_DEFAULT);
+    booleanProperties.put(CARBON_MERGE_SORT_PREFETCH,
+            CARBON_MERGE_SORT_PREFETCH_DEFAULT);
+    booleanProperties.put(ENABLE_CONCURRENT_COMPACTION,
+            DEFAULT_ENABLE_CONCURRENT_COMPACTION);
+    booleanProperties.put(CARBON_HORIZONTAL_COMPACTION_ENABLE,
+            CARBON_HORIZONTAL_COMPACTION_ENABLE_DEFAULT);
+    booleanProperties.put(ENABLE_UNSAFE_COLUMN_PAGE,
+            ENABLE_UNSAFE_COLUMN_PAGE_DEFAULT);
+    booleanProperties.put(CARBON_LOADING_USE_YARN_LOCAL_DIR,
+            CARBON_LOADING_USE_YARN_LOCAL_DIR_DEFAULT);
+    booleanProperties.put(CARBON_QUERY_MIN_MAX_ENABLED,
+            MIN_MAX_DEFAULT_VALUE);
+    booleanProperties.put(BITSET_PIPE_LINE,
+            BITSET_PIPE_LINE_DEFAULT);
+    booleanProperties.put(CARBON_READ_PARTITION_HIVE_DIRECT,
+            CARBON_READ_PARTITION_HIVE_DIRECT_DEFAULT);
+    booleanProperties.put(CARBON_SHOW_DATAMAPS,
+            CARBON_SHOW_DATAMAPS_DEFAULT);
+    booleanProperties.put(ENABLE_HIVE_SCHEMA_META_STORE,
+            ENABLE_HIVE_SCHEMA_META_STORE_DEFAULT);
+    booleanProperties.put(CARBON_SKIP_EMPTY_LINE,
+            CARBON_SKIP_EMPTY_LINE_DEFAULT);
+    booleanProperties.put(ENABLE_DATA_LOADING_STATISTICS,
+            ENABLE_DATA_LOADING_STATISTICS_DEFAULT);
+    booleanProperties.put(ENABLE_AUTO_LOAD_MERGE,
+            DEFAULT_ENABLE_AUTO_LOAD_MERGE);
+    booleanProperties.put(CARBON_INSERT_PERSIST_ENABLED,
+            CARBON_INSERT_PERSIST_ENABLED_DEFAULT);
+    booleanProperties.put(ENABLE_INMEMORY_MERGE_SORT,
+            ENABLE_INMEMORY_MERGE_SORT_DEFAULT);
+    booleanProperties.put(USE_PREFETCH_WHILE_LOADING,
+            USE_PREFETCH_WHILE_LOADING_DEFAULT);
+    booleanProperties.put(CARBON_ENABLE_PAGE_LEVEL_READER_IN_COMPACTION,
+            CARBON_ENABLE_PAGE_LEVEL_READER_IN_COMPACTION_DEFAULT);
+    booleanProperties.put(CARBON_COMPACTION_PREFETCH_ENABLE,
+            CARBON_COMPACTION_PREFETCH_ENABLE_DEFAULT);
+    booleanProperties.put(ENABLE_QUERY_STATISTICS,
+            ENABLE_QUERY_STATISTICS_DEFAULT);
+    booleanProperties.put(IS_DRIVER_INSTANCE,
+            IS_DRIVER_INSTANCE_DEFAULT);
+    booleanProperties.put(ENABLE_UNSAFE_IN_QUERY_EXECUTION,
+            ENABLE_UNSAFE_IN_QUERY_EXECUTION_DEFAULTVALUE);
+    booleanProperties.put(CARBON_PUSH_ROW_FILTERS_FOR_VECTOR,
+            CARBON_PUSH_ROW_FILTERS_FOR_VECTOR_DEFAULT);
+    booleanProperties.put(IS_INTERNAL_LOAD_CALL,
+            IS_INTERNAL_LOAD_CALL_DEFAULT);
+    booleanProperties.put(IS_DRIVER_INSTANCE,
+            IS_DRIVER_INSTANCE_DEFAULT);
+    booleanProperties.put(USE_DISTRIBUTED_DATAMAP,
+            USE_DISTRIBUTED_DATAMAP_DEFAULT);
+    booleanProperties.put(SUPPORT_DIRECT_QUERY_ON_DATAMAP,
+            SUPPORT_DIRECT_QUERY_ON_DATAMAP_DEFAULTVALUE);
+    booleanProperties.put(CARBON_LUCENE_INDEX_STOP_WORDS,
+            CARBON_LUCENE_INDEX_STOP_WORDS_DEFAULT);
+    booleanProperties.put(CARBON_OPTIONS_BAD_RECORDS_LOGGER_ENABLE,
+            CARBON_OPTIONS_BAD_RECORDS_LOGGER_ENABLE_DEFAULT);
+    booleanProperties.put(CARBON_OPTIONS_IS_EMPTY_DATA_BAD_RECORD,
+            CARBON_OPTIONS_IS_EMPTY_DATA_BAD_RECORD_DEFAULT);
+    booleanProperties.put(CARBON_OPTIONS_SINGLE_PASS,
+            CARBON_OPTIONS_SINGLE_PASS_DEFAULT);
+    booleanProperties.put(ENABLE_CARBON_LOAD_DIRECT_WRITE_TO_STORE_PATH,
+            ENABLE_CARBON_LOAD_DIRECT_WRITE_TO_STORE_PATH_DEFAULT);
+  }
+
   private void validatePrefetchBufferSize() {
     String prefetchBufferSizeStr =
         carbonProperties.getProperty(CARBON_PREFETCH_BUFFERSIZE);
@@ -749,6 +804,8 @@ public final class CarbonProperties {
     } catch (IllegalAccessException e) {
       LOGGER.error("Illegal access to declared field" + e.getMessage());
     }
+
+    initBooleanProperties();
   }
 
   /**
@@ -1582,6 +1639,28 @@ public final class CarbonProperties {
             + DETAIL_QUERY_BATCH_SIZE_DEFAULT);
         carbonProperties.setProperty(DETAIL_QUERY_BATCH_SIZE,
             Integer.toString(DETAIL_QUERY_BATCH_SIZE_DEFAULT));
+      }
+    }
+  }
+
+  /**
+   * This method validates the Boolean type property. If some invalid input is set, we use the
+   * default value for this property
+   */
+  private void validateBooleanProperty(String key) {
+    if (!CarbonUtil.validateBoolean(carbonProperties.getProperty(key))) {
+      carbonProperties.setProperty(key, booleanProperties.get(key));
+    }
+  }
+
+  /**
+   * This method validates the Boolean type properties. If some invalid input is set, we use the
+   * default value for this property
+   */
+  private void validateBooleanProperties() {
+    for (Map.Entry<String, String> property: booleanProperties.entrySet()) {
+      if (!CarbonUtil.validateBoolean(carbonProperties.getProperty(property.getKey()))) {
+        carbonProperties.setProperty(property.getKey(), property.getValue());
       }
     }
   }


### PR DESCRIPTION
[CARBONDATA-3229]Validate the true/false for all boolean parameters.Validate the true/false for all boolean parameters when input, like in carbonsession, sdk, spark carbon file format, in beeline and so on.
This pull request add validation of other Boolean type properties defined in CarbonCommonConstants,CarbonLoadOptionConstants.When the boolean property has not been set,this property should be set with default value.

 - [x] Any interfaces changed?
        No
 - [x] Any backward compatibility impacted?
       No
 - [x] Document update required?
       No
 - [x] Testing done
       Yes
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
       No