### PR TITLE
[CARBONDATA-3394]Clean files command optimization

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/statusmanager/SegmentUpdateStatusManager.java
+++ b/core/src/main/java/org/apache/carbondata/core/statusmanager/SegmentUpdateStatusManager.java
@@ -442,29 +442,22 @@ public class SegmentUpdateStatusManager {
   /**
    * Returns all update delta files of specified Segment.
    *
-   * @param segmentId
+   * @param loadMetadataDetail metadatadetails of segment
    * @param validUpdateFiles if true then only the valid range files will be returned.
    * @return
    */
-  public CarbonFile[] getUpdateDeltaFilesList(String segmentId, final boolean validUpdateFiles,
-      final String fileExtension, final boolean excludeOriginalFact,
+  public CarbonFile[] getUpdateDeltaFilesList(LoadMetadataDetails loadMetadataDetail,
+      final boolean validUpdateFiles, final String fileExtension, final boolean excludeOriginalFact,
       CarbonFile[] allFilesOfSegment, boolean isAbortedFile) {
 
     String endTimeStamp = "";
     String startTimeStamp = "";
     long factTimeStamp = 0;
 
-    LoadMetadataDetails[] segmentDetails = SegmentStatusManager.readLoadMetadata(
-        CarbonTablePath.getMetadataPath(identifier.getTablePath()));
-
-    for (LoadMetadataDetails eachSeg : segmentDetails) {
-      if (eachSeg.getLoadName().equalsIgnoreCase(segmentId)) {
-        // if the segment is found then take the start and end time stamp.
-        startTimeStamp = eachSeg.getUpdateDeltaStartTimestamp();
-        endTimeStamp = eachSeg.getUpdateDeltaEndTimestamp();
-        factTimeStamp = eachSeg.getLoadStartTime();
-      }
-    }
+    // if the segment is found then take the start and end time stamp.
+    startTimeStamp = loadMetadataDetail.getUpdateDeltaStartTimestamp();
+    endTimeStamp = loadMetadataDetail.getUpdateDeltaEndTimestamp();
+    factTimeStamp = loadMetadataDetail.getLoadStartTime();
 
     // if start timestamp is empty then no update delta is found. so return empty list.
     if (startTimeStamp.isEmpty()) {

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/api/CarbonStore.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/api/CarbonStore.scala
@@ -217,7 +217,7 @@ object CarbonStore {
    */
   def cleanUpPartitionFoldersRecursively(carbonTable: CarbonTable,
       partitionSpecList: List[PartitionSpec]): Unit = {
-    if (carbonTable != null) {
+    if (carbonTable != null && carbonTable.isHivePartitionTable) {
       val loadMetadataDetails = SegmentStatusManager
         .readLoadMetadata(carbonTable.getMetadataPath)
 
@@ -265,7 +265,6 @@ object CarbonStore {
         if (CarbonTablePath.DataFileUtil.compareCarbonFileTimeStamp(fileName, timestamp)) {
           // delete the file
           FileFactory.deleteFile(filePath, FileFactory.getFileType(filePath))
-
         }
     }
   }


### PR DESCRIPTION
### Problem
Clean files is taking of lot of time to finish, even though there are no segments to delete 
Tested for 5000 segments, and clean files takes 15 minutes time to finish

### Root cause and Solution
1. Lot of table status read operations are were happening during clean files
2. lot of listing operations are happening, even though they are not required.

Read and list operations are reduced to reduce overall time for clean files.
After changes, for the same store, it takes  35 seconds in same 3 node cluster.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 NA
 - [x] Any backward compatibility impacted?
 NA
 - [x] Document update required?
NA
 - [x] Testing done
tested on three node cluster
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA
