### PR TITLE
[HOTFIX] Fixed count(*) issue when MV is created with simple projection.

### DIFF
--- a/datamap/mv/core/src/main/scala/org/apache/carbondata/mv/rewrite/DefaultMatchMaker.scala
+++ b/datamap/mv/core/src/main/scala/org/apache/carbondata/mv/rewrite/DefaultMatchMaker.scala
@@ -179,7 +179,9 @@ object SelectSelectNoChildDelta extends DefaultMatchPattern with PredicateHelper
           sel_1q.predicateList.exists(_.semanticEquals(expr)))
         val isPredicateEmdR = sel_1q.predicateList.forall(expr =>
           isDerivable(expr, sel_1a.outputList ++ rejoinOutputList, sel_1q, sel_1a, None))
-        val isOutputEdR = sel_1q.outputList.forall(expr =>
+        // Check if sel_1q.outputList is non empty and then check whether
+        // it can be derivable with sel_1a otherwise for empty cases it returns true.
+        val isOutputEdR = sel_1q.outputList.nonEmpty && sel_1q.outputList.forall(expr =>
           isDerivable(expr, sel_1a.outputList ++ rejoinOutputList, sel_1q, sel_1a, None))
 
         if (isUniqueRmE.isEmpty && isUniqueEmR.isEmpty && extrajoin.isEmpty && isPredicateRmE &&

--- a/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/MVCreateTestCase.scala
+++ b/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/MVCreateTestCase.scala
@@ -1061,6 +1061,19 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     assert(TestUtil.verifyMVDataMap(analyzed3, "single_mv"))
   }
 
+  test("count test case") {
+
+    sql("drop table if exists mvtable1")
+    sql("create table mvtable1(name string,age int,salary int) stored by 'carbondata'")
+    sql("create datamap MV11 using 'mv' as select name from mvtable1")
+    sql("insert into mvtable1 select 'n1',12,12")
+    sql("rebuild datamap MV11")
+    val frame = sql("select count(*) from mvtable1")
+    assert(!TestUtil.verifyMVDataMap(frame.queryExecution.analyzed, "MV11"))
+    checkAnswer(frame,Seq(Row(1)))
+    sql("drop table if exists mvtable1")
+  }
+
   def verifyMVDataMap(logicalPlan: LogicalPlan, dataMapName: String): Boolean = {
     val tables = logicalPlan collect {
       case l: LogicalRelation => l.catalogTable.get


### PR DESCRIPTION
Problem:
When MV is created with simple projection and select count(*) is fired on main table then it is wrongly taking MV table with wrong projections. 

Solution:
Simple projection MV should not be selected when count(*) is fired.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

