### PR TITLE
[CARBONDATA-3420] Concurrent Datamap Creation is not synchronised across different sessions

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/datamap/CarbonCreateDataMapCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/datamap/CarbonCreateDataMapCommand.scala
@@ -175,6 +175,7 @@ case class CarbonCreateDataMapCommand(
         systemFolderLocation, tableIdentifier, dmProviderName)
     OperationListenerBus.getInstance().fireEvent(createDataMapPostExecutionEvent,
       operationContext)
+    CarbonEnv.getInstance(sparkSession).carbonMetaStore.updateAndTouchSchemasUpdatedTime()
     Seq.empty
   }
 

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonFileMetastore.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonFileMetastore.scala
@@ -417,7 +417,7 @@ class CarbonFileMetastore extends CarbonMetaStore {
     thriftWriter.open(FileWriteOperation.OVERWRITE)
     thriftWriter.write(thriftTableInfo)
     thriftWriter.close()
-    updateSchemasUpdatedTime(touchSchemaFileSystemTime())
+    updateAndTouchSchemasUpdatedTime()
     identifier.getTablePath
   }
 
@@ -514,7 +514,7 @@ class CarbonFileMetastore extends CarbonMetaStore {
       checkSchemasModifiedTimeAndReloadTable(TableIdentifier(tableName, Some(dbName)))
 
       CarbonHiveMetadataUtil.invalidateAndDropTable(dbName, tableName, sparkSession)
-      updateSchemasUpdatedTime(touchSchemaFileSystemTime())
+      updateAndTouchSchemasUpdatedTime()
       // discard cached table info in cachedDataSourceTables
       val tableIdentifier = TableIdentifier(tableName, Option(dbName))
       sparkSession.sessionState.catalog.refreshTable(tableIdentifier)


### PR DESCRIPTION
**Problem**: Create (preaggregate) datamap from two or more concurrent sessions. After this only one datamap creation is success, others failed. Now do `SHOW DATAMAP ON TABLE tableName`. Some sessions do not display the newly created datamap.

**RCA**: One session successfully creates the datamap and other failed on the create table command (create table command being called from `DataMapProvider.initMeta` from `CarbonCreateDataMapCommand.processMetadata`). So now all the sessions have their `CarbonFileMetastore.tableModifiedTimeStore` synced with the `SCHEMAS_MODIFIED_TIME_FILE` but the CarbonTable is not updated. So next time also it will not update the CarbonTable as the `SCHEMAS_MODIFIED_TIME_FILE` is already synced with `CarbonFileMetastore.tableModifiedTimeStore`.

**Solution**: Update the last modified time of `SCHEMAS_MODIFIED_TIME_FILE` after the datamap creation is finished.

 - [x] Any interfaces changed?  ->  No
 - [x] Any backward compatibility impacted?  ->  No
 - [x] Document update required?  ->  No
 - [x] Testing done  ->  Yes
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 