### PR TITLE
[CARBONDATA-3442] Fix creating mv datamap with column name having length more than 128

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -2235,4 +2235,9 @@ public final class CarbonCommonConstants {
    * index server temp file name
    */
   public static final String INDEX_SERVER_TEMP_FOLDER_NAME = "indexservertmp";
+
+  /**
+   * hive column-name maximum length
+   */
+  public static final int MAXIMUM_CHAR_LENGTH = 128;
 }

--- a/datamap/mv/core/src/main/scala/org/apache/carbondata/mv/datamap/MVHelper.scala
+++ b/datamap/mv/core/src/main/scala/org/apache/carbondata/mv/datamap/MVHelper.scala
@@ -61,7 +61,8 @@ object MVHelper {
         s"MV datamap does not support streaming"
       )
     }
-    MVUtil.validateDMProperty(dmProperties)
+    val mvUtil = new MVUtil
+    mvUtil.validateDMProperty(dmProperties)
     val updatedQuery = new CarbonSpark2SqlParser().addPreAggFunction(queryString)
     val query = sparkSession.sql(updatedQuery)
     val logicalPlan = MVHelper.dropDummFuc(query.queryExecution.analyzed)
@@ -79,6 +80,7 @@ object MVHelper {
     }
     val updatedQueryWithDb = validateMVQuery(sparkSession, logicalPlan)
     val fullRebuild = isFullReload(logicalPlan)
+    var counter = 0
     // the ctas query can have duplicate columns, so we should take distinct and create fields,
     // so that it won't fail during create mv table
     val fields = logicalPlan.output.map { attr =>
@@ -87,7 +89,8 @@ object MVHelper {
         throw new UnsupportedOperationException(
           s"MV datamap is unsupported for ComplexData type column: " + attr.name)
       }
-      val name = updateColumnName(attr)
+      val name = updateColumnName(attr, counter)
+      counter += 1
       val rawSchema = '`' + name + '`' + ' ' + attr.dataType.typeName
       if (attr.dataType.typeName.startsWith("decimal")) {
         val (precision, scale) = CommonUtil.getScaleAndPrecision(attr.dataType.catalogString)
@@ -137,7 +140,7 @@ object MVHelper {
     tableProperties.put(CarbonCommonConstants.DATAMAP_NAME, dataMapSchema.getDataMapName)
     tableProperties.put(CarbonCommonConstants.PARENT_TABLES, parentTables.asScala.mkString(","))
 
-    val fieldRelationMap = MVUtil.getFieldsAndDataMapFieldsFromPlan(
+    val fieldRelationMap = mvUtil.getFieldsAndDataMapFieldsFromPlan(
       logicalPlan, queryString, sparkSession)
     // If dataMap is mapped to single main table, then inherit table properties from main table,
     // else, will use default table properties. If DMProperties contains table properties, then
@@ -329,19 +332,22 @@ object MVHelper {
     modularPlan.asCompactSQL
   }
 
-  def getUpdatedName(name: String): String = {
-    val updatedName = name.replace("(", "_")
+  def getUpdatedName(name: String, counter: Int): String = {
+    var updatedName = name.replace("(", "_")
       .replace(")", "")
       .replace(" ", "_")
       .replace("=", "")
       .replace(",", "")
       .replace(".", "_")
       .replace("`", "")
+    if (updatedName.length >= CarbonCommonConstants.MAXIMUM_CHAR_LENGTH) {
+      updatedName = updatedName.substring(0, 110) + CarbonCommonConstants.UNDERSCORE + counter
+    }
     updatedName
   }
 
-  def updateColumnName(attr: Attribute): String = {
-    val name = getUpdatedName(attr.name)
+  def updateColumnName(attr: Attribute, counter: Int): String = {
+    val name = getUpdatedName(attr.name, counter)
     attr.qualifier.map(qualifier => qualifier + "_" + name).getOrElse(name)
   }
 

--- a/datamap/mv/core/src/main/scala/org/apache/carbondata/mv/rewrite/Navigator.scala
+++ b/datamap/mv/core/src/main/scala/org/apache/carbondata/mv/rewrite/Navigator.scala
@@ -121,17 +121,18 @@ private[mv] class Navigator(catalog: SummaryDatasetCatalog, session: MVSession) 
       subsumee: ModularPlan,
       dataMapRelation: ModularPlan): ModularPlan = {
     // Update datamap table relation to the subsumer modular plan
+    val mVUtil = new MVUtil
     val updatedSubsumer = subsumer match {
       // In case of order by it adds extra select but that can be ignored while doing selection.
       case s@Select(_, _, _, _, _, Seq(g: GroupBy), _, _, _, _) =>
         s.copy(children = Seq(g.copy(dataMapTableRelation = Some(dataMapRelation))),
-            outputList = MVUtil.updateDuplicateColumns(s.outputList))
+          outputList = mVUtil.updateDuplicateColumns(s.outputList))
       case s: Select => s
         .copy(dataMapTableRelation = Some(dataMapRelation),
-          outputList = MVUtil.updateDuplicateColumns(s.outputList))
+          outputList = mVUtil.updateDuplicateColumns(s.outputList))
       case g: GroupBy => g
         .copy(dataMapTableRelation = Some(dataMapRelation),
-          outputList = MVUtil.updateDuplicateColumns(g.outputList))
+          outputList = mVUtil.updateDuplicateColumns(g.outputList))
       case other => other
     }
     (updatedSubsumer, subsumee) match {


### PR DESCRIPTION
Problem:
creating mv datamap with column name having length more than 128 fails
Solution:
If column name is more than 128, then take substring and append a counter
 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

