### PR TITLE
[CARBONDATA-3266] Remove redundant warn messages when carbon session is creating.

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -1317,6 +1317,11 @@ public final class CarbonCommonConstants {
   public static final String CARBON_CUSTOM_BLOCK_DISTRIBUTION = "carbon.custom.block.distribution";
 
   /**
+   * default property of custom block distribution
+   */
+  public static final String CARBON_CUSTOM_BLOCK_DISTRIBUTION_DEFAULT = "false";
+
+  /**
    * This property defines how the tasks are split/combined and launch spark tasks during query
    */
   @CarbonProperty


### PR DESCRIPTION
### Problem:
For some configurations, if customer not set the value for it, when creating carbon session, validateAndLoadDefaultProperties will print WARN message and then set the value to default. It is redundant, no need print the message, just set to default value directly.
### Solution:
No need to validate properties when properties' value are not set. Use default value directly.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Covered by existed test cases.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 