### PR TITLE
[DO NOT MERGE] CI test for pr3209

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/FilterUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/FilterUtil.java
@@ -1535,6 +1535,7 @@ public final class FilterUtil {
         }
       }
       msrColumnExecuterInfo.setFilterKeys(keysBasedOnFilter);
+      msrColumnExecuterInfo.setFilterKeysSet(keysBasedOnFilter);
     } else {
       if (filterValues == null) {
         dimColumnExecuterInfo.setFilterKeys(new byte[0][]);

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/MeasureColumnExecuterFilterInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/MeasureColumnExecuterFilterInfo.java
@@ -16,15 +16,29 @@
  */
 package org.apache.carbondata.core.scan.filter.executer;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
 public class MeasureColumnExecuterFilterInfo {
 
   Object[] filterKeys;
+  Set filterKeysSet;
 
   public void setFilterKeys(Object[] filterKeys) {
     this.filterKeys = filterKeys;
   }
 
+  public void setFilterKeysSet(Object[] filterKeys) {
+    this.filterKeysSet = new HashSet<Object>(Arrays.asList(filterKeys));
+  }
+
   public Object[] getFilterKeys() {
     return filterKeys;
   }
+
+  public Set getFilterKeysSet() {
+    return filterKeysSet;
+  }
+
 }


### PR DESCRIPTION
This PR is mirror of #3209 

---

when sql with 'in numbers' and spark.sql.codegen.wholeStage is false，the query is slow,

the reason is that canbonscan row level filter's time complexity is O(n^2), we can replace list with hashset to improve query performance

sql example: select * from xx where filed in (1,2,3,4,5,6)


Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

