### PR TITLE
[CARBONDATA-3305] Added DDL to drop cache for a table

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/cache/CarbonLRUCache.java
+++ b/core/src/main/java/org/apache/carbondata/core/cache/CarbonLRUCache.java
@@ -62,10 +62,10 @@ public final class CarbonLRUCache {
    */
   public CarbonLRUCache(String propertyName, String defaultPropertyName) {
     try {
-      lruCacheMemorySize = Integer
-          .parseInt(CarbonProperties.getInstance().getProperty(propertyName, defaultPropertyName));
+      lruCacheMemorySize = Long
+          .parseLong(CarbonProperties.getInstance().getProperty(propertyName, defaultPropertyName));
     } catch (NumberFormatException e) {
-      lruCacheMemorySize = Integer.parseInt(defaultPropertyName);
+      lruCacheMemorySize = Long.parseLong(defaultPropertyName);
     }
     initCache();
     if (lruCacheMemorySize > 0) {
@@ -302,6 +302,9 @@ public final class CarbonLRUCache {
    */
   public void clear() {
     synchronized (lruCacheMap) {
+      for (Cacheable cachebleObj : lruCacheMap.values()) {
+        cachebleObj.invalidate();
+      }
       lruCacheMap.clear();
     }
   }

--- a/core/src/main/java/org/apache/carbondata/core/cache/CarbonLRUCache.java
+++ b/core/src/main/java/org/apache/carbondata/core/cache/CarbonLRUCache.java
@@ -149,6 +149,17 @@ public final class CarbonLRUCache {
   }
 
   /**
+   * @param keys
+   */
+  public void removeAll(List<String> keys) {
+    synchronized (lruCacheMap) {
+      for (String key : keys) {
+        removeKey(key);
+      }
+    }
+  }
+
+  /**
    * This method will remove the key from lru cache
    *
    * @param key

--- a/core/src/main/java/org/apache/carbondata/core/cache/CarbonLRUCache.java
+++ b/core/src/main/java/org/apache/carbondata/core/cache/CarbonLRUCache.java
@@ -65,6 +65,9 @@ public final class CarbonLRUCache {
       lruCacheMemorySize = Long
           .parseLong(CarbonProperties.getInstance().getProperty(propertyName, defaultPropertyName));
     } catch (NumberFormatException e) {
+      LOGGER.error(CarbonCommonConstants.CARBON_MAX_DRIVER_LRU_CACHE_SIZE
+          + " is not in a valid format. Falling back to default value: "
+          + CarbonCommonConstants.CARBON_MAX_LRU_CACHE_SIZE_DEFAULT);
       lruCacheMemorySize = Long.parseLong(defaultPropertyName);
     }
     initCache();

--- a/docs/ddl-of-carbondata.md
+++ b/docs/ddl-of-carbondata.md
@@ -1110,3 +1110,12 @@ Users can specify which columns to include and exclude for local dictionary gene
   its dictionary files, its datamaps and children tables.
   
   This command is not allowed on child tables.
+
+  ```sql
+    DROP METADATA ON TABLE tableName
+   ```
+    
+  This clears any entry in cache by the table `tableName`, its carbonindex files, 
+  its dictionary files, its datamaps and children tables.
+    
+  This command is not allowed on child tables.

--- a/docs/ddl-of-carbondata.md
+++ b/docs/ddl-of-carbondata.md
@@ -1095,7 +1095,7 @@ Users can specify which columns to include and exclude for local dictionary gene
   about current cache used status in memory through the following command:
 
   ```sql
-  SHOW METADATA
+  SHOW METACACHE
   ``` 
   
   This shows the overall memory consumed in the cache by categories - index files, dictionary and 
@@ -1103,7 +1103,7 @@ Users can specify which columns to include and exclude for local dictionary gene
   database.
   
   ```sql
-  SHOW METADATA ON TABLE tableName
+  SHOW METACACHE ON TABLE tableName
   ```
   
   This shows detailed information on cache usage by the table `tableName` and its carbonindex files, 
@@ -1112,7 +1112,7 @@ Users can specify which columns to include and exclude for local dictionary gene
   This command is not allowed on child tables.
 
   ```sql
-    DROP METADATA ON TABLE tableName
+    DROP METACACHE ON TABLE tableName
    ```
     
   This clears any entry in cache by the table `tableName`, its carbonindex files, 

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/sql/commands/TestCarbonDropCacheCommand.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/sql/commands/TestCarbonDropCacheCommand.scala
@@ -25,12 +25,11 @@ import org.apache.spark.sql.CarbonEnv
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException
 import org.apache.spark.sql.test.util.QueryTest
-import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
-
+import org.scalatest.BeforeAndAfterAll
 import org.apache.carbondata.core.cache.CacheProvider
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 
-class TestCarbonDropCacheCommand extends QueryTest with BeforeAndAfterEach with BeforeAndAfterAll {
+class TestCarbonDropCacheCommand extends QueryTest with BeforeAndAfterAll {
 
   val dbName = "cache_db"
 
@@ -42,11 +41,6 @@ class TestCarbonDropCacheCommand extends QueryTest with BeforeAndAfterEach with 
 
   override protected def afterAll(): Unit = {
     sql(s"DROP DATABASE $dbName CASCADE")
-  }
-
-  override protected def beforeEach(): Unit = {
-    sql("DROP TABLE IF EXISTS t1")
-    sql("DROP TABLE IF EXISTS t2")
   }
 
 
@@ -70,11 +64,6 @@ class TestCarbonDropCacheCommand extends QueryTest with BeforeAndAfterEach with 
     droppedCacheKeys.removeAll(cacheAfterDrop)
 
     val tableIdentifier = new TableIdentifier(tableName, Some(dbName))
-    val table = sqlContext.sparkSession.sessionState.catalog.listTables(dbName)
-      .find(_.table.equalsIgnoreCase(tableName))
-    if (table.isEmpty) {
-      fail("Table does not exists")
-    }
     val carbonTable = CarbonEnv.getCarbonTable(tableIdentifier)(sqlContext.sparkSession)
     val tablePath = carbonTable.getTablePath + CarbonCommonConstants.FILE_SEPARATOR
     val dictIds = carbonTable.getAllDimensions.asScala.filter(_.isGlobalDictionaryEncoding)
@@ -111,7 +100,6 @@ class TestCarbonDropCacheCommand extends QueryTest with BeforeAndAfterEach with 
     sql(s"SELECT * FROM $tableName").collect()
     sql(s"SELECT AVG(salary), workgroupcategoryname from $tableName " +
         s"GROUP BY workgroupcategoryname").collect()
-
     val droppedCacheKeys = clone(CacheProvider.getInstance().getCarbonCache.getCacheMap.keySet())
 
     sql(s"DROP METACACHE ON TABLE $tableName")
@@ -120,11 +108,6 @@ class TestCarbonDropCacheCommand extends QueryTest with BeforeAndAfterEach with 
     droppedCacheKeys.removeAll(cacheAfterDrop)
 
     val tableIdentifier = new TableIdentifier(tableName, Some(dbName))
-    val table = sqlContext.sparkSession.sessionState.catalog.listTables(dbName)
-      .find(_.table.equalsIgnoreCase(tableName))
-    if (table.isEmpty) {
-      fail("Table does not exists")
-    }
     val carbonTable = CarbonEnv.getCarbonTable(tableIdentifier)(sqlContext.sparkSession)
     val dbPath = CarbonEnv
       .getDatabaseLocation(tableIdentifier.database.get, sqlContext.sparkSession)
@@ -168,11 +151,6 @@ class TestCarbonDropCacheCommand extends QueryTest with BeforeAndAfterEach with 
     droppedCacheKeys.removeAll(cacheAfterDrop)
 
     val tableIdentifier = new TableIdentifier(tableName, Some(dbName))
-    val table = sqlContext.sparkSession.sessionState.catalog.listTables(dbName)
-      .find(_.table.equalsIgnoreCase(tableName))
-    if (table.isEmpty) {
-      fail("Table does not exists")
-    }
     val carbonTable = CarbonEnv.getCarbonTable(tableIdentifier)(sqlContext.sparkSession)
     val tablePath = carbonTable.getTablePath
     val bloomPath = tablePath + CarbonCommonConstants.FILE_SEPARATOR + "dblom" +

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/sql/commands/TestCarbonDropCacheCommand.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/sql/commands/TestCarbonDropCacheCommand.scala
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.sql.commands
+
+import java.util
+
+import scala.collection.JavaConverters._
+
+import org.apache.spark.sql.CarbonEnv
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.analysis.NoSuchTableException
+import org.apache.spark.sql.test.util.QueryTest
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
+
+import org.apache.carbondata.core.cache.CacheProvider
+import org.apache.carbondata.core.constants.CarbonCommonConstants
+
+class TestCarbonDropCacheCommand extends QueryTest with BeforeAndAfterEach with BeforeAndAfterAll {
+
+  val dbName = "cache_db"
+
+  override protected def beforeAll(): Unit = {
+    sql(s"DROP DATABASE IF EXISTS $dbName CASCADE")
+    sql(s"CREATE DATABASE $dbName")
+    sql(s"USE $dbName")
+  }
+
+  override protected def afterAll(): Unit = {
+    sql(s"DROP DATABASE $dbName CASCADE")
+  }
+
+  override protected def beforeEach(): Unit = {
+    sql("DROP TABLE IF EXISTS t1")
+    sql("DROP TABLE IF EXISTS t2")
+  }
+
+
+  test("Test dictionary") {
+    val tableName = "t1"
+
+    sql(s"CREATE TABLE $tableName(age int, name string) stored by 'carbondata' " +
+        s"TBLPROPERTIES('DICTIONARY_INCLUDE'='age, name')")
+    sql(s"LOAD DATA INPATH '/home/root1/Desktop/CSVs/age_name.csv' INTO TABLE $tableName")
+    sql(s"LOAD DATA INPATH '/home/root1/Desktop/CSVs/age_name.csv' INTO TABLE $tableName")
+    sql(s"SELECT * FROM $tableName").collect()
+
+    val droppedCacheKeys = clone(CacheProvider.getInstance().getCarbonCache.getCacheMap.keySet())
+
+    sql(s"DROP METACACHE FOR TABLE $tableName")
+
+    val cacheAfterDrop = clone(CacheProvider.getInstance().getCarbonCache.getCacheMap.keySet())
+    droppedCacheKeys.removeAll(cacheAfterDrop)
+
+    val tableIdentifier = new TableIdentifier(tableName, Some(dbName))
+    val table = sqlContext.sparkSession.sessionState.catalog.listTables(dbName)
+      .find(_.table.equalsIgnoreCase(tableName))
+    if (table.isEmpty) {
+      fail("Table does not exists")
+    }
+    val carbonTable = CarbonEnv.getCarbonTable(tableIdentifier)(sqlContext.sparkSession)
+    val tablePath = carbonTable.getTablePath + CarbonCommonConstants.FILE_SEPARATOR
+    val dictIds = carbonTable.getAllDimensions.asScala.filter(_.isGlobalDictionaryEncoding)
+      .map(_.getColumnId).toArray
+
+    // Check if table index entries are dropped
+    assert(droppedCacheKeys.asScala.exists(key => key.startsWith(tablePath)))
+
+    // check if cache does not have any more table index entries
+    assert(!cacheAfterDrop.asScala.exists(key => key.startsWith(tablePath)))
+
+    // check if table dictionary entries are dropped
+    for (dictId <- dictIds) {
+      assert(droppedCacheKeys.asScala.exists(key => key.contains(dictId)))
+    }
+
+    // check if cache does not have any more table dictionary entries
+    for (dictId <- dictIds) {
+      assert(!cacheAfterDrop.asScala.exists(key => key.contains(dictId)))
+    }
+  }
+
+
+  test("Test preaggregate datamap") {
+    val tableName = "t2"
+
+    sql(s"CREATE TABLE $tableName(age int, name string) stored by 'carbondata'")
+    sql(s"CREATE DATAMAP dpagg ON TABLE $tableName USING 'preaggregate' AS " +
+        s"SELECT AVG(age), name from $tableName GROUP BY name")
+    sql(s"LOAD DATA INPATH '/home/root1/Desktop/CSVs/age_name.csv' INTO TABLE $tableName")
+    sql(s"SELECT * FROM $tableName").collect()
+    sql(s"SELECT AVG(age), name from $tableName GROUP BY name").collect()
+
+    val droppedCacheKeys = clone(CacheProvider.getInstance().getCarbonCache.getCacheMap.keySet())
+
+    sql(s"DROP METACACHE FOR TABLE $tableName")
+
+    val cacheAfterDrop = clone(CacheProvider.getInstance().getCarbonCache.getCacheMap.keySet())
+    droppedCacheKeys.removeAll(cacheAfterDrop)
+
+    val tableIdentifier = new TableIdentifier(tableName, Some(dbName))
+    val table = sqlContext.sparkSession.sessionState.catalog.listTables(dbName)
+      .find(_.table.equalsIgnoreCase(tableName))
+    if (table.isEmpty) {
+      fail("Table does not exists")
+    }
+    val carbonTable = CarbonEnv.getCarbonTable(tableIdentifier)(sqlContext.sparkSession)
+    val dbPath = CarbonEnv
+      .getDatabaseLocation(tableIdentifier.database.get, sqlContext.sparkSession)
+    val tablePath = carbonTable.getTablePath
+    val preaggPath = dbPath + CarbonCommonConstants.FILE_SEPARATOR + carbonTable.getTableName +
+                     "_" + carbonTable.getTableInfo.getDataMapSchemaList.get(0).getDataMapName +
+                     CarbonCommonConstants.FILE_SEPARATOR
+
+    // Check if table index entries are dropped
+    assert(droppedCacheKeys.asScala.exists(key => key.startsWith(tablePath)))
+
+    // check if cache does not have any more table index entries
+    assert(!cacheAfterDrop.asScala.exists(key => key.startsWith(tablePath)))
+
+    // Check if preaggregate index entries are dropped
+    assert(droppedCacheKeys.asScala.exists(key => key.startsWith(preaggPath)))
+
+    // check if cache does not have any more preaggregate index entries
+    assert(!cacheAfterDrop.asScala.exists(key => key.startsWith(preaggPath)))
+  }
+
+
+  test("Test bloom filter") {
+    val tableName = "t3"
+
+    sql(s"CREATE TABLE $tableName(age int, name string) stored by 'carbondata'")
+    sql(s"CREATE DATAMAP dblom ON TABLE $tableName USING 'bloomfilter' " +
+        "DMPROPERTIES('INDEX_COLUMNS'='age')")
+    sql(s"LOAD DATA INPATH '/home/root1/Desktop/CSVs/age_name.csv' INTO TABLE $tableName")
+    sql(s"SELECT * FROM $tableName").collect()
+    sql(s"SELECT * FROM $tableName WHERE age=25").collect()
+
+    val droppedCacheKeys = clone(CacheProvider.getInstance().getCarbonCache.getCacheMap.keySet())
+
+    sql(s"DROP METACACHE FOR TABLE $tableName")
+
+    val cacheAfterDrop = clone(CacheProvider.getInstance().getCarbonCache.getCacheMap.keySet())
+    droppedCacheKeys.removeAll(cacheAfterDrop)
+
+    val tableIdentifier = new TableIdentifier(tableName, Some(dbName))
+    val table = sqlContext.sparkSession.sessionState.catalog.listTables(dbName)
+      .find(_.table.equalsIgnoreCase(tableName))
+    if (table.isEmpty) {
+      fail("Table does not exists")
+    }
+    val carbonTable = CarbonEnv.getCarbonTable(tableIdentifier)(sqlContext.sparkSession)
+    val tablePath = carbonTable.getTablePath
+    val bloomPath = tablePath + CarbonCommonConstants.FILE_SEPARATOR + "dblom" +
+                    CarbonCommonConstants.FILE_SEPARATOR
+
+    // Check if table index entries are dropped
+    assert(droppedCacheKeys.asScala.exists(key => key.startsWith(tablePath)))
+
+    // check if cache does not have any more table index entries
+    assert(!cacheAfterDrop.asScala.exists(key => key.startsWith(tablePath)))
+
+    // Check if bloom entries are dropped
+    assert(droppedCacheKeys.asScala.exists(key => key.contains(bloomPath)))
+
+    // check if cache does not have any more bloom entries
+    assert(!cacheAfterDrop.asScala.exists(key => key.contains(bloomPath)))
+  }
+
+  def clone(oldSet: util.Set[String]): util.HashSet[String] = {
+    val newSet = new util.HashSet[String]
+    newSet.addAll(oldSet)
+    newSet
+  }
+}

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/sql/commands/TestCarbonDropCacheCommand.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/sql/commands/TestCarbonDropCacheCommand.scala
@@ -40,6 +40,7 @@ class TestCarbonDropCacheCommand extends QueryTest with BeforeAndAfterAll {
   }
 
   override protected def afterAll(): Unit = {
+    sql(s"use default")
     sql(s"DROP DATABASE $dbName CASCADE")
   }
 

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/sql/commands/TestCarbonDropCacheCommand.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/sql/commands/TestCarbonDropCacheCommand.scala
@@ -53,15 +53,18 @@ class TestCarbonDropCacheCommand extends QueryTest with BeforeAndAfterEach with 
   test("Test dictionary") {
     val tableName = "t1"
 
-    sql(s"CREATE TABLE $tableName(age int, name string) stored by 'carbondata' " +
-        s"TBLPROPERTIES('DICTIONARY_INCLUDE'='age, name')")
-    sql(s"LOAD DATA INPATH '/home/root1/Desktop/CSVs/age_name.csv' INTO TABLE $tableName")
-    sql(s"LOAD DATA INPATH '/home/root1/Desktop/CSVs/age_name.csv' INTO TABLE $tableName")
+    sql(s"CREATE TABLE $tableName(empno int, empname String, designation String, " +
+        s"doj Timestamp, workgroupcategory int, workgroupcategoryname String, deptno int, " +
+        s"deptname String, projectcode int, projectjoindate Timestamp, projectenddate Timestamp," +
+        s"attendance int,utilization int, salary int) stored by 'carbondata' " +
+        s"TBLPROPERTIES('DICTIONARY_INCLUDE'='designation, workgroupcategoryname')")
+    sql(s"LOAD DATA INPATH '$resourcesPath/data.csv' INTO TABLE $tableName")
+    sql(s"LOAD DATA INPATH '$resourcesPath/data.csv' INTO TABLE $tableName")
     sql(s"SELECT * FROM $tableName").collect()
 
     val droppedCacheKeys = clone(CacheProvider.getInstance().getCarbonCache.getCacheMap.keySet())
 
-    sql(s"DROP METACACHE FOR TABLE $tableName")
+    sql(s"DROP METACACHE ON TABLE $tableName")
 
     val cacheAfterDrop = clone(CacheProvider.getInstance().getCarbonCache.getCacheMap.keySet())
     droppedCacheKeys.removeAll(cacheAfterDrop)
@@ -98,16 +101,20 @@ class TestCarbonDropCacheCommand extends QueryTest with BeforeAndAfterEach with 
   test("Test preaggregate datamap") {
     val tableName = "t2"
 
-    sql(s"CREATE TABLE $tableName(age int, name string) stored by 'carbondata'")
+    sql(s"CREATE TABLE $tableName(empno int, empname String, designation String, " +
+        s"doj Timestamp, workgroupcategory int, workgroupcategoryname String, deptno int, " +
+        s"deptname String, projectcode int, projectjoindate Timestamp, projectenddate Timestamp," +
+        s"attendance int, utilization int, salary int) stored by 'carbondata'")
     sql(s"CREATE DATAMAP dpagg ON TABLE $tableName USING 'preaggregate' AS " +
-        s"SELECT AVG(age), name from $tableName GROUP BY name")
-    sql(s"LOAD DATA INPATH '/home/root1/Desktop/CSVs/age_name.csv' INTO TABLE $tableName")
+        s"SELECT AVG(salary), workgroupcategoryname from $tableName GROUP BY workgroupcategoryname")
+    sql(s"LOAD DATA INPATH '$resourcesPath/data.csv' INTO TABLE $tableName")
     sql(s"SELECT * FROM $tableName").collect()
-    sql(s"SELECT AVG(age), name from $tableName GROUP BY name").collect()
+    sql(s"SELECT AVG(salary), workgroupcategoryname from $tableName " +
+        s"GROUP BY workgroupcategoryname").collect()
 
     val droppedCacheKeys = clone(CacheProvider.getInstance().getCarbonCache.getCacheMap.keySet())
 
-    sql(s"DROP METACACHE FOR TABLE $tableName")
+    sql(s"DROP METACACHE ON TABLE $tableName")
 
     val cacheAfterDrop = clone(CacheProvider.getInstance().getCarbonCache.getCacheMap.keySet())
     droppedCacheKeys.removeAll(cacheAfterDrop)
@@ -143,16 +150,19 @@ class TestCarbonDropCacheCommand extends QueryTest with BeforeAndAfterEach with 
   test("Test bloom filter") {
     val tableName = "t3"
 
-    sql(s"CREATE TABLE $tableName(age int, name string) stored by 'carbondata'")
+    sql(s"CREATE TABLE $tableName(empno int, empname String, designation String, " +
+        s"doj Timestamp, workgroupcategory int, workgroupcategoryname String, deptno int, " +
+        s"deptname String, projectcode int, projectjoindate Timestamp, projectenddate Timestamp," +
+        s"attendance int, utilization int, salary int) stored by 'carbondata'")
     sql(s"CREATE DATAMAP dblom ON TABLE $tableName USING 'bloomfilter' " +
-        "DMPROPERTIES('INDEX_COLUMNS'='age')")
-    sql(s"LOAD DATA INPATH '/home/root1/Desktop/CSVs/age_name.csv' INTO TABLE $tableName")
+        "DMPROPERTIES('INDEX_COLUMNS'='deptno')")
+    sql(s"LOAD DATA INPATH '$resourcesPath/data.csv' INTO TABLE $tableName")
     sql(s"SELECT * FROM $tableName").collect()
-    sql(s"SELECT * FROM $tableName WHERE age=25").collect()
+    sql(s"SELECT * FROM $tableName WHERE deptno=10").collect()
 
     val droppedCacheKeys = clone(CacheProvider.getInstance().getCarbonCache.getCacheMap.keySet())
 
-    sql(s"DROP METACACHE FOR TABLE $tableName")
+    sql(s"DROP METACACHE ON TABLE $tableName")
 
     val cacheAfterDrop = clone(CacheProvider.getInstance().getCarbonCache.getCacheMap.keySet())
     droppedCacheKeys.removeAll(cacheAfterDrop)

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/sql/commands/TestCarbonShowCacheCommand.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/sql/commands/TestCarbonShowCacheCommand.scala
@@ -128,7 +128,7 @@ class TestCarbonShowCacheCommand extends QueryTest with BeforeAndAfterAll {
     sql("use cache_empty_db").collect()
     val result1 = sql("show metacache").collect()
     assertResult(2)(result1.length)
-    assertResult(Row("cache_empty_db", "ALL", "0", "0", "0"))(result1(1))
+    assertResult(Row("cache_empty_db", "ALL", "0 bytes", "0 bytes", "0 bytes"))(result1(1))
 
     sql("use cache_db").collect()
     val result2 = sql("show metacache").collect()

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/events/DropCacheEvents.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/events/DropCacheEvents.scala
@@ -23,5 +23,6 @@ import org.apache.carbondata.core.metadata.schema.table.CarbonTable
 
 case class DropCacheEvent(
     carbonTable: CarbonTable,
-    sparkSession: SparkSession)
+    sparkSession: SparkSession,
+    internalCall: Boolean)
   extends Event with DropCacheEventInfo

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/events/DropCacheEvents.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/events/DropCacheEvents.scala
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.events
+
+import org.apache.spark.sql.SparkSession
+
+import org.apache.carbondata.core.metadata.schema.table.CarbonTable
+
+case class DropCacheEvent(
+    carbonTable: CarbonTable,
+    sparkSession: SparkSession)
+  extends Event with DropCacheEventInfo

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/events/Events.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/events/Events.scala
@@ -63,6 +63,13 @@ trait DropTableEventInfo {
 }
 
 /**
+ * event for drop cache
+ */
+trait DropCacheEventInfo {
+  val carbonTable: CarbonTable
+}
+
+/**
  * event for alter_table_drop_column
  */
 trait AlterTableDropColumnEventInfo {

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
@@ -23,6 +23,7 @@ import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException
 import org.apache.spark.sql.catalyst.catalog.SessionCatalog
 import org.apache.spark.sql.events.{MergeBloomIndexEventListener, MergeIndexEventListener}
+import org.apache.spark.sql.execution.command.cache.DropCachePreAggEventListener
 import org.apache.spark.sql.execution.command.preaaggregate._
 import org.apache.spark.sql.execution.command.timeseries.TimeSeriesFunction
 import org.apache.spark.sql.hive._
@@ -185,6 +186,7 @@ object CarbonEnv {
       .addListener(classOf[AlterTableCompactionPostEvent], new MergeIndexEventListener)
       .addListener(classOf[AlterTableMergeIndexEvent], new MergeIndexEventListener)
       .addListener(classOf[BuildDataMapPostExecutionEvent], new MergeBloomIndexEventListener)
+      .addListener(classOf[DropCacheEvent], DropCachePreAggEventListener)
   }
 
   /**

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/cache/CarbonDropCacheCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/cache/CarbonDropCacheCommand.scala
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.command.cache
+
+import scala.collection.JavaConverters._
+
+import org.apache.spark.sql.{CarbonEnv, Row, SparkSession}
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.analysis.NoSuchTableException
+import org.apache.spark.sql.execution.command.DataCommand
+
+import org.apache.carbondata.core.cache.CacheProvider
+import org.apache.carbondata.core.cache.dictionary.AbstractColumnDictionaryInfo
+import org.apache.carbondata.core.constants.CarbonCommonConstants
+import org.apache.carbondata.core.indexstore.BlockletDataMapIndexWrapper
+import org.apache.carbondata.datamap.bloom.BloomCacheKeyValue
+
+case class CarbonDropCacheCommand(tableIdentifier: TableIdentifier) extends DataCommand {
+
+  def clearCache(sparkSession: SparkSession, tableIdentifier: TableIdentifier): Unit = {
+    val cache = CacheProvider.getInstance().getCarbonCache
+    if (cache != null) {
+      val dbLocation = CarbonEnv
+        .getDatabaseLocation(tableIdentifier.database
+          .getOrElse(sparkSession.catalog.currentDatabase), sparkSession)
+        .replace(CarbonCommonConstants.WINDOWS_FILE_SEPARATOR,
+          CarbonCommonConstants.FILE_SEPARATOR)
+      val carbonTable = CarbonEnv
+        .getCarbonTable(tableIdentifier.database, tableIdentifier.table)(sparkSession)
+
+      if (carbonTable.isChildDataMap) {
+        throw new UnsupportedOperationException("Operation not allowed on child table.")
+      }
+
+      // If table has children tables as well, add them to tablePathsBuffer
+      val tablePathsBuffer = scala.collection.mutable.ArrayBuffer.empty[String]
+      tablePathsBuffer += dbLocation + CarbonCommonConstants.FILE_SEPARATOR +
+                          tableIdentifier.table + CarbonCommonConstants.FILE_SEPARATOR
+      if (carbonTable.hasDataMapSchema) {
+        val childrenSchemas = carbonTable.getTableInfo.getDataMapSchemaList.asScala
+          .filter(_.getRelationIdentifier != null)
+        for (childSchema <- childrenSchemas) {
+          tablePathsBuffer += dbLocation + CarbonCommonConstants.FILE_SEPARATOR +
+                              childSchema.getRelationIdentifier.getTableName +
+                              CarbonCommonConstants.FILE_SEPARATOR
+        }
+      }
+      val tablePaths = tablePathsBuffer.toArray
+
+      // Dictionary IDs
+      val dictIds = carbonTable.getAllDimensions.asScala.filter(_.isGlobalDictionaryEncoding)
+        .map(_.getColumnId).toArray
+
+      // Remove elements from cache
+      val cacheIterator = cache.getCacheMap.entrySet().iterator()
+      while (cacheIterator.hasNext) {
+        val entry = cacheIterator.next()
+        val cache = entry.getValue
+
+        if (cache.isInstanceOf[BlockletDataMapIndexWrapper]) {
+          // index
+          val indexPath = entry.getKey.replace(CarbonCommonConstants.WINDOWS_FILE_SEPARATOR,
+            CarbonCommonConstants.FILE_SEPARATOR)
+          val validTablePath = tablePaths.find(tablePath => indexPath.startsWith(tablePath))
+          if (validTablePath.isDefined) {
+            cache.invalidate()
+            cacheIterator.remove()
+          }
+        } else if (cache.isInstanceOf[BloomCacheKeyValue.CacheValue]) {
+          // bloom datamap
+          val shardPath = entry.getKey.replace(CarbonCommonConstants.WINDOWS_FILE_SEPARATOR,
+            CarbonCommonConstants.FILE_SEPARATOR)
+          val validTablePath = tablePaths.find(tablePath => shardPath.contains(tablePath))
+          if (validTablePath.isDefined) {
+            cache.invalidate()
+            cacheIterator.remove()
+          }
+        } else if (cache.isInstanceOf[AbstractColumnDictionaryInfo]) {
+          // dictionary
+          val dictId = dictIds.find(id => entry.getKey.startsWith(id))
+          if (dictId.isDefined) {
+            cache.invalidate()
+            cacheIterator.remove()
+          }
+        }
+      }
+    }
+  }
+
+  override def processData(sparkSession: SparkSession): Seq[Row] = {
+    val dbName = CarbonEnv.getDatabaseName(tableIdentifier.database)(sparkSession)
+    val table = sparkSession.sessionState.catalog.listTables(dbName)
+      .find(_.table.equalsIgnoreCase(tableIdentifier.table))
+    if (table.isEmpty) {
+      throw new NoSuchTableException(dbName, tableIdentifier.table)
+    }
+    clearCache(sparkSession, tableIdentifier)
+    Seq.empty
+  }
+
+  override protected def opName: String = "DROP CACHE"
+
+}

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/cache/CarbonShowCacheCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/cache/CarbonShowCacheCommand.scala
@@ -73,9 +73,6 @@ case class CarbonShowCacheCommand(tableIdentifier: Option[TableIdentifier])
           byteCountToDisplaySize(0L), byteCountToDisplaySize(0L)))
     } else {
       val tableIdents = sparkSession.sessionState.catalog.listTables(currentDatabase).toArray
-      val dbLocation = CarbonEnv.getDatabaseLocation(currentDatabase, sparkSession)
-      val tempLocation = dbLocation.replace(
-        CarbonCommonConstants.WINDOWS_FILE_SEPARATOR, CarbonCommonConstants.FILE_SEPARATOR)
       val tablePaths = tableIdents.map { tableIdent =>
         (CarbonEnv.getCarbonTable(tableIdent)(sparkSession).getTablePath +
          CarbonCommonConstants.FILE_SEPARATOR,
@@ -190,15 +187,10 @@ case class CarbonShowCacheCommand(tableIdentifier: Option[TableIdentifier])
   }
 
   def showTableCache(sparkSession: SparkSession, carbonTable: CarbonTable): Seq[Row] = {
-    val tableName = carbonTable.getTableName
-    val databaseName = carbonTable.getDatabaseName
     val cache = CacheProvider.getInstance().getCarbonCache()
     if (cache == null) {
       Seq.empty
     } else {
-      val dbLocation = CarbonEnv
-        .getDatabaseLocation(databaseName, sparkSession)
-        .replace(CarbonCommonConstants.WINDOWS_FILE_SEPARATOR, CarbonCommonConstants.FILE_SEPARATOR)
       val tablePath = carbonTable.getTablePath + CarbonCommonConstants.FILE_SEPARATOR
       var numIndexFilesCached = 0
 

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/cache/DropCachePreAggEventListener.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/cache/DropCachePreAggEventListener.scala
@@ -1,0 +1,64 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.apache.spark.sql.execution.command.cache
+
+import scala.collection.JavaConverters._
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.CarbonEnv
+import org.apache.spark.sql.catalyst.TableIdentifier
+
+import org.apache.carbondata.common.logging.LogServiceFactory
+import org.apache.carbondata.events.{DropCacheEvent, Event, OperationContext,
+  OperationEventListener}
+
+object DropCachePreAggEventListener extends OperationEventListener {
+
+  val LOGGER = LogServiceFactory.getLogService(this.getClass.getCanonicalName)
+
+  /**
+   * Called on a specified event occurrence
+   *
+   * @param event
+   * @param operationContext
+   */
+  override protected def onEvent(event: Event,
+      operationContext: OperationContext): Unit = {
+
+    event match {
+      case dropCacheEvent: DropCacheEvent =>
+        val carbonTable = dropCacheEvent.carbonTable
+        val sparkSession = dropCacheEvent.sparkSession
+
+        if (carbonTable.hasDataMapSchema) {
+          val childrenSchemas = carbonTable.getTableInfo.getDataMapSchemaList.asScala
+            .filter(_.getRelationIdentifier != null)
+          for (childSchema <- childrenSchemas) {
+            val childTable =
+              CarbonEnv.getCarbonTable(
+                TableIdentifier(childSchema.getRelationIdentifier.getTableName,
+                  Some(childSchema.getRelationIdentifier.getDatabaseName)))(sparkSession)
+            val dropCacheCommandForChildTable = CarbonDropCacheCommand(TableIdentifier(childTable
+              .getTableName, Some(childTable.getDatabaseName)), true)
+            dropCacheCommandForChildTable.processMetadata(sparkSession)
+          }
+        }
+    }
+
+  }
+}

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSpark2SqlParser.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSpark2SqlParser.scala
@@ -504,7 +504,7 @@ class CarbonSpark2SqlParser extends CarbonDDLSqlParser {
     }
 
   protected lazy val dropCache: Parser[LogicalPlan] =
-    DROP ~> METACACHE ~> forTable <~ opt(";") ^^ {
+    DROP ~> METACACHE ~> ontable <~ opt(";") ^^ {
       case table =>
         CarbonDropCacheCommand(table)
     }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSpark2SqlParser.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSpark2SqlParser.scala
@@ -33,7 +33,7 @@ import org.apache.spark.sql.execution.command.table.CarbonCreateTableCommand
 import org.apache.spark.sql.types.StructField
 import org.apache.spark.sql.CarbonExpressions.CarbonUnresolvedRelation
 import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
-import org.apache.spark.sql.execution.command.cache.CarbonShowCacheCommand
+import org.apache.spark.sql.execution.command.cache.{CarbonShowCacheCommand, CarbonDropCacheCommand}
 import org.apache.spark.sql.execution.command.stream.{CarbonCreateStreamCommand, CarbonDropStreamCommand, CarbonShowStreamsCommand}
 import org.apache.spark.sql.util.CarbonException
 import org.apache.spark.util.CarbonReflectionUtils
@@ -95,7 +95,7 @@ class CarbonSpark2SqlParser extends CarbonDDLSqlParser {
     createStream | dropStream | showStreams
 
   protected lazy val cacheManagement: Parser[LogicalPlan] =
-    showCache
+    showCache | dropCache
 
   protected lazy val alterAddPartition: Parser[LogicalPlan] =
     ALTER ~> TABLE ~> (ident <~ ".").? ~ ident ~ (ADD ~> PARTITION ~>
@@ -501,6 +501,12 @@ class CarbonSpark2SqlParser extends CarbonDDLSqlParser {
     SHOW ~> METACACHE ~> opt(ontable) <~ opt(";") ^^ {
       case table =>
         CarbonShowCacheCommand(table)
+    }
+
+  protected lazy val dropCache: Parser[LogicalPlan] =
+    DROP ~> METACACHE ~> forTable <~ opt(";") ^^ {
+      case table =>
+        CarbonDropCacheCommand(table)
     }
 
   protected lazy val cli: Parser[LogicalPlan] =

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSpark2SqlParser.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSpark2SqlParser.scala
@@ -506,7 +506,7 @@ class CarbonSpark2SqlParser extends CarbonDDLSqlParser {
   protected lazy val dropCache: Parser[LogicalPlan] =
     DROP ~> METACACHE ~> ontable <~ opt(";") ^^ {
       case table =>
-        CarbonDropCacheCommand(table, internalCall = false)
+        CarbonDropCacheCommand(table)
     }
 
   protected lazy val cli: Parser[LogicalPlan] =

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSpark2SqlParser.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSpark2SqlParser.scala
@@ -506,7 +506,7 @@ class CarbonSpark2SqlParser extends CarbonDDLSqlParser {
   protected lazy val dropCache: Parser[LogicalPlan] =
     DROP ~> METACACHE ~> ontable <~ opt(";") ^^ {
       case table =>
-        CarbonDropCacheCommand(table)
+        CarbonDropCacheCommand(table, internalCall = false)
     }
 
   protected lazy val cli: Parser[LogicalPlan] =

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSpark2SqlParser.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSpark2SqlParser.scala
@@ -33,7 +33,7 @@ import org.apache.spark.sql.execution.command.table.CarbonCreateTableCommand
 import org.apache.spark.sql.types.StructField
 import org.apache.spark.sql.CarbonExpressions.CarbonUnresolvedRelation
 import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
-import org.apache.spark.sql.execution.command.cache.{CarbonShowCacheCommand, CarbonDropCacheCommand}
+import org.apache.spark.sql.execution.command.cache.{CarbonDropCacheCommand, CarbonShowCacheCommand}
 import org.apache.spark.sql.execution.command.stream.{CarbonCreateStreamCommand, CarbonDropStreamCommand, CarbonShowStreamsCommand}
 import org.apache.spark.sql.util.CarbonException
 import org.apache.spark.util.CarbonReflectionUtils


### PR DESCRIPTION
Added CarbonDropCacheCommand to drop all cache entries for a particular table.

usage:
```sql
DROP METACACHE ON TABLE tableName
```

Dropping cache for child table is not supported, the table has to be parent table.
Running the above command will clear all the entries belonging to the table, its index entries, its datamap entries and it's forward and reverse dictionary.

 - [x] Any interfaces changed?  -->  No
 - [x] Any backward compatibility impacted?  -->  No
 - [x] Document update required?  -->  Yes
 - [x] Testing done  ->  Yes