### PR TITLE
[HOTFIX] fix valid log4j config in example module

### DIFF
--- a/examples/spark2/src/main/resources/log4j.properties
+++ b/examples/spark2/src/main/resources/log4j.properties
@@ -1,7 +1,35 @@
-log4j.logger.org.apache.spark.sql.profiler.ProfilerLogger$=INFO,F1
-log4j.appender.F1=org.apache.log4j.RollingFileAppender
-log4j.appender.F1.File=${path.target}/profiler.log
-log4j.appender.F1.MaxFileSize=4024KB
-log4j.appender.F1.MaxBackupIndex=20
-log4j.appender.F1.layout=org.apache.log4j.PatternLayout
-log4j.appender.F1.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss,SSS} %5p %c - %m%n
+
+log4j.rootLogger=INFO, console, file
+
+# console
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss,SSS} %5p %c - %m%n
+
+# file
+log4j.appender.file=org.apache.log4j.RollingFileAppender
+log4j.appender.file.File=profiler.log
+log4j.appender.file.MaxFileSize=4024KB
+log4j.appender.file.MaxBackupIndex=20
+log4j.appender.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.file.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss,SSS} %5p %c - %m%n
+
+# suppress
+log4j.logger.org.apache.spark.sql.profiler.ProfilerLogger=INFO, file, console
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/examples/spark2/src/main/resources/log4j.properties
+++ b/examples/spark2/src/main/resources/log4j.properties
@@ -17,19 +17,3 @@ log4j.appender.file.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss,SSS} %5p %c 
 # suppress
 log4j.logger.org.apache.spark.sql.profiler.ProfilerLogger=INFO, file, console
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
fix valid log4j config

#### Detail trace
```
log4j:ERROR setFile(null,true) call failed.
java.io.FileNotFoundException: /profiler.log (Permission denied)
	at java.io.FileOutputStream.open0(Native Method)
	at java.io.FileOutputStream.open(FileOutputStream.java:270)
	at java.io.FileOutputStream.<init>(FileOutputStream.java:213)
	at java.io.FileOutputStream.<init>(FileOutputStream.java:133)
	at org.apache.log4j.FileAppender.setFile(FileAppender.java:294)
	at org.apache.log4j.RollingFileAppender.setFile(RollingFileAppender.java:207)
	at org.apache.log4j.FileAppender.activateOptions(FileAppender.java:165)
	at org.apache.log4j.config.PropertySetter.activate(PropertySetter.java:307)
	at org.apache.log4j.config.PropertySetter.setProperties(PropertySetter.java:172)
	at org.apache.log4j.config.PropertySetter.setProperties(PropertySetter.java:104)
	at org.apache.log4j.PropertyConfigurator.parseAppender(PropertyConfigurator.java:842)
	at org.apache.log4j.PropertyConfigurator.parseCategory(PropertyConfigurator.java:768)
	at org.apache.log4j.PropertyConfigurator.parseCatsAndRenderers(PropertyConfigurator.java:672)
	at org.apache.log4j.PropertyConfigurator.doConfigure(PropertyConfigurator.java:516)
	at org.apache.log4j.PropertyConfigurator.doConfigure(PropertyConfigurator.java:580)
	at org.apache.log4j.helpers.OptionConverter.selectAndConfigure(OptionConverter.java:526)
	at org.apache.log4j.LogManager.<clinit>(LogManager.java:127)
	at org.apache.log4j.Logger.getLogger(Logger.java:104)
	at org.apache.carbondata.common.logging.LogServiceFactory.getLogService(LogServiceFactory.java:37)
	at org.apache.carbondata.core.util.CarbonProperties.<clinit>(CarbonProperties.java:83)
	at org.apache.carbondata.examples.util.ExampleUtils$.createCarbonSession(ExampleUtils.scala:47)
	at org.apache.carbondata.examples.LuceneDataMapExample$.main(LuceneDataMapExample.scala:32)
	at org.apache.carbondata.examples.LuceneDataMapExample.main(LuceneDataMapExample.scala)
log4j:WARN No appenders could be found for logger (org.apache.carbondata.core.util.CarbonProperties).
log4j:WARN Please initialize the log4j system properly.
log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.
```

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

