### PR TITLE
[CARBONDATA-3402] Fix block complex data type and validate dmproperties for MV

### DIFF
--- a/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/MVCoalesceTestCase.scala
+++ b/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/MVCoalesceTestCase.scala
@@ -43,7 +43,7 @@ class MVCoalesceTestCase  extends QueryTest with BeforeAndAfterAll  {
     sql("rebuild datamap coalesce_test_main_mv")
 
     val frame = sql("select coalesce(sum(id),0) as sumid,name from coalesce_test_main group by name")
-    assert(verifyMVDataMap(frame.queryExecution.analyzed, "coalesce_test_main_mv"))
+    assert(TestUtil.verifyMVDataMap(frame.queryExecution.analyzed, "coalesce_test_main_mv"))
     checkAnswer(frame, Seq(Row(3, "tom"), Row(3, "lily")))
 
     sql("drop datamap if exists coalesce_test_main_mv")
@@ -59,7 +59,7 @@ class MVCoalesceTestCase  extends QueryTest with BeforeAndAfterAll  {
     assert("MV doesn't support Coalesce".equals(exception.getMessage))
 
     val frame = sql("select coalesce(sum(id),0) as sumid,name from coalesce_test_main group by name")
-    assert(!verifyMVDataMap(frame.queryExecution.analyzed, "coalesce_test_main_mv"))
+    assert(!TestUtil.verifyMVDataMap(frame.queryExecution.analyzed, "coalesce_test_main_mv"))
     checkAnswer(frame, Seq(Row(3, "tom"), Row(3, "lily")))
 
     sql("drop datamap if exists coalesce_test_main_mv")
@@ -72,20 +72,22 @@ class MVCoalesceTestCase  extends QueryTest with BeforeAndAfterAll  {
     sql("rebuild datamap coalesce_test_main_mv")
 
     val frame = sql("select sum(coalesce(id,0)) as sumid,name from coalesce_test_main group by name")
-    assert(verifyMVDataMap(frame.queryExecution.analyzed, "coalesce_test_main_mv"))
+    assert(TestUtil.verifyMVDataMap(frame.queryExecution.analyzed, "coalesce_test_main_mv"))
     checkAnswer(frame, Seq(Row(3, "tom"), Row(3, "lily")))
 
     sql("drop datamap if exists coalesce_test_main_mv")
   }
 
+  override def afterAll(): Unit ={
+    drop
+  }
+}
+
+object TestUtil {
   def verifyMVDataMap(logicalPlan: LogicalPlan, dataMapName: String): Boolean = {
     val tables = logicalPlan collect {
       case l: LogicalRelation => l.catalogTable.get
     }
     tables.exists(_.identifier.table.equalsIgnoreCase(dataMapName+"_table"))
-  }
-
-  override def afterAll(): Unit ={
-    drop
   }
 }

--- a/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/MVCountAndCaseTestCase.scala
+++ b/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/MVCountAndCaseTestCase.scala
@@ -79,14 +79,7 @@ class MVCountAndCaseTestCase  extends QueryTest with BeforeAndAfterAll{
                        | GROUP BY MT.`3600`, MT.`2250410101`
                        | ORDER BY `3600` ASC LIMIT 5000""".stripMargin)
 
-    assert(verifyMVDataMap(frame.queryExecution.analyzed, "data_table_mv"))
-  }
-
-  def verifyMVDataMap(logicalPlan: LogicalPlan, dataMapName: String): Boolean = {
-    val tables = logicalPlan collect {
-      case l: LogicalRelation => l.catalogTable.get
-    }
-    tables.exists(_.identifier.table.equalsIgnoreCase(dataMapName+"_table"))
+    assert(TestUtil.verifyMVDataMap(frame.queryExecution.analyzed, "data_table_mv"))
   }
 
   override def afterAll(): Unit = {

--- a/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/MVCreateTestCase.scala
+++ b/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/MVCreateTestCase.scala
@@ -107,7 +107,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     sql("create datamap datamap1 using 'mv' as select empname, designation from fact_table1")
     val df = sql("select empname,designation from fact_table1")
     val analyzed = df.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap1"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap1"))
     checkAnswer(df, sql("select empname,designation from fact_table2"))
     sql(s"drop datamap datamap1")
   }
@@ -117,7 +117,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     sql("create datamap datamap2 using 'mv' as select empname, designation from fact_table1")
     val df = sql("select empname from fact_table1")
     val analyzed = df.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap2"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap2"))
     checkAnswer(df, sql("select empname from fact_table2"))
     sql(s"drop datamap datamap2")
   }
@@ -127,7 +127,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     sql("create datamap datamap3 using 'mv' as select empname, designation from fact_table1")
     val frame = sql("select empname, designation from fact_table1 where empname='shivani'")
     val analyzed = frame.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap3"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap3"))
 
     checkAnswer(frame, sql("select empname, designation from fact_table2 where empname='shivani'"))
     sql(s"drop datamap datamap3")
@@ -137,7 +137,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     sql("create datamap datamap4 using 'mv' as select empname, designation from fact_table1")
     val frame = sql("select designation from fact_table1 where empname='shivani'")
     val analyzed = frame.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap4"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap4"))
     checkAnswer(frame, sql("select designation from fact_table2 where empname='shivani'"))
     sql(s"drop datamap datamap4")
   }
@@ -146,7 +146,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     sql("create datamap datamap5 using 'mv' as select empname, designation from fact_table1 where empname='shivani'")
     val frame = sql("select designation from fact_table1 where empname='shivani'")
     val analyzed = frame.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap5"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap5"))
     checkAnswer(frame, sql("select designation from fact_table2 where empname='shivani'"))
     sql(s"drop datamap datamap5")
   }
@@ -155,7 +155,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     sql("create datamap datamap6 using 'mv' as select empname, designation from fact_table1 where empname='shivani'")
     val frame = sql("select empname,designation from fact_table1 where empname='shivani'")
     val analyzed = frame.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap6"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap6"))
     checkAnswer(frame, sql("select empname,designation from fact_table2 where empname='shivani'"))
     sql(s"drop datamap datamap6")
   }
@@ -165,7 +165,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     val frame = sql(
       "select empname,designation from fact_table1 where empname='shivani' and designation='SA'")
     val analyzed = frame.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap7"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap7"))
     checkAnswer(frame, sql("select empname,designation from fact_table2 where empname='shivani' and designation='SA'"))
     sql(s"drop datamap datamap7")
   }
@@ -174,7 +174,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     sql("create datamap datamap8 using 'mv' as select empname, designation from fact_table1 where empname='shivani'")
     val frame = sql("select empname,designation from fact_table1 where designation='SA'")
     val analyzed = frame.queryExecution.analyzed
-    assert(!verifyMVDataMap(analyzed, "datamap8"))
+    assert(!TestUtil.verifyMVDataMap(analyzed, "datamap8"))
     checkAnswer(frame, sql("select empname,designation from fact_table2 where designation='SA'"))
     sql(s"drop datamap datamap8")
   }
@@ -183,7 +183,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     sql("create datamap datamap9 using 'mv' as select empname, designation,deptname  from fact_table1 where deptname='cloud'")
     val frame = sql("select empname,designation from fact_table1 where deptname='cloud'")
     val analyzed = frame.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap9"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap9"))
     checkAnswer(frame, sql("select empname,designation from fact_table2 where deptname='cloud'"))
     sql(s"drop datamap datamap9")
   }
@@ -192,7 +192,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     sql("create datamap datamap10 using 'mv' as select empname, designation,deptname from fact_table1 where deptname='cloud'")
     val frame = sql("select empname,designation from fact_table1")
     val analyzed = frame.queryExecution.analyzed
-    assert(!verifyMVDataMap(analyzed, "datamap10"))
+    assert(!TestUtil.verifyMVDataMap(analyzed, "datamap10"))
     checkAnswer(frame, sql("select empname,designation from fact_table2"))
     sql(s"drop datamap datamap10")
   }
@@ -201,7 +201,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     sql("create datamap datamap11 using 'mv' as select empname, designation,deptname from fact_table1 where deptname='cloud'")
     val frame = sql("select empname,designation from fact_table1 where designation='SA'")
     val analyzed = frame.queryExecution.analyzed
-    assert(!verifyMVDataMap(analyzed, "datamap11"))
+    assert(!TestUtil.verifyMVDataMap(analyzed, "datamap11"))
     checkAnswer(frame, sql("select empname,designation from fact_table2 where designation='SA'"))
     sql(s"drop datamap datamap11")
   }
@@ -211,7 +211,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     sql("create datamap datamap12 using 'mv' as select empname, sum(utilization) from fact_table1 group by empname")
     val frame = sql("select empname, sum(utilization) from fact_table1 group by empname")
     val analyzed = frame.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap12"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap12"))
     checkAnswer(frame, sql("select empname, sum(utilization) from fact_table2 group by empname"))
     sql(s"drop datamap datamap12")
   }
@@ -221,7 +221,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     sql("create datamap datamap13 using 'mv' as select empname, sum(utilization) from fact_table1 group by empname")
     val frame = sql("select sum(utilization) from fact_table1 group by empname")
     val analyzed = frame.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap13"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap13"))
     checkAnswer(frame, sql("select sum(utilization) from fact_table2 group by empname"))
     sql(s"drop datamap datamap13")
   }
@@ -232,7 +232,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     val frame = sql(
       "select empname,sum(utilization) from fact_table1 group by empname having empname='shivani'")
     val analyzed = frame.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap14"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap14"))
     checkAnswer(frame, sql("select empname,sum(utilization) from fact_table2 where empname='shivani' group by empname"))
     sql(s"drop datamap datamap14")
   }
@@ -243,7 +243,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     val frame = sql(
       "select empname, sum(utilization) from fact_table1 group by empname having empname='shivani'")
     val analyzed = frame.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap32"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap32"))
     checkAnswer(frame, sql( "select empname, sum(utilization) from fact_table2 group by empname having empname='shivani'"))
     sql(s"drop datamap datamap32")
   }
@@ -253,7 +253,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     val frame = sql(
       "select empname,sum(utilization) from fact_table1 where empname='shivani' group by empname")
     val analyzed = frame.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap15"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap15"))
     checkAnswer(frame, sql("select empname,sum(utilization) from fact_table2 where empname='shivani' group by empname"))
     sql(s"drop datamap datamap15")
   }
@@ -262,7 +262,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     sql("create datamap datamap16 using 'mv' as select empname, sum(utilization) from fact_table1 where empname='shivani' group by empname")
     val frame = sql("select empname,sum(utilization) from fact_table1 group by empname")
     val analyzed = frame.queryExecution.analyzed
-    assert(!verifyMVDataMap(analyzed, "datamap16"))
+    assert(!TestUtil.verifyMVDataMap(analyzed, "datamap16"))
     checkAnswer(frame, sql("select empname,sum(utilization) from fact_table2 group by empname"))
     sql(s"drop datamap datamap16")
   }
@@ -273,7 +273,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
       "select empname, sum(CASE WHEN utilization=27 THEN deptno ELSE 0 END) from fact_table1 group" +
       " by empname")
     val analyzed = frame.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap17"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap17"))
     checkAnswer(frame, sql("select empname, sum(CASE WHEN utilization=27 THEN deptno ELSE 0 END) from fact_table2 group" +
                            " by empname"))
     sql(s"drop datamap datamap17")
@@ -285,7 +285,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     val frame = sql(
       "select sum(CASE WHEN utilization=27 THEN deptno ELSE 0 END) from fact_table1 group by empname")
     val analyzed = frame.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap18"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap18"))
     checkAnswer(frame, sql("select sum(CASE WHEN utilization=27 THEN deptno ELSE 0 END) from fact_table2 group by empname"))
     sql(s"drop datamap datamap18")
   }
@@ -296,7 +296,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     val frame = sql(
       "select count(CASE WHEN utilization=27 THEN deptno ELSE 0 END) from fact_table1 group by empname")
     val analyzed = frame.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap19"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap19"))
     checkAnswer(frame, sql("select count(CASE WHEN utilization=27 THEN deptno ELSE 0 END) from fact_table2 group by empname"))
     sql(s"drop datamap datamap19")
   }
@@ -308,7 +308,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
       "select sum(CASE WHEN utilization=27 THEN deptno ELSE 0 END) from fact_table1 where " +
       "empname='shivani' group by empname")
     val analyzed = frame.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap20"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap20"))
     checkAnswer(frame, sql("select sum(CASE WHEN utilization=27 THEN deptno ELSE 0 END) from fact_table2 where " +
                            "empname='shivani' group by empname"))
     sql(s"drop datamap datamap20")
@@ -320,7 +320,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     val frame = sql(
       "select t1.empname as c1, t2.designation from fact_table1 t1,fact_table2 t2 where t1.empname = t2.empname")
     val analyzed = frame.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap21"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap21"))
     checkAnswer(frame, sql("select t1.empname, t2.designation from fact_table4 t1,fact_table5 t2 where t1.empname = t2.empname"))
     sql(s"drop datamap datamap21")
   }
@@ -332,7 +332,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
       "select t1.empname, t2.designation from fact_table1 t1,fact_table2 t2 where t1.empname = " +
       "t2.empname and t1.empname='shivani'")
     val analyzed = frame.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap22"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap22"))
     checkAnswer(frame, sql("select t1.empname, t2.designation from fact_table4 t1,fact_table5 t2 where t1.empname = " +
                            "t2.empname and t1.empname='shivani'"))
     sql(s"drop datamap datamap22")
@@ -346,7 +346,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
       "select t1.empname, t2.designation from fact_table1 t1,fact_table2 t2 where t1.empname = " +
       "t2.empname and t1.empname='shivani'")
     val analyzed = frame.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap23"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap23"))
     checkAnswer(frame, sql("select t1.empname, t2.designation from fact_table4 t1,fact_table5 t2 where t1.empname = " +
                            "t2.empname and t1.empname='shivani'"))
     sql(s"drop datamap datamap23")
@@ -358,7 +358,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     val frame = sql(
       "select t1.empname, t2.designation from fact_table1 t1,fact_table2 t2 where t1.empname = t2.empname")
     val analyzed = frame.queryExecution.analyzed
-    assert(!verifyMVDataMap(analyzed, "datamap24"))
+    assert(!TestUtil.verifyMVDataMap(analyzed, "datamap24"))
     checkAnswer(frame, sql("select t1.empname, t2.designation from fact_table4 t1,fact_table5 t2 where t1.empname = t2.empname"))
     sql(s"drop datamap datamap24")
   }
@@ -369,11 +369,11 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     val frame = sql(
       "select t1.empname as c1, t2.designation from fact_table1 t1,fact_table2 t2 where t1.empname = t2.empname")
     val analyzed = frame.queryExecution.analyzed
-    assert(!verifyMVDataMap(analyzed, "datamap25"))
+    assert(!TestUtil.verifyMVDataMap(analyzed, "datamap25"))
     val frame1 = sql(
       "select t1.empname as c1, t2.designation from fact_table1 t1 inner join fact_table2 t2 on (t1.empname = t2.empname) inner join fact_table3 t3  on (t1.empname=t3.empname)")
     val analyzed1 = frame1.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed1, "datamap25"))
+    assert(TestUtil.verifyMVDataMap(analyzed1, "datamap25"))
     checkAnswer(frame, sql("select t1.empname, t2.designation from fact_table4 t1,fact_table5 t2 where t1.empname = t2.empname"))
     sql(s"drop datamap datamap25")
   }
@@ -384,7 +384,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
       "select t1.empname, t2.designation from fact_table1 t1,fact_table2 t2,fact_table3 " +
       "t3  where t1.empname = t2.empname and t1.empname=t3.empname")
     val analyzed = frame.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap26"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap26"))
     checkAnswer(frame, sql("select t1.empname, t2.designation from fact_table4 t1,fact_table5 t2,fact_table6 " +
                            "t3  where t1.empname = t2.empname and t1.empname=t3.empname"))
     sql(s"drop datamap datamap26")
@@ -396,7 +396,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
       "select t1.empname, t2.designation, sum(t1.utilization) from fact_table1 t1,fact_table2 t2  " +
       "where t1.empname = t2.empname group by t1.empname, t2.designation")
     val analyzed = frame.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap27"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap27"))
     checkAnswer(frame, sql("select t1.empname, t2.designation, sum(t1.utilization) from fact_table4 t1,fact_table5 t2  " +
                            "where t1.empname = t2.empname group by t1.empname, t2.designation"))
     sql(s"drop datamap datamap27")
@@ -409,7 +409,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
       "select t2.designation, sum(t1.utilization) from fact_table1 t1,fact_table2 t2  where " +
       "t1.empname = t2.empname group by t2.designation")
     val analyzed = frame.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap28"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap28"))
     checkAnswer(frame, sql("select t2.designation, sum(t1.utilization) from fact_table4 t1,fact_table5 t2  where " +
                            "t1.empname = t2.empname group by t2.designation"))
     sql(s"drop datamap datamap28")
@@ -422,7 +422,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
       "select t2.designation, sum(t1.utilization) from fact_table1 t1,fact_table2 t2  where " +
       "t1.empname = t2.empname and t1.empname='shivani' group by t2.designation")
     val analyzed = frame.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap29"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap29"))
     checkAnswer(frame, sql("select t2.designation, sum(t1.utilization) from fact_table4 t1,fact_table5 t2  where " +
                            "t1.empname = t2.empname and t1.empname='shivani' group by t2.designation"))
     sql(s"drop datamap datamap29")
@@ -435,7 +435,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
       "select t1.empname, t2.designation, sum(t1.utilization) from fact_table1 t1,fact_table2 t2  " +
       "where t1.empname = t2.empname and t2.designation='SA' group by t1.empname, t2.designation")
     val analyzed = frame.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap30"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap30"))
     checkAnswer(frame, sql("select t1.empname, t2.designation, sum(t1.utilization) from fact_table4 t1,fact_table5 t2  " +
                            "where t1.empname = t2.empname and t2.designation='SA' group by t1.empname, t2.designation"))
     sql(s"drop datamap datamap30")
@@ -447,7 +447,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     val frame = sql(
       "select empname, designation, utilization+projectcode from fact_table1")
     val analyzed = frame.queryExecution.analyzed
-    assert(!verifyMVDataMap(analyzed, "datamap31"))
+    assert(!TestUtil.verifyMVDataMap(analyzed, "datamap31"))
     checkAnswer(frame, sql("select empname, designation, utilization+projectcode from fact_table2"))
     sql(s"drop datamap datamap31")
   }
@@ -457,7 +457,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     sql("create datamap datamap32 using 'mv' as select empname, count(utilization) from fact_table1 group by empname")
     val frame = sql("select empname,count(utilization) from fact_table1 where empname='shivani' group by empname")
     val analyzed = frame.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap32"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap32"))
     checkAnswer(frame, sql("select empname,count(utilization) from fact_table2 where empname='shivani' group by empname"))
     sql(s"drop datamap datamap32")
   }
@@ -467,7 +467,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     sql("create datamap datamap33 using 'mv' as select empname, avg(utilization) from fact_table1 group by empname")
     val frame = sql("select empname,avg(utilization) from fact_table1 where empname='shivani' group by empname")
     val analyzed = frame.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap33"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap33"))
     checkAnswer(frame, sql("select empname,avg(utilization) from fact_table2 where empname='shivani' group by empname"))
     sql(s"drop datamap datamap33")
   }
@@ -479,7 +479,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
       "select t1.empname, t2.designation, sum(t1.utilization) from fact_table1 t1 left join fact_table2 t2  " +
       "on t1.empname = t2.empname group by t1.empname, t2.designation")
     val analyzed = frame.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap34"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap34"))
     checkAnswer(frame, sql("select t1.empname, t2.designation, sum(t1.utilization) from fact_table4 t1 left join fact_table5 t2  " +
                            "on t1.empname = t2.empname group by t1.empname, t2.designation"))
     sql(s"drop datamap datamap34")
@@ -490,7 +490,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     val frame = sql(
       "select designation, sum(utilization) from fact_table1 where empname='shivani' group by designation")
     val analyzed = frame.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap35"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap35"))
     checkAnswer(frame, sql("select designation, sum(utilization) from fact_table2 where empname='shivani' group by designation"))
     sql(s"drop datamap datamap35")
   }
@@ -500,7 +500,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     val frame = sql(
       "select sum(utilization) from fact_table1 where empname='shivani' group by designation")
     val analyzed = frame.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap36"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap36"))
     checkAnswer(frame, sql("select sum(utilization) from fact_table2 where empname='shivani' group by designation"))
     sql(s"drop datamap datamap36")
   }
@@ -512,7 +512,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
       "select t1.empname, sum(t1.utilization) from fact_table1 t1,fact_table2 t2  " +
       "where t1.empname = t2.empname group by t1.empname")
     val analyzed = frame.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap37"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap37"))
     checkAnswer(frame, sql("select t1.empname, sum(t1.utilization) from fact_table3 t1,fact_table4 t2  " +
                            "where t1.empname = t2.empname group by t1.empname, t1.designation"))
     sql(s"drop datamap datamap37")
@@ -525,7 +525,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
       "select t1.empname, t1.designation, sum(t1.utilization) from fact_table1 t1,fact_table2 t2  " +
       "where t1.empname = t2.empname group by t1.empname,t1.designation")
     val analyzed = frame.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap38"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap38"))
     checkAnswer(frame, sql("select t1.empname,t1.designation, sum(t1.utilization) from fact_table3 t1,fact_table4 t2  " +
                            "where t1.empname = t2.empname group by t1.empname, t1.designation"))
     sql(s"drop datamap datamap38")
@@ -538,7 +538,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
       "select t1.empname, t1.designation, sum(t1.utilization) from fact_table1 t1,fact_table2 t2  " +
       "where t1.empname = t2.empname and t1.empname='shivani' group by t1.empname,t1.designation")
     val analyzed = frame.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap39"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap39"))
     checkAnswer(frame, sql("select t1.empname,t1.designation, sum(t1.utilization) from fact_table3 t1,fact_table4 t2  " +
                            "where t1.empname = t2.empname and t1.empname='shivani' group by t1.empname, t1.designation"))
     sql(s"drop datamap datamap39")
@@ -551,7 +551,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
       "select t1.empname, t1.designation, sum(t1.utilization),count(t1.utilization) from fact_table1 t1,fact_table2 t2  " +
       "where t1.empname = t2.empname and t1.empname='shivani' group by t1.empname,t1.designation")
     val analyzed = frame.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap40"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap40"))
     checkAnswer(frame, sql("select t1.empname, t1.designation, sum(t1.utilization),count(t1.utilization) from fact_table3 t1,fact_table4 t2  " +
                            "where t1.empname = t2.empname and t1.empname='shivani' group by t1.empname,t1.designation"))
     sql(s"drop datamap datamap40")
@@ -564,7 +564,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
       "select t1.empname, t2.designation, sum(t1.utilization) from fact_table1 t1 left join fact_table2 t2  " +
       "on t1.empname = t2.empname where t1.empname='shivani' group by t1.empname, t2.designation")
     val analyzed = frame.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap41"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap41"))
     checkAnswer(frame, sql("select t1.empname, t2.designation, sum(t1.utilization) from fact_table4 t1 left join fact_table5 t2  " +
                            "on t1.empname = t2.empname where t1.empname='shivani' group by t1.empname, t2.designation"))
     sql(s"drop datamap datamap41")
@@ -577,7 +577,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
       "select t1.empname, sum(t1.utilization) from fact_table1 t1 left join fact_table2 t2  " +
       "on t1.empname = t2.empname group by t1.empname")
     val analyzed = frame.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap42"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap42"))
     checkAnswer(frame, sql("select t1.empname, sum(t1.utilization) from fact_table4 t1 left join fact_table5 t2  " +
                            "on t1.empname = t2.empname group by t1.empname"))
     sql(s"drop datamap datamap42")
@@ -590,7 +590,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
       "select t1.empname, sum(t1.utilization) from fact_table1 t1 left join fact_table2 t2  " +
       "on t1.empname = t2.empname where t1.empname='shivani' group by t1.empname")
     val analyzed = frame.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap43"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap43"))
     checkAnswer(frame, sql("select t1.empname, sum(t1.utilization) from fact_table4 t1 left join fact_table5 t2  " +
                            "on t1.empname = t2.empname where t1.empname='shivani' group by t1.empname"))
     sql(s"drop datamap datamap43")
@@ -603,7 +603,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
       "select t1.empname, sum(t1.utilization) from fact_table1 t1 left join fact_table2 t2  " +
       "on t1.empname = t2.empname where t1.empname='shivani' group by t1.empname")
     val analyzed = frame.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap44"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap44"))
     checkAnswer(frame, sql("select t1.empname, sum(t1.utilization) from fact_table4 t1 left join fact_table5 t2  " +
                            "on t1.empname = t2.empname where t1.empname='shivani' group by t1.empname"))
     sql(s"drop datamap datamap44")
@@ -618,7 +618,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
       "select t1.empname, t2.designation, sum(t1.utilization) from fact_table1 t1 left join fact_table2 t2  " +
       "on t1.empname = t2.empname where t2.designation='SA' group by t1.empname, t2.designation")
     val analyzed = frame.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap45"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap45"))
     checkAnswer(frame, sql("select t1.empname, t2.designation, sum(t1.utilization) from fact_table4 t1 left join fact_table5 t2  " +
                            "on t1.empname = t2.empname where t2.designation='SA' group by t1.empname, t2.designation"))
     sql(s"drop datamap datamap45")
@@ -635,7 +635,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     val frame = sql(
       "select name,sum(salary) from test4 group by name")
     val analyzed = frame.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "mv13"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "mv13"))
   }
 
   test("jira carbondata-2528-1") {
@@ -645,7 +645,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     val frame = sql(
       "select empname,sum(salary) as total from fact_table1 group by empname order by empname")
     val analyzed = frame.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "MV_order"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "MV_order"))
   }
 
   test("jira carbondata-2528-2") {
@@ -655,7 +655,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     val frame = sql(
       "select empname,sum(salary)+sum(utilization) as total from fact_table1 group by empname order by empname")
     val analyzed = frame.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "MV_order"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "MV_order"))
   }
 
   test("jira carbondata-2528-3") {
@@ -665,7 +665,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     val frame = sql(
       "select empname,sum(salary)+sum(utilization) as total from fact_table1 group by empname order by empname DESC")
     val analyzed = frame.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "MV_order"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "MV_order"))
     sql("drop datamap if exists MV_order")
   }
 
@@ -676,7 +676,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     val frame = sql(
       "select empname,sum(salary)+sum(utilization) as total from fact_table1 where empname = 'ravi' group by empname order by empname DESC")
     val analyzed = frame.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "MV_order"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "MV_order"))
     sql("drop datamap if exists MV_order")
   }
 
@@ -689,11 +689,11 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     sql("create datamap datamv2 using 'mv' as select country,sum(salary) from test1 group by country")
     val frame = sql("select country,sum(salary) from test1 where country='USA' group by country")
     val analyzed = frame.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamv2"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamv2"))
     sql("insert into test1 select 'name1','USA',12,23")
     val frame1 = sql("select country,sum(salary) from test1 where country='USA' group by country")
     val analyzed1 = frame1.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed1, "datamv2"))
+    assert(TestUtil.verifyMVDataMap(analyzed1, "datamv2"))
     sql("drop datamap if exists datamv2")
     sql("drop table if exists test1")
   }
@@ -705,7 +705,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     val frame = sql(
       "select sum(salary),substring(empname,2,5),designation from fact_table1 group by substring(empname,2,5),designation")
     val analyzed = frame.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "MV_exp"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "MV_exp"))
     sql("drop datamap if exists MV_exp")
   }
 
@@ -725,7 +725,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     val frame = sql(
       "select doj,sum(salary) from xy.fact_tablexy group by doj")
     val analyzed = frame.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "MV_exp"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "MV_exp"))
     sql("drop datamap if exists MV_exp")
     sql("""drop database if exists xy cascade""")
   }
@@ -742,7 +742,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     sql("create datamap map1 using 'mv' as select name,sum(salary) from mvtable1 group by name")
     val frame = sql("select name,sum(salary) from mvtable1 group by name limit 1")
     val analyzed = frame.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "map1"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "map1"))
     sql("drop datamap if exists map1")
     sql("drop table if exists mvtable1")
   }
@@ -754,7 +754,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     val frame = sql(
       "select empname,max(projectenddate),sum(salary),min(projectjoindate),avg(attendance) from fact_table1 group by empname")
     val analyzed = frame.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap_comp_maxsumminavg"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap_comp_maxsumminavg"))
     sql("drop datamap if exists datamap_comp_maxsumminavg")
   }
 
@@ -778,7 +778,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
       val frame = sql(
         "select sum(case when deptno=11 and (utilization=92) then salary else 0 end) as t from fact_table1 group by empname")
       val analyzed = frame.queryExecution.analyzed
-      assert(verifyMVDataMap(analyzed, "MV_exp"))
+      assert(TestUtil.verifyMVDataMap(analyzed, "MV_exp"))
     }
     sql("drop datamap if exists MV_exp")
   }
@@ -797,7 +797,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     val frame = sql(
       "select empname, sum(utilization) from fact_table1 group by empname")
     val analyzed = frame.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "MV_exp1"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "MV_exp1"))
     sql("drop datamap if exists MV_exp1")
     sql("drop datamap if exists MV_exp2")
   }
@@ -809,7 +809,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     val frame = sql(
       "select deptname as babu, sum(salary) from fact_table1 as tt group by deptname")
     val analyzed = frame.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap46"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap46"))
     sql("drop datamap if exists datamap46")
   }
 
@@ -820,7 +820,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     val frame = sql(
       "SELECT max(utilization) FROM fact_table1 WHERE salary IN (select min(salary) from fact_table1 group by empname ) group by empname")
     val analyzed = frame.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap_subqry"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap_subqry"))
     sql("drop datamap if exists datamap_subqry")
   }
 
@@ -832,7 +832,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     val frame = sql(
       "SELECT max(utilization) FROM fact_table1 WHERE salary IN (select min(salary) from fact_table1) group by empname")
     val analyzed = frame.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap_subqry"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap_subqry"))
     sql("drop datamap if exists datamap_subqry")
   }
 
@@ -947,7 +947,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
 
     val frame = sql(querySQL)
     val analyzed = frame.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "all_table_mv"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "all_table_mv"))
     assert(1 == frame.collect().size)
 
     sql("drop table if exists all_table")
@@ -963,18 +963,11 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
       val df = sql("select distinct(empname) from limit_fail limit 10")
       sql("select * from limit_fail limit 10").show()
       val analyzed = df.queryExecution.analyzed
-      assert(verifyMVDataMap(analyzed, "limit_fail_dm1"))
+      assert(TestUtil.verifyMVDataMap(analyzed, "limit_fail_dm1"))
     } catch {
       case ex: Exception =>
         assert(false)
     }
-  }
-
-  def verifyMVDataMap(logicalPlan: LogicalPlan, dataMapName: String): Boolean = {
-    val tables = logicalPlan collect {
-      case l: LogicalRelation => l.catalogTable.get
-    }
-    tables.exists(_.identifier.table.equalsIgnoreCase(dataMapName+"_table"))
   }
 
   def drop(): Unit = {

--- a/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/MVIncrementalLoadingTestcase.scala
+++ b/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/MVIncrementalLoadingTestcase.scala
@@ -60,7 +60,7 @@ class MVIncrementalLoadingTestcase extends QueryTest with BeforeAndAfterAll {
     val query: String = "select empname from test_table"
     val df1 = sql(s"$query")
     val analyzed1 = df1.queryExecution.analyzed
-    assert(!verifyMVDataMap(analyzed1, "datamap1"))
+    assert(!TestUtil.verifyMVDataMap(analyzed1, "datamap1"))
     sql(s"rebuild datamap datamap1")
     val dataMapTable = CarbonMetadata.getInstance().getCarbonTable(
       CarbonCommonConstants.DATABASE_DEFAULT_NAME,
@@ -73,7 +73,7 @@ class MVIncrementalLoadingTestcase extends QueryTest with BeforeAndAfterAll {
     assert(segmentList.containsAll( segmentMap.get("default.test_table")))
     val df2 = sql(s"$query")
     val analyzed2 = df2.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed2, "datamap1"))
+    assert(TestUtil.verifyMVDataMap(analyzed2, "datamap1"))
     loadDataToFactTable("test_table")
     loadDataToFactTable("test_table1")
     sql(s"rebuild datamap datamap1")
@@ -86,12 +86,12 @@ class MVIncrementalLoadingTestcase extends QueryTest with BeforeAndAfterAll {
       sql("select empname, designation from test_table1"))
     val df3 = sql(s"$query")
     val analyzed3 = df3.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed3, "datamap1"))
+    assert(TestUtil.verifyMVDataMap(analyzed3, "datamap1"))
     loadDataToFactTable("test_table")
     loadDataToFactTable("test_table1")
     val df4 = sql(s"$query")
     val analyzed4 = df4.queryExecution.analyzed
-    assert(!verifyMVDataMap(analyzed4, "datamap1"))
+    assert(!TestUtil.verifyMVDataMap(analyzed4, "datamap1"))
     checkAnswer(sql("select empname, designation from test_table"),
       sql("select empname, designation from test_table1"))
   }
@@ -141,7 +141,7 @@ class MVIncrementalLoadingTestcase extends QueryTest with BeforeAndAfterAll {
     var df = sql(
       s"""select a, sum(b) from main_table group by a""".stripMargin)
     var analyzed = df.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap1"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap1"))
     checkAnswer(sql(" select a, sum(b) from testtable group by a"),
       sql(" select a, sum(b) from main_table group by a"))
     sql("update main_table set(a) = ('aaa') where b = 'abc'").show(false)
@@ -162,7 +162,7 @@ class MVIncrementalLoadingTestcase extends QueryTest with BeforeAndAfterAll {
     assert(segmentList.containsAll( segmentMap.get("default.main_table")))
     df = sql(s""" select a, sum(b) from main_table group by a""".stripMargin)
     analyzed = df.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap1"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap1"))
     checkAnswer(sql(" select a, sum(b) from testtable group by a"),
       sql(" select a, sum(b) from main_table group by a"))
     sql("drop table IF EXISTS main_table")
@@ -327,12 +327,12 @@ class MVIncrementalLoadingTestcase extends QueryTest with BeforeAndAfterAll {
     sql(s"rebuild datamap datamap1")
     val df = sql("select a, sum(c) from main_table  group by a")
     val analyzed = df.queryExecution.analyzed
-    assert(!verifyMVDataMap(analyzed, "datamap1"))
+    assert(!TestUtil.verifyMVDataMap(analyzed, "datamap1"))
     sql("reset")
     checkAnswer(sql("select a, sum(c) from main_table  group by a"), Seq(Row("a", 1), Row("b", 2)))
     val df1= sql("select a, sum(c) from main_table  group by a")
     val analyzed1 = df1.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed1, "datamap1"))
+    assert(TestUtil.verifyMVDataMap(analyzed1, "datamap1"))
     sql("drop table IF EXISTS main_table")
   }
 
@@ -406,7 +406,7 @@ class MVIncrementalLoadingTestcase extends QueryTest with BeforeAndAfterAll {
     assert(segmentList.containsAll( segmentMap.get("default.test_table")))
     val df2 = sql(s"$query")
     val analyzed2 = df2.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed2, "datamap1"))
+    assert(TestUtil.verifyMVDataMap(analyzed2, "datamap1"))
     loadDataToFactTable("test_table")
     loadDataToFactTable("test_table1")
     loadMetadataDetails = SegmentStatusManager.readLoadMetadata(dataMapTable.getMetadataPath)
@@ -418,12 +418,12 @@ class MVIncrementalLoadingTestcase extends QueryTest with BeforeAndAfterAll {
       sql("select empname, designation from test_table1"))
     val df3 = sql(s"$query")
     val analyzed3 = df3.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed3, "datamap1"))
+    assert(TestUtil.verifyMVDataMap(analyzed3, "datamap1"))
     loadDataToFactTable("test_table")
     loadDataToFactTable("test_table1")
     val df4 = sql(s"$query")
     val analyzed4 = df4.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed4, "datamap1"))
+    assert(TestUtil.verifyMVDataMap(analyzed4, "datamap1"))
     checkAnswer(sql("select empname, designation from test_table"),
       sql("select empname, designation from test_table1"))
   }
@@ -441,7 +441,7 @@ class MVIncrementalLoadingTestcase extends QueryTest with BeforeAndAfterAll {
     sql("create datamap datamap1 using 'mv' as select a, sum(b) from main_table group by a")
     var df = sql(s"""select a, sum(b) from main_table group by a""".stripMargin)
     var analyzed = df.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap1"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap1"))
     checkAnswer(sql(" select a, sum(b) from testtable group by a"),
       sql(" select a, sum(b) from main_table group by a"))
     sql("update main_table set(a) = ('aaa') where b = 'abc'").show(false)
@@ -458,7 +458,7 @@ class MVIncrementalLoadingTestcase extends QueryTest with BeforeAndAfterAll {
     assert(segmentList.containsAll(segmentMap.get("default.main_table")))
     df = sql(s""" select a, sum(b) from main_table group by a""".stripMargin)
     analyzed = df.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap1"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap1"))
     checkAnswer(sql(" select a, sum(b) from testtable group by a"),
       sql(" select a, sum(b) from main_table group by a"))
     sql("drop table IF EXISTS main_table")
@@ -478,7 +478,7 @@ class MVIncrementalLoadingTestcase extends QueryTest with BeforeAndAfterAll {
     sql("create datamap datamap1 using 'mv' as select a, sum(b) from main_table group by a")
     var df = sql(s"""select a, sum(b) from main_table group by a""".stripMargin)
     var analyzed = df.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap1"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap1"))
     checkAnswer(sql(" select a, sum(b) from testtable group by a"),
       sql(" select a, sum(b) from main_table group by a"))
     sql("delete from  main_table  where b = 'abc'").show(false)
@@ -495,7 +495,7 @@ class MVIncrementalLoadingTestcase extends QueryTest with BeforeAndAfterAll {
     assert(segmentList.containsAll(segmentMap.get("default.main_table")))
     df = sql(s""" select a, sum(b) from main_table group by a""".stripMargin)
     analyzed = df.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap1"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap1"))
     checkAnswer(sql(" select a, sum(b) from testtable group by a"),
       sql(" select a, sum(b) from main_table group by a"))
     sql("drop table IF EXISTS main_table")
@@ -565,13 +565,6 @@ class MVIncrementalLoadingTestcase extends QueryTest with BeforeAndAfterAll {
     val segmentList = new java.util.ArrayList[String]()
     segmentList.add("0.1")
     assert(segmentList.containsAll(segmentMap.get("default.test_table")))
-  }
-
-  def verifyMVDataMap(logicalPlan: LogicalPlan, dataMapName: String): Boolean = {
-    val tables = logicalPlan collect {
-      case l: LogicalRelation => l.catalogTable.get
-    }
-    tables.exists(_.identifier.table.equalsIgnoreCase(dataMapName + "_table"))
   }
 
   override def afterAll(): Unit = {

--- a/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/MVMultiJoinTestCase.scala
+++ b/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/MVMultiJoinTestCase.scala
@@ -52,7 +52,7 @@ class MVMultiJoinTestCase extends QueryTest with BeforeAndAfterAll {
         "select p.title,c.title,c.pid,p.aid from areas as p inner join areas as c on " +
         "c.pid=p.aid where p.title = 'hebei'")
     val frame = sql(mvSQL)
-    assert(verifyMVDataMap(frame.queryExecution.analyzed, "table_mv"))
+    assert(TestUtil.verifyMVDataMap(frame.queryExecution.analyzed, "table_mv"))
     checkAnswer(frame, Seq(Row("hebei","shijiazhuang"), Row("hebei","handan")))
   }
 
@@ -73,15 +73,8 @@ class MVMultiJoinTestCase extends QueryTest with BeforeAndAfterAll {
        """.stripMargin
     sql("create datamap table_mv using 'mv' as " + "select sdr.name,sum(sdr.score),dim.age,dim_other.height,count(dim.name) as c1, count(dim_other.name) as c2 from sdr_table sdr left join dim_table dim on sdr.name = dim.name left join dim_table dim_other on sdr.name = dim_other.name group by sdr.name,dim.age,dim_other.height")
     val frame = sql(mvSQL)
-    assert(verifyMVDataMap(frame.queryExecution.analyzed, "table_mv"))
+    assert(TestUtil.verifyMVDataMap(frame.queryExecution.analyzed, "table_mv"))
     checkAnswer(frame, Seq(Row("lily",80,30,160),Row("tom",120,20,170)))
-  }
-
-  def verifyMVDataMap(logicalPlan: LogicalPlan, dataMapName: String): Boolean = {
-    val tables = logicalPlan collect {
-      case l: LogicalRelation => l.catalogTable.get
-    }
-    tables.exists(_.identifier.table.equalsIgnoreCase(dataMapName+"_table"))
   }
 
   def drop: Unit ={

--- a/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/MVRewriteTestCase.scala
+++ b/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/MVRewriteTestCase.scala
@@ -80,14 +80,7 @@ class MVRewriteTestCase extends QueryTest with BeforeAndAfterAll {
                        	                       | GROUP BY MT.`3600`, MT.`2250410101`
                        	                       | ORDER BY `3600` ASC LIMIT 5000""".stripMargin)
 
-    assert(verifyMVDataMap(frame.queryExecution.analyzed, "data_table_mv"))
-  }
-
-  def verifyMVDataMap(logicalPlan: LogicalPlan, dataMapName: String): Boolean = {
-    val tables = logicalPlan collect {
-      case l: LogicalRelation => l.catalogTable.get
-    }
-    tables.exists(_.identifier.table.equalsIgnoreCase(dataMapName+"_table"))
+    assert(TestUtil.verifyMVDataMap(frame.queryExecution.analyzed, "data_table_mv"))
   }
 
   override def afterAll(): Unit = {

--- a/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/MVSampleTestCase.scala
+++ b/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/MVSampleTestCase.scala
@@ -85,7 +85,7 @@ class MVSampleTestCase extends QueryTest with BeforeAndAfterAll {
     sql(s"create datamap datamap_sm1 using 'mv' as ${sampleTestCases(0)._2}")
     val df = sql(sampleTestCases(0)._3)
     val analyzed = df.queryExecution.analyzed
-    assert(!verifyMVDataMap(analyzed, "datamap_sm1"))
+    assert(!TestUtil.verifyMVDataMap(analyzed, "datamap_sm1"))
     sql(s"drop datamap datamap_sm1")
   }
 
@@ -94,7 +94,7 @@ class MVSampleTestCase extends QueryTest with BeforeAndAfterAll {
     sql(s"create datamap datamap_sm2 using 'mv' as ${sampleTestCases(2)._2}")
     val df = sql(sampleTestCases(2)._3)
     val analyzed = df.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap_sm2"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap_sm2"))
     sql(s"drop datamap datamap_sm2")
   }
 
@@ -103,7 +103,7 @@ class MVSampleTestCase extends QueryTest with BeforeAndAfterAll {
     sql(s"create datamap datamap_sm3 using 'mv' as ${sampleTestCases(3)._2}")
     val df = sql(sampleTestCases(3)._3)
     val analyzed = df.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap_sm3"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap_sm3"))
     sql(s"drop datamap datamap_sm3")
   }
 
@@ -112,7 +112,7 @@ class MVSampleTestCase extends QueryTest with BeforeAndAfterAll {
     sql(s"create datamap datamap_sm4 using 'mv' as ${sampleTestCases(4)._2}")
     val df = sql(sampleTestCases(4)._3)
     val analyzed = df.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap_sm4"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap_sm4"))
     sql(s"drop datamap datamap_sm4")
   }
 
@@ -121,7 +121,7 @@ class MVSampleTestCase extends QueryTest with BeforeAndAfterAll {
     sql(s"create datamap datamap_sm5 using 'mv' as ${sampleTestCases(5)._2}")
     val df = sql(sampleTestCases(5)._3)
     val analyzed = df.queryExecution.analyzed
-    assert(!verifyMVDataMap(analyzed, "datamap_sm5"))
+    assert(!TestUtil.verifyMVDataMap(analyzed, "datamap_sm5"))
     sql(s"drop datamap datamap_sm5")
   }
 
@@ -130,7 +130,7 @@ class MVSampleTestCase extends QueryTest with BeforeAndAfterAll {
     sql(s"create datamap datamap_sm6 using 'mv' as ${sampleTestCases(6)._2}")
     val df = sql(sampleTestCases(6)._3)
     val analyzed = df.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap_sm6"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap_sm6"))
     sql(s"drop datamap datamap_sm6")
   }
 
@@ -139,7 +139,7 @@ class MVSampleTestCase extends QueryTest with BeforeAndAfterAll {
     sql(s"create datamap datamap_sm7 using 'mv' as ${sampleTestCases(7)._2}")
     val df = sql(sampleTestCases(7)._3)
     val analyzed = df.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap_sm7"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap_sm7"))
     sql(s"drop datamap datamap_sm7")
   }
 
@@ -148,18 +148,9 @@ class MVSampleTestCase extends QueryTest with BeforeAndAfterAll {
     sql(s"create datamap datamap_sm8 using 'mv' as ${sampleTestCases(8)._2}")
     val df = sql(sampleTestCases(8)._3)
     val analyzed = df.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap_sm8"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap_sm8"))
     sql(s"drop datamap datamap_sm8")
   }
-
-
-  def verifyMVDataMap(logicalPlan: LogicalPlan, dataMapName: String): Boolean = {
-    val tables = logicalPlan collect {
-      case l: LogicalRelation => l.catalogTable.get
-    }
-    tables.exists(_.identifier.table.equalsIgnoreCase(dataMapName+"_table"))
-  }
-
 
   def drop(): Unit = {
     sql("use default")

--- a/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/MVTPCDSTestCase.scala
+++ b/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/MVTPCDSTestCase.scala
@@ -53,7 +53,7 @@ class MVTPCDSTestCase extends QueryTest with BeforeAndAfterAll {
     sql(s"create datamap datamap_tpcds1 using 'mv' as ${tpcds_1_4_testCases(0)._2}")
     val df = sql(tpcds_1_4_testCases(0)._3)
     val analyzed = df.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap_tpcds1"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap_tpcds1"))
     sql(s"drop datamap datamap_tpcds1")
   }
 
@@ -62,7 +62,7 @@ class MVTPCDSTestCase extends QueryTest with BeforeAndAfterAll {
     sql(s"create datamap datamap_tpcds3 using 'mv' as ${tpcds_1_4_testCases(2)._2}")
     val df = sql(tpcds_1_4_testCases(2)._3)
     val analyzed = df.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap_tpcds3"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap_tpcds3"))
     sql(s"drop datamap datamap_tpcds3")
   }
 
@@ -71,7 +71,7 @@ class MVTPCDSTestCase extends QueryTest with BeforeAndAfterAll {
     sql(s"create datamap datamap_tpcds4 using 'mv' as ${tpcds_1_4_testCases(3)._2}")
     val df = sql(tpcds_1_4_testCases(3)._3)
     val analyzed = df.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap_tpcds4"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap_tpcds4"))
     sql(s"drop datamap datamap_tpcds4")
   }
 
@@ -80,7 +80,7 @@ class MVTPCDSTestCase extends QueryTest with BeforeAndAfterAll {
     sql(s"create datamap datamap_tpcds5 using 'mv' as ${tpcds_1_4_testCases(4)._2}")
     val df = sql(tpcds_1_4_testCases(4)._3)
     val analyzed = df.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap_tpcds5"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap_tpcds5"))
     sql(s"drop datamap datamap_tpcds5")
   }
 
@@ -89,7 +89,7 @@ class MVTPCDSTestCase extends QueryTest with BeforeAndAfterAll {
     sql(s"create datamap datamap_tpcds6 using 'mv' as ${tpcds_1_4_testCases(5)._2}")
     val df = sql(tpcds_1_4_testCases(5)._3)
     val analyzed = df.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap_tpcds6"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap_tpcds6"))
     sql(s"drop datamap datamap_tpcds6")
   }
 
@@ -98,7 +98,7 @@ class MVTPCDSTestCase extends QueryTest with BeforeAndAfterAll {
     sql(s"create datamap datamap_tpcds8 using 'mv' as ${tpcds_1_4_testCases(7)._2}")
     val df = sql(tpcds_1_4_testCases(7)._3)
     val analyzed = df.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap_tpcds8"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap_tpcds8"))
     sql(s"drop datamap datamap_tpcds8")
   }
 
@@ -107,7 +107,7 @@ class MVTPCDSTestCase extends QueryTest with BeforeAndAfterAll {
     sql(s"create datamap datamap_tpcds11 using 'mv' as ${tpcds_1_4_testCases(10)._2}")
     val df = sql(tpcds_1_4_testCases(10)._3)
     val analyzed = df.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap_tpcds11"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap_tpcds11"))
     sql(s"drop datamap datamap_tpcds11")
   }
 
@@ -116,7 +116,7 @@ class MVTPCDSTestCase extends QueryTest with BeforeAndAfterAll {
     sql(s"create datamap datamap_tpcds15 using 'mv' as ${tpcds_1_4_testCases(14)._2}")
     val df = sql(tpcds_1_4_testCases(14)._3)
     val analyzed = df.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap_tpcds15"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap_tpcds15"))
     sql(s"drop datamap datamap_tpcds15")
   }
 
@@ -125,19 +125,9 @@ class MVTPCDSTestCase extends QueryTest with BeforeAndAfterAll {
     sql(s"create datamap datamap_tpcds16 using 'mv' as ${tpcds_1_4_testCases(15)._2}")
     val df = sql(tpcds_1_4_testCases(15)._3)
     val analyzed = df.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap_tpcds16"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap_tpcds16"))
     sql(s"drop datamap datamap_tpcds16")
   }
-
-
-
-  def verifyMVDataMap(logicalPlan: LogicalPlan, dataMapName: String): Boolean = {
-    val tables = logicalPlan collect {
-      case l: LogicalRelation => l.catalogTable.get
-    }
-    tables.exists(_.identifier.table.equalsIgnoreCase(dataMapName+"_table"))
-  }
-
 
   def drop(): Unit = {
     sql("use default")

--- a/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/MVTpchTestCase.scala
+++ b/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/MVTpchTestCase.scala
@@ -73,7 +73,7 @@ class MVTpchTestCase extends QueryTest with BeforeAndAfterAll {
     sql("create datamap datamap1 using 'mv' as select l_returnflag, l_linestatus,l_shipdate, sum(l_quantity) as sum_qty, sum(l_extendedprice) as sum_base_price, sum(l_extendedprice*(1-l_discount)) as sum_disc_price, sum(l_extendedprice*(1-l_discount)*(1+l_tax)) as sum_charge,count(*) as count_order from lineitem group by l_returnflag, l_linestatus,l_shipdate")
     val df = sql("select l_returnflag, l_linestatus, sum(l_quantity) as sum_qty, sum(l_extendedprice) as sum_base_price, sum(l_extendedprice*(1-l_discount)) as sum_disc_price, sum(l_extendedprice*(1-l_discount)*(1+l_tax)) as sum_charge,count(*) as count_order from lineitem where l_shipdate <= date('1998-09-02') group by l_returnflag, l_linestatus order by l_returnflag, l_linestatus")
     val analyzed = df.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap1"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap1"))
 //    checkAnswer(df, sql("select l_returnflag, l_linestatus, sum(l_quantity) as sum_qty, sum(l_extendedprice) as sum_base_price, sum(l_extendedprice*(1-l_discount)) as sum_disc_price, sum(l_extendedprice*(1-l_discount)*(1+l_tax)) as sum_charge,count(*) as count_order from lineitem1 where l_shipdate <= date('1998-09-02') group by l_returnflag, l_linestatus order by l_returnflag, l_linestatus"))
     sql(s"drop datamap datamap1")
   }
@@ -83,7 +83,7 @@ class MVTpchTestCase extends QueryTest with BeforeAndAfterAll {
     sql("create datamap datamap2 using 'mv' as select l_returnflag, l_linestatus,l_shipdate, sum(l_quantity) as sum_qty, sum(l_extendedprice) as sum_base_price, sum(l_extendedprice*(1-l_discount)) as sum_disc_price, sum(l_extendedprice*(1-l_discount)*(1+l_tax)) as sum_charge from lineitem group by l_returnflag, l_linestatus,l_shipdate order by l_returnflag, l_linestatus")
     val df = sql("select l_returnflag, l_linestatus, sum(l_quantity) as sum_qty, sum(l_extendedprice) as sum_base_price, sum(l_extendedprice*(1-l_discount)) as sum_disc_price, sum(l_extendedprice*(1-l_discount)*(1+l_tax)) as sum_charge from lineitem where l_shipdate <= date('1998-09-02') group by l_returnflag, l_linestatus order by l_returnflag, l_linestatus")
     val analyzed = df.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap2"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap2"))
 //    checkAnswer(df, sql("select l_returnflag, l_linestatus, sum(l_quantity) as sum_qty, sum(l_extendedprice) as sum_base_price, sum(l_extendedprice*(1-l_discount)) as sum_disc_price, sum(l_extendedprice*(1-l_discount)*(1+l_tax)) as sum_charge from lineitem1 where l_shipdate <= date('1998-09-02') group by l_returnflag, l_linestatus order by l_returnflag, l_linestatus"))
     sql(s"drop datamap datamap2")
   }
@@ -93,7 +93,7 @@ class MVTpchTestCase extends QueryTest with BeforeAndAfterAll {
     sql("create datamap datamap3 using 'mv' as select l_returnflag, l_linestatus,l_shipdate, sum(l_quantity) as sum_qty, sum(l_extendedprice) as sum_base_price, sum(l_extendedprice*(1-l_discount)) as sum_disc_price, sum(l_extendedprice*(1-l_discount)*(1+l_tax)) as sum_charge from lineitem group by l_returnflag, l_linestatus,l_shipdate")
     val df = sql("select l_returnflag, l_linestatus, sum(l_quantity) as sum_qty, sum(l_extendedprice) as sum_base_price, sum(l_extendedprice*(1-l_discount)) as sum_disc_price from lineitem where l_shipdate <= date('1998-09-02') group by l_returnflag, l_linestatus order by l_returnflag, l_linestatus")
     val analyzed = df.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap3"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap3"))
 //    checkAnswer(df, sql("select l_returnflag, l_linestatus, sum(l_quantity) as sum_qty, sum(l_extendedprice) as sum_base_price, sum(l_extendedprice*(1-l_discount)) as sum_disc_price from lineitem1 where l_shipdate <= date('1998-09-02') group by l_returnflag, l_linestatus order by l_returnflag, l_linestatus"))
     sql(s"drop datamap datamap3")
   }
@@ -103,7 +103,7 @@ class MVTpchTestCase extends QueryTest with BeforeAndAfterAll {
     sql("create datamap datamap4 using 'mv' as select l_orderkey, sum(l_extendedprice * (1 - l_discount)) as revenue, o_orderdate, o_shippriority from customer, orders, lineitem where c_mktsegment = 'BUILDING' and c_custkey = o_custkey and l_orderkey = o_orderkey and o_orderdate < date('1995-03-15') and l_shipdate > date('1995-03-15') group by l_orderkey, o_orderdate, o_shippriority")
     val df = sql("select l_orderkey, sum(l_extendedprice * (1 - l_discount)) as revenue, o_orderdate, o_shippriority from customer, orders, lineitem where c_mktsegment = 'BUILDING' and c_custkey = o_custkey and l_orderkey = o_orderkey and o_orderdate < date('1995-03-15') and l_shipdate > date('1995-03-15') group by l_orderkey, o_orderdate, o_shippriority order by revenue desc, o_orderdate limit 10")
     val analyzed = df.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap4"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap4"))
 //    checkAnswer(df, sql("select l_orderkey, sum(l_extendedprice * (1 - l_discount)) as revenue, o_orderdate, o_shippriority from customer1, orders1, lineitem1 where c_mktsegment = 'BUILDING' and c_custkey = o_custkey and l_orderkey = o_orderkey and o_orderdate < date('1995-03-15') and l_shipdate > date('1995-03-15') group by l_orderkey, o_orderdate, o_shippriority order by revenue desc, o_orderdate limit 10"))
     sql(s"drop datamap datamap4")
   }
@@ -113,7 +113,7 @@ class MVTpchTestCase extends QueryTest with BeforeAndAfterAll {
     sql("create datamap datamap5 using 'mv' as select l_orderkey, sum(l_extendedprice * (1 - l_discount)) as revenue, o_orderdate, o_shippriority,c_mktsegment,l_shipdate, c_custkey as c1, o_custkey as c2,o_orderkey as o1  from customer, orders, lineitem where c_custkey = o_custkey and l_orderkey = o_orderkey group by l_orderkey, o_orderdate, o_shippriority,c_mktsegment,l_shipdate,c_custkey,o_custkey, o_orderkey ")
     val df = sql("select l_orderkey, sum(l_extendedprice * (1 - l_discount)) as revenue, o_orderdate, o_shippriority from customer, orders, lineitem where c_mktsegment = 'BUILDING' and c_custkey = o_custkey and l_orderkey = o_orderkey and o_orderdate < date('1995-03-15') and l_shipdate > date('1995-03-15') group by l_orderkey, o_orderdate, o_shippriority order by revenue desc, o_orderdate limit 10")
     val analyzed = df.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap5"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap5"))
 //    checkAnswer(df, sql("select l_orderkey, sum(l_extendedprice * (1 - l_discount)) as revenue, o_orderdate, o_shippriority from customer1, orders1, lineitem1 where c_mktsegment = 'BUILDING' and c_custkey = o_custkey and l_orderkey = o_orderkey and o_orderdate < date('1995-03-15') and l_shipdate > date('1995-03-15') group by l_orderkey, o_orderdate, o_shippriority order by revenue desc, o_orderdate limit 10"))
     sql(s"drop datamap datamap5")
   }
@@ -123,7 +123,7 @@ class MVTpchTestCase extends QueryTest with BeforeAndAfterAll {
     sql("create datamap datamap5 using 'mv' as select l_orderkey, sum(l_extendedprice * (1 - l_discount)) as revenue, o_orderdate, o_shippriority,c_mktsegment,l_shipdate from customer, orders, lineitem where c_mktsegment = 'BUILDING' and c_custkey = o_custkey and l_orderkey = o_orderkey and o_orderdate < date('1995-03-15') and l_shipdate > date('1995-03-15') group by l_orderkey, o_orderdate, o_shippriority,c_mktsegment,l_shipdate")
     val df = sql("select l_orderkey, sum(l_extendedprice * (1 - l_discount)) as revenue, o_orderdate, o_shippriority from customer, orders, lineitem where c_mktsegment = 'BUILDING' and c_custkey = o_custkey and l_orderkey = o_orderkey and o_orderdate < date('1995-03-15') and l_shipdate > date('1995-03-15') group by l_orderkey, o_orderdate, o_shippriority order by revenue desc, o_orderdate limit 10")
     val analyzed = df.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap5"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap5"))
 //    checkAnswer(df, sql("select l_orderkey, sum(l_extendedprice * (1 - l_discount)) as revenue, o_orderdate, o_shippriority from customer1, orders1, lineitem1 where c_mktsegment = 'BUILDING' and c_custkey = o_custkey and l_orderkey = o_orderkey and o_orderdate < date('1995-03-15') and l_shipdate > date('1995-03-15') group by l_orderkey, o_orderdate, o_shippriority order by revenue desc, o_orderdate limit 10"))
     sql(s"drop datamap datamap5")
   }
@@ -133,7 +133,7 @@ class MVTpchTestCase extends QueryTest with BeforeAndAfterAll {
     sql("create datamap datamap6 using 'mv' as select o_orderpriority, count(*) as order_count from orders where o_orderdate >= date('1993-07-01') and o_orderdate < date('1993-10-01') and exists ( select * from lineitem where l_orderkey = o_orderkey and l_commitdate < l_receiptdate ) group by o_orderpriority order by o_orderpriority")
     val df = sql("select o_orderpriority, count(*) as order_count from orders where o_orderdate >= date('1993-07-01') and o_orderdate < date('1993-10-01') and exists ( select * from lineitem where l_orderkey = o_orderkey and l_commitdate < l_receiptdate ) group by o_orderpriority order by o_orderpriority")
     val analyzed = df.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap6"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap6"))
 //    checkAnswer(df, sql("select o_orderpriority, count(*) as order_count from orders1 where o_orderdate >= date('1993-07-01') and o_orderdate < date('1993-10-01') and exists ( select * from lineitem1 where l_orderkey = o_orderkey and l_commitdate < l_receiptdate ) group by o_orderpriority order by o_orderpriority"))
     sql(s"drop datamap datamap6")
   }
@@ -143,7 +143,7 @@ class MVTpchTestCase extends QueryTest with BeforeAndAfterAll {
     sql("create datamap datamap7 using 'mv' as select n_name, sum(l_extendedprice * (1 - l_discount)) as revenue from customer, orders, lineitem, supplier, nation, region where c_custkey = o_custkey and l_orderkey = o_orderkey and l_suppkey = s_suppkey and c_nationkey = s_nationkey and s_nationkey = n_nationkey and n_regionkey = r_regionkey and r_name = 'ASIA' and o_orderdate >= date('1994-01-01') and o_orderdate < date('1995-01-01') group by n_name")
     val df = sql("select n_name, sum(l_extendedprice * (1 - l_discount)) as revenue from customer, orders, lineitem, supplier, nation, region where c_custkey = o_custkey and l_orderkey = o_orderkey and l_suppkey = s_suppkey and c_nationkey = s_nationkey and s_nationkey = n_nationkey and n_regionkey = r_regionkey and r_name = 'ASIA' and o_orderdate >= date('1994-01-01') and o_orderdate < date('1995-01-01') group by n_name order by revenue desc")
     val analyzed = df.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap7"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap7"))
 //    checkAnswer(df, sql("select n_name, sum(l_extendedprice * (1 - l_discount)) as revenue from customer1, orders1, lineitem1, supplier1, nation1, region1 where c_custkey = o_custkey and l_orderkey = o_orderkey and l_suppkey = s_suppkey and c_nationkey = s_nationkey and s_nationkey = n_nationkey and n_regionkey = r_regionkey and r_name = 'ASIA' and o_orderdate >= date('1994-01-01') and o_orderdate < date('1995-01-01') group by n_name order by revenue desc"))
     sql(s"drop datamap datamap7")
   }
@@ -153,7 +153,7 @@ class MVTpchTestCase extends QueryTest with BeforeAndAfterAll {
     sql("create datamap datamap8 using 'mv' as select n_name,o_orderdate,r_name, sum(l_extendedprice * (1 - l_discount)) as revenue, sum(c_custkey), sum(o_custkey), sum(l_orderkey),sum(o_orderkey), sum(l_suppkey), sum(s_suppkey), sum(c_nationkey), sum(s_nationkey), sum(n_nationkey), sum(n_regionkey), sum(r_regionkey)  from customer, orders, lineitem, supplier, nation, region where c_custkey = o_custkey and l_orderkey = o_orderkey and l_suppkey = s_suppkey and c_nationkey = s_nationkey and s_nationkey = n_nationkey and n_regionkey = r_regionkey  group by n_name,o_orderdate,r_name")
     val df = sql("select n_name, sum(l_extendedprice * (1 - l_discount)) as revenue from customer, orders, lineitem, supplier, nation, region where c_custkey = o_custkey and l_orderkey = o_orderkey and l_suppkey = s_suppkey and c_nationkey = s_nationkey and s_nationkey = n_nationkey and n_regionkey = r_regionkey and r_name = 'ASIA' and o_orderdate >= date('1994-01-01') and o_orderdate < date('1995-01-01') group by n_name order by revenue desc")
     val analyzed = df.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap8"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap8"))
 //    checkAnswer(df, sql("select n_name, sum(l_extendedprice * (1 - l_discount)) as revenue from customer1, orders1, lineitem1, supplier1, nation1, region1 where c_custkey = o_custkey and l_orderkey = o_orderkey and l_suppkey = s_suppkey and c_nationkey = s_nationkey and s_nationkey = n_nationkey and n_regionkey = r_regionkey and r_name = 'ASIA' and o_orderdate >= date('1994-01-01') and o_orderdate < date('1995-01-01') group by n_name order by revenue desc"))
     sql(s"drop datamap datamap8")
   }
@@ -163,7 +163,7 @@ class MVTpchTestCase extends QueryTest with BeforeAndAfterAll {
     sql("create datamap datamap9 using 'mv' as select sum(l_extendedprice * l_discount) as revenue, count(l_shipdate), sum(l_discount),sum(l_quantity)  from lineitem where l_shipdate >= date('1994-01-01') and l_shipdate < date('1995-01-01') and l_discount between 0.05 and 0.07 and l_quantity < 24")
     val df = sql("select sum(l_extendedprice * l_discount) as revenue from lineitem where l_shipdate >= date('1994-01-01') and l_shipdate < date('1995-01-01') and l_discount between 0.05 and 0.07 and l_quantity < 24")
     val analyzed = df.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap9"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap9"))
     assert(verifyAgg(analyzed))
 //    checkAnswer(df, sql("select sum(l_extendedprice * l_discount) as revenue from lineitem1 where l_shipdate >= date('1994-01-01') and l_shipdate < date('1995-01-01') and l_discount between 0.05 and 0.07 and l_quantity < 24"))
     sql(s"drop datamap datamap9")
@@ -174,7 +174,7 @@ class MVTpchTestCase extends QueryTest with BeforeAndAfterAll {
     sql("create datamap datamap10 using 'mv' as select sum(l_extendedprice * l_discount) as revenue,l_shipdate,l_discount,l_quantity from lineitem group by l_shipdate,l_discount,l_quantity")
     val df = sql("select sum(l_extendedprice * l_discount) as revenue from lineitem where l_shipdate >= date('1994-01-01') and l_shipdate < date('1995-01-01') and l_discount between 0.05 and 0.07 and l_quantity < 24")
     val analyzed = df.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap10"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap10"))
     assert(verifyAgg(analyzed))
 //    checkAnswer(df, sql("select sum(l_extendedprice * l_discount) as revenue from lineitem1 where l_shipdate >= date('1994-01-01') and l_shipdate < date('1995-01-01') and l_discount between 0.05 and 0.07 and l_quantity < 24"))
     sql(s"drop datamap datamap10")
@@ -185,7 +185,7 @@ class MVTpchTestCase extends QueryTest with BeforeAndAfterAll {
     sql("create datamap datamap11 using 'mv' as select l_shipdate,n_name , l_extendedprice , l_discount, s_suppkey,l_suppkey, o_orderkey,l_orderkey, c_custkey, o_custkey, s_nationkey,  n1.n_nationkey, c_nationkey from supplier,lineitem,orders,customer,nation n1 where s_suppkey = l_suppkey and o_orderkey = l_orderkey and c_custkey = o_custkey and s_nationkey = n1.n_nationkey and c_nationkey = n1.n_nationkey")
     val df = sql("select year(l_shipdate) as l_year, l_extendedprice * (1 - l_discount) as volume from supplier,lineitem,orders,customer,nation n1 where s_suppkey = l_suppkey and o_orderkey = l_orderkey and c_custkey = o_custkey and s_nationkey = n1.n_nationkey and c_nationkey = n1.n_nationkey and ( (n1.n_name = 'FRANCE') or (n1.n_name = 'GERMANY') ) and l_shipdate between date('1995-01-01') and date('1996-12-31')")
     val analyzed = df.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap11"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap11"))
 //    checkAnswer(df, sql("select year(l_shipdate) as l_year, l_extendedprice * (1 - l_discount) as volume from supplier1,lineitem1,orders1,customer1,nation1 n1 where s_suppkey = l_suppkey and o_orderkey = l_orderkey and c_custkey = o_custkey and s_nationkey = n1.n_nationkey and c_nationkey = n1.n_nationkey and ( (n1.n_name = 'FRANCE') or (n1.n_name = 'GERMANY') ) and l_shipdate between date('1995-01-01') and date('1996-12-31')"))
     sql(s"drop datamap datamap11")
   }
@@ -195,7 +195,7 @@ class MVTpchTestCase extends QueryTest with BeforeAndAfterAll {
     sql("create datamap datamap12 using 'mv' as select n1.n_name, l_shipdate, l_extendedprice ,l_discount,s_suppkey, l_suppkey,o_orderkey,l_orderkey, c_custkey,o_custkey,s_nationkey,  n1.n_nationkey,c_nationkey from supplier,lineitem,orders,customer,nation n1 where s_suppkey = l_suppkey and o_orderkey = l_orderkey and c_custkey = o_custkey and s_nationkey = n1.n_nationkey and c_nationkey = n1.n_nationkey")
     val df = sql("select supp_nation, l_year, sum(volume) as revenue from ( select n1.n_name as supp_nation, year(l_shipdate) as l_year, l_extendedprice * (1 - l_discount) as volume from supplier,lineitem,orders,customer,nation n1 where s_suppkey = l_suppkey and o_orderkey = l_orderkey and c_custkey = o_custkey and s_nationkey = n1.n_nationkey and c_nationkey = n1.n_nationkey and ( (n1.n_name = 'FRANCE' ) or (n1.n_name = 'GERMANY') ) and l_shipdate between date('1995-01-01') and date('1996-12-31') ) as shipping group by supp_nation, l_year order by supp_nation, l_year")
     val analyzed = df.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap12"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap12"))
 //    checkAnswer(df, sql("select supp_nation, l_year, sum(volume) as revenue from ( select n1.n_name as supp_nation, year(l_shipdate) as l_year, l_extendedprice * (1 - l_discount) as volume from supplier1,lineitem1,orders1,customer1,nation1 n1 where s_suppkey = l_suppkey and o_orderkey = l_orderkey and c_custkey = o_custkey and s_nationkey = n1.n_nationkey and c_nationkey = n1.n_nationkey and ( (n1.n_name = 'FRANCE' ) or (n1.n_name = 'GERMANY') ) and l_shipdate between date('1995-01-01') and date('1996-12-31') ) as shipping group by supp_nation, l_year order by supp_nation, l_year"))
     sql(s"drop datamap datamap12")
   }
@@ -205,18 +205,11 @@ class MVTpchTestCase extends QueryTest with BeforeAndAfterAll {
     sql("create datamap datamap13 using 'mv' as select n1.n_name as supp_nation, n2.n_name as cust_nation, l_shipdate, l_extendedprice * (1 - l_discount) as volume from supplier,lineitem,orders,customer,nation n1,nation n2 where s_suppkey = l_suppkey and o_orderkey = l_orderkey and c_custkey = o_custkey and s_nationkey = n1.n_nationkey and c_nationkey = n2.n_nationkey")
     val df = sql("select supp_nation, cust_nation, l_year, sum(volume) as revenue from ( select n1.n_name as supp_nation, n2.n_name as cust_nation, year(l_shipdate) as l_year, l_extendedprice * (1 - l_discount) as volume from supplier,lineitem,orders,customer,nation n1,nation n2 where s_suppkey = l_suppkey and o_orderkey = l_orderkey and c_custkey = o_custkey and s_nationkey = n1.n_nationkey and c_nationkey = n2.n_nationkey and ( (n1.n_name = 'FRANCE' and n2.n_name = 'GERMANY') or (n1.n_name = 'GERMANY' and n2.n_name = 'FRANCE') ) and l_shipdate between date('1995-01-01') and date('1996-12-31') ) as shipping group by supp_nation, cust_nation, l_year order by supp_nation, cust_nation, l_year")
     val analyzed = df.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "datamap13"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "datamap13"))
 //    checkAnswer(df, sql("select supp_nation, cust_nation, l_year, sum(volume) as revenue from ( select n1.n_name as supp_nation, n2.n_name as cust_nation, year(l_shipdate) as l_year, l_extendedprice * (1 - l_discount) as volume from supplier,lineitem1,orders1,customer1,nation1 n1,nation1 n2 where s_suppkey = l_suppkey and o_orderkey = l_orderkey and c_custkey = o_custkey and s_nationkey = n1.n_nationkey and c_nationkey = n2.n_nationkey and ( (n1.n_name = 'FRANCE' and n2.n_name = 'GERMANY') or (n1.n_name = 'GERMANY' and n2.n_name = 'FRANCE') ) and l_shipdate between date('1995-01-01') and date('1996-12-31') ) as shipping group by supp_nation, cust_nation, l_year order by supp_nation, cust_nation, l_year"))
     sql(s"drop datamap datamap13")
   }
 
-
-  def verifyMVDataMap(logicalPlan: LogicalPlan, dataMapName: String): Boolean = {
-    val tables = logicalPlan collect {
-      case l: LogicalRelation => l.catalogTable.get
-    }
-    tables.exists(_.identifier.table.equalsIgnoreCase(dataMapName+"_table"))
-  }
   def verifyAgg(logicalPlan: LogicalPlan): Boolean = {
     var aggExpExists = false
     logicalPlan transformExpressions {

--- a/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/TestPartitionWithMV.scala
+++ b/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/TestPartitionWithMV.scala
@@ -98,7 +98,7 @@ class TestPartitionWithMV extends QueryTest with BeforeAndAfterAll {
     checkAnswer(sql("select empname, sum(year) from partitionone group by empname, year, month,day"), Seq(Row("v", 2014)))
     val df1 = sql(s"select empname, sum(year) from partitionone group by empname, year, month,day")
     val analyzed1 = df1.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed1, "p1"))
+    assert(TestUtil.verifyMVDataMap(analyzed1, "p1"))
     assert(CarbonEnv.getCarbonTable(Some("partition_mv"), "p1_table")(sqlContext.sparkSession).isHivePartitionTable)
   }
 
@@ -117,7 +117,7 @@ class TestPartitionWithMV extends QueryTest with BeforeAndAfterAll {
     checkAnswer(sql("select * from partitionone"), Seq(Row("k",2,2014,1,1), Row("v",2,2015,1,1)))
     val df1 = sql(s"select empname, sum(year) from partitionone group by empname, year, month,day")
     val analyzed1 = df1.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed1, "p1"))
+    assert(TestUtil.verifyMVDataMap(analyzed1, "p1"))
     checkAnswer(sql("select * from p1_table"), Seq(Row("k",2014,2014,1,1), Row("v",2015,2015,1,1)))
   }
 
@@ -676,13 +676,6 @@ class TestPartitionWithMV extends QueryTest with BeforeAndAfterAll {
     sql("create datamap dm1 on table partitionone using 'mv' as select c,sum(b) from partitionone group by c")
     checkAnswer(sql("select c,sum(b) from partitionone group by c"), Seq(Row(3,2)))
     sql("drop table if exists partitionone")
-  }
-
-  def verifyMVDataMap(logicalPlan: LogicalPlan, dataMapName: String): Boolean = {
-    val tables = logicalPlan collect {
-      case l: LogicalRelation => l.catalogTable.get
-    }
-    tables.exists(_.identifier.table.equalsIgnoreCase(dataMapName + "_table"))
   }
 
 }

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggCreateCommand.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/preaggregate/TestPreAggCreateCommand.scala
@@ -206,8 +206,8 @@ class TestPreAggCreateCommand extends QueryTest with BeforeAndAfterAll {
     sql("create datamap agg0 on table mainTable using 'preaggregate' as select column3, sum(column3),column5, sum(column5) from maintable group by column3,column5")
     val df = sql("select * from maintable_agg0")
     val carbontable = getCarbonTable(df.queryExecution.analyzed)
-    assert(carbontable.getAllMeasures.size()==3)
-    assert(carbontable.getAllDimensions.size()==1)
+    assert(carbontable.getAllMeasures.size()==2)
+    assert(carbontable.getAllDimensions.size()==2)
     carbontable.getAllDimensions.asScala.foreach{ f =>
       assert(!f.getEncoder.contains(Encoding.DICTIONARY))
     }
@@ -218,8 +218,8 @@ class TestPreAggCreateCommand extends QueryTest with BeforeAndAfterAll {
     sql("create datamap agg0 on table mainTable using 'preaggregate' as select column3, sum(column3),column5, sum(column5) from maintable group by column3,column5,column2")
     val df = sql("select * from maintable_agg0")
     val carbontable = getCarbonTable(df.queryExecution.analyzed)
-    assert(carbontable.getAllMeasures.size()==3)
-    assert(carbontable.getAllDimensions.size()==2)
+    assert(carbontable.getAllMeasures.size()==2)
+    assert(carbontable.getAllDimensions.size()==3)
     carbontable.getAllDimensions.asScala.foreach{ f =>
       assert(!f.getEncoder.contains(Encoding.DICTIONARY))
     }

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
@@ -971,7 +971,8 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
    */
   def isDataTypeSupportedForDictionary_Exclude(columnDataType: String): Boolean = {
     val dataTypes =
-      Array("string", "timestamp", "int", "long", "bigint", "struct", "array", "map", "binary")
+      Array("string", "timestamp", "int", "integer", "long", "bigint", "struct", "array",
+        "map", "binary")
     dataTypes.exists(x => x.equalsIgnoreCase(columnDataType))
   }
 

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonLoadDataCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonLoadDataCommand.scala
@@ -612,13 +612,11 @@ case class CarbonLoadDataCommand(
       (dataFrame, dataFrame)
     }
     val table = carbonLoadModel.getCarbonDataLoadSchema.getCarbonTable
-    if (!table.isChildDataMap) {
-      GlobalDictionaryUtil.generateGlobalDictionary(
-        sparkSession.sqlContext,
-        carbonLoadModel,
-        hadoopConf,
-        dictionaryDataFrame)
-    }
+    GlobalDictionaryUtil.generateGlobalDictionary(
+      sparkSession.sqlContext,
+      carbonLoadModel,
+      hadoopConf,
+      dictionaryDataFrame)
     if (table.isHivePartitionTable) {
       rows = loadDataWithPartition(
         sparkSession,


### PR DESCRIPTION

This PR includes,
1. Blocked complex data types with mv
2. Fixed to_date function while creating mv datamap
3. Added inheriting Global dictionary from parent table to child table for preaggregate & mv
4. Validate DMproperties for MV

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [x] Testing done
       added
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

