### PR TITLE
[CARBONDATA-3379] thrift file-format support generate c++ code

### DIFF
--- a/format/src/main/thrift/carbondata.thrift
+++ b/format/src/main/thrift/carbondata.thrift
@@ -19,6 +19,7 @@
  * File format description for the CarbonData file format
  */
 namespace java org.apache.carbondata.format
+namespace cpp carbondata.format
 
 include "schema.thrift"
 include "dictionary.thrift"
@@ -141,6 +142,16 @@ struct DataChunk2{
     11: optional i32 numberOfRowsInpage;
  }
 
+struct LocalDictionaryChunkMeta {
+    1: required list<schema.Encoding> encoders; // The List of encoders overriden at node level
+    2: required list<binary> encoder_meta; // Extra information required by encoders
+}
+
+struct LocalDictionaryChunk {
+    1: required LocalDictionaryChunkMeta dictionary_meta
+    2: required binary dictionary_data; // the values in dictionary order, each value is represented in binary format
+    3: required binary dictionary_values; // surrogate keys used in the blocklet
+}
 
 /**
  * Represents a chunk of data. The chunk can be a single column stored in Column Major format or a group of columns stored in Row Major Format.
@@ -240,15 +251,4 @@ struct BlockletHeader{
 	3: optional BlockletIndex blocklet_index;  // Index for the following blocklet
 	4: required BlockletInfo blocklet_info;  // Info for the following blocklet
 	5: optional dictionary.ColumnDictionaryChunk dictionary; // Blocklet local dictionary
-}
-
-struct LocalDictionaryChunk {
-  1: required LocalDictionaryChunkMeta dictionary_meta
-	2: required binary dictionary_data; // the values in dictionary order, each value is represented in binary format
-	3: required binary dictionary_values; // surrogate keys used in the blocklet
-}
-
-struct LocalDictionaryChunkMeta {
-  1: required list<schema.Encoding> encoders; // The List of encoders overriden at node level
-  2: required list<binary> encoder_meta; // Extra information required by encoders
 }

--- a/format/src/main/thrift/carbondata_index.thrift
+++ b/format/src/main/thrift/carbondata_index.thrift
@@ -19,6 +19,7 @@
  * File format description for CarbonData index file for btree.
  */
 namespace java org.apache.carbondata.format
+namespace cpp carbondata.format
 
 include "schema.thrift"
 include "carbondata.thrift"

--- a/format/src/main/thrift/carbondata_index_merge.thrift
+++ b/format/src/main/thrift/carbondata_index_merge.thrift
@@ -19,6 +19,7 @@
  * File format description for CarbonData merged index file.
  */
 namespace java org.apache.carbondata.format
