### PR TITLE
[CARBONDATA-3403]Fix MV is not working for like and filter AND and OR queries

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/timeseries/TestTimeSeriesCreateTable.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/timeseries/TestTimeSeriesCreateTable.scala
@@ -517,7 +517,7 @@ class TestTimeSeriesCreateTable extends QueryTest with BeforeAndAfterAll with Be
            |GROUP BY dataTime
         """.stripMargin)
     }
-    assert(e.getMessage.contains("Table or view not found: maintableno"))
+    assert(e.getMessage.contains("Table or view not found: mainTableNo"))
   }
 
   test("test timeseries create table 33: support event_time and granularity key with space") {

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/preaaggregate/PreAggregateUtil.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/preaaggregate/PreAggregateUtil.scala
@@ -196,7 +196,7 @@ object PreAggregateUtil {
       parentDatabaseName: String,
       carbonTable: CarbonTable) : ColumnTableRelation = {
     val parentColumnId = carbonTable.getColumnByName(parentTableName, parentColumnName).getColumnId
-    val columnTableRelation = ColumnTableRelation(parentColumnName = parentColumnName,
+    val columnTableRelation = ColumnTableRelation(parentColumnName = parentColumnName.toLowerCase(),
       parentColumnId = parentColumnId,
       parentTableName = parentTableName,
       parentDatabaseName = parentDatabaseName, parentTableId = parentTableId)
@@ -386,13 +386,14 @@ object PreAggregateUtil {
       aggregateType: String = "",
       parentTableName: String,
       columnTableRelationList: Seq[ColumnTableRelation]): (Field, DataMapField) = {
-    val actualColumnName = if (aggregateType.equals("")) {
+    var actualColumnName = if (aggregateType.equals("")) {
       parentTableName + '_' + columnName
     } else {
       parentTableName + '_' + columnName + '_' + aggregateType
     }
     val rawSchema = '`' + actualColumnName + '`' + ' ' + dataType.typeName
     val dataMapField = DataMapField(aggregateType, Some(columnTableRelationList))
+    actualColumnName = actualColumnName.toLowerCase()
     if (dataType.typeName.startsWith("decimal")) {
       val (precision, scale) = CommonUtil.getScaleAndPrecision(dataType.catalogString)
       (Field(column = actualColumnName,

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSpark2SqlParser.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSpark2SqlParser.scala
@@ -691,7 +691,7 @@ class CarbonSpark2SqlParser extends CarbonDDLSqlParser {
   }
 
   def addPreAggFunction(sql: String): String = {
-    addPreAgg(new lexical.Scanner(sql.toLowerCase)) match {
+    addPreAgg(new lexical.Scanner(sql)) match {
       case Success(query, _) => query
       case _ =>
         throw new MalformedCarbonCommandException(s"Unsupported query")
@@ -699,7 +699,7 @@ class CarbonSpark2SqlParser extends CarbonDDLSqlParser {
   }
 
   def addPreAggLoadFunction(sql: String): String = {
-    addPreAggLoad(new lexical.Scanner(sql.toLowerCase)) match {
+    addPreAggLoad(new lexical.Scanner(sql)) match {
       case Success(query, _) => query
       case _ =>
         throw new MalformedCarbonCommandException(s"Unsupported query")


### PR DESCRIPTION
### Problem:
MV table is not hit during query for like and filter AND and OR queries, 
When we have like or filter queries, the queries will have literals which will be case sensitive to fetch the data.
But dring MV modular plan generation, we register the schema for datamap where we convert the complete datamap query to lower case, which will even convert the literals.
So after modular plan generation of user query, during matching pahse of modular plan of datamap and user query, the semantic equals fails for literals, that is Attribute reference type.

### Solution:
Do not convert the query to lower case when registering schema, that is when adding the preagg fun to query. So it will be handled for MV
For preaggregate, instead converting complete query to lowercase, convert to lower case during ColumnTableRelation generation and createField for preaggregate generation, so it will be handled for preaggregate.




Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 NA
 - [x] Any backward compatibility impacted?
 NA
 - [x] Document update required?
NA
 - [x] Testing done
Added UT
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA
