### PR TITLE
[CARBONDATA-3382] Fixed compressor type display in desc formatted

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/describeTable/TestDescribeTable.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/describeTable/TestDescribeTable.scala
@@ -20,6 +20,9 @@ import org.apache.spark.sql.Row
 import org.apache.spark.sql.test.util.QueryTest
 import org.scalatest.BeforeAndAfterAll
 
+import org.apache.carbondata.core.constants.CarbonCommonConstants
+import org.apache.carbondata.core.util.CarbonProperties
+
 /**
   * test class for describe table .
   */
@@ -65,10 +68,22 @@ class TestDescribeTable extends QueryTest with BeforeAndAfterAll {
     assert(descPar.exists(_.toString().contains("Partition Parameters:")))
   }
 
+  test(testName = "Compressor Type update from carbon properties") {
+    sql("drop table if exists b")
+    sql(sqlText = "create table b(a int,b string) stored by 'carbondata'")
+    CarbonProperties.getInstance().addProperty(CarbonCommonConstants.COMPRESSOR, "gzip")
+    val result = sql(sqlText = "desc formatted b").collect()
+    assert(result.filter(row => row.getString(0).contains("Data File Compressor")).head.getString
+    (1).equalsIgnoreCase("gzip"))
+  }
+
   override def afterAll: Unit = {
     sql("DROP TABLE Desc1")
     sql("DROP TABLE Desc2")
     sql("drop table if exists a")
+    sql("drop table if exists b")
+    CarbonProperties.getInstance().addProperty(CarbonCommonConstants.COMPRESSOR,
+      CarbonCommonConstants.DEFAULT_COMPRESSOR)
   }
 
 }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonDescribeFormattedCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonDescribeFormattedCommand.scala
@@ -113,7 +113,9 @@ private[sql] case class CarbonDescribeFormattedCommand(
             CarbonCommonConstants.CARBON_LOAD_MIN_SIZE_INMB_DEFAULT).toFloat), ""),
       ("Data File Compressor ", tblProps
         .getOrElse(CarbonCommonConstants.COMPRESSOR,
-          CarbonCommonConstants.DEFAULT_COMPRESSOR), ""),
+          CarbonProperties.getInstance()
+            .getProperty(CarbonCommonConstants.COMPRESSOR,
+          CarbonCommonConstants.DEFAULT_COMPRESSOR)), ""),
       //////////////////////////////////////////////////////////////////////////////
       //  Index Information
       //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
**Problem :**
Describe formatted table does not display the correct compression type when its is configured in carbon.properties instead it always shows the default compressor type.

**Solution : **
Get the compressor type from the instance of CarbonProperties.




Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

