### PR TITLE
[CARBONDATA-3454] optimized index server output for count(*)

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datamap/DataMapJob.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/DataMapJob.java
@@ -35,4 +35,6 @@ public interface DataMapJob extends Serializable {
 
   List<ExtendedBlocklet> execute(DistributableDataMapFormat dataMapFormat);
 
+  Long executeCountJob(DistributableDataMapFormat dataMapFormat);
+
 }

--- a/core/src/main/java/org/apache/carbondata/core/datamap/DistributableDataMapFormat.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/DistributableDataMapFormat.java
@@ -28,7 +28,6 @@ import java.util.UUID;
 
 import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
-import org.apache.carbondata.core.datamap.dev.DataMap;
 import org.apache.carbondata.core.datamap.dev.expr.DataMapDistributableWrapper;
 import org.apache.carbondata.core.datastore.impl.FileFactory;
 import org.apache.carbondata.core.indexstore.ExtendedBlocklet;
@@ -91,6 +90,8 @@ public class DistributableDataMapFormat extends FileInputFormat<Void, ExtendedBl
 
   private boolean isWriteToFile = true;
 
+  private boolean isCountStarJob = false;
+
   DistributableDataMapFormat() {
 
   }
@@ -103,7 +104,7 @@ public class DistributableDataMapFormat extends FileInputFormat<Void, ExtendedBl
     this.dataMapToClear = dataMapToClear;
   }
 
-  DistributableDataMapFormat(CarbonTable table, FilterResolverIntf filterResolverIntf,
+  public DistributableDataMapFormat(CarbonTable table, FilterResolverIntf filterResolverIntf,
       List<Segment> validSegments, List<String> invalidSegments, List<PartitionSpec> partitions,
       boolean isJobToClearDataMaps, DataMapLevel dataMapLevel, boolean isFallbackJob)
       throws IOException {
@@ -136,7 +137,6 @@ public class DistributableDataMapFormat extends FileInputFormat<Void, ExtendedBl
     return new RecordReader<Void, ExtendedBlocklet>() {
       private Iterator<ExtendedBlocklet> blockletIterator;
       private ExtendedBlocklet currBlocklet;
-      private List<DataMap> dataMaps;
 
       @Override
       public void initialize(InputSplit inputSplit, TaskAttemptContext taskAttemptContext)
@@ -149,7 +149,6 @@ public class DistributableDataMapFormat extends FileInputFormat<Void, ExtendedBl
         if (dataMapLevel == null) {
           TableDataMap defaultDataMap = DataMapStoreManager.getInstance()
               .getDataMap(table, distributable.getDistributable().getDataMapSchema());
-          dataMaps = defaultDataMap.getTableDataMaps(distributable.getDistributable());
           blocklets = defaultDataMap
               .prune(segmentsToLoad, new DataMapFilter(filterResolverIntf), partitions);
           blocklets = DataMapUtil
@@ -192,11 +191,6 @@ public class DistributableDataMapFormat extends FileInputFormat<Void, ExtendedBl
 
       @Override
       public void close() throws IOException {
-        if (null != dataMaps) {
-          for (DataMap dataMap : dataMaps) {
-            dataMap.finish();
-          }
-        }
       }
     };
   }
@@ -247,6 +241,7 @@ public class DistributableDataMapFormat extends FileInputFormat<Void, ExtendedBl
     out.writeUTF(taskGroupDesc);
     out.writeUTF(queryId);
     out.writeBoolean(isWriteToFile);
+    out.writeBoolean(isCountStarJob);
   }
 
   @Override
@@ -292,6 +287,7 @@ public class DistributableDataMapFormat extends FileInputFormat<Void, ExtendedBl
     this.taskGroupDesc = in.readUTF();
     this.queryId = in.readUTF();
     this.isWriteToFile = in.readBoolean();
+    this.isCountStarJob = in.readBoolean();
   }
 
   private void initReadCommittedScope() throws IOException {
@@ -398,9 +394,29 @@ public class DistributableDataMapFormat extends FileInputFormat<Void, ExtendedBl
     return validSegments;
   }
 
