### PR TITLE
[CARBONDATA-3337][CARBONDATA-3306] Distributed index server

### DIFF
--- a/bin/start-indexserver.sh
+++ b/bin/start-indexserver.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# Shell script for starting the Distributed Index Server
+
+# Enter posix mode for bash
+set -o posix
+
+if [ -z "${SPARK_HOME}" ]; then
+  export SPARK_HOME="$(cd "`dirname "$0"`"/..; pwd)"
+fi
+
+# NOTE: This exact class name is matched downstream by SparkSubmit.
+# Any changes need to be reflected there.
+CLASS="org.apache.carbondata.indexserver.IndexServer"
+
+function usage {
+  echo "Usage: ./sbin/start-indexserver [options] [index server options]"
+  pattern="usage"
+  pattern+="\|Spark assembly has been built with Hive"
+  pattern+="\|NOTE: SPARK_PREPEND_CLASSES is set"
+  pattern+="\|Spark Command: "
+  pattern+="\|======="
+  pattern+="\|--help"
+
+  "${SPARK_HOME}"/bin/spark-submit --help 2>&1 | grep -v Usage 1>&2
+  echo
+  echo "Thrift server options:"
+  "${SPARK_HOME}"/bin/spark-class $CLASS --help 2>&1 | grep -v "$pattern" 1>&2
+}
+
+if [[ "$@" = *--help ]] || [[ "$@" = *-h ]]; then
+  usage
+  exit 0
+fi
+
+export SUBMIT_USAGE_FUNCTION=usage
+
+exec "${SPARK_HOME}"/sbin/spark-daemon.sh submit $CLASS 1 --name "DistributedIndexServer" "$@"

--- a/bin/stop-indexserver.sh
+++ b/bin/stop-indexserver.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Stops the Distributed Index Server on the machine this script is executed on.
+
+if [ -z "${SPARK_HOME}" ]; then
+  export SPARK_HOME="$(cd "`dirname "$0"`"/..; pwd)"
+fi
+
+"${SPARK_HOME}/sbin"/spark-daemon.sh stop org.apache.carbondata.indexserver.IndexServer 1

--- a/core/src/main/java/org/apache/carbondata/core/cache/CarbonLRUCache.java
+++ b/core/src/main/java/org/apache/carbondata/core/cache/CarbonLRUCache.java
@@ -217,6 +217,7 @@ public final class CarbonLRUCache {
     } else {
       synchronized (lruCacheMap) {
         addEntryToLRUCacheMap(columnIdentifier, cacheInfo);
+        currentSize = currentSize + requiredSize;
       }
       columnKeyAddedSuccessfully = true;
     }
