### PR TITLE
[CARBONDATA-3373] Fixed measure column filter perf

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -109,6 +109,11 @@
       <version>0.5.11</version>
     </dependency>
     <dependency>
+      <groupId>it.unimi.dsi</groupId>
+      <artifactId>fastutil</artifactId>
+      <version>8.2.3</version>
+    </dependency>
+    <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-all</artifactId>
       <version>4.0.42.Final</version>

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/FilterExecutorUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/FilterExecutorUtil.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.core.scan.filter;
+
+import java.util.AbstractCollection;
+import java.util.BitSet;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.carbondata.core.datastore.page.ColumnPage;
+import org.apache.carbondata.core.metadata.datatype.DataType;
+import org.apache.carbondata.core.metadata.datatype.DataTypes;
+import org.apache.carbondata.core.metadata.schema.table.column.CarbonMeasure;
+import org.apache.carbondata.core.scan.filter.executer.FilterBitSetUpdater;
+import org.apache.carbondata.core.scan.filter.executer.MeasureColumnExecuterFilterInfo;
+import org.apache.carbondata.core.scan.filter.resolver.resolverinfo.MeasureColumnResolvedFilterInfo;
+import org.apache.carbondata.core.util.DataTypeUtil;
+
+import it.unimi.dsi.fastutil.booleans.BooleanOpenHashSet;
+import it.unimi.dsi.fastutil.bytes.ByteOpenHashSet;
+import it.unimi.dsi.fastutil.doubles.DoubleOpenHashSet;
+import it.unimi.dsi.fastutil.floats.FloatOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+import it.unimi.dsi.fastutil.shorts.ShortOpenHashSet;
+
+/**
+ * Utility class for executing the filter
+ */
+public class FilterExecutorUtil {
+  /**
+   * Below method will be used to execute measure filter based on data type
+   * This is done to avoid conversion of primitive type to primitive object
+   * as it may cause lots of gc when number of record is high and will impact performance
+   *
+   * @param page
+   * @param bitSet
+   * @param measureColumnExecuterFilterInfo
+   * @param measureColumnResolvedFilterInfo
+   * @param filterBitSetUpdater
+   */
+  public static void executeIncludeExcludeFilterForMeasure(ColumnPage page, BitSet bitSet,
+      MeasureColumnExecuterFilterInfo measureColumnExecuterFilterInfo,
+      MeasureColumnResolvedFilterInfo measureColumnResolvedFilterInfo,
+      FilterBitSetUpdater filterBitSetUpdater) {
+    final CarbonMeasure measure = measureColumnResolvedFilterInfo.getMeasure();
+    final DataType dataType = FilterUtil.getMeasureDataType(measureColumnResolvedFilterInfo);
+    int numberOfRows = page.getPageSize();
+    BitSet nullBitSet = page.getNullBits();
+    Object[] filterKeys = measureColumnExecuterFilterInfo.getFilterKeys();
+    // to handle the null value
+    for (int i = 0; i < filterKeys.length; i++) {
+      if (filterKeys[i] == null) {
+        for (int j = nullBitSet.nextSetBit(0); j >= 0; j = nullBitSet.nextSetBit(j + 1)) {
+          bitSet.flip(j);
+        }
+      }
+    }
+    AbstractCollection filterSet = measureColumnExecuterFilterInfo.getFilterSet();
+    if (dataType == DataTypes.BYTE) {
+      ByteOpenHashSet byteOpenHashSet = (ByteOpenHashSet) filterSet;
+      for (int i = 0; i < numberOfRows; i++) {
+        if (!nullBitSet.get(i)) {
+          if (byteOpenHashSet.contains((byte) page.getLong(i))) {
+            filterBitSetUpdater.updateBitset(bitSet, i);
+          }
+        }
+      }
+    } else if (dataType == DataTypes.BOOLEAN) {
+      BooleanOpenHashSet booleanOpenHashSet = (BooleanOpenHashSet) filterSet;
+      for (int i = 0; i < numberOfRows; i++) {
+        if (!nullBitSet.get(i)) {
+          if (booleanOpenHashSet.contains(page.getBoolean(i))) {
+            filterBitSetUpdater.updateBitset(bitSet, i);
+          }
+        }
+      }
+    } else if (dataType == DataTypes.SHORT) {
+      ShortOpenHashSet shortOpenHashSet = (ShortOpenHashSet) filterSet;
+      for (int i = 0; i < numberOfRows; i++) {
+        if (!nullBitSet.get(i)) {
+          if (shortOpenHashSet.contains((short) page.getLong(i))) {
+            filterBitSetUpdater.updateBitset(bitSet, i);
+          }
+        }
+      }
+    } else if (dataType == DataTypes.INT) {
+      IntOpenHashSet intOpenHashSet = (IntOpenHashSet) filterSet;
+      for (int i = 0; i < numberOfRows; i++) {
+        if (!nullBitSet.get(i)) {
+          if (intOpenHashSet.contains((int) page.getLong(i))) {
+            filterBitSetUpdater.updateBitset(bitSet, i);
+          }
+        }
+      }
+    } else if (dataType == DataTypes.FLOAT) {
+      FloatOpenHashSet floatOpenHashSet = (FloatOpenHashSet) filterSet;
+      for (int i = 0; i < numberOfRows; i++) {
+        if (!nullBitSet.get(i)) {
+          if (floatOpenHashSet.contains((float) page.getDouble(i))) {
+            filterBitSetUpdater.updateBitset(bitSet, i);
+          }
+        }
+      }
+    } else if (dataType == DataTypes.DOUBLE) {
+      DoubleOpenHashSet doubleOpenHashSet = (DoubleOpenHashSet) filterSet;
+      for (int i = 0; i < numberOfRows; i++) {
+        if (!nullBitSet.get(i)) {
+          if (doubleOpenHashSet.contains(page.getDouble(i))) {
+            filterBitSetUpdater.updateBitset(bitSet, i);
+          }
+        }
+      }
+    } else if (dataType == DataTypes.LONG) {
+      LongOpenHashSet longOpenHashSet = (LongOpenHashSet) filterSet;
+      for (int i = 0; i < numberOfRows; i++) {
+        if (!nullBitSet.get(i)) {
+          if (longOpenHashSet.contains(page.getLong(i))) {
+            filterBitSetUpdater.updateBitset(bitSet, i);
+          }
+        }
+      }
+    } else if (DataTypes.isDecimal(dataType)) {
+      Set bigDecimalHashSet = (HashSet) filterSet;
+      for (int i = 0; i < numberOfRows; i++) {
+        if (!nullBitSet.get(i)) {
+          final Object measureObjectBasedOnDataType =
+              DataTypeUtil.getMeasureObjectBasedOnDataType(page, i, dataType, measure);
+          if (bigDecimalHashSet.contains(measureObjectBasedOnDataType)) {
+            filterBitSetUpdater.updateBitset(bitSet, i);
+          }
+        }
+      }
+    } else {
+      throw new IllegalArgumentException("Invalid data type");
+    }
+  }
+}

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/FilterUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/FilterUtil.java
@@ -1534,7 +1534,7 @@ public final class FilterUtil {
                   converter);
         }
       }