+  public List<Segment> getValidSegments() {
+    return validSegments;
+  }
+
   public void createDataMapChooser() throws IOException {
     if (null != filterResolverIntf) {
       this.dataMapChooser = new DataMapChooser(table);
     }
+  }
+
+  public void setCountStarJob() {
+    this.isCountStarJob = true;
+  }
+
+  public boolean isCountStarJob() {
+    return this.isCountStarJob;
+  }
+
+  public List<PartitionSpec> getPartitions() {
+    return partitions;
+  }
+
+  public ReadCommittedScope getReadCommittedScope() {
+    return readCommittedScope;
   }
 }

--- a/integration/spark2/src/main/scala/org/apache/carbondata/indexserver/DistributedCountRDD.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/indexserver/DistributedCountRDD.scala
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.indexserver
+
+import java.util.concurrent.Executors
+
+import scala.collection.JavaConverters._
+import scala.concurrent.{Await, ExecutionContext, ExecutionContextExecutor, Future}
+import scala.concurrent.duration.Duration
+
+import org.apache.hadoop.mapred.TaskAttemptID
+import org.apache.hadoop.mapreduce.{InputSplit, TaskType}
+import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl
+import org.apache.spark.{Partition, SparkEnv, TaskContext}
+import org.apache.spark.sql.SparkSession
+
+import org.apache.carbondata.common.logging.LogServiceFactory
+import org.apache.carbondata.core.cache.CacheProvider
+import org.apache.carbondata.core.datamap.{DataMapStoreManager, DistributableDataMapFormat}
+import org.apache.carbondata.core.datamap.dev.expr.DataMapDistributableWrapper
+import org.apache.carbondata.core.datastore.impl.FileFactory
+import org.apache.carbondata.core.util.{CarbonProperties, CarbonThreadFactory}
+import org.apache.carbondata.spark.rdd.CarbonRDD
+
+/**
+ * An RDD which will get the count for the table.
+ */
+class DistributedCountRDD(@transient ss: SparkSession, dataMapFormat: DistributableDataMapFormat)
+  extends CarbonRDD[(String, String)](ss, Nil) {
+
+  @transient private val LOGGER = LogServiceFactory.getLogService(classOf[DistributedPruneRDD]
+    .getName)
+
+  override protected def getPreferredLocations(split: Partition): Seq[String] = {
+    if (split.asInstanceOf[DataMapRDDPartition].getLocations != null) {
+      split.asInstanceOf[DataMapRDDPartition].getLocations.toSeq
+    } else {
+      Seq()
+    }
+  }
+
+  override def internalCompute(split: Partition,
+      context: TaskContext): Iterator[(String, String)] = {
+    val attemptId = new TaskAttemptID(DistributedRDDUtils.generateTrackerId,
+      id, TaskType.MAP, split.index, 0)
+    val attemptContext = new TaskAttemptContextImpl(FileFactory.getConfiguration, attemptId)
+    val inputSplits = split.asInstanceOf[DataMapRDDPartition].inputSplit
+    val numOfThreads = CarbonProperties.getInstance().getNumOfThreadsForExecutorPruning
+    val service = Executors
+      .newFixedThreadPool(numOfThreads, new CarbonThreadFactory("IndexPruningPool", true))
+    implicit val ec: ExecutionContextExecutor = ExecutionContext
+      .fromExecutor(service)
+    val futures = if (inputSplits.length <= numOfThreads) {
+      inputSplits.map {
+        split => generateFuture(Seq(split))
+      }
+    } else {
+      DistributedRDDUtils.groupSplits(inputSplits, numOfThreads).map {
+        splits => generateFuture(splits)
+      }
+    }
+    // scalastyle:off awaitresult
+    val results = Await.result(Future.sequence(futures), Duration.Inf).flatten
+    // scalastyle:on awaitresult
+    val executorIP = s"${ SparkEnv.get.blockManager.blockManagerId.host }_${
+      SparkEnv.get.blockManager.blockManagerId.executorId
+    }"
+    val cacheSize = if (CacheProvider.getInstance().getCarbonCache != null) {
+      CacheProvider.getInstance().getCarbonCache.getCurrentSize
+    } else {
+      0L
+    }
+    Iterator((executorIP + "_" + cacheSize.toString, results.map(_._2.toLong).sum.toString))
+  }
+
+  override protected def internalGetPartitions: Array[Partition] = {
+    new DistributedPruneRDD(ss, dataMapFormat).partitions
+  }
+
+  private def generateFuture(split: Seq[InputSplit])
+    (implicit executionContext: ExecutionContext) = {
+    Future {
+      val segments = split.map { inputSplit =>
+        val distributable = inputSplit.asInstanceOf[DataMapDistributableWrapper]
+        distributable.getDistributable.getSegment
+          .setReadCommittedScope(dataMapFormat.getReadCommittedScope)
+        distributable.getDistributable.getSegment
+      }
+      val defaultDataMap = DataMapStoreManager.getInstance
+        .getDataMap(dataMapFormat.getCarbonTable, split.head
+          .asInstanceOf[DataMapDistributableWrapper].getDistributable.getDataMapSchema)
+      defaultDataMap.getBlockRowCount(segments.toList.asJava, dataMapFormat
+        .getPartitions, defaultDataMap).asScala
+    }
+  }
+
+}

--- a/integration/spark2/src/main/scala/org/apache/carbondata/indexserver/DistributedPruneRDD.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/indexserver/DistributedPruneRDD.scala
@@ -17,15 +17,12 @@
 
 package org.apache.carbondata.indexserver
 
-import java.text.SimpleDateFormat
-import java.util.Date
 import java.util.concurrent.Executors
 
 import scala.collection.JavaConverters._
 import scala.concurrent.{Await, ExecutionContext, ExecutionContextExecutor, Future}
 import scala.concurrent.duration.Duration
 
-import org.apache.commons.lang.StringUtils
 import org.apache.hadoop.mapred.{RecordReader, TaskAttemptID}
 import org.apache.hadoop.mapreduce.{InputSplit, Job, TaskType}
 import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl
@@ -35,9 +32,8 @@ import org.apache.spark.sql.hive.DistributionUtil
 
 import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.core.cache.CacheProvider
-import org.apache.carbondata.core.datamap.{DataMapDistributable, DataMapStoreManager, DistributableDataMapFormat, TableDataMap}
+import org.apache.carbondata.core.datamap.{DataMapStoreManager, DistributableDataMapFormat}
 import org.apache.carbondata.core.datamap.dev.expr.DataMapDistributableWrapper
-import org.apache.carbondata.core.datastore.block.SegmentPropertiesAndSchemaHolder
 import org.apache.carbondata.core.datastore.impl.FileFactory
 import org.apache.carbondata.core.indexstore.{ExtendedBlocklet, ExtendedBlockletWrapper}
 import org.apache.carbondata.core.util.{CarbonProperties, CarbonThreadFactory}
@@ -65,21 +61,13 @@ private[indexserver] class DistributedPruneRDD(@transient private val ss: SparkS
 
   @transient private val LOGGER = LogServiceFactory.getLogService(classOf[DistributedPruneRDD]
     .getName)
-  private val jobTrackerId: String = {
-    val formatter = new SimpleDateFormat("yyyyMMddHHmm")
-    formatter.format(new Date())
-  }
-  var readers: scala.collection.Iterator[RecordReader[Void, ExtendedBlocklet]] = _
 
-  private def groupSplits(xs: Seq[InputSplit], n: Int) = {
-    val (quot, rem) = (xs.size / n, xs.size % n)
-    val (smaller, bigger) = xs.splitAt(xs.size - rem * (quot + 1))
-    (smaller.grouped(quot) ++ bigger.grouped(quot + 1)).toList
-  }
+  var readers: scala.collection.Iterator[RecordReader[Void, ExtendedBlocklet]] = _
 
   override def internalCompute(split: Partition,
       context: TaskContext): Iterator[(String, ExtendedBlockletWrapper)] = {
-    val attemptId = new TaskAttemptID(jobTrackerId, id, TaskType.MAP, split.index, 0)
+    val attemptId = new TaskAttemptID(DistributedRDDUtils.generateTrackerId,
+      id, TaskType.MAP, split.index, 0)
     val attemptContext = new TaskAttemptContextImpl(FileFactory.getConfiguration, attemptId)
     val inputSplits = split.asInstanceOf[DataMapRDDPartition].inputSplit
     if (dataMapFormat.isJobToClearDataMaps) {
@@ -118,7 +106,7 @@ private[indexserver] class DistributedPruneRDD(@transient private val ss: SparkS
           split => generateFuture(Seq(split), attemptContext)
         }
       } else {
-        groupSplits(inputSplits, numOfThreads).map {
+        DistributedRDDUtils.groupSplits(inputSplits, numOfThreads).map {
           splits => generateFuture(splits, attemptContext)
         }
       }
@@ -139,14 +127,13 @@ private[indexserver] class DistributedPruneRDD(@transient private val ss: SparkS
       }"
       val value = (executorIP + "_" + cacheSize.toString, new ExtendedBlockletWrapper(f.toList
         .asJava, dataMapFormat.getCarbonTable.getTablePath, dataMapFormat.getQueryId,
-        dataMapFormat.isWriteToFile))
+        dataMapFormat.isWriteToFile, dataMapFormat.isCountStarJob))
       Iterator(value)
     }
   }
 
