### PR TITLE
[CARBONDATA-3433]Fix MV issues related to duplicate columns, limit and constant columns

### DIFF
--- a/datamap/mv/core/src/main/scala/org/apache/carbondata/mv/datamap/MVUtil.scala
+++ b/datamap/mv/core/src/main/scala/org/apache/carbondata/mv/datamap/MVUtil.scala
@@ -129,7 +129,12 @@ object MVUtil {
       val arrayBuffer: ArrayBuffer[ColumnTableRelation] = new ArrayBuffer[ColumnTableRelation]()
       agg.collect {
         case Alias(attr: AggregateExpression, name) =>
-          if (attr.aggregateFunction.isInstanceOf[Count]) {
+          var isLiteralPresent = false
+          attr.aggregateFunction.collect {
+            case l@Literal(_, _) =>
+              isLiteralPresent = true
+          }
+          if (isLiteralPresent) {
             fieldToDataMapFieldMap +=
             getFieldToDataMapFields(name,
               attr.aggregateFunction.dataType,
@@ -137,7 +142,7 @@ object MVUtil {
               attr.aggregateFunction.nodeName,
               arrayBuffer,
               "")
-            aggregateType = "count"
+            aggregateType = attr.aggregateFunction.nodeName
           } else {
             aggregateType = attr.aggregateFunction.nodeName
           }

--- a/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/MVExceptionTestCase.scala
+++ b/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/MVExceptionTestCase.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.carbondata.mv.rewrite
 
-import org.apache.carbondata.common.exceptions.sql.MalformedDataMapCommandException
+import org.apache.carbondata.common.exceptions.sql.{MalformedCarbonCommandException, MalformedDataMapCommandException}
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException
 import org.apache.spark.sql.test.util.QueryTest
 import org.scalatest.BeforeAndAfterAll
@@ -40,6 +40,13 @@ class MVExceptionTestCase  extends QueryTest with BeforeAndAfterAll {
       sql("create datamap main_table_mv1 on table main_table using 'mv' as select sum(age),name from main_table group by name")
     }
     assertResult("DataMap with name main_table_mv1 already exists in storage")(ex.getMessage)
+  }
+
+  test("test mv creation with limit in query") {
+    val ex = intercept[MalformedCarbonCommandException] {
+      sql("create datamap maintable_mv2 on table main_table using 'mv' as select sum(age),name from main_table group by name limit 10")
+    }
+    assertResult("MV datamap does not support the query with limit")(ex.getMessage)
   }
 
   def drop(): Unit = {


### PR DESCRIPTION
### Problem:
MV has below issues:
1. when has duplicate columns in select query, MV creation fails, but select is valid query
2. when used constant column in ctas for datamap creation, it fails
3. when limit is used in ctas for datamap creation, it fails

### Solution:
1. since duplicate columns in query is valid, MV should support, so when creating columns, better take distinct columns
2. handle getting field relation map when we have constant column in query
3. block MV creation for limit ctas query, as it is not a valid case to use MV datamap.


Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 NA
 - [x] Any backward compatibility impacted?
 NA
 - [x] Document update required?
NA
 - [x] Testing done
      added UT
  Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA
