### PR TITLE
[CARBONDATA-3423] Validate dictionary for binary data type

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/binary/TestBinaryDataType.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/binary/TestBinaryDataType.scala
@@ -158,6 +158,63 @@ class TestBinaryDataType extends QueryTest with BeforeAndAfterAll {
         assert(true)
     }
 
+
+    test("Unsupport DICTIONARY_INCLUDE for binary") {
+
+        sql("DROP TABLE IF EXISTS binaryTable")
+        val exception = intercept[MalformedCarbonCommandException] {
+            sql(
+                """
+                  | CREATE TABLE binaryTable(
+                  |     id int,
+                  |     name string,
+                  |     city string,
+                  |     age int,
+                  |     binaryField binary)
+                  | STORED BY 'carbondata'
+                  | tblproperties('dictionary_enable'='true','dictionary_include'='binaryField')
+                """.stripMargin)
+        }
+        assert(exception.getMessage.contains(
+            "DICTIONARY_INCLUDE is unsupported for binary data type column: binaryfield"))
+    }
+
+    test("Unsupport DICTIONARY_INCLUDE for binary, multiple column") {
+
+        sql("DROP TABLE IF EXISTS binaryTable")
+        val exception = intercept[MalformedCarbonCommandException] {
+            sql(
+                """
+                  | CREATE TABLE binaryTable(
+                  |     id int,
+                  |     name string,
+                  |     city string,
+                  |     age int,
+                  |     binaryField binary)
+                  | STORED BY 'carbondata'
+                  | tblproperties('dictionary_enable'='true','dictionary_include'='name,binaryField')
+                """.stripMargin)
+        }
+        assert(exception.getMessage.contains(
+            "DICTIONARY_INCLUDE is unsupported for binary data type column: binaryfield"))
+    }
+
+    test("Supports DICTIONARY_EXCLUDE for binary") {
+        sql("DROP TABLE IF EXISTS binaryTable")
+        sql(
+            """
+              | CREATE TABLE binaryTable(
+              |     id int,
+              |     name string,
+              |     city string,
+              |     age int,
+              |     binaryField binary)
+              | STORED BY 'org.apache.carbondata.format'
+              | tblproperties('dictionary_enable'='true','DICTIONARY_EXCLUDE'='binaryField')
+            """.stripMargin)
+        assert(true)
+    }
+
     test("Unsupport inverted_index for binary") {
         sql("DROP TABLE IF EXISTS binaryTable")
         val exception = intercept[MalformedCarbonCommandException] {

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
@@ -36,7 +36,7 @@ import org.apache.carbondata.common.exceptions.sql.MalformedCarbonCommandExcepti
 import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.exception.InvalidConfigurationException
-import org.apache.carbondata.core.metadata.datatype.{DataType, DataTypes}
+import org.apache.carbondata.core.metadata.datatype.DataTypes
 import org.apache.carbondata.core.metadata.schema.PartitionInfo
 import org.apache.carbondata.core.metadata.schema.partition.PartitionType
 import org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema
@@ -840,6 +840,12 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
                          " does not exist in table or unsupported for complex child column. " +
                          "Please check the create table statement."
           throw new MalformedCarbonCommandException(errorMsg)
+        }
+        val rangeField = fields.find(_.column.equalsIgnoreCase(distIncludeCol.trim))
+        if ("binary".equalsIgnoreCase(rangeField.get.dataType.get)) {
+          throw new MalformedCarbonCommandException(
+            "DICTIONARY_INCLUDE is unsupported for binary data type column: " +
+                    distIncludeCol.trim)
         }
         if (varcharCols.exists(x => x.equalsIgnoreCase(distIncludeCol.trim))) {
           throw new MalformedCarbonCommandException(


### PR DESCRIPTION
it will throw exception if dictionary_include has binary column, it will not throw exception if DICTIONARY_EXCLUDE has binary column

optimize

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 No
 - [ ] Any backward compatibility impacted?
 No
 - [ ] Document update required?
yes
 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
  yes
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
No
