### PR TITLE
[CARBONDATA-3381] Large response size Exception fix for index server

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datamap/DistributableDataMapFormat.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/DistributableDataMapFormat.java
@@ -254,6 +254,7 @@ public class DistributableDataMapFormat extends FileInputFormat<Void, ExtendedBl
     if (partitions == null) {
       out.writeBoolean(false);
     } else {
+      out.writeBoolean(true);
       out.writeInt(partitions.size());
       for (PartitionSpec partitionSpec : partitions) {
         partitionSpec.write(out);

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/ExtendedBlockletWrapper.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/ExtendedBlockletWrapper.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.core.indexstore;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.hadoop.io.Writable;
+
+/**
+ * Wrapper to write and read the list of extended blocklets over RPC communication.
+ */
+public class ExtendedBlockletWrapper implements Writable {
+
+  private List<ExtendedBlocklet> extendedBlocklets;
+
+  public ExtendedBlockletWrapper() {
+    this.extendedBlocklets = new ArrayList<>();
+  }
+
+  public ExtendedBlockletWrapper(ExtendedBlocklet[] extendedBlocklets) {
+    this.extendedBlocklets = Arrays.asList(extendedBlocklets);
+  }
+
+  public List<ExtendedBlocklet> getExtendedBlocklets() {
+    return extendedBlocklets;
+  }
+
+  @Override public void write(DataOutput out) throws IOException {
+    out.writeInt(extendedBlocklets.size());
+    for (ExtendedBlocklet extendedBlocklet : extendedBlocklets) {
+      extendedBlocklet.write(out);
+    }
+  }
+
+  @Override public void readFields(DataInput in) throws IOException {
+    int numOfExtendedBlocklets = in.readInt();
+    this.extendedBlocklets = new ArrayList<>(numOfExtendedBlocklets);
+    for (int i = 0; i < numOfExtendedBlocklets; i++) {
+      ExtendedBlocklet extendedBlocklet = new ExtendedBlocklet();
+      extendedBlocklet.readFields(in);
+      extendedBlocklets.add(extendedBlocklet);
+    }
+  }
+}

--- a/integration/spark2/src/main/scala/org/apache/carbondata/indexserver/DataMapJobs.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/indexserver/DataMapJobs.scala
@@ -42,7 +42,7 @@ class DistributedDataMapJob extends AbstractDataMapJob {
       LOGGER.debug(s"Size of message sent to Index Server: $messageSize")
     }
     val (resonse, time) = logTime {
-      IndexServer.getClient.getSplits(dataMapFormat).toList.asJava
+      IndexServer.getClient.getSplits(dataMapFormat).getExtendedBlocklets
     }
     LOGGER.info(s"Time taken to get response from server: $time ms")
     resonse
@@ -56,7 +56,7 @@ class DistributedDataMapJob extends AbstractDataMapJob {
 class EmbeddedDataMapJob extends AbstractDataMapJob {
 
   override def execute(dataMapFormat: DistributableDataMapFormat): util.List[ExtendedBlocklet] = {
-    IndexServer.getSplits(dataMapFormat).toList.asJava
+    IndexServer.getSplits(dataMapFormat).getExtendedBlocklets
   }
 
 }

--- a/integration/spark2/src/main/scala/org/apache/carbondata/indexserver/IndexServer.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/indexserver/IndexServer.scala
@@ -32,7 +32,7 @@ import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.datamap.DistributableDataMapFormat
 import org.apache.carbondata.core.datastore.impl.FileFactory
-import org.apache.carbondata.core.indexstore.ExtendedBlocklet
+import org.apache.carbondata.core.indexstore.ExtendedBlockletWrapper
 import org.apache.carbondata.core.util.CarbonProperties
 
 @ProtocolInfo(protocolName = "Server", protocolVersion = 1)
@@ -42,7 +42,7 @@ trait ServerInterface {
   /**
    * Used to prune and cache the datamaps for the table.
    */
-  def getSplits(request: DistributableDataMapFormat): Array[ExtendedBlocklet]
+  def getSplits(request: DistributableDataMapFormat): ExtendedBlockletWrapper
 
   /**
    * Invalidate the cache for the provided table.
@@ -100,10 +100,10 @@ object IndexServer extends ServerInterface {
     })
   }
 
-  def getSplits(request: DistributableDataMapFormat): Array[ExtendedBlocklet] = doAs {
+  def getSplits(request: DistributableDataMapFormat): ExtendedBlockletWrapper = doAs {
     val splits = new DistributedPruneRDD(sparkSession, request).collect()
     DistributedRDDUtils.updateExecutorCacheSize(splits.map(_._1).toSet)
-    splits.map(_._2)
+    new ExtendedBlockletWrapper(splits.map(_._2))
   }
 
   override def invalidateCache(request: DistributableDataMapFormat): Unit = doAs {


### PR DESCRIPTION
**Issue:** Response size from the server is being bloated up 10x because, hadoop RPC is writting class name for each array element that is returned as a response. This causes the RPC framework to throw Large response size exception.   

**Solution:** Make a ExtendedBlockletWrapper and write the ExtendedBlocklets as List instead of array.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

