### PR TITLE
[CARBONDATA-3383] fix thrift version conflict bug in examples module

### DIFF
--- a/examples/spark2/pom.xml
+++ b/examples/spark2/pom.xml
@@ -35,9 +35,20 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.apache.thrift</groupId>
+      <artifactId>libthrift</artifactId>
+      <version>0.9.3</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.carbondata</groupId>
       <artifactId>carbondata-hive</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.thrift</groupId>
+          <artifactId>libthrift</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.carbondata</groupId>


### PR DESCRIPTION
Thrift version conflict in examples module, in example module needs carbondata-hive and carbondata-store-sdk, one version is 0.9.3 another is 0.9.2. This cause NPE when use carbondata-sdk write demo data.

[JIRA-3383](https://issues.apache.org/jira/browse/CARBONDATA-3383)

### Detail stackstrace
```
java.lang.NullPointerException
    at org.apache.thrift.protocol.TCompactProtocol.writeString(TCompactProtocol.java:356)
    at org.apache.carbondata.format.FileFooter3$FileFooter3StandardScheme.write(FileFooter3.java:1053)
    at org.apache.carbondata.format.FileFooter3$FileFooter3StandardScheme.write(FileFooter3.java:877)
    at org.apache.carbondata.format.FileFooter3.write(FileFooter3.java:768)
    at org.apache.carbondata.core.util.CarbonUtil.getByteArray(CarbonUtil.java:1444)
    at org.apache.carbondata.processing.store.writer.v3.CarbonFactDataWriterImplV3.writeFooterToFile(CarbonFactDataWriterImplV3.java:122)
    at org.apache.carbondata.processing.store.writer.v3.CarbonFactDataWriterImplV3.writeFooter(CarbonFactDataWriterImplV3.java:415)
    at org.apache.carbondata.processing.store.CarbonFactDataHandlerColumnar.closeHandler(CarbonFactDataHandlerColumnar.java:502)
    at org.apache.carbondata.processing.loading.steps.CarbonRowDataWriterProcessorStepImpl.processingComplete(CarbonRowDataWriterProcessorStepImpl.java:234)
    at org.apache.carbondata.processing.loading.steps.CarbonRowDataWriterProcessorStepImpl.finish(CarbonRowDataWriterProcessorStepImpl.java:212)
    at org.apache.carbondata.processing.loading.steps.CarbonRowDataWriterProcessorStepImpl.doExecute(CarbonRowDataWriterProcessorStepImpl.java:179)
    at org.apache.carbondata.processing.loading.steps.CarbonRowDataWriterProcessorStepImpl.execute(CarbonRowDataWriterProcessorStepImpl.java:133)
    at org.apache.carbondata.processing.loading.DataLoadExecutor.execute(DataLoadExecutor.java:52)
    at org.apache.carbondata.hadoop.api.CarbonTableOutputFormat$1.run(CarbonTableOutputFormat.java:274)
    at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
    at java.util.concurrent.FutureTask.run(FutureTask.java:266)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
    at java.lang.Thread.run(Thread.java:748)
```

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 
 - [x] Any backward compatibility impacted?
 
 - [x] Document update required?

 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

