### PR TITLE
[CARBONDATA-3434] Fix Data Mismatch between MainTable and MV DataMap table during compaction

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datamap/DataMapProvider.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/DataMapProvider.java
@@ -370,17 +370,15 @@ public abstract class DataMapProvider {
   private boolean checkIfSegmentsToBeReloaded(LoadMetadataDetails[] loadMetaDataDetails,
       List<String> segmentIds, String segmentId) {
     boolean isToBeLoadedAgain = true;
-    for (String loadName : segmentIds) {
-      for (LoadMetadataDetails loadMetadataDetail : loadMetaDataDetails) {
-        if (loadMetadataDetail.getLoadName().equalsIgnoreCase(loadName)) {
-          if (null != loadMetadataDetail.getMergedLoadName() && loadMetadataDetail
-              .getMergedLoadName().equalsIgnoreCase(segmentId)) {
-            isToBeLoadedAgain = false;
-          } else {
-            return true;
-          }
-        }
+    List<String> mergedSegments = new ArrayList<>();
+    for (LoadMetadataDetails loadMetadataDetail : loadMetaDataDetails) {
+      if (null != loadMetadataDetail.getMergedLoadName() && loadMetadataDetail.getMergedLoadName()
+          .equalsIgnoreCase(segmentId)) {
+        mergedSegments.add(loadMetadataDetail.getLoadName());
       }
+    }
+    if (!mergedSegments.isEmpty() && segmentIds.containsAll(mergedSegments)) {
+      isToBeLoadedAgain = false;
     }
     return isToBeLoadedAgain;
   }

--- a/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/TestAllOperationsOnMV.scala
+++ b/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/TestAllOperationsOnMV.scala
@@ -509,5 +509,16 @@ class TestAllOperationsOnMV extends QueryTest with BeforeAndAfterEach {
     }.getMessage.contains("Cannot set SORT_COLUMNS as empty when SORT_SCOPE is LOCAL_SORT")
   }
 
+  test("test delete on datamap table") {
+    sql("drop table IF EXISTS maintable")
+    sql("create table maintable(name string, c_code int, price int) stored by 'carbondata' tblproperties('sort_scope'='no_sort','sort_columns'='name', 'inverted_index'='name')")
+    sql("insert into table maintable select 'abc',21,2000")
+    sql("create datamap dm_mv on table maintable using 'mv' as select name, sum(price) from maintable group by name")
+    intercept[UnsupportedOperationException] {
+      sql("delete from dm_mv_table where maintable_name='abc'")
+    }.getMessage.contains("Delete operation is not supported for datamap table")
+    sql("drop table IF EXISTS maintable")
+  }
+
 }
 

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonAnalysisRules.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonAnalysisRules.scala
@@ -202,14 +202,9 @@ case class CarbonIUDAnalysisRule(sparkSession: SparkSession) extends Rule[Logica
         val projList = Seq(UnresolvedAlias(UnresolvedStar(alias.map(Seq(_)))), tupleId)
         val carbonTable = CarbonEnv.getCarbonTable(table.tableIdentifier)(sparkSession)
         if (carbonTable != null) {
-          if (CarbonUtil.hasAggregationDataMap(carbonTable)) {
+          if (carbonTable.isChildTable) {
             throw new UnsupportedOperationException(
-              "Delete operation is not supported for tables which have a pre-aggregate table. " +
-              "Drop pre-aggregate tables to continue.")
-          }
-          if (carbonTable.isChildDataMap) {
-            throw new UnsupportedOperationException(
-              "Delete operation is not supported for pre-aggregate table")
+              "Delete operation is not supported for datamap table")
           }
           val indexSchemas = DataMapStoreManager.getInstance().getDataMapSchemasOfTable(carbonTable)
           if (DataMapUtil.hasMVDataMap(carbonTable)) {


### PR DESCRIPTION
1) Problem:
    checkIfSegmentsToBeReloaded method of DataMapProvider was ignoring one main table segment    to be loaded, considering it as already loaded
   Solution:
   Get all segments merged to given segment and check if it contains all list  of segments stored in SegmentMapInfo. If true, then no need to load the segment, only update segment mapping 

2) Block delete operation on datamap table

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [x] Testing done
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

