### PR TITLE
[CARBONDATA-3413] Fix io.netty out of direct memory exception in arrow integration

### DIFF
--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/ArrowCarbonReader.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/ArrowCarbonReader.java
@@ -62,6 +62,7 @@ public class ArrowCarbonReader<T> extends CarbonReader<T> {
    * Carbon reader will fill the arrow vector after reading the carbondata files.
    * This arrow byte[] can be used to create arrow table and used for in memory analytics
    * Note: create a reader at blocklet level, so that arrow byte[] will not exceed INT_MAX
+   * User need to close the VectorSchemaRoot after usage by calling VectorSchemaRoot.close()
    *
    * @param carbonSchema
    * @return


### PR DESCRIPTION
problem : io.netty out of direct memory exception in arrow integration

cause: In ArrowConverter, allocator is not closed 

solution: close the allocator in arrowConverter.
Also handle the problems in test utility API 

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed? NA
 
 - [ ] Any backward compatibility impacted? NA
 
 - [ ] Document update required? NA

 - [ ] Testing done
done. Updated UT.

 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.  NA

