### PR TITLE
[CARBONDATA-3317] Fix NPE when execute 'show segments' command for stream table

### DIFF
--- a/integration/spark-common/src/main/scala/org/apache/carbondata/api/CarbonStore.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/api/CarbonStore.scala
@@ -111,7 +111,6 @@ object CarbonStore {
             } else {
               (-1L, -1L)
             }
-            
           } else {
             // for batch segment, we can get the data size from table status file directly
             (if (load.getDataSize == null) -1L else load.getDataSize.toLong,

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/api/CarbonStore.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/api/CarbonStore.scala
@@ -103,8 +103,15 @@ object CarbonStore {
             // since it is continuously inserting data
             val segmentDir = CarbonTablePath.getSegmentPath(tablePath, load.getLoadName)
             val indexPath = CarbonTablePath.getCarbonStreamIndexFilePath(segmentDir)
-            val indices = StreamSegment.readIndexFile(indexPath, FileFactory.getFileType(indexPath))
-            (indices.asScala.map(_.getFile_size).sum, FileFactory.getCarbonFile(indexPath).getSize)
+            val indexFile = FileFactory.getCarbonFile(indexPath)
+            if (indexFile.exists()) {
+              val indices =
+                StreamSegment.readIndexFile(indexPath, FileFactory.getFileType(indexPath))
+              (indices.asScala.map(_.getFile_size).sum, indexFile.getSize)
+            } else {
+              (-1L, -1L)
+            }
+            
           } else {
             // for batch segment, we can get the data size from table status file directly
             (if (load.getDataSize == null) -1L else load.getDataSize.toLong,


### PR DESCRIPTION

When spark streaming app starts to create new stream segment, it does not create carbondataindex file before writing data successfully, and now if execute 'show segments' command, it will throw NPE.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed? NO
 
 - [ ] Any backward compatibility impacted?  NO
 
 - [ ] Document update required?  NO

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       Test manually.
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

