### PR TITLE
[CARBONDATA-3445] Aggregate query empty list error fix.

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonCatalystOperators.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonCatalystOperators.scala
@@ -179,6 +179,9 @@ object CountStarPlan {
     if (groupingExpressions.nonEmpty) {
       return false
     }
+    if (partialComputation.isEmpty) {
+      return false
+    }
     if (partialComputation.size > 1 && partialComputation.nonEmpty) {
       return false
     }


### PR DESCRIPTION
Problem: In Aggregate query, CountStarPlan throws head of empty list error.
When right node of join node has Aggregate node with the empty aggregate and group expression then it matches with the count(*) plan and we try to get the Head of the aggregate expression assuming only one aggregate expression is present. This happens only in Spark 2.3 so added an empty list check that if aggregate expression is empty, it will not treat as count(*) plan.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

