### PR TITLE
[CARBONDATA-3392] Make LRU mandatory for index server

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datamap/DataMapUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/DataMapUtil.java
@@ -115,7 +115,15 @@ public class DataMapUtil {
     DistributableDataMapFormat dataMapFormat = new DistributableDataMapFormat(carbonTable,
         validAndInvalidSegmentsInfo.getValidSegments(), invalidSegment, true,
         dataMapToClear);
-    dataMapJob.execute(dataMapFormat);
+    try {
+      dataMapJob.execute(dataMapFormat);
+    } catch (Exception e) {
+      if (dataMapJob.getClass().getName().equalsIgnoreCase(DISTRIBUTED_JOB_NAME)) {
+        LOGGER.warn("Failed to clear distributed cache.", e);
+      } else {
+        throw e;
+      }
+    }
   }
 
   public static void executeClearDataMapJob(CarbonTable carbonTable, String jobClassName)

--- a/core/src/main/java/org/apache/carbondata/core/util/BlockletDataMapUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/BlockletDataMapUtil.java
@@ -228,7 +228,7 @@ public class BlockletDataMapUtil {
     List<TableBlockIndexUniqueIdentifier> tableBlockIndexUniqueIdentifiers = new ArrayList<>();
     String mergeFilePath =
         identifier.getIndexFilePath() + CarbonCommonConstants.FILE_SEPARATOR + identifier
-            .getMergeIndexFileName();
+            .getIndexFileName();
     segmentIndexFileStore.readMergeFile(mergeFilePath);
     List<String> indexFiles =
         segmentIndexFileStore.getCarbonMergeFileToIndexFilesMap().get(mergeFilePath);

--- a/integration/spark2/src/main/scala/org/apache/carbondata/indexserver/DataMapJobs.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/indexserver/DataMapJobs.scala
@@ -60,21 +60,3 @@ class EmbeddedDataMapJob extends AbstractDataMapJob {
   }
 
 }
-
-class DistributedClearCacheJob extends AbstractDataMapJob {
-
-  val LOGGER: Logger = LogServiceFactory.getLogService(this.getClass.getCanonicalName)
-
-  override def execute(dataMapFormat: DistributableDataMapFormat): util.List[ExtendedBlocklet] = {
-    if (LOGGER.isDebugEnabled) {
-      val messageSize = SizeEstimator.estimate(dataMapFormat)
-      LOGGER.debug(s"Size of message sent to Index Server: $messageSize")
-    }
-    val (response, time) = logTime {
-      IndexServer.getClient.invalidateCache(dataMapFormat)
-      new util.ArrayList[ExtendedBlocklet]()
-    }
-    LOGGER.info(s"Time taken to get response from server: $time ms")
-    response
-  }
-}

--- a/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -257,8 +257,14 @@ object CarbonDataRDDFactory {
           // Remove compacted segments from executor cache.
           if (CarbonProperties.getInstance().isDistributedPruningEnabled(
               carbonLoadModel.getDatabaseName, carbonLoadModel.getTableName)) {
-            IndexServer.getClient.invalidateSegmentCache(carbonLoadModel.getDatabaseName,
-              carbonLoadModel.getTableName, compactedSegments.asScala.toArray)
+            try {
+              IndexServer.getClient.invalidateSegmentCache(carbonLoadModel.getDatabaseName,
+                carbonLoadModel.getTableName, compactedSegments.asScala.toArray)
+            } catch {
+              case ex: Exception =>
+                LOGGER.warn(s"Clear cache job has failed for ${carbonLoadModel
+                  .getDatabaseName}.${carbonLoadModel.getTableName}", ex)
+            }
           }
           // giving the user his error for telling in the beeline if his triggered table
           // compaction is failed.

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/cache/CarbonShowCacheCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/cache/CarbonShowCacheCommand.scala
@@ -218,16 +218,21 @@ case class CarbonShowCacheCommand(tableIdentifier: Option[TableIdentifier],
       case None => ""
     }
     val (result, time) = CarbonScalaUtil.logTime {
-      IndexServer.getClient.showCache(tableUniqueName).map(_.split(":"))
-        .groupBy(_.head).map { t =>
-        var sum = 0L
-        var length = 0
-        t._2.foreach {
-          arr =>
-            sum += arr(2).toLong
-            length += arr(1).toInt
+      try {
+        IndexServer.getClient.showCache(tableUniqueName).map(_.split(":"))
+          .groupBy(_.head).map { t =>
+          var sum = 0L
+          var length = 0
+          t._2.foreach {
+            arr =>
+              sum += arr(2).toLong
+              length += arr(1).toInt
+          }
+          (t._1, length, sum)
         }
-        (t._1, length, sum)
+      } catch {
+        case e: Exception =>
+          throw new RuntimeException("Failed to get Cache Information. ", e)
       }
     }
     LOGGER.info(s"Time taken to get cache results from Index Server is $time ms")


### PR DESCRIPTION
**Background:**
Currently LRU is optional for the user to configure, but this will raise some concerns in case of index server because the invalid segments have to be constantly removed from the cache in case of update/delete/compaction scenarios.

Therefore if clear segment job is failed then the job would not fail bu there has to be a mechanism to prevent that segment from being in cache forever.

To prevent the above mentioned scenario LRU cache size for executor is a mandatory property for the index server application.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

