### PR TITLE
[CARBONDATA-3380] Fix missing appName and AnalysisException bug in DirectSQLExample

### DIFF
--- a/examples/spark2/src/main/scala/org/apache/carbondata/examples/DirectSQLExample.scala
+++ b/examples/spark2/src/main/scala/org/apache/carbondata/examples/DirectSQLExample.scala
@@ -72,6 +72,19 @@ object DirectSQLExample {
 
   }
 
+  def exampleBodyDebug(carbonSession : SparkSession): Unit = {
+
+    import carbonSession._
+
+    println("Running SQL on carbon files directly")
+    try {
+      sql(s"""select 1""".stripMargin).show()
+    } catch {
+      case e: Exception => throw e
+    }
+
+  }
+
   // prepare SDK writer output
   def buildTestData(
       path: String,

--- a/examples/spark2/src/main/scala/org/apache/carbondata/examples/DirectSQLExample.scala
+++ b/examples/spark2/src/main/scala/org/apache/carbondata/examples/DirectSQLExample.scala
@@ -81,13 +81,20 @@ object DirectSQLExample {
     import carbonSession._
     // 1. generate data file
     cleanTestData(path)
-    buildTestData(path, 20, sparkSession = carbonSession)
+
+    val rows = 20;
+    buildTestData(path, rows, sparkSession = carbonSession)
     val readPath = path
 
     println("Running SQL on carbon files directly")
     try {
       // 2. run queries directly, no need to create table first
       sql(s"""select * FROM carbon.`$readPath` limit 10""".stripMargin).show()
+
+      // 3. check rows count
+      val counts = sql(s"""select * FROM carbon.`$readPath`""".stripMargin).count()
+      assert(rows == counts)
+
     } catch {
       case e: Exception => throw e
     } finally {

--- a/examples/spark2/src/main/scala/org/apache/carbondata/examples/DirectSQLExample.scala
+++ b/examples/spark2/src/main/scala/org/apache/carbondata/examples/DirectSQLExample.scala
@@ -31,18 +31,56 @@ import org.apache.carbondata.sdk.file.{CarbonWriter, Field, Schema}
  * No need to create table first
  * TODO: support more than one carbon file
  */
+// scalastyle:off println
 object DirectSQLExample {
+
+  def main(args: Array[String]) {
+    val carbonSession = ExampleUtils.createCarbonSession("DirectSQLExample")
+    exampleBody(carbonSession)
+    carbonSession.close()
+  }
+
+  def exampleBody(carbonSession : SparkSession): Unit = {
+
+    val rootPath = new File(this.getClass.getResource("/").getPath
+      + "../../../..").getCanonicalPath
+    val path = s"$rootPath/examples/spark2/target/carbonFile/"
+
+    import carbonSession._
+    // 1. generate data file
+    cleanTestData(path)
+
+    val rows = 20
+    buildTestData(path, rows)
+    val readPath = path
+
+    println("Running SQL on carbon files directly")
+    try {
+      // 2. run queries directly, no need to create table first
+      sql(s"""select * FROM carbon.`$readPath` limit 10""".stripMargin).show()
+
+      // 3. check rows count
+      val counts = sql(s"""select * FROM carbon.`$readPath`""".stripMargin).count()
+      assert(rows == counts)
+
+    } catch {
+      case e: Exception => throw e
+    } finally {
+      // 3.delete data files
+      cleanTestData(path)
+    }
+
+  }
 
   // prepare SDK writer output
   def buildTestData(
       path: String,
-      num: Int = 3,
-      sparkSession: SparkSession): Any = {
+      num: Int = 3): Unit = {
 
     // getCanonicalPath gives path with \, but the code expects /.
-    val writerPath = path.replace("\\", "/");
+    val writerPath = path.replace("\\", "/")
 
-    val fields: Array[Field] = new Array[Field](3)
+    val fields = new Array[Field](3)
     fields(0) = new Field("name", DataTypes.STRING)
     fields(1) = new Field("age", DataTypes.INT)
     fields(2) = new Field("height", DataTypes.DOUBLE)
@@ -71,36 +109,5 @@ object DirectSQLExample {
     FileUtils.deleteDirectory(new File(path))
   }
 
-  // scalastyle:off
-  def main(args: Array[String]) {
-    val carbonSession = ExampleUtils.createCarbonSession("DirectSQLExample")
-    val rootPath = new File(this.getClass.getResource("/").getPath
-      + "../../../..").getCanonicalPath
-    val path = s"$rootPath/examples/spark2/target/carbonFile/"
-
-    import carbonSession._
-    // 1. generate data file
-    cleanTestData(path)
-
-    val rows = 20;
-    buildTestData(path, rows, sparkSession = carbonSession)
-    val readPath = path
-
-    println("Running SQL on carbon files directly")
-    try {
-      // 2. run queries directly, no need to create table first
-      sql(s"""select * FROM carbon.`$readPath` limit 10""".stripMargin).show()
-
-      // 3. check rows count
-      val counts = sql(s"""select * FROM carbon.`$readPath`""".stripMargin).count()
-      assert(rows == counts)
-
-    } catch {
-      case e: Exception => throw e
-    } finally {
-      // 3.delete data files
-      cleanTestData(path)
-    }
-  }
-  // scalastyle:on
 }
+// scalastyle:on println

--- a/examples/spark2/src/main/scala/org/apache/carbondata/examples/DirectSQLExample.scala
+++ b/examples/spark2/src/main/scala/org/apache/carbondata/examples/DirectSQLExample.scala
@@ -72,19 +72,6 @@ object DirectSQLExample {
 
   }
 
-  def exampleBodyDebug(carbonSession : SparkSession): Unit = {
-
-    import carbonSession._
-
-    println("Running SQL on carbon files directly")
-    try {
-      sql(s"""select 1""".stripMargin).show()
-    } catch {
-      case e: Exception => throw e
-    }
-
-  }
-
   // prepare SDK writer output
   def buildTestData(
       path: String,

--- a/examples/spark2/src/main/scala/org/apache/carbondata/examples/DirectSQLExample.scala
+++ b/examples/spark2/src/main/scala/org/apache/carbondata/examples/DirectSQLExample.scala
@@ -54,6 +54,7 @@ object DirectSQLExample {
         .uniqueIdentifier(System.currentTimeMillis)
         .withBlockSize(2)
         .withCsvInput(new Schema(fields))
+        .writtenBy("DirectSQLExample")
       val writer = builder.build()
       var i = 0
       while (i < num) {
@@ -86,7 +87,7 @@ object DirectSQLExample {
     println("Running SQL on carbon files directly")
     try {
       // 2. run queries directly, no need to create table first
-      sql(s"""select * FROM  carbonfile.`$readPath` limit 10""".stripMargin).show()
+      sql(s"""select * FROM carbon.`$readPath` limit 10""".stripMargin).show()
     } catch {
       case e: Exception => throw e
     } finally {

--- a/examples/spark2/src/test/scala/org/apache/carbondata/examplesCI/RunExamples.scala
+++ b/examples/spark2/src/test/scala/org/apache/carbondata/examplesCI/RunExamples.scala
@@ -131,6 +131,6 @@ class RunExamples extends QueryTest with BeforeAndAfterAll {
   }
 
   test("DirectSQLExample") {
-    DirectSQLExample.main(null)
+    DirectSQLExample.exampleBody(spark)
   }
 }

--- a/examples/spark2/src/test/scala/org/apache/carbondata/examplesCI/RunExamples.scala
+++ b/examples/spark2/src/test/scala/org/apache/carbondata/examplesCI/RunExamples.scala
@@ -127,12 +127,11 @@ class RunExamples extends QueryTest with BeforeAndAfterAll {
   }
 
   test("DirectSQLExample") {
-    DirectSQLExample.exampleBodyDebug(spark)
+    DirectSQLExample.exampleBody(spark)
   }
 
   test("HiveExample") {
     HiveExample.exampleBody(spark, TestQueryExecutor.warehouse)
   }
-
 
 }

--- a/examples/spark2/src/test/scala/org/apache/carbondata/examplesCI/RunExamples.scala
+++ b/examples/spark2/src/test/scala/org/apache/carbondata/examplesCI/RunExamples.scala
@@ -129,4 +129,8 @@ class RunExamples extends QueryTest with BeforeAndAfterAll {
   test("HiveExample") {
     HiveExample.exampleBody(spark, TestQueryExecutor.warehouse)
   }
+
+  test("DirectSQLExample") {
+    DirectSQLExample.main(null)
+  }
 }

--- a/examples/spark2/src/test/scala/org/apache/carbondata/examplesCI/RunExamples.scala
+++ b/examples/spark2/src/test/scala/org/apache/carbondata/examplesCI/RunExamples.scala
@@ -131,6 +131,6 @@ class RunExamples extends QueryTest with BeforeAndAfterAll {
   }
 
   test("DirectSQLExample") {
-    DirectSQLExample.exampleBody(spark)
+    DirectSQLExample.exampleBodyDebug(spark)
   }
 }

--- a/examples/spark2/src/test/scala/org/apache/carbondata/examplesCI/RunExamples.scala
+++ b/examples/spark2/src/test/scala/org/apache/carbondata/examplesCI/RunExamples.scala
@@ -126,11 +126,13 @@ class RunExamples extends QueryTest with BeforeAndAfterAll {
     CarbonReaderExample.main(null)
   }
 
+  test("DirectSQLExample") {
+    DirectSQLExample.exampleBodyDebug(spark)
+  }
+
   test("HiveExample") {
     HiveExample.exampleBody(spark, TestQueryExecutor.warehouse)
   }
 
-  test("DirectSQLExample") {
-    DirectSQLExample.exampleBodyDebug(spark)
-  }
+
 }


### PR DESCRIPTION
Fix two bug in DirectSQLExample
- fix missing appName which is writing the carbondata files.
- fix AnalysisException bug because of carbonfile
<br>

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed? NO
 
 - [x] Any backward compatibility impacted? NO
 
 - [x] Document update required? NO

 - [x] Testing done YES
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required? It's a example.
        - How it is tested? Please attach test report. 
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
