### PR TITLE
[CARBONDATA-3371] Fix ArrayIndexOutOfBoundsException of compaction after sort_columns modification

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/block/SegmentPropertiesAndSchemaHolder.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/block/SegmentPropertiesAndSchemaHolder.java
@@ -346,15 +346,9 @@ public class SegmentPropertiesAndSchemaHolder {
       if (obj1 == null || obj2 == null || (obj1.size() != obj2.size())) {
         return false;
       }
-      List<ColumnSchema> clonedObj1 = new ArrayList<>(obj1);
-      List<ColumnSchema> clonedObj2 = new ArrayList<>(obj2);
-      clonedObj1.addAll(obj1);
-      clonedObj2.addAll(obj2);
-      sortList(clonedObj1);
-      sortList(clonedObj2);
       boolean exists = true;
       for (int i = 0; i < obj1.size(); i++) {
-        if (!clonedObj1.get(i).equalsWithStrictCheck(clonedObj2.get(i))) {
+        if (!obj1.get(i).equalsWithStrictCheck(obj2.get(i))) {
           exists = false;
           break;
         }
@@ -372,11 +366,14 @@ public class SegmentPropertiesAndSchemaHolder {
 
     @Override public int hashCode() {
       int allColumnsHashCode = 0;
+      // check column order
+      StringBuilder builder = new StringBuilder();
       for (ColumnSchema columnSchema: columnsInTable) {
         allColumnsHashCode = allColumnsHashCode + columnSchema.strictHashCode();
+        builder.append(columnSchema.getColumnUniqueId()).append(",");
       }
       return carbonTable.getAbsoluteTableIdentifier().hashCode() + allColumnsHashCode + Arrays
-          .hashCode(columnCardinality);
+          .hashCode(columnCardinality) + builder.toString().hashCode();
     }
 
     public AbsoluteTableIdentifier getTableIdentifier() {

--- a/core/src/main/java/org/apache/carbondata/core/scan/executor/impl/AbstractQueryExecutor.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/executor/impl/AbstractQueryExecutor.java
@@ -605,7 +605,7 @@ public abstract class AbstractQueryExecutor<E> implements QueryExecutor<E> {
     // setting the size of fixed key column (dictionary column)
     blockExecutionInfo
         .setFixedLengthKeySize(getKeySize(projectDimensions, segmentProperties));
-    Set<Integer> dictionaryColumnChunkIndex = new HashSet<Integer>();
+    List<Integer> dictionaryColumnChunkIndex = new ArrayList<Integer>();
     List<Integer> noDictionaryColumnChunkIndex = new ArrayList<Integer>();
     // get the block index to be read from file for query dimension
     // for both dictionary columns and no dictionary columns
@@ -616,7 +616,9 @@ public abstract class AbstractQueryExecutor<E> implements QueryExecutor<E> {
         dictionaryColumnChunkIndex.toArray(new Integer[dictionaryColumnChunkIndex.size()]));
     // need to sort the dictionary column as for all dimension
     // column key will be filled based on key order
-    Arrays.sort(queryDictionaryColumnChunkIndexes);
+    if (!queryModel.isForcedDetailRawQuery()) {
+      Arrays.sort(queryDictionaryColumnChunkIndexes);
+    }
     blockExecutionInfo.setDictionaryColumnChunkIndex(queryDictionaryColumnChunkIndexes);
     // setting the no dictionary column block indexes
     blockExecutionInfo.setNoDictionaryColumnChunkIndexes(ArrayUtils.toPrimitive(

--- a/core/src/main/java/org/apache/carbondata/core/scan/executor/util/QueryUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/executor/util/QueryUtil.java
@@ -509,7 +509,7 @@ public class QueryUtil {
   public static void fillQueryDimensionChunkIndexes(
       List<ProjectionDimension> projectDimensions,
       Map<Integer, Integer> columnOrdinalToChunkIndexMapping,
-      Set<Integer> dictionaryDimensionChunkIndex,
+      List<Integer> dictionaryDimensionChunkIndex,
       List<Integer> noDictionaryDimensionChunkIndex) {
     for (ProjectionDimension queryDimension : projectDimensions) {
       if (CarbonUtil.hasEncoding(queryDimension.getDimension().getEncoder(), Encoding.DICTIONARY)

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/iterator/ColumnDriftRawResultIterator.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/iterator/ColumnDriftRawResultIterator.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.core.scan.result.iterator;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.carbondata.common.CarbonIterator;
+import org.apache.carbondata.common.logging.LogServiceFactory;
+import org.apache.carbondata.core.datastore.block.SegmentProperties;
+import org.apache.carbondata.core.keygenerator.KeyGenException;
+import org.apache.carbondata.core.metadata.datatype.DataType;
+import org.apache.carbondata.core.metadata.encoder.Encoding;
+import org.apache.carbondata.core.metadata.schema.table.column.CarbonDimension;
+import org.apache.carbondata.core.metadata.schema.table.column.CarbonMeasure;
+import org.apache.carbondata.core.scan.executor.util.RestructureUtil;
+import org.apache.carbondata.core.scan.result.RowBatch;
+import org.apache.carbondata.core.scan.wrappers.ByteArrayWrapper;
+import org.apache.carbondata.core.util.DataTypeUtil;
+
+import org.apache.log4j.Logger;
+
+/**
+ * This is a wrapper iterator over the detail raw query iterator.
+ * This iterator will handle the processing of the raw rows.
+ * This will handle the batch results and will iterate on the batches and give single row.
+ */
+public class ColumnDriftRawResultIterator extends RawResultIterator {
+
+  // column reorder for no-dictionary column
+  private int noDictCount;
+  private int[] noDictMap;
+  // column drift
+  private boolean[] isColumnDrift;
+  private int measureCount;
+  private DataType[] measureDataTypes;
+
+  /**
+   * LOGGER
+   */
+  private static final Logger LOGGER =
+      LogServiceFactory.getLogService(ColumnDriftRawResultIterator.class.getName());
+
+  public ColumnDriftRawResultIterator(CarbonIterator<RowBatch> detailRawQueryResultIterator,
+      SegmentProperties sourceSegProperties, SegmentProperties destinationSegProperties) {
+    super(detailRawQueryResultIterator, sourceSegProperties, destinationSegProperties, false);
+    initForColumnDrift();
+    init();
+  }
+
+  private void initForColumnDrift() {
+    List<CarbonDimension> noDictDims =
+        new ArrayList<>(destinationSegProperties.getDimensions().size());
+    for (CarbonDimension dimension : destinationSegProperties.getDimensions()) {
+      if (dimension.getNumberOfChild() == 0) {
+        if (!dimension.hasEncoding(Encoding.DICTIONARY)) {
+          noDictDims.add(dimension);
+        }
+      }
+    }
+    measureCount = destinationSegProperties.getMeasures().size();
+    noDictCount = noDictDims.size();
+    isColumnDrift = new boolean[noDictCount];
+    noDictMap = new int[noDictCount];
+    measureDataTypes = new DataType[noDictCount];
+    List<CarbonMeasure> sourceMeasures = sourceSegProperties.getMeasures();
+    int tableMeasureCount = sourceMeasures.size();
+    for (int i = 0; i < noDictCount; i++) {
+      for (int j = 0; j < tableMeasureCount; j++) {
+        if (RestructureUtil.isColumnMatches(true, noDictDims.get(i), sourceMeasures.get(j))) {
+          isColumnDrift[i] = true;
+          measureDataTypes[i] = sourceMeasures.get(j).getDataType();
+          break;
+        }
+      }
+    }
+    int noDictIndex = 0;
+    // the column drift are at the end of measures
+    int measureIndex = measureCount + 1;
+    for (int i = 0; i < noDictCount; i++) {
+      if (isColumnDrift[i]) {
+        noDictMap[i] = measureIndex++;
+      } else {
+        noDictMap[i] = noDictIndex++;
+      }
+    }
+  }
+
+  @Override
+  protected Object[] convertRow(Object[] rawRow) throws KeyGenException {
+    super.convertRow(rawRow);
+    ByteArrayWrapper dimObject = (ByteArrayWrapper) rawRow[0];
+    // need move measure to dimension and return new row by current schema
+    byte[][] noDicts = dimObject.getNoDictionaryKeys();
+    byte[][] newNoDicts = new byte[noDictCount][];
+    for (int i = 0; i < noDictCount; i++) {
+      if (isColumnDrift[i]) {
+        newNoDicts[i] = DataTypeUtil
+            .getBytesDataDataTypeForNoDictionaryColumn(rawRow[noDictMap[i]], measureDataTypes[i]);
+      } else {
+        newNoDicts[i] = noDicts[noDictMap[i]];
+      }
+    }
+    ByteArrayWrapper newWrapper = new ByteArrayWrapper();
+    newWrapper.setDictionaryKey(dimObject.getDictionaryKey());
+    newWrapper.setNoDictionaryKeys(newNoDicts);
+    newWrapper.setComplexTypesKeys(dimObject.getComplexTypesKeys());
+    newWrapper.setImplicitColumnByteArray(dimObject.getImplicitColumnByteArray());
+    Object[] finalRawRow = new Object[1 + measureCount];
+    finalRawRow[0] = newWrapper;
+    System.arraycopy(rawRow, 1, finalRawRow, 1, measureCount);
+    return finalRawRow;
+  }
+}

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/iterator/RawResultIterator.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/iterator/RawResultIterator.java
@@ -28,15 +28,9 @@ import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.datastore.block.SegmentProperties;
 import org.apache.carbondata.core.keygenerator.KeyGenException;
-import org.apache.carbondata.core.metadata.datatype.DataType;
-import org.apache.carbondata.core.metadata.encoder.Encoding;
-import org.apache.carbondata.core.metadata.schema.table.column.CarbonDimension;
-import org.apache.carbondata.core.metadata.schema.table.column.CarbonMeasure;
-import org.apache.carbondata.core.scan.executor.util.RestructureUtil;
 import org.apache.carbondata.core.scan.result.RowBatch;
 import org.apache.carbondata.core.scan.wrappers.ByteArrayWrapper;
 import org.apache.carbondata.core.util.CarbonProperties;
-import org.apache.carbondata.core.util.DataTypeUtil;
 
 import org.apache.log4j.Logger;
 
@@ -47,9 +41,9 @@ import org.apache.log4j.Logger;
  */
 public class RawResultIterator extends CarbonIterator<Object[]> {
 
-  private final SegmentProperties sourceSegProperties;
+  protected final SegmentProperties sourceSegProperties;
 
-  private final SegmentProperties destinationSegProperties;
+  protected final SegmentProperties destinationSegProperties;
   /**
    * Iterator of the Batch raw result.
    */
@@ -64,15 +58,6 @@ public class RawResultIterator extends CarbonIterator<Object[]> {
   private Object[] currentRawRow = null;
   private boolean isBackupFilled = false;
 
-  // column reorder for no-dictionary column
-  private int noDictCount;
-  private int[] noDictMap;
-  // column drift
-  private final boolean hasColumnDrift;
-  private boolean[] isColumnDrift;
-  private int measureCount;
-  private DataType[] measureDataTypes;
-
   /**
    * LOGGER
    */
@@ -81,62 +66,18 @@ public class RawResultIterator extends CarbonIterator<Object[]> {
 
   public RawResultIterator(CarbonIterator<RowBatch> detailRawQueryResultIterator,
       SegmentProperties sourceSegProperties, SegmentProperties destinationSegProperties,
-      boolean isStreamingHandoff, boolean hasColumnDrift) {
+      boolean init) {
     this.detailRawQueryResultIterator = detailRawQueryResultIterator;
     this.sourceSegProperties = sourceSegProperties;
     this.destinationSegProperties = destinationSegProperties;
     this.executorService = Executors.newFixedThreadPool(1);
-    this.hasColumnDrift = hasColumnDrift;
-    if (!isStreamingHandoff) {
+
+    if (init) {
       init();
     }
   }
 
-  private void initForColumnDrift() {
-    List<CarbonDimension> noDictDims =
-        new ArrayList<>(destinationSegProperties.getDimensions().size());
-    for (CarbonDimension dimension : destinationSegProperties.getDimensions()) {
-      if (dimension.getNumberOfChild() == 0) {
-        if (!dimension.hasEncoding(Encoding.DICTIONARY)) {
-          noDictDims.add(dimension);
-        }
-      }
-    }
-    measureCount = destinationSegProperties.getMeasures().size();
-    noDictCount = noDictDims.size();
-    isColumnDrift = new boolean[noDictCount];
-    noDictMap = new int[noDictCount];
-    measureDataTypes = new DataType[noDictCount];
-    List<CarbonMeasure> sourceMeasures = sourceSegProperties.getMeasures();
-    int tableMeasureCount = sourceMeasures.size();
-    for (int i = 0; i < noDictCount; i++) {
-      for (int j = 0; j < tableMeasureCount; j++) {
-        if (RestructureUtil.isColumnMatches(true, noDictDims.get(i), sourceMeasures.get(j))) {
-          isColumnDrift[i] = true;
-          measureDataTypes[i] = sourceMeasures.get(j).getDataType();
-          break;
-        }
-      }
-      if (measureDataTypes[i] == null) {
-        isColumnDrift[i] = false;
-      }
-    }
-    int noDictIndex = 0;
-    // the column drift are at the end of measures
-    int measureIndex = measureCount + 1;
-    for (int i = 0; i < noDictCount; i++) {
-      if (isColumnDrift[i]) {
-        noDictMap[i] = measureIndex++;
-      } else {
-        noDictMap[i] = noDictIndex++;
-      }
-    }
-  }
-
-  private void init() {
-    if (hasColumnDrift) {
-      initForColumnDrift();
-    }
+  protected void init() {
     this.prefetchEnabled = CarbonProperties.getInstance().getProperty(
         CarbonCommonConstants.CARBON_COMPACTION_PREFETCH_ENABLE,
         CarbonCommonConstants.CARBON_COMPACTION_PREFETCH_ENABLE_DEFAULT).equalsIgnoreCase("true");
@@ -252,35 +193,12 @@ public class RawResultIterator extends CarbonIterator<Object[]> {
     return this.currentRawRow;
   }
 
-  private Object[] convertRow(Object[] rawRow) throws KeyGenException {
-    ByteArrayWrapper dimObject = (ByteArrayWrapper) rawRow[0];
-    byte[] dims = dimObject.getDictionaryKey();
+  protected Object[] convertRow(Object[] rawRow) throws KeyGenException {
+    byte[] dims = ((ByteArrayWrapper) rawRow[0]).getDictionaryKey();
     long[] keyArray = sourceSegProperties.getDimensionKeyGenerator().getKeyArray(dims);
     byte[] covertedBytes =
         destinationSegProperties.getDimensionKeyGenerator().generateKey(keyArray);
-    dimObject.setDictionaryKey(covertedBytes);
-    if (hasColumnDrift) {
-      // need move measure to dimension and return new row by current schema
-      byte[][] noDicts = dimObject.getNoDictionaryKeys();
-      byte[][] newNoDicts = new byte[noDictCount][];
-      for (int i = 0; i < noDictCount; i++) {
-        if (isColumnDrift[i]) {
-          newNoDicts[i] = DataTypeUtil
-              .getBytesDataDataTypeForNoDictionaryColumn(rawRow[noDictMap[i]], measureDataTypes[i]);
-        } else {
-          newNoDicts[i] = noDicts[noDictMap[i]];
-        }
-      }
-      ByteArrayWrapper newWrapper = new ByteArrayWrapper();
-      newWrapper.setDictionaryKey(covertedBytes);
-      newWrapper.setNoDictionaryKeys(newNoDicts);
-      newWrapper.setComplexTypesKeys(dimObject.getComplexTypesKeys());
-      newWrapper.setImplicitColumnByteArray(dimObject.getImplicitColumnByteArray());
-      Object[] finalRawRow = new Object[1 + measureCount];
-      finalRawRow[0] = newWrapper;
-      System.arraycopy(rawRow, 1, finalRawRow, 1, measureCount);
-      return finalRawRow;
-    }
+    ((ByteArrayWrapper) rawRow[0]).setDictionaryKey(covertedBytes);
     return rawRow;
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/iterator/RawResultIterator.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/iterator/RawResultIterator.java
@@ -28,9 +28,15 @@ import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.datastore.block.SegmentProperties;
 import org.apache.carbondata.core.keygenerator.KeyGenException;
+import org.apache.carbondata.core.metadata.datatype.DataType;
+import org.apache.carbondata.core.metadata.encoder.Encoding;
+import org.apache.carbondata.core.metadata.schema.table.column.CarbonDimension;
+import org.apache.carbondata.core.metadata.schema.table.column.CarbonMeasure;
+import org.apache.carbondata.core.scan.executor.util.RestructureUtil;
 import org.apache.carbondata.core.scan.result.RowBatch;
 import org.apache.carbondata.core.scan.wrappers.ByteArrayWrapper;
 import org.apache.carbondata.core.util.CarbonProperties;
+import org.apache.carbondata.core.util.DataTypeUtil;
 
 import org.apache.log4j.Logger;
 
@@ -58,6 +64,15 @@ public class RawResultIterator extends CarbonIterator<Object[]> {
   private Object[] currentRawRow = null;
   private boolean isBackupFilled = false;
 
+  // column reorder
+  private int noDictCount;
+  private int[] noDictMap;
+  private final int measureCount;
+  // column drift
+  private final boolean hasColumnDrift;
+  private boolean[] isColumnDrift;
+  private DataType[] measureDataTypes;
+
   /**
    * LOGGER
    */
@@ -66,18 +81,59 @@ public class RawResultIterator extends CarbonIterator<Object[]> {
 
   public RawResultIterator(CarbonIterator<RowBatch> detailRawQueryResultIterator,
       SegmentProperties sourceSegProperties, SegmentProperties destinationSegProperties,
-      boolean isStreamingHandoff) {
+      boolean isStreamingHandoff, boolean hasColumnDrift) {
     this.detailRawQueryResultIterator = detailRawQueryResultIterator;
     this.sourceSegProperties = sourceSegProperties;
     this.destinationSegProperties = destinationSegProperties;
     this.executorService = Executors.newFixedThreadPool(1);
-
+    this.hasColumnDrift = hasColumnDrift;
+    this.measureCount = destinationSegProperties.getMeasures().size();
     if (!isStreamingHandoff) {
       init();
     }
   }
 
+  private void initForColumnReorder() {
+    List<CarbonDimension> noDictDims =
+        new ArrayList<>(destinationSegProperties.getDimensions().size());
+    for (CarbonDimension dimension : destinationSegProperties.getDimensions()) {
+      if (dimension.getNumberOfChild() == 0) {
+        if (!dimension.hasEncoding(Encoding.DICTIONARY)) {
+          noDictDims.add(dimension);
+        }
+      }
+    }
+    noDictCount = noDictDims.size();
+    isColumnDrift = new boolean[noDictCount];
+    noDictMap = new int[noDictCount];
+    measureDataTypes = new DataType[noDictCount];
+    List<CarbonMeasure> sourceMeasures = sourceSegProperties.getMeasures();
+    int tableMeasureCount = sourceMeasures.size();
+    for (int i = 0; i < noDictCount; i++) {
+      for (int j = 0; j < tableMeasureCount; j++) {
+        if (RestructureUtil.isColumnMatches(true, noDictDims.get(i), sourceMeasures.get(j))) {
+          isColumnDrift[i] = true;
+          measureDataTypes[i] = sourceMeasures.get(j).getDataType();
+          break;
+        }
+      }
+      if (measureDataTypes[i] == null) {
+        isColumnDrift[i] = false;
+      }
+    }
+    int noDictIndex = 0;
+    int measureIndex = measureCount + 1;
+    for(int i = 0; i< noDictCount; i++) {
+      if (isColumnDrift[i]) {
+        noDictMap[i] = measureIndex++;
+      } else {
+        noDictMap[i] = noDictIndex++;
+      }
+    }
+  }
+
   private void init() {
+    initForColumnReorder();
     this.prefetchEnabled = CarbonProperties.getInstance().getProperty(
         CarbonCommonConstants.CARBON_COMPACTION_PREFETCH_ENABLE,
         CarbonCommonConstants.CARBON_COMPACTION_PREFETCH_ENABLE_DEFAULT).equalsIgnoreCase("true");
@@ -194,11 +250,33 @@ public class RawResultIterator extends CarbonIterator<Object[]> {
   }
 
   private Object[] convertRow(Object[] rawRow) throws KeyGenException {
-    byte[] dims = ((ByteArrayWrapper) rawRow[0]).getDictionaryKey();
+    ByteArrayWrapper dimObject = (ByteArrayWrapper) rawRow[0];
+    byte[] dims = dimObject.getDictionaryKey();
     long[] keyArray = sourceSegProperties.getDimensionKeyGenerator().getKeyArray(dims);
     byte[] covertedBytes =
         destinationSegProperties.getDimensionKeyGenerator().generateKey(keyArray);
-    ((ByteArrayWrapper) rawRow[0]).setDictionaryKey(covertedBytes);
+    dimObject.setDictionaryKey(covertedBytes);
+    if (hasColumnDrift) {
+      byte[][] noDicts = dimObject.getNoDictionaryKeys();
+      byte[][] newNoDicts = new byte[noDictCount][];
+      for(int i = 0; i < noDictCount; i++) {
+        if (isColumnDrift[i]) {
+          newNoDicts[i] = DataTypeUtil.getBytesDataDataTypeForNoDictionaryColumn(
+              rawRow[noDictMap[i]], measureDataTypes[i]);
+        } else {
+          newNoDicts[i] = noDicts[noDictMap[i]];
+        }
+      }
+      ByteArrayWrapper newWrapper = new ByteArrayWrapper();
+      newWrapper.setDictionaryKey(covertedBytes);
+      newWrapper.setNoDictionaryKeys(newNoDicts);
+      newWrapper.setComplexTypesKeys(dimObject.getComplexTypesKeys());
+      newWrapper.setImplicitColumnByteArray(dimObject.getImplicitColumnByteArray());
+      Object[] finalRawRow = new Object[1 + measureCount];
+      finalRawRow[0] = newWrapper;
+      System.arraycopy(rawRow, 1, finalRawRow, 1, measureCount);
+      return finalRawRow;
+    }
     return rawRow;
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/iterator/RawResultIterator.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/iterator/RawResultIterator.java
@@ -70,7 +70,7 @@ public class RawResultIterator extends CarbonIterator<Object[]> {
   // column drift
   private final boolean hasColumnDrift;
   private boolean[] isColumnDrift;
-  private final int measureCount;
+  private int measureCount;
   private DataType[] measureDataTypes;
 
   /**
@@ -87,7 +87,6 @@ public class RawResultIterator extends CarbonIterator<Object[]> {
     this.destinationSegProperties = destinationSegProperties;
     this.executorService = Executors.newFixedThreadPool(1);
     this.hasColumnDrift = hasColumnDrift;
-    this.measureCount = destinationSegProperties.getMeasures().size();
     if (!isStreamingHandoff) {
       init();
     }
@@ -103,6 +102,7 @@ public class RawResultIterator extends CarbonIterator<Object[]> {
         }
       }
     }
+    measureCount = destinationSegProperties.getMeasures().size();
     noDictCount = noDictDims.size();
     isColumnDrift = new boolean[noDictCount];
     noDictMap = new int[noDictCount];

--- a/core/src/main/java/org/apache/carbondata/core/scan/wrappers/ByteArrayWrapper.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/wrappers/ByteArrayWrapper.java
@@ -218,4 +218,7 @@ public class ByteArrayWrapper implements Comparable<ByteArrayWrapper>, Serializa
     this.implicitColumnByteArray = implicitColumnByteArray;
   }
 
+  public byte[] getImplicitColumnByteArray() {
+    return implicitColumnByteArray;
+  }
 }

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/StreamHandoffRDD.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/StreamHandoffRDD.scala
@@ -74,7 +74,7 @@ class HandoffPartition(
  */
 class StreamingRawResultIterator(
     recordReader: RecordReader[Void, Any]
-) extends RawResultIterator(null, null, null, true) {
+) extends RawResultIterator(null, null, null, true, false) {
 
   override def hasNext: Boolean = {
     recordReader.nextKeyValue()

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/StreamHandoffRDD.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/StreamHandoffRDD.scala
@@ -74,7 +74,7 @@ class HandoffPartition(
  */
 class StreamingRawResultIterator(
     recordReader: RecordReader[Void, Any]
-) extends RawResultIterator(null, null, null, true, false) {
+) extends RawResultIterator(null, null, null, false) {
 
   override def hasNext: Boolean = {
     recordReader.nextKeyValue()

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/test/Spark2TestQueryExecutor.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/test/Spark2TestQueryExecutor.scala
@@ -72,7 +72,6 @@ object Spark2TestQueryExecutor {
     .enableHiveSupport()
     .config("spark.sql.warehouse.dir", warehouse)
     .config("spark.sql.crossJoin.enabled", "true")
-    .config("spark.network.timeout", 10000000)
     .getOrCreateCarbonSession(null, TestQueryExecutor.metaStoreDB)
   if (warehouse.startsWith("hdfs://")) {
     System.setProperty(CarbonCommonConstants.HDFS_TEMP_LOCATION, warehouse)

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/test/Spark2TestQueryExecutor.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/test/Spark2TestQueryExecutor.scala
@@ -72,6 +72,7 @@ object Spark2TestQueryExecutor {
     .enableHiveSupport()
     .config("spark.sql.warehouse.dir", warehouse)
     .config("spark.sql.crossJoin.enabled", "true")
+    .config("spark.network.timeout", 10000000)
     .getOrCreateCarbonSession(null, TestQueryExecutor.metaStoreDB)
   if (warehouse.startsWith("hdfs://")) {
     System.setProperty(CarbonCommonConstants.HDFS_TEMP_LOCATION, warehouse)

--- a/processing/src/main/java/org/apache/carbondata/processing/merger/CarbonCompactionExecutor.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/merger/CarbonCompactionExecutor.java
@@ -37,6 +37,7 @@ import org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema;
 import org.apache.carbondata.core.scan.executor.QueryExecutor;
 import org.apache.carbondata.core.scan.executor.QueryExecutorFactory;
 import org.apache.carbondata.core.scan.executor.exception.QueryExecutionException;
+import org.apache.carbondata.core.scan.executor.util.RestructureUtil;
 import org.apache.carbondata.core.scan.expression.Expression;
 import org.apache.carbondata.core.scan.model.QueryModel;
 import org.apache.carbondata.core.scan.model.QueryModelBuilder;
@@ -175,11 +176,13 @@ public class CarbonCompactionExecutor {
   private RawResultIterator getRawResultIterator(Configuration configuration, String segmentId,
       String task, List<TableBlockInfo> tableBlockInfoList)
       throws QueryExecutionException, IOException {
+    SegmentProperties sourceSegmentProperties = getSourceSegmentProperties(
+        Collections.singletonList(tableBlockInfoList.get(0).getDataFileFooter()));
+    boolean hasColumnDrift = carbonTable.hasColumnDrift() &&
+        RestructureUtil.hasColumnDriftOnSegment(carbonTable, sourceSegmentProperties);
     return new RawResultIterator(
         executeBlockList(tableBlockInfoList, segmentId, task, configuration),
-        getSourceSegmentProperties(
-            Collections.singletonList(tableBlockInfoList.get(0).getDataFileFooter())),
-        destinationSegProperties, false);
+        sourceSegmentProperties, destinationSegProperties, false, hasColumnDrift);
   }
 
   /**

--- a/processing/src/main/java/org/apache/carbondata/processing/merger/CarbonCompactionExecutor.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/merger/CarbonCompactionExecutor.java
@@ -42,6 +42,7 @@ import org.apache.carbondata.core.scan.expression.Expression;
 import org.apache.carbondata.core.scan.model.QueryModel;
 import org.apache.carbondata.core.scan.model.QueryModelBuilder;
 import org.apache.carbondata.core.scan.result.RowBatch;
+import org.apache.carbondata.core.scan.result.iterator.ColumnDriftRawResultIterator;
 import org.apache.carbondata.core.scan.result.iterator.RawResultIterator;
 import org.apache.carbondata.core.scan.wrappers.IntArrayWrapper;
 import org.apache.carbondata.core.stats.QueryStatistic;
@@ -180,9 +181,15 @@ public class CarbonCompactionExecutor {
         Collections.singletonList(tableBlockInfoList.get(0).getDataFileFooter()));
     boolean hasColumnDrift = carbonTable.hasColumnDrift() &&
         RestructureUtil.hasColumnDriftOnSegment(carbonTable, sourceSegmentProperties);
-    return new RawResultIterator(
-        executeBlockList(tableBlockInfoList, segmentId, task, configuration),
-        sourceSegmentProperties, destinationSegProperties, false, hasColumnDrift);
+    if (hasColumnDrift) {
+      return new ColumnDriftRawResultIterator(
+          executeBlockList(tableBlockInfoList, segmentId, task, configuration),
+          sourceSegmentProperties, destinationSegProperties);
+    } else {
+      return new RawResultIterator(
+          executeBlockList(tableBlockInfoList, segmentId, task, configuration),
+          sourceSegmentProperties, destinationSegProperties, true);
+    }
   }
 
   /**


### PR DESCRIPTION
Modification:
1. SegmentPropertiesWrapper should check the column order for different segments 
Because sort_columns modification can change the column order.
2.  dictionaryColumnChunkIndex of blockExecutionInfo should keep projection order for compaction
3. if column drift happened, it should convert measure to dimension in RawResultIterator


 - [x] Any interfaces changed?
 no
 - [x] Any backward compatibility impacted?
 no
 - [x] Document update required?
 no
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
           added unit test cases
        - How it is tested? Please attach test report.
           unit test cases passed
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
 small chagnes
