### PR TITLE
[CARBONDATA-3290] No need to apply MV/Preaggregate rules for Command

### DIFF
--- a/integration/spark2/src/main/commonTo2.2And2.3/org/apache/spark/sql/hive/CarbonAnalyzer.scala
+++ b/integration/spark2/src/main/commonTo2.2And2.3/org/apache/spark/sql/hive/CarbonAnalyzer.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.hive
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.analysis.Analyzer
 import org.apache.spark.sql.catalyst.catalog.SessionCatalog
-import org.apache.spark.sql.catalyst.plans.logical.{Command, LogicalPlan}
+import org.apache.spark.sql.catalyst.plans.logical.{Command, DeserializeToObject, LogicalPlan}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.util.CarbonReflectionUtils
@@ -40,7 +40,7 @@ class CarbonAnalyzer(catalog: SessionCatalog,
 
   override def execute(plan: LogicalPlan): LogicalPlan = {
     var logicalPlan = analyzer.execute(plan)
-    if (!logicalPlan.isInstanceOf[Command]) {
+    if (!logicalPlan.isInstanceOf[Command] && !logicalPlan.isInstanceOf[DeserializeToObject]) {
       logicalPlan = CarbonPreAggregateDataLoadingRules(sparkSession).apply(logicalPlan)
       logicalPlan = CarbonPreAggregateQueryRules(sparkSession).apply(logicalPlan)
       if (mvPlan != null) {


### PR DESCRIPTION
MVAnalyzerRule/CarbonPreAggregateQueryRules  is used to rewrite query for MV/pre-agg datamap.
CarbonPreAggregateDataLoadingRules is used to update query plan for building pre-agg datamap.
These rules are NO need to apply to Command


Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

