### PR TITLE
[CARBONDATA-3363] SDK supports read carbon data by given file lists, file or folder

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/CarbonTable.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/CarbonTable.java
@@ -250,12 +250,7 @@ public class CarbonTable implements Serializable, Writable {
   public static CarbonTable buildTable(
       String tablePath,
       String tableName,
-      Configuration configuration,
-      boolean isFile) throws IOException {
-    if (isFile) {
-      int index = tablePath.lastIndexOf("/");
-      tablePath = tablePath.substring(0, index);
-    }
+      Configuration configuration) throws IOException {
     TableInfo tableInfoInfer = CarbonUtil.buildDummyTableInfo(tablePath, "null", "null");
     // InferSchema from data file
     org.apache.carbondata.format.TableInfo tableInfo =

--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/CarbonTable.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/CarbonTable.java
@@ -250,7 +250,12 @@ public class CarbonTable implements Serializable, Writable {
   public static CarbonTable buildTable(
       String tablePath,
       String tableName,
-      Configuration configuration) throws IOException {
+      Configuration configuration,
+      boolean isFile) throws IOException {
+    if (isFile) {
+      int index = tablePath.lastIndexOf("/");
+      tablePath = tablePath.substring(0, index);
+    }
     TableInfo tableInfoInfer = CarbonUtil.buildDummyTableInfo(tablePath, "null", "null");
     // InferSchema from data file
     org.apache.carbondata.format.TableInfo tableInfo =

--- a/examples/spark2/src/main/java/org/apache/carbondata/examples/sdk/SDKS3ReadExample.java
+++ b/examples/spark2/src/main/java/org/apache/carbondata/examples/sdk/SDKS3ReadExample.java
@@ -17,16 +17,20 @@
 
 package org.apache.carbondata.examples.sdk;
 
+import java.util.List;
+
 import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.metadata.datatype.DataTypes;
 import org.apache.carbondata.core.scan.expression.ColumnExpression;
 import org.apache.carbondata.core.scan.expression.LiteralExpression;
 import org.apache.carbondata.core.scan.expression.conditional.EqualToExpression;
+import org.apache.carbondata.core.util.path.CarbonTablePath;
 import org.apache.carbondata.sdk.file.CarbonReader;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.log4j.Logger;
 
+import static org.apache.carbondata.sdk.file.utils.SDKUtil.listFiles;
 import static org.apache.hadoop.fs.s3a.Constants.ACCESS_KEY;
 import static org.apache.hadoop.fs.s3a.Constants.ENDPOINT;
 import static org.apache.hadoop.fs.s3a.Constants.SECRET_KEY;
@@ -35,60 +39,69 @@ import static org.apache.hadoop.fs.s3a.Constants.SECRET_KEY;
  * Example for testing carbonReader on S3
  */
 public class SDKS3ReadExample {
-    public static void main(String[] args) throws Exception {
-        Logger logger = LogServiceFactory.getLogService(SDKS3ReadExample.class.getName());
-        if (args == null || args.length < 3) {
-            logger.error("Usage: java CarbonS3Example: <access-key> <secret-key>"
-                + "<s3-endpoint> [table-path-on-s3]");
-            System.exit(0);
-        }
-
-        String path = "s3a://sdk/WriterOutput/carbondata5";
-        if (args.length > 3) {
-            path=args[3];
-        }
-
-        // Read data
-        EqualToExpression equalToExpression = new EqualToExpression(
-            new ColumnExpression("name", DataTypes.STRING),
-            new LiteralExpression("robot1", DataTypes.STRING));
-
-        CarbonReader reader = CarbonReader
-            .builder(path, "_temp")
-            .projection(new String[]{"name", "age"})
-            .filter(equalToExpression)
-            .withHadoopConf(ACCESS_KEY, args[0])
-            .withHadoopConf(SECRET_KEY, args[1])
-            .withHadoopConf(ENDPOINT, args[2])
-            .build();
-
-        System.out.println("\nData:");
-        int i = 0;
-        while (i < 20 && reader.hasNext()) {
-            Object[] row = (Object[]) reader.readNextRow();
-            System.out.println(row[0] + " " + row[1]);
-            i++;
-        }
-        System.out.println("\nFinished");
-        reader.close();
-
-        // Read without filter
-        CarbonReader reader2 = CarbonReader
-            .builder(path, "_temp")
-            .projection(new String[]{"name", "age"})
-            .withHadoopConf(ACCESS_KEY, args[0])
-            .withHadoopConf(SECRET_KEY, args[1])
-            .withHadoopConf(ENDPOINT, args[2])
-            .build();
-
-        System.out.println("\nData:");
-        i = 0;
-        while (i < 20 && reader2.hasNext()) {
-            Object[] row = (Object[]) reader2.readNextRow();
-            System.out.println(row[0] + " " + row[1]);
-            i++;
-        }
-        System.out.println("\nFinished");
-        reader2.close();
+  public static void main(String[] args) throws Exception {
+    Logger logger = LogServiceFactory.getLogService(SDKS3ReadExample.class.getName());
+    if (args == null || args.length < 3) {
+      logger.error("Usage: java CarbonS3Example: <access-key> <secret-key>"
+          + "<s3-endpoint> [table-path-on-s3]");
+      System.exit(0);
     }
+
+    String path = "s3a://sdk/WriterOutput/carbondata5";
+    if (args.length > 3) {
+      path = args[3];
+    }
+
+    // 1. read with file list
+    Configuration conf = new Configuration();
+
+    conf.set(ACCESS_KEY, args[0]);
+    conf.set(SECRET_KEY, args[1]);
+    conf.set(ENDPOINT, args[2]);
+    List fileLists = listFiles(path, CarbonTablePath.CARBON_DATA_EXT, conf);
+
+    // Read data
+    EqualToExpression equalToExpression = new EqualToExpression(
+        new ColumnExpression("name", DataTypes.STRING),
+        new LiteralExpression("robot1", DataTypes.STRING));
+
+    CarbonReader reader = CarbonReader
+        .builder()
+        .projection(new String[]{"name", "age"})
+        .filter(equalToExpression)
+        .withHadoopConf(ACCESS_KEY, args[0])
+        .withHadoopConf(SECRET_KEY, args[1])
+        .withHadoopConf(ENDPOINT, args[2])
+        .withFileLists(fileLists)
+        .build();
+
+    System.out.println("\nData:");
+    int i = 0;
+    while (i < 20 && reader.hasNext()) {
+      Object[] row = (Object[]) reader.readNextRow();
+      System.out.println(row[0] + " " + row[1]);
+      i++;
+    }
+    System.out.println("\nFinished");
+    reader.close();
+
+    // Read without filter
+    CarbonReader reader2 = CarbonReader
+        .builder(path, "_temp")
+        .projection(new String[]{"name", "age"})
+        .withHadoopConf(ACCESS_KEY, args[0])
+        .withHadoopConf(SECRET_KEY, args[1])
+        .withHadoopConf(ENDPOINT, args[2])
+        .build();
+
+    System.out.println("\nData:");
+    i = 0;
+    while (i < 20 && reader2.hasNext()) {
+      Object[] row = (Object[]) reader2.readNextRow();
+      System.out.println(row[0] + " " + row[1]);
+      i++;
+    }
+    System.out.println("\nFinished");
+    reader2.close();
+  }
 }

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonFileInputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonFileInputFormat.java
@@ -150,7 +150,17 @@ public class CarbonFileInputFormat<T> extends CarbonInputFormat<T> implements Se
         LoadMetadataDetails[] loadMetadataDetails = readCommittedScope.getSegmentList();
         for (LoadMetadataDetails load : loadMetadataDetails) {
           seg = new Segment(load.getLoadName(), null, readCommittedScope);
-          externalTableSegments.add(seg);
+          if (fileLists != null) {
+            for (int i = 0; i < fileLists.size(); i++) {
+              if (fileLists.get(i).toString().endsWith(seg.getSegmentNo()
+                  + CarbonTablePath.CARBON_DATA_EXT)) {
+                externalTableSegments.add(seg);
+                break;
+              }
+            }
+          } else {
+            externalTableSegments.add(seg);
+          }
         }
       }
       List<InputSplit> splits = new ArrayList<>();

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonFileInputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonFileInputFormat.java
@@ -162,7 +162,14 @@ public class CarbonFileInputFormat<T> extends CarbonInputFormat<T> implements Se
         // do block filtering and get split
         splits = getSplits(job, filter, externalTableSegments, null, partitionInfo, null);
       } else {
-        for (CarbonFile carbonFile : getAllCarbonDataFiles(carbonTable.getTablePath())) {
+        List<CarbonFile> carbonFiles = null;
+        if (null != this.fileLists) {
+          carbonFiles = getAllCarbonDataFiles(this.fileLists);
+        } else {
+          carbonFiles = getAllCarbonDataFiles(carbonTable.getTablePath());
+        }
+
+        for (CarbonFile carbonFile : carbonFiles) {
           // Segment id is set to null because SDK does not write carbondata files with respect
           // to segments. So no specific name is present for this load.
           CarbonInputSplit split =
@@ -203,6 +210,18 @@ public class CarbonFileInputFormat<T> extends CarbonInputFormat<T> implements Se
         }
       });
     } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+    return carbonFiles;
+  }
+
+  private List<CarbonFile> getAllCarbonDataFiles(List fileLists) {
+    List<CarbonFile> carbonFiles = new LinkedList<CarbonFile>();
+    try {
+      for (int i = 0; i < fileLists.size(); i++) {
+        carbonFiles.add(FileFactory.getCarbonFile(fileLists.get(i).toString()));
+      }
+    } catch (Exception e) {
       throw new RuntimeException(e);
     }
     return carbonFiles;

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonInputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonInputFormat.java
@@ -132,6 +132,7 @@ public abstract class CarbonInputFormat<T> extends FileInputFormat<Void, T> {
   protected int numStreamFiles = 0;
   protected int hitedStreamFiles = 0;
   protected int numBlocks = 0;
+  protected List fileLists = null;
 
   private CarbonTable carbonTable;
 
@@ -154,6 +155,10 @@ public abstract class CarbonInputFormat<T> extends FileInputFormat<Void, T> {
 
   public int getNumBlocks() {
     return numBlocks;
+  }
+
+  public void setFileLists(List fileLists) {
+    this.fileLists = fileLists;
   }
 
   /**

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonReader.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonReader.java
@@ -171,6 +171,17 @@ public class CarbonReader<T> {
   }
 
   /**
+   * Return a new {@link CarbonReaderBuilder} instance
+   *
+   * @return CarbonReaderBuilder object
+   */
+  public static CarbonReaderBuilder builder() {
+    UUID uuid = UUID.randomUUID();
+    String tableName = "UnknownTable" + uuid;
+    return new CarbonReaderBuilder(tableName);
+  }
+
+  /**
    * Breaks the list of CarbonRecordReader in CarbonReader into multiple
    * CarbonReader objects, each iterating through some 'carbondata' files
    * and return that list of CarbonReader objects

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonReaderBuilder.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonReaderBuilder.java
@@ -63,6 +63,7 @@ public class CarbonReaderBuilder {
   private boolean useVectorReader = true;
   private InputSplit inputSplit;
   private boolean useArrowReader;
+  private List fileLists;
 
   /**
    * Construct a CarbonReaderBuilder with table path and table name
@@ -79,6 +80,54 @@ public class CarbonReaderBuilder {
   CarbonReaderBuilder(InputSplit inputSplit) {
     this.inputSplit = inputSplit;
     ThreadLocalSessionInfo.setCarbonSessionInfo(new CarbonSessionInfo());
+  }
+
+  /**
+   * Construct a CarbonReaderBuilder with table name
+   *
+   * @param tableName table name
+   */
+  CarbonReaderBuilder(String tableName) {
+    this.tableName = tableName;
+    ThreadLocalSessionInfo.setCarbonSessionInfo(new CarbonSessionInfo());
+  }
+
+  /**
+   * set carbonData file folder
+   *
+   * @param tablePath table path
+   * @return CarbonReaderBuilder object
+   */
+  public CarbonReaderBuilder withFolder(String tablePath) {
+    this.tablePath = tablePath;
+    return this;
+  }
+
+  /**
+   * set carbondata file lists
+   *
+   * @param fileLists carbondata file lists
+   * @return CarbonReaderBuilder object
+   */
+  public CarbonReaderBuilder withFileLists(List fileLists) {
+    if (null == this.fileLists) {
+      this.fileLists = fileLists;
+    } else {
+      this.fileLists.addAll(fileLists);
+    }
+    return this;
+  }
+
+  /**
+   * set one carbondata file
+   *
+   * @param file carbondata file
+   * @return CarbonReaderBuilder object
+   */
+  public CarbonReaderBuilder withFile(String file) {
+    List fileLists = new ArrayList();
+    fileLists.add(file);
+    return withFileLists(fileLists);
   }
 
   /**
@@ -190,7 +239,19 @@ public class CarbonReaderBuilder {
           ((CarbonInputSplit) inputSplit).getSegment().getReadCommittedScope().getFilePath();
       tableName = "UnknownTable" + UUID.randomUUID();
     }
-    CarbonTable table = CarbonTable.buildTable(tablePath, tableName, hadoopConf);
+    CarbonTable table;
+    // now always infer schema. TODO:Refactor in next version.
+    if (null == this.fileLists && null == tablePath) {
+      throw new IllegalArgumentException("Please set table path first.");
+    }
+    if (null != this.fileLists) {
+      if (fileLists.size() < 1) {
+        throw new IllegalArgumentException("fileLists must have one file in list as least!");
+      }
+      table = CarbonTable.buildTable(this.fileLists.get(0).toString(), tableName, hadoopConf, true);
+    } else {
+      table = CarbonTable.buildTable(tablePath, tableName, hadoopConf, false);
+    }
     if (enableBlockletDistribution) {
       // set cache level to blocklet level
       Map<String, String> tableProperties =
@@ -205,6 +266,9 @@ public class CarbonReaderBuilder {
     format.setDatabaseName(job.getConfiguration(), table.getDatabaseName());
     if (filterExpression != null) {
       format.setFilterPredicates(job.getConfiguration(), filterExpression);
+    }
+    if (null != this.fileLists) {
+      format.setFileLists(this.fileLists);
     }
     if (projectionColumns != null) {
       // set the user projection

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonReaderBuilder.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonReaderBuilder.java
@@ -41,6 +41,7 @@ import org.apache.carbondata.hadoop.CarbonInputSplit;
 import org.apache.carbondata.hadoop.api.CarbonFileInputFormat;
 import org.apache.carbondata.hadoop.util.CarbonVectorizedRecordReader;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapreduce.InputSplit;
@@ -248,9 +249,17 @@ public class CarbonReaderBuilder {
       if (fileLists.size() < 1) {
         throw new IllegalArgumentException("fileLists must have one file in list as least!");
       }
-      table = CarbonTable.buildTable(this.fileLists.get(0).toString(), tableName, hadoopConf, true);
+      String commonString = String.valueOf(fileLists.get(0));
+      for (int i = 1; i < fileLists.size(); i++) {
+        commonString = commonString.substring(0, StringUtils.indexOfDifference(commonString,
+            String.valueOf(fileLists.get(i))));
+      }
+      int index = commonString.lastIndexOf("/");
+      commonString = commonString.substring(0, index);
+
+      table = CarbonTable.buildTable(commonString, tableName, hadoopConf);
     } else {
-      table = CarbonTable.buildTable(tablePath, tableName, hadoopConf, false);
+      table = CarbonTable.buildTable(tablePath, tableName, hadoopConf);
     }
     if (enableBlockletDistribution) {
       // set cache level to blocklet level

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/utils/SDKUtil.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/utils/SDKUtil.java
@@ -34,7 +34,7 @@ public class SDKUtil {
                                     final String suf, Configuration conf) throws Exception {
     final String sufImageFinal = suf;
     ArrayList result = new ArrayList();
-    CarbonFile[] fileList = FileFactory.getCarbonFile(sourceImageFolder).listFiles();
+    CarbonFile[] fileList = FileFactory.getCarbonFile(sourceImageFolder, conf).listFiles();
     for (int i = 0; i < fileList.length; i++) {
       if (fileList[i].isDirectory()) {
         result.addAll(listFiles(fileList[i].getCanonicalPath(), sufImageFinal, conf));


### PR DESCRIPTION
SDK supports read carbon data by given file lists, file or folder
```
   CarbonReader reader = CarbonReader
        .builder()
        .withFileLists(fileLists.subList(0,2))
        .projection(projectionLists)
        .build();

```
or withFile:
```
    CarbonReader reader2 = CarbonReader
        .builder()
        .withFile(fileName)
        .build();
```

withFolder
```
 CarbonReader reader = CarbonReader
        .builder()
        .withFolder(path)
        .build();

```
Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 No
 - [x] Any backward compatibility impacted?
 No
 - [x] Document update required?
No
 - [x] Testing done
add test case
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
No
