### PR TITLE
[CARBONDATA-3360]fix NullPointerException in delete and clean files operation

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/mutate/CarbonUpdateUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/mutate/CarbonUpdateUtil.java
@@ -713,10 +713,7 @@ public class CarbonUpdateUtil {
       LOGGER.info("deleting the invalid file : " + invalidFile.getName());
       CarbonUtil.deleteFoldersAndFiles(invalidFile);
       isDeleted = true;
-    } catch (IOException e) {
-      LOGGER.error("error in clean up of invalid files." + e.getMessage(), e);
-      isDeleted = false;
-    } catch (InterruptedException e) {
+    } catch (IOException | InterruptedException e) {
       LOGGER.error("error in clean up of invalid files." + e.getMessage(), e);
       isDeleted = false;
     }


### PR DESCRIPTION
### Problem:
when delete is failed due to hdfs quota exceeded or disk space is full, then tableUpdateStatus.write will be present in store.
So after that if clean files operation is done, we were trying to assign null to primitive type long, which will throw runtime exception, and .write file will not be deleted, since we consider it as invalid file.

### Solution:
if `.write` file is present, then we do not fail clean files, we check for max query timeout for `tableUpdateStatus.write` file and then delete these .write files for any clean files operation after that.



Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 NA
 - [x] Any backward compatibility impacted?
 NA
 - [x] Document update required?
NA
 - [x] Testing done
tested in three node cluster and verified this scenario.
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

