### PR TITLE
[CARBONDATA-3453] Fix set segment issue in adaptive execution

### DIFF
--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
@@ -670,8 +670,9 @@ class CarbonScanRDD[T: ClassTag](
       CarbonInputFormat
         .setQuerySegment(conf,
           carbonSessionInfo.getThreadParams
-            .getProperty(inputSegmentsKey,
-              CarbonProperties.getInstance().getProperty(inputSegmentsKey, "*")))
+            .getProperty(inputSegmentsKey, carbonSessionInfo.getSessionParams
+              .getProperty(inputSegmentsKey,
+              CarbonProperties.getInstance().getProperty(inputSegmentsKey, "*"))))
       if (queryOnPreAggStreaming) {
         CarbonInputFormat.setAccessStreamingSegments(conf, queryOnPreAggStreaming)
         // union for streaming preaggregate can happen concurrently from spark.

--- a/integration/spark2/src/test/scala/org/apache/carbondata/spark/testsuite/segmentreading/TestSegmentReading.scala
+++ b/integration/spark2/src/test/scala/org/apache/carbondata/spark/testsuite/segmentreading/TestSegmentReading.scala
@@ -40,6 +40,8 @@ class TestSegmentReading extends QueryTest with BeforeAndAfterAll {
 
   override def afterAll(): Unit = {
     cleanAllTable()
+    // reset
+    sql("SET carbon.input.segments.default.carbon_table=*")
   }
 
   test("test SET -V for segment reading property") {

--- a/integration/spark2/src/test/scala/org/apache/carbondata/spark/testsuite/segmentreading/TestSegmentReading.scala
+++ b/integration/spark2/src/test/scala/org/apache/carbondata/spark/testsuite/segmentreading/TestSegmentReading.scala
@@ -366,4 +366,19 @@ class TestSegmentReading extends QueryTest with BeforeAndAfterAll {
         "SET carbon.input.segments.default.carbon_table=*")
     }
   }
+  test("test with the adaptive execution") {
+    sql("set spark.sql.adaptive.enabled=true")
+
+    sql("SET carbon.input.segments.default.carbon_table=1")
+    checkAnswer(sql("select count(*) from carbon_table"), Seq(Row(10)))
+
+    // segment doesn't exist
+    sql("SET carbon.input.segments.default.carbon_table=5")
+    checkAnswer(sql("select count(*) from carbon_table"), Seq(Row(0)))
+
+    sql("SET carbon.input.segments.default.carbon_table=1")
+    checkAnswer(sql("select count(*) from carbon_table"), Seq(Row(10)))
+
+    sql("set spark.sql.adaptive.enabled=false")
+  }
 }


### PR DESCRIPTION
problem: Set segment doesn't work with adaptive execution.

cause: For set segments, driver will check carbon property and carbon property will look for segments in session params, which is not set in current thread incase of adaptive execution.

solution: Use the session params from RDD's session info, where it will be set correctly.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed? NA
 
 - [ ] Any backward compatibility impacted? NA
 
 - [ ] Document update required? NA

 - [ ] Testing done
done. Updated UT.

 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.  NA

