### PR TITLE
[CARBONDATA-3391] Count star output is wrong when BLOCKLET CACHE is enabled

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockDataMap.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockDataMap.java
@@ -689,7 +689,13 @@ public class BlockDataMap extends CoarseGrainDataMap
           CarbonCommonConstants.DEFAULT_CHARSET_CLASS) + CarbonTablePath.getCarbonDataExtension();
       int rowCount = dataMapRow.getInt(ROW_COUNT_INDEX);
       // prepend segment number with the blocklet file path
-      blockletToRowCountMap.put((segment.getSegmentNo() + "," + fileName), (long) rowCount);
+      String blockletMapKey = segment.getSegmentNo() + "," + fileName;
+      Long existingCount = blockletToRowCountMap.get(blockletMapKey);
+      if (null != existingCount) {
+        blockletToRowCountMap.put(blockletMapKey, (long) rowCount + existingCount);
+      } else {
+        blockletToRowCountMap.put(blockletMapKey, (long) rowCount);
+      }
     }
     return blockletToRowCountMap;
   }


### PR DESCRIPTION
Wrong Cont(*) value when blocklet cache is enabled
Root cause :-  blockletToRowCountMap has key with segmentNo+carbonfile name . so when carbonfile has multiple blocklets , blockletToRowCountMap  overrites existing rowcount.


Solution :- update the existing rowcount if any.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

