### PR TITLE
[CARBONDATA-3329] Fixed deadlock issue during failed query

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonDatasourceHadoopRelation.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonDatasourceHadoopRelation.scala
@@ -56,8 +56,6 @@ case class CarbonDatasourceHadoopRelation(
     paths.head,
     CarbonEnv.getDatabaseName(caseInsensitiveMap.get("dbname"))(sparkSession),
     caseInsensitiveMap("tablename"))
-  lazy val databaseName: String = carbonTable.getDatabaseName
-  lazy val tableName: String = carbonTable.getTableName
   CarbonSession.updateSessionInfoToCurrentThread(sparkSession)
 
   @transient lazy val carbonRelation: CarbonRelation =
@@ -198,8 +196,8 @@ case class CarbonDatasourceHadoopRelation(
   override def unhandledFilters(filters: Array[Filter]): Array[Filter] = new Array[Filter](0)
 
   override def toString: String = {
-    "CarbonDatasourceHadoopRelation [ " + "Database name :" + databaseName +
-    ", " + "Table name :" + tableName + ", Schema :" + tableSchema + " ]"
+    "CarbonDatasourceHadoopRelation [ " + "Database name :" + identifier.getDatabaseName +
+    ", " + "Table name :" + identifier.getTableName + ", Schema :" + tableSchema + " ]"
   }
 
   override def sizeInBytes: Long = carbonRelation.sizeInBytes

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/cache/CacheUtil.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/cache/CacheUtil.scala
@@ -44,6 +44,9 @@ object CacheUtil {
       CarbonDataMergerUtil.getValidSegmentList(absoluteTableIdentifier).asScala.flatMap {
         segment =>
           segment.getCommittedIndexFile.keySet().asScala
+      }.map { indexFile =>
+        indexFile.replace(CarbonCommonConstants.WINDOWS_FILE_SEPARATOR,
+          CarbonCommonConstants.FILE_SEPARATOR)
       }.toList
     } else {
       val tablePath = carbonTable.getTablePath
@@ -53,6 +56,9 @@ object CacheUtil {
         load =>
           val seg = new Segment(load.getLoadName, null, readCommittedScope)
           seg.getCommittedIndexFile.keySet().asScala
+      }.map { indexFile =>
+        indexFile.replace(CarbonCommonConstants.WINDOWS_FILE_SEPARATOR,
+          CarbonCommonConstants.FILE_SEPARATOR)
       }.toList
     }
   }


### PR DESCRIPTION
**Problem:** When query fail, SparkExecuteStatementOperation.logError will trigger, a call to CarbonDatasourceHadoopRelation.toString which will try to extract carbontable from relation. For this a lock is acquired on HiveExternalCatalog and then in logger. But  SparkExecuteStatementOperation.logError has already acquired lock on logger and is internally expecting a lock on HiveExternalCatalog which will lead to a deadlock

**Solution:** Dont use carbontable to get the dbName and tableName. Extract from identifier.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

