### PR TITLE
[CARBONDATA-3293] Prune datamaps improvement

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datamap/dev/DataMap.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/dev/DataMap.java
@@ -18,8 +18,10 @@ package org.apache.carbondata.core.datamap.dev;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.carbondata.common.annotations.InterfaceAudience;
+import org.apache.carbondata.core.datamap.Segment;
 import org.apache.carbondata.core.datastore.block.SegmentProperties;
 import org.apache.carbondata.core.indexstore.Blocklet;
 import org.apache.carbondata.core.indexstore.PartitionSpec;
@@ -53,6 +55,12 @@ public interface DataMap<T extends Blocklet> {
    */
   List<T> prune(Expression filter, SegmentProperties segmentProperties,
       List<PartitionSpec> partitions, CarbonTable carbonTable) throws IOException;
+
+  /**
+   * Get the row count. It returns a Map of blockletpath and the row count
+   */
+  Map<String, Integer> getRowCount(Segment segment, SegmentProperties segmentProperties,
+      List<PartitionSpec> partitions) throws IOException;
 
   // TODO Move this method to Abstract class
   /**

--- a/core/src/main/java/org/apache/carbondata/core/datamap/dev/cgdatamap/CoarseGrainDataMap.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/dev/cgdatamap/CoarseGrainDataMap.java
@@ -18,9 +18,11 @@ package org.apache.carbondata.core.datamap.dev.cgdatamap;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.carbondata.common.annotations.InterfaceAudience;
 import org.apache.carbondata.common.annotations.InterfaceStability;
+import org.apache.carbondata.core.datamap.Segment;
 import org.apache.carbondata.core.datamap.dev.DataMap;
 import org.apache.carbondata.core.datastore.block.SegmentProperties;
 import org.apache.carbondata.core.indexstore.Blocklet;
@@ -40,6 +42,13 @@ public abstract class CoarseGrainDataMap implements DataMap<Blocklet> {
       List<PartitionSpec> partitions, CarbonTable carbonTable) throws IOException {
     throw new UnsupportedOperationException("Filter expression not supported");
   }
+
+  @Override
+  public Map<String, Integer> getRowCount(Segment segment, SegmentProperties segmentProperties,
+      List<PartitionSpec> partitions) throws IOException {
+    throw new UnsupportedOperationException("Operation not supported");
+  }
+
 
   @Override public int getNumberOfEntries() {
     // keep default, one record in one datamap

--- a/core/src/main/java/org/apache/carbondata/core/datamap/dev/fgdatamap/FineGrainDataMap.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/dev/fgdatamap/FineGrainDataMap.java
@@ -18,9 +18,11 @@ package org.apache.carbondata.core.datamap.dev.fgdatamap;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.carbondata.common.annotations.InterfaceAudience;
 import org.apache.carbondata.common.annotations.InterfaceStability;
+import org.apache.carbondata.core.datamap.Segment;
 import org.apache.carbondata.core.datamap.dev.DataMap;
 import org.apache.carbondata.core.datastore.block.SegmentProperties;
 import org.apache.carbondata.core.indexstore.PartitionSpec;
@@ -38,6 +40,12 @@ public abstract class FineGrainDataMap implements DataMap<FineGrainBlocklet> {
   public List<FineGrainBlocklet> prune(Expression filter, SegmentProperties segmentProperties,
       List<PartitionSpec> partitions, CarbonTable carbonTable) throws IOException {
     throw new UnsupportedOperationException("Filter expression not supported");
+  }
+
+  @Override
+  public Map<String, Integer> getRowCount(Segment segment, SegmentProperties segmentProperties,
+      List<PartitionSpec> partitions) throws IOException {
+    throw new UnsupportedOperationException("Operation not supported");
   }
 
   @Override public int getNumberOfEntries() {


### PR DESCRIPTION
**Problem:**

(1) Currently for count (*) , the prune is same as select * query.  Blocklet and ExtendedBlocklet are formed from the DataMapRow and that is of no need and it is a time consuming process.

(2) Pruning in select * query consumes time in convertToSafeRow() - converting the DataMapRow to safe as in an unsafe row to get the position of data, we need to traverse through the whole row to reach a position.

(3) In case of filter queries, even if the blocklet is valid or invalid, we are converting the DataMapRow to safeRow. This conversion is time consuming increasing the number of blocklets.

 

**Solution:**

(1) We have the blocklet row count in the DataMapRow itself, so it is just enough to read the count. With this count (*) query performance can be improved.

(2) Maintain the data length also to the DataMapRow, so that traversing the whole row can be avoided. With the length we can directly hit the data position.

(3) Read only the MinMax from the DataMapRow, decide whether scan is required on that blocklet, if required only then it can be converted to safeRow, if needed.

**Performance Report:**
3 node cluster
Number of cores - 30
Number of segments - 5000
Number of DataMaps per Segment - 150
Total record count - 5000000

|            |    count(*)    |     count(*)     |   CTAS(parquet)  |
|:----------:|:--------------:|:----------------:|:----------------:|
|            | E2E Time(secs) | Prune Time(secs) | Prune Time(secs) |
| Before Fix |     425.097    |        331       |        332       |
|  After Fix |     142.107    |        136       |        172       |




 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [x] Testing done
        Existing UT
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

