### PR TITLE
[CARBONDATA-3416]Correct the preparing of carbon analyzer with custom rules with spark analyzer

### DIFF
--- a/integration/spark2/src/main/commonTo2.2And2.3/org/apache/spark/sql/hive/CarbonSessionState.scala
+++ b/integration/spark2/src/main/commonTo2.2And2.3/org/apache/spark/sql/hive/CarbonSessionState.scala
@@ -236,29 +236,33 @@ class CarbonSessionStateBuilder(sparkSession: SparkSession,
 
   override lazy val optimizer: Optimizer = new CarbonOptimizer(catalog, conf, experimentalMethods)
 
-  override protected def analyzer: Analyzer = new CarbonAnalyzer(catalog, conf, sparkSession,
+  override protected def analyzer: Analyzer = {
+    new CarbonAnalyzer(catalog,
+      conf,
+      sparkSession,
+      getAnalyzer(super.analyzer))
+  }
+
+  /**
+   * This method adds carbon rules to Hive Analyzer and returns new analyzer
+   * @param analyzer hiveSessionStateBuilder analyzer
+   * @return
+   */
+  def getAnalyzer(analyzer: Analyzer): Analyzer = {
     new Analyzer(catalog, conf) {
 
       override val extendedResolutionRules: Seq[Rule[LogicalPlan]] =
-        new ResolveHiveSerdeTable(session) +:
-        new FindDataSourceTable(session) +:
-        new ResolveSQLOnFile(session) +:
-        new CarbonIUDAnalysisRule(sparkSession) +:
-        new CarbonPreInsertionCasts(sparkSession) +: customResolutionRules
+        analyzer.extendedResolutionRules ++
+        Seq(CarbonIUDAnalysisRule(sparkSession)) ++
+        Seq(CarbonPreInsertionCasts(sparkSession)) ++ customResolutionRules
 
       override val extendedCheckRules: Seq[LogicalPlan => Unit] =
-      PreWriteCheck :: HiveOnlyCheck :: Nil
+        analyzer.extendedCheckRules
 
       override val postHocResolutionRules: Seq[Rule[LogicalPlan]] =
-        new DetermineTableStats(session) +:
-        RelationConversions(conf, catalog) +:
-        PreprocessTableCreation(session) +:
-        PreprocessTableInsertion(conf) +:
-        DataSourceAnalysis(conf) +:
-        HiveAnalysis +:
-        customPostHocResolutionRules
+        analyzer.postHocResolutionRules
     }
-  )
+  }
 
   override protected def newBuilder: NewBuilder = new CarbonSessionStateBuilder(_, _)
 }


### PR DESCRIPTION
### Problem:
When new analyzer rule added in spark, not reflecting in carbon.

Carbon prepares the session state builder by extending the hivesession state builder, and create new analyzer by overiding all the rules added by spark, so when new rule is added in spark, it will not be reflected in carbon as we have overridden the complete analyzer

### Solution
While making the new analyzer in carbon side, better to get all the rules from super class and add the carbon rules in analyzer, so that when new rules are added in spark side, since we take super.rules, we get all the updated rules from spark, before adding the carbon custom rules.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

