### PR TITLE
[CARBONDATA-3400] Support IndexSever for Spark-Shell in secure Mode(kerberos)

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/carbondata/indexserver/IndexServer.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/indexserver/IndexServer.scala
@@ -170,9 +170,16 @@ object IndexServer extends ServerInterface {
    */
   def getClient: ServerInterface = {
     import org.apache.hadoop.ipc.RPC
+    val indexServerUser = sparkSession.sparkContext.getConf
+      .get("spark.carbon.indexserver.principal", "")
+    val indexServerKeyTab = sparkSession.sparkContext.getConf
+      .get("spark.carbon.indexserver.keytab", "")
+    val ugi = UserGroupInformation.loginUserFromKeytabAndReturnUGI(indexServerUser,
+      indexServerKeyTab)
+    LOGGER.info("Login successful for user " + indexServerUser);
     RPC.getProxy(classOf[ServerInterface],
       RPC.getProtocolVersion(classOf[ServerInterface]),
-      new InetSocketAddress(serverIp, serverPort), UserGroupInformation.getLoginUser,
+      new InetSocketAddress(serverIp, serverPort), ugi,
       FileFactory.getConfiguration, NetUtils.getDefaultSocketFactory(FileFactory.getConfiguration))
   }
 }


### PR DESCRIPTION
### Problem
In spark-shell OR Spark-Submit mode, Application user  and  IndexServer User are different .
Application user is based on Kinit user OR based on spark.yarn.principle user whereas Indexserver user is based on spark.carbon.indexserver.principal . it is possible that both are different as Indexserver should have it's own authentication principle and should not depend on Application principle so that any application's Query(Thrifserver,Spark-shell,Spark-sql,Spark-Submit)  can be served from IndexServer.

### Solution 
Authenticate the IndexServer by it's own principle and keytab. 
keytab is required so that long run application (client and indexserver ) does not impacted on token expire.

Note:- Spark-default.conf of Thriftserver (beeline), spark-submit ,spark-sql  should have both spark.carbon.indexserver.principal and spark.carbon.indexserver.keytab.  
 
 



Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 NA
 - [ ] Any backward compatibility impacted?
 NA
 - [ ] Document update required?
NA
 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
     Manually tested  
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA
