### PR TITLE
[CARBONDATA-3408] CarbonSession partition support binary data type

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/util/DataTypeUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/DataTypeUtil.java
@@ -478,7 +478,12 @@ public final class DataTypeUtil {
     } else if (actualDataType == DataTypes.TIMESTAMP) {
       return ByteUtil.toXorBytes((Long) dimensionValue);
     } else if (actualDataType == DataTypes.BINARY) {
-      return (byte[]) dimensionValue;
+      if (dimensionValue instanceof String) {
+        return ((String) dimensionValue).getBytes(
+            Charset.forName(CarbonCommonConstants.DEFAULT_CHARSET));
+      } else {
+        return (byte[]) dimensionValue;
+      }
     } else {
       // Default action for String/Varchar
       return ByteUtil.toBytes(dimensionValue.toString());

--- a/docs/ddl-of-carbondata.md
+++ b/docs/ddl-of-carbondata.md
@@ -918,7 +918,7 @@ Users can specify which columns to include and exclude for local dictionary gene
   PARTITIONED BY (productCategory STRING, productBatch STRING)
   STORED AS carbondata
   ```
-   **NOTE:** Hive partition is not supported on complex data type columns and binary data type.
+   **NOTE:** Hive partition is not supported on complex data type columns.
 
 
 #### Show Partitions
@@ -961,7 +961,7 @@ Users can specify which columns to include and exclude for local dictionary gene
 
 ### CARBONDATA PARTITION(HASH,RANGE,LIST) -- Alpha feature, this partition feature does not support update and delete data.
 
-  The partition supports three type:(Hash,Range,List), similar to other system's partition features, CarbonData's partition feature can be used to improve query performance by filtering on the partition column. Partition feature doesn't support binary data type.
+  The partition supports three type:(Hash,Range,List), similar to other system's partition features, CarbonData's partition feature can be used to improve query performance by filtering on the partition column.
 
 ### Create Hash Partition Table
 

--- a/integration/spark-common-test/src/test/resources/binarystringdatawithHead.csv
+++ b/integration/spark-common-test/src/test/resources/binarystringdatawithHead.csv
@@ -1,0 +1,4 @@
+id|label|name|autolabel|binaryfield
+2|false|2.png|true|binary
+3|false|3.png|false|1
+1|true|1.png|true|Hello world

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/model/CarbonLoadModelBuilder.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/model/CarbonLoadModelBuilder.java
@@ -40,7 +40,9 @@ import org.apache.carbondata.core.util.CarbonProperties;
 import org.apache.carbondata.core.util.CarbonUtil;
 import org.apache.carbondata.processing.loading.constants.DataLoadProcessorConstants;
 import org.apache.carbondata.processing.loading.csvinput.CSVInputFormat;
+import org.apache.carbondata.processing.loading.exception.CarbonDataLoadingException;
 import org.apache.carbondata.processing.util.CarbonBadRecordUtil;
+import org.apache.carbondata.processing.util.CarbonLoaderUtil;
 import org.apache.carbondata.processing.util.TableOptionConstant;
 
 import org.apache.commons.lang.StringUtils;
@@ -434,6 +436,10 @@ public class CarbonLoadModelBuilder {
 
   private void validateAndSetBinaryDecoder(CarbonLoadModel carbonLoadModel) {
     String binaryDecoder = carbonLoadModel.getBinaryDecoder();
+    if (!CarbonLoaderUtil.isValidBinaryDecoder(binaryDecoder)) {
+      throw new CarbonDataLoadingException("Binary decoder only support Base64, " +
+          "Hex or no decode for string, don't support " + binaryDecoder);
+    }
     if (StringUtils.isBlank(binaryDecoder)) {
       binaryDecoder = CarbonProperties.getInstance().getProperty(
           CarbonLoadOptionConstants.CARBON_OPTIONS_BINARY_DECODER,

--- a/processing/src/main/java/org/apache/carbondata/processing/util/CarbonLoaderUtil.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/util/CarbonLoaderUtil.java
@@ -426,10 +426,10 @@ public final class CarbonLoaderUtil {
   }
 
   public static boolean isValidBinaryDecoder(String binaryDecoderChar) {
-    return binaryDecoderChar.equalsIgnoreCase(
-        CarbonLoadOptionConstants.CARBON_OPTIONS_BINARY_DECODER_BASE64) ||
-        binaryDecoderChar.equalsIgnoreCase(
-            CarbonLoadOptionConstants.CARBON_OPTIONS_BINARY_DECODER_HEX) ||
+    return CarbonLoadOptionConstants.CARBON_OPTIONS_BINARY_DECODER_BASE64.equalsIgnoreCase(
+        binaryDecoderChar) ||
+        CarbonLoadOptionConstants.CARBON_OPTIONS_BINARY_DECODER_HEX.equalsIgnoreCase(
+            binaryDecoderChar) ||
         StringUtils.isBlank(binaryDecoderChar);
   }
 


### PR DESCRIPTION
CarbonSession partition support binary data type, only little work on it.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 No
 - [x] Any backward compatibility impacted?
 NA
 - [x] Document update required?
Yes
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       Added
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
JIRA-3336
