### PR TITLE
[CARBONDATA-3332] Blocked concurrent compaction and update/delete

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/locks/LockUsage.java
+++ b/core/src/main/java/org/apache/carbondata/core/locks/LockUsage.java
@@ -36,5 +36,6 @@ public class LockUsage {
   public static final String STREAMING_LOCK = "streaming.lock";
   public static final String DATAMAP_STATUS_LOCK = "datamapstatus.lock";
   public static final String CONCURRENT_LOAD_LOCK = "concurrentload.lock";
+  public static final String UPDATE_LOCK = "update.lock";
 
 }

--- a/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -871,7 +871,7 @@ object CarbonDataRDDFactory {
         val updateLock = CarbonLockFactory.getCarbonLockObj(carbonTable
           .getAbsoluteTableIdentifier, LockUsage.UPDATE_LOCK)
         try {
-          if (updateLock.lockWithRetries()) {
+          if (updateLock.lockWithRetries(3, 3)) {
             if (lock.lockWithRetries()) {
               LOGGER.info("Acquired the compaction lock.")
               startCompactionThreads(sqlContext,

--- a/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -54,6 +54,7 @@ import org.apache.carbondata.core.datastore.compression.CompressorFactory
 import org.apache.carbondata.core.datastore.filesystem.CarbonFile
 import org.apache.carbondata.core.datastore.impl.FileFactory
 import org.apache.carbondata.core.dictionary.server.DictionaryServer
+import org.apache.carbondata.core.exception.ConcurrentOperationException
 import org.apache.carbondata.core.locks.{CarbonLockFactory, ICarbonLock, LockUsage}
 import org.apache.carbondata.core.metadata.{CarbonTableIdentifier, ColumnarFormatVersion, SegmentFileStore}
 import org.apache.carbondata.core.metadata.datatype.DataTypes
@@ -867,27 +868,34 @@ object CarbonDataRDDFactory {
         val lock = CarbonLockFactory.getCarbonLockObj(
           carbonTable.getAbsoluteTableIdentifier,
           LockUsage.COMPACTION_LOCK)
-
-        if (lock.lockWithRetries()) {
-          LOGGER.info("Acquired the compaction lock.")
-          try {
-            startCompactionThreads(sqlContext,
-              carbonLoadModel,
-              storeLocation,
-              compactionModel,
-              lock,
-              compactedSegments,
-              operationContext
-            )
-          } catch {
-            case e: Exception =>
-              LOGGER.error(s"Exception in start compaction thread. ${ e.getMessage }")
-              lock.unlock()
-              throw e
+        val updateLock = CarbonLockFactory.getCarbonLockObj(carbonTable
+          .getAbsoluteTableIdentifier, LockUsage.UPDATE_LOCK)
+        try {
+          if (updateLock.lockWithRetries()) {
+            if (lock.lockWithRetries()) {
+              LOGGER.info("Acquired the compaction lock.")
+              startCompactionThreads(sqlContext,
+                carbonLoadModel,
+                storeLocation,
+                compactionModel,
+                lock,
+                compactedSegments,
+                operationContext
+              )
+            } else {
+              LOGGER.error("Not able to acquire the compaction lock for table " +
+                           s"${ carbonLoadModel.getDatabaseName }.${ carbonLoadModel.getTableName}")
+            }
+          } else {
+            throw new ConcurrentOperationException(carbonTable, "update", "compaction")
           }
-        } else {
-          LOGGER.error("Not able to acquire the compaction lock for table " +
-                       s"${ carbonLoadModel.getDatabaseName }.${ carbonLoadModel.getTableName}")
+        } catch {
+          case e: Exception =>
+            LOGGER.error(s"Exception in start compaction thread.", e)
+            lock.unlock()
+            throw e
+        } finally {
+          updateLock.unlock()
         }
       }
     }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonAlterTableCompactionCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonAlterTableCompactionCommand.scala
@@ -291,7 +291,7 @@ case class CarbonAlterTableCompactionCommand(
       val updateLock = CarbonLockFactory.getCarbonLockObj(carbonTable
         .getAbsoluteTableIdentifier, LockUsage.UPDATE_LOCK)
       try {
-        if (updateLock.lockWithRetries()) {
+        if (updateLock.lockWithRetries(3, 3)) {
           if (lock.lockWithRetries()) {
             LOGGER.info("Acquired the compaction lock for table" +
                         s" ${ carbonLoadModel.getDatabaseName }.${ carbonLoadModel.getTableName }")

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/mutation/CarbonProjectForUpdateCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/mutation/CarbonProjectForUpdateCommand.scala
@@ -98,6 +98,8 @@ private[sql] case class CarbonProjectForUpdateCommand(
         LockUsage.METADATA_LOCK)
     val compactionLock = CarbonLockFactory.getCarbonLockObj(carbonTable
       .getAbsoluteTableIdentifier, LockUsage.COMPACTION_LOCK)
+    val updateLock = CarbonLockFactory.getCarbonLockObj(carbonTable.getAbsoluteTableIdentifier,
+      LockUsage.UPDATE_LOCK)
     var lockStatus = false
     // get the current time stamp which should be same for delete and update.
     val currentTime = CarbonUpdateUtil.readCurrentTime
@@ -114,44 +116,48 @@ private[sql] case class CarbonProjectForUpdateCommand(
       }
 
       val executionErrors = new ExecutionErrors(FailureCauses.NONE, "")
-      if (compactionLock.lockWithRetries()) {
-        // Get RDD.
-        dataSet = if (isPersistEnabled) {
-          Dataset.ofRows(sparkSession, plan).persist(StorageLevel.fromString(
-            CarbonProperties.getInstance.getUpdateDatasetStorageLevel()))
+      if (updateLock.lockWithRetries(3, 3)) {
+        if (compactionLock.lockWithRetries(3, 3)) {
+          // Get RDD.
+          dataSet = if (isPersistEnabled) {
+            Dataset.ofRows(sparkSession, plan).persist(StorageLevel.fromString(
+              CarbonProperties.getInstance.getUpdateDatasetStorageLevel()))
+          }
+          else {
+            Dataset.ofRows(sparkSession, plan)
+          }
+
+          // handle the clean up of IUD.
+          CarbonUpdateUtil.cleanUpDeltaFiles(carbonTable, false)
+
+          // do delete operation.
+          val segmentsToBeDeleted = DeleteExecution.deleteDeltaExecution(
+            databaseNameOp,
+            tableName,
+            sparkSession,
+            dataSet.rdd,
+            currentTime + "",
+            isUpdateOperation = true,
+            executionErrors)
+
+          if (executionErrors.failureCauses != FailureCauses.NONE) {
+            throw new Exception(executionErrors.errorMsg)
+          }
+
+          // do update operation.
+          performUpdate(dataSet,
+            databaseNameOp,
+            tableName,
+            plan,
+            sparkSession,
+            currentTime,
+            executionErrors,
+            segmentsToBeDeleted)
+        } else {
+          throw new ConcurrentOperationException(carbonTable, "compaction", "update")
         }
-        else {
-          Dataset.ofRows(sparkSession, plan)
-        }
-
-        // handle the clean up of IUD.
-        CarbonUpdateUtil.cleanUpDeltaFiles(carbonTable, false)
-
-        // do delete operation.
-        val segmentsToBeDeleted = DeleteExecution.deleteDeltaExecution(
-          databaseNameOp,
-          tableName,
-          sparkSession,
-          dataSet.rdd,
-          currentTime + "",
-          isUpdateOperation = true,
-          executionErrors)
-
-        if (executionErrors.failureCauses != FailureCauses.NONE) {
-          throw new Exception(executionErrors.errorMsg)
-        }
-
-        // do update operation.
-        performUpdate(dataSet,
-          databaseNameOp,
-          tableName,
-          plan,
-          sparkSession,
-          currentTime,
-          executionErrors,
-          segmentsToBeDeleted)
       } else {
-        throw new ConcurrentOperationException(carbonTable, "compaction", "update")
+        throw new ConcurrentOperationException(carbonTable, "update/delete", "update")
       }
       if (executionErrors.failureCauses != FailureCauses.NONE) {
         throw new Exception(executionErrors.errorMsg)
@@ -190,6 +196,7 @@ private[sql] case class CarbonProjectForUpdateCommand(
       if (null != dataSet && isPersistEnabled) {
         dataSet.unpersist()
       }
+      updateLock.unlock()
       compactionLock.unlock()
       if (lockStatus) {
         CarbonLockUtil.fileUnlock(metadataLock, LockUsage.METADATA_LOCK)


### PR DESCRIPTION
**Problem:**
When update and compaction are executed concurrently then update is trying to update the contents of segment 0 whereas compaction has already marked the segment as COMPACTED. This compacted segment is of no use to the update command and therefore when trying to access the segment info from map it throws key not found.

**Solution:**
Block update and compaction concurrent operations.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

