### PR TITLE
[WIP] Improve index read

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMap.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMap.java
@@ -167,6 +167,7 @@ public class BlockletDataMap extends BlockDataMap implements Serializable {
       BlockletInfo blockletInfo = blockletList.get(index);
       blockletInfo.setSorted(fileFooter.isSorted());
       BlockletMinMaxIndex minMaxIndex = blockletInfo.getBlockletIndex().getMinMaxIndex();
+      row.setInt(blockletInfo.getNumberOfRows(), ordinal++);
       // get min max values for columns to be cached
       byte[][] minValuesForColumnsToBeCached = BlockletDataMapUtil
           .getMinMaxForColumnsToBeCached(segmentProperties, minMaxCacheColumns,
@@ -188,7 +189,9 @@ public class BlockletDataMap extends BlockDataMap implements Serializable {
       addTaskMinMaxValues(summaryRow, taskSummarySchema, taskMinMaxOrdinal,
           maxValuesForColumnsToBeCached, TASK_MAX_VALUES_INDEX, false);
       ordinal++;
-      row.setInt(blockletInfo.getNumberOfRows(), ordinal++);
+      // add min max flag for all the dimension columns
+      addMinMaxFlagValues(row, schema[ordinal], minMaxFlagValuesForColumnsToBeCached, ordinal);
+      ordinal++;
       // add file name
       byte[] filePathBytes =
           getFileNameFromPath(filePath).getBytes(CarbonCommonConstants.DEFAULT_CHARSET_CLASS);
@@ -204,9 +207,7 @@ public class BlockletDataMap extends BlockDataMap implements Serializable {
         setLocations(blockMetaInfo.getLocationInfo(), row, ordinal++);
         // Store block size
         row.setLong(blockMetaInfo.getSize(), ordinal++);
-        // add min max flag for all the dimension columns
-        addMinMaxFlagValues(row, schema[ordinal], minMaxFlagValuesForColumnsToBeCached, ordinal);
-        ordinal++;
+
         // add blocklet info
         ByteArrayOutputStream stream = new ByteArrayOutputStream();
         DataOutput dataOutput = new DataOutputStream(stream);
@@ -235,8 +236,8 @@ public class BlockletDataMap extends BlockDataMap implements Serializable {
         .convertToSafeRow();
     short relativeBlockletId = safeRow.getShort(BLOCKLET_ID_INDEX);
     String filePath = getFilePath();
-    return createBlocklet(safeRow, getFileNameWithFilePath(safeRow, filePath), relativeBlockletId,
-        false);
+    return createBlocklet(safeRow, getFileNameWithFilePath(safeRow, filePath, -1),
+        relativeBlockletId, false);
   }
 
   @Override

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMap.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMap.java
@@ -224,8 +224,10 @@ public class BlockletDataMap extends BlockDataMap implements Serializable {
       return super.getDetailedBlocklet(blockletId);
     }
     int absoluteBlockletId = Integer.parseInt(blockletId);
-    DataMapRow safeRow = memoryDMStore.getDataMapRow(getFileFooterEntrySchema(), absoluteBlockletId)
-        .convertToSafeRow();
+    DataMapRow row =
+        memoryDMStore.getDataMapRow(getFileFooterEntrySchema(), absoluteBlockletId);
+    DataMapRow safeRow = row.convertToSafeRow(FILE_PATH_INDEX, 0);
+    safeRow.setInt(row.getInt(ROW_COUNT_INDEX), ROW_COUNT_INDEX);
     short relativeBlockletId = safeRow.getShort(BLOCKLET_ID_INDEX);
     String filePath = getFilePath();
     return createBlocklet(safeRow, getFileNameWithFilePath(safeRow, filePath, -1),

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMapRowIndexes.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMapRowIndexes.java
@@ -22,25 +22,25 @@ package org.apache.carbondata.core.indexstore.blockletindex;
 public interface BlockletDataMapRowIndexes {
 
   // Each DataMapRow Indexes for blocklet and block dataMap
-  int MIN_VALUES_INDEX = 0;
+  int ROW_COUNT_INDEX = 0;
 
-  int MAX_VALUES_INDEX = 1;
+  int MIN_VALUES_INDEX = 1;
 
-  int ROW_COUNT_INDEX = 2;
+  int MAX_VALUES_INDEX = 2;
 
-  int FILE_PATH_INDEX = 3;
+  int BLOCK_MIN_MAX_FLAG = 3;
 
-  int VERSION_INDEX = 4;
+  int FILE_PATH_INDEX = 4;
 
-  int SCHEMA_UPADATED_TIME_INDEX = 5;
+  int VERSION_INDEX = 5;
 
-  int BLOCK_FOOTER_OFFSET = 6;
+  int SCHEMA_UPADATED_TIME_INDEX = 6;
 
-  int LOCATIONS = 7;
+  int BLOCK_FOOTER_OFFSET = 7;
 
-  int BLOCK_LENGTH = 8;
+  int LOCATIONS = 8;
 
-  int BLOCK_MIN_MAX_FLAG = 9;
+  int BLOCK_LENGTH = 9;
 
   // below variables are specific for blockletDataMap
   int BLOCKLET_INFO_INDEX = 10;

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMapRowIndexes.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMapRowIndexes.java
@@ -26,39 +26,31 @@ public interface BlockletDataMapRowIndexes {
 
   int MIN_VALUES_INDEX = 1;
 
-  int MAX_VALUES_INDEX = 2;
+  int FILE_PATH_INDEX = 2;
 
-  int BLOCK_MIN_MAX_FLAG = 3;
+  int LOCATIONS = 3;
 
-  int FILE_PATH_INDEX = 4;
+  int VERSION_INDEX = 4;
 
-  int VERSION_INDEX = 5;
+  int SCHEMA_UPADATED_TIME_INDEX = 5;
 
-  int SCHEMA_UPADATED_TIME_INDEX = 6;
+  int BLOCK_FOOTER_OFFSET = 6;
 
-  int BLOCK_FOOTER_OFFSET = 7;
-
-  int LOCATIONS = 8;
-
-  int BLOCK_LENGTH = 9;
+  int BLOCK_LENGTH = 7;
 
   // below variables are specific for blockletDataMap
-  int BLOCKLET_INFO_INDEX = 10;
+  int BLOCKLET_INFO_INDEX = 8;
 
-  int BLOCKLET_PAGE_COUNT_INDEX = 11;
+  int BLOCKLET_PAGE_COUNT_INDEX = 9;
 
-  int BLOCKLET_ID_INDEX = 12;
+  int BLOCKLET_ID_INDEX = 10;
 
   // Summary dataMap row indexes
   int TASK_MIN_VALUES_INDEX = 0;
 
-  int TASK_MAX_VALUES_INDEX = 1;
+  int SUMMARY_INDEX_FILE_NAME = 1;
 
-  int SUMMARY_INDEX_FILE_NAME = 2;
+  int SUMMARY_SEGMENTID = 2;
 
-  int SUMMARY_SEGMENTID = 3;
-
-  int TASK_MIN_MAX_FLAG = 4;
-
-  int SUMMARY_INDEX_PATH = 5;
+  int SUMMARY_INDEX_PATH = 3;
 }

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/row/DataMapRow.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/row/DataMapRow.java
@@ -114,7 +114,7 @@ public abstract class DataMapRow implements Serializable {
    *
    * @return
    */
-  public DataMapRow convertToSafeRow() {
+  public DataMapRow convertToSafeRow(int ordinal, int position) {
     return this;
   }
 
@@ -125,6 +125,10 @@ public abstract class DataMapRow implements Serializable {
   }
 
   public int getPosition() {
+    return 0;
+  }
+
+  public int getCurrentPointer() {
     return 0;
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/row/DataMapRow.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/row/DataMapRow.java
@@ -37,7 +37,11 @@ public abstract class DataMapRow implements Serializable {
 
   public abstract byte[] getByteArray(int ordinal);
 
+  public abstract byte[] getByteArray(int ordinal, int position);
+
   public abstract DataMapRow getRow(int ordinal);
+
+  public abstract DataMapRow getRow(int ordinal, int position);
 
   public abstract void setRow(DataMapRow row, int ordinal);
 
@@ -118,5 +122,9 @@ public abstract class DataMapRow implements Serializable {
     if (null == this.schemas) {
       this.schemas = schemas;
     }
+  }
+
+  public int getPosition() {
+    return 0;
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/row/DataMapRowImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/row/DataMapRowImpl.java
@@ -37,6 +37,10 @@ public class DataMapRowImpl extends DataMapRow {
     return (byte[]) data[ordinal];
   }
 
+  @Override public byte[] getByteArray(int ordinal, int position) {
+    return (byte[]) data[ordinal];
+  }
+
   @Override public int getLengthInBytes(int ordinal) {
     return ((byte[]) data[ordinal]).length;
   }
@@ -51,6 +55,10 @@ public class DataMapRowImpl extends DataMapRow {
   }
 
   @Override public DataMapRow getRow(int ordinal) {
+    return (DataMapRow) data[ordinal];
+  }
+
+  @Override public DataMapRow getRow(int ordinal, int position) {
     return (DataMapRow) data[ordinal];
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/row/UnsafeDataMapRow.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/row/UnsafeDataMapRow.java
@@ -46,8 +46,14 @@ public class UnsafeDataMapRow extends DataMapRow {
   }
 
   @Override public byte[] getByteArray(int ordinal) {
+    return getByteArray(ordinal, getPosition(ordinal));
+  }
+
+  @Override public byte[] getByteArray(int ordinal, int position) {
+    if (position < 0) {
+      position = getPosition(ordinal);
+    }
     int length;
-    int position = getPosition(ordinal);
     switch (schemas[ordinal].getSchemaType()) {
       case VARIABLE_SHORT:
         length = getUnsafe().getShort(block.getBaseObject(),
@@ -116,6 +122,15 @@ public class UnsafeDataMapRow extends DataMapRow {
     CarbonRowSchema[] childSchemas =
         ((CarbonRowSchema.StructCarbonRowSchema) schemas[ordinal]).getChildSchemas();
     return new UnsafeDataMapRow(childSchemas, block, pointer + getPosition(ordinal));
+  }
+
+  @Override public DataMapRow getRow(int ordinal, int position) {
+    CarbonRowSchema[] childSchemas =
+        ((CarbonRowSchema.StructCarbonRowSchema) schemas[ordinal]).getChildSchemas();
+    if (position < 0) {
+      position = getPosition(ordinal);
+    }
+    return new UnsafeDataMapRow(childSchemas, block, pointer + position);
   }
 
   @Override public void setByteArray(byte[] byteArray, int ordinal) {
@@ -313,5 +328,9 @@ public class UnsafeDataMapRow extends DataMapRow {
       position += getSizeInBytes(i, position);
     }
     return position;
+  }
+
+  @Override public int getPosition() {
+    return pointer;
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/schema/SchemaGenerator.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/schema/SchemaGenerator.java
@@ -40,10 +40,13 @@ public class SchemaGenerator {
   public static CarbonRowSchema[] createBlockSchema(SegmentProperties segmentProperties,
       List<CarbonColumn> minMaxCacheColumns) {
     List<CarbonRowSchema> indexSchemas = new ArrayList<>();
-    // get MinMax Schema
-    getMinMaxSchema(segmentProperties, indexSchemas, minMaxCacheColumns);
     // for number of rows.
     indexSchemas.add(new CarbonRowSchema.FixedCarbonRowSchema(DataTypes.INT));
+    // get MinMax Schema
+    getMinMaxSchema(segmentProperties, indexSchemas, minMaxCacheColumns);
+    // for storing min max flag for each column which reflects whether min max for a column is
+    // written in the metadata or not.
+    addMinMaxFlagSchema(segmentProperties, indexSchemas, minMaxCacheColumns);
     // for table block path
     indexSchemas.add(new CarbonRowSchema.VariableCarbonRowSchema(DataTypes.BYTE_ARRAY));
     // for version number.
@@ -56,9 +59,6 @@ public class SchemaGenerator {
     indexSchemas.add(new CarbonRowSchema.VariableCarbonRowSchema(DataTypes.BYTE_ARRAY));
     // for storing block length.
     indexSchemas.add(new CarbonRowSchema.FixedCarbonRowSchema(DataTypes.LONG));
-    // for storing min max flag for each column which reflects whether min max for a column is
-    // written in the metadata or not.
-    addMinMaxFlagSchema(segmentProperties, indexSchemas, minMaxCacheColumns);
     CarbonRowSchema[] schema = indexSchemas.toArray(new CarbonRowSchema[indexSchemas.size()]);
     return schema;
   }
@@ -72,10 +72,13 @@ public class SchemaGenerator {
   public static CarbonRowSchema[] createBlockletSchema(SegmentProperties segmentProperties,
       List<CarbonColumn> minMaxCacheColumns) {
     List<CarbonRowSchema> indexSchemas = new ArrayList<>();
-    // get MinMax Schema
-    getMinMaxSchema(segmentProperties, indexSchemas, minMaxCacheColumns);
     // for number of rows.
     indexSchemas.add(new CarbonRowSchema.FixedCarbonRowSchema(DataTypes.INT));
+    // get MinMax Schema
+    getMinMaxSchema(segmentProperties, indexSchemas, minMaxCacheColumns);
+    // for storing min max flag for each column which reflects whether min max for a column is
+    // written in the metadata or not.
+    addMinMaxFlagSchema(segmentProperties, indexSchemas, minMaxCacheColumns);
     // for table block path
     indexSchemas.add(new CarbonRowSchema.VariableCarbonRowSchema(DataTypes.BYTE_ARRAY));
     // for version number.
@@ -88,9 +91,7 @@ public class SchemaGenerator {
     indexSchemas.add(new CarbonRowSchema.VariableCarbonRowSchema(DataTypes.BYTE_ARRAY));
     // for storing block length.
     indexSchemas.add(new CarbonRowSchema.FixedCarbonRowSchema(DataTypes.LONG));
-    // for storing min max flag for each column which reflects whether min max for a column is
-    // written in the metadata or not.
-    addMinMaxFlagSchema(segmentProperties, indexSchemas, minMaxCacheColumns);
+
     //for blocklet info
     indexSchemas.add(new CarbonRowSchema.VariableCarbonRowSchema(DataTypes.BYTE_ARRAY));
     // for number of pages.

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/schema/SchemaGenerator.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/schema/SchemaGenerator.java
@@ -143,6 +143,13 @@ public class SchemaGenerator {
       List<CarbonRowSchema> minMaxSchemas, List<CarbonColumn> minMaxCacheColumns) {
     // Index key
     int[] minMaxLen = getMinMaxLength(segmentProperties, minMaxCacheColumns);
+    if (minMaxLen.length == 0) {
+      CarbonRowSchema mapSchema =
+          new CarbonRowSchema.StructCarbonRowSchema(DataTypes.createDefaultStructType(),
+              new CarbonRowSchema[0]);
+      minMaxSchemas.add(mapSchema);
+      return;
+    }
     int[] columnOrdinals = getColumnOrdinalsToAccess(segmentProperties, minMaxCacheColumns);
     // do it 2 times, one for min and one for max.
     CarbonRowSchema[] mapSchemas = new CarbonRowSchema[(minMaxLen.length * 2) + 1];

--- a/core/src/main/java/org/apache/carbondata/core/util/BlockletDataMapUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/BlockletDataMapUtil.java
@@ -423,7 +423,7 @@ public class BlockletDataMapUtil {
    * @param minMaxFlag
    * @return
    */
-  public static boolean[] getMinMaxFlagValuesForColumnsToBeCached(
+  public static byte[] getMinMaxFlagValuesForColumnsToBeCached(
       SegmentProperties segmentProperties, List<CarbonColumn> minMaxCacheColumns,
       boolean[] minMaxFlag) {
     boolean[] minMaxFlagValuesForColumnsToBeCached = minMaxFlag;
@@ -435,7 +435,11 @@ public class BlockletDataMapUtil {
             minMaxFlag[getColumnOrdinal(segmentProperties, column)];
       }
     }
-    return minMaxFlagValuesForColumnsToBeCached;
+    byte[] flags = new byte[minMaxFlagValuesForColumnsToBeCached.length];
+    for (int i = 0; i < flags.length; i++) {
+      flags[i] = (byte) (minMaxFlagValuesForColumnsToBeCached[i] ? 1 : 0);
+    }
+    return flags;
   }
 
   /**

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/allqueries/TestQueryWithColumnMetCacheAndCacheLevelProperty.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/allqueries/TestQueryWithColumnMetCacheAndCacheLevelProperty.scala
@@ -95,7 +95,7 @@ class TestQueryWithColumnMetCacheAndCacheLevelProperty extends QueryTest with Be
       .getSegmentPropertiesWrapper(index).getTaskSummarySchemaForBlock(storeBlockletCount, false)
     val minSchemas = summarySchema(0).asInstanceOf[CarbonRowSchema.StructCarbonRowSchema]
       .getChildSchemas
-    minSchemas.length == expectedLength
+    (minSchemas.length - 1) / 2 == expectedLength
   }
 
   test("verify if number of columns cached are as per the COLUMN_META_CACHE property dataMap instance is as per CACHE_LEVEL property") {


### PR DESCRIPTION
Problem:
In current BlockDataMap the data stored in unsafe and it does not maintain many offsets to keep the memory more compact but converting the unsafe to safe row to create the blocklet it takes more time for a large number of blocks scenario.

Solution:
We have 2 scenarios for reading the datamap , one is pruning and another one is listing of all blocks for non-filter queries. During filter queries, we should read only min/max and path information not completely and during block creation, we should not read min/max. To achieve this I proposed the following changes. 
1. Group the schema in such a way that filter queries first read part of the necessary schema for pruning, so min/max/minmaxflags are grouped to struct. This will compact the schema better and skip them easily when not needed.
2. When you are accessing the fields from unsafe we can get the last position of it and pass it as starting position for next fields, this will avoid the position calculation if fields are read sequentially.
3. During converttosafe from unsafe we can now pass from which field ordinal we want to read data, this will avoid unnecessary read during blocklet creation.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

