### PR TITLE
[CARBONDATA-3418] Inherit Column Compressor Property from parent table to its child table's

### DIFF
--- a/docs/ddl-of-carbondata.md
+++ b/docs/ddl-of-carbondata.md
@@ -811,6 +811,7 @@ Users can specify which columns to include and exclude for local dictionary gene
        new SORT_COLUMNS.  
        
        UNSET is not supported, but it can set SORT_COLUMNS to empty string instead of using UNSET.
+       NOTE: When SORT_SCOPE is not NO_SORT, then setting SORT_COLUMNS to empty string is not valid.
        ```
        ALTER TABLE tablename SET TBLPROPERTIES('SORT_COLUMNS'='')
        ```

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
@@ -35,6 +35,7 @@ import org.apache.carbondata.common.constants.LoggerAction
 import org.apache.carbondata.common.exceptions.sql.MalformedCarbonCommandException
 import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.core.constants.CarbonCommonConstants
+import org.apache.carbondata.core.constants.SortScopeOptions.SortScope
 import org.apache.carbondata.core.exception.InvalidConfigurationException
 import org.apache.carbondata.core.metadata.datatype.{DataType, DataTypes}
 import org.apache.carbondata.core.metadata.schema.PartitionInfo
@@ -294,6 +295,18 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
 
     fields.zipWithIndex.foreach { case (field, index) =>
       field.schemaOrdinal = index
+    }
+
+    // If sort_scope is not no_sort && sort_columns specified by user is empty, then throw exception
+    if (tableProperties.get(CarbonCommonConstants.SORT_COLUMNS).isDefined
+        && tableProperties(CarbonCommonConstants.SORT_COLUMNS).equalsIgnoreCase("") &&
+        tableProperties.get(CarbonCommonConstants.SORT_SCOPE).isDefined &&
+        !tableProperties(CarbonCommonConstants.SORT_SCOPE)
+          .equalsIgnoreCase(SortScope.NO_SORT.name())) {
+      throw new MalformedCarbonCommandException(
+        s"Cannot set SORT_COLUMNS as empty when SORT_SCOPE is ${
+          tableProperties(CarbonCommonConstants.SORT_SCOPE)
+        } ")
     }
     val (dims, msrs, noDictionaryDims, sortKeyDims, varcharColumns) = extractDimAndMsrFields(
       fields, tableProperties)

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonDescribeFormattedCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonDescribeFormattedCommand.scala
@@ -124,8 +124,8 @@ private[sql] case class CarbonDescribeFormattedCommand(
       ("## Index Information", "", ""),
       ("Sort Scope", sortScope, ""),
       ("Sort Columns", relation.metaData.carbonTable.getSortColumns.asScala.mkString(", "), ""),
-      ("Inverted Index Columns", carbonTable.getInvertedIndexColumns.asScala
-        .map(_.getColumnName).mkString(", "), ""),
+      ("Inverted Index Columns", carbonTable.getTableInfo.getFactTable.getTableProperties.asScala
+        .getOrElse(CarbonCommonConstants.INVERTED_INDEX, ""), ""),
       ("Cached Min/Max Index Columns",
         carbonTable.getMinMaxCachedColumnsInCreateOrder.asScala.mkString(", "), ""),
       ("Min/Max Index Cache Level",

--- a/integration/spark2/src/test/scala/org/apache/carbondata/spark/testsuite/booleantype/BooleanDataTypesLoadTest.scala
+++ b/integration/spark2/src/test/scala/org/apache/carbondata/spark/testsuite/booleantype/BooleanDataTypesLoadTest.scala
@@ -247,7 +247,7 @@ class BooleanDataTypesLoadTest extends QueryTest with BeforeAndAfterEach with Be
          | booleanField2 BOOLEAN
          | )
          | STORED BY 'carbondata'
-         | TBLPROPERTIES('sort_columns'='','DICTIONARY_EXCLUDE'='charField','TABLE_BLOCKSIZE'='512','NO_INVERTED_INDEX'='charField', 'SORT_SCOPE'='GLOBAL_SORT')
+         | TBLPROPERTIES('DICTIONARY_EXCLUDE'='charField','TABLE_BLOCKSIZE'='512','NO_INVERTED_INDEX'='charField', 'SORT_SCOPE'='GLOBAL_SORT')
        """.stripMargin)
 
     val storeLocation = s"$rootPath/integration/spark2/src/test/resources/bool/supportBoolean.csv"
@@ -337,7 +337,7 @@ class BooleanDataTypesLoadTest extends QueryTest with BeforeAndAfterEach with Be
          | complexData ARRAY<STRING>
          | )
          | STORED BY 'carbondata'
-         | TBLPROPERTIES('sort_columns'='','DICTIONARY_EXCLUDE'='charField','TABLE_BLOCKSIZE'='512','NO_INVERTED_INDEX'='charField', 'SORT_SCOPE'='GLOBAL_SORT')
+         | TBLPROPERTIES('DICTIONARY_EXCLUDE'='charField','TABLE_BLOCKSIZE'='512','NO_INVERTED_INDEX'='charField', 'SORT_SCOPE'='GLOBAL_SORT')
        """.stripMargin)
 
     val storeLocation = s"$rootPath/integration/spark2/src/test/resources/bool/supportBooleanWithFileHeader.csv"


### PR DESCRIPTION
1. Inherited Column Compressor Property from parent table to its child table's
2. Fixed Describe formatted command to show inverted_index column, even if sort_scope is 'no_sort'
3. Fixed inheriting sort_scope to child tables, when sort_columns is provided and sort_scope is not provided
4. Alter set sort_columns="",when sort_scope is not no_sort is not supported. the same behavior is added for create table with sort_columns="" and sort_scope is not no_sort

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [x] Testing done
       added
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

