### PR TITLE
[HOTFIX] fix wrong some logger names

### DIFF
--- a/processing/src/main/java/org/apache/carbondata/processing/loading/csvinput/CSVInputFormat.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/csvinput/CSVInputFormat.java
@@ -85,7 +85,6 @@ public class CSVInputFormat extends FileInputFormat<NullWritable, StringArrayWri
   private static final Logger LOGGER =
       LogServiceFactory.getLogService(CSVInputFormat.class.getName());
 
-
   @Override
   public RecordReader<NullWritable, StringArrayWritable> createRecordReader(InputSplit inputSplit,
       TaskAttemptContext context) throws IOException, InterruptedException {

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/csvinput/CSVInputFormat.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/csvinput/CSVInputFormat.java
@@ -83,7 +83,7 @@ public class CSVInputFormat extends FileInputFormat<NullWritable, StringArrayWri
   public static final int THRESHOLD_MAX_NUMBER_OF_COLUMNS_FOR_PARSING = 20000;
 
   private static final Logger LOGGER =
-      LogServiceFactory.getLogService(CSVInputFormat.class.toString());
+      LogServiceFactory.getLogService(CSVInputFormat.class.getName());
 
 
   @Override

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/AvroCarbonWriter.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/AvroCarbonWriter.java
@@ -37,7 +37,6 @@ import org.apache.carbondata.core.metadata.datatype.DataTypes;
 import org.apache.carbondata.core.metadata.datatype.MapType;
 import org.apache.carbondata.core.metadata.datatype.StructField;
 import org.apache.carbondata.core.metadata.datatype.StructType;
-import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
 import org.apache.carbondata.hadoop.api.CarbonTableOutputFormat;
 import org.apache.carbondata.hadoop.internal.ObjectArrayWritable;
 import org.apache.carbondata.processing.loading.complexobjects.ArrayObject;

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/AvroCarbonWriter.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/AvroCarbonWriter.java
@@ -72,7 +72,7 @@ public class AvroCarbonWriter extends CarbonWriter {
   private ObjectArrayWritable writable;
   private Schema avroSchema;
   private static final Logger LOGGER =
-      LogServiceFactory.getLogService(CarbonTable.class.getName());
+      LogServiceFactory.getLogService(AvroCarbonWriter.class.getName());
 
   AvroCarbonWriter(CarbonLoadModel loadModel, Configuration hadoopConf) throws IOException {
     CarbonTableOutputFormat.setLoadModel(hadoopConf, loadModel);


### PR DESCRIPTION
#### Changes
- `AvroCarbonWriter` use wrong logger name
- `CSVInputFormat` use wrong way to get logger name


Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 
 - [x] Any backward compatibility impacted?
 
 - [x] Document update required?

 - [x] Testing done
        Please provide details on 
        - W
hether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

