### PR TITLE
[HOTFIX] optimize the carbondata thriftserver code

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/carbondata/spark/thriftserver/CarbonThriftServer.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/spark/thriftserver/CarbonThriftServer.scala
@@ -19,15 +19,11 @@ package org.apache.carbondata.spark.thriftserver
 
 import java.io.File
 
-import org.apache.hadoop.fs.s3a.Constants.{ACCESS_KEY, ENDPOINT, SECRET_KEY}
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.hive.thriftserver.HiveThriftServer2
 import org.slf4j.{Logger, LoggerFactory}
 
-import org.apache.carbondata.common.logging.LogServiceFactory
-import org.apache.carbondata.core.constants.CarbonCommonConstants
-import org.apache.carbondata.core.util.CarbonProperties
 import org.apache.carbondata.spark.util.CarbonSparkUtil
 
  /**
@@ -78,17 +74,6 @@ object CarbonThriftServer {
         .config(secretKey, args(2))
         .config(endpoint, CarbonSparkUtil.getS3EndPoint(args))
         .getOrCreateCarbonSession(storePath)
-    }
-
-    val warmUpTime = CarbonProperties.getInstance().getProperty("carbon.spark.warmUpTime", "5000")
-    try {
-      Thread.sleep(Integer.parseInt(warmUpTime))
-    } catch {
-      case e: Exception =>
-        val LOG = LogServiceFactory.getLogService(this.getClass.getCanonicalName)
-        LOG.error(s"Wrong value for carbon.spark.warmUpTime $warmUpTime " +
-          "Using default Value and proceeding")
-        Thread.sleep(5000)
     }
 
     HiveThriftServer2.startWithContext(spark.sqlContext)


### PR DESCRIPTION
### Two changes
- remove unuse imports
- remove `carbon.spark.warmUpTime` option, it's no need to block there and usless.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

