### PR TITLE
[CARBONDATA-3349] support carboncli show sort_columns for a segment folder

### DIFF
--- a/tools/cli/src/main/java/org/apache/carbondata/tool/CarbonCli.java
+++ b/tools/cli/src/main/java/org/apache/carbondata/tool/CarbonCli.java
@@ -51,6 +51,10 @@ public class CarbonCli {
   // by default true, and it will be set to false if the cli is trigerred via sql command
   private static boolean isPrintInConsole = true;
 
+  static class OptionsHolder {
+    static Options instance = buildOptions();
+  }
+
   private static Options buildOptions() {
     Option help = new Option("h", "help", false,"print this message");
     Option path = OptionBuilder.withArgName("path")
@@ -117,7 +121,7 @@ public class CarbonCli {
     // this boolean to check whether to print in console or not
     isPrintInConsole = false;
     outPuts = e;
-    Options options = buildOptions();
+    Options options = OptionsHolder.instance;
     CommandLineParser parser = new PosixParser();
 
     CommandLine line;
@@ -131,7 +135,7 @@ public class CarbonCli {
   }
 
   public static void run(String[] args, PrintStream out) {
-    Options options = buildOptions();
+    Options options = OptionsHolder.instance;
     CommandLineParser parser = new PosixParser();
 
     CommandLine line;
@@ -169,6 +173,18 @@ public class CarbonCli {
       command = new DataSummary(path, outPuts);
     } else if (cmd.equalsIgnoreCase("benchmark")) {
       command = new ScanBenchmark(path, outPuts);
+    } else if (cmd.equalsIgnoreCase("sort_columns")) {
+      if (line.hasOption("p")) {
+        try {
+          new FileCollector(outPuts).collectSortColumns(line.getOptionValue("p"));
+        } catch (IOException e) {
+          e.printStackTrace();
+        }
+        for (String output : outPuts) {
+          out.println(output);
+        }
+      }
+      return;
     } else {
       out.println("command " + cmd + " is not supported");
       outPuts.add("command " + cmd + " is not supported");

--- a/tools/cli/src/main/java/org/apache/carbondata/tool/CarbonCli.java
+++ b/tools/cli/src/main/java/org/apache/carbondata/tool/CarbonCli.java
@@ -220,4 +220,8 @@ public class CarbonCli {
     outPuts.add(stringWriter.toString());
   }
 
+  public static void cleanOutPuts() {
+    outPuts = null;
+  }
+
 }

--- a/tools/cli/src/test/java/org/apache/carbondata/tool/CarbonCliTest.java
+++ b/tools/cli/src/test/java/org/apache/carbondata/tool/CarbonCliTest.java
@@ -185,6 +185,19 @@ public class CarbonCliTest {
   }
 
   @Test
+  public void testSortColumnsOfSegmentFolder() {
+    String[] args = {"-cmd", "sort_columns", "-p", path};
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    PrintStream stream = new PrintStream(out);
+    CarbonCli.run(args, stream);
+    String output = new String(out.toByteArray());
+    String expectedOutput = buildLines(
+        "Input Folder: ./CarbonCliTest",
+        "sorted by name");
+    Assert.assertTrue(output.contains(expectedOutput));
+  }
+
+  @Test
   public void testSummaryOutputAll() {
     String[] args = {"-cmd", "summary", "-p", path, "-a", "-c", "age"};
     ByteArrayOutputStream out = new ByteArrayOutputStream();


### PR DESCRIPTION
carboncli support to show sort_columns for a segment folder.
carboncli -cmd sort_columns -p <segment_folder>

result example:
 sorted by col1,col2
or 
unsorted


 - [x] Any interfaces changed?
 yes, add two optional parameters: CarbonStore.showSegments
 - [x] Any backward compatibility impacted?
 no
 - [x] Document update required?
 yes
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
           unit test case
        - How it is tested? Please attach test report.
           test case passed
        - Is it a performance related change? Please attach the performance test report.
           no
        - Any additional information to help reviewers in testing this change.
           comment added
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
   small change
