### PR TITLE
[CARBONDATA-3378]Display original query in Indexserver Job

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -2184,4 +2184,9 @@ public final class CarbonCommonConstants {
 
   public static final String LOAD_SYNC_TIME = "load_sync_time";
 
+  public  static final String CARBON_INDEX_SERVER_JOBNAME_LENGTH =
+          "carbon.index.server.max.jobname.length";
+
+  public  static final String CARBON_INDEX_SERVER_JOBNAME_LENGTH_DEFAULT =
+          "50";
 }

--- a/integration/spark2/src/main/scala/org/apache/carbondata/indexserver/DataMapJobs.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/indexserver/DataMapJobs.scala
@@ -21,6 +21,7 @@ import java.util
 import scala.collection.JavaConverters._
 
 import org.apache.log4j.Logger
+import org.apache.spark.sql.util.SparkSQLUtil
 import org.apache.spark.util.SizeEstimator
 
 import org.apache.carbondata.common.logging.LogServiceFactory
@@ -47,6 +48,17 @@ class DistributedDataMapJob extends AbstractDataMapJob {
       LOGGER.debug(s"Size of message sent to Index Server: $messageSize")
     }
     val (resonse, time) = logTime {
+      val spark = SparkSQLUtil.getSparkSession
+      val taskGroupId = spark.sparkContext.getLocalProperty("spark.jobGroup.id") match {
+        case null => ""
+        case _ => spark.sparkContext.getLocalProperty("spark.jobGroup.id")
+      }
+      val taskGroupDesc = spark.sparkContext.getLocalProperty("spark.job.description") match {
+        case null => ""
+        case _ => spark.sparkContext.getLocalProperty("spark.job.description")
+      }
+      dataMapFormat.setTaskGroupId(taskGroupId)
+      dataMapFormat.setTaskGroupDesc(taskGroupDesc)
       var filterInf = dataMapFormat.getFilterResolverIntf
       val filterProcessor = new FilterExpressionProcessor
       filterInf = removeSparkUnknown(filterInf,
@@ -95,6 +107,17 @@ class DistributedDataMapJob extends AbstractDataMapJob {
 class EmbeddedDataMapJob extends AbstractDataMapJob {
 
   override def execute(dataMapFormat: DistributableDataMapFormat): util.List[ExtendedBlocklet] = {
+    val spark = SparkSQLUtil.getSparkSession
+    val taskGroupId = spark.sparkContext.getLocalProperty("spark.jobGroup.id") match {
+      case null => ""
+      case _ => spark.sparkContext.getLocalProperty("spark.jobGroup.id")
+    }
+    val taskGroupDesc = spark.sparkContext.getLocalProperty("spark.job.description") match {
+      case null => ""
+      case _ => spark.sparkContext.getLocalProperty("spark.job.description")
+    }
+    dataMapFormat.setTaskGroupId(taskGroupId)
+    dataMapFormat.setTaskGroupDesc(taskGroupDesc)
     IndexServer.getSplits(dataMapFormat).toList.asJava
   }
 


### PR DESCRIPTION
This PR is depend on #3177 
When any query fired in main jdbcserver , in Index server there is no mapping of it. it is difficult to find which job in index server belong to which query specially in concurrent queries. 

This PR will display query in index server also along with Executionid .

Result :-
![image](https://user-images.githubusercontent.com/12861989/57305209-4dc0dd00-70fe-11e9-9b24-23aaaefb76f3.png)



Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 NA
 - [ ] Any backward compatibility impacted?
 NA
 - [ ] Document update required?
NA
 - [ ] Testing done
       Manually tested.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

NA