@@ -357,5 +358,12 @@ public final class CarbonLRUCache {
   private double getPartOfXmx() {
     long mSizeMB = Runtime.getRuntime().maxMemory() / BYTE_CONVERSION_CONSTANT;
     return mSizeMB * CarbonCommonConstants.CARBON_LRU_CACHE_PERCENT_OVER_MAX_SIZE;
+  }
+
+  /**
+   * @return current size of the cache in memory.
+   */
+  public long getCurrentSize() {
+    return currentSize;
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -2124,4 +2124,38 @@ public final class CarbonCommonConstants {
    */
   public static final String CARBON_QUERY_DATAMAP_BLOOM_CACHE_SIZE_DEFAULT_VAL = "512";
 
+  /**
+   * The IP on which Index Server will be started.
+   */
+  @CarbonProperty
+  public static final String CARBON_INDEX_SERVER_IP = "carbon.index.server.ip";
+
+  /**
+   * The Port to be used to start Index Server.
+   */
+  @CarbonProperty
+  public static final String CARBON_INDEX_SERVER_PORT = "carbon.index.server.port";
+
+  /**
+   * Whether to use index server for caching and pruning or not.
+   * This property can be used for
+   * 1. the whole application(carbon.properties).
+   * 2. the whole session(set carbon.enable.index.server)
+   * 3. a specific table for one session (set carbon.enable.index.server.<dbName>.<tableName>)
+   */
+  @CarbonProperty(dynamicConfigurable = true)
+  public static final String CARBON_ENABLE_INDEX_SERVER = "carbon.enable.index.server";
+
+  /**
+   * Property is used to enable/disable fallback for indexserver.
+   * Used for testing purposes only.
+   */
+  public static final String CARBON_DISABLE_INDEX_SERVER_FALLBACK =
+      "carbon.disable.index.server.fallback";
+
+  public static final String CARBON_INDEX_SERVER_WORKER_THREADS =
+      "carbon.index.server.max.worker.threads";
+
+  public static final int CARBON_INDEX_SERVER_WORKER_THREADS_DEFAULT =
+      500;
 }

--- a/core/src/main/java/org/apache/carbondata/core/datamap/DataMapChooser.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/DataMapChooser.java
@@ -120,7 +120,7 @@ public class DataMapChooser {
     return chooseDataMap(DataMapLevel.CG, resolverIntf);
   }
 
-  private DataMapExprWrapper chooseDataMap(DataMapLevel level, FilterResolverIntf resolverIntf) {
+  DataMapExprWrapper chooseDataMap(DataMapLevel level, FilterResolverIntf resolverIntf) {
     if (resolverIntf != null) {
       Expression expression = resolverIntf.getFilterExpression();
       List<TableDataMap> datamaps = level == DataMapLevel.CG ? cgDataMaps : fgDataMaps;

--- a/core/src/main/java/org/apache/carbondata/core/datamap/DataMapJob.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/DataMapJob.java
@@ -22,7 +22,6 @@ import java.util.List;
 import org.apache.carbondata.core.indexstore.BlockletDataMapIndexWrapper;
 import org.apache.carbondata.core.indexstore.ExtendedBlocklet;
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
-import org.apache.carbondata.core.scan.filter.resolver.FilterResolverIntf;
 
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 
@@ -34,7 +33,6 @@ public interface DataMapJob extends Serializable {
 
   void execute(CarbonTable carbonTable, FileInputFormat<Void, BlockletDataMapIndexWrapper> format);
 
-  List<ExtendedBlocklet> execute(DistributableDataMapFormat dataMapFormat,
-      FilterResolverIntf filter);
+  List<ExtendedBlocklet> execute(DistributableDataMapFormat dataMapFormat);
 
 }

--- a/core/src/main/java/org/apache/carbondata/core/datamap/TableDataMap.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/TableDataMap.java
@@ -356,14 +356,7 @@ public final class TableDataMap extends OperationEventListener {
   public List<DataMapDistributable> toDistributable(List<Segment> segments) throws IOException {
     List<DataMapDistributable> distributables = new ArrayList<>();
     for (Segment segment : segments) {
-      List<DataMapDistributable> list =
-          dataMapFactory.toDistributable(segment);
-      for (DataMapDistributable distributable : list) {
-        distributable.setDataMapSchema(dataMapSchema);
-        distributable.setSegment(segment);
-        distributable.setTablePath(identifier.getTablePath());
-      }
-      distributables.addAll(list);
+      distributables.addAll(dataMapFactory.toDistributable(segment));
     }
     return distributables;
   }
@@ -420,10 +413,10 @@ public final class TableDataMap extends OperationEventListener {
 
   /**
    * Clear only the datamaps of the segments
-   * @param segments
+   * @param segmentIds list of segmentIds to be cleared from cache.
    */
-  public void clear(List<Segment> segments) {
-    for (Segment segment: segments) {
+  public void clear(List<String> segmentIds) {
+    for (String segment: segmentIds) {
       dataMapFactory.clear(segment);
     }
   }
@@ -452,6 +445,13 @@ public final class TableDataMap extends OperationEventListener {
     dataMapFactory.deleteDatamapData();
   }
 
+  /**
+   * delete datamap data for a segment if any
+   */
+  public void deleteSegmentDatamapData(String segmentNo) throws IOException {
+    dataMapFactory.deleteSegmentDatamapData(segmentNo);
+  }
+
   public DataMapSchema getDataMapSchema() {
     return dataMapSchema;
   }
@@ -462,31 +462,6 @@ public final class TableDataMap extends OperationEventListener {
 
   @Override public void onEvent(Event event, OperationContext opContext) throws Exception {
     dataMapFactory.fireEvent(event);
-  }
-
-  /**
-   * Method to prune the segments based on task min/max values
-   *
-   * @param segments
-   * @param filterExp
-   * @return
-   * @throws IOException
-   */
-  public List<Segment> pruneSegments(List<Segment> segments, FilterResolverIntf filterExp)
-      throws IOException {
-    List<Segment> prunedSegments = new ArrayList<>(CarbonCommonConstants.DEFAULT_COLLECTION_SIZE);
-    for (Segment segment : segments) {
-      List<DataMap> dataMaps = dataMapFactory.getDataMaps(segment);
-      for (DataMap dataMap : dataMaps) {
-        if (dataMap.isScanRequired(filterExp)) {
-          // If any one task in a given segment contains the data that means the segment need to
-          // be scanned and we need to validate further data maps in the same segment
-          prunedSegments.add(segment);
-          break;
-        }
-      }
-    }
-    return prunedSegments;
   }
 
   /**

--- a/core/src/main/java/org/apache/carbondata/core/datamap/dev/DataMapFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/dev/DataMapFactory.java
@@ -111,9 +111,11 @@ public abstract class DataMapFactory<T extends DataMap> {
   public abstract void fireEvent(Event event);
 
   /**
-   * Clears datamap of the segment
+   * Clear all datamaps for a segment from memory
    */
-  public abstract void clear(Segment segment);
+  public void clear(String segmentNo) {
+
+  }
 
   /**
    * Clear all datamaps from memory
@@ -139,6 +141,13 @@ public abstract class DataMapFactory<T extends DataMap> {
    * delete datamap data if any
    */
   public abstract void deleteDatamapData();
+
+  /**
+   * delete datamap data if any
+   */
+  public void deleteSegmentDatamapData(String segmentNo) throws IOException {
+
+  }
 
   /**
    * This function should return true is the input operation enum will make the datamap become stale

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/Blocklet.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/Blocklet.java
@@ -21,7 +21,7 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.io.Serializable;
 
-import org.apache.carbondata.core.metadata.schema.table.Writable;
+import org.apache.hadoop.io.Writable;
 
 /**
  * Blocklet
@@ -67,14 +67,28 @@ public class Blocklet implements Writable,Serializable {
 
   @Override
   public void write(DataOutput out) throws IOException {
-    out.writeUTF(filePath);
-    out.writeUTF(blockletId);
+    if (filePath == null) {
+      out.writeBoolean(false);
+    } else {
+      out.writeBoolean(true);
+      out.writeUTF(filePath);
+    }
+    if (blockletId == null) {
+      out.writeBoolean(false);
+    } else {
+      out.writeBoolean(true);
+      out.writeUTF(blockletId);
+    }
   }
 
   @Override
   public void readFields(DataInput in) throws IOException {
-    filePath = in.readUTF();
-    blockletId = in.readUTF();
+    if (in.readBoolean()) {
+      filePath = in.readUTF();
+    }
+    if (in.readBoolean()) {
+      blockletId = in.readUTF();
+    }
   }
 
   @Override

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/BlockletDetailsFetcher.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/BlockletDetailsFetcher.java
@@ -60,4 +60,6 @@ public interface BlockletDetailsFetcher {
    * clears the datamap from cache and segmentMap from executor
    */
   void clear();
+
+  String getCacheSize() throws IOException ;
 }

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/PartitionSpec.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/PartitionSpec.java
@@ -16,19 +16,24 @@
  */
 package org.apache.carbondata.core.indexstore;
 
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
 import java.io.Serializable;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
 import org.apache.carbondata.core.datastore.impl.FileFactory;
 
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.Writable;
 
 /**
  * Holds partition information.
  */
-public class PartitionSpec implements Serializable {
+public class PartitionSpec implements Serializable, Writable {
 
   private static final long serialVersionUID = 4828007433384867678L;
 
@@ -42,6 +47,10 @@ public class PartitionSpec implements Serializable {
   private String location;
 
   private String uuid;
+
+  public PartitionSpec() {
+
+  }
 
   public PartitionSpec(List<String> partitions, String location) {
     this.partitions = partitions;
@@ -89,4 +98,45 @@ public class PartitionSpec implements Serializable {
     return "PartitionSpec{" + "partitions=" + partitions + ", locationPath=" + locationPath
         + ", location='" + location + '\'' + '}';
   }
+
+  @Override public void write(DataOutput out) throws IOException {
+    if (partitions == null) {
+      out.writeBoolean(false);
+    } else {
+      out.writeBoolean(true);
+      out.writeInt(partitions.size());
+      for (String partition : partitions) {
+        out.writeUTF(partition);
+      }
+    }
+    if (uuid == null) {
+      out.writeBoolean(false);
+    } else {
+      out.writeBoolean(true);
+      out.writeUTF(uuid);
+    }
+    if (location == null) {
+      out.writeBoolean(false);
+    } else {
+      out.writeBoolean(true);
+      out.writeUTF(location);
+    }
+  }
+
+  @Override public void readFields(DataInput in) throws IOException {
+    if (in.readBoolean()) {
+      int numPartitions = in.readInt();
+      partitions = new ArrayList<>(numPartitions);
+      for (int i = 0; i < numPartitions; i++) {
+        partitions.add(in.readUTF());
+      }
+    }
+    if (in.readBoolean()) {
+      uuid = in.readUTF();
+    }
+    if (in.readBoolean()) {
+      location = in.readUTF();
+    }
+  }
+
 }

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/TableBlockIndexUniqueIdentifierWrapper.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/TableBlockIndexUniqueIdentifierWrapper.java
@@ -53,7 +53,7 @@ public class TableBlockIndexUniqueIdentifierWrapper implements Serializable {
     this.configuration = FileFactory.getConfiguration();
   }
 
-  public TableBlockIndexUniqueIdentifierWrapper(
+  private TableBlockIndexUniqueIdentifierWrapper(
       TableBlockIndexUniqueIdentifier tableBlockIndexUniqueIdentifier, CarbonTable carbonTable,
       Configuration configuration) {
     this.tableBlockIndexUniqueIdentifier = tableBlockIndexUniqueIdentifier;
@@ -65,9 +65,8 @@ public class TableBlockIndexUniqueIdentifierWrapper implements Serializable {
   // Kindly do not remove
   public TableBlockIndexUniqueIdentifierWrapper(
       TableBlockIndexUniqueIdentifier tableBlockIndexUniqueIdentifier, CarbonTable carbonTable,
-      boolean addTableBlockToUnsafeAndLRUCache) {
-    this(tableBlockIndexUniqueIdentifier, carbonTable);
-    this.configuration = FileFactory.getConfiguration();
+      Configuration configuration, boolean addTableBlockToUnsafeAndLRUCache) {
+    this(tableBlockIndexUniqueIdentifier, carbonTable, configuration);
     this.addTableBlockToUnsafeAndLRUCache = addTableBlockToUnsafeAndLRUCache;
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMapDistributable.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMapDistributable.java
@@ -32,7 +32,13 @@ public class BlockletDataMapDistributable extends DataMapDistributable {
    */
   private String filePath;
 
+  private String segmentPath;
+
   private TableBlockIndexUniqueIdentifier tableBlockIndexUniqueIdentifier;
+
+  public BlockletDataMapDistributable() {
+
+  }
 
   public BlockletDataMapDistributable(String indexFilePath) {
     this.filePath = indexFilePath;
@@ -49,5 +55,13 @@ public class BlockletDataMapDistributable extends DataMapDistributable {
   public void setTableBlockIndexUniqueIdentifier(
       TableBlockIndexUniqueIdentifier tableBlockIndexUniqueIdentifiers) {
     this.tableBlockIndexUniqueIdentifier = tableBlockIndexUniqueIdentifiers;
+  }
+
+  public String getSegmentPath() {
+    return segmentPath;
+  }
+
+  public void setSegmentPath(String segmentPath) {
+    this.segmentPath = segmentPath;
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMapFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMapFactory.java
@@ -23,7 +23,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.apache.carbondata.core.cache.Cache;
 import org.apache.carbondata.core.cache.CacheProvider;
 import org.apache.carbondata.core.cache.CacheType;
-import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.datamap.DataMapDistributable;
 import org.apache.carbondata.core.datamap.DataMapMeta;
 import org.apache.carbondata.core.datamap.Segment;
@@ -33,6 +32,7 @@ import org.apache.carbondata.core.datamap.dev.DataMapBuilder;
 import org.apache.carbondata.core.datamap.dev.DataMapWriter;
 import org.apache.carbondata.core.datamap.dev.cgdatamap.CoarseGrainDataMap;
 import org.apache.carbondata.core.datamap.dev.cgdatamap.CoarseGrainDataMapFactory;
+import org.apache.carbondata.core.datamap.dev.expr.DataMapDistributableWrapper;
 import org.apache.carbondata.core.datastore.block.SegmentProperties;
 import org.apache.carbondata.core.datastore.filesystem.CarbonFile;
 import org.apache.carbondata.core.datastore.impl.FileFactory;
@@ -54,10 +54,7 @@ import org.apache.carbondata.core.util.BlockletDataMapUtil;
 import org.apache.carbondata.core.util.path.CarbonTablePath;
 import org.apache.carbondata.events.Event;
 
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.RemoteIterator;
 
 /**
  * Table map for blocklet
@@ -134,7 +131,7 @@ public class BlockletDataMapFactory extends CoarseGrainDataMapFactory
       for (TableBlockIndexUniqueIdentifier tableBlockIndexUniqueIdentifier : identifiers) {
         tableBlockIndexUniqueIdentifierWrappers.add(
             new TableBlockIndexUniqueIdentifierWrapper(tableBlockIndexUniqueIdentifier,
-                this.getCarbonTable(), segment.getConfiguration()));
+                this.getCarbonTable(), segment.getConfiguration(), segment.isCacheable()));
       }
     }
     List<BlockletDataMapIndexWrapper> blockletDataMapIndexWrappers =
@@ -257,29 +254,14 @@ public class BlockletDataMapFactory extends CoarseGrainDataMapFactory
   public List<DataMapDistributable> toDistributable(Segment segment) {
     List<DataMapDistributable> distributables = new ArrayList<>();
     try {
-      Set<TableBlockIndexUniqueIdentifier> tableBlockIndexUniqueIdentifiers =
-          getTableBlockIndexUniqueIdentifiers(segment);
-      CarbonFile[] carbonIndexFiles = new CarbonFile[tableBlockIndexUniqueIdentifiers.size()];
-      int identifierCounter = 0;
-      for (TableBlockIndexUniqueIdentifier tableBlockIndexUniqueIdentifier :
-          tableBlockIndexUniqueIdentifiers) {
-        String indexFilePath = tableBlockIndexUniqueIdentifier.getIndexFilePath();
-        String fileName = tableBlockIndexUniqueIdentifier.getIndexFileName();
-        carbonIndexFiles[identifierCounter++] = FileFactory
-            .getCarbonFile(indexFilePath + CarbonCommonConstants.FILE_SEPARATOR + fileName);
-      }
-      for (int i = 0; i < carbonIndexFiles.length; i++) {
-        Path path = new Path(carbonIndexFiles[i].getPath());
-        FileSystem fs = path.getFileSystem(FileFactory.getConfiguration());
-        RemoteIterator<LocatedFileStatus> iter = fs.listLocatedStatus(path);
-        LocatedFileStatus fileStatus = iter.next();
-        String[] location = fileStatus.getBlockLocations()[0].getHosts();
-        BlockletDataMapDistributable distributable =
-            new BlockletDataMapDistributable(path.toString());
-        distributable.setLocations(location);
-        distributables.add(distributable);
-      }
-    } catch (IOException e) {
+      BlockletDataMapDistributable distributable = new BlockletDataMapDistributable();
+      distributable.setSegment(segment);
+      distributable.setDataMapSchema(DATA_MAP_SCHEMA);
+      distributable.setSegmentPath(CarbonTablePath.getSegmentPath(identifier.getTablePath(),
+          segment.getSegmentNo()));
+      distributables.add(new DataMapDistributableWrapper(UUID.randomUUID().toString(),
+          distributable).getDistributable());
+    } catch (Exception e) {
       throw new RuntimeException(e);
     }
     return distributables;
@@ -291,8 +273,8 @@ public class BlockletDataMapFactory extends CoarseGrainDataMapFactory
   }
 
   @Override
-  public void clear(Segment segment) {
-    Set<TableBlockIndexUniqueIdentifier> blockIndexes = segmentMap.remove(segment.getSegmentNo());
+  public void clear(String segment) {
+    Set<TableBlockIndexUniqueIdentifier> blockIndexes = segmentMap.remove(segment);
     if (blockIndexes != null) {
       for (TableBlockIndexUniqueIdentifier blockIndex : blockIndexes) {
         TableBlockIndexUniqueIdentifierWrapper blockIndexWrapper =
@@ -315,33 +297,34 @@ public class BlockletDataMapFactory extends CoarseGrainDataMapFactory
   public synchronized void clear() {
     if (segmentMap.size() > 0) {
       for (String segmentId : segmentMap.keySet().toArray(new String[segmentMap.size()])) {
-        clear(new Segment(segmentId, null, null));
+        clear(segmentId);
       }
     }
   }
 
-  @Override
-  public List<CoarseGrainDataMap> getDataMaps(DataMapDistributable distributable)
+  @Override public String getCacheSize() throws IOException {
+    long sum = 0L;
+    int numOfIndexFiles = 0;
+    for (Map.Entry<String, Set<TableBlockIndexUniqueIdentifier>> entry : segmentMap.entrySet()) {
+      for (TableBlockIndexUniqueIdentifier tableBlockIndexUniqueIdentifier : entry.getValue()) {
+        sum += cache.get(new TableBlockIndexUniqueIdentifierWrapper(tableBlockIndexUniqueIdentifier,
+            getCarbonTable())).getMemorySize();
+        numOfIndexFiles++;
+      }
+    }
+    return numOfIndexFiles + ":" + sum;
+  }
+
+  @Override public List<CoarseGrainDataMap> getDataMaps(DataMapDistributable distributable)
       throws IOException {
     BlockletDataMapDistributable mapDistributable = (BlockletDataMapDistributable) distributable;
-    List<TableBlockIndexUniqueIdentifierWrapper> identifiersWrapper = new ArrayList<>();
-    Path indexPath = new Path(mapDistributable.getFilePath());
+    List<TableBlockIndexUniqueIdentifierWrapper> identifiersWrapper;
     String segmentNo = mapDistributable.getSegment().getSegmentNo();
-    if (indexPath.getName().endsWith(CarbonTablePath.INDEX_FILE_EXT)) {
-      String parent = indexPath.getParent().toString();
-      identifiersWrapper.add(new TableBlockIndexUniqueIdentifierWrapper(
-          new TableBlockIndexUniqueIdentifier(parent, indexPath.getName(), null, segmentNo),
-          this.getCarbonTable()));
-    } else if (indexPath.getName().endsWith(CarbonTablePath.MERGE_INDEX_FILE_EXT)) {
-      SegmentIndexFileStore fileStore = new SegmentIndexFileStore();
-      CarbonFile carbonFile = FileFactory.getCarbonFile(indexPath.toString());
-      String parentPath = carbonFile.getParentFile().getAbsolutePath();
-      List<String> indexFiles = fileStore.getIndexFilesFromMergeFile(carbonFile.getAbsolutePath());
-      for (String indexFile : indexFiles) {
-        identifiersWrapper.add(new TableBlockIndexUniqueIdentifierWrapper(
-            new TableBlockIndexUniqueIdentifier(parentPath, indexFile, carbonFile.getName(),
-                segmentNo), this.getCarbonTable()));
-      }
+    if (mapDistributable.getSegmentPath() != null) {
+      identifiersWrapper = getTableBlockIndexUniqueIdentifier(distributable);
+    } else {
+      identifiersWrapper =
+          getTableBlockIndexUniqueIdentifier(mapDistributable.getFilePath(), segmentNo);
     }
     List<CoarseGrainDataMap> dataMaps = new ArrayList<>();
     try {
@@ -353,6 +336,69 @@ public class BlockletDataMapFactory extends CoarseGrainDataMapFactory
       throw new RuntimeException(e);
     }
     return dataMaps;
+  }
+
+  private List<TableBlockIndexUniqueIdentifierWrapper> getTableBlockIndexUniqueIdentifier(
+      DataMapDistributable distributable) throws IOException {
+    List<TableBlockIndexUniqueIdentifierWrapper> identifiersWrapper = new ArrayList<>();
+    Set<TableBlockIndexUniqueIdentifier> tableBlockIndexUniqueIdentifiers =
+        segmentMap.get(distributable.getSegment().getSegmentNo());
+    if (tableBlockIndexUniqueIdentifiers == null) {
+      Set<String> indexFiles = distributable.getSegment().getCommittedIndexFile().keySet();
+      for (String indexFile : indexFiles) {
+        CarbonFile carbonFile = FileFactory.getCarbonFile(indexFile);
+        String indexFileName;
+        String mergeIndexName;
+        if (indexFile.endsWith(CarbonTablePath.INDEX_FILE_EXT)) {
+          indexFileName = carbonFile.getName();
+          mergeIndexName = null;
+        } else {
+          indexFileName = carbonFile.getName();
+          mergeIndexName = carbonFile.getName();
+        }
+        String parentPath = carbonFile.getParentFile().getAbsolutePath();
+        TableBlockIndexUniqueIdentifier tableBlockIndexUniqueIdentifier =
+            new TableBlockIndexUniqueIdentifier(parentPath, indexFileName, mergeIndexName,
+                distributable.getSegment().getSegmentNo());
+        identifiersWrapper.add(
+            new TableBlockIndexUniqueIdentifierWrapper(tableBlockIndexUniqueIdentifier,
+                this.getCarbonTable()));
+        tableBlockIndexUniqueIdentifiers = new HashSet<>();
+        tableBlockIndexUniqueIdentifiers.add(tableBlockIndexUniqueIdentifier);
+        segmentMap.put(distributable.getSegment().getSegmentNo(), tableBlockIndexUniqueIdentifiers);
+      }
+    } else {
+      for (TableBlockIndexUniqueIdentifier tableBlockIndexUniqueIdentifier :
+          tableBlockIndexUniqueIdentifiers) {
+        identifiersWrapper.add(
+            new TableBlockIndexUniqueIdentifierWrapper(tableBlockIndexUniqueIdentifier,
+                getCarbonTable()));
+      }
+    }
+    return identifiersWrapper;
+  }
+
+  private List<TableBlockIndexUniqueIdentifierWrapper> getTableBlockIndexUniqueIdentifier(
+      String indexFilePath, String segmentId) throws IOException {
+    Path indexPath = new Path(indexFilePath);
+    List<TableBlockIndexUniqueIdentifierWrapper> identifiersWrapper = new ArrayList<>();
+    if (indexPath.getName().endsWith(CarbonTablePath.INDEX_FILE_EXT)) {
+      String parent = indexPath.getParent().toString();
+      identifiersWrapper.add(new TableBlockIndexUniqueIdentifierWrapper(
+          new TableBlockIndexUniqueIdentifier(parent, indexPath.getName(), null, segmentId),
+          this.getCarbonTable()));
+    } else if (indexPath.getName().endsWith(CarbonTablePath.MERGE_INDEX_FILE_EXT)) {
+      SegmentIndexFileStore fileStore = new SegmentIndexFileStore();
+      CarbonFile carbonFile = FileFactory.getCarbonFile(indexPath.toString());
+      String parentPath = carbonFile.getParentFile().getAbsolutePath();
+      List<String> indexFiles = fileStore.getIndexFilesFromMergeFile(carbonFile.getAbsolutePath());
+      for (String indexFile : indexFiles) {
+        identifiersWrapper.add(new TableBlockIndexUniqueIdentifierWrapper(
+            new TableBlockIndexUniqueIdentifier(parentPath, indexFile, carbonFile.getName(),
+                segmentId), this.getCarbonTable()));
+      }
+    }
+    return identifiersWrapper;
   }
 
   @Override

--- a/core/src/main/java/org/apache/carbondata/core/metadata/SegmentFileStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/SegmentFileStore.java
@@ -342,13 +342,10 @@ public class SegmentFileStore {
    */
   public static void clearBlockDataMapCache(CarbonTable carbonTable, String segmentId) {
     TableDataMap defaultDataMap = DataMapStoreManager.getInstance().getDefaultDataMap(carbonTable);
-    Segment segment = new Segment(segmentId);
-    List<Segment> segments = new ArrayList<>();
-    segments.add(segment);
     LOGGER.info(
         "clearing cache while updating segment file entry in table status file for segmentId: "
             + segmentId);
-    defaultDataMap.clear(segments);
+    defaultDataMap.getDataMapFactory().clear(segmentId);
   }
 
   private static CarbonFile[] getSegmentFiles(String segmentPath) {

--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/AggregationDataMapSchema.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/AggregationDataMapSchema.java
@@ -34,6 +34,7 @@ import org.apache.carbondata.core.preagg.TimeSeriesFunctionEnum;
  */
 public class AggregationDataMapSchema extends DataMapSchema {
 
+  private static final long serialVersionUID = 5900935117929888412L;
   /**
    * map of parent column name to set of child column column without
    * aggregation function
@@ -63,7 +64,9 @@ public class AggregationDataMapSchema extends DataMapSchema {
    */
   private int ordinal = Integer.MAX_VALUE;
 
-  private Set aggExpToColumnMapping;
+  // Dont remove transient otherwise serialization for carbonTable will fail using
+  // JavaSerialization in spark.
+  private transient Set aggExpToColumnMapping;
 
   AggregationDataMapSchema(String dataMapName, String className) {
     super(dataMapName, className);

--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/CarbonTable.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/CarbonTable.java
@@ -17,6 +17,8 @@
 
 package org.apache.carbondata.core.metadata.schema.table;
 
+import java.io.DataInput;
+import java.io.DataOutput;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -73,7 +75,7 @@ import org.apache.log4j.Logger;
 /**
  * Mapping class for Carbon actual table
  */
-public class CarbonTable implements Serializable {
+public class CarbonTable implements Serializable, Writable {
 
   private static final Logger LOGGER =
       LogServiceFactory.getLogService(CarbonTable.class.getName());
@@ -186,7 +188,7 @@ public class CarbonTable implements Serializable {
    */
   private boolean isTransactionalTable = true;
 
-  private CarbonTable() {
+  public CarbonTable() {
     this.tableDimensionsMap = new HashMap<String, List<CarbonDimension>>();
     this.tableImplicitDimensionsMap = new HashMap<String, List<CarbonDimension>>();
     this.tableMeasuresMap = new HashMap<String, List<CarbonMeasure>>();
@@ -1404,5 +1406,15 @@ public class CarbonTable implements Serializable {
     } else {
       return SortScopeOptions.getSortScope(sortScope);
     }
+  }
+
+  @Override public void write(DataOutput out) throws IOException {
+    tableInfo.write(out);
+  }
+
+  @Override public void readFields(DataInput in) throws IOException {
+    tableInfo = new TableInfo();
+    tableInfo.readFields(in);
+    updateTableByTableInfo(this, tableInfo);
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/util/BlockletDataMapUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/BlockletDataMapUtil.java
@@ -228,7 +228,7 @@ public class BlockletDataMapUtil {
     List<TableBlockIndexUniqueIdentifier> tableBlockIndexUniqueIdentifiers = new ArrayList<>();
     String mergeFilePath =
         identifier.getIndexFilePath() + CarbonCommonConstants.FILE_SEPARATOR + identifier
-            .getIndexFileName();
+            .getMergeIndexFileName();
     segmentIndexFileStore.readMergeFile(mergeFilePath);
     List<String> indexFiles =
         segmentIndexFileStore.getCarbonMergeFileToIndexFilesMap().get(mergeFilePath);

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
@@ -1601,4 +1601,56 @@ public final class CarbonProperties {
       }
     }
   }
+
+  /**
+   * Check whether the Distributed Pruning is enabled by the user or not.
+   */
+  public boolean isDistributedPruningEnabled(String dbName, String tableName) {
+    // Check if user has enabled/disabled the use of index server for the current session using
+    // the set command
+    String configuredValue = getSessionPropertyValue(
+        CarbonCommonConstants.CARBON_ENABLE_INDEX_SERVER + "." + dbName + "." + tableName);
+    if (configuredValue == null) {
+      // if not set in session properties then check carbon.properties for the same.
+      configuredValue = getProperty(CarbonCommonConstants.CARBON_ENABLE_INDEX_SERVER);
+    }
+    boolean isServerEnabledByUser = Boolean.parseBoolean(configuredValue);
+    if (isServerEnabledByUser) {
+      LOGGER.info("Distributed Index server is enabled for " + dbName + "." + tableName);
+    }
+    return isServerEnabledByUser;
+  }
+
+  public String getIndexServerIP() {
+    return carbonProperties.getProperty(CarbonCommonConstants.CARBON_INDEX_SERVER_IP, "");
+  }
+
+  public int getIndexServerPort() {
+    String configuredPort =
+        carbonProperties.getProperty(CarbonCommonConstants.CARBON_INDEX_SERVER_PORT);
+    try {
+      return Integer.parseInt(configuredPort);
+    } catch (NumberFormatException e) {
+      LOGGER.error("Configured port for index server is not a valid number", e);
+      throw e;
+    }
+  }
+
+  /**
+   * Whether fallback is disabled by the user or not.
+   */
+  public boolean isFallBackDisabled() {
+    return Boolean.parseBoolean(carbonProperties
+        .getProperty(CarbonCommonConstants.CARBON_DISABLE_INDEX_SERVER_FALLBACK, "false"));
+  }
+
+  public int getNumberOfHandlersForIndexServer() {
+    String configuredValue =
+        carbonProperties.getProperty(CarbonCommonConstants.CARBON_INDEX_SERVER_WORKER_THREADS);
+    if (configuredValue != null) {
+      return Integer.parseInt(configuredValue);
+    }
+    return CarbonCommonConstants.CARBON_INDEX_SERVER_WORKER_THREADS_DEFAULT;
+  }
+
 }

--- a/core/src/main/java/org/apache/carbondata/core/util/SessionParams.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/SessionParams.java
@@ -143,6 +143,7 @@ public class SessionParams implements Serializable, Cloneable {
       case ENABLE_UNSAFE_IN_QUERY_EXECUTION:
       case ENABLE_AUTO_LOAD_MERGE:
       case CARBON_PUSH_ROW_FILTERS_FOR_VECTOR:
+      case CARBON_ENABLE_INDEX_SERVER:
         isValid = CarbonUtil.validateBoolean(value);
         if (!isValid) {
           throw new InvalidConfigurationException("Invalid value " + value + " for key " + key);

--- a/core/src/main/java/org/apache/carbondata/hadoop/CarbonInputSplit.java
+++ b/core/src/main/java/org/apache/carbondata/hadoop/CarbonInputSplit.java
@@ -625,4 +625,8 @@ public class CarbonInputSplit extends FileSplit
     }
     return this.location;
   }
+
+  public void setLocation(String[] location) {
+    this.location = location;
+  }
 }

--- a/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomCoarseGrainDataMapFactory.java
+++ b/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/BloomCoarseGrainDataMapFactory.java
@@ -313,6 +313,8 @@ public class BloomCoarseGrainDataMapFactory extends DataMapFactory<CoarseGrainDa
           filteredShards.contains(new File(shardPath).getName())) {
         DataMapDistributable bloomDataMapDistributable =
             new BloomDataMapDistributable(shardPath, filteredShards);
+        bloomDataMapDistributable.setSegment(segment);
+        bloomDataMapDistributable.setDataMapSchema(getDataMapSchema());
         dataMapDistributableList.add(bloomDataMapDistributable);
       }
     }
@@ -325,8 +327,8 @@ public class BloomCoarseGrainDataMapFactory extends DataMapFactory<CoarseGrainDa
   }
 
   @Override
-  public void clear(Segment segment) {
-    Set<String> shards = segmentMap.remove(segment.getSegmentNo());
+  public void clear(String segment) {
+    Set<String> shards = segmentMap.remove(segment);
     if (shards != null) {
       for (String shard : shards) {
         for (CarbonColumn carbonColumn : dataMapMeta.getIndexedColumns()) {
@@ -341,15 +343,19 @@ public class BloomCoarseGrainDataMapFactory extends DataMapFactory<CoarseGrainDa
     if (segmentMap.size() > 0) {
       List<String> segments = new ArrayList<>(segmentMap.keySet());
       for (String segmentId : segments) {
-        clear(new Segment(segmentId, null, null));
+        clear(segmentId);
       }
     }
   }
 
   @Override
   public void deleteDatamapData(Segment segment) throws IOException {
+    deleteSegmentDatamapData(segment.getSegmentNo());
+  }
+
+  @Override
+  public void deleteSegmentDatamapData(String segmentId) throws IOException {
     try {
-      String segmentId = segment.getSegmentNo();
       String datamapPath = CarbonTablePath
           .getDataMapStorePath(getCarbonTable().getTablePath(), segmentId, dataMapName);
       if (FileFactory.isFileExist(datamapPath)) {
@@ -357,9 +363,9 @@ public class BloomCoarseGrainDataMapFactory extends DataMapFactory<CoarseGrainDa
             FileFactory.getFileType(datamapPath));
         CarbonUtil.deleteFoldersAndFilesSilent(file);
       }
-      clear(segment);
+      clear(segmentId);
     } catch (InterruptedException ex) {
-      throw new IOException("Failed to delete datamap for segment_" + segment.getSegmentNo());
+      throw new IOException("Failed to delete datamap for segment_" + segmentId);
     }
   }
 

--- a/datamap/lucene/src/main/java/org/apache/carbondata/datamap/lucene/LuceneDataMapFactoryBase.java
+++ b/datamap/lucene/src/main/java/org/apache/carbondata/datamap/lucene/LuceneDataMapFactoryBase.java
@@ -221,6 +221,8 @@ abstract class LuceneDataMapFactoryBase<T extends DataMap> extends DataMapFactor
         DataMapDistributable luceneDataMapDistributable =
             new LuceneDataMapDistributable(tableIdentifier.getTablePath(),
                 indexDir.getAbsolutePath());
+        luceneDataMapDistributable.setSegment(segment);
+        luceneDataMapDistributable.setDataMapSchema(getDataMapSchema());
         lstDataMapDistribute.add(luceneDataMapDistributable);
       }
       return lstDataMapDistribute;
@@ -234,6 +236,8 @@ abstract class LuceneDataMapFactoryBase<T extends DataMap> extends DataMapFactor
       DataMapDistributable luceneDataMapDistributable = new LuceneDataMapDistributable(
           CarbonTablePath.getSegmentPath(tableIdentifier.getTablePath(), segment.getSegmentNo()),
           indexDir.getAbsolutePath());
+      luceneDataMapDistributable.setSegment(segment);
+      luceneDataMapDistributable.setDataMapSchema(getDataMapSchema());
       lstDataMapDistribute.add(luceneDataMapDistributable);
     }
     return lstDataMapDistribute;
@@ -241,14 +245,6 @@ abstract class LuceneDataMapFactoryBase<T extends DataMap> extends DataMapFactor
 
   @Override
   public void fireEvent(Event event) {
-
-  }
-
-  /**
-   * Clears datamap of the segment
-   */
-  @Override
-  public void clear(Segment segment) {
 
   }
 
@@ -262,8 +258,11 @@ abstract class LuceneDataMapFactoryBase<T extends DataMap> extends DataMapFactor
 
   @Override
   public void deleteDatamapData(Segment segment) throws IOException {
+    deleteSegmentDatamapData(segment.getSegmentNo());
+  }
+
+  @Override public void deleteSegmentDatamapData(String segmentId) throws IOException {
     try {
-      String segmentId = segment.getSegmentNo();
       String datamapPath = CarbonTablePath
           .getDataMapStorePath(tableIdentifier.getTablePath(), segmentId, dataMapName);
       if (FileFactory.isFileExist(datamapPath)) {

--- a/dev/findbugs-exclude.xml
+++ b/dev/findbugs-exclude.xml
@@ -59,6 +59,10 @@
     <Bug pattern="STCAL_INVOKE_ON_STATIC_DATE_FORMAT_INSTANCE"/>
   </Match>
   <Match>
+    <Class name="org.apache.carbondata.core.datamap.DistributableDataMapFormat"/>
+    <Bug pattern="SE_TRANSIENT_FIELD_NOT_RESTORED"/>
+  </Match>
+  <Match>
     <!--
     Returning a reference to a mutable object value stored in one of the object's fields exposes
     the internal representation of the object.  If instances are accessed by untrusted code,
@@ -101,5 +105,9 @@
   </Match>
   <Match>
     <Bug pattern="JLM_JSR166_UTILCONCURRENT_MONITORENTER"/>
+  </Match>
+  <Match>
+    <Class name="org.apache.carbondata.core.datamap.Segment"/>
+    <Bug pattern="SE_TRANSIENT_FIELD_NOT_RESTORED"/>
   </Match>
 </FindBugsFilter>

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonFileInputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonFileInputFormat.java
@@ -225,8 +225,8 @@ public class CarbonFileInputFormat<T> extends CarbonInputFormat<T> implements Se
 
     // for each segment fetch blocks matching filter in Driver BTree
     List<CarbonInputSplit> dataBlocksOfSegment =
-        getDataBlocksOfSegment(job, carbonTable, expression, matchedPartitions,
-            validSegments, partitionInfo, oldPartitionIdList);
+        getDataBlocksOfSegment(job, carbonTable, expression, matchedPartitions, validSegments,
+            partitionInfo, oldPartitionIdList, new ArrayList<Segment>(), new ArrayList<String>());
     numBlocks = dataBlocksOfSegment.size();
     result.addAll(dataBlocksOfSegment);
     return result;

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonInputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonInputFormat.java
@@ -36,6 +36,7 @@ import org.apache.carbondata.core.constants.CarbonCommonConstantsInternal;
 import org.apache.carbondata.core.datamap.DataMapChooser;
 import org.apache.carbondata.core.datamap.DataMapFilter;
 import org.apache.carbondata.core.datamap.DataMapJob;
+import org.apache.carbondata.core.datamap.DataMapLevel;
 import org.apache.carbondata.core.datamap.DataMapStoreManager;
 import org.apache.carbondata.core.datamap.DataMapUtil;
 import org.apache.carbondata.core.datamap.Segment;
@@ -47,6 +48,7 @@ import org.apache.carbondata.core.indexstore.ExtendedBlocklet;
 import org.apache.carbondata.core.indexstore.PartitionSpec;
 import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
 import org.apache.carbondata.core.metadata.schema.PartitionInfo;
+import org.apache.carbondata.core.metadata.schema.SchemaReader;
 import org.apache.carbondata.core.metadata.schema.partition.PartitionType;
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
 import org.apache.carbondata.core.metadata.schema.table.TableInfo;
@@ -55,6 +57,7 @@ import org.apache.carbondata.core.profiler.ExplainCollector;
 import org.apache.carbondata.core.readcommitter.ReadCommittedScope;
 import org.apache.carbondata.core.scan.expression.Expression;
 import org.apache.carbondata.core.scan.filter.FilterUtil;
+import org.apache.carbondata.core.scan.filter.resolver.FilterResolverIntf;
 import org.apache.carbondata.core.scan.model.QueryModel;
 import org.apache.carbondata.core.scan.model.QueryModelBuilder;
 import org.apache.carbondata.core.stats.QueryStatistic;
@@ -130,6 +133,9 @@ public abstract class CarbonInputFormat<T> extends FileInputFormat<Void, T> {
   protected int hitedStreamFiles = 0;
   protected int numBlocks = 0;
 
+  private CarbonTable carbonTable;
+
+
   public int getNumSegments() {
     return numSegments;
   }
@@ -178,8 +184,25 @@ public abstract class CarbonInputFormat<T> extends FileInputFormat<Void, T> {
   /**
    * Get the cached CarbonTable or create it by TableInfo in `configuration`
    */
-  public abstract CarbonTable getOrCreateCarbonTable(Configuration configuration)
-      throws IOException;
+  public CarbonTable getOrCreateCarbonTable(Configuration configuration)
+      throws IOException {
+    if (carbonTable == null) {
+      // carbon table should be created either from deserialized table info (schema saved in
+      // hive metastore) or by reading schema in HDFS (schema saved in HDFS)
+      TableInfo tableInfo = getTableInfo(configuration);
+      CarbonTable carbonTable;
+      if (tableInfo != null) {
+        carbonTable = CarbonTable.buildFromTableInfo(tableInfo);
+      } else {
+        carbonTable = SchemaReader.readCarbonTableFromStore(
+            getAbsoluteTableIdentifier(configuration));
+      }
+      this.carbonTable = carbonTable;
+      return carbonTable;
+    } else {
+      return this.carbonTable;
+    }
+  }
 
   public static void setTablePath(Configuration configuration, String tablePath) {
     configuration.set(FileInputFormat.INPUT_DIR, tablePath);
@@ -384,6 +407,33 @@ m filterExpression
    */
   @Override public abstract List<InputSplit> getSplits(JobContext job) throws IOException;
 
+  List<ExtendedBlocklet> getDistributedSplit(CarbonTable table,
+      FilterResolverIntf filterResolverIntf, List<PartitionSpec> partitionNames,
+      List<Segment> validSegments, List<Segment> invalidSegments,
+      List<String> segmentsToBeRefreshed) throws IOException {
+    try {
+      DataMapJob dataMapJob =
+          (DataMapJob) DataMapUtil.createDataMapJob(DataMapUtil.DISTRIBUTED_JOB_NAME);
+      if (dataMapJob == null) {
+        throw new ExceptionInInitializerError("Unable to create DistributedDataMapJob");
+      }
+      return DataMapUtil
+          .executeDataMapJob(table, filterResolverIntf, dataMapJob, partitionNames, validSegments,
+              invalidSegments, null, segmentsToBeRefreshed);
+    } catch (Exception e) {
+      // Check if fallback is disabled for testing purposes then directly throw exception.
+      if (CarbonProperties.getInstance().isFallBackDisabled()) {
+        throw e;
+      }
+      LOG.error("Exception occurred while getting splits using index server. Initiating Fall "
+          + "back to embedded mode", e);
+      return DataMapUtil
+          .executeDataMapJob(table, filterResolverIntf,
+              DataMapUtil.getEmbeddedJob(), partitionNames, validSegments, invalidSegments, null,
+              true, segmentsToBeRefreshed);
+    }
+  }
+
   protected Expression getFilterPredicates(Configuration configuration) {
     try {
       String filterExprString = configuration.get(FILTER_PREDICATE);
@@ -402,7 +452,9 @@ m filterExpression
    */
   protected List<CarbonInputSplit> getDataBlocksOfSegment(JobContext job, CarbonTable carbonTable,
       Expression expression, BitSet matchedPartitions, List<Segment> segmentIds,
-      PartitionInfo partitionInfo, List<Integer> oldPartitionIdList) throws IOException {
+      PartitionInfo partitionInfo, List<Integer> oldPartitionIdList,
+      List<Segment> invalidSegments, List<String> segmentsToBeRefreshed)
+      throws IOException {
 
     QueryStatisticsRecorder recorder = CarbonTimeStatisticsFactory.createDriverRecorder();
     QueryStatistic statistic = new QueryStatistic();
@@ -411,7 +463,8 @@ m filterExpression
     TokenCache.obtainTokensForNamenodes(job.getCredentials(),
         new Path[] { new Path(carbonTable.getTablePath()) }, job.getConfiguration());
     List<ExtendedBlocklet> prunedBlocklets =
-        getPrunedBlocklets(job, carbonTable, expression, segmentIds);
+        getPrunedBlocklets(job, carbonTable, expression, segmentIds, invalidSegments,
+            segmentsToBeRefreshed);
     List<CarbonInputSplit> resultFilteredBlocks = new ArrayList<>();
     int partitionIndex = 0;
     List<Integer> partitionIdList = new ArrayList<>();
@@ -466,7 +519,8 @@ m filterExpression
    * First pruned with default blocklet datamap, then pruned with CG and FG datamaps
    */
   private List<ExtendedBlocklet> getPrunedBlocklets(JobContext job, CarbonTable carbonTable,
-      Expression expression, List<Segment> segmentIds) throws IOException {
+      Expression expression, List<Segment> segmentIds, List<Segment> invalidSegments,
+      List<String> segmentsToBeRefreshed) throws IOException {
     ExplainCollector.addPruningInfo(carbonTable.getTableName());
     final DataMapFilter filter = new DataMapFilter(carbonTable, expression);
     ExplainCollector.setFilterStatement(expression == null ? "none" : expression.getStatement());
@@ -480,57 +534,83 @@ m filterExpression
     List<ExtendedBlocklet> prunedBlocklets = null;
     // This is to log the event, so user will know what is happening by seeing logs.
     LOG.info("Started block pruning ...");
-    prunedBlocklets = defaultDataMap.prune(segmentIds, filter, partitionsToPrune);
-
-    if (ExplainCollector.enabled()) {
-      ExplainCollector.setDefaultDataMapPruningBlockHit(getBlockCount(prunedBlocklets));
-    }
-
-    if (prunedBlocklets.size() == 0) {
-      return prunedBlocklets;
-    }
-
-    DataMapChooser chooser = new DataMapChooser(getOrCreateCarbonTable(job.getConfiguration()));
-
-    // Get the available CG datamaps and prune further.
-    DataMapExprWrapper cgDataMapExprWrapper = chooser.chooseCGDataMap(filter.getResolver());
-    if (cgDataMapExprWrapper != null) {
-      // Prune segments from already pruned blocklets
-      pruneSegments(segmentIds, prunedBlocklets);
-      List<ExtendedBlocklet> cgPrunedBlocklets;
-      // Again prune with CG datamap.
-      if (distributedCG && dataMapJob != null) {
-        cgPrunedBlocklets = DataMapUtil.executeDataMapJob(carbonTable, filter.getResolver(),
-            segmentIds, cgDataMapExprWrapper, dataMapJob, partitionsToPrune);
-      } else {
-        cgPrunedBlocklets = cgDataMapExprWrapper.prune(segmentIds, partitionsToPrune);
+    boolean isDistributedPruningEnabled = CarbonProperties.getInstance()
+        .isDistributedPruningEnabled(carbonTable.getDatabaseName(), carbonTable.getTableName());
+    if (isDistributedPruningEnabled) {
+      try {
+        prunedBlocklets =
+            getDistributedSplit(carbonTable, filter.getResolver(), partitionsToPrune, segmentIds,
+                invalidSegments, segmentsToBeRefreshed);
+      } catch (Exception e) {
+        // Check if fallback is disabled then directly throw exception otherwise try driver
+        // pruning.
+        if (CarbonProperties.getInstance().isFallBackDisabled()) {
+          throw e;
+        }
+        prunedBlocklets = defaultDataMap.prune(segmentIds, filter, partitionsToPrune);
       }
-      // since index datamap prune in segment scope,
-      // the result need to intersect with previous pruned result
-      prunedBlocklets = intersectFilteredBlocklets(carbonTable, prunedBlocklets, cgPrunedBlocklets);
-      ExplainCollector.recordCGDataMapPruning(
-          DataMapWrapperSimpleInfo.fromDataMapWrapper(cgDataMapExprWrapper),
-          prunedBlocklets.size(), getBlockCount(prunedBlocklets));
-    }
+    } else {
+      prunedBlocklets = defaultDataMap.prune(segmentIds, filter, partitionsToPrune);
 
-    if (prunedBlocklets.size() == 0) {
-      return prunedBlocklets;
-    }
-    // Now try to prune with FG DataMap.
-    if (isFgDataMapPruningEnable(job.getConfiguration()) && dataMapJob != null) {
-      DataMapExprWrapper fgDataMapExprWrapper = chooser.chooseFGDataMap(filter.getResolver());
-      if (fgDataMapExprWrapper != null) {
+      if (ExplainCollector.enabled()) {
+        ExplainCollector.setDefaultDataMapPruningBlockHit(getBlockCount(prunedBlocklets));
+      }
+
+      if (prunedBlocklets.size() == 0) {
+        return prunedBlocklets;
+      }
+
+      DataMapChooser chooser = new DataMapChooser(getOrCreateCarbonTable(job.getConfiguration()));
+
+      // Get the available CG datamaps and prune further.
+      DataMapExprWrapper cgDataMapExprWrapper = chooser.chooseCGDataMap(filter.getResolver());
+
+      if (cgDataMapExprWrapper != null) {
         // Prune segments from already pruned blocklets
-        pruneSegments(segmentIds, prunedBlocklets);
-        List<ExtendedBlocklet> fgPrunedBlocklets = DataMapUtil.executeDataMapJob(carbonTable,
-            filter.getResolver(), segmentIds, fgDataMapExprWrapper, dataMapJob, partitionsToPrune);
-        // note that the 'fgPrunedBlocklets' has extra datamap related info compared with
-        // 'prunedBlocklets', so the intersection should keep the elements in 'fgPrunedBlocklets'
-        prunedBlocklets = intersectFilteredBlocklets(carbonTable, prunedBlocklets,
-            fgPrunedBlocklets);
-        ExplainCollector.recordFGDataMapPruning(
-            DataMapWrapperSimpleInfo.fromDataMapWrapper(fgDataMapExprWrapper),
-            prunedBlocklets.size(), getBlockCount(prunedBlocklets));
+        DataMapUtil.pruneSegments(segmentIds, prunedBlocklets);
+        List<ExtendedBlocklet> cgPrunedBlocklets;
+        // Again prune with CG datamap.
+        if (distributedCG && dataMapJob != null) {
+          cgPrunedBlocklets = DataMapUtil
+              .executeDataMapJob(carbonTable, filter.getResolver(), dataMapJob, partitionsToPrune,
+                  segmentIds, invalidSegments, DataMapLevel.CG, new ArrayList<String>());
+        } else {
+          cgPrunedBlocklets = cgDataMapExprWrapper.prune(segmentIds, partitionsToPrune);
+        }
+        // since index datamap prune in segment scope,
+        // the result need to intersect with previous pruned result
+        prunedBlocklets =
+            intersectFilteredBlocklets(carbonTable, prunedBlocklets, cgPrunedBlocklets);
+        if (ExplainCollector.enabled()) {
+          ExplainCollector.recordCGDataMapPruning(
+              DataMapWrapperSimpleInfo.fromDataMapWrapper(cgDataMapExprWrapper),
+              prunedBlocklets.size(), getBlockCount(prunedBlocklets));
+        }
+      }
+
+      if (prunedBlocklets.size() == 0) {
+        return prunedBlocklets;
+      }
+      // Now try to prune with FG DataMap.
+      if (isFgDataMapPruningEnable(job.getConfiguration()) && dataMapJob != null) {
+        DataMapExprWrapper fgDataMapExprWrapper = chooser.chooseFGDataMap(filter.getResolver());
+        List<ExtendedBlocklet> fgPrunedBlocklets;
+        if (fgDataMapExprWrapper != null) {
+          // Prune segments from already pruned blocklets
+          DataMapUtil.pruneSegments(segmentIds, prunedBlocklets);
+          // Prune segments from already pruned blocklets
+          fgPrunedBlocklets = DataMapUtil
+              .executeDataMapJob(carbonTable, filter.getResolver(), dataMapJob, partitionsToPrune,
+                  segmentIds, invalidSegments, fgDataMapExprWrapper.getDataMapLevel(),
+                  new ArrayList<String>());
+          // note that the 'fgPrunedBlocklets' has extra datamap related info compared with
+          // 'prunedBlocklets', so the intersection should keep the elements in 'fgPrunedBlocklets'
+          prunedBlocklets =
+              intersectFilteredBlocklets(carbonTable, prunedBlocklets, fgPrunedBlocklets);
+          ExplainCollector.recordFGDataMapPruning(
+              DataMapWrapperSimpleInfo.fromDataMapWrapper(fgDataMapExprWrapper),
+              prunedBlocklets.size(), getBlockCount(prunedBlocklets));
+        }
       }
     }
     LOG.info("Finished block pruning ...");
@@ -555,33 +635,15 @@ m filterExpression
     return prunedBlocklets;
   }
 
-  /**
-   * Prune the segments from the already pruned blocklets.
-   * @param segments
-   * @param prunedBlocklets
-   */
-  private void pruneSegments(List<Segment> segments, List<ExtendedBlocklet> prunedBlocklets) {
-    List<Segment> toBeRemovedSegments = new ArrayList<>();
-    for (Segment segment : segments) {
-      boolean found = false;
-      // Clear the old pruned index files if any present
-      segment.getFilteredIndexShardNames().clear();
-      // Check the segment exist in any of the pruned blocklets.
-      for (ExtendedBlocklet blocklet : prunedBlocklets) {
-        if (blocklet.getSegment().toString().equals(segment.toString())) {
-          found = true;
-          // Set the pruned index file to the segment for further pruning.
-          String shardName = CarbonTablePath.getShardName(blocklet.getFilePath());
-          segment.setFilteredIndexShardName(shardName);
-        }
-      }
-      // Add to remove segments list if not present in pruned blocklets.
-      if (!found) {
-        toBeRemovedSegments.add(segment);
+
+  static List<InputSplit> convertToCarbonInputSplit(List<ExtendedBlocklet> extendedBlocklets) {
+    List<InputSplit> resultFilteredBlocks = new ArrayList<>();
+    for (ExtendedBlocklet blocklet : extendedBlocklets) {
+      if (blocklet != null) {
+        resultFilteredBlocks.add(blocklet.getInputSplit());
       }
     }
-    // Remove all segments which are already pruned from pruned blocklets
-    segments.removeAll(toBeRemovedSegments);
+    return resultFilteredBlocks;
   }
 
   @Override public RecordReader<Void, T> createRecordReader(InputSplit inputSplit,

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableInputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableInputFormat.java
@@ -36,10 +36,8 @@ import org.apache.carbondata.core.datastore.impl.FileFactory;
 import org.apache.carbondata.core.indexstore.PartitionSpec;
 import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
 import org.apache.carbondata.core.metadata.schema.PartitionInfo;
-import org.apache.carbondata.core.metadata.schema.SchemaReader;
 import org.apache.carbondata.core.metadata.schema.partition.PartitionType;
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
-import org.apache.carbondata.core.metadata.schema.table.TableInfo;
 import org.apache.carbondata.core.mutate.CarbonUpdateUtil;
 import org.apache.carbondata.core.mutate.SegmentUpdateDetails;
 import org.apache.carbondata.core.mutate.UpdateVO;
@@ -57,10 +55,10 @@ import org.apache.carbondata.core.statusmanager.SegmentStatusManager;
 import org.apache.carbondata.core.statusmanager.SegmentUpdateStatusManager;
 import org.apache.carbondata.core.stream.StreamFile;
 import org.apache.carbondata.core.stream.StreamPruner;
+import org.apache.carbondata.core.util.CarbonProperties;
 import org.apache.carbondata.core.util.CarbonUtil;
 import org.apache.carbondata.hadoop.CarbonInputSplit;
 
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.BlockLocation;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -98,28 +96,6 @@ public class CarbonTableInputFormat<T> extends CarbonInputFormat<T> {
   private ReadCommittedScope readCommittedScope;
 
   /**
-   * Get the cached CarbonTable or create it by TableInfo in `configuration`
-   */
-  public CarbonTable getOrCreateCarbonTable(Configuration configuration) throws IOException {
-    if (carbonTable == null) {
-      // carbon table should be created either from deserialized table info (schema saved in
-      // hive metastore) or by reading schema in HDFS (schema saved in HDFS)
-      TableInfo tableInfo = getTableInfo(configuration);
-      CarbonTable carbonTable;
-      if (tableInfo != null) {
-        carbonTable = CarbonTable.buildFromTableInfo(tableInfo);
-      } else {
-        carbonTable = SchemaReader.readCarbonTableFromStore(
-            getAbsoluteTableIdentifier(configuration));
-      }
-      this.carbonTable = carbonTable;
-      return carbonTable;
-    } else {
-      return this.carbonTable;
-    }
-  }
-
-  /**
    * {@inheritDoc}
    * Configurations FileInputFormat.INPUT_DIR
    * are used to get table path to read.
@@ -131,7 +107,7 @@ public class CarbonTableInputFormat<T> extends CarbonInputFormat<T> {
   @Override
   public List<InputSplit> getSplits(JobContext job) throws IOException {
     AbsoluteTableIdentifier identifier = getAbsoluteTableIdentifier(job.getConfiguration());
-    CarbonTable carbonTable = getOrCreateCarbonTable(job.getConfiguration());
+    carbonTable = getOrCreateCarbonTable(job.getConfiguration());
     if (null == carbonTable) {
       throw new IOException("Missing/Corrupt schema file for table.");
     }
@@ -140,7 +116,7 @@ public class CarbonTableInputFormat<T> extends CarbonInputFormat<T> {
 
     SegmentUpdateStatusManager updateStatusManager =
         new SegmentUpdateStatusManager(carbonTable, loadMetadataDetails);
-    List<Segment> invalidSegments = new ArrayList<>();
+    List<String> invalidSegmentIds = new ArrayList<>();
     List<Segment> streamSegments = null;
     // get all valid segments and set them into the configuration
     SegmentStatusManager segmentStatusManager = new SegmentStatusManager(identifier,
@@ -177,10 +153,13 @@ public class CarbonTableInputFormat<T> extends CarbonInputFormat<T> {
         setSegmentsToAccess(job.getConfiguration(),filteredNormalSegments);
       }
       // remove entry in the segment index if there are invalid segments
-      invalidSegments.addAll(segments.getInvalidSegments());
-      if (invalidSegments.size() > 0) {
+      for (Segment segment : segments.getInvalidSegments()) {
+        invalidSegmentIds.add(segment.getSegmentNo());
+      }
+      if (invalidSegmentIds.size() > 0) {
         DataMapStoreManager.getInstance()
-            .clearInvalidSegments(getOrCreateCarbonTable(job.getConfiguration()), invalidSegments);
+            .clearInvalidSegments(getOrCreateCarbonTable(job.getConfiguration()),
+                invalidSegmentIds);
       }
     }
     List<Segment> validAndInProgressSegments = new ArrayList<>(segments.getValidSegments());
@@ -191,8 +170,6 @@ public class CarbonTableInputFormat<T> extends CarbonInputFormat<T> {
     List<Segment> filteredSegmentToAccess =
         getFilteredSegment(job, new ArrayList<>(validAndInProgressSegments), false,
             readCommittedScope);
-    // Clean the updated segments from memory if the update happens on segments
-    refreshSegmentCacheIfRequired(job, carbonTable, updateStatusManager, filteredSegmentToAccess);
 
     // process and resolve the expression
     Expression filter = getFilterPredicates(job.getConfiguration());
@@ -216,7 +193,7 @@ public class CarbonTableInputFormat<T> extends CarbonInputFormat<T> {
     // do block filtering and get split
     List<InputSplit> splits =
         getSplits(job, filter, filteredSegmentToAccess, matchedPartitions, partitionInfo,
-            null, updateStatusManager);
+            null, updateStatusManager, segments.getInvalidSegments());
     // add all splits of streaming
     List<InputSplit> splitsOfStreaming = getSplitsOfStreaming(job, streamSegments, carbonTable);
     if (!splitsOfStreaming.isEmpty()) {
@@ -234,32 +211,7 @@ public class CarbonTableInputFormat<T> extends CarbonInputFormat<T> {
    * @param filteredSegmentToAccess
    * @throws IOException
    */
-  public void refreshSegmentCacheIfRequired(JobContext job, CarbonTable carbonTable,
-      SegmentUpdateStatusManager updateStatusManager, List<Segment> filteredSegmentToAccess)
-      throws IOException {
-    List<Segment> toBeCleanedSegments = new ArrayList<>();
-    for (Segment filteredSegment : filteredSegmentToAccess) {
-      boolean refreshNeeded =
-          DataMapStoreManager.getInstance().getTableSegmentRefresher(carbonTable)
-              .isRefreshNeeded(filteredSegment,
-                  updateStatusManager.getInvalidTimestampRange(filteredSegment.getSegmentNo()));
-      if (refreshNeeded) {
-        toBeCleanedSegments.add(filteredSegment);
-      }
-    }
-    // Clean segments if refresh is needed
-    for (Segment segment : filteredSegmentToAccess) {
-      if (DataMapStoreManager.getInstance().getTableSegmentRefresher(carbonTable)
-          .isRefreshNeeded(segment.getSegmentNo())) {
-        toBeCleanedSegments.add(segment);
-      }
-    }
-    if (toBeCleanedSegments.size() > 0) {
-      DataMapStoreManager.getInstance()
-          .clearInvalidSegments(getOrCreateCarbonTable(job.getConfiguration()),
-              toBeCleanedSegments);
-    }
-  }
+
 
   /**
    * Below method will be used to get the filter segments when query is fired on pre Aggregate
@@ -435,7 +387,8 @@ public class CarbonTableInputFormat<T> extends CarbonInputFormat<T> {
 
       // do block filtering and get split
       List<InputSplit> splits = getSplits(job, filter, segmentList, matchedPartitions,
-          partitionInfo, oldPartitionIdList, new SegmentUpdateStatusManager(carbonTable));
+          partitionInfo, oldPartitionIdList, new SegmentUpdateStatusManager(carbonTable),
+          new ArrayList<Segment>());
       return splits;
     } catch (IOException e) {
       throw new RuntimeException("Can't get splits of the target segment ", e);
@@ -479,8 +432,20 @@ public class CarbonTableInputFormat<T> extends CarbonInputFormat<T> {
    */
   private List<InputSplit> getSplits(JobContext job, Expression expression,
       List<Segment> validSegments, BitSet matchedPartitions, PartitionInfo partitionInfo,
-      List<Integer> oldPartitionIdList, SegmentUpdateStatusManager updateStatusManager)
-      throws IOException {
+      List<Integer> oldPartitionIdList, SegmentUpdateStatusManager updateStatusManager,
+      List<Segment> invalidSegments) throws IOException {
+
+    List<String> segmentsToBeRefreshed = new ArrayList<>();
+    if (!CarbonProperties.getInstance()
+        .isDistributedPruningEnabled(carbonTable.getDatabaseName(), carbonTable.getTableName())) {
+      // Clean the updated segments from memory if the update happens on segments
+      DataMapStoreManager.getInstance().refreshSegmentCacheIfRequired(carbonTable,
+          updateStatusManager,
+          validSegments);
+    } else {
+      segmentsToBeRefreshed = DataMapStoreManager.getInstance()
+          .getSegmentsToBeRefreshed(carbonTable, updateStatusManager, validSegments);
+    }
 
     numSegments = validSegments.size();
     List<InputSplit> result = new LinkedList<InputSplit>();
@@ -491,8 +456,8 @@ public class CarbonTableInputFormat<T> extends CarbonInputFormat<T> {
 
     // for each segment fetch blocks matching filter in Driver BTree
     List<org.apache.carbondata.hadoop.CarbonInputSplit> dataBlocksOfSegment =
-        getDataBlocksOfSegment(job, carbonTable, expression, matchedPartitions,
-            validSegments, partitionInfo, oldPartitionIdList);
+        getDataBlocksOfSegment(job, carbonTable, expression, matchedPartitions, validSegments,
+            partitionInfo, oldPartitionIdList, invalidSegments, segmentsToBeRefreshed);
     numBlocks = dataBlocksOfSegment.size();
     for (org.apache.carbondata.hadoop.CarbonInputSplit inputSplit : dataBlocksOfSegment) {
 
@@ -550,7 +515,6 @@ public class CarbonTableInputFormat<T> extends CarbonInputFormat<T> {
     ExplainCollector.remove();
 
     AbsoluteTableIdentifier identifier = table.getAbsoluteTableIdentifier();
-    TableDataMap defaultDataMap = DataMapStoreManager.getInstance().getDefaultDataMap(table);
 
     ReadCommittedScope readCommittedScope = getReadCommitted(job, identifier);
     LoadMetadataDetails[] loadMetadataDetails = readCommittedScope.getSegmentList();
@@ -572,26 +536,42 @@ public class CarbonTableInputFormat<T> extends CarbonInputFormat<T> {
     For NonTransactional table, one of the reason for a segment refresh is below scenario.
     SDK is written one set of files with UUID, with same UUID it can write again.
     So, latest files content should reflect the new count by refreshing the segment */
-    List<Segment> toBeCleanedSegments = new ArrayList<>();
+    List<String> toBeCleanedSegments = new ArrayList<>();
     for (Segment eachSegment : filteredSegment) {
       boolean refreshNeeded = DataMapStoreManager.getInstance()
           .getTableSegmentRefresher(getOrCreateCarbonTable(job.getConfiguration()))
           .isRefreshNeeded(eachSegment,
               updateStatusManager.getInvalidTimestampRange(eachSegment.getSegmentNo()));
       if (refreshNeeded) {
-        toBeCleanedSegments.add(eachSegment);
+        toBeCleanedSegments.add(eachSegment.getSegmentNo());
       }
     }
-    // remove entry in the segment index if there are invalid segments
-    toBeCleanedSegments.addAll(allSegments.getInvalidSegments());
+    for (Segment segment : allSegments.getInvalidSegments()) {
+      // remove entry in the segment index if there are invalid segments
+      toBeCleanedSegments.add(segment.getSegmentNo());
+    }
     if (toBeCleanedSegments.size() > 0) {
       DataMapStoreManager.getInstance()
           .clearInvalidSegments(getOrCreateCarbonTable(job.getConfiguration()),
               toBeCleanedSegments);
     }
     if (isIUDTable || isUpdateFlow) {
-      Map<String, Long> blockletToRowCountMap =
-          defaultDataMap.getBlockRowCount(filteredSegment, partitions, defaultDataMap);
+      Map<String, Long> blockletToRowCountMap = new HashMap<>();
+      if (CarbonProperties.getInstance().isDistributedPruningEnabled(table.getDatabaseName(),
+          table.getTableName())) {
+        List<InputSplit> extendedBlocklets = CarbonTableInputFormat.convertToCarbonInputSplit(
+            getDistributedSplit(table, null, partitions, filteredSegment,
+                allSegments.getInvalidSegments(), toBeCleanedSegments));
+        for (InputSplit extendedBlocklet : extendedBlocklets) {
+          CarbonInputSplit blocklet = (CarbonInputSplit) extendedBlocklet;
+          blockletToRowCountMap.put(blocklet.getSegmentId() + "," + blocklet.getFilePath(),
+              (long) blocklet.getDetailInfo().getRowCount());
+        }
+      } else {
+        TableDataMap defaultDataMap = DataMapStoreManager.getInstance().getDefaultDataMap(table);
+        blockletToRowCountMap.putAll(
+            defaultDataMap.getBlockRowCount(filteredSegment, partitions, defaultDataMap));
+      }
       // key is the (segmentId","+blockletPath) and key is the row count of that blocklet
       for (Map.Entry<String, Long> eachBlocklet : blockletToRowCountMap.entrySet()) {
         String[] segmentIdAndPath = eachBlocklet.getKey().split(",", 2);
@@ -620,7 +600,19 @@ public class CarbonTableInputFormat<T> extends CarbonInputFormat<T> {
         }
       }
     } else {
-      long totalRowCount = defaultDataMap.getRowCount(filteredSegment, partitions, defaultDataMap);
+      long totalRowCount = 0L;
+      if (CarbonProperties.getInstance().isDistributedPruningEnabled(table.getDatabaseName(),
+          table.getTableName())) {
+        List<InputSplit> extendedBlocklets = CarbonTableInputFormat.convertToCarbonInputSplit(
+            getDistributedSplit(table, null, partitions, filteredSegment,
+                allSegments.getInvalidSegments(), new ArrayList<String>()));
+        for (InputSplit extendedBlocklet : extendedBlocklets) {
+          totalRowCount += ((CarbonInputSplit) extendedBlocklet).getDetailInfo().getRowCount();
+        }
+      } else {
+        TableDataMap defaultDataMap = DataMapStoreManager.getInstance().getDefaultDataMap(table);
+        totalRowCount = defaultDataMap.getRowCount(filteredSegment, partitions, defaultDataMap);
+      }
       blockRowCountMapping.put(CarbonCommonConstantsInternal.ROW_COUNT, totalRowCount);
     }
     return new BlockMappingVO(blockRowCountMapping, segmentAndBlockCountMapping);

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/util/CarbonInputFormatUtil.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/util/CarbonInputFormatUtil.java
@@ -163,7 +163,7 @@ public class CarbonInputFormatUtil {
    * @throws IOException
    */
   public static void setDataMapJobIfConfigured(Configuration conf) throws IOException {
-    String className = "org.apache.carbondata.spark.rdd.SparkDataMapJob";
+    String className = "org.apache.carbondata.indexserver.EmbeddedDataMapJob";
     DataMapUtil.setDataMapJob(conf, DataMapUtil.createDataMapJob(className));
   }
 

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/allqueries/TestQueryWithColumnMetCacheAndCacheLevelProperty.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/allqueries/TestQueryWithColumnMetCacheAndCacheLevelProperty.scala
@@ -20,18 +20,18 @@ package org.apache.carbondata.spark.testsuite.allqueries
 import scala.collection.JavaConverters._
 
 import org.apache.hadoop.conf.Configuration
-import org.apache.spark.sql.{CarbonEnv, Row}
 import org.apache.spark.sql.hive.CarbonRelation
 import org.apache.spark.sql.test.util.QueryTest
+import org.apache.spark.sql.{CarbonEnv, Row}
 import org.scalatest.BeforeAndAfterAll
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.datamap.dev.DataMap
 import org.apache.carbondata.core.datamap.{DataMapChooser, DataMapStoreManager, Segment, TableDataMap}
 import org.apache.carbondata.core.datastore.block.SegmentPropertiesAndSchemaHolder
+import org.apache.carbondata.core.indexstore.Blocklet
 import org.apache.carbondata.core.indexstore.blockletindex.{BlockDataMap, BlockletDataMap, BlockletDataMapRowIndexes}
 import org.apache.carbondata.core.indexstore.schema.CarbonRowSchema
-import org.apache.carbondata.core.indexstore.Blocklet
 import org.apache.carbondata.core.metadata.datatype.DataTypes
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable
 import org.apache.carbondata.core.metadata.schema.table.column.CarbonDimension

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datamap/CGDataMapTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datamap/CGDataMapTestCase.scala
@@ -114,14 +114,6 @@ class CGDataMapFactory(
     }.toList.asJava
   }
 
-
-  /**
-   * Clears datamap of the segment
-   */
-  override def clear(segment: Segment): Unit = {
-
-  }
-
   /**
    * Clear all datamaps from memory
    */

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datamap/DataMapWriterSuite.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datamap/DataMapWriterSuite.scala
@@ -47,8 +47,6 @@ class C2DataMapFactory(
 
   override def fireEvent(event: Event): Unit = ???
 
-  override def clear(segment: Segment): Unit = {}
-
   override def clear(): Unit = {}
 
   override def getDataMaps(distributable: DataMapDistributable): util.List[CoarseGrainDataMap] = ???

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datamap/FGDataMapTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datamap/FGDataMapTestCase.scala
@@ -98,6 +98,8 @@ class FGDataMapFactory(carbonTable: CarbonTable,
     val files = file.listFiles()
     files.map { f =>
       val d: DataMapDistributable = new BlockletDataMapDistributable(f.getCanonicalPath)
+      d.setSegment(segment)
+      d.setDataMapSchema(getDataMapSchema)
       d
     }.toList.asJava
   }
@@ -108,12 +110,6 @@ class FGDataMapFactory(carbonTable: CarbonTable,
    */
   override def fireEvent(event: Event):Unit = {
     ???
-  }
-
-  /**
-   * Clears datamap of the segment
-   */
-  override def clear(segment: Segment): Unit = {
   }
 
   /**

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datamap/TestDataMapStatus.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datamap/TestDataMapStatus.scala
@@ -226,8 +226,6 @@ class TestDataMapFactory(
 
   override def fireEvent(event: Event): Unit = ???
 
-  override def clear(segmentId: Segment): Unit = {}
-
   override def clear(): Unit = {}
 
   override def getDataMaps(distributable: DataMapDistributable): util.List[CoarseGrainDataMap] = {

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/iud/TestInsertAndOtherCommandConcurrent.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/iud/TestInsertAndOtherCommandConcurrent.scala
@@ -306,8 +306,6 @@ class WaitingDataMapFactory(
 
   override def fireEvent(event: Event): Unit = ???
 
-  override def clear(segmentId: Segment): Unit = {}
-
   override def clear(): Unit = {}
 
   override def getDataMaps(distributable: DataMapDistributable): util.List[CoarseGrainDataMap] = ???

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/CarbonScalaUtil.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/CarbonScalaUtil.scala
@@ -39,7 +39,7 @@ import org.apache.spark.util.CarbonReflectionUtils
 
 import org.apache.carbondata.common.exceptions.MetadataProcessException
 import org.apache.carbondata.common.exceptions.sql.MalformedCarbonCommandException
-import org.apache.carbondata.common.logging.{LogService, LogServiceFactory}
+import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.core.cache.{Cache, CacheProvider, CacheType}
 import org.apache.carbondata.core.cache.dictionary.{Dictionary, DictionaryColumnUniqueIdentifier}
 import org.apache.carbondata.core.constants.CarbonCommonConstants
@@ -58,7 +58,7 @@ import org.apache.carbondata.streaming.parser.FieldConverter
 
 object CarbonScalaUtil {
 
-  val LOGGER = LogServiceFactory.getLogService(this.getClass.getCanonicalName)
+  private val LOGGER: Logger = LogServiceFactory.getLogService(this.getClass.getCanonicalName)
 
   def getString(value: Any,
       serializationNullFormat: String,
@@ -698,6 +698,13 @@ object CarbonScalaUtil {
     newColumnSchemas ++= columnSchemas.filter(columnSchema => columnSchema.isSortColumn)
     newColumnSchemas ++= columnSchemas.filterNot(columnSchema => columnSchema.isSortColumn)
     newColumnSchemas
+  }
+
+  def logTime[T](f: => T): (T, Long) = {
+    val startTime = System.currentTimeMillis()
+    val response = f
+    val endTime = System.currentTimeMillis() - startTime
+    (response, endTime)
   }
 
 }

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/hive/DistributionUtil.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/hive/DistributionUtil.scala
@@ -95,7 +95,7 @@ object DistributionUtil {
     while (iface.hasMoreElements) {
       addresses = iface.nextElement().getInterfaceAddresses.asScala.toList ++ addresses
     }
-    val inets = addresses.map(_.getAddress.getHostAddress)
+    val inets = addresses.map(_.getAddress.getHostName)
     inets
   }
 

--- a/integration/spark2/src/main/java/org/apache/carbondata/datamap/IndexDataMapProvider.java
+++ b/integration/spark2/src/main/java/org/apache/carbondata/datamap/IndexDataMapProvider.java
@@ -93,7 +93,7 @@ public class IndexDataMapProvider extends DataMapProvider {
     if (mainTable == null) {
       throw new UnsupportedOperationException("Table need to be specified in index datamaps");
     }
-    DataMapStoreManager.getInstance().clearDataMap(
+    DataMapStoreManager.getInstance().deleteDataMap(
         mainTable.getAbsoluteTableIdentifier(), getDataMapSchema().getDataMapName());
   }
 

--- a/integration/spark2/src/main/scala/org/apache/carbondata/indexserver/DataMapJobs.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/indexserver/DataMapJobs.scala
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.indexserver
+
+import java.util
+
+import scala.collection.JavaConverters._
+
+import org.apache.log4j.Logger
+import org.apache.spark.util.SizeEstimator
+
+import org.apache.carbondata.common.logging.LogServiceFactory
+import org.apache.carbondata.core.datamap.{AbstractDataMapJob, DistributableDataMapFormat}
+import org.apache.carbondata.core.indexstore.ExtendedBlocklet
+import org.apache.carbondata.spark.util.CarbonScalaUtil.logTime
+
+/**
+ * Spark job to execute datamap job and prune all the datamaps distributable. This job will prune
+ * and cache the appropriate datamaps in executor LRUCache.
+ */
+class DistributedDataMapJob extends AbstractDataMapJob {
+
+  val LOGGER: Logger = LogServiceFactory.getLogService(this.getClass.getCanonicalName)
+
+  override def execute(dataMapFormat: DistributableDataMapFormat): util.List[ExtendedBlocklet] = {
+    if (LOGGER.isDebugEnabled) {
+      val messageSize = SizeEstimator.estimate(dataMapFormat)
+      LOGGER.debug(s"Size of message sent to Index Server: $messageSize")
+    }
+    val (resonse, time) = logTime {
+      IndexServer.getClient.getSplits(dataMapFormat).toList.asJava
+    }
+    LOGGER.info(s"Time taken to get response from server: $time ms")
+    resonse
+  }
+}
+
+/**
+ * Spark job to execute datamap job and prune all the datamaps distributable. This job will just
+ * prune the datamaps but will not cache in executors.
+ */
+class EmbeddedDataMapJob extends AbstractDataMapJob {
+
+  override def execute(dataMapFormat: DistributableDataMapFormat): util.List[ExtendedBlocklet] = {
+    IndexServer.getSplits(dataMapFormat).toList.asJava
+  }
+
+}
+
+class DistributedClearCacheJob extends AbstractDataMapJob {
+
+  val LOGGER: Logger = LogServiceFactory.getLogService(this.getClass.getCanonicalName)
+
+  override def execute(dataMapFormat: DistributableDataMapFormat): util.List[ExtendedBlocklet] = {
+    if (LOGGER.isDebugEnabled) {
+      val messageSize = SizeEstimator.estimate(dataMapFormat)
+      LOGGER.debug(s"Size of message sent to Index Server: $messageSize")
+    }
+    val (response, time) = logTime {
+      IndexServer.getClient.invalidateCache(dataMapFormat)
+      new util.ArrayList[ExtendedBlocklet]()
+    }
+    LOGGER.info(s"Time taken to get response from server: $time ms")
+    response
+  }
+}

--- a/integration/spark2/src/main/scala/org/apache/carbondata/indexserver/DistributedPruneRDD.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/indexserver/DistributedPruneRDD.scala
@@ -14,71 +14,73 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.carbondata.spark.rdd
+
+package org.apache.carbondata.indexserver
 
 import java.text.SimpleDateFormat
-import java.util
 import java.util.Date
 
 import scala.collection.JavaConverters._
 
-import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.mapreduce.{InputSplit, Job, TaskAttemptID, TaskType}
+import org.apache.hadoop.mapred.TaskAttemptID
+import org.apache.hadoop.mapreduce.{InputSplit, Job, TaskType}
 import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl
-import org.apache.spark.{Partition, TaskContext, TaskKilledException}
+import org.apache.spark.{Partition, SparkEnv, TaskContext, TaskKilledException}
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.util.SparkSQLUtil
+import org.apache.spark.sql.hive.DistributionUtil
 
-import org.apache.carbondata.core.datamap.{AbstractDataMapJob, DistributableDataMapFormat}
+import org.apache.carbondata.common.logging.LogServiceFactory
+import org.apache.carbondata.core.cache.CacheProvider
+import org.apache.carbondata.core.datamap.DistributableDataMapFormat
 import org.apache.carbondata.core.datastore.impl.FileFactory
 import org.apache.carbondata.core.indexstore.ExtendedBlocklet
-import org.apache.carbondata.core.scan.filter.resolver.FilterResolverIntf
+import org.apache.carbondata.spark.rdd.CarbonRDD
+import org.apache.carbondata.spark.util.CarbonScalaUtil
 
-/**
- * Spark job to execute datamap job and prune all the datamaps distributable
- */
-class SparkDataMapJob extends AbstractDataMapJob {
+private[indexserver] class DataMapRDDPartition(rddId: Int, idx: Int, val inputSplit: InputSplit)
+  extends Partition {
 
-  override def execute(dataMapFormat: DistributableDataMapFormat,
-      filter: FilterResolverIntf): util.List[ExtendedBlocklet] = {
-    new DataMapPruneRDD(SparkSQLUtil.getSparkSession, dataMapFormat, filter).collect()
-      .toList.asJava
-  }
-}
-
-class DataMapRDDPartition(rddId: Int, idx: Int, val inputSplit: InputSplit) extends Partition {
   override def index: Int = idx
 
   override def hashCode(): Int = 41 * (41 + rddId) + idx
 }
 
-/**
- * RDD to prune the datamaps across spark cluster
- * @param ss
- * @param dataMapFormat
- */
-class DataMapPruneRDD(
-    @transient private val ss: SparkSession,
-    dataMapFormat: DistributableDataMapFormat,
-    resolverIntf: FilterResolverIntf)
-  extends CarbonRDD[(ExtendedBlocklet)](ss, Nil) {
+private[indexserver] class DistributedPruneRDD(@transient private val ss: SparkSession,
+    dataMapFormat: DistributableDataMapFormat)
+  extends CarbonRDD[(String, ExtendedBlocklet)](ss, Nil) {
+
+  val executorsList: Set[String] = DistributionUtil.getNodeList(ss.sparkContext).toSet
+
+  @transient private val LOGGER = LogServiceFactory.getLogService(classOf[DistributedPruneRDD]
+    .getName)
 
   private val jobTrackerId: String = {
     val formatter = new SimpleDateFormat("yyyyMMddHHmm")
     formatter.format(new Date())
   }
 
+  override protected def getPreferredLocations(split: Partition): Seq[String] = {
+    split.asInstanceOf[DataMapRDDPartition].inputSplit.getLocations.toSeq
+  }
+
   override def internalCompute(split: Partition,
-      context: TaskContext): Iterator[ExtendedBlocklet] = {
+      context: TaskContext): Iterator[(String, ExtendedBlocklet)] = {
     val attemptId = new TaskAttemptID(jobTrackerId, id, TaskType.MAP, split.index, 0)
     val attemptContext = new TaskAttemptContextImpl(FileFactory.getConfiguration, attemptId)
     val inputSplit = split.asInstanceOf[DataMapRDDPartition].inputSplit
     val reader = dataMapFormat.createRecordReader(inputSplit, attemptContext)
     reader.initialize(inputSplit, attemptContext)
+    val cacheSize = if (CacheProvider.getInstance().getCarbonCache != null) {
+      CacheProvider.getInstance().getCarbonCache.getCurrentSize
+    } else {
+      0L
+    }
     context.addTaskCompletionListener(_ => {
-      reader.close()
+      if (reader != null) {
+        reader.close()
+      }
     })
-    val iter = new Iterator[ExtendedBlocklet] {
+    val iter: Iterator[(String, ExtendedBlocklet)] = new Iterator[(String, ExtendedBlocklet)] {
 
       private var havePair = false
       private var finished = false
@@ -94,12 +96,13 @@ class DataMapPruneRDD(
         !finished
       }
 
-      override def next(): ExtendedBlocklet = {
+      override def next(): (String, ExtendedBlocklet) = {
         if (!hasNext) {
           throw new java.util.NoSuchElementException("End of stream")
         }
         havePair = false
-        val value = reader.getCurrentValue
+        val executorIP = SparkEnv.get.blockManager.blockManagerId.host
+        val value = (executorIP + "_" + cacheSize.toString, reader.getCurrentValue)
         value
       }
     }
@@ -108,7 +111,18 @@ class DataMapPruneRDD(
 
   override protected def internalGetPartitions: Array[Partition] = {
     val job = Job.getInstance(FileFactory.getConfiguration)
-    val splits = dataMapFormat.getSplits(job)
-    splits.asScala.zipWithIndex.map(f => new DataMapRDDPartition(id, f._2, f._1)).toArray
+    val splits = dataMapFormat.getSplits(job).asScala
+    if (dataMapFormat.isFallbackJob || splits.isEmpty) {
+      splits.zipWithIndex.map {
+        f => new DataMapRDDPartition(id, f._2, f._1)
+      }.toArray
+    } else {
+      val (response, time) = CarbonScalaUtil.logTime {
+        DistributedRDDUtils.getExecutors(splits.toArray, executorsList, dataMapFormat
+          .getCarbonTable.getTableUniqueName, id)
+      }
+      LOGGER.debug(s"Time taken to assign executors to ${splits.length} is $time ms")
+      response.toArray
+    }
   }
 }

--- a/integration/spark2/src/main/scala/org/apache/carbondata/indexserver/DistributedRDDUtils.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/indexserver/DistributedRDDUtils.scala
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.indexserver
+
+import java.util.concurrent.ConcurrentHashMap
+
+import scala.collection.JavaConverters._
+
+import org.apache.commons.lang.StringUtils
+import org.apache.hadoop.mapreduce.InputSplit
+import org.apache.spark.Partition
+
+import org.apache.carbondata.core.datamap.{DataMapDistributable, Segment}
+import org.apache.carbondata.core.datamap.dev.expr.DataMapDistributableWrapper
+
+object DistributedRDDUtils {
+  // Segment number to executorNode mapping
+  val segmentToExecutorMapping: java.util.Map[String, String] =
+    new ConcurrentHashMap[String, String]()
+
+  // executorNode to segmentSize mapping
+  val executorToCacheSizeMapping: java.util.Map[String, Long] =
+    new ConcurrentHashMap[String, Long]()
+
+  def getExecutors(segment: Array[InputSplit], executorsList : Set[String],
+      tableUniqueName: String, rddId: Int): Seq[Partition] = {
+    // sort the partitions in increasing order of index size.
+    val (segments, legacySegments) = segment.span(split => split
+      .asInstanceOf[DataMapDistributableWrapper].getDistributable.getSegment.getIndexSize > 0)
+    val sortedPartitions = segments.sortWith(_.asInstanceOf[DataMapDistributableWrapper]
+                                              .getDistributable.getSegment.getIndexSize >
+                                            _.asInstanceOf[DataMapDistributableWrapper]
+                                              .getDistributable.getSegment.getIndexSize)
+    val executorCache = DistributedRDDUtils.executorToCacheSizeMapping
+    // check if any executor is dead.
+    val invalidExecutors = executorCache.keySet().asScala.diff(executorsList)
+    if (invalidExecutors.nonEmpty) {
+      // extract the dead executor host name
+      DistributedRDDUtils.invalidateExecutors(invalidExecutors.toSeq)
+    }
+    (convertToPartition(legacySegments, tableUniqueName, executorsList) ++
+     convertToPartition(sortedPartitions, tableUniqueName, executorsList)).zipWithIndex.map {
+      case (dataMapDistributable, index) =>
+        new DataMapRDDPartition(rddId, index, dataMapDistributable)
+    }
+  }
+
+  private def convertToPartition(segments: Seq[InputSplit], tableUniqueName: String,
+      executorList: Set[String]): Seq[InputSplit] = {
+    segments.map { partition =>
+      val wrapper: DataMapDistributable = partition.asInstanceOf[DataMapDistributableWrapper]
+        .getDistributable
+      if (wrapper.getSegment.getIndexSize == 0L) {
+        wrapper.getSegment.setIndexSize(1L)
+      }
+      wrapper.setLocations(Array(DistributedRDDUtils
+        .assignExecutor(tableUniqueName, wrapper.getSegment, executorList)))
+      partition
+    }
+  }
+
+  /**
+   * Update the cache size returned by the executors to the driver mapping.
+   */
+  def updateExecutorCacheSize(cacheSizes: Set[String]): Unit = {
+    synchronized {
+      cacheSizes.foreach {
+        executorCacheSize =>
+          // executorCacheSize would be in the form of 127.0.0.1_10024 where the left of '_'
+          // would be the executor IP and the right would be the cache that executor is holding.
+          val executorIP = executorCacheSize.substring(0, executorCacheSize.lastIndexOf('_'))
+          val size = executorCacheSize.substring(executorCacheSize.lastIndexOf('_') + 1,
+            executorCacheSize.length)
+          executorToCacheSizeMapping.put(executorIP, size.toLong)
+      }
+    }
+  }
+
+  def invalidateCache(tableUniqueName: String): Unit = {
+    segmentToExecutorMapping.keySet().asScala.foreach {
+      key =>
+        if (key.split("_")(0).equalsIgnoreCase(tableUniqueName)) {
+          segmentToExecutorMapping.remove(key)
+        }
+    }
+  }
+
+  /**
+   * Invalidate the dead executors from the mapping and assign the segments to some other
+   * executor, so that the query can load the segments to the new assigned executor.
+   */
+  def invalidateExecutors(invalidExecutors: Seq[String]): Unit = synchronized {
+    // remove all invalidExecutor mapping from cache.
+    for ((key: String, value: String) <- segmentToExecutorMapping.asScala) {
+      // find the invalid executor in cache.
+      if (invalidExecutors.contains(value)) {
+        // remove mapping for the invalid executor.
+        val invalidExecutorSize = executorToCacheSizeMapping.remove(key)
+        // find a new executor for the segment
+        val reassignedExecutor = getLeastLoadedExecutor
+        segmentToExecutorMapping.put(key, reassignedExecutor)
+        // add the size size of the invalid executor to the reassigned executor.
+        executorToCacheSizeMapping.put(
+          reassignedExecutor,
+          executorToCacheSizeMapping.get(reassignedExecutor) + invalidExecutorSize
+        )
+      }
+    }
+  }
+
+  /**
+   * Sorts the executor cache based on the size each one is handling and returns the least of them.
+   *
+   * @return
+   */
+  private def getLeastLoadedExecutor: String = {
+    executorToCacheSizeMapping.asScala.toSeq.sortWith(_._2 < _._2).head._1
+  }
+
+  /**
+   * Assign a executor for the current segment. If a executor was previously assigned to the
+   * segment then the same would be returned.
+   *
+   * @return
+   */
+  def assignExecutor(tableName: String, segment: Segment, validExecutors: Set[String]): String = {
+    val cacheKey = s"${ tableName }_${ segment.getSegmentNo }"
+    val executor = segmentToExecutorMapping.get(cacheKey)
+    if (executor != null) {
+      executor
+    } else {
+      // check if any executor is not assigned. If yes then give priority to that executor
+      // otherwise get the executor which has handled the least size.
+      val unassignedExecutors = validExecutors
+        .diff(executorToCacheSizeMapping.asScala.keys.toSet)
+      val newExecutor = if (unassignedExecutors.nonEmpty) {
+        unassignedExecutors.head.split(":")(0)
+      } else {
+        val identifiedExecutor = getLeastLoadedExecutor
+        identifiedExecutor
+      }
+      val existingExecutorSize = executorToCacheSizeMapping.get(newExecutor)
+      executorToCacheSizeMapping.put(newExecutor, existingExecutorSize + segment.getIndexSize
+        .toInt)
+      segmentToExecutorMapping.put(cacheKey, newExecutor)
+      newExecutor
+    }
+  }
+
+}

--- a/integration/spark2/src/main/scala/org/apache/carbondata/indexserver/DistributedShowCacheRDD.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/indexserver/DistributedShowCacheRDD.scala
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.indexserver
+
+import org.apache.spark.{Partition, TaskContext}
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.hive.DistributionUtil
+import scala.collection.JavaConverters._
+
+import org.apache.carbondata.core.cache.CacheProvider
+import org.apache.carbondata.core.datamap.DataMapStoreManager
+import org.apache.carbondata.hadoop.CarbonInputSplit
+import org.apache.carbondata.spark.rdd.CarbonRDD
+
+class DistributedShowCacheRDD(@transient private val ss: SparkSession, tableName: String)
+  extends CarbonRDD[String](ss, Nil) {
+
+  val executorsList: Array[String] = DistributionUtil.getNodeList(ss.sparkContext)
+
+  override protected def internalGetPartitions: Array[Partition] = {
+    executorsList.zipWithIndex.map {
+      case (executor, idx) =>
+        // create a dummy split for each executor to accumulate the cache size.
+        val dummySplit = new CarbonInputSplit()
+        dummySplit.setLocation(Array(executor))
+        new DataMapRDDPartition(id, idx, dummySplit)
+    }
+  }
+
+  override def internalCompute(split: Partition, context: TaskContext): Iterator[String] = {
+    val dataMaps = DataMapStoreManager.getInstance().getAllDataMaps.asScala
+    val iterator = dataMaps.collect {
+      case (table, tableDataMaps) if table.isEmpty ||
+                                     (tableName.nonEmpty && tableName.equalsIgnoreCase(table)) =>
+        val sizeAndIndexLengths = tableDataMaps.asScala
+          .map(_.getBlockletDetailsFetcher.getCacheSize)
+        // return tableName_indexFileLength_indexCachesize for each executor.
+        sizeAndIndexLengths.map {
+          x => s"$table:$x"
+        }
+    }.flatten.toIterator
+    iterator
+  }
+}

--- a/integration/spark2/src/main/scala/org/apache/carbondata/indexserver/IndexServer.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/indexserver/IndexServer.scala
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.indexserver
+
+import java.net.InetSocketAddress
+import java.security.PrivilegedAction
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.ipc.{ProtocolInfo, RPC}
+import org.apache.hadoop.net.NetUtils
+import org.apache.hadoop.security.{KerberosInfo, SecurityUtil, UserGroupInformation}
+import org.apache.spark.SparkConf
+import org.apache.spark.scheduler.{SparkListener, SparkListenerApplicationEnd}
+import org.apache.spark.sql.{CarbonSession, SparkSession}
+import org.apache.spark.sql.util.SparkSQLUtil
+
+import org.apache.carbondata.common.logging.LogServiceFactory
+import org.apache.carbondata.core.constants.CarbonCommonConstants
+import org.apache.carbondata.core.datamap.DistributableDataMapFormat
+import org.apache.carbondata.core.datastore.impl.FileFactory
+import org.apache.carbondata.core.indexstore.ExtendedBlocklet
+import org.apache.carbondata.core.util.CarbonProperties
+
+@ProtocolInfo(protocolName = "Server", protocolVersion = 1)
+@KerberosInfo(serverPrincipal = "spark.carbon.indexserver.principal",
+  clientPrincipal = "spark.carbon.indexserver.principal")
+trait ServerInterface {
+  /**
+   * Used to prune and cache the datamaps for the table.
+   */
+  def getSplits(request: DistributableDataMapFormat): Array[ExtendedBlocklet]
+
+  /**
+   * Invalidate the cache for the provided table.
+   */
+  def invalidateCache(request: DistributableDataMapFormat): Unit
+
+  /**
+   * Get the cache size for the specified table.
+   */
+  def showCache(tableName: String) : Array[String]
+
+  /**
+   * Invalidate the cache for the specified segments only. Used in case of compaction/Update/Delete.
+   */
+  def invalidateSegmentCache(databaseName: String,
+      tableName: String,
+      segmentIds: Array[String]): Unit
+}
+
+/**
+ * An instance of a distributed Index Server which will be used for:
+ * 1. Pruning the datamaps in a distributed way by using the executors.
+ * 2. Caching the pruned datamaps in executor size to be reused in the next query.
+ * 3. Getting the size of the datamaps cached in the executors.
+ * 4. Clearing the datamaps for a table or for the specified invalid segments.
+ *
+ * Start using ./bin/start-indexserver.sh
+ * Stop using ./bin/stop-indexserver.sh
+ */
+object IndexServer extends ServerInterface {
+
+  val isDistributedPruning: Boolean =
+    CarbonProperties.getInstance().isDistributedPruningEnabled("", "")
+
+  private val LOGGER = LogServiceFactory.getLogService(this.getClass.getName)
+
+  private val serverIp: String = CarbonProperties.getInstance().getIndexServerIP
+
+  private lazy val serverPort: Int = CarbonProperties.getInstance().getIndexServerPort
+
+  private val numHandlers: Int = CarbonProperties.getInstance().getNumberOfHandlersForIndexServer
+
+  /**
+   * Getting sparkSession from ActiveSession because in case of embedded mode the session would
+   * have already been created whereas in case of distributed mode the session would be
+   * created by the main method after some validations.
+   */
+  private lazy val sparkSession: SparkSession = SparkSQLUtil.getSparkSession
+
+  private def doAs[T](f: => T): T = {
+    UserGroupInformation.getLoginUser.doAs(new PrivilegedAction[T] {
+      override def run(): T = {
+        f
+      }
+    })
+  }
+
+  def getSplits(request: DistributableDataMapFormat): Array[ExtendedBlocklet] = doAs {
+    val splits = new DistributedPruneRDD(sparkSession, request).collect()
+    DistributedRDDUtils.updateExecutorCacheSize(splits.map(_._1).toSet)
+    splits.map(_._2)
+  }
+
+  override def invalidateCache(request: DistributableDataMapFormat): Unit = doAs {
+    val splits = new DistributedPruneRDD(sparkSession, request).collect()
+    DistributedRDDUtils.updateExecutorCacheSize(splits.map(_._1).toSet)
+    if (request.isJobToClearDataMaps) {
+      DistributedRDDUtils.invalidateCache(request.getCarbonTable.getTableUniqueName)
+    }
+  }
+
+  override def invalidateSegmentCache(databaseName: String, tableName: String,
+      segmentIds: Array[String]): Unit = doAs {
+    new InvalidateSegmentCacheRDD(sparkSession, databaseName, tableName, segmentIds.toList)
+      .collect()
+  }
+
+  override def showCache(tableName: String = ""): Array[String] = doAs {
+    new DistributedShowCacheRDD(sparkSession, tableName).collect()
+  }
+
+  def main(args: Array[String]): Unit = {
+    if (serverIp.isEmpty) {
+      throw new RuntimeException(s"Please set the server IP to use Index Cache Server")
+    } else if (!isDistributedPruning) {
+      throw new RuntimeException(
+        s"Please set ${ CarbonCommonConstants.CARBON_ENABLE_INDEX_SERVER }" +
+        s" as true to use index server")
+    } else {
+      createCarbonSession()
+      LOGGER.info("Starting Index Cache Server")
+      val conf = new Configuration()
+      val server: RPC.Server = new RPC.Builder(conf).setInstance(this)
+        .setBindAddress(serverIp)
+        .setPort(serverPort)
+        .setNumHandlers(numHandlers)
+        .setProtocol(classOf[ServerInterface]).build
+      server.start()
+      SecurityUtil.login(sparkSession.asInstanceOf[CarbonSession].sessionState.newHadoopConf(),
+        "spark.carbon.indexserver.keytab", "spark.carbon.indexserver.principal")
+      sparkSession.sparkContext.addSparkListener(new SparkListener {
+        override def onApplicationEnd(applicationEnd: SparkListenerApplicationEnd): Unit = {
+          LOGGER.info("Spark Application has ended. Stopping the Index Server")
+          server.stop()
+        }
+      })
+      LOGGER.info(s"Index cache server running on ${ server.getPort } port")
+    }
+  }
+
+  private def createCarbonSession(): SparkSession = {
+    import org.apache.spark.sql.CarbonSession._
+    val spark = SparkSession
+      .builder().config(new SparkConf())
+      .appName("DistributedIndexServer")
+      .enableHiveSupport()
+      .getOrCreateCarbonSession(CarbonProperties.getStorePath)
+    SparkSession.setActiveSession(spark)
+    SparkSession.setDefaultSession(spark)
+    spark
+  }
+
+  /**
+   * @return Return a new Client to communicate with the Index Server.
+   */
+  def getClient: ServerInterface = {
+    import org.apache.hadoop.ipc.RPC
+    RPC.getProxy(classOf[ServerInterface],
+      RPC.getProtocolVersion(classOf[ServerInterface]),
+      new InetSocketAddress(serverIp, serverPort), UserGroupInformation.getLoginUser,
+      FileFactory.getConfiguration, NetUtils.getDefaultSocketFactory(FileFactory.getConfiguration))
+  }
+}

--- a/integration/spark2/src/main/scala/org/apache/carbondata/indexserver/InvalidateSegmentCacheRDD.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/indexserver/InvalidateSegmentCacheRDD.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.indexserver
+
+import scala.collection.JavaConverters._
+
+import org.apache.spark.{Partition, TaskContext}
+import org.apache.spark.sql.{CarbonEnv, SparkSession}
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.hive.DistributionUtil
+
+import org.apache.carbondata.core.datamap.DataMapStoreManager
+import org.apache.carbondata.core.metadata.schema.table.CarbonTable
+import org.apache.carbondata.hadoop.CarbonInputSplit
+import org.apache.carbondata.spark.rdd.CarbonRDD
+
+class InvalidateSegmentCacheRDD(@transient private val ss: SparkSession, databaseName: String,
+    tableName: String, invalidSegmentIds: List[String]) extends CarbonRDD[String](ss, Nil) {
+
+  val carbonTable: CarbonTable = CarbonEnv
+    .getCarbonTable(TableIdentifier(tableName, Some(databaseName)))(ss)
+
+  val executorsList: Array[String] = DistributionUtil.getNodeList(ss.sparkContext)
+
+  override def internalCompute(split: Partition,
+      context: TaskContext): Iterator[String] = {
+    DataMapStoreManager.getInstance().clearInvalidSegments(carbonTable, invalidSegmentIds.asJava)
+    Iterator.empty
+  }
+
+  override protected def internalGetPartitions: Array[Partition] = {
+    executorsList.zipWithIndex.map {
+      case (executor, idx) =>
+        // create a dummy split for each executor to accumulate the cache size.
+        val dummySplit = new CarbonInputSplit()
+        dummySplit.setLocation(Array(executor))
+        new DataMapRDDPartition(id, idx, dummySplit)
+    }
+  }
+}

--- a/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -66,6 +66,7 @@ import org.apache.carbondata.core.statusmanager.{LoadMetadataDetails, SegmentSta
 import org.apache.carbondata.core.util.{ByteUtil, CarbonProperties, CarbonUtil, ThreadLocalSessionInfo}
 import org.apache.carbondata.core.util.path.CarbonTablePath
 import org.apache.carbondata.events.{OperationContext, OperationListenerBus}
+import org.apache.carbondata.indexserver.IndexServer
 import org.apache.carbondata.processing.exception.DataLoadingException
 import org.apache.carbondata.processing.loading.FailureCauses
 import org.apache.carbondata.processing.loading.csvinput.{BlockDetails, CSVInputFormat, StringArrayWritable}
@@ -252,6 +253,12 @@ object CarbonDataRDDFactory {
                   .listAllTables(sqlContext.sparkSession).toArray,
                 skipCompactionTables.asJava)
             }
+          }
+          // Remove compacted segments from executor cache.
+          if (CarbonProperties.getInstance().isDistributedPruningEnabled(
+              carbonLoadModel.getDatabaseName, carbonLoadModel.getTableName)) {
+            IndexServer.getClient.invalidateSegmentCache(carbonLoadModel.getDatabaseName,
+              carbonLoadModel.getTableName, compactedSegments.asScala.toArray)
           }
           // giving the user his error for telling in the beeline if his triggered table
           // compaction is failed.

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonCountStar.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonCountStar.scala
@@ -19,7 +19,6 @@ package org.apache.spark.sql
 
 import scala.collection.JavaConverters._
 
-import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.mapred.JobConf
 import org.apache.hadoop.mapreduce.Job

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/events/MergeBloomIndexEventListener.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/events/MergeBloomIndexEventListener.scala
@@ -74,9 +74,4 @@ class MergeBloomIndexEventListener extends OperationEventListener with Logging {
     }
   }
 
-
-  private def clearBloomCache(carbonTable: CarbonTable, segmentIds: Seq[String]): Unit = {
-    DataMapStoreManager.getInstance.clearDataMaps(carbonTable.getTableUniqueName)
-  }
-
 }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/mutation/CarbonProjectForUpdateCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/mutation/CarbonProjectForUpdateCommand.scala
@@ -37,6 +37,7 @@ import org.apache.carbondata.core.mutate.CarbonUpdateUtil
 import org.apache.carbondata.core.statusmanager.SegmentStatusManager
 import org.apache.carbondata.core.util.CarbonProperties
 import org.apache.carbondata.events.{OperationContext, OperationListenerBus, UpdateTablePostEvent, UpdateTablePreEvent}
+import org.apache.carbondata.indexserver.IndexServer
 import org.apache.carbondata.processing.loading.FailureCauses
 
 private[sql] case class CarbonProjectForUpdateCommand(
@@ -153,6 +154,9 @@ private[sql] case class CarbonProjectForUpdateCommand(
             currentTime,
             executionErrors,
             segmentsToBeDeleted)
+
+          DeleteExecution.clearDistributedSegmentCache(carbonTable, segmentsToBeDeleted)
+
         } else {
           throw new ConcurrentOperationException(carbonTable, "compaction", "update")
         }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/mutation/DeleteExecution.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/mutation/DeleteExecution.scala
@@ -37,13 +37,15 @@ import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.datamap.Segment
 import org.apache.carbondata.core.datastore.impl.FileFactory
 import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier
+import org.apache.carbondata.core.metadata.schema.table.CarbonTable
 import org.apache.carbondata.core.mutate.{CarbonUpdateUtil, DeleteDeltaBlockDetails, SegmentUpdateDetails, TupleIdEnum}
 import org.apache.carbondata.core.mutate.data.RowCountDetailsVO
 import org.apache.carbondata.core.statusmanager.{SegmentStatus, SegmentStatusManager, SegmentUpdateStatusManager}
-import org.apache.carbondata.core.util.{CarbonUtil, ThreadLocalSessionInfo}
+import org.apache.carbondata.core.util.{CarbonProperties, CarbonUtil, ThreadLocalSessionInfo}
 import org.apache.carbondata.core.util.path.CarbonTablePath
 import org.apache.carbondata.core.writer.CarbonDeleteDeltaWriterImpl
 import org.apache.carbondata.hadoop.api.{CarbonInputFormat, CarbonTableInputFormat}
+import org.apache.carbondata.indexserver.IndexServer
 import org.apache.carbondata.processing.exception.MultipleMatchingException
 import org.apache.carbondata.processing.loading.FailureCauses
 import org.apache.carbondata.spark.DeleteDelataResultImpl
@@ -312,6 +314,22 @@ object DeleteExecution {
     }
 
     segmentsTobeDeleted
+  }
+
+  def clearDistributedSegmentCache(carbonTable: CarbonTable,
+      segmentsToBeCleared: Seq[Segment]): Unit = {
+    if (CarbonProperties.getInstance().isDistributedPruningEnabled(carbonTable
+      .getDatabaseName, carbonTable.getTableName)) {
+      try {
+        IndexServer.getClient.invalidateSegmentCache(carbonTable
+          .getDatabaseName, carbonTable.getTableName, segmentsToBeCleared.map(_.getSegmentNo)
+          .toArray)
+      } catch {
+        case _: Exception =>
+          LOGGER.warn(s"Clearing of invalid segments for ${
+            carbonTable.getTableUniqueName} has failed")
+      }
+    }
   }
 
   private def createCarbonInputFormat(absoluteTableIdentifier: AbsoluteTableIdentifier) :

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/hive/execution/command/CarbonHiveCommands.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/hive/execution/command/CarbonHiveCommands.scala
@@ -123,6 +123,11 @@ object CarbonSetCommand {
           "property should be in \" carbon.table.load.sort.scope.<database_name>" +
           ".<table_name>=<sort_sope> \" format.")
       }
+    } else if (key.startsWith(CarbonCommonConstants.CARBON_ENABLE_INDEX_SERVER)) {
+      val keySplits = key.split("\\.")
+      if (keySplits.length == 6 || keySplits.length == 4) {
+        sessionParams.addProperty(key.toString, value)
+      }
     }
     else if (isCarbonProperty) {
       sessionParams.addProperty(key, value)


### PR DESCRIPTION
Implement Distributed Index Server which will cache and prune the datamaps using executors.
1. Implemented Hadoop RPC framework.
2. Implemented DistributedPruneRDD which will prune and cache the datamaps.
3. Implemented DistributedShowCacheRDD.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

