### PR TITLE
[CARBONDATA-3344] Fix Drop column not present in table

### DIFF
--- a/integration/spark-common-cluster-test/src/test/scala/org/apache/carbondata/cluster/sdv/generated/AlterTableTestCase.scala
+++ b/integration/spark-common-cluster-test/src/test/scala/org/apache/carbondata/cluster/sdv/generated/AlterTableTestCase.scala
@@ -29,6 +29,8 @@ import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.util.CarbonProperties
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException
 
+import org.apache.carbondata.spark.exception.ProcessMetaDataException
+
 /**
  * Test Class for AlterTableTestCase to verify all scenerios
  */
@@ -1022,6 +1024,16 @@ class AlterTableTestCase extends QueryTest with BeforeAndAfterAll {
       sql("alter table alter_hive add columns(add string)")
       sql("insert into alter_hive select 'abc','banglore'")
     }
+  }
+
+  test("Test drop columns not present in the table") {
+    sql("drop table if exists test1")
+    sql("create table test1(col1 int) stored by 'carbondata'")
+    val exception = intercept[ProcessMetaDataException] {
+      sql("alter table test1 drop columns(name)")
+    }
+    assert(exception.getMessage.contains("Column name does not exists in the table default.test1"))
+    sql("drop table if exists test1")
   }
 
   val prop = CarbonProperties.getInstance()

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/schema/CarbonAlterTableDropColumnCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/schema/CarbonAlterTableDropColumnCommand.scala
@@ -76,15 +76,6 @@ private[sql] case class CarbonAlterTableDropColumnCommand(
         }
       }
 
-      // Check if column to be dropped is of complex dataType
-      alterTableDropColumnModel.columns.foreach { column =>
-        if (carbonTable.getColumnByName(alterTableDropColumnModel.tableName, column).getDataType
-          .isComplexType) {
-          val errMsg = "Complex column cannot be dropped"
-          throw new MalformedCarbonCommandException(errMsg)
-        }
-      }
-
       val tableColumns = carbonTable.getCreateOrderColumn(tableName).asScala
       var dictionaryColumns = Seq[org.apache.carbondata.core.metadata.schema.table.column
       .ColumnSchema]()
@@ -98,6 +89,11 @@ private[sql] case class CarbonAlterTableDropColumnCommand(
               if (tableColumn.hasEncoding(Encoding.DICTIONARY)) {
                 dictionaryColumns ++= Seq(tableColumn.getColumnSchema)
               }
+            }
+            // Check if column to be dropped is of complex dataType
+            if (tableColumn.getDataType.isComplexType) {
+              val errMsg = "Complex column cannot be dropped"
+              throw new MalformedCarbonCommandException(errMsg)
             }
             columnExist = true
           }


### PR DESCRIPTION
Why this PR needed?
When trying to drop column which is not present in main table, it is throwing Null pointer exception, instead of throwing exception for column does not exists in table.

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [x] Testing done
        testcase added
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

