### PR TITLE
[CARBONDATA-3411] [CARBONDATA-3414] Fix clear datamaps logs an exception in SDK

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonLoadDataCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonLoadDataCommand.scala
@@ -847,7 +847,7 @@ case class CarbonLoadDataCommand(
         }
         LOGGER.info(errorMessage)
         LOGGER.error(ex)
-        throw new Exception(errorMessage)
+        throw ex
     } finally {
       CarbonSession.threadUnset("partition.operationcontext")
       if (isOverwriteTable) {

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonReaderBuilder.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonReaderBuilder.java
@@ -359,7 +359,8 @@ public class CarbonReaderBuilder {
     } catch (Exception ex) {
       // Clear the datamap cache as it can get added in getSplits() method
       DataMapStoreManager.getInstance().clearDataMaps(
-          format.getOrCreateCarbonTable((job.getConfiguration())).getAbsoluteTableIdentifier());
+          format.getOrCreateCarbonTable((job.getConfiguration())).getAbsoluteTableIdentifier(),
+          false);
       throw ex;
     }
   }
@@ -417,7 +418,8 @@ public class CarbonReaderBuilder {
       if (format != null) {
         // Clear the datamap cache as it is added in getSplits() method
         DataMapStoreManager.getInstance().clearDataMaps(
-            format.getOrCreateCarbonTable((job.getConfiguration())).getAbsoluteTableIdentifier());
+            format.getOrCreateCarbonTable((job.getConfiguration())).getAbsoluteTableIdentifier(),
+            false);
       }
     }
     return splits.toArray(new InputSplit[splits.size()]);


### PR DESCRIPTION
problem: In sdk when datamaps are cleared, below exception is logged
java.io.IOException: File does not exist: ../carbondata/store/sdk/testWriteFiles/771604793030370/Metadata/schema

cause: CarbonTable is required for only launching the job, SDK there is no need to launch job. so , no need to build a carbon table.

solution: build carbon table only when need to launch job.

problem [CARBONDATA-3411]: when Insert into partition table fails, exception doesn't print reason.

cause: Exception was caught , but error message was not from that exception. 

solution: throw the exception directly 

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed? NA
 
 - [ ] Any backward compatibility impacted? NA
 
 - [ ] Document update required? NA

 - [ ] Testing done. done. checked logs       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.  NA