-  private def generateFuture(split: Seq[InputSplit],
-      attemptContextImpl: TaskAttemptContextImpl)
-    (implicit executionContext: ExecutionContext) = {
+  private def generateFuture(split: Seq[InputSplit], attemptContextImpl: TaskAttemptContextImpl)
+    (implicit executionContext: ExecutionContext): Future[Seq[ExtendedBlocklet]] = {
     Future {
       split.flatMap { inputSplit =>
         val blocklets = new java.util.ArrayList[ExtendedBlocklet]()

--- a/integration/spark2/src/main/scala/org/apache/carbondata/indexserver/DistributedRDDUtils.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/indexserver/DistributedRDDUtils.scala
@@ -16,6 +16,8 @@
  */
 package org.apache.carbondata.indexserver
 
+import java.text.SimpleDateFormat
+import java.util.Date
 import java.util.concurrent.ConcurrentHashMap
 
 import scala.collection.JavaConverters._
@@ -323,6 +325,17 @@ object DistributedRDDUtils {
       }
       s"executor_${newHost}_$newExecutor"
     }
+  }
+
+  def groupSplits(xs: Seq[InputSplit], n: Int): List[Seq[InputSplit]] = {
+    val (quot, rem) = (xs.size / n, xs.size % n)
+    val (smaller, bigger) = xs.splitAt(xs.size - rem * (quot + 1))
+    (smaller.grouped(quot) ++ bigger.grouped(quot + 1)).toList
+  }
+
+  def generateTrackerId: String = {
+    val formatter = new SimpleDateFormat("yyyyMMddHHmm")
+    formatter.format(new Date())
   }
 
 }

--- a/integration/spark2/src/main/scala/org/apache/carbondata/indexserver/IndexServer.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/indexserver/IndexServer.scala
@@ -23,6 +23,7 @@ import java.util.UUID
 import scala.collection.JavaConverters._
 
 import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.io.LongWritable
 import org.apache.hadoop.ipc.{ProtocolInfo, RPC}
 import org.apache.hadoop.net.NetUtils
 import org.apache.hadoop.security.{KerberosInfo, SecurityUtil, UserGroupInformation}
@@ -58,6 +59,9 @@ trait ServerInterface {
    */
   def invalidateSegmentCache(carbonTable: CarbonTable,
       segmentIds: Array[String], jobGroupId: String = ""): Unit
+
+  def getCount(request: DistributableDataMapFormat): LongWritable
+
 }
 
 /**
@@ -97,6 +101,21 @@ object IndexServer extends ServerInterface {
         f
       }
     })
+  }
+
+  def getCount(request: DistributableDataMapFormat): LongWritable = {
+    doAs {
+      if (!request.isFallbackJob) {
+        sparkSession.sparkContext.setLocalProperty("spark.jobGroup.id", request.getTaskGroupId)
+        sparkSession.sparkContext
+          .setLocalProperty("spark.job.description", request.getTaskGroupDesc)
+      }
+      val splits = new DistributedCountRDD(sparkSession, request).collect()
+      if (!request.isFallbackJob) {
+        DistributedRDDUtils.updateExecutorCacheSize(splits.map(_._1).toSet)
+      }
+      new LongWritable(splits.map(_._2.toLong).sum)
+    }
   }
 
   def getSplits(request: DistributableDataMapFormat): ExtendedBlockletWrapperContainer = {


### PR DESCRIPTION
Optimised the output for count(*) queries so that only a long is send back to the driver to reduce the network transfer cost for index server

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

