### PR TITLE
[CARBONDATA-3387] Support Partition with MV datamap & Show DataMap Status

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -2174,4 +2174,6 @@ public final class CarbonCommonConstants {
    */
   public static final String PARENT_TABLES = "parent_tables";
 
+  public static final String LOAD_SYNC_TIME = "load_sync_time";
+
 }

--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/DataMapSchema.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/DataMapSchema.java
@@ -86,6 +86,11 @@ public class DataMapSchema implements Serializable, Writable {
    */
   private Map<String, Set<String>> mainTableColumnList;
 
+  /**
+   * DataMap table column order map as per Select query
+   */
+  private Map<Integer, String> columnsOrderMap;
+
   public DataMapSchema(String dataMapName, String providerName) {
     this.dataMapName = dataMapName;
     this.providerName = providerName;
@@ -263,5 +268,13 @@ public class DataMapSchema implements Serializable, Writable {
 
   public void setMainTableColumnList(Map<String, Set<String>> mainTableColumnList) {
     this.mainTableColumnList = mainTableColumnList;
+  }
+
+  public Map<Integer, String> getColumnsOrderMap() {
+    return columnsOrderMap;
+  }
+
+  public void setColumnsOrderMap(Map<Integer, String> columnsOrderMap) {
+    this.columnsOrderMap = columnsOrderMap;
   }
 }

--- a/datamap/mv/core/pom.xml
+++ b/datamap/mv/core/pom.xml
@@ -78,7 +78,7 @@
           <systemProperties>
             <java.awt.headless>true</java.awt.headless>
           </systemProperties>
-          <testFailureIgnore>false</testFailureIgnore>
+          <!-- testFailureIgnore>false</testFailureIgnore -->
           <failIfNoTests>false</failIfNoTests>
         </configuration>
       </plugin>

--- a/datamap/mv/core/src/main/scala/org/apache/carbondata/mv/datamap/MVHelper.scala
+++ b/datamap/mv/core/src/main/scala/org/apache/carbondata/mv/datamap/MVHelper.scala
@@ -55,6 +55,11 @@ object MVHelper {
       queryString: String,
       ifNotExistsSet: Boolean = false): Unit = {
     val dmProperties = dataMapSchema.getProperties.asScala
+    if (dmProperties.contains("streaming") && dmProperties("streaming").equalsIgnoreCase("true")) {
+      throw new MalformedCarbonCommandException(
+        s"MV datamap does not support streaming"
+      )
+    }
     val updatedQuery = new CarbonSpark2SqlParser().addPreAggFunction(queryString)
     val query = sparkSession.sql(updatedQuery)
     val logicalPlan = MVHelper.dropDummFuc(query.queryExecution.analyzed)

--- a/datamap/mv/core/src/main/scala/org/apache/carbondata/mv/datamap/MVUtil.scala
+++ b/datamap/mv/core/src/main/scala/org/apache/carbondata/mv/datamap/MVUtil.scala
@@ -106,7 +106,7 @@ object MVUtil {
             arrayBuffer += relation
           }
           fieldToDataMapFieldMap +=
-          getFieldToDataMapFields(name, attr.dataType, attr.qualifier, "", arrayBuffer, "")
+          getFieldToDataMapFields(name, attr.dataType, None, "", arrayBuffer, "")
         }
     }
     fieldToDataMapFieldMap
@@ -134,6 +134,7 @@ object MVUtil {
               attr.aggregateFunction.nodeName,
               arrayBuffer,
               "")
+            aggregateType = "count"
           } else {
             aggregateType = attr.aggregateFunction.nodeName
           }

--- a/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/TestAllOperationsOnMV.scala
+++ b/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/TestAllOperationsOnMV.scala
@@ -340,5 +340,28 @@ class TestAllOperationsOnMV extends QueryTest with BeforeAndAfterEach {
     sql("drop table IF EXISTS maintable")
   }
 
+  test("test datamap with streaming dmproperty") {
+    sql("drop table IF EXISTS maintable")
+    sql("create table maintable(name string, c_code int, price int) stored by 'carbondata'")
+    sql("insert into table maintable select 'abc',21,2000")
+    sql("drop datamap if exists dm ")
+    intercept[MalformedCarbonCommandException] {
+      sql("create datamap dm using 'mv' dmproperties('STREAMING'='true') as select name from maintable")
+    }.getMessage.contains("MV datamap does not support streaming")
+    sql("drop table IF EXISTS maintable")
+  }
+
+  test("test set streaming after creating datamap table") {
+    sql("drop table IF EXISTS maintable")
+    sql("create table maintable(name string, c_code int, price int) stored by 'carbondata'")
+    sql("insert into table maintable select 'abc',21,2000")
+    sql("drop datamap if exists dm ")
+    sql("create datamap dm using 'mv' as select name from maintable")
+    intercept[MalformedCarbonCommandException] {
+      sql("ALTER TABLE dm_table SET TBLPROPERTIES('streaming'='true')")
+    }.getMessage.contains("Datamap table does not support set streaming property")
+    sql("drop table IF EXISTS maintable")
+  }
+
 }
 

--- a/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/TestAllOperationsOnMV.scala
+++ b/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/TestAllOperationsOnMV.scala
@@ -186,19 +186,6 @@ class TestAllOperationsOnMV extends QueryTest with BeforeAndAfterEach {
     }.getMessage.contains("Delete segment operation is not supported on mv table")
   }
 
