### PR TITLE
[CARBONDATA-3415] Merge index is not working for partition table. Merge index for partition table is taking significantly longer time than normal table.

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/SegmentIndexFileStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/SegmentIndexFileStore.java
@@ -296,7 +296,7 @@ public class SegmentIndexFileStore {
    * @param indexFile
    * @throws IOException
    */
-  private void readIndexFile(CarbonFile indexFile) throws IOException {
+  public void readIndexFile(CarbonFile indexFile) throws IOException {
     String indexFilePath = indexFile.getCanonicalPath();
     DataInputStream dataInputStream = FileFactory
         .getDataInputStream(indexFilePath, FileFactory.getFileType(indexFilePath), configuration);

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonOutputCommitter.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonOutputCommitter.java
@@ -134,19 +134,26 @@ public class CarbonOutputCommitter extends FileOutputCommitter {
       newMetaEntry.setSegmentFile(segmentFileName + CarbonTablePath.SEGMENT_EXT);
     }
     OperationContext operationContext = (OperationContext) getOperationContext();
+    CarbonTable carbonTable = loadModel.getCarbonDataLoadSchema().getCarbonTable();
     String uuid = "";
     if (loadModel.getCarbonDataLoadSchema().getCarbonTable().isChildDataMap() &&
         operationContext != null) {
       uuid = operationContext.getProperty("uuid").toString();
     }
+
+    SegmentFileStore.updateSegmentFile(carbonTable, loadModel.getSegmentId(),
+        segmentFileName + CarbonTablePath.SEGMENT_EXT,
+        carbonTable.getCarbonTableIdentifier().getTableId(),
+        new SegmentFileStore(carbonTable.getTablePath(),
+            segmentFileName + CarbonTablePath.SEGMENT_EXT));
+
     CarbonLoaderUtil
         .populateNewLoadMetaEntry(newMetaEntry, SegmentStatus.SUCCESS, loadModel.getFactTimeStamp(),
             true);
-    CarbonTable carbonTable = loadModel.getCarbonDataLoadSchema().getCarbonTable();
     long segmentSize = CarbonLoaderUtil
         .addDataIndexSizeIntoMetaEntry(newMetaEntry, loadModel.getSegmentId(), carbonTable);
     if (segmentSize > 0 || overwriteSet) {
-      if (operationContext != null && carbonTable.hasAggregationDataMap()) {
+      if (operationContext != null) {
         operationContext
             .setProperty("current.segmentfile", newMetaEntry.getSegmentFile());
         LoadEvents.LoadTablePreStatusUpdateEvent event =

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/CarbonIndexFileMergeTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/datacompaction/CarbonIndexFileMergeTestCase.scala
@@ -493,14 +493,24 @@ class CarbonIndexFileMergeTestCase
     val table = CarbonMetadata.getInstance().getCarbonTable(tableName)
     val path = CarbonTablePath
       .getSegmentPath(table.getAbsoluteTableIdentifier.getTablePath, segment)
-    val carbonFiles = FileFactory.getCarbonFile(path).listFiles(new CarbonFileFilter {
-      override def accept(file: CarbonFile): Boolean = {
-        file.getName.endsWith(CarbonTablePath
-          .INDEX_FILE_EXT)
-      }
-    })
+    val carbonFiles = if (table.isHivePartitionTable) {
+      FileFactory.getCarbonFile(table.getAbsoluteTableIdentifier.getTablePath)
+        .listFiles(true, new CarbonFileFilter {
+          override def accept(file: CarbonFile): Boolean = {
+            file.getName.endsWith(CarbonTablePath
+              .INDEX_FILE_EXT)
+          }
+        })
+    } else {
+      FileFactory.getCarbonFile(path).listFiles(true, new CarbonFileFilter {
+        override def accept(file: CarbonFile): Boolean = {
+          file.getName.endsWith(CarbonTablePath
+            .INDEX_FILE_EXT)
+        }
+      })
+    }
     if (carbonFiles != null) {
-      carbonFiles.length
+      carbonFiles.size()
     } else {
       0
     }

--- a/integration/spark-common/src/main/scala/org/apache/spark/rdd/CarbonMergeFilesRDD.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/rdd/CarbonMergeFilesRDD.scala
@@ -17,20 +17,28 @@
 
 package org.apache.spark.rdd
 
+import java.util
+
+import scala.collection.JavaConverters._
+
 import org.apache.spark.{Partition, TaskContext}
 import org.apache.spark.sql.SparkSession
 
 import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.core.constants.CarbonCommonConstants
+import org.apache.carbondata.core.metadata.SegmentFileStore
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable
+import org.apache.carbondata.core.statusmanager.SegmentStatusManager
 import org.apache.carbondata.core.util.CarbonProperties
 import org.apache.carbondata.core.util.path.CarbonTablePath
 import org.apache.carbondata.core.writer.CarbonIndexFileMergeWriter
 import org.apache.carbondata.processing.util.CarbonLoaderUtil
 import org.apache.carbondata.spark.rdd.CarbonRDD
 
-case class CarbonMergeFilePartition(rddId: Int, idx: Int, segmentId: String)
-  extends Partition {
+case class CarbonMergeFilePartition(rddId: Int,
+    idx: Int,
+    segmentId: String,
+    partitionPath: String = null) extends Partition {
 
   override val index: Int = idx
 
@@ -94,6 +102,20 @@ object CarbonMergeFilesRDD {
           }
       }
     }
+    if (carbonTable.isHivePartitionTable) {
+      segmentIds.foreach(segmentId => {
+        val readPath: String = CarbonTablePath.getSegmentFilesLocation(tablePath) +
+                               CarbonCommonConstants.FILE_SEPARATOR + segmentId + "_" +
+                               segmentFileNameToSegmentIdMap.get(segmentId) + ".tmp"
+        // Merge all partition files into a single file.
+        val segmentFileName: String = SegmentFileStore
+          .genSegmentFileName(segmentId, segmentFileNameToSegmentIdMap.get(segmentId))
+        SegmentFileStore
+          .mergeSegmentFiles(readPath,
+            segmentFileName,
+            CarbonTablePath.getSegmentFilesLocation(tablePath))
+      })
+    }
   }
 
   /**
@@ -130,9 +152,33 @@ class CarbonMergeFilesRDD(
   extends CarbonRDD[String](ss, Nil) {
 
   override def internalGetPartitions: Array[Partition] = {
-    segments.zipWithIndex.map {s =>
-      CarbonMergeFilePartition(id, s._2, s._1)
-    }.toArray
+    if (isHivePartitionedTable) {
+      val metadataDetails = SegmentStatusManager
+        .readLoadMetadata(CarbonTablePath.getMetadataPath(carbonTable.getTablePath))
+      // in case of partition table make rdd partitions per partition of the carbon table
+      val partitionPaths: java.util.Map[String, java.util.List[String]] = new java.util.HashMap()
+      segments.foreach(segment => {
+        val partitionSpecs = SegmentFileStore
+          .getPartitionSpecs(segment, carbonTable.getTablePath, metadataDetails)
+          .asScala.map(_.getLocation.toString)
+        partitionPaths.put(segment, partitionSpecs.asJava)
+      })
+      var index: Int = -1
+      val rddPartitions: java.util.List[Partition] = new java.util.ArrayList()
+      partitionPaths.asScala.foreach(partitionPath => {
+        val segmentId = partitionPath._1
+        partitionPath._2.asScala.map { partition =>
+          index = index + 1
+          rddPartitions.add(CarbonMergeFilePartition(id, index, segmentId, partition))
+        }
+      })
+      rddPartitions.asScala.toArray
+    } else {
+      // in case of normal carbon table, make rdd partitions per segment
+      segments.zipWithIndex.map { s =>
+        CarbonMergeFilePartition(id, s._2, s._1)
+      }.toArray
+    }
   }
 
   override def internalCompute(theSplit: Partition, context: TaskContext): Iterator[String] = {
@@ -145,7 +191,7 @@ class CarbonMergeFilesRDD(
       if (isHivePartitionedTable) {
         CarbonLoaderUtil
           .mergeIndexFilesInPartitionedSegment(carbonTable, split.segmentId,
-            segmentFileNameToSegmentIdMap.get(split.segmentId))
+            segmentFileNameToSegmentIdMap.get(split.segmentId), split.partitionPath)
       } else {
         new CarbonIndexFileMergeWriter(carbonTable)
           .mergeCarbonIndexFilesOfSegment(split.segmentId,

--- a/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonTableCompactor.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonTableCompactor.scala
@@ -214,10 +214,6 @@ class CarbonTableCompactor(carbonLoadModel: CarbonLoadModel,
       val mergedLoadNumber = CarbonDataMergerUtil.getLoadNumberFromLoadName(mergedLoadName)
       var segmentFilesForIUDCompact = new util.ArrayList[Segment]()
       var segmentFileName: String = null
-      if (compactionType != CompactionType.IUD_DELETE_DELTA &&
-          compactionType != CompactionType.IUD_UPDDEL_DELTA) {
-        MergeIndexUtil.mergeIndexFilesOnCompaction(compactionCallableModel)
-      }
       if (carbonTable.isHivePartitionTable) {
         val readPath =
           CarbonTablePath.getSegmentFilesLocation(carbonLoadModel.getTablePath) +
@@ -282,6 +278,11 @@ class CarbonTableCompactor(carbonLoadModel: CarbonLoadModel,
           carbonLoadModel,
           compactionType,
           segmentFileName)
+
+      if (compactionType != CompactionType.IUD_DELETE_DELTA &&
+          compactionType != CompactionType.IUD_UPDDEL_DELTA) {
+        MergeIndexUtil.mergeIndexFilesOnCompaction(compactionCallableModel)
+      }
 
       val compactionLoadStatusPostEvent = AlterTableCompactionPostStatusUpdateEvent(sc.sparkSession,
         carbonTable,

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonLoadDataCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonLoadDataCommand.scala
@@ -886,7 +886,8 @@ case class CarbonLoadDataCommand(
           "load is passed.", e)
     }
     val specs =
-      SegmentFileStore.getPartitionSpecs(carbonLoadModel.getSegmentId, carbonLoadModel.getTablePath)
+      SegmentFileStore.getPartitionSpecs(carbonLoadModel.getSegmentId, carbonLoadModel.getTablePath,
+        SegmentStatusManager.readLoadMetadata(CarbonTablePath.getMetadataPath(table.getTablePath)))
     if (specs != null) {
       specs.asScala.map{ spec =>
         Row(spec.getPartitions.asScala.mkString("/"), spec.getLocation.toString, spec.getUuid)

--- a/integration/spark2/src/main/scala/org/apache/spark/util/MergeIndexUtil.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/util/MergeIndexUtil.scala
@@ -52,9 +52,17 @@ object MergeIndexUtil {
                      CarbonCommonConstants.LOAD_FOLDER.length)
         mergedSegmentIds.add(loadName)
       })
+      val loadFolderDetailsArray = SegmentStatusManager
+        .readLoadMetadata(carbonTable.getMetadataPath)
+      val segmentFileNameMap: java.util.Map[String, String] = new util.HashMap[String, String]()
+      loadFolderDetailsArray.foreach(loadMetadataDetails => {
+        segmentFileNameMap
+          .put(loadMetadataDetails.getLoadName,
+            String.valueOf(loadMetadataDetails.getLoadStartTime))
+      })
       CarbonMergeFilesRDD.mergeIndexFiles(sparkSession,
         mergedSegmentIds.asScala,
-        new util.HashMap[String, String](),
+        segmentFileNameMap,
         carbonTable.getTablePath,
         carbonTable, false)
     }

--- a/processing/src/main/java/org/apache/carbondata/processing/util/CarbonLoaderUtil.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/util/CarbonLoaderUtil.java
@@ -1182,10 +1182,10 @@ public final class CarbonLoaderUtil {
    * @throws IOException
    */
   public static String mergeIndexFilesInPartitionedSegment(CarbonTable table, String segmentId,
-      String uuid) throws IOException {
+      String uuid, String partitionPath) throws IOException {
     String tablePath = table.getTablePath();
     return new CarbonIndexFileMergeWriter(table)
-        .mergeCarbonIndexFilesOfSegment(segmentId, uuid, tablePath);
+        .mergeCarbonIndexFilesOfSegment(segmentId, uuid, tablePath, partitionPath);
   }
 
   private static void deleteFiles(List<String> filesToBeDeleted) throws IOException {


### PR DESCRIPTION
**Problem:**
(1) Merge index is not working for partition table.
(2) Merge index for partition table is significantly more than the normal carbon table.

**Root cause:**
(1) Merge index event listener is moved to preStatusUpdateEvent in #3221 . But preStatusUpdateEvent is not triggered in case of partition table. Test case to validate merge index on partition table is also wrong. Not caught in the test builders.
(2) Currently, merge index job will trigger tasks like one segment one task. But for a partition table, there are partitions in a segments and merge index is for partitions. So per segment it has to iterate and merge the index files inside partitions, because of this the time is little more when the number of partitions are high. Number of Tasks = Number of Segments.

**Solution:**
(1) Correct the test case and trigger merge index listener for partition table.
(2) Parallelize the tasks launched to the partitions. Number of tasks = Number of partitions in a segment

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [x] Testing done
        UT Changed
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

