### PR TITLE
[HOTFIX] Fixed Compatibilty Issue

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/metadata/blocklet/BlockletInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/blocklet/BlockletInfo.java
@@ -235,6 +235,9 @@ public class BlockletInfo implements Serializable, Writable {
       for (int i = 0; i < getNumberOfRowsPerPage().length; i++) {
         output.writeInt(getNumberOfRowsPerPage()[i]);
       }
+    } else {
+      //for old store
+      output.writeShort(0);
     }
   }
 


### PR DESCRIPTION
Problem : EOF exception was being thrown in case of old store while reading the blocklet Info.

Solution : Added a fix by writing the number of rows per page in case of old store.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