-  test("test partition table with mv") {
-    sql("drop table if exists par_table")
-    sql("CREATE TABLE par_table(id INT, name STRING, age INT) PARTITIONED BY(city string) STORED BY 'carbondata'")
-    sql("insert into par_table values(1,'abc',3,'def')")
-    sql("drop datamap if exists p1")
-    sql("create datamap p1 using 'mv' WITH DEFERRED REBUILD as select city, id from par_table")
-    sql("rebuild datamap p1")
-    intercept[MalformedCarbonCommandException] {
-      sql("alter table par_table drop partition (city='def')")
-    }.getMessage.contains("Drop Partition is not supported for datamap table or for tables which have child datamap")
-    sql("drop datamap if exists p1")
-  }
-
   test("test direct load to mv datamap table") {
     sql("drop table IF EXISTS maintable")
     sql("create table maintable(name string, c_code int, price int) stored by 'carbondata'")
@@ -249,6 +236,108 @@ class TestAllOperationsOnMV extends QueryTest with BeforeAndAfterEach {
       sql("Create datamap p using 'mv' as Select product from noncarbon")
     }.getMessage.contains("Non-Carbon table does not support creating MV datamap")
     sql("drop table if exists noncarbon")
+  }
+
+  //Test show datamap
+  test("test datamap status with single table") {
+    sql("drop table IF EXISTS maintable")
+    sql("create table maintable(name string, c_code int, price int) stored by 'carbondata'")
+    sql("insert into table maintable select 'abc',21,2000")
+    sql("drop datamap if exists dm1 ")
+    sql("create datamap dm1 using 'mv' WITH DEFERRED REBUILD as select price from maintable")
+    checkExistence(sql("show datamap on table maintable"), true, "DISABLED")
+    sql("rebuild datamap dm1")
+    var result = sql("show datamap on table maintable").collectAsList()
+    assert(result.get(0).get(4).toString.equalsIgnoreCase("ENABLED"))
+    assert(result.get(0).get(5).toString.contains("{\"default.maintable\":\"0\""))
+    sql("insert into table maintable select 'abc',21,2000")
+    checkExistence(sql("show datamap on table maintable"), true, "DISABLED")
+    sql("rebuild datamap dm1")
+    result = sql("show datamap on table maintable").collectAsList()
+    assert(result.get(0).get(4).toString.equalsIgnoreCase("ENABLED"))
+    assert(result.get(0).get(5).toString.contains("{\"default.maintable\":\"1\""))
+    sql("drop table IF EXISTS maintable")
+  }
+
+  test("test datamap status with multiple tables") {
+    sql("drop table if exists products")
+    sql("create table products (product string, amount int) stored by 'carbondata' ")
+    sql(s"load data INPATH '$resourcesPath/products.csv' into table products")
+    sql("drop table if exists sales")
+    sql("create table sales (product string, quantity int) stored by 'carbondata'")
+    sql(s"load data INPATH '$resourcesPath/sales_data.csv' into table sales")
+    sql("drop datamap if exists innerjoin")
+    sql(
+      "Create datamap innerjoin using 'mv'  with deferred rebuild as Select p.product, p.amount, " +
+      "s.quantity, s.product from " +
+      "products p, sales s where p.product=s.product")
+    checkExistence(sql("show datamap on table products"), true, "DISABLED")
+    checkExistence(sql("show datamap on table sales"), true, "DISABLED")
+    sql("rebuild datamap innerjoin")
+    var result = sql("show datamap on table products").collectAsList()
+    assert(result.get(0).get(4).toString.equalsIgnoreCase("ENABLED"))
+    assert(result.get(0).get(5).toString.contains("\"default.products\":\"0\",\"default.sales\":\"0\"}"))
+    result = sql("show datamap on table sales").collectAsList()
+    assert(result.get(0).get(4).toString.equalsIgnoreCase("ENABLED"))
+    assert(result.get(0).get(5).toString.contains("\"default.products\":\"0\",\"default.sales\":\"0\"}"))
+    sql(s"load data INPATH '$resourcesPath/sales_data.csv' into table sales")
+    checkExistence(sql("show datamap on table products"), true, "DISABLED")
+    checkExistence(sql("show datamap on table sales"), true, "DISABLED")
+    sql("rebuild datamap innerjoin")
+    result = sql("show datamap on table sales").collectAsList()
+    assert(result.get(0).get(4).toString.equalsIgnoreCase("ENABLED"))
+    assert(result.get(0).get(5).toString.contains("\"default.products\":\"0\",\"default.sales\":\"1\"}"))
+    sql("drop table if exists products")
+    sql("drop table if exists sales")
+  }
+
+  test("directly drop datamap table") {
+    sql("drop table IF EXISTS maintable")
+    sql("create table maintable(name string, c_code int, price int) stored by 'carbondata'")
+    sql("insert into table maintable select 'abc',21,2000")
+    sql("drop datamap if exists dm1 ")
+    sql("create datamap dm1 using 'mv' WITH DEFERRED REBUILD as select price from maintable")
+    intercept[ProcessMetaDataException] {
+      sql("drop table dm1_table")
+    }.getMessage.contains("Child table which is associated with datamap cannot be dropped, use DROP DATAMAP command to drop")
+    sql("drop table IF EXISTS maintable")
+  }
+
+  test("create datamap on child table") {
+    sql("drop table IF EXISTS maintable")
+    sql("create table maintable(name string, c_code int, price int) stored by 'carbondata'")
+    sql("insert into table maintable select 'abc',21,2000")
+    sql("drop datamap if exists dm1 ")
+    sql("create datamap dm1 using 'mv' as select name, price from maintable")
+    intercept[Exception] {
+      sql("create datamap dm_agg on table dm1_table using 'preaggregate' as select maintable_name, sum(maintable_price) from dm1_table group by maintable_name")
+    }.getMessage.contains("Cannot create DataMap on child table default.dm1_table")
+    intercept[Exception] {
+      sql("create datamap dm_agg using 'mv' as select maintable_name, sum(maintable_price) from dm1_table group by maintable_name")
+    }.getMessage.contains("Cannot create DataMap on child table default.dm1_table")
+  }
+
+  test("create datamap if already exists") {
+    sql("drop table IF EXISTS maintable")
+    sql("create table maintable(name string, c_code int, price int) stored by 'carbondata'")
+    sql("insert into table maintable select 'abc',21,2000")
+    sql("drop datamap if exists dm1 ")
+    sql("create datamap dm1 using 'mv' as select name from maintable")
+    intercept[Exception] {
+      sql("create datamap dm1 using 'mv' as select price from maintable")
+    }.getMessage.contains("DataMap with name dm1 already exists in storage")
+    checkAnswer(sql("select name from maintable"), Seq(Row("abc")))
+  }
+
+  test("test create datamap with select query having 'like' expression") {
+    sql("drop table IF EXISTS maintable")
+    sql("create table maintable(name string, c_code int, price int) stored by 'carbondata'")
+    sql("insert into table maintable select 'abc',21,2000")
+    sql("select name from maintable where name like '%b%'").show(false)
+    sql("drop datamap if exists dm_like ")
+    sql("create datamap dm_like using 'mv' as select name from maintable where name like '%b%'")
+    checkAnswer(sql("select name from maintable where name like '%b%'"), Seq(Row("abc")))
+    sql("drop table IF EXISTS maintable")
   }
 
 }

--- a/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/TestPartitionWithMV.scala
+++ b/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/TestPartitionWithMV.scala
@@ -1,0 +1,678 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain id copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.apache.carbondata.mv.rewrite
+
+import scala.collection.JavaConverters._
+
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.execution.datasources.LogicalRelation
+import org.apache.spark.sql.test.util.QueryTest
+import org.apache.spark.sql.{CarbonEnv, Row}
+import org.scalatest.BeforeAndAfterAll
+
+import org.apache.carbondata.core.datastore.impl.FileFactory
+
+/**
+ * Test class for MV to verify partition scenarios
+ */
+class TestPartitionWithMV extends QueryTest with BeforeAndAfterAll {
+
+  val testData = s"$resourcesPath/sample.csv"
+
+  override def beforeAll(): Unit = {
+    sql("drop database if exists partition_mv cascade")
+    sql("create database partition_mv")
+    sql("use partition_mv")
+    sql(
+      """
+        | CREATE TABLE par(id INT, name STRING, age INT) PARTITIONED BY(city STRING)
+        | STORED BY 'org.apache.carbondata.format'
+      """.stripMargin)
+    sql(
+      """
+        | CREATE TABLE maintable(id int, name string, city string) partitioned by (age int)
+        | STORED BY 'org.apache.carbondata.format'
+      """.stripMargin)
+    sql(s"LOAD DATA LOCAL INPATH '$testData' into table maintable")
+  }
+
+  override def afterAll(): Unit = {
+    sql("drop database if exists partition_mv cascade")
+    sql("use default")
+  }
+
+  // Create mv table on partition with partition column in aggregation only.
+  test("test mv table creation on partition table with partition col as aggregation") {
+    sql("create datamap p1 on table par using 'mv' as select id, sum(city) from par group by id")
+    assert(!CarbonEnv.getCarbonTable(Some("partition_mv"), "p1_table")(sqlContext.sparkSession).isHivePartitionTable)
+  }
+
+  // Create mv table on partition with partition column in projection and aggregation only.
+  test("test mv table creation on partition table with partition col as projection") {
+    sql("create datamap p2 on table par using 'mv' as select id, city, min(city) from par group by id,city ")
+    assert(CarbonEnv.getCarbonTable(Some("partition_mv"), "p2_table")(sqlContext.sparkSession).isHivePartitionTable)
+  }
+
+  // Create mv table on partition with partition column as group by.
+  test("test mv table creation on partition table with partition col as group by") {
+    sql("create datamap p3 on table par using 'mv' as select id, city, max(city) from par group by id,city ")
+    assert(CarbonEnv.getCarbonTable(Some("partition_mv"), "p3_table")(sqlContext.sparkSession).isHivePartitionTable)
+  }
+
+  // Create mv table on partition without partition column.
+  test("test mv table creation on partition table without partition column") {
+    sql("create datamap p4 on table par using 'mv' as select name, count(id) from par group by name ")
+    assert(!CarbonEnv.getCarbonTable(Some("partition_mv"), "p4_table")(sqlContext.sparkSession).isHivePartitionTable)
+    sql("drop datamap if exists p4")
+  }
+
+  test("test data correction with insert overwrite") {
+    sql("drop table if exists partitionone")
+    sql(
+      """
+        | CREATE TABLE if not exists partitionone (empname String, age int)
+        | PARTITIONED BY (year int, month int,day int)
+        | STORED BY 'org.apache.carbondata.format'
+      """.stripMargin)
+    sql("drop datamap if exists p1")
+    sql("create datamap p1 on table partitionone using 'mv' as select empname, year, sum(year),month,day from partitionone group by empname, year, month,day")
+    sql("insert into partitionone values('k',2,2014,1,1)")
+    sql("insert overwrite table partitionone values('v',2,2014,1,1)")
+    checkAnswer(sql("select * from partitionone"), Seq(Row("v",2,2014,1,1)))
+    checkAnswer(sql("select * from p1_table"), Seq(Row("v",2014,2014,1,1)))
+    checkAnswer(sql("select empname, sum(year) from partitionone group by empname, year, month,day"), Seq(Row("v", 2014)))
+    val df1 = sql(s"select empname, sum(year) from partitionone group by empname, year, month,day")
+    val analyzed1 = df1.queryExecution.analyzed
+    assert(verifyMVDataMap(analyzed1, "p1"))
+    assert(CarbonEnv.getCarbonTable(Some("partition_mv"), "p1_table")(sqlContext.sparkSession).isHivePartitionTable)
+  }
+
+  test("test data correction with insert overwrite on different value") {
+    sql("drop table if exists partitionone")
+    sql(
+      """
+        | CREATE TABLE if not exists partitionone (empname String, age int)
+        | PARTITIONED BY (year int, month int,day int)
+        | STORED BY 'org.apache.carbondata.format'
+      """.stripMargin)
+    sql("drop datamap if exists p1")
+    sql("create datamap p1 on table partitionone using 'mv' as select empname, year, sum(year),month,day from partitionone group by empname, year, month,day")
+    sql("insert into partitionone values('k',2,2014,1,1)")
+    sql("insert overwrite table partitionone values('v',2,2015,1,1)")
+    checkAnswer(sql("select * from partitionone"), Seq(Row("k",2,2014,1,1), Row("v",2,2015,1,1)))
+    val df1 = sql(s"select empname, sum(year) from partitionone group by empname, year, month,day")
+    val analyzed1 = df1.queryExecution.analyzed
+    assert(verifyMVDataMap(analyzed1, "p1"))
+    checkAnswer(sql("select * from p1_table"), Seq(Row("k",2014,2014,1,1), Row("v",2015,2015,1,1)))
+  }
+
+  test("test to check column ordering in parent and child table") {
+    sql("drop table if exists partitionone")
+    sql(
+      """
+        | CREATE TABLE if not exists partitionone (empname String, age int)
+        | PARTITIONED BY (year int, month int,day int)
+        | STORED BY 'org.apache.carbondata.format'
+      """.stripMargin)
+    sql("drop datamap if exists p1")
+    sql("create datamap p1 on table partitionone using 'mv' as select empname,  year, sum(year),month,day from partitionone group by empname, month, year,day")
+    val parentTable = CarbonEnv.getCarbonTable(Some("partition_mv"), "partitionone")(sqlContext.sparkSession)
+    val childTable = CarbonEnv.getCarbonTable(Some("partition_mv"), "p1_table")(sqlContext.sparkSession)
+    val parentPartitionColumns = parentTable.getPartitionInfo.getColumnSchemaList
+    val childPartitionColumns = childTable.getPartitionInfo.getColumnSchemaList
+    assert(parentPartitionColumns.asScala.zip(childPartitionColumns.asScala).forall {
+      case (a,b) =>
+        a.getColumnName
+          .equalsIgnoreCase(b.getColumnName
+            .substring(b.getColumnName.lastIndexOf("_") + 1, b.getColumnName.length))
+    })
+  }
+
+  test("test data after minor compaction on partition table with mv") {
+    sql("drop table if exists partitionone")
+    sql(
+      """
+        | CREATE TABLE if not exists partitionone (empname String, age int)
+        | PARTITIONED BY (year int, month int,day int)
+        | STORED BY 'org.apache.carbondata.format'
+      """.stripMargin)
+    sql("drop datamap if exists p1")
+    sql("create datamap p1 on table partitionone using 'mv' as select empname,  year, sum(year),month,day from partitionone group by empname, year, month,day")
+    sql("insert into partitionone values('k',2,2014,1,1)")
+    sql("insert into partitionone values('k',2,2014,1,2)")
+    sql("insert into partitionone values('k',2,2014,1,1)")
+    sql("insert into partitionone values('k',2,2015,2,1)")
+    sql("alter table partitionone compact 'minor'")
+    val showSegments = sql("show segments for table partitionone").collect().map{a=> (a.get(0), a.get(1))}
+    assert(showSegments.count(_._2 == "Success") == 1)
+    assert(showSegments.count(_._2 == "Compacted") == 4)
+    assert(CarbonEnv.getCarbonTable(Some("partition_mv"), "p1_table")(sqlContext.sparkSession).isHivePartitionTable)
+  }
+
+  test("test data after major compaction on partition table with mv") {
+    sql("drop table if exists partitionone")
+    sql(
+      """
+        | CREATE TABLE if not exists partitionone (empname String, age int)
+        | PARTITIONED BY (year int, month int,day int)
+        | STORED BY 'org.apache.carbondata.format'
+      """.stripMargin)
+    sql("drop datamap if exists p1")
+    sql("create datamap p1 on table partitionone using 'mv' as select empname,  year, sum(year),month,day from partitionone group by empname, year, month,day")
+    sql("insert into partitionone values('k',2,2014,1,1)")
+    sql("insert into partitionone values('k',2,2014,1,2)")
+    sql("insert into partitionone values('k',2,2014,1,1)")
+    sql("insert into partitionone values('k',2,2015,2,1)")
+    sql("insert into partitionone values('k',2,2015,2,1)")
+    sql("alter table partitionone compact 'major'")
+    val showSegments = sql("show segments for table partitionone").collect().map{a=> (a.get(0), a.get(1))}
+    assert(showSegments.count(_._2 == "Success") == 1)
+    assert(showSegments.count(_._2 == "Compacted") == 5)
+  }
+
+  test("test drop partition 1") {
+    sql("drop table if exists partitionone")
+    sql(
+      """
+        | CREATE TABLE if not exists partitionone (empname String, age int)
+        | PARTITIONED BY (year int, month int,day int)
+        | STORED BY 'org.apache.carbondata.format'
+      """.stripMargin)
+    sql("drop datamap if exists p1")
+    sql("create datamap p1 on table partitionone using 'mv' as select empname,  year, sum(year),month,day from partitionone group by empname, year, month, day")
+    sql("insert into partitionone values('k',2,2014,1,1)")
+    sql("insert into partitionone values('k',2,2014,1,2)")
+    sql("insert into partitionone values('k',2,2014,1,1)")
+    sql("insert into partitionone values('k',2,2015,2,1)")
+    sql("insert into partitionone values('k',2,2015,2,1)")
+    sql("alter table partitionone drop partition(day=1)")
+    checkAnswer(sql("select * from partitionone"), Seq(Row("k",2,2014,1,2)))
+    checkAnswer(sql("select * from p1_table"), Seq(Row("k",2014,2014,1,2)))
+  }
+
+  test("test drop partition 2") {
+    sql("drop table if exists partitionone")
+    sql(
+      """
+        | CREATE TABLE if not exists partitionone (empname String, age int)
+        | PARTITIONED BY (year int, month int,day int)
+        | STORED BY 'org.apache.carbondata.format'
+      """.stripMargin)
+    sql("drop datamap if exists p1")
+    sql("create datamap p1 on table partitionone using 'mv' as select empname,  year, sum(year),month,day from partitionone group by empname, year, month, day")
+    sql("insert into partitionone values('k',2,2014,1,1)")
+    sql("insert into partitionone values('k',2,2014,1,2)")
+    sql("insert into partitionone values('k',2,2014,1,1)")
+    sql("insert into partitionone values('k',2,2015,2,3)")
+    sql("insert into partitionone values('k',2,2015,2,1)")
+    sql("alter table partitionone drop partition(day=1)")
+    checkAnswer(sql("select * from partitionone"), Seq(Row("k",2,2014,1,2), Row("k",2,2015,2,3)))
+    checkAnswer(sql("select * from p1_table"), Seq(Row("k",2014,2014,1,2), Row("k",2015,2015,2,3)))
+  }
+
+  test("test drop partition directory") {
+    sql("drop table if exists droppartition")
+    sql(
+      """
+        | CREATE TABLE if not exists droppartition (empname String, age int)
+        | PARTITIONED BY (year int, month int,day int)
+        | STORED BY 'org.apache.carbondata.format'
+      """.stripMargin)
+    sql("drop datamap if exists p1")
+    sql("create datamap p1 using 'mv' as select empname,  year, sum(year),month,day from droppartition group by empname, year, month, day")
+    sql("insert into droppartition values('k',2,2014,1,1)")
+    sql("insert into droppartition values('k',2,2015,2,3)")
+    sql("alter table droppartition drop partition(year=2015,month=2,day=3)")
+    sql("clean files for table droppartition")
+    val table = CarbonEnv.getCarbonTable(Option("partition_mv"), "droppartition")(sqlContext.sparkSession)
+    val dataMapTable = CarbonEnv.getCarbonTable(Option("partition_mv"), "droppartition")(sqlContext.sparkSession)
+    val dataMaptablePath = dataMapTable.getTablePath
+    val tablePath = table.getTablePath
+    val carbonFiles = FileFactory.getCarbonFile(tablePath).listFiles().filter{
+      file => file.getName.equalsIgnoreCase("year=2015")
+    }
+    val dataMapCarbonFiles = FileFactory.getCarbonFile(dataMaptablePath).listFiles().filter{
+      file => file.getName.equalsIgnoreCase("year=2015")
+    }
+    assert(dataMapCarbonFiles.length == 0)
+    assert(carbonFiles.length == 0)
+  }
+
+  test("test data with filter query") {
+    sql("drop table if exists partitionone")
+    sql(
+      """
+        | CREATE TABLE if not exists partitionone (empname String, age int)
+        | PARTITIONED BY (year int, month int,day int)
+        | STORED BY 'org.apache.carbondata.format'
+      """.stripMargin)
+    sql("drop datamap if exists p1")
+    sql("create datamap p1 on table partitionone using 'mv' as select empname,  year, sum(year),month,day from partitionone group by empname, year, month, day")
+    sql("insert into partitionone values('k',2,2014,1,1)")
+    sql("insert into partitionone values('k',2,2014,1,2)")
+    sql("insert into partitionone values('k',2,2014,1,1)")
+    sql("insert into partitionone values('k',2,2015,2,3)")
+    sql("insert into partitionone values('k',2,2015,2,1)")
+    sql("alter table partitionone drop partition(day=1)")
+    checkAnswer(sql("select empname, sum(year) from partitionone where day=3 group by empname, year, month, day"), Seq(Row("k",2015)))
+    checkAnswer(sql("select * from p1_table"), Seq(Row("k",2014,2014,1,2), Row("k",2015,2015,2,3)))
+  }
+
+  test("test drop partition 3") {
+    sql("drop table if exists partitionone")
+    sql(
+      """
+        | CREATE TABLE if not exists partitionone (empname String,age int)
+        | PARTITIONED BY (year int, month int,day int)
+        | STORED BY 'org.apache.carbondata.format'
+      """.stripMargin)
+    sql("drop datamap if exists p1")
+    sql("create datamap p1 on table partitionone using 'mv' as select empname,  year, sum(year),month,day from partitionone group by empname, year, month, day")
+    sql("insert into partitionone values('k',2,2014,1,1)")
+    sql("insert into partitionone values('k',2,2014,1,2)")
+    sql("insert into partitionone values('k',2,2014,1,1)")
+    sql("insert into partitionone values('k',2,2015,2,3)")
+    sql("insert into partitionone values('k',2,2015,2,1)")
+    sql("alter table partitionone drop partition(day=1,month=1)")
+    checkAnswer(sql("select * from partitionone"), Seq(Row("k",2,2014,1,2), Row("k",2,2015, 2,3), Row("k",2,2015, 2,1)))
+    checkAnswer(sql("select * from p1_table"), Seq(Row("k",2014,2014,1,2), Row("k",2015,2015,2,3), Row("k",2015,2015,2,1)))
+  }
+
+  test("test drop partition 4") {
+    sql("drop table if exists partitionone")
+    sql(
+      """
+        | CREATE TABLE if not exists partitionone (empname String, age int)
+        | PARTITIONED BY (year int, month int,day int)
+        | STORED BY 'org.apache.carbondata.format'
+      """.stripMargin)
+    sql("drop datamap if exists p1")
+    sql("create datamap p1 on table partitionone using 'mv' as select empname,  year, sum(year),month,day from partitionone group by empname, year, month, day")
+    sql("insert into partitionone values('k',2,2014,1,1)")
+    sql("insert into partitionone values('k',2,2014,1,2)")
+    sql("insert into partitionone values('k',2,2014,1,1)")
+    sql("insert into partitionone values('k',2,2015,2,3)")
+    sql("insert into partitionone values('k',2,2015,2,1)")
+    sql("alter table partitionone drop partition(year=2014,day=1)")
+    checkAnswer(sql("select * from partitionone"), Seq(Row("k",2,2014,1,2), Row("k",2,2015, 2,3), Row("k",2,2015, 2,1)))
+    checkAnswer(sql("select * from p1_table"), Seq(Row("k",2014,2014,1,2), Row("k",2015,2015, 2,3), Row("k",2015,2015, 2,1)))
+  }
+
+  test("test drop partition 5") {
+    sql("drop table if exists partitionone")
+    sql(
+      """
+        | CREATE TABLE if not exists partitionone (empname String, age int)
+        | PARTITIONED BY (year int, month int,day int)
+        | STORED BY 'org.apache.carbondata.format'
+      """.stripMargin)
+    sql("drop datamap if exists p1")
+    sql("create datamap p1 on table partitionone using 'mv' as select empname,  year, sum(year),month,day from partitionone group by empname, year, month, day")
+    sql("insert into partitionone values('k',2,2014,1,1)")
+    sql("insert into partitionone values('k',2,2014,1,2)")
+    sql("insert into partitionone values('k',2,2014,1,1)")
+    sql("insert into partitionone values('k',2,2015,2,3)")
+    sql("insert into partitionone values('k',2,2015,2,1)")
+    sql("alter table partitionone drop partition(year=2014,month=1, day=1)")
+
+    checkAnswer(sql("select * from partitionone"), Seq(Row("k",2,2014,1,2), Row("k",2,2015, 2,3), Row("k",2,2015, 2,1)))
+    checkAnswer(sql("select * from p1_table"), Seq(Row("k",2014,2014,1,2), Row("k",2015,2015,2,3), Row("k",2015,2015,2,1)))
+  }
+
+  test("test drop partition 6") {
+    sql("drop table if exists partitionone")
+    sql(
+      """
+        | CREATE TABLE if not exists partitionone (empname String, age int)
+        | PARTITIONED BY (year int, month int,day int)
+        | STORED BY 'org.apache.carbondata.format'
+      """.stripMargin)
+    sql("drop datamap if exists p1")
+    sql("create datamap p1 on table partitionone using 'mv' as select empname,  year, sum(year),month,day from partitionone group by empname, year, month, day")
+    sql("insert into partitionone values('k',2,2014,1,1)")
+    sql("insert into partitionone values('k',2,2014,1,2)")
+    sql("insert into partitionone values('k',2,2014,1,1)")
+    sql("insert into partitionone values('k',2,2015,2,3)")
+    sql("insert into partitionone values('k',2,2015,2,1)")
+    sql("alter table partitionone drop partition(year=2014,month=1, day=1)")
+    checkAnswer(sql("select * from partitionone"), Seq(Row("k",2,2014,1,2), Row("k",2,2015, 2,3), Row("k",2,2015, 2,1)))
+    checkAnswer(sql("select * from p1_table"), Seq(Row("k",2014,2014,1,2), Row("k",2015,2015,2,3), Row("k",2015,2015,2,1)))
+  }
+
+  test("test drop partition 7") {
+    sql("drop table if exists partitionone")
+    sql(
+      """
+        | CREATE TABLE if not exists partitionone (empname String,age int)
+        | PARTITIONED BY (year int, month int,day int)
+        | STORED BY 'org.apache.carbondata.format'
+      """.stripMargin)
+    sql("drop datamap if exists p1")
+    sql("drop datamap if exists p2")
+    sql(
+      "create datamap p1 on table partitionone using 'mv' as select empname, year,sum(year),day from partitionone group by empname, year, day")
+    sql(
+      "create datamap p2 on table partitionone using 'mv' as select empname, month,sum(year) from partitionone group by empname, month")
+    sql("insert into partitionone values('k',2,2014,1,1)")
+    sql("insert into partitionone values('k',2,2014,1,2)")
+
+        val exceptionMessage = intercept[Exception] {
+      sql("alter table partitionone drop partition(year=2014,month=1, day=1)")
+    }.getMessage
+    assert(exceptionMessage.contains("Cannot drop partition as one of the partition"))
+    assert(exceptionMessage.contains("p2"))
+    assert(exceptionMessage.contains("p1"))
+  }
+
+  test("test drop partition 8") {
+    sql("drop table if exists partitionone")
+    sql(
+      """
+        | CREATE TABLE if not exists partitionone (empname String, age int)
+        | PARTITIONED BY (year int, month int,day int)
+        | STORED BY 'org.apache.carbondata.format'
+      """.stripMargin)
+    sql("drop datamap if exists p1")
+    sql("drop datamap if exists p2")
+    sql("drop datamap if exists p3")
+    sql(
+      "create datamap p1 on table partitionone using 'mv' as select empname, year,month,sum(year) from partitionone group by empname, year, month")
+    sql(
+      "create datamap p2 on table partitionone using 'mv' as select empname, month, day, sum(year) from partitionone group by empname, month, day")
+    sql(
+      "create datamap p3 on table partitionone using 'mv' as select empname,month,sum(year) from partitionone group by empname, month")
+    sql("insert into partitionone values('k',2,2014,1,1)")
+    sql("insert into partitionone values('k',2,2014,1,2)")
+    val exceptionMessage = intercept[Exception] {
+      sql("alter table partitionone drop partition(year=2014,month=1, day=1)")
+    }.getMessage
+    assert(exceptionMessage.contains("Cannot drop partition as one of the partition"))
+    assert(!exceptionMessage.contains("p2"))
+    assert(exceptionMessage.contains("p3"))
+    assert(exceptionMessage.contains("p1"))
+  }
+
+  test("test drop partition 9") {
+    sql("drop table if exists partitionone")
+    sql(
+      """
+        | CREATE TABLE if not exists partitionone (empname String)
+        | PARTITIONED BY (year int, month int,day int)
+        | STORED BY 'org.apache.carbondata.format'
+      """.stripMargin)
+    sql("drop datamap if exists p1")
+    sql(
+      "create datamap p1 on table partitionone using 'mv' as select empname, sum(year) from partitionone group by empname")
+    sql("insert into partitionone values('k',2014,1,1)")
+    sql("insert into partitionone values('k',2014,1,2)")
+    val exceptionMessage = intercept[Exception] {
+      sql("alter table partitionone drop partition(year=2014,month=1, day=1)")
+    }.getMessage
+    assert(exceptionMessage.contains("Cannot drop partition as one of the partition"))
+    assert(exceptionMessage.contains("p1"))
+  }
+
+  test("test drop partition 10") {
+    sql("drop table if exists partitionone")
+    sql(
+      """
+        | CREATE TABLE if not exists partitionone (empname String, age int)
+        | PARTITIONED BY (year int, month int,day int)
+        | STORED BY 'org.apache.carbondata.format'
+      """.stripMargin)
+    sql("drop datamap if exists p1")
+    sql("drop datamap if exists p2")
+    sql(
+      "create datamap p1 on table partitionone using 'mv' as select empname, sum(year) from partitionone group by empname")
+    sql(
+      "create datamap p2 on table partitionone using 'mv' as select empname, year,sum(year),month,day from partitionone group by empname, year, month, day")
+    sql("insert into partitionone values('k',2,2014,1,1)")
+    sql("insert into partitionone values('k',2,2014,1,2)")
+    val exceptionMessage = intercept[Exception] {
+      sql("alter table partitionone drop partition(year=2014,month=1, day=1)")
+    }.getMessage
+    assert(exceptionMessage.contains("Cannot drop partition as one of the partition"))
+    assert(exceptionMessage.contains("p1"))
+    sql("drop datamap p1 on table partitionone")
+    sql("alter table partitionone drop partition(year=2014,month=1, day=1)")
+  }
+
+  test("test drop partition 11") {
+    sql("drop table if exists partitionone")
+    sql(
+      """
+        | CREATE TABLE if not exists partitionone (empname String)
+        | PARTITIONED BY (year int, month int,day int)
+        | STORED BY 'org.apache.carbondata.format'
+      """.stripMargin)
+    sql("drop datamap if exists p1")
+    sql(
+      "create datamap p1 on table partitionone using 'mv' as select empname, year, sum(year) from partitionone group by empname, year")
+    sql("insert into partitionone values('k',2014,1,1)")
+    val exceptionMessage = intercept[Exception] {
+      sql("alter table p1_table drop partition(partitionone_year=1)")
+    }.getMessage
+    assert(exceptionMessage.contains("Cannot drop partition directly on child table"))
+  }
+
+  test("test drop partition 12") {
+    sql("drop table if exists partitionone")
+    sql(
+      """
+        | CREATE TABLE if not exists partitionone (empname String)
+        | PARTITIONED BY (year int, month int,day int)
+        | STORED BY 'org.apache.carbondata.format'
+      """.stripMargin)
+    sql("drop datamap if exists p1")
+    sql(
+      "create datamap p1 on table partitionone using 'mv' as select empname, sum(year) from partitionone group by empname")
+    sql("insert into partitionone values('k',2014,1,1)")
+    val exceptionMessage = intercept[Exception] {
+      sql("alter table p1_table drop partition(year=2014)")
+    }.getMessage
+    assert(exceptionMessage.contains("operation failed for partition_mv.p1_table: Not a partitioned table"))
+  }
+
+  test("test add partition on mv table") {
+    sql("drop table if exists partitionone")
+    sql(
+      """
+        | CREATE TABLE if not exists partitionone (empname String)
+        | PARTITIONED BY (year int, month int,day int)
+        | STORED BY 'org.apache.carbondata.format'
+      """.stripMargin)
+    sql("drop datamap if exists p1")
+    sql(
+      "create datamap p1 on table partitionone using 'mv' as select empname, sum(year) from partitionone group by empname")
+    assert(intercept[Exception] {
+      sql("alter table p1_table add partition(c=1)")
+    }.getMessage.equals("Cannot add partition directly on non partitioned table"))
+  }
+
+  test("test if alter rename is blocked on partition table with mv") {
+    sql("drop table if exists partitionone")
+    sql(
+      """
+        | CREATE TABLE if not exists partitionone (empname String, id int)
+        | PARTITIONED BY (year int, month int,day int)
+        | STORED BY 'org.apache.carbondata.format'
+      """.stripMargin)
+    sql("drop datamap if exists p1")
+    sql(
+      "create datamap p1 on table partitionone using 'mv' as select empname, sum(year) from partitionone group by empname")
+    intercept[Exception] {
+      sql("alter table partitionone rename to p")
+    }
+  }
+
+  test("test dropping partition which has already been deleted") {
+    sql("drop table if exists partitiontable")
+    sql("create table partitiontable(id int,name string) partitioned by (email string) " +
+        "stored by 'carbondata' tblproperties('sort_scope'='global_sort')")
+    sql("insert into table partitiontable select 1,'huawei','abc'")
+    sql("create datamap ag1 on table partitiontable using 'mv' as select count(email),id" +
+        " from partitiontable group by id")
+    sql("create datamap ag2 on table partitiontable using 'mv' as select sum(email),name" +
+        " from partitiontable group by name")
+    sql("create datamap ag3 on table partitiontable using 'mv' as select max(email),name" +
+        " from partitiontable group by name")
+    sql("create datamap ag4 on table partitiontable using 'mv' as select min(email),name" +
+        " from partitiontable group by name")
+    sql("create datamap ag5 on table partitiontable using 'mv' as select avg(email),name" +
+        " from partitiontable group by name")
+    sql("alter table partitiontable add partition (email='def')")
+    sql("insert into table partitiontable select 1,'huawei','def'")
+    sql("drop datamap ag1 on table partitiontable")
+    sql("drop datamap ag2 on table partitiontable")
+    sql("drop datamap ag3 on table partitiontable")
+    sql("drop datamap ag4 on table partitiontable")
+    sql("drop datamap ag5 on table partitiontable")
+    sql("alter table partitiontable drop partition(email='def')")
+    assert(intercept[Exception] {
+      sql("alter table partitiontable drop partition(email='def')")
+    }.getMessage.contains("No partition is dropped. One partition spec 'Map(email -> def)' does not exist in table 'partitiontable' database 'partition_mv'"))
+    sql("drop table if exists partitiontable")
+  }
+
+  test("test mv table creation with count(*) on Partition table") {
+    sql("drop table if exists partitiontable")
+    sql("create table partitiontable(id int,name string) partitioned by (email string) " +
+        "stored by 'carbondata' tblproperties('sort_scope'='global_sort')")
+    sql("insert into table partitiontable select 1,'huawei','abc'")
+    sql("drop datamap if exists ag1")
+    sql("create datamap ag1 on table partitiontable using 'mv' as select count(*),id" +
+        " from partitiontable group by id")
+    sql("insert into table partitiontable select 1,'huawei','def'")
+    assert(sql("show datamap on table partitiontable").collect().head.get(0).toString.equalsIgnoreCase("ag1"))
+    sql("drop datamap ag1 on table partitiontable")
+  }
+
+  test("test blocking partitioning of mv table") {
+    sql("drop table if exists updatetime_8")
+    sql("create table updatetime_8" +
+        "(countryid smallint,hs_len smallint,minstartdate string,startdate string,newdate string,minnewdate string) partitioned by (imex smallint) stored by 'carbondata' tblproperties('sort_scope'='global_sort','sort_columns'='countryid,imex,hs_len,minstartdate,startdate,newdate,minnewdate','table_blocksize'='256')")
+    sql("drop datamap if exists ag")
+    sql("create datamap ag on table updatetime_8 using 'mv' dmproperties('partitioning'='false') as select imex,sum(hs_len) from updatetime_8 group by imex")
+    val carbonTable = CarbonEnv.getCarbonTable(Some("partition_mv"), "ag_table")(sqlContext.sparkSession)
+    assert(!carbonTable.isHivePartitionTable)
+    sql("drop table if exists updatetime_8")
+  }
+
+  test("Test data updation after compaction on Partition with mv tables") {
+    sql("drop table if exists partitionallcompaction")
+    sql(
+      "create table partitionallcompaction(empno int,empname String,designation String," +
+      "workgroupcategory int,workgroupcategoryname String,deptno int,projectjoindate timestamp," +
+      "projectenddate date,attendance int,utilization int,salary int) partitioned by (deptname " +
+      "String,doj timestamp,projectcode int) stored  by 'carbondata' tblproperties" +
+      "('sort_scope'='global_sort')")
+    sql(
+      "create datamap sensor_1 on table partitionallcompaction using 'mv' as select " +
+      "sum(salary),doj, deptname,projectcode from partitionallcompaction group by doj," +
+      "deptname,projectcode")
+    sql(
+      s"""LOAD DATA local inpath '$resourcesPath/data.csv' OVERWRITE INTO TABLE
+         |partitionallcompaction OPTIONS('DELIMITER'= ',', 'QUOTECHAR'= '"')""".stripMargin)
+    sql(
+      s"""LOAD DATA local inpath '$resourcesPath/data.csv' OVERWRITE INTO TABLE
+         |partitionallcompaction OPTIONS('DELIMITER'= ',', 'QUOTECHAR'= '"')""".stripMargin)
+    sql(
+      s"""LOAD DATA local inpath '$resourcesPath/data.csv' OVERWRITE INTO TABLE
+         |partitionallcompaction PARTITION(deptname='Learning', doj, projectcode) OPTIONS
+         |('DELIMITER'= ',', 'QUOTECHAR'= '"') """.stripMargin)
+    sql(
+      s"""LOAD DATA local inpath '$resourcesPath/data.csv' OVERWRITE INTO TABLE
+         |partitionallcompaction PARTITION(deptname='configManagement', doj, projectcode) OPTIONS
+         |('DELIMITER'= ',', 'QUOTECHAR'= '"')""".stripMargin)
+    sql(
+      s"""LOAD DATA local inpath '$resourcesPath/data.csv' OVERWRITE INTO TABLE
+         |partitionallcompaction PARTITION(deptname='network', doj, projectcode) OPTIONS
+         |('DELIMITER'= ',', 'QUOTECHAR'= '"')""".stripMargin)
+    sql(
+      s"""LOAD DATA local inpath '$resourcesPath/data.csv' OVERWRITE INTO TABLE
+         |partitionallcompaction PARTITION(deptname='protocol', doj, projectcode) OPTIONS
+         |('DELIMITER'= ',', 'QUOTECHAR'= '"')""".stripMargin)
+    sql(
+      s"""LOAD DATA local inpath '$resourcesPath/data.csv' OVERWRITE INTO TABLE
+         |partitionallcompaction PARTITION(deptname='security', doj, projectcode) OPTIONS
+         |('DELIMITER'= ',', 'QUOTECHAR'= '"')""".stripMargin)
+    sql("ALTER TABLE partitionallcompaction COMPACT 'MINOR'").collect()
+    checkAnswer(sql("select count(empno) from partitionallcompaction where empno=14"),
+      Seq(Row(5)))
+    sql("drop table if exists partitionallcompaction")
+  }
+
+  test("Test data updation in Aggregate query after compaction on Partitioned table with mv table") {
+    sql("drop table if exists updatetime_8")
+    sql("create table updatetime_8" +
+        "(countryid smallint,hs_len smallint,minstartdate string,startdate string,newdate string,minnewdate string) partitioned by (imex smallint) stored by 'carbondata' tblproperties('sort_scope'='global_sort','sort_columns'='countryid,imex,hs_len,minstartdate,startdate,newdate,minnewdate','table_blocksize'='256')")
+    sql("drop datamap if exists ag")
+    sql("create datamap ag on table updatetime_8 using 'mv' as select sum(hs_len), imex from updatetime_8 group by imex")
+    sql("insert into updatetime_8 select 21,20,'fbv','gbv','wvsw','vwr',23")
+    sql("insert into updatetime_8 select 21,20,'fbv','gbv','wvsw','vwr',24")
+    sql("insert into updatetime_8 select 21,20,'fbv','gbv','wvsw','vwr',23")
+    sql("insert into updatetime_8 select 21,21,'fbv','gbv','wvsw','vwr',24")
+    sql("insert into updatetime_8 select 21,21,'fbv','gbv','wvsw','vwr',24")
+    sql("insert into updatetime_8 select 21,21,'fbv','gbv','wvsw','vwr',24")
+    sql("insert into updatetime_8 select 21,21,'fbv','gbv','wvsw','vwr',25")
+    sql("insert into updatetime_8 select 21,21,'fbv','gbv','wvsw','vwr',25")
+    sql("alter table updatetime_8 compact 'minor'")
+    sql("alter table updatetime_8 compact 'minor'")
+    checkAnswer(sql("select sum(hs_len) from updatetime_8 group by imex"),Seq(Row(40),Row(42),Row(83)))
+  }
+
+  test("check partitioning for child tables with various combinations") {
+    sql("drop table if exists partitionone")
+    sql(
+      """
+        | CREATE TABLE if not exists partitionone (empname String, id int)
+        | PARTITIONED BY (year int, month int,day int)
+        | STORED BY 'org.apache.carbondata.format'
+      """.stripMargin)
+    sql(
+      "create datamap p7 on table partitionone using 'mv' as select empname, year, day, sum(year), sum(day) from partitionone group by empname, year, day")
+    sql(
+      "create datamap p1 on table partitionone using 'mv' as select empname, sum(year) from partitionone group by empname")
+    sql(
+      "create datamap p2 on table partitionone using 'mv' as select empname, year,sum(year) from partitionone group by empname, year")
+    sql(
+      "create datamap p3 on table partitionone using 'mv' as select empname, year, month, sum(year), sum(month) from partitionone group by empname, year, month")
+    sql(
+      "create datamap p4 on table partitionone using 'mv' as select empname, year,month,day,sum(year) from partitionone group by empname, year, month, day")
+    sql(
+      "create datamap p5 on table partitionone using 'mv' as select empname, month,sum(year) from partitionone group by empname, month")
+    sql(
+      "create datamap p6 on table partitionone using 'mv' as select empname, month, day, sum(year), sum(month) from partitionone group by empname, month, day")
+    assert(!CarbonEnv.getCarbonTable(Some("partition_mv"),"p1_table")(sqlContext.sparkSession).isHivePartitionTable)
+    assert(CarbonEnv.getCarbonTable(Some("partition_mv"),"p2_table")(sqlContext.sparkSession).getPartitionInfo.getColumnSchemaList.size() == 1)
+    assert(CarbonEnv.getCarbonTable(Some("partition_mv"),"p3_table")(sqlContext.sparkSession).getPartitionInfo.getColumnSchemaList.size == 2)
+    assert(CarbonEnv.getCarbonTable(Some("partition_mv"),"p4_table")(sqlContext.sparkSession).getPartitionInfo.getColumnSchemaList.size == 3)
+    assert(!CarbonEnv.getCarbonTable(Some("partition_mv"),"p5_table")(sqlContext.sparkSession).isHivePartitionTable)
+    assert(!CarbonEnv.getCarbonTable(Some("partition_mv"),"p6_table")(sqlContext.sparkSession).isHivePartitionTable)
+    assert(!CarbonEnv.getCarbonTable(Some("partition_mv"),"p7_table")(sqlContext.sparkSession).isHivePartitionTable)
+    sql("drop table if exists partitionone")
+  }
+
+  def verifyMVDataMap(logicalPlan: LogicalPlan, dataMapName: String): Boolean = {
+    val tables = logicalPlan collect {
+      case l: LogicalRelation => l.catalogTable.get
+    }
+    tables.exists(_.identifier.table.equalsIgnoreCase(dataMapName + "_table"))
+  }
+
+}

