### PR TITLE
[CARBONDATA-3302] [Spark-Integration] code cleaning related to CarbonCreateTable command

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonCreateTableCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonCreateTableCommand.scala
@@ -78,8 +78,8 @@ case class CarbonCreateTableCommand(
         path
       }
       val streaming = tableInfo.getFactTable.getTableProperties.get("streaming")
-      if (path.startsWith("s3") && streaming != null && streaming != null &&
-          streaming.equalsIgnoreCase("true")) {
+      if (streaming != null &&
+        streaming.equalsIgnoreCase("true") && path.startsWith("s3")) {
         throw new UnsupportedOperationException("streaming is not supported with s3 store")
       }
       tableInfo.setTablePath(tablePath)

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonCreateTableCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonCreateTableCommand.scala
@@ -78,8 +78,7 @@ case class CarbonCreateTableCommand(
         path
       }
       val streaming = tableInfo.getFactTable.getTableProperties.get("streaming")
-      if (streaming != null &&
-        streaming.equalsIgnoreCase("true") && path.startsWith("s3")) {
+      if (streaming != null && streaming.equalsIgnoreCase("true") && path.startsWith("s3")) {
         throw new UnsupportedOperationException("streaming is not supported with s3 store")
       }
       tableInfo.setTablePath(tablePath)


### PR DESCRIPTION
## What changes were proposed in this pull request?
Removed Extra check to validate whether the stream relation is not null , moreover condition can be optimized further, currently the condition has path validation whether path is part of s3 file system and then system is  checking whether the stream relation is not null, this check can be added  initially as this overall condition has to be evaluated for stream table only if stream is not null.

## How was this patch tested?
Manual testing and existing test-cases


