### PR TITLE
[CARBONDATA-3398]Block show/drop metacache directly on child table

### DIFF
--- a/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/TestAllOperationsOnMV.scala
+++ b/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/TestAllOperationsOnMV.scala
@@ -520,5 +520,20 @@ class TestAllOperationsOnMV extends QueryTest with BeforeAndAfterEach {
     sql("drop table IF EXISTS maintable")
   }
 
+  test("test drop/show meta cache directly on mv datamap table") {
+    sql("drop table IF EXISTS maintable")
+    sql("create table maintable(name string, c_code int, price int) stored by 'carbondata'")
+    sql("insert into table maintable select 'abc',21,2000")
+    sql("drop datamap if exists dm ")
+    sql("create datamap dm using 'mv' as select name, sum(price) from maintable group by name")
+    sql("select name, sum(price) from maintable group by name").collect()
+    intercept[UnsupportedOperationException] {
+      sql("show metacache on table dm_table").show(false)
+    }.getMessage.contains("Operation not allowed on child table.")
+    intercept[UnsupportedOperationException] {
+      sql("drop metacache on table dm_table").show(false)
+    }.getMessage.contains("Operation not allowed on child table.")
+  }
+
 }
 

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/cache/DropCacheEventListeners.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/cache/DropCacheEventListeners.scala
@@ -49,7 +49,7 @@ object DropCachePreAggEventListener extends OperationEventListener {
         val carbonTable = dropCacheEvent.carbonTable
         val sparkSession = dropCacheEvent.sparkSession
         val internalCall = dropCacheEvent.internalCall
-        if (carbonTable.isChildDataMap && !internalCall) {
+        if ((carbonTable.isChildDataMap || carbonTable.isChildTable) && !internalCall) {
           throw new UnsupportedOperationException("Operation not allowed on child table.")
         }
 

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/cache/ShowCacheEventListeners.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/cache/ShowCacheEventListeners.scala
@@ -52,7 +52,7 @@ object ShowCachePreAggEventListener extends OperationEventListener {
         val carbonTable = showTableCacheEvent.carbonTable
         val sparkSession = showTableCacheEvent.sparkSession
         val internalCall = showTableCacheEvent.internalCall
-        if (carbonTable.isChildDataMap && !internalCall) {
+        if ((carbonTable.isChildDataMap || carbonTable.isChildTable) && !internalCall) {
           throw new UnsupportedOperationException("Operation not allowed on child table.")
         }
 


### PR DESCRIPTION
Problem:
show/drop metacache directly on mv child table is not blocked
Solution:
Blocked show/drop metacache directly on mv child table

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [x] Testing done
     Added
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

