### PR TITLE
[CARBONDATA-3342] Fix the IllegalArgumentException when using filter and result is null.

### DIFF
--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/util/CarbonVectorizedRecordReader.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/util/CarbonVectorizedRecordReader.java
@@ -135,6 +135,9 @@ public class CarbonVectorizedRecordReader extends AbstractRecordReader<Object> {
     if (iterator.hasNext()) {
       iterator.processNextBatch(carbonColumnarBatch);
       numBatched = carbonColumnarBatch.getActualSize();
+      if (numBatched == 0) {
+        return nextBatch();
+      }
       batchIdx = 0;
       return true;
     }

--- a/sdk/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonReader.java
+++ b/sdk/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonReader.java
@@ -91,9 +91,9 @@ public class CarbonReader<T> {
         readers.set(index, null);
         index++;
         currentReader = readers.get(index);
-        boolean result = currentReader.nextKeyValue();
-        if (result) {
-          return result;
+        boolean hasNext = currentReader.nextKeyValue();
+        if (hasNext) {
+          return hasNext;
         }
       }
     }

--- a/sdk/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonReader.java
+++ b/sdk/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonReader.java
@@ -93,7 +93,7 @@ public class CarbonReader<T> {
         currentReader = readers.get(index);
         boolean hasNext = currentReader.nextKeyValue();
         if (hasNext) {
-          return hasNext;
+          return true;
         }
       }
     }

--- a/sdk/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonReader.java
+++ b/sdk/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonReader.java
@@ -71,7 +71,7 @@ public class CarbonReader<T> {
    * Return true if has next row
    */
   public boolean hasNext() throws IOException, InterruptedException {
-    if (0 == readers.size()) {
+    if (0 == readers.size() || currentReader == null) {
       return false;
     }
     validateReader();

--- a/sdk/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonReader.java
+++ b/sdk/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonReader.java
@@ -57,19 +57,23 @@ public class CarbonReader<T> {
    * Call {@link #builder(String)} to construct an instance
    */
   CarbonReader(List<RecordReader<Void, T>> readers) {
-    if (readers.size() == 0) {
-      throw new IllegalArgumentException("no reader");
-    }
     this.initialise = true;
     this.readers = readers;
     this.index = 0;
-    this.currentReader = readers.get(0);
+    if (0 == readers.size()) {
+      this.currentReader = null;
+    } else {
+      this.currentReader = readers.get(0);
+    }
   }
 
   /**
    * Return true if has next row
    */
   public boolean hasNext() throws IOException, InterruptedException {
+    if (0 == readers.size()) {
+      return false;
+    }
     validateReader();
     if (currentReader.nextKeyValue()) {
       return true;
@@ -87,9 +91,13 @@ public class CarbonReader<T> {
         readers.set(index, null);
         index++;
         currentReader = readers.get(index);
-        return currentReader.nextKeyValue();
+        boolean result = currentReader.nextKeyValue();
+        if (result) {
+          return result;
+        }
       }
     }
+    return false;
   }
 
   /**
@@ -242,7 +250,9 @@ public class CarbonReader<T> {
     CarbonProperties.getInstance()
         .addProperty(CarbonCommonConstants.DETAIL_QUERY_BATCH_SIZE,
             String.valueOf(CarbonCommonConstants.DETAIL_QUERY_BATCH_SIZE_DEFAULT));
-    this.currentReader.close();
+    if (null != this.currentReader) {
+      this.currentReader.close();
+    }
     this.initialise = false;
   }
 

--- a/sdk/sdk/src/main/java/org/apache/carbondata/sdk/file/utils/SDKUtil.java
+++ b/sdk/sdk/src/main/java/org/apache/carbondata/sdk/file/utils/SDKUtil.java
@@ -26,8 +26,8 @@ import org.apache.carbondata.core.datastore.impl.FileFactory;
 import org.apache.hadoop.conf.Configuration;
 
 public class SDKUtil {
-  public static ArrayList listFiles(String sourceImageFolder, final String suf) {
-    return listFiles(sourceImageFolder, suf, new Configuration(true));
+  public static ArrayList listFiles(String sourceFolder, final String suf) {
+    return listFiles(sourceFolder, suf, new Configuration(true));
   }
 
   public static ArrayList listFiles(String sourceImageFolder,

--- a/sdk/sdk/src/test/java/org/apache/carbondata/sdk/file/CarbonReaderTest.java
+++ b/sdk/sdk/src/test/java/org/apache/carbondata/sdk/file/CarbonReaderTest.java
@@ -2528,4 +2528,36 @@ public class CarbonReaderTest extends TestCase {
     FileUtils.deleteDirectory(new File(path));
   }
 
+  @Test
+  public void testReadWithFilterNonResult() throws IOException, InterruptedException {
+    String path = "./testWriteFiles";
+    FileUtils.deleteDirectory(new File(path));
+    Field[] fields = new Field[2];
+    fields[0] = new Field("name", DataTypes.STRING);
+    fields[1] = new Field("age", DataTypes.INT);
+
+    TestUtil.writeFilesAndVerify(200, new Schema(fields), path);
+
+    ColumnExpression columnExpression = new ColumnExpression("age", DataTypes.INT);
+
+    EqualToExpression equalToExpression = new EqualToExpression(columnExpression,
+      new LiteralExpression("-11", DataTypes.INT));
+    CarbonReader reader = CarbonReader
+      .builder(path, "_temp")
+      .projection(new String[]{"name", "age"})
+      .filter(equalToExpression)
+      .build();
+
+    int i = 0;
+    while (reader.hasNext()) {
+      Assert.assertTrue(false);
+      i++;
+    }
+    Assert.assertEquals(i, 0);
+
+    reader.close();
+
+    FileUtils.deleteDirectory(new File(path));
+  }
+
 }


### PR DESCRIPTION
This PR fixs the IllegalArgumentException when using filter and result is null.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 No
 - [x] Any backward compatibility impacted?
 No
 - [x] Document update required?
No
 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       Yes,added
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
No
