### PR TITLE
[CARBONDATA-3397]Remove SparkUnknown Expression to Index Server

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datamap/DistributableDataMapFormat.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/DistributableDataMapFormat.java
@@ -334,4 +334,12 @@ public class DistributableDataMapFormat extends FileInputFormat<Void, ExtendedBl
   public boolean isJobToClearDataMaps() {
     return isJobToClearDataMaps;
   }
+
+  public FilterResolverIntf getFilterResolverIntf() {
+    return filterResolverIntf;
+  }
+
+  public void setFilterResolverIntf(FilterResolverIntf filterResolverIntf) {
+    this.filterResolverIntf = filterResolverIntf;
+  }
 }

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/FilterExpressionProcessor.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/FilterExpressionProcessor.java
@@ -42,6 +42,8 @@ import org.apache.carbondata.core.scan.expression.conditional.ListExpression;
 import org.apache.carbondata.core.scan.expression.conditional.StartsWithExpression;
 import org.apache.carbondata.core.scan.expression.exception.FilterUnsupportedException;
 import org.apache.carbondata.core.scan.expression.logical.AndExpression;
+import org.apache.carbondata.core.scan.expression.logical.OrExpression;
+import org.apache.carbondata.core.scan.expression.logical.TrueExpression;
 import org.apache.carbondata.core.scan.filter.executer.FilterExecuter;
 import org.apache.carbondata.core.scan.filter.executer.ImplicitColumnFilterExecutor;
 import org.apache.carbondata.core.scan.filter.intf.ExpressionType;
@@ -486,5 +488,46 @@ public class FilterExpressionProcessor implements FilterProcessor {
       BitSet bitSet = filterExecuter.isScanRequired(maxValue, minValue, isMinMaxSet);
       return !bitSet.isEmpty();
     }
+  }
+
+  /**
+   * Remove UnknownExpression and change to TrueExpression
+   *
+   * @param expressionTree
+   * @return expressionTree without UnknownExpression
+   */
+  public Expression removeUnknownExpression(Expression expressionTree) {
+    ExpressionType filterExpressionType = expressionTree.getFilterExpressionType();
+    BinaryExpression currentExpression = null;
+    switch (filterExpressionType) {
+      case OR:
+        currentExpression = (BinaryExpression) expressionTree;
+        return new OrExpression(
+                removeUnknownExpression(currentExpression.getLeft()),
+                removeUnknownExpression(currentExpression.getRight())
+        );
+      case AND:
+        currentExpression = (BinaryExpression) expressionTree;
+        return new AndExpression(
+                removeUnknownExpression(currentExpression.getLeft()),
+                removeUnknownExpression(currentExpression.getRight())
+        );
+      case UNKNOWN:
+        return new TrueExpression(null);
+      default:
+        return expressionTree;
+    }
+  }
+
+  /**
+   * Change UnknownReslover to TrueExpression Reslover.
+   *
+   * @param tableIdentifier
+   * @return
+   */
+  public FilterResolverIntf changeUnknownResloverToTrue(AbsoluteTableIdentifier tableIdentifier) {
+    return getFilterResolverBasedOnExpressionType(ExpressionType.TRUE, false,
+        new TrueExpression(null), tableIdentifier, new TrueExpression(null));
+
   }
 }


### PR DESCRIPTION
### Problem 
if Query has UDF and it is registered to the Main driver Since  UDF function will not be available in Index server , query will be failed in Indexserver (with NoClassDefincationFound). 
<br>

### Solution
1. UDF are  SparkUnkownFilter(RowLevelFilterExecuterImpl) so  Remove the  SparkUnknown  Expression because anyway for pruning we select all blocks. org.apache.carbondata.core.scan.filter.executer.RowLevelFilterExecuterImpl#isScanRequired.

2. Supply all the UDFs functions and it's related lambda expressions to IndexServer also. But it has below issues
 a. Spark FunctionRegistry is not writable 
 b. sending All functions from Main Server to Index server will be costly(in Size) &  no way to find implicit function and explicit user created functions. 

So Solution 1 is adopted.
 


Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 NO
 - [ ] Any backward compatibility impacted?
 NO
 - [ ] Document update required?
NO
 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
     Manually tested  
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA
