### PR TITLE
[CARBONDATA-3412] Empty results are displayed for non-transactional tables

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datamap/DistributableDataMapFormat.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/DistributableDataMapFormat.java
@@ -33,6 +33,7 @@ import org.apache.carbondata.core.datastore.impl.FileFactory;
 import org.apache.carbondata.core.indexstore.ExtendedBlocklet;
 import org.apache.carbondata.core.indexstore.PartitionSpec;
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
+import org.apache.carbondata.core.readcommitter.LatestFilesReadCommittedScope;
 import org.apache.carbondata.core.readcommitter.ReadCommittedScope;
 import org.apache.carbondata.core.readcommitter.TableStatusReadCommittedScope;
 import org.apache.carbondata.core.scan.filter.resolver.FilterResolverIntf;
@@ -301,9 +302,15 @@ public class DistributableDataMapFormat extends FileInputFormat<Void, ExtendedBl
 
   private void initReadCommittedScope() throws IOException {
     if (readCommittedScope == null) {
-      this.readCommittedScope =
-          new TableStatusReadCommittedScope(table.getAbsoluteTableIdentifier(),
-              FileFactory.getConfiguration());
+      if (table.isTransactionalTable()) {
+        this.readCommittedScope =
+            new TableStatusReadCommittedScope(table.getAbsoluteTableIdentifier(),
+                FileFactory.getConfiguration());
+      } else {
+        this.readCommittedScope =
+            new LatestFilesReadCommittedScope(table.getTablePath(),
+                FileFactory.getConfiguration());
+      }
     }
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/CarbonTable.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/CarbonTable.java
@@ -67,6 +67,7 @@ import static org.apache.carbondata.core.util.CarbonUtil.thriftColumnSchemaToWra
 
 import com.google.common.collect.Lists;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.Writable;
 import org.apache.log4j.Logger;
 
 /**

--- a/integration/spark2/src/main/scala/org/apache/carbondata/indexserver/IndexServer.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/indexserver/IndexServer.scala
@@ -18,6 +18,7 @@ package org.apache.carbondata.indexserver
 
 import java.net.InetSocketAddress
 import java.security.PrivilegedAction
+import java.util.UUID
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.ipc.{ProtocolInfo, RPC}
@@ -121,7 +122,11 @@ object IndexServer extends ServerInterface {
   }
 
   override def showCache(tableName: String = ""): Array[String] = doAs {
-    val jobgroup: String = "Show Cache for " + tableName
+    val jobgroup: String = "Show Cache for " + (tableName match {
+      case "" => "for all tables"
+      case table => s"for $table"
+    })
+    sparkSession.sparkContext.setLocalProperty("spark.jobGroup.id", UUID.randomUUID().toString)
     sparkSession.sparkContext.setLocalProperty("spark.job.description", jobgroup)
     new DistributedShowCacheRDD(sparkSession, tableName).collect()
   }

--- a/integration/spark2/src/main/scala/org/apache/carbondata/indexserver/InvalidateSegmentCacheRDD.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/indexserver/InvalidateSegmentCacheRDD.scala
@@ -19,8 +19,7 @@ package org.apache.carbondata.indexserver
 import scala.collection.JavaConverters._
 
 import org.apache.spark.{Partition, TaskContext}
-import org.apache.spark.sql.{CarbonEnv, SparkSession}
-import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.hive.DistributionUtil
 
 import org.apache.carbondata.core.datamap.DataMapStoreManager
@@ -28,11 +27,8 @@ import org.apache.carbondata.core.metadata.schema.table.CarbonTable
 import org.apache.carbondata.hadoop.CarbonInputSplit
 import org.apache.carbondata.spark.rdd.CarbonRDD
 
-class InvalidateSegmentCacheRDD(@transient private val ss: SparkSession, databaseName: String,
-    tableName: String, invalidSegmentIds: List[String]) extends CarbonRDD[String](ss, Nil) {
-
-  val carbonTable: CarbonTable = CarbonEnv
-    .getCarbonTable(TableIdentifier(tableName, Some(databaseName)))(ss)
+class InvalidateSegmentCacheRDD(@transient private val ss: SparkSession, carbonTable: CarbonTable,
+    invalidSegmentIds: List[String]) extends CarbonRDD[String](ss, Nil) {
 
   val executorsList: Array[String] = DistributionUtil.getNodeList(ss.sparkContext)
 

--- a/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -258,8 +258,8 @@ object CarbonDataRDDFactory {
           if (CarbonProperties.getInstance().isDistributedPruningEnabled(
               carbonLoadModel.getDatabaseName, carbonLoadModel.getTableName)) {
             try {
-              IndexServer.getClient.invalidateSegmentCache(carbonLoadModel.getDatabaseName,
-                carbonLoadModel.getTableName, compactedSegments.asScala.toArray)
+              IndexServer.getClient.invalidateSegmentCache(carbonLoadModel
+                .getCarbonDataLoadSchema.getCarbonTable, compactedSegments.asScala.toArray)
             } catch {
               case ex: Exception =>
                 LOGGER.warn(s"Clear cache job has failed for ${carbonLoadModel

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/cache/CacheUtil.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/cache/CacheUtil.scala
@@ -56,8 +56,7 @@ object CacheUtil {
         val invalidSegmentIds = validAndInvalidSegmentsInfo.getInvalidSegments.asScala
           .map(_.getSegmentNo).toArray
         try {
-          IndexServer.getClient.invalidateSegmentCache(carbonTable.getDatabaseName, carbonTable
-            .getTableName, invalidSegmentIds)
+          IndexServer.getClient.invalidateSegmentCache(carbonTable, invalidSegmentIds)
         } catch {
           case e: Exception =>
             LOGGER.warn("Failed to clear cache from executors. ", e)

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/mutation/DeleteExecution.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/mutation/DeleteExecution.scala
@@ -321,8 +321,8 @@ object DeleteExecution {
     if (CarbonProperties.getInstance().isDistributedPruningEnabled(carbonTable
       .getDatabaseName, carbonTable.getTableName)) {
       try {
-        IndexServer.getClient.invalidateSegmentCache(carbonTable
-          .getDatabaseName, carbonTable.getTableName, segmentsToBeCleared.map(_.getSegmentNo)
+        IndexServer.getClient
+          .invalidateSegmentCache(carbonTable, segmentsToBeCleared.map(_.getSegmentNo)
           .toArray)
       } catch {
         case _: Exception =>


### PR DESCRIPTION
**Solution:**
Added a check for nonTransactional table when generating the read committed scope.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

