### PR TITLE
[CARBONDATA-3402] Added Inherit Inverted Index Property  from Parent Table for Preagg & MV

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/util/DataMapUtil.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/util/DataMapUtil.scala
@@ -146,6 +146,26 @@ object DataMapUtil {
       tableProperties
         .put(CarbonCommonConstants.DICTIONARY_EXCLUDE, newGlobalDictExclude.mkString(","))
     }
+
+    val parentInvertedIndex = parentTable.getTableInfo.getFactTable.getTableProperties.asScala
+      .getOrElse(CarbonCommonConstants.INVERTED_INDEX, "").split(",")
+
+    val newInvertedIndex = getDataMapColumns(parentInvertedIndex, fields, fieldRelationMap)
+
+    val parentNoInvertedIndex = parentTable.getTableInfo.getFactTable.getTableProperties.asScala
+      .getOrElse(CarbonCommonConstants.NO_INVERTED_INDEX, "").split(",")
+
+    val newNoInvertedIndex = getDataMapColumns(parentNoInvertedIndex, fields, fieldRelationMap)
+
+    if (newInvertedIndex.nonEmpty) {
+      tableProperties
+        .put(CarbonCommonConstants.INVERTED_INDEX, newInvertedIndex.mkString(","))
+    }
+    if (newNoInvertedIndex.nonEmpty) {
+      tableProperties
+        .put(CarbonCommonConstants.NO_INVERTED_INDEX, newNoInvertedIndex.mkString(","))
+    }
+
   }
 
   private def getDataMapColumns(parentColumns: Array[String], fields: Seq[Field],


### PR DESCRIPTION
This PR includes,

1. Inherit  Inverted Index Property  from Parent Table for Preagg & MV datamap
2. When Preaggregate and mv datamap are present, while loading data to preaggregate table, we should skip applying mv plan

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