+namespace cpp carbondata.format
 
 struct MergedBlockIndexHeader{
   1: required list<string> file_names; // list of carbon index file names

--- a/format/src/main/thrift/dictionary.thrift
+++ b/format/src/main/thrift/dictionary.thrift
@@ -19,6 +19,8 @@
  * File format description for CarbonData dictionary file
  */
 namespace java org.apache.carbondata.format
+namespace cpp carbondata.format
+
 struct ColumnDictionaryChunk {
 	1: list<binary> values; // the values in dictionary order, each value is represented in binary format
 }

--- a/format/src/main/thrift/dictionary_metadata.thrift
+++ b/format/src/main/thrift/dictionary_metadata.thrift
@@ -19,6 +19,7 @@
  * File format description for CarbonData dictionary metadata file
  */
 namespace java org.apache.carbondata.format
+namespace cpp carbondata.format
 
 struct ColumnDictionaryChunkMeta {
 	1: required i32 min_surrogate_key; //The least surrogate key in this dictionary, in most cases min will be 0, but after history data deletion, min can be non-zero

--- a/format/src/main/thrift/schema.thrift
+++ b/format/src/main/thrift/schema.thrift
@@ -19,6 +19,7 @@
  * File format description for CarbonData schema file
  */
 namespace java org.apache.carbondata.format
+namespace cpp carbondata.format
 
 /**
  * The types supported by Carbon Data.

--- a/format/src/main/thrift/sort_index.thrift
+++ b/format/src/main/thrift/sort_index.thrift
@@ -19,6 +19,7 @@
  * File format description for CarbonData sort index file
  */
 namespace java org.apache.carbondata.format
+namespace cpp carbondata.format
 
 struct ColumnSortInfo {
 	1: list<i32> sort_index; // The surrogate values sorted by the original value order

--- a/store/CSDK/test/build_carbondata_test.sh
+++ b/store/CSDK/test/build_carbondata_test.sh
@@ -1,0 +1,36 @@
+export CFLAGS=`pkg-config --cflags thrift`" -g3 -O0"
+export LDFLAGS=`pkg-config --libs-only-L thrift`
+export LIBS=`pkg-config --libs-only-l thrift`
+
+export FORMAT_FILE_PATH=../../../format/src/main/thrift
+
+thrift --gen cpp -o . $FORMAT_FILE_PATH/carbondata_index_merge.thrift 
+thrift --gen cpp -o . $FORMAT_FILE_PATH/carbondata_index.thrift
+thrift --gen cpp -o . $FORMAT_FILE_PATH/carbondata.thrift
+thrift --gen cpp -o . $FORMAT_FILE_PATH/dictionary_metadata.thrift
+thrift --gen cpp -o . $FORMAT_FILE_PATH/dictionary.thrift
+thrift --gen cpp -o . $FORMAT_FILE_PATH/schema.thrift
+thrift --gen cpp -o . $FORMAT_FILE_PATH/sort_index.thrift
+
+g++ gen-cpp/carbondata_constants.cpp -c $CFLAGS
+g++ gen-cpp/carbondata_index_constants.cpp -c $CFLAGS
+g++ gen-cpp/carbondata_index_merge_constants.cpp -c $CFLAGS
+g++ gen-cpp/carbondata_index_merge_types.cpp -c $CFLAGS
+g++ gen-cpp/carbondata_index_types.cpp -c $CFLAGS
+g++ gen-cpp/carbondata_types.cpp -c $CFLAGS
+g++ gen-cpp/dictionary_constants.cpp -c $CFLAGS
+g++ gen-cpp/dictionary_metadata_constants.cpp -c $CFLAGS
+g++ gen-cpp/dictionary_metadata_types.cpp -c $CFLAGS
+g++ gen-cpp/dictionary_types.cpp -c $CFLAGS
+g++ gen-cpp/schema_constants.cpp -c $CFLAGS
+g++ gen-cpp/schema_types.cpp -c $CFLAGS
+g++ gen-cpp/sort_index_constants.cpp -c $CFLAGS
+g++ gen-cpp/sort_index_types.cpp -c $CFLAGS
+
+g++ carbondata_test.cpp -c $CFLAGS -I./gen-cpp/
+
+g++ carbondata_constants.o carbondata_index_constants.o carbondata_index_merge_constants.o \
+carbondata_index_merge_types.o carbondata_index_types.o carbondata_test.o carbondata_types.o \
+dictionary_constants.o dictionary_metadata_constants.o dictionary_metadata_types.o dictionary_types.o \
+schema_constants.o schema_types.o sort_index_constants.o sort_index_types.o -o carbondata_test \
+$LDFLAGS $LIBS

--- a/store/CSDK/test/carbondata_test.cpp
+++ b/store/CSDK/test/carbondata_test.cpp
@@ -1,0 +1,61 @@
+#include <iostream>
+
+#include <boost/shared_ptr.hpp>
+
+#include <thrift/transport/TBufferTransports.h>
+#include <thrift/protocol/TCompactProtocol.h>
+
+#include "carbondata_index_types.h"
+
+using namespace std;
+using namespace apache::thrift::transport;
+using namespace apache::thrift::protocol;
+using namespace carbondata::format;
+
+void print_usage();
+
+int main(int argc, char const *argv[])
+{
+	if (argc < 2)
+	{
+		print_usage();
+		return 0;
+	}
+	
+	const char* file_path = argv[1];
+
+	FILE *fp = fopen(file_path, "r");
+	fseek(fp, 0L, SEEK_END);
+	long file_size = ftell(fp);
+	fseek(fp, 0L, SEEK_SET);
+
+	unsigned char *buffer = new unsigned char[file_size];
+
+	size_t read_len = fread(buffer, 1, file_size, fp);
+
+	TCompactProtocolFactory factory;
+
+	boost::shared_ptr<TMemoryBuffer> trans(new TMemoryBuffer(const_cast<uint8_t*>(buffer), read_len));
+	boost::shared_ptr<TProtocol> protocol = factory.getProtocol(trans);
+
+	// read IndexHeader
+	IndexHeader indexheader;
+	indexheader.read(protocol.get());
+
+	cout << indexheader.version << endl;
+
+	// read BlockIndex
+	BlockIndex blockindex;
+	while (trans->peek())
+	{
+		blockindex.read(protocol.get());
+		cout << blockindex.file_name << endl;
+	}
+
+    return 0;
+}
+
+void print_usage()
+{
+	printf("Usage:\n  carbondata_test <CARBONDATA_INDEXFILE>\n");
+}


### PR DESCRIPTION
**Problem:**
Using thrift compiler to generate c++ code for file-format. 
1. It have some compile error for generate c++ code.
2. Without c++ namespace in generate c++ code.

**Solution**:
1. adjust the order of smoe struct declaration
2. add c++ namespace in file-format

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

