### PR TITLE
[CARBONDATA-3370] fix missing version of maven-duplicate-finder-plugin in pom file

### DIFF
--- a/datamap/mv/core/pom.xml
+++ b/datamap/mv/core/pom.xml
@@ -129,6 +129,7 @@
       <plugin>
         <groupId>com.ning.maven.plugins</groupId>
         <artifactId>maven-duplicate-finder-plugin</artifactId>
+        <version>1.0.9</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/datamap/mv/plan/pom.xml
+++ b/datamap/mv/plan/pom.xml
@@ -123,6 +123,7 @@
       <plugin>
         <groupId>com.ning.maven.plugins</groupId>
         <artifactId>maven-duplicate-finder-plugin</artifactId>
+        <version>1.0.9</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/examples/spark2/pom.xml
+++ b/examples/spark2/pom.xml
@@ -201,6 +201,7 @@
       <plugin>
         <groupId>com.ning.maven.plugins</groupId>
         <artifactId>maven-duplicate-finder-plugin</artifactId>
+        <version>1.0.9</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/integration/presto/pom.xml
+++ b/integration/presto/pom.xml
@@ -634,6 +634,7 @@
       <plugin>
         <groupId>com.ning.maven.plugins</groupId>
         <artifactId>maven-duplicate-finder-plugin</artifactId>
+        <version>1.0.9</version>
         <configuration>
           <skip>true</skip>
         </configuration>


### PR DESCRIPTION
fix missing version of maven-duplicate-finder-plugin in pom file

 - [x] Any interfaces changed?
 
 - [x] Any backward compatibility impacted?
 
 - [x] Document update required?

 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