-      msrColumnExecuterInfo.setFilterKeys(keysBasedOnFilter);
+      msrColumnExecuterInfo.setFilterKeys(keysBasedOnFilter,  measures.getDataType());
     } else {
       if (filterValues == null) {
         dimColumnExecuterInfo.setFilterKeys(new byte[0][]);

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/BitSetUpdaterFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/BitSetUpdaterFactory.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.core.scan.filter.executer;
+
+import java.util.BitSet;
+
+import org.apache.carbondata.core.scan.filter.intf.FilterExecuterType;
+
+/**
+ * Class for updating the bitset
+ * If include it will set the bit
+ * If exclude it will flip the bit
+ */
+public final class BitSetUpdaterFactory {
+
+  public static final BitSetUpdaterFactory INSTANCE = new BitSetUpdaterFactory();
+
+  public FilterBitSetUpdater getBitSetUpdater(FilterExecuterType filterExecuterType) {
+    switch (filterExecuterType) {
+      case INCLUDE:
+        return new IncludeFilterBitSetUpdater();
+      case EXCLUDE:
+        return new ExcludeFilterBitSetUpdater();
+      default:
+        throw new UnsupportedOperationException(
+            "Invalid filter executor type:" + filterExecuterType);
+    }
+  }
+
+  /**
+   * Below class will be used to updating the bitset in case of include filter
+   */
+  class IncludeFilterBitSetUpdater implements FilterBitSetUpdater {
+    @Override public void updateBitset(BitSet bitSet, int bitIndex) {
+      bitSet.set(bitIndex);
+    }
+  }
+
+  /**
+   * Below class will be used to updating the bitset in case of exclude filter
+   */
+  class ExcludeFilterBitSetUpdater implements FilterBitSetUpdater {
+    @Override public void updateBitset(BitSet bitSet, int bitIndex) {
+      bitSet.flip(bitIndex);
+    }
+  }
+}

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/BitSetUpdaterFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/BitSetUpdaterFactory.java
@@ -44,7 +44,7 @@ public final class BitSetUpdaterFactory {
   /**
    * Below class will be used to updating the bitset in case of include filter
    */
-  class IncludeFilterBitSetUpdater implements FilterBitSetUpdater {
+  static class IncludeFilterBitSetUpdater implements FilterBitSetUpdater {
     @Override public void updateBitset(BitSet bitSet, int bitIndex) {
       bitSet.set(bitIndex);
     }
@@ -53,7 +53,7 @@ public final class BitSetUpdaterFactory {
   /**
    * Below class will be used to updating the bitset in case of exclude filter
    */
-  class ExcludeFilterBitSetUpdater implements FilterBitSetUpdater {
+  static class ExcludeFilterBitSetUpdater implements FilterBitSetUpdater {
     @Override public void updateBitset(BitSet bitSet, int bitIndex) {
       bitSet.flip(bitIndex);
     }

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/ExcludeFilterExecuterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/ExcludeFilterExecuterImpl.java
@@ -18,7 +18,6 @@ package org.apache.carbondata.core.scan.filter.executer;
 
 import java.io.IOException;
 import java.util.BitSet;
-import java.util.Set;
 
 import org.apache.carbondata.core.datastore.block.SegmentProperties;
 import org.apache.carbondata.core.datastore.chunk.DimensionColumnPage;
@@ -26,9 +25,10 @@ import org.apache.carbondata.core.datastore.chunk.impl.DimensionRawColumnChunk;
 import org.apache.carbondata.core.datastore.chunk.impl.MeasureRawColumnChunk;
 import org.apache.carbondata.core.datastore.page.ColumnPage;
 import org.apache.carbondata.core.metadata.datatype.DataType;
-import org.apache.carbondata.core.metadata.datatype.DataTypes;
 import org.apache.carbondata.core.scan.expression.exception.FilterUnsupportedException;
+import org.apache.carbondata.core.scan.filter.FilterExecutorUtil;
 import org.apache.carbondata.core.scan.filter.FilterUtil;
+import org.apache.carbondata.core.scan.filter.intf.FilterExecuterType;
 import org.apache.carbondata.core.scan.filter.intf.RowIntf;
 import org.apache.carbondata.core.scan.filter.resolver.resolverinfo.DimColumnResolvedFilterInfo;
 import org.apache.carbondata.core.scan.filter.resolver.resolverinfo.MeasureColumnResolvedFilterInfo;
@@ -39,14 +39,6 @@ import org.apache.carbondata.core.util.CarbonUtil;
 import org.apache.carbondata.core.util.DataTypeUtil;
 import org.apache.carbondata.core.util.comparator.Comparator;
 import org.apache.carbondata.core.util.comparator.SerializableComparator;
-
-import it.unimi.dsi.fastutil.booleans.BooleanOpenHashSet;
-import it.unimi.dsi.fastutil.bytes.ByteOpenHashSet;
-import it.unimi.dsi.fastutil.doubles.DoubleOpenHashSet;
-import it.unimi.dsi.fastutil.floats.FloatOpenHashSet;
-import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
-import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
-import it.unimi.dsi.fastutil.shorts.ShortOpenHashSet;
 
 public class ExcludeFilterExecuterImpl implements FilterExecuter {
 
@@ -65,13 +57,19 @@ public class ExcludeFilterExecuterImpl implements FilterExecuter {
 
   private byte[][] filterValues;
 
+  private FilterBitSetUpdater filterBitSetUpdater;
+
   public ExcludeFilterExecuterImpl(byte[][] filterValues, boolean isNaturalSorted) {
     this.filterValues = filterValues;
     this.isNaturalSorted = isNaturalSorted;
+    this.filterBitSetUpdater =
+        BitSetUpdaterFactory.INSTANCE.getBitSetUpdater(FilterExecuterType.EXCLUDE);
   }
   public ExcludeFilterExecuterImpl(DimColumnResolvedFilterInfo dimColEvaluatorInfo,
       MeasureColumnResolvedFilterInfo msrColumnEvaluatorInfo, SegmentProperties segmentProperties,
       boolean isMeasure) {
+    this.filterBitSetUpdater =
+        BitSetUpdaterFactory.INSTANCE.getBitSetUpdater(FilterExecuterType.EXCLUDE);
     this.segmentProperties = segmentProperties;
     if (!isMeasure) {
       this.dimColEvaluatorInfo = dimColEvaluatorInfo;
@@ -198,17 +196,8 @@ public class ExcludeFilterExecuterImpl implements FilterExecuter {
     // the filter values. The one that matches sets it Bitset.
     BitSet bitSet = new BitSet(numerOfRows);
     bitSet.flip(0, numerOfRows);
-    Object[] filterValues = msrColumnExecutorInfo.getFilterKeys();
-    BitSet nullBitSet = columnPage.getNullBits();
-    for (int i = 0; i < filterValues.length; i++) {
-      if (filterValues[i] == null) {
-        for (int j = nullBitSet.nextSetBit(0); j >= 0; j = nullBitSet.nextSetBit(j + 1)) {
-          bitSet.flip(j);
-        }
-      }
-    }
-    executeExcludeFilterForMeasure(columnPage, numerOfRows, bitSet, nullBitSet,
-        msrColumnExecutorInfo, msrType);
+    FilterExecutorUtil.executeIncludeExcludeFilterForMeasure(columnPage,bitSet,
+        msrColumnExecutorInfo, msrColumnEvaluatorInfo, filterBitSetUpdater);
     return bitSet;
   }
 
@@ -449,101 +438,6 @@ public class ExcludeFilterExecuterImpl implements FilterExecuter {
             rawBlockletColumnChunks.getDataBlock().readMeasureChunk(
                 rawBlockletColumnChunks.getFileReader(), chunkIndex);
       }
-    }
-  }
-
-  /**
-   * Below method will be used to execute measure filter based on data type
-   * This is done to avoid conversion of primitive type to primitive object
-   * as it may cause lots of gc when number of record is high and will impact performance
-   * @param page
-   * @param numberOfRows
-   * @param bitSet
-   * @param nullBitset
-   * @param measureColumnExecuterFilterInfo
-   * @param dataType
-   */
-  private void executeExcludeFilterForMeasure(ColumnPage page, int numberOfRows, BitSet bitSet,
-      BitSet nullBitset, MeasureColumnExecuterFilterInfo measureColumnExecuterFilterInfo,
-      DataType dataType) {
-    if (dataType == DataTypes.BYTE) {
-      ByteOpenHashSet byteOpenHashSet = measureColumnExecuterFilterInfo.getByteOpenHashSet();
-      for (int i = 0; i < numberOfRows; i++) {
-        if (!nullBitset.get(i)) {
-          if (byteOpenHashSet.contains((byte) page.getLong(i))) {
-            bitSet.flip(i);
-          }
-        }
-      }
-    } else if (dataType == DataTypes.BOOLEAN) {
-      final BooleanOpenHashSet booleanOpenHashSet =
-          measureColumnExecuterFilterInfo.getBooleanOpenHashSet();
-      for (int i = 0; i < numberOfRows; i++) {
-        if (!nullBitset.get(i)) {
-          if (booleanOpenHashSet.contains(page.getBoolean(i))) {
-            bitSet.flip(i);
-          }
-        }
-      }
-    } else if (dataType == DataTypes.SHORT) {
-      ShortOpenHashSet shortOpenHashSet = measureColumnExecuterFilterInfo.getShortOpenHashSet();
-      for (int i = 0; i < numberOfRows; i++) {
-        if (!nullBitset.get(i)) {
-          if (shortOpenHashSet.contains((short) page.getLong(i))) {
-            bitSet.flip(i);
-          }
-        }
-      }
-    } else if (dataType == DataTypes.INT) {
-      IntOpenHashSet intOpenHashSet = measureColumnExecuterFilterInfo.getIntOpenHashSet();
-      for (int i = 0; i < numberOfRows; i++) {
-        if (!nullBitset.get(i)) {
-          if (intOpenHashSet.contains((int) page.getLong(i))) {
-            bitSet.flip(i);
-          }
-        }
-      }
-    } else if (dataType == DataTypes.FLOAT) {
-      FloatOpenHashSet floatOpenHashSet = measureColumnExecuterFilterInfo.getFloatOpenHashSet();
-      for (int i = 0; i < numberOfRows; i++) {
-        if (!nullBitset.get(i)) {
-          if (floatOpenHashSet.contains((float) page.getDouble(i))) {
-            bitSet.flip(i);
-          }
-        }
-      }
-    } else if (dataType == DataTypes.DOUBLE) {
-      DoubleOpenHashSet doubleOpenHashSet = measureColumnExecuterFilterInfo.getDoubleOpenHashSet();
-      for (int i = 0; i < numberOfRows; i++) {
-        if (!nullBitset.get(i)) {
-          if (doubleOpenHashSet.contains(page.getDouble(i))) {
-            bitSet.flip(i);
-          }
-        }
-      }
-    } else if (dataType == DataTypes.LONG) {
-      LongOpenHashSet longOpenHashSet = measureColumnExecuterFilterInfo.getLongOpenHashSet();
-      for (int i = 0; i < numberOfRows; i++) {
-        if (!nullBitset.get(i)) {
-          if (longOpenHashSet.contains(page.getLong(i))) {
-            bitSet.flip(i);
-          }
-        }
-      }
-    } else if (DataTypes.isDecimal(dataType)) {
-      Set<Object> bigDecimalHashSet = measureColumnExecuterFilterInfo.getBigDecimalHashSet();
-      for (int i = 0; i < numberOfRows; i++) {
-        if (!nullBitset.get(i)) {
-          final Object measureObjectBasedOnDataType = DataTypeUtil
-              .getMeasureObjectBasedOnDataType(page, i, dataType,
-                  msrColumnEvaluatorInfo.getMeasure());
-          if (bigDecimalHashSet.contains(measureObjectBasedOnDataType)) {
-            bitSet.flip(i);
-          }
-        }
-      }
-    } else {
-      throw new IllegalArgumentException("Invalid data type");
     }
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/ExcludeFilterExecuterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/ExcludeFilterExecuterImpl.java
@@ -469,17 +469,17 @@ public class ExcludeFilterExecuterImpl implements FilterExecuter {
     if (dataType == DataTypes.BYTE) {
       ByteOpenHashSet byteOpenHashSet = measureColumnExecuterFilterInfo.getByteOpenHashSet();
       for (int i = 0; i < numberOfRows; i++) {
-        if (!nullBitset.get(i) && !bitSet.get(i)) {
+        if (!nullBitset.get(i)) {
           if (byteOpenHashSet.contains((byte) page.getLong(i))) {
             bitSet.flip(i);
           }
         }
       }
     } else if (dataType == DataTypes.BOOLEAN) {
-      BooleanOpenHashSet booleanOpenHashSet =
+      final BooleanOpenHashSet booleanOpenHashSet =
           measureColumnExecuterFilterInfo.getBooleanOpenHashSet();
       for (int i = 0; i < numberOfRows; i++) {
-        if (!nullBitset.get(i) && !bitSet.get(i)) {
+        if (!nullBitset.get(i)) {
           if (booleanOpenHashSet.contains(page.getBoolean(i))) {
             bitSet.flip(i);
           }
@@ -488,7 +488,7 @@ public class ExcludeFilterExecuterImpl implements FilterExecuter {
     } else if (dataType == DataTypes.SHORT) {
       ShortOpenHashSet shortOpenHashSet = measureColumnExecuterFilterInfo.getShortOpenHashSet();
       for (int i = 0; i < numberOfRows; i++) {
-        if (!nullBitset.get(i) && !bitSet.get(i)) {
+        if (!nullBitset.get(i)) {
           if (shortOpenHashSet.contains((short) page.getLong(i))) {
             bitSet.flip(i);
           }
@@ -497,7 +497,7 @@ public class ExcludeFilterExecuterImpl implements FilterExecuter {
     } else if (dataType == DataTypes.INT) {
       IntOpenHashSet intOpenHashSet = measureColumnExecuterFilterInfo.getIntOpenHashSet();
       for (int i = 0; i < numberOfRows; i++) {
-        if (!nullBitset.get(i) && !bitSet.get(i)) {
+        if (!nullBitset.get(i)) {
           if (intOpenHashSet.contains((int) page.getLong(i))) {
             bitSet.flip(i);
           }
@@ -506,7 +506,7 @@ public class ExcludeFilterExecuterImpl implements FilterExecuter {
     } else if (dataType == DataTypes.FLOAT) {
       FloatOpenHashSet floatOpenHashSet = measureColumnExecuterFilterInfo.getFloatOpenHashSet();
       for (int i = 0; i < numberOfRows; i++) {
-        if (!nullBitset.get(i) && !bitSet.get(i)) {
+        if (!nullBitset.get(i)) {
           if (floatOpenHashSet.contains((float) page.getDouble(i))) {
             bitSet.flip(i);
           }
@@ -515,7 +515,7 @@ public class ExcludeFilterExecuterImpl implements FilterExecuter {
     } else if (dataType == DataTypes.DOUBLE) {
       DoubleOpenHashSet doubleOpenHashSet = measureColumnExecuterFilterInfo.getDoubleOpenHashSet();
       for (int i = 0; i < numberOfRows; i++) {
-        if (!nullBitset.get(i) && !bitSet.get(i)) {
+        if (!nullBitset.get(i)) {
           if (doubleOpenHashSet.contains(page.getDouble(i))) {
             bitSet.flip(i);
           }
@@ -524,7 +524,7 @@ public class ExcludeFilterExecuterImpl implements FilterExecuter {
     } else if (dataType == DataTypes.LONG) {
       LongOpenHashSet longOpenHashSet = measureColumnExecuterFilterInfo.getLongOpenHashSet();
       for (int i = 0; i < numberOfRows; i++) {
-        if (!nullBitset.get(i) && !bitSet.get(i)) {
+        if (!nullBitset.get(i)) {
           if (longOpenHashSet.contains(page.getLong(i))) {
             bitSet.flip(i);
           }
@@ -533,7 +533,7 @@ public class ExcludeFilterExecuterImpl implements FilterExecuter {
     } else if (DataTypes.isDecimal(dataType)) {
       Set<Object> bigDecimalHashSet = measureColumnExecuterFilterInfo.getBigDecimalHashSet();
       for (int i = 0; i < numberOfRows; i++) {
-        if (!nullBitset.get(i) && !bitSet.get(i)) {
+        if (!nullBitset.get(i)) {
           final Object measureObjectBasedOnDataType = DataTypeUtil
               .getMeasureObjectBasedOnDataType(page, i, dataType,
                   msrColumnEvaluatorInfo.getMeasure());

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/FilterBitSetUpdater.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/FilterBitSetUpdater.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.core.scan.filter.executer;
+
+import java.util.BitSet;
+
+public interface FilterBitSetUpdater {
+  void updateBitset(BitSet bitSet, int bitIndex);
+}
+

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/IncludeFilterExecuterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/IncludeFilterExecuterImpl.java
@@ -18,7 +18,6 @@ package org.apache.carbondata.core.scan.filter.executer;
 
 import java.io.IOException;
 import java.util.BitSet;
-import java.util.Set;
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.datastore.block.SegmentProperties;
@@ -27,10 +26,11 @@ import org.apache.carbondata.core.datastore.chunk.impl.DimensionRawColumnChunk;
 import org.apache.carbondata.core.datastore.chunk.impl.MeasureRawColumnChunk;
 import org.apache.carbondata.core.datastore.page.ColumnPage;
 import org.apache.carbondata.core.metadata.datatype.DataType;
-import org.apache.carbondata.core.metadata.datatype.DataTypes;
 import org.apache.carbondata.core.metadata.encoder.Encoding;
 import org.apache.carbondata.core.scan.expression.exception.FilterUnsupportedException;
+import org.apache.carbondata.core.scan.filter.FilterExecutorUtil;
 import org.apache.carbondata.core.scan.filter.FilterUtil;
+import org.apache.carbondata.core.scan.filter.intf.FilterExecuterType;
 import org.apache.carbondata.core.scan.filter.intf.RowIntf;
 import org.apache.carbondata.core.scan.filter.resolver.resolverinfo.DimColumnResolvedFilterInfo;
 import org.apache.carbondata.core.scan.filter.resolver.resolverinfo.MeasureColumnResolvedFilterInfo;
@@ -41,14 +41,6 @@ import org.apache.carbondata.core.util.CarbonUtil;
 import org.apache.carbondata.core.util.DataTypeUtil;
 import org.apache.carbondata.core.util.comparator.Comparator;
 import org.apache.carbondata.core.util.comparator.SerializableComparator;
-
-import it.unimi.dsi.fastutil.booleans.BooleanOpenHashSet;
-import it.unimi.dsi.fastutil.bytes.ByteOpenHashSet;
-import it.unimi.dsi.fastutil.doubles.DoubleOpenHashSet;
-import it.unimi.dsi.fastutil.floats.FloatOpenHashSet;
-import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
-import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
-import it.unimi.dsi.fastutil.shorts.ShortOpenHashSet;
 
 public class IncludeFilterExecuterImpl implements FilterExecuter {
 
@@ -67,15 +59,20 @@ public class IncludeFilterExecuterImpl implements FilterExecuter {
 
   private byte[][] filterValues;
 
+  private FilterBitSetUpdater filterBitSetUpdater;
+
   public IncludeFilterExecuterImpl(byte[][] filterValues, boolean isNaturalSorted) {
     this.filterValues = filterValues;
     this.isNaturalSorted = isNaturalSorted;
+    this.filterBitSetUpdater =
+        BitSetUpdaterFactory.INSTANCE.getBitSetUpdater(FilterExecuterType.INCLUDE);
   }
 
   public IncludeFilterExecuterImpl(DimColumnResolvedFilterInfo dimColumnEvaluatorInfo,
       MeasureColumnResolvedFilterInfo msrColumnEvaluatorInfo, SegmentProperties segmentProperties,
       boolean isMeasure) {
-
+    this.filterBitSetUpdater =
+        BitSetUpdaterFactory.INSTANCE.getBitSetUpdater(FilterExecuterType.INCLUDE);
     this.segmentProperties = segmentProperties;
     if (!isMeasure) {
       this.dimColumnEvaluatorInfo = dimColumnEvaluatorInfo;
@@ -282,18 +279,8 @@ public class IncludeFilterExecuterImpl implements FilterExecuter {
     // Get the measure values from the chunk. compare sequentially with the
     // the filter values. The one that matches sets it Bitset.
     BitSet bitSet = new BitSet(rowsInPage);
-    Object[] filterValues = msrColumnExecutorInfo.getFilterKeys();
-
-    BitSet nullBitSet = columnPage.getNullBits();
-    for (int i = 0; i < filterValues.length; i++) {
-      if (filterValues[i] == null) {
-        for (int j = nullBitSet.nextSetBit(0); j >= 0; j = nullBitSet.nextSetBit(j + 1)) {
-          bitSet.set(j);
-        }
-      }
-    }
-    executeIncludeFilterMeasure(columnPage, rowsInPage, bitSet, nullBitSet, msrColumnExecutorInfo,
-        msrType);
+    FilterExecutorUtil.executeIncludeExcludeFilterForMeasure(columnPage,bitSet,
+        msrColumnExecutorInfo, msrColumnEvaluatorInfo, filterBitSetUpdater);
     return bitSet;
   }
 
@@ -623,101 +610,6 @@ public class IncludeFilterExecuterImpl implements FilterExecuter {
             rawBlockletColumnChunks.getDataBlock().readMeasureChunk(
                 rawBlockletColumnChunks.getFileReader(), chunkIndex);
       }
-    }
-  }
-
-  /**
-   * Below method will be used to execute measure filter based on data type
-   * This is done to avoid conversion of primitive type to primitive object
-   * as it may cause lots of gc when number of record is high and will impact performance
-   * @param page
-   * @param numberOfRows
-   * @param bitSet
-   * @param nullBitset
-   * @param measureColumnExecuterFilterInfo
-   * @param dataType
-   */
-  private void executeIncludeFilterMeasure(ColumnPage page, int numberOfRows, BitSet bitSet,
-      BitSet nullBitset, MeasureColumnExecuterFilterInfo measureColumnExecuterFilterInfo,
-      DataType dataType) {
-    if (dataType == DataTypes.BYTE) {
-      ByteOpenHashSet byteOpenHashSet = measureColumnExecuterFilterInfo.getByteOpenHashSet();
-      for (int i = 0; i < numberOfRows; i++) {
-        if (!nullBitset.get(i)) {
-          if (byteOpenHashSet.contains((byte) page.getLong(i))) {
-            bitSet.set(i);
-          }
-        }
-      }
-    } else if (dataType == DataTypes.BOOLEAN) {
-      BooleanOpenHashSet booleanOpenHashSet =
-          measureColumnExecuterFilterInfo.getBooleanOpenHashSet();
-      for (int i = 0; i < numberOfRows; i++) {
-        if (!nullBitset.get(i)) {
-          if (booleanOpenHashSet.contains(page.getBoolean(i))) {
-            bitSet.set(i);
-          }
-        }
-      }
-    } else if (dataType == DataTypes.SHORT) {
-      ShortOpenHashSet shortOpenHashSet = measureColumnExecuterFilterInfo.getShortOpenHashSet();
-      for (int i = 0; i < numberOfRows; i++) {
-        if (!nullBitset.get(i)) {
-          if (shortOpenHashSet.contains((short) page.getLong(i))) {
-            bitSet.set(i);
-          }
-        }
-      }
-    } else if (dataType == DataTypes.INT) {
-      IntOpenHashSet intOpenHashSet = measureColumnExecuterFilterInfo.getIntOpenHashSet();
-      for (int i = 0; i < numberOfRows; i++) {
-        if (!nullBitset.get(i)) {
-          if (intOpenHashSet.contains((int) page.getLong(i))) {
-            bitSet.set(i);
-          }
-        }
-      }
-    } else if (dataType == DataTypes.FLOAT) {
-      FloatOpenHashSet floatOpenHashSet = measureColumnExecuterFilterInfo.getFloatOpenHashSet();
-      for (int i = 0; i < numberOfRows; i++) {
-        if (!nullBitset.get(i)) {
-          if (floatOpenHashSet.contains((float) page.getDouble(i))) {
-            bitSet.set(i);
-          }
-        }
-      }
-    } else if (dataType == DataTypes.DOUBLE) {
-      DoubleOpenHashSet doubleOpenHashSet = measureColumnExecuterFilterInfo.getDoubleOpenHashSet();
-      for (int i = 0; i < numberOfRows; i++) {
-        if (!nullBitset.get(i)) {
-          if (doubleOpenHashSet.contains(page.getDouble(i))) {
-            bitSet.set(i);
-          }
-        }
-      }
-    } else if (dataType == DataTypes.LONG) {
-      LongOpenHashSet longOpenHashSet = measureColumnExecuterFilterInfo.getLongOpenHashSet();
-      for (int i = 0; i < numberOfRows; i++) {
-        if (!nullBitset.get(i)) {
-          if (longOpenHashSet.contains(page.getLong(i))) {
-            bitSet.set(i);
-          }
-        }
-      }
-    } else if (DataTypes.isDecimal(dataType)) {
-      Set<Object> bigDecimalHashSet = measureColumnExecuterFilterInfo.getBigDecimalHashSet();
-      for (int i = 0; i < numberOfRows; i++) {
-        if (!nullBitset.get(i)) {
-          final Object measureObjectBasedOnDataType = DataTypeUtil
-              .getMeasureObjectBasedOnDataType(page, i, dataType,
-                  msrColumnEvaluatorInfo.getMeasure());
-          if (bigDecimalHashSet.contains(measureObjectBasedOnDataType)) {
-            bitSet.set(i);
-          }
-        }
-      }
-    } else {
-      throw new IllegalArgumentException("Invalid data type");
     }
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/IncludeFilterExecuterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/IncludeFilterExecuterImpl.java
@@ -18,6 +18,7 @@ package org.apache.carbondata.core.scan.filter.executer;
 
 import java.io.IOException;
 import java.util.BitSet;
+import java.util.Set;
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.datastore.block.SegmentProperties;
@@ -26,6 +27,7 @@ import org.apache.carbondata.core.datastore.chunk.impl.DimensionRawColumnChunk;
 import org.apache.carbondata.core.datastore.chunk.impl.MeasureRawColumnChunk;
 import org.apache.carbondata.core.datastore.page.ColumnPage;
 import org.apache.carbondata.core.metadata.datatype.DataType;
+import org.apache.carbondata.core.metadata.datatype.DataTypes;
 import org.apache.carbondata.core.metadata.encoder.Encoding;
 import org.apache.carbondata.core.scan.expression.exception.FilterUnsupportedException;
 import org.apache.carbondata.core.scan.filter.FilterUtil;
@@ -39,6 +41,14 @@ import org.apache.carbondata.core.util.CarbonUtil;
 import org.apache.carbondata.core.util.DataTypeUtil;
 import org.apache.carbondata.core.util.comparator.Comparator;
 import org.apache.carbondata.core.util.comparator.SerializableComparator;
+
+import it.unimi.dsi.fastutil.booleans.BooleanOpenHashSet;
+import it.unimi.dsi.fastutil.bytes.ByteOpenHashSet;
+import it.unimi.dsi.fastutil.doubles.DoubleOpenHashSet;
+import it.unimi.dsi.fastutil.floats.FloatOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+import it.unimi.dsi.fastutil.shorts.ShortOpenHashSet;
 
 public class IncludeFilterExecuterImpl implements FilterExecuter {
 
@@ -274,29 +284,16 @@ public class IncludeFilterExecuterImpl implements FilterExecuter {
     BitSet bitSet = new BitSet(rowsInPage);
     Object[] filterValues = msrColumnExecutorInfo.getFilterKeys();
 
-    SerializableComparator comparator = Comparator.getComparatorByDataTypeForMeasure(msrType);
     BitSet nullBitSet = columnPage.getNullBits();
     for (int i = 0; i < filterValues.length; i++) {
       if (filterValues[i] == null) {
         for (int j = nullBitSet.nextSetBit(0); j >= 0; j = nullBitSet.nextSetBit(j + 1)) {
           bitSet.set(j);
         }
-        continue;
-      }
-      for (int startIndex = 0; startIndex < rowsInPage; startIndex++) {
-        if (!nullBitSet.get(startIndex)) {
-          // Check if filterValue[i] matches with measure Values.
-          Object msrValue = DataTypeUtil
-              .getMeasureObjectBasedOnDataType(columnPage, startIndex,
-                  msrType, msrColumnEvaluatorInfo.getMeasure());
-
-          if (comparator.compare(msrValue, filterValues[i]) == 0) {
-            // This is a match.
-            bitSet.set(startIndex);
-          }
-        }
       }
     }
+    executeIncludeFilterMeasure(columnPage, rowsInPage, bitSet, nullBitSet, msrColumnExecutorInfo,
+        msrType);
     return bitSet;
   }
 
@@ -629,6 +626,101 @@ public class IncludeFilterExecuterImpl implements FilterExecuter {
             rawBlockletColumnChunks.getDataBlock().readMeasureChunk(
                 rawBlockletColumnChunks.getFileReader(), chunkIndex);
       }
+    }
+  }
+
+  /**
+   * Below method will be used to execute measure filter based on data type
+   * This is done to avoid conversion of primitive type to primitive object
+   * as it may cause lots of gc when number of record is high and will impact performance
+   * @param page
+   * @param numberOfRows
+   * @param bitSet
+   * @param nullBitset
+   * @param measureColumnExecuterFilterInfo
+   * @param dataType
+   */
+  private void executeIncludeFilterMeasure(ColumnPage page, int numberOfRows, BitSet bitSet,
+      BitSet nullBitset, MeasureColumnExecuterFilterInfo measureColumnExecuterFilterInfo,
+      DataType dataType) {
+    if (dataType == DataTypes.BYTE) {
+      ByteOpenHashSet byteOpenHashSet = measureColumnExecuterFilterInfo.getByteOpenHashSet();
+      for (int i = 0; i < numberOfRows; i++) {
+        if (!nullBitset.get(i) && !bitSet.get(i)) {
+          if (byteOpenHashSet.contains((byte) page.getLong(i))) {
+            bitSet.set(i);
+          }
+        }
+      }
+    } else if (dataType == DataTypes.BOOLEAN) {
+      BooleanOpenHashSet booleanOpenHashSet =
+          measureColumnExecuterFilterInfo.getBooleanOpenHashSet();
+      for (int i = 0; i < numberOfRows; i++) {
+        if (!nullBitset.get(i) && !bitSet.get(i)) {
+          if (booleanOpenHashSet.contains(page.getBoolean(i))) {
+            bitSet.set(i);
+          }
+        }
+      }
+    } else if (dataType == DataTypes.SHORT) {
+      ShortOpenHashSet shortOpenHashSet = measureColumnExecuterFilterInfo.getShortOpenHashSet();
+      for (int i = 0; i < numberOfRows; i++) {
+        if (!nullBitset.get(i) && !bitSet.get(i)) {
+          if (shortOpenHashSet.contains((short) page.getLong(i))) {
+            bitSet.set(i);
+          }
+        }
+      }
+    } else if (dataType == DataTypes.INT) {
+      IntOpenHashSet intOpenHashSet = measureColumnExecuterFilterInfo.getIntOpenHashSet();
+      for (int i = 0; i < numberOfRows; i++) {
+        if (!nullBitset.get(i) && !bitSet.get(i)) {
+          if (intOpenHashSet.contains((int) page.getLong(i))) {
+            bitSet.set(i);
+          }
+        }
+      }
+    } else if (dataType == DataTypes.FLOAT) {
+      FloatOpenHashSet floatOpenHashSet = measureColumnExecuterFilterInfo.getFloatOpenHashSet();
+      for (int i = 0; i < numberOfRows; i++) {
+        if (!nullBitset.get(i) && !bitSet.get(i)) {
+          if (floatOpenHashSet.contains((float) page.getDouble(i))) {
+            bitSet.set(i);
+          }
+        }
+      }
+    } else if (dataType == DataTypes.DOUBLE) {
+      DoubleOpenHashSet doubleOpenHashSet = measureColumnExecuterFilterInfo.getDoubleOpenHashSet();
+      for (int i = 0; i < numberOfRows; i++) {
+        if (!nullBitset.get(i) && !bitSet.get(i)) {
+          if (doubleOpenHashSet.contains(page.getDouble(i))) {
+            bitSet.set(i);
+          }
+        }
+      }
+    } else if (dataType == DataTypes.LONG) {
+      LongOpenHashSet longOpenHashSet = measureColumnExecuterFilterInfo.getLongOpenHashSet();
+      for (int i = 0; i < numberOfRows; i++) {
+        if (!nullBitset.get(i) && !bitSet.get(i)) {
+          if (longOpenHashSet.contains(page.getLong(i))) {
+            bitSet.set(i);
+          }
+        }
+      }
+    } else if (DataTypes.isDecimal(dataType)) {
+      Set<Object> bigDecimalHashSet = measureColumnExecuterFilterInfo.getBigDecimalHashSet();
+      for (int i = 0; i < numberOfRows; i++) {
+        if (!nullBitset.get(i) && !bitSet.get(i)) {
+          final Object measureObjectBasedOnDataType = DataTypeUtil
+              .getMeasureObjectBasedOnDataType(page, i, dataType,
+                  msrColumnEvaluatorInfo.getMeasure());
+          if (bigDecimalHashSet.contains(measureObjectBasedOnDataType)) {
+            bitSet.set(i);
+          }
+        }
+      }
+    } else {
+      throw new IllegalArgumentException("Invalid data type");
     }
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/IncludeFilterExecuterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/IncludeFilterExecuterImpl.java
@@ -522,12 +522,9 @@ public class IncludeFilterExecuterImpl implements FilterExecuter {
       }
     } else if (isMeasurePresentInCurrentBlock) {
       chunkIndex = msrColumnEvaluatorInfo.getColumnIndexInMinMaxByteArray();
-      if (isMinMaxSet[chunkIndex]) {
-        isScanRequired = isScanRequired(blkMaxVal[chunkIndex], blkMinVal[chunkIndex],
-            msrColumnExecutorInfo.getFilterKeys(), msrColumnEvaluatorInfo.getType());
-      } else {
-        isScanRequired = true;
-      }
+      isScanRequired = isScanRequired(blkMaxVal[chunkIndex], blkMinVal[chunkIndex],
+          msrColumnExecutorInfo.getFilterKeys(),
+          msrColumnEvaluatorInfo.getType());
     }
 
     if (isScanRequired) {
@@ -646,7 +643,7 @@ public class IncludeFilterExecuterImpl implements FilterExecuter {
     if (dataType == DataTypes.BYTE) {
       ByteOpenHashSet byteOpenHashSet = measureColumnExecuterFilterInfo.getByteOpenHashSet();
       for (int i = 0; i < numberOfRows; i++) {
-        if (!nullBitset.get(i) && !bitSet.get(i)) {
+        if (!nullBitset.get(i)) {
           if (byteOpenHashSet.contains((byte) page.getLong(i))) {
             bitSet.set(i);
           }
@@ -656,7 +653,7 @@ public class IncludeFilterExecuterImpl implements FilterExecuter {
       BooleanOpenHashSet booleanOpenHashSet =
           measureColumnExecuterFilterInfo.getBooleanOpenHashSet();
       for (int i = 0; i < numberOfRows; i++) {
-        if (!nullBitset.get(i) && !bitSet.get(i)) {
+        if (!nullBitset.get(i)) {
           if (booleanOpenHashSet.contains(page.getBoolean(i))) {
             bitSet.set(i);
           }
@@ -665,7 +662,7 @@ public class IncludeFilterExecuterImpl implements FilterExecuter {
     } else if (dataType == DataTypes.SHORT) {
       ShortOpenHashSet shortOpenHashSet = measureColumnExecuterFilterInfo.getShortOpenHashSet();
       for (int i = 0; i < numberOfRows; i++) {
-        if (!nullBitset.get(i) && !bitSet.get(i)) {
+        if (!nullBitset.get(i)) {
           if (shortOpenHashSet.contains((short) page.getLong(i))) {
             bitSet.set(i);
           }
@@ -674,7 +671,7 @@ public class IncludeFilterExecuterImpl implements FilterExecuter {
     } else if (dataType == DataTypes.INT) {
       IntOpenHashSet intOpenHashSet = measureColumnExecuterFilterInfo.getIntOpenHashSet();
       for (int i = 0; i < numberOfRows; i++) {
-        if (!nullBitset.get(i) && !bitSet.get(i)) {
+        if (!nullBitset.get(i)) {
           if (intOpenHashSet.contains((int) page.getLong(i))) {
             bitSet.set(i);
           }
@@ -683,7 +680,7 @@ public class IncludeFilterExecuterImpl implements FilterExecuter {
     } else if (dataType == DataTypes.FLOAT) {
       FloatOpenHashSet floatOpenHashSet = measureColumnExecuterFilterInfo.getFloatOpenHashSet();
       for (int i = 0; i < numberOfRows; i++) {
-        if (!nullBitset.get(i) && !bitSet.get(i)) {
+        if (!nullBitset.get(i)) {
           if (floatOpenHashSet.contains((float) page.getDouble(i))) {
             bitSet.set(i);
           }
@@ -692,7 +689,7 @@ public class IncludeFilterExecuterImpl implements FilterExecuter {
     } else if (dataType == DataTypes.DOUBLE) {
       DoubleOpenHashSet doubleOpenHashSet = measureColumnExecuterFilterInfo.getDoubleOpenHashSet();
       for (int i = 0; i < numberOfRows; i++) {
-        if (!nullBitset.get(i) && !bitSet.get(i)) {
+        if (!nullBitset.get(i)) {
           if (doubleOpenHashSet.contains(page.getDouble(i))) {
             bitSet.set(i);
           }
@@ -701,7 +698,7 @@ public class IncludeFilterExecuterImpl implements FilterExecuter {
     } else if (dataType == DataTypes.LONG) {
       LongOpenHashSet longOpenHashSet = measureColumnExecuterFilterInfo.getLongOpenHashSet();
       for (int i = 0; i < numberOfRows; i++) {
-        if (!nullBitset.get(i) && !bitSet.get(i)) {
+        if (!nullBitset.get(i)) {
           if (longOpenHashSet.contains(page.getLong(i))) {
             bitSet.set(i);
           }
@@ -710,7 +707,7 @@ public class IncludeFilterExecuterImpl implements FilterExecuter {
     } else if (DataTypes.isDecimal(dataType)) {
       Set<Object> bigDecimalHashSet = measureColumnExecuterFilterInfo.getBigDecimalHashSet();
       for (int i = 0; i < numberOfRows; i++) {
-        if (!nullBitset.get(i) && !bitSet.get(i)) {
+        if (!nullBitset.get(i)) {
           final Object measureObjectBasedOnDataType = DataTypeUtil
               .getMeasureObjectBasedOnDataType(page, i, dataType,
                   msrColumnEvaluatorInfo.getMeasure());

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/MeasureColumnExecuterFilterInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/MeasureColumnExecuterFilterInfo.java
@@ -16,15 +16,143 @@
  */
 package org.apache.carbondata.core.scan.filter.executer;
 
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.carbondata.core.metadata.datatype.DataType;
+import org.apache.carbondata.core.metadata.datatype.DataTypes;
+
+import it.unimi.dsi.fastutil.booleans.BooleanOpenHashSet;
+import it.unimi.dsi.fastutil.bytes.ByteOpenHashSet;
+import it.unimi.dsi.fastutil.doubles.DoubleOpenHashSet;
+import it.unimi.dsi.fastutil.floats.FloatOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+import it.unimi.dsi.fastutil.shorts.ShortOpenHashSet;
+
+/**
+ * Below class will be used to keep all the filter values based on data type
+ * for measure column.
+ * In this class there are multiple type of set is used to avoid conversion of
+ * primitive type to primitive object to avoid gc which cause perofrmace degrade when
+ * number of records are high
+ */
 public class MeasureColumnExecuterFilterInfo {
 
   Object[] filterKeys;
 
-  public void setFilterKeys(Object[] filterKeys) {
+  private ByteOpenHashSet byteOpenHashSet;
+
+  private IntOpenHashSet intOpenHashSet;
+
+  private DoubleOpenHashSet doubleOpenHashSet;
+
+  private ShortOpenHashSet shortOpenHashSet;
+
+  private Set<Object> bigDecimalHashSet;
+
+  private LongOpenHashSet longOpenHashSet;
+
+  private BooleanOpenHashSet booleanOpenHashSet;
+
+  private FloatOpenHashSet floatOpenHashSet;
+
+  public void setFilterKeys(Object[] filterKeys, DataType dataType) {
     this.filterKeys = filterKeys;
+    if (dataType == DataTypes.BOOLEAN) {
+      booleanOpenHashSet = new BooleanOpenHashSet();
+      for (int i = 0; i < filterKeys.length; i++) {
+        if (null != filterKeys[i]) {
+          booleanOpenHashSet.add(((Boolean) filterKeys[i]).booleanValue());
+        }
+      }
+    }
+    if (dataType == DataTypes.BYTE) {
+      byteOpenHashSet = new ByteOpenHashSet();
+      for (int i = 0; i < filterKeys.length; i++) {
+        if (null != filterKeys[i]) {
+          byteOpenHashSet.add(((Byte) filterKeys[i]).byteValue());
+        }
+      }
+    }
+    if (dataType == DataTypes.SHORT) {
+      shortOpenHashSet = new ShortOpenHashSet();
+      for (int i = 0; i < filterKeys.length; i++) {
+        if (null != filterKeys[i]) {
+          shortOpenHashSet.add(((Short) filterKeys[i]).shortValue());
+        }
+      }
+    } else if (dataType == DataTypes.INT) {
+      intOpenHashSet = new IntOpenHashSet();
+      for (int i = 0; i < filterKeys.length; i++) {
+        if (null != filterKeys[i]) {
+          intOpenHashSet.add(((Integer) filterKeys[i]).intValue());
+        }
+      }
+    } else if (dataType == DataTypes.FLOAT) {
+      floatOpenHashSet = new FloatOpenHashSet();
+      for (int i = 0; i < filterKeys.length; i++) {
+        if (null != filterKeys[i]) {
+          floatOpenHashSet.add(((Float) filterKeys[i]).floatValue());
+        }
+      }
+    } else if (dataType == DataTypes.LONG) {
+      longOpenHashSet = new LongOpenHashSet();
+      for (int i = 0; i < filterKeys.length; i++) {
+        if (null != filterKeys[i]) {
+          longOpenHashSet.add(((Long) filterKeys[i]).longValue());
+        }
+      }
+    } else if (dataType == DataTypes.DOUBLE) {
+      doubleOpenHashSet = new DoubleOpenHashSet();
+      for (int i = 0; i < filterKeys.length; i++) {
+        if (null != filterKeys[i]) {
+          doubleOpenHashSet.add(((Double) filterKeys[i]).doubleValue());
+        }
+      }
+    } else {
+      this.bigDecimalHashSet = new HashSet<>();
+      for (int i = 0; i < filterKeys.length; i++) {
+        if (null != filterKeys[i]) {
+          bigDecimalHashSet.add(filterKeys[i]);
+        }
+      }
+    }
   }
 
   public Object[] getFilterKeys() {
     return filterKeys;
+  }
+
+  public ByteOpenHashSet getByteOpenHashSet() {
+    return byteOpenHashSet;
+  }
+
+  public IntOpenHashSet getIntOpenHashSet() {
+    return intOpenHashSet;
+  }
+
+  public DoubleOpenHashSet getDoubleOpenHashSet() {
+    return doubleOpenHashSet;
+  }
+
+  public ShortOpenHashSet getShortOpenHashSet() {
+    return shortOpenHashSet;
+  }
+
+  public Set<Object> getBigDecimalHashSet() {
+    return bigDecimalHashSet;
+  }
+
+  public LongOpenHashSet getLongOpenHashSet() {
+    return longOpenHashSet;
+  }
+
+  public BooleanOpenHashSet getBooleanOpenHashSet() {
+    return booleanOpenHashSet;
+  }
+
+  public FloatOpenHashSet getFloatOpenHashSet() {
+    return floatOpenHashSet;
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/MeasureColumnExecuterFilterInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/MeasureColumnExecuterFilterInfo.java
@@ -16,8 +16,8 @@
  */
 package org.apache.carbondata.core.scan.filter.executer;
 
+import java.util.AbstractCollection;
 import java.util.HashSet;
-import java.util.Set;
 
 import org.apache.carbondata.core.metadata.datatype.DataType;
 import org.apache.carbondata.core.metadata.datatype.DataTypes;
@@ -41,81 +41,35 @@ public class MeasureColumnExecuterFilterInfo {
 
   Object[] filterKeys;
 
-  private ByteOpenHashSet byteOpenHashSet;
-
-  private IntOpenHashSet intOpenHashSet;
-
-  private DoubleOpenHashSet doubleOpenHashSet;
-
-  private ShortOpenHashSet shortOpenHashSet;
-
-  private Set<Object> bigDecimalHashSet;
-
-  private LongOpenHashSet longOpenHashSet;
-
-  private BooleanOpenHashSet booleanOpenHashSet;
-
-  private FloatOpenHashSet floatOpenHashSet;
+  /**
+   * filter set used for filtering the measure value based on data type
+   */
+  private AbstractCollection filterSet;
 
   public void setFilterKeys(Object[] filterKeys, DataType dataType) {
     this.filterKeys = filterKeys;
     if (dataType == DataTypes.BOOLEAN) {
-      booleanOpenHashSet = new BooleanOpenHashSet();
-      for (int i = 0; i < filterKeys.length; i++) {
-        if (null != filterKeys[i]) {
-          booleanOpenHashSet.add(((Boolean) filterKeys[i]).booleanValue());
-        }
-      }
-    }
-    if (dataType == DataTypes.BYTE) {
-      byteOpenHashSet = new ByteOpenHashSet();
-      for (int i = 0; i < filterKeys.length; i++) {
-        if (null != filterKeys[i]) {
-          byteOpenHashSet.add(((Byte) filterKeys[i]).byteValue());
-        }
-      }
-    }
-    if (dataType == DataTypes.SHORT) {
-      shortOpenHashSet = new ShortOpenHashSet();
-      for (int i = 0; i < filterKeys.length; i++) {
-        if (null != filterKeys[i]) {
-          shortOpenHashSet.add(((Short) filterKeys[i]).shortValue());
-        }
-      }
+      filterSet = new BooleanOpenHashSet();
+    } else if (dataType == DataTypes.BYTE) {
+      filterSet = new ByteOpenHashSet();
+    } else if (dataType == DataTypes.SHORT) {
+      filterSet = new ShortOpenHashSet();
     } else if (dataType == DataTypes.INT) {
-      intOpenHashSet = new IntOpenHashSet();
-      for (int i = 0; i < filterKeys.length; i++) {
-        if (null != filterKeys[i]) {
-          intOpenHashSet.add(((Integer) filterKeys[i]).intValue());
-        }
-      }
+      filterSet = new IntOpenHashSet();
     } else if (dataType == DataTypes.FLOAT) {
-      floatOpenHashSet = new FloatOpenHashSet();
-      for (int i = 0; i < filterKeys.length; i++) {
-        if (null != filterKeys[i]) {
-          floatOpenHashSet.add(((Float) filterKeys[i]).floatValue());
-        }
-      }
+      filterSet = new FloatOpenHashSet();
     } else if (dataType == DataTypes.LONG) {
-      longOpenHashSet = new LongOpenHashSet();
-      for (int i = 0; i < filterKeys.length; i++) {
-        if (null != filterKeys[i]) {
-          longOpenHashSet.add(((Long) filterKeys[i]).longValue());
-        }
-      }
+      filterSet = new LongOpenHashSet();
     } else if (dataType == DataTypes.DOUBLE) {
-      doubleOpenHashSet = new DoubleOpenHashSet();
-      for (int i = 0; i < filterKeys.length; i++) {
-        if (null != filterKeys[i]) {
-          doubleOpenHashSet.add(((Double) filterKeys[i]).doubleValue());
-        }
-      }
+      filterSet = new DoubleOpenHashSet();
+    } else if (DataTypes.isDecimal(dataType)) {
+      filterSet = new HashSet();
     } else {
-      this.bigDecimalHashSet = new HashSet<>();
-      for (int i = 0; i < filterKeys.length; i++) {
-        if (null != filterKeys[i]) {
-          bigDecimalHashSet.add(filterKeys[i]);
-        }
+      throw new IllegalArgumentException("Invalid data type");
+    }
+    for (int i = 0; i < filterKeys.length; i++) {
+      if (null != filterKeys[i]) {
+        filterSet.add(filterKeys[i]);
       }
     }
   }
@@ -124,35 +78,7 @@ public class MeasureColumnExecuterFilterInfo {
     return filterKeys;
   }
 
-  public ByteOpenHashSet getByteOpenHashSet() {
-    return byteOpenHashSet;
-  }
-
-  public IntOpenHashSet getIntOpenHashSet() {
-    return intOpenHashSet;
-  }
-
-  public DoubleOpenHashSet getDoubleOpenHashSet() {
-    return doubleOpenHashSet;
-  }
-
-  public ShortOpenHashSet getShortOpenHashSet() {
-    return shortOpenHashSet;
-  }
-
-  public Set<Object> getBigDecimalHashSet() {
-    return bigDecimalHashSet;
-  }
-
-  public LongOpenHashSet getLongOpenHashSet() {
-    return longOpenHashSet;
-  }
-
-  public BooleanOpenHashSet getBooleanOpenHashSet() {
-    return booleanOpenHashSet;
-  }
-
-  public FloatOpenHashSet getFloatOpenHashSet() {
-    return floatOpenHashSet;
+  public AbstractCollection getFilterSet() {
+    return filterSet;
   }
 }

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/filterexpr/TestInFilter.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/filterexpr/TestInFilter.scala
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.spark.testsuite.filterexpr
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.test.util.QueryTest
+import org.scalatest.BeforeAndAfterAll
+
+class TestInFilter extends QueryTest with BeforeAndAfterAll{
+
+  override def beforeAll: Unit = {
+    sql("drop table if exists test_table")
+    sql("create table test_table(intField INT, floatField FLOAT, doubleField DOUBLE, " +
+        "decimalField DECIMAL(18,2))  stored by 'carbondata'")
+
+    // turn on carbon row level filter by setting spark.sql.codegen.wholeStage=false
+    // because only row level is on, 'in' will be pushdowned into CarbonScanRDD
+    //  or in filter will be handled by spark.
+    sql("set spark.sql.codegen.wholeStage=false")
+    sql("insert into test_table values(8,8,8,8),(5,5.0,5.0,5.0),(4,1.00,2.00,3.00)," +
+        "(6,6.0000,6.0000,6.0000),(4743,4743.00,4743.0000,4743.0),(null,null,null,null)")
+  }
+
+  test("sql with in different measurement type") {
+    // the precision of filter value is less one digit than column value
+    // float type test
+    checkAnswer(
+      sql("select * from test_table where floatField in(1.0)"),
+      Seq(Row(4, 1.00, 2.00, 3.00)))
+    checkAnswer(
+      sql("select * from test_table where floatField in(4743.0)"),
+      Seq(Row(4743, 4743.00, 4743.0000, 4743.0)))
+    checkAnswer(
+      sql("select * from test_table where floatField in(5)"),
+      Seq(Row(5, 5.0, 5.0, 5.0)))
+    checkAnswer(
+      sql("select * from test_table where floatField in(6.000)"),
+      Seq(Row(6, 6.0000, 6.0000, 6.0000)))
+
+    // double type test
+    checkAnswer(
+      sql("select * from test_table where doubleField in(2.0)"),
+      Seq(Row(4, 1.00, 2.00, 3.00)))
+    checkAnswer(
+      sql("select * from test_table where doubleField in(4743.000)"),
+      Seq(Row(4743, 4743.00, 4743.0000, 4743.0)))
+    checkAnswer(
+      sql("select * from test_table where doubleField in(5)"),
+      Seq(Row(5, 5.0, 5.0, 5.0)))
+    checkAnswer(
+      sql("select * from test_table where doubleField in(6.000)"),
+      Seq(Row(6, 6.0000, 6.0000, 6.0000)))
+
+    // decimalField type test
+    checkAnswer(
+      sql("select * from test_table where decimalField in(3.0)"),
+      Seq(Row(4, 1.00, 2.00, 3.00)))
+    checkAnswer(
+      sql("select * from test_table where decimalField in(4743)"),
+      Seq(Row(4743, 4743.00, 4743.0000, 4743.0)))
+    checkAnswer(
+      sql("select * from test_table where decimalField in(5)"),
+      Seq(Row(5, 5.0, 5.0, 5.0)))
+    checkAnswer(
+      sql("select * from test_table where decimalField in(6.000)"),
+      Seq(Row(6, 6.0000, 6.0000, 6.0000)))
+
+    // the precision of filter value is more one digit than column value
+    // int type test
+    checkAnswer(
+      sql("select * from test_table where intField in(4.0)"),
+      Seq(Row(4, 1.00, 2.00, 3.00)))
+    checkAnswer(
+      sql("select * from test_table where intField in(4743.0)"),
+      Seq(Row(4743, 4743.00, 4743.0000, 4743.0)))
+    checkAnswer(
+      sql("select * from test_table where intField in(5.0)"),
+      Seq(Row(5, 5.0, 5.0, 5.0)))
+    checkAnswer(
+      sql("select * from test_table where intField in(6.0)"),
+      Seq(Row(6, 6.0000, 6.0000, 6.0000)))
+
+    // float type test
+    checkAnswer(
+      sql("select * from test_table where floatField in(1.000)"),
+      Seq(Row(4, 1.00, 2.00, 3.00)))
+    checkAnswer(
+      sql("select * from test_table where floatField in(4743.000)"),
+      Seq(Row(4743, 4743.00, 4743.0000, 4743.0)))
+    checkAnswer(
+      sql("select * from test_table where floatField in(5.00)"),
+      Seq(Row(5, 5.0, 5.0, 5.0)))
+    checkAnswer(
+      sql("select * from test_table where floatField in(6.00000)"),
+      Seq(Row(6, 6.0000, 6.0000, 6.0000)))
+
+    // double type test
+    checkAnswer(
+      sql("select * from test_table where doubleField in(2.000)"),
+      Seq(Row(4, 1.00, 2.00, 3.00)))
+    checkAnswer(
+      sql("select * from test_table where doubleField in(4743.00000)"),
+      Seq(Row(4743, 4743.00, 4743.0000, 4743.0)))
+    checkAnswer(
+      sql("select * from test_table where doubleField in(5.00)"),
+      Seq(Row(5, 5.0, 5.0, 5.0)))
+    checkAnswer(
+      sql("select * from test_table where doubleField in(6.00000)"),
+      Seq(Row(6, 6.0000, 6.0000, 6.0000)))
+
+    // decimalField type test
+    checkAnswer(
+      sql("select * from test_table where decimalField in(3.000)"),
+      Seq(Row(4, 1.00, 2.00, 3.00)))
+    checkAnswer(
+      sql("select * from test_table where decimalField in(4743.00)"),
+      Seq(Row(4743, 4743.00, 4743.0000, 4743.0)))
+    checkAnswer(
+      sql("select * from test_table where decimalField in(5.00)"),
+      Seq(Row(5, 5.0, 5.0, 5.0)))
+    checkAnswer(
+      sql("select * from test_table where decimalField in(6.00000)"),
+      Seq(Row(6, 6.0000, 6.0000, 6.0000)))
+
+    // case: filter value is null
+    checkAnswer(
+      sql("select * from test_table where decimalField is null"),
+      Seq(Row(null, null, null, null)))
+
+    // filter value and column 's precision are the same
+    checkAnswer(
+      sql("select * from test_table where doubleField in(5.0) " +
+          "and floatField in(5.0) and decimalField in(5.0) and intField in(5)"),
+      Seq(Row(5, 5.0, 5.0, 5.0)))
+    checkAnswer(
+      sql("select * from test_table where doubleField in(6.0000) " +
+          "and floatField in(6.0000) and decimalField in(6.0000) and intField in(6.0000)"),
+      Seq(Row(6, 6.0000, 6.0000, 6.0000)))
+    checkAnswer(
+      sql("select * from test_table where doubleField in(8) " +
+          "and floatField in(8) and decimalField in(8) and intField in(8)"),
+      Seq(Row(8, 8, 8, 8)))
+    checkAnswer(
+      sql("select * from test_table where doubleField in(4743.0000) " +
+          "and floatField in(4743.00) and decimalField in(4743.0) and intField in(4743)"),
+      Seq(Row(4743, 4743.00, 4743.0000, 4743.0)))
+    checkAnswer(
+      sql("select * from test_table where doubleField in(2.00) " +
+          "and floatField in(1.00) and decimalField in(3.00) and intField in(4)"),
+      Seq(Row(4, 1.00, 2.00, 3.00)))
+  }
+
+  override def afterAll(): Unit = {
+    sql("drop table if exists test_table")
+    sql("set spark.sql.codegen.wholeStage=true")
+  }
+
+}

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/filterexpr/TestInFilter.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/filterexpr/TestInFilter.scala
@@ -28,7 +28,7 @@ class TestInFilter extends QueryTest with BeforeAndAfterAll{
     sql("create table test_table(intField INT, floatField FLOAT, doubleField DOUBLE, " +
         "decimalField DECIMAL(18,2))  stored by 'carbondata'")
 
-    // turn on carbon row level filter by setting spark.sql.codegen.wholeStage=false
+    // turn on carbon row level filter by setting carbon.push.rowfilters.for.vector=false
     // because only row level is on, 'in' will be pushdowned into CarbonScanRDD
     //  or in filter will be handled by spark.
     sql("set carbon.push.rowfilters.for.vector=true")

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/filterexpr/TestInFilter.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/filterexpr/TestInFilter.scala
@@ -31,7 +31,7 @@ class TestInFilter extends QueryTest with BeforeAndAfterAll{
     // turn on carbon row level filter by setting spark.sql.codegen.wholeStage=false
     // because only row level is on, 'in' will be pushdowned into CarbonScanRDD
     //  or in filter will be handled by spark.
-    sql("set spark.sql.codegen.wholeStage=false")
+    sql("set carbon.push.rowfilters.for.vector=true")
     sql("insert into test_table values(8,8,8,8),(5,5.0,5.0,5.0),(4,1.00,2.00,3.00)," +
         "(6,6.0000,6.0000,6.0000),(4743,4743.00,4743.0000,4743.0),(null,null,null,null)")
   }
@@ -167,7 +167,7 @@ class TestInFilter extends QueryTest with BeforeAndAfterAll{
 
   override def afterAll(): Unit = {
     sql("drop table if exists test_table")
-    sql("set spark.sql.codegen.wholeStage=true")
+    sql("set carbon.push.rowfilters.for.vector=false")
   }
 
 }

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/filterexpr/TestInFilter.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/filterexpr/TestInFilter.scala
@@ -28,7 +28,7 @@ class TestInFilter extends QueryTest with BeforeAndAfterAll{
     sql("create table test_table(intField INT, floatField FLOAT, doubleField DOUBLE, " +
         "decimalField DECIMAL(18,2))  stored by 'carbondata'")
 
-    // turn on carbon row level filter by setting carbon.push.rowfilters.for.vector=false
+    // turn on  row level filter in carbon
     // because only row level is on, 'in' will be pushdowned into CarbonScanRDD
     //  or in filter will be handled by spark.
     sql("set carbon.push.rowfilters.for.vector=true")


### PR DESCRIPTION
This solves the problem as #3209

when sql with 'in numbers' and spark.sql.codegen.wholeStage is false，the query is slow,

the reason is that canbonscan row level filter's time complexity is O(n^2), we can replace list with hashset to improve query performance

sql example: select * from xx where filed in (1,2,3,4,5,6)
Be sure to do all of the following checklist to help us incorporate

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

