### PR TITLE
[HOTFIX][DOC] Optimize quick-start-guide.md and dml-of-carbondata.md

### DIFF
--- a/docs/dml-of-carbondata.md
+++ b/docs/dml-of-carbondata.md
@@ -35,10 +35,14 @@ CarbonData DML statements are documented here,which includes:
   This command is used to load csv files to carbondata, OPTIONS are not mandatory for data loading process. 
 
   ```
-  LOAD DATA [LOCAL] INPATH 'folder_path' 
+  LOAD DATA INPATH 'folder_path'
   INTO TABLE [db_name.]table_name 
   OPTIONS(property_name=property_value, ...)
   ```
+  **NOTE**:
+   - If run the sql on cluster mode, please upload all input files to HDFS or S3 and so on.
+   - If run the sql on local mode with HDFS, please upload all input files to HDFS.
+   - If run the sql on local mode with local file system, it just supports to read input files from local file system.
 
   **Supported Properties:**
 
@@ -232,7 +236,7 @@ CarbonData DML statements are documented here,which includes:
    Example:
 
    ```
-   LOAD DATA local inpath '/opt/rawdata/data.csv' INTO table carbontable
+   LOAD DATA inpath '/opt/rawdata/data.csv' INTO table carbontable
    options('DELIMITER'=',', 'QUOTECHAR'='"','COMMENTCHAR'='#',
    'HEADER'='false',
    'FILEHEADER'='empno,empname,designation,doj,workgroupcategory,
@@ -350,17 +354,19 @@ CarbonData DML statements are documented here,which includes:
   This command allows you to load data using static partition.
 
   ```
-  LOAD DATA [LOCAL] INPATH 'folder_path' 
+  LOAD DATA INPATH 'folder_path'
   INTO TABLE [db_name.]table_name PARTITION (partition_spec) 
-  OPTIONS(property_name=property_value, ...)    
+  OPTIONS(property_name=property_value, ...)
+
   INSERT INTO INTO TABLE [db_name.]table_name PARTITION (partition_spec) <SELECT STATEMENT>
   ```
 
   Example:
   ```
-  LOAD DATA LOCAL INPATH '${env:HOME}/staticinput.csv'
+  LOAD DATA INPATH '${env:HOME}/staticinput.csv'
   INTO TABLE locationTable
-  PARTITION (country = 'US', state = 'CA')  
+  PARTITION (country = 'US', state = 'CA')
+
   INSERT INTO TABLE locationTable
   PARTITION (country = 'US', state = 'AL')
   SELECT <columns list excluding partition columns> FROM another_user
@@ -372,8 +378,9 @@ CarbonData DML statements are documented here,which includes:
 
   Example:
   ```
-  LOAD DATA LOCAL INPATH '${env:HOME}/staticinput.csv'
-  INTO TABLE locationTable          
+  LOAD DATA INPATH '${env:HOME}/staticinput.csv'
+  INTO TABLE locationTable
+
   INSERT INTO TABLE locationTable
   SELECT <columns list excluding partition columns> FROM another_user
   ```

--- a/docs/dml-of-carbondata.md
+++ b/docs/dml-of-carbondata.md
@@ -40,9 +40,8 @@ CarbonData DML statements are documented here,which includes:
   OPTIONS(property_name=property_value, ...)
   ```
   **NOTE**:
-   - If run the sql on cluster mode, please upload all input files to HDFS or S3 and so on.
-   - If run the sql on local mode with HDFS, please upload all input files to HDFS.
-   - If run the sql on local mode with local file system, it just supports to read input files from local file system.
+    * Use 'file://' prefix to indicate local input files path, but it just supports local mode.
+    * If run on cluster mode, please upload all input files to distributed file system, for example 'hdfs://' for hdfs.
 
   **Supported Properties:**
 
@@ -358,7 +357,7 @@ CarbonData DML statements are documented here,which includes:
   INTO TABLE [db_name.]table_name PARTITION (partition_spec) 
   OPTIONS(property_name=property_value, ...)
 
-  INSERT INTO INTO TABLE [db_name.]table_name PARTITION (partition_spec) <SELECT STATEMENT>
+  INSERT INTO TABLE [db_name.]table_name PARTITION (partition_spec) <SELECT STATEMENT>
   ```
 
   Example:

--- a/docs/quick-start-guide.md
+++ b/docs/quick-start-guide.md
@@ -241,7 +241,9 @@ mv carbondata.tar.gz carbonlib/
 --executor-cores 2
 ```
 
-**NOTE**: Make sure you have permissions for CarbonData JARs and files through which driver and executor will start.
+**NOTE**:
+ - Make sure you have permissions for CarbonData JARs and files through which driver and executor will start.
+ - If use Spark + Hive 1.1.X, it needs to add carbondata assembly jar and carbondata-hive jar into parameter 'spark.sql.hive.metastore.jars' in spark-default.conf file.
 
 
 


### PR DESCRIPTION
1. add note for using Spark + Hive 1.1.X in 'quick-start-guide.md' file
2. separate 'load data' and 'insert into' sql to avoid ambiguity
3. remove 'LOAD DATA LOCAL' semantic, currently the 'LOCAL' is invalid.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

