### PR TITLE
[HOTFIX] Fix compatibility issue with page size

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/metadata/blocklet/BlockletInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/blocklet/BlockletInfo.java
@@ -310,9 +310,13 @@ public class BlockletInfo implements Serializable, Writable {
     if (isSortedPresent) {
       this.isSorted = input.readBoolean();
     }
-    numberOfRowsPerPage = new int[input.readShort()];
-    for (int i = 0; i < numberOfRowsPerPage.length; i++) {
-      numberOfRowsPerPage[i] = input.readInt();
+    short pageCount = input.readShort();
+    if (pageCount != 0) {
+      // should set only for new store, old store will be set via setNumberOfRowsPerPage
+      numberOfRowsPerPage = new int[pageCount];
+      for (int i = 0; i < numberOfRowsPerPage.length; i++) {
+        numberOfRowsPerPage[i] = input.readInt();
+      }
     }
   }
 


### PR DESCRIPTION
problem:  Array Out of bound exception when old store is read from latest code.

Cause: #3239 partially fix the problem, After this change, For old store, length is written as zero. so in BlockletInfo, numberOfRowsPerPage will be array of zero elements. Hence the ArrayOutOfBound exception.

solution: Fill the numberOfRowsPerPage only when length is non-zero, when length is zero, it will be filled from setNumberOfRowsPerPage in BlockletDataRefNode as numberOfRowsPerPage is null.


Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed? NA
 
 - [ ] Any backward compatibility impacted? NA
 
 - [ ] Document update required? NA

 - [ ] Testing done
             yes, tested locally.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.  NA

