### PR TITLE
[CARBONDATA-3427] Beautify DAG by showing less text

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonDatasourceHadoopRelation.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonDatasourceHadoopRelation.scala
@@ -195,8 +195,7 @@ case class CarbonDatasourceHadoopRelation(
   override def unhandledFilters(filters: Array[Filter]): Array[Filter] = new Array[Filter](0)
 
   override def toString: String = {
-    "CarbonDatasourceHadoopRelation [ " + "Database name :" + identifier.getDatabaseName +
-    ", " + "Table name :" + identifier.getTableName + ", Schema :" + tableSchema + " ]"
+    "carbondata"
   }
 
   override def sizeInBytes: Long = carbonRelation.sizeInBytes

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonDatasourceHadoopRelation.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonDatasourceHadoopRelation.scala
@@ -195,7 +195,7 @@ case class CarbonDatasourceHadoopRelation(
   override def unhandledFilters(filters: Array[Filter]): Array[Filter] = new Array[Filter](0)
 
   override def toString: String = {
-    "carbondata"
+    "CarbonDatasourceHadoopRelation"
   }
 
   override def sizeInBytes: Long = carbonRelation.sizeInBytes

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/strategy/CarbonLateDecodeStrategy.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/strategy/CarbonLateDecodeStrategy.scala
@@ -55,6 +55,7 @@ import org.apache.carbondata.spark.rdd.CarbonScanRDD
  */
 private[sql] class CarbonLateDecodeStrategy extends SparkStrategy {
   val PUSHED_FILTERS = "PushedFilters"
+  val READ_SCHEMA = "ReadSchema"
 
   /*
   Spark 2.3.1 plan there can be case of multiple projections like below
@@ -274,6 +275,7 @@ private[sql] class CarbonLateDecodeStrategy extends SparkStrategy {
       if (pushedFilters.nonEmpty) {
         pairs += (PUSHED_FILTERS -> pushedFilters.mkString("[", ", ", "]"))
       }
+      pairs += (READ_SCHEMA -> projectSet.++(filterSet).toSeq.toStructType.catalogString)
       pairs.toMap
     }
 


### PR DESCRIPTION

currently, the DAG of carbon table scan is not showing friendly because it prints schema too. When we do a large query, we often need to drag the scroll to see the DAG.

![image](https://user-images.githubusercontent.com/3809732/59318383-6faf1000-8cf9-11e9-8be4-c44552f653ad.png)

To make it clear as other format on Spark like parquet, we remove the schema info, and it finally looks like below

![image](https://user-images.githubusercontent.com/3809732/59318594-15627f00-8cfa-11e9-9aaa-6752a4d389a1.png)



Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

