### PR TITLE
[CARBONDATA-3426] Fix load performance by fixing task distribution issue

### DIFF
--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/hive/DistributionUtil.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/hive/DistributionUtil.scala
@@ -103,7 +103,7 @@ object DistributionUtil {
     while (iface.hasMoreElements) {
       addresses = iface.nextElement().getInterfaceAddresses.asScala.toList ++ addresses
     }
-    val inets = addresses.map(_.getAddress.getHostName)
+    val inets = addresses.map(_.getAddress.getHostAddress)
     inets
   }
 


### PR DESCRIPTION
**Problem:** Load performance degrade due to task distribution issue.

**Cause:** Consider 3 node cluster (host name a,b,c with IP1, IP2, IP3 as ip address), to launch load task, host name is required from NewCarbonDataLoadRDD in getPreferredLocations(). But if the driver is 'a' (IP1), 

Result is IP1, b,c instead of a,b,c. Hence task was not launching to one executor which is same ip as driver.

getLocalhostIPs is modified in current version recently and instead of IP it was returning hostname, hence local ip hostname was removed instead of IP address.

**solution:** Revert the change in getLocalhostIPs as it is not used in any other flow. 

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed? NA
 
 - [ ] Any backward compatibility impacted? NA
 
 - [ ] Document update required? NA

 - [ ] Testing done
   yes, tested with 17 node spark clusters with huge data. 
   Load performance is same as previous version. [degrade was 30%]

- [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.  NA
