### PR TITLE
[CARBONDATA-3295] Fix that MV datamap throw exception because its rewrite algorithm when query SQL has multiply subquery

### DIFF
--- a/datamap/mv/core/src/main/scala/org/apache/carbondata/mv/datamap/MVHelper.scala
+++ b/datamap/mv/core/src/main/scala/org/apache/carbondata/mv/datamap/MVHelper.scala
@@ -596,18 +596,6 @@ object MVHelper {
         case g: GroupBy =>
           MVHelper.updateDataMap(g, rewrite)
       }
-
-      // Use coarse equal to rewrite
-      updatedDataMapTablePlan.map(plan => {
-        if (rewrittenPlan.find (
-          oriPlan => oriPlan.rewritten && (plan match {
-            case select: Select => select.coarseEqual(oriPlan)
-            case groupby: GroupBy => groupby.coarseEqual(oriPlan)
-            case _ => plan.equals(oriPlan)
-          })).isDefined) {
-          plan.setRewritten()
-        }
-      })
       updatedDataMapTablePlan
     } else {
       rewrittenPlan

--- a/datamap/mv/core/src/main/scala/org/apache/carbondata/mv/datamap/MVHelper.scala
+++ b/datamap/mv/core/src/main/scala/org/apache/carbondata/mv/datamap/MVHelper.scala
@@ -596,12 +596,18 @@ object MVHelper {
         case g: GroupBy =>
           MVHelper.updateDataMap(g, rewrite)
       }
-      // TODO Find a better way to set the rewritten flag, it may fail in some conditions.
-      val mapping =
-        rewrittenPlan.collect { case m: ModularPlan => m } zip
-        updatedDataMapTablePlan.collect { case m: ModularPlan => m }
-      mapping.foreach(f => if (f._1.rewritten) f._2.setRewritten())
 
+      // Use coarse equal to rewrite
+      updatedDataMapTablePlan.map(plan => {
+        if (rewrittenPlan.find (
+          oriPlan => oriPlan.rewritten && (plan match {
+            case select: Select => select.coarseEqual(oriPlan)
+            case groupby: GroupBy => groupby.coarseEqual(oriPlan)
+            case _ => plan.equals(oriPlan)
+          })).isDefined) {
+          plan.setRewritten()
+        }
+      })
       updatedDataMapTablePlan
     } else {
       rewrittenPlan

--- a/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/MVRewriteTestCase.scala
+++ b/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/MVRewriteTestCase.scala
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.mv.rewrite
+
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.execution.datasources.LogicalRelation
+import org.apache.spark.sql.test.util.QueryTest
+import org.scalatest.BeforeAndAfterAll
+
+class MVRewriteTestCase extends QueryTest with BeforeAndAfterAll {
+
+
+  override def beforeAll(): Unit = {
+    drop
+    sql("create table region(l4id string,l4name string) using carbondata")
+    sql(
+      s"""create table data_table(
+         	         |starttime int, seq long,succ long,LAYER4ID string,tmp int)
+         	         |using carbondata""".stripMargin)
+  }
+
+  def drop(): Unit ={
+    sql("drop table if exists region")
+    sql("drop table if exists data_table")
+  }
+
+  test("test mv count and case when expression") {
+    sql("drop datamap if exists data_table_mv")
+    sql(s"""create datamap data_table_mv using 'mv' as
+           	           | SELECT STARTTIME,LAYER4ID,
+           	           | COALESCE (SUM(seq),0) AS seq_c,
+           	           | COALESCE (SUM(succ),0)  AS succ_c
+           	           | FROM data_table
+           	           | GROUP BY STARTTIME,LAYER4ID""".stripMargin)
+
+    sql("rebuild datamap data_table_mv")
+
+    var frame = sql(s"""SELECT  MT.`3600` AS `3600`,
+                       	                       | MT.`2250410101` AS `2250410101`,
+                       	                       | (CASE WHEN (SUM(COALESCE(seq_c, 0))) = 0 THEN NULL
+                       	                       |   ELSE
+                       	                       |   (CASE WHEN (CAST((SUM(COALESCE(seq_c, 0))) AS int)) = 0 THEN 0
+                       	                       |     ELSE ((CAST((SUM(COALESCE(succ_c, 0))) AS double))
+                       	                       |     / (CAST((SUM(COALESCE(seq_c, 0))) AS double)))
+                       	                       |     END) * 100
+                       	                       |   END) AS rate
+                       	                       | FROM (
+                       	                       |   SELECT sum_result.*, H_REGION.`2250410101` FROM
+                       	                       |   (SELECT cast(floor((starttime + 28800) / 3600) * 3600 - 28800 as int) AS `3600`,
+                       	                       |     LAYER4ID,
+                       	                       |     COALESCE(SUM(seq), 0) AS seq_c,
+                       	                       |     COALESCE(SUM(succ), 0) AS succ_c
+                       	                       |       FROM data_table
+                       	                       |       WHERE STARTTIME >= 1549866600 AND STARTTIME < 1549899900
+                       	                       |       GROUP BY cast(floor((STARTTIME + 28800) / 3600) * 3600 - 28800 as int),LAYER4ID
+                       	                       |   )sum_result
+                       	                       |   LEFT JOIN
+                       	                       |   (SELECT l4id AS `225040101`,
+                       	                       |     l4name AS `2250410101`,
+                       	                       |     l4name AS NAME_2250410101
+                       	                       |       FROM region
+                       	                       |       GROUP BY l4id, l4name) H_REGION
+                       	                       |   ON sum_result.LAYER4ID = H_REGION.`225040101`
+                       	                       | WHERE H_REGION.NAME_2250410101 IS NOT NULL
+                       	                       | ) MT
+                       	                       | GROUP BY MT.`3600`, MT.`2250410101`
+                       	                       | ORDER BY `3600` ASC LIMIT 5000""".stripMargin)
+
+    assert(verifyMVDataMap(frame.queryExecution.analyzed, "data_table_mv"))
+  }
+
+  def verifyMVDataMap(logicalPlan: LogicalPlan, dataMapName: String): Boolean = {
+    val tables = logicalPlan collect {
+      case l: LogicalRelation => l.catalogTable.get
+    }
+    tables.exists(_.identifier.table.equalsIgnoreCase(dataMapName+"_table"))
+  }
+
+  override def afterAll(): Unit = {
+    drop
+  }
+}

--- a/datamap/mv/plan/src/main/scala/org/apache/carbondata/mv/plans/modular/basicOperators.scala
+++ b/datamap/mv/plan/src/main/scala/org/apache/carbondata/mv/plans/modular/basicOperators.scala
@@ -40,19 +40,10 @@ case class GroupBy(
     dataMapTableRelation: Option[ModularPlan] = None) extends UnaryNode with Matchable {
   override def output: Seq[Attribute] = outputList.map(_.toAttribute)
 
-  def coarseEqual(other: Any): Boolean = {
-    if (!this.getClass.equals(other.getClass)) {
-      return false
-    }
-    val otherGroupBy = other.asInstanceOf[GroupBy]
-    if (outputList == otherGroupBy.outputList &&
-      inputList == otherGroupBy.inputList && predicateList == otherGroupBy.predicateList
-      && alias == otherGroupBy.alias && flags == otherGroupBy.flags
-      && flagSpec == otherGroupBy.flagSpec
-      && dataMapTableRelation == otherGroupBy.dataMapTableRelation) {
-      return true
-    }
-    false
+  override def makeCopy(newArgs: Array[AnyRef]): GroupBy = {
+    val groupBy = super.makeCopy(newArgs).asInstanceOf[GroupBy]
+    if (rewritten) groupBy.setRewritten()
+    groupBy
   }
 }
 
@@ -90,20 +81,10 @@ case class Select(
     predicateList.filter(p => canEvaluate(p, plan))
   }
 
-  def coarseEqual(other: Any): Boolean = {
-    if (!this.getClass.equals(other.getClass)) {
-      return false
-    }
-    val otherSelect = other.asInstanceOf[Select]
-    if (outputList == otherSelect.outputList &&
-      inputList == otherSelect.inputList && predicateList == otherSelect.predicateList
-      && aliasMap == otherSelect.aliasMap && flags == otherSelect.flags
-      && flagSpec == otherSelect.flagSpec
-      && dataMapTableRelation == otherSelect.dataMapTableRelation
-      && windowSpec == otherSelect.windowSpec && joinEdges == otherSelect.joinEdges) {
-      return true
-    }
-    false
+  override def makeCopy(newArgs: Array[AnyRef]): Select = {
+    val select = super.makeCopy(newArgs).asInstanceOf[Select]
+    if (rewritten) select.setRewritten()
+    select
   }
 }
 

--- a/datamap/mv/plan/src/main/scala/org/apache/carbondata/mv/plans/modular/basicOperators.scala
+++ b/datamap/mv/plan/src/main/scala/org/apache/carbondata/mv/plans/modular/basicOperators.scala
@@ -39,6 +39,21 @@ case class GroupBy(
     flagSpec: Seq[Seq[Any]],
     dataMapTableRelation: Option[ModularPlan] = None) extends UnaryNode with Matchable {
   override def output: Seq[Attribute] = outputList.map(_.toAttribute)
+
+  def coarseEqual(other: Any): Boolean = {
+    if (!this.getClass.equals(other.getClass)) {
+      return false
+    }
+    val otherGroupBy = other.asInstanceOf[GroupBy]
+    if (outputList == otherGroupBy.outputList &&
+      inputList == otherGroupBy.inputList && predicateList == otherGroupBy.predicateList
+      && alias == otherGroupBy.alias && flags == otherGroupBy.flags
+      && flagSpec == otherGroupBy.flagSpec
+      && dataMapTableRelation == otherGroupBy.dataMapTableRelation) {
+      return true
+    }
+    false
+  }
 }
 
 case class Select(
@@ -73,6 +88,22 @@ case class Select(
 
   override def extractEvaluableConditions(plan: ModularPlan): Seq[Expression] = {
     predicateList.filter(p => canEvaluate(p, plan))
+  }
+
+  def coarseEqual(other: Any): Boolean = {
+    if (!this.getClass.equals(other.getClass)) {
+      return false
+    }
+    val otherSelect = other.asInstanceOf[Select]
+    if (outputList == otherSelect.outputList &&
+      inputList == otherSelect.inputList && predicateList == otherSelect.predicateList
+      && aliasMap == otherSelect.aliasMap && flags == otherSelect.flags
+      && flagSpec == otherSelect.flagSpec
+      && dataMapTableRelation == otherSelect.dataMapTableRelation
+      && windowSpec == otherSelect.windowSpec && joinEdges == otherSelect.joinEdges) {
+      return true
+    }
+    false
   }
 }
 


### PR DESCRIPTION
### [Problem]
Error:
```
java.lang.UnsupportedOperationException was thrown.
java.lang.UnsupportedOperationException
	at org.apache.carbondata.mv.plans.util.SQLBuildDSL$Fragment.productArity(SQLBuildDSL.scala:36)
	at scala.runtime.ScalaRunTime$$anon$1.<init>(ScalaRunTime.scala:174)
	at scala.runtime.ScalaRunTime$.typedProductIterator(ScalaRunTime.scala:172)`

MV sql:
`create datamap data_table_mv using 'mv' as
 SELECT STARTTIME,LAYER4ID,
 COALESCE (SUM(seq),0) AS seq_c,
 COALESCE (SUM(succ),0)  AS succ_c
 FROM data_table
 GROUP BY STARTTIME,LAYER4ID`

Query sql:
`SELECT  MT.`3600` AS `3600`,
 MT.`2250410101` AS `2250410101`,
 (CASE WHEN (SUM(COALESCE(seq_c, 0))) = 0 THEN NULL
   ELSE
   (CASE WHEN (CAST((SUM(COALESCE(seq_c, 0))) AS int)) = 0 THEN 0
     ELSE ((CAST((SUM(COALESCE(succ_c, 0))) AS double))
     / (CAST((SUM(COALESCE(seq_c, 0))) AS double)))
     END) * 100
   END) AS rate
 FROM (
   SELECT sum_result.*, H_REGION.`2250410101` FROM
   (SELECT cast(floor((starttime + 28800) / 3600) * 3600 - 28800 as int) AS `3600`,
     LAYER4ID,
     COALESCE(SUM(seq), 0) AS seq_c,
     COALESCE(SUM(succ), 0) AS succ_c
       FROM data_table
       WHERE STARTTIME >= 1549866600 AND STARTTIME < 1549899900
       GROUP BY cast(floor((STARTTIME + 28800) / 3600) * 3600 - 28800 as int),LAYER4ID
   )sum_result
   LEFT JOIN
   (SELECT l4id AS `225040101`,
     l4name AS `2250410101`,
     l4name AS NAME_2250410101
       FROM region
       GROUP BY l4id, l4name) H_REGION
   ON sum_result.LAYER4ID = H_REGION.`225040101`
 WHERE H_REGION.NAME_2250410101 IS NOT NULL
 ) MT
 GROUP BY MT.`3600`, MT.`2250410101`
 ORDER BY `3600` ASC LIMIT 5000
```

### [Root Cause]
```
      // TODO Find a better way to set the rewritten flag, it may fail in some conditions.
      val mapping =
        rewrittenPlan.collect { case m: ModularPlan => m } zip
        updatedDataMapTablePlan.collect { case m: ModularPlan => m }
      mapping.foreach(f => if (f._1.rewritten) f._2.setRewritten())
```
this rewrite algorithm has bug, nodes are not sequential in some scenes

### [Solution]
Fix the mv rewrite algorithm to fix this，we can compare the Select and Group object between oriPlan and rewrittenPlan, but the ModularPlan tree has beed changed, so we cann't compare their childrens, this pr add coarseEqual to compare.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