--- a/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/TestPartitionWithMV.scala
+++ b/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/TestPartitionWithMV.scala
@@ -668,6 +668,16 @@ class TestPartitionWithMV extends QueryTest with BeforeAndAfterAll {
     sql("drop table if exists partitionone")
   }
 
+  test("test partition at last column") {
+    sql("drop table if exists partitionone")
+    sql("create table partitionone(a int,b int) partitioned by (c int) stored by 'carbondata'")
+    sql("insert into partitionone values(1,2,3)")
+    sql("drop datamap if exists dm1")
+    sql("create datamap dm1 on table partitionone using 'mv' as select c,sum(b) from partitionone group by c")
+    checkAnswer(sql("select c,sum(b) from partitionone group by c"), Seq(Row(3,2)))
+    sql("drop table if exists partitionone")
+  }
+
   def verifyMVDataMap(logicalPlan: LogicalPlan, dataMapName: String): Boolean = {
     val tables = logicalPlan collect {
       case l: LogicalRelation => l.catalogTable.get

--- a/datamap/mv/plan/pom.xml
+++ b/datamap/mv/plan/pom.xml
@@ -72,7 +72,7 @@
           <systemProperties>
             <java.awt.headless>true</java.awt.headless>
           </systemProperties>
-          <testFailureIgnore>false</testFailureIgnore>
+          <!-- testFailureIgnore>false</testFailureIgnore -->
           <failIfNoTests>false</failIfNoTests>
         </configuration>
       </plugin>

--- a/datamap/mv/plan/src/main/scala/org/apache/carbondata/mv/plans/util/BirdcageOptimizer.scala
+++ b/datamap/mv/plan/src/main/scala/org/apache/carbondata/mv/plans/util/BirdcageOptimizer.scala
@@ -96,7 +96,9 @@ object BirdcageOptimizer extends RuleExecutor[LogicalPlan] {
         //      OptimizeIn(conf),
         ConstantFolding,
         ReorderAssociativeOperator,
-        LikeSimplification,
+        // No need to apply LikeSimplification rule while creating datamap
+        // as modular plan asCompactSql will be set in datamapschema
+        //        LikeSimplification,
         BooleanSimplification,
         SimplifyConditionals,
         RemoveDispensableExpressions,

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datamap/TestDataMapCommand.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datamap/TestDataMapCommand.scala
@@ -229,9 +229,9 @@ class TestDataMapCommand extends QueryTest with BeforeAndAfterAll {
        """.stripMargin)
     var result = sql(s"show datamap on table $tableName").cache()
     checkAnswer(sql(s"show datamap on table $tableName"),
-      Seq(Row(datamapName, "bloomfilter", s"default.$tableName", "'bloom_fpp'='0.001', 'bloom_size'='32000', 'index_columns'='a'"),
-        Row(datamapName2, "bloomfilter", s"default.$tableName", "'index_columns'='b'"),
-        Row(datamapName3, "bloomfilter", s"default.$tableName", "'index_columns'='c'")))
+      Seq(Row(datamapName, "bloomfilter", s"default.$tableName", "'bloom_fpp'='0.001', 'bloom_size'='32000', 'index_columns'='a'", "ENABLED", "NA"),
+        Row(datamapName2, "bloomfilter", s"default.$tableName", "'index_columns'='b'","ENABLED", "NA"),
+        Row(datamapName3, "bloomfilter", s"default.$tableName", "'index_columns'='c'", "ENABLED", "NA")))
     result.unpersist()
     sql(s"drop table if exists $tableName")
 
@@ -248,7 +248,7 @@ class TestDataMapCommand extends QueryTest with BeforeAndAfterAll {
          | GROUP BY mytime
        """.stripMargin)
     checkAnswer(sql(s"show datamap on table $tableName"),
-      Seq(Row("agg0_hour", "timeSeries", s"default.${tableName}_agg0_hour", "'event_time'='mytime', 'hour_granularity'='1'")))
+      Seq(Row("agg0_hour", "timeSeries", s"default.${tableName}_agg0_hour", "'event_time'='mytime', 'hour_granularity'='1'","NA", "NA")))
     sql(s"drop table if exists $tableName")
 
     // for preaggreate datamap, the property is empty
@@ -262,7 +262,7 @@ class TestDataMapCommand extends QueryTest with BeforeAndAfterAll {
          | FROM $tableName GROUP BY name
          | """.stripMargin)
     checkAnswer(sql(s"show datamap on table $tableName"),
-      Seq(Row("agg0", "preaggregate", s"default.${tableName}_agg0", "")))
+      Seq(Row("agg0", "preaggregate", s"default.${tableName}_agg0", "","NA","NA")))
     sql(s"drop table if exists $tableName")
   }
 

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/standardpartition/StandardPartitionWithPreaggregateTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/standardpartition/StandardPartitionWithPreaggregateTestCase.scala
@@ -639,6 +639,16 @@ class StandardPartitionWithPreaggregateTestCase extends QueryTest with BeforeAnd
     assert(!CarbonEnv.getCarbonTable(Some("partition_preaggregate"),"partitionone_p7")(sqlContext.sparkSession).isHivePartitionTable)
   }
 
+  test("test partition at last column") {
+    sql("drop table if exists partitionone")
+    sql("create table partitionone(a int,b int) partitioned by (c int) stored by 'carbondata'")
+    sql("insert into partitionone values(1,2,3)")
+    sql("drop datamap if exists dm1")
+    sql("create datamap dm1 on table partitionone using 'preaggregate' as select c,sum(b) from partitionone group by c")
+    checkAnswer(sql("select c,sum(b) from partitionone group by c"), Seq(Row(3,2)))
+    sql("drop table if exists partitionone")
+  }
+
   def preAggTableValidator(plan: LogicalPlan, actualTableName: String) : Unit = {
     var isValidPlan = false
     plan.transform {

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
@@ -201,7 +201,10 @@ object CarbonEnv {
       .addListener(classOf[AlterTableColRenameAndDataTypeChangePreEvent],
         DataMapChangeDataTypeorRenameColumnPreListener)
       .addListener(classOf[AlterTableAddColumnPreEvent], DataMapAddColumnsPreListener)
-
+      .addListener(classOf[AlterTableDropPartitionMetaEvent],
+        DataMapAlterTableDropPartitionMetaListener)
+      .addListener(classOf[AlterTableDropPartitionPreStatusEvent],
+        DataMapAlterTableDropPartitionPreStatusListener)
   }
 
   /**

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/partition/CarbonAlterTableDropHivePartitionCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/partition/CarbonAlterTableDropHivePartitionCommand.scala
@@ -70,10 +70,6 @@ case class CarbonAlterTableDropHivePartitionCommand(
     table = CarbonEnv.getCarbonTable(tableName)(sparkSession)
     setAuditTable(table)
     setAuditInfo(Map("partition" -> specs.mkString(",")))
-    if (DataMapUtil.hasMVDataMap(table) || table.isChildTable) {
-      throw new MalformedCarbonCommandException(
-        "Drop Partition is not supported for datamap table or for tables which have child datamap")
-    }
     if (table.isHivePartitionTable) {
       var locks = List.empty[ICarbonLock]
       try {

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/preaaggregate/PreAggregateListeners.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/preaaggregate/PreAggregateListeners.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.parser.CarbonSpark2SqlParser
 import org.apache.carbondata.common.exceptions.MetadataProcessException
 import org.apache.carbondata.common.logging.{LogService, LogServiceFactory}
 import org.apache.carbondata.core.constants.CarbonCommonConstants
-import org.apache.carbondata.core.datamap.{DataMapStoreManager, DataMapUtil, Segment}
+import org.apache.carbondata.core.datamap.Segment
 import org.apache.carbondata.core.datastore.filesystem.{CarbonFile, CarbonFileFilter}
 import org.apache.carbondata.core.datastore.impl.FileFactory
 import org.apache.carbondata.core.locks.{CarbonLockUtil, ICarbonLock}

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/strategy/DDLStrategy.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/strategy/DDLStrategy.scala
@@ -326,6 +326,10 @@ class DDLStrategy(sparkSession: SparkSession) extends SparkStrategy {
               throw new MalformedCarbonCommandException(
                 "The table which has MV datamap does not support set streaming property")
             }
+            if (carbonTable.isChildTable) {
+              throw new MalformedCarbonCommandException(
+                "Datamap table does not support set streaming property")
+            }
           }
         }
         ExecutedCommandExec(CarbonAlterTableSetCommand(tableName, properties, isView)) :: Nil


### PR DESCRIPTION

This PR includes,
1. Support Partition with Mv Datamap [Datamap with single parent table]

2. Show DataMap status and ParentTable to Datamap table segment Sync Information with "SHOW DATAMAP" ddl

| DataMapName | ClassName | Associated Table | DataMap Properties     | DataMap Status | Sync Status                                                |
|-------------|-----------|------------------|------------------------|----------------|------------------------------------------------------------|
| dm          | mv        | default.dm_table | 'full_refresh'='false' | DISABLED       | {"default.maintable":"0","load_sync_time":"2019-05-21 01:11:29.857"} |

    Newly Added columns to "SHOW DATAMAP" ddl:
    1. DataMap Status - Displays whether datamap is disabled or enabled
    2. Sync status - Last segment Id of main table synced with datamap table and its load end time

3. Optimization for Incremental DataLoad.
    In case of below scenario we can avoid reloading the MV
    Maintable segments:0,1,2
    MV: 0 => 0,1,2
    Now after maintable compaction it will reload the 0.1 segment of maintable to MV, this is avoided by changing the mapping {0,1,2}=>{0.1}

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
    
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

