### PR TITLE
[CARBONDATA-3459] Fixed id based distribution for showcache command

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/carbondata/indexserver/DistributedRDDUtils.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/indexserver/DistributedRDDUtils.scala
@@ -316,10 +316,10 @@ object DistributedRDDUtils {
       if (existingSegmentMapping == null) {
         val newSegmentMapping = new ConcurrentHashMap[String, String]()
         newSegmentMapping.put(segment.getSegmentNo, s"${newHost}_$newExecutor")
-        tableToExecutorMapping.put(tableUniqueName, newSegmentMapping)
+        tableToExecutorMapping.putIfAbsent(tableUniqueName, newSegmentMapping)
       } else {
-        existingSegmentMapping.put(segment.getSegmentNo, s"${newHost}_$newExecutor")
-        tableToExecutorMapping.put(tableUniqueName, existingSegmentMapping)
+        existingSegmentMapping.putIfAbsent(segment.getSegmentNo, s"${newHost}_$newExecutor")
+        tableToExecutorMapping.putIfAbsent(tableUniqueName, existingSegmentMapping)
       }
       s"executor_${newHost}_$newExecutor"
     }

--- a/integration/spark2/src/main/scala/org/apache/carbondata/indexserver/DistributedShowCacheRDD.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/indexserver/DistributedShowCacheRDD.scala
@@ -37,6 +37,14 @@ class DistributedShowCacheRDD(@transient private val ss: SparkSession, tableName
       }
   }.toArray
 
+  override protected def getPreferredLocations(split: Partition): Seq[String] = {
+    if (split.asInstanceOf[DataMapRDDPartition].getLocations != null) {
+      split.asInstanceOf[DataMapRDDPartition].getLocations.toSeq
+    } else {
+      Seq()
+    }
+  }
+
   override protected def internalGetPartitions: Array[Partition] = {
     executorsList.zipWithIndex.map {
       case (executor, idx) =>


### PR DESCRIPTION
Problem: Currently tasks are not being fired based on the executor ID because getPrefferedLocation was not overridden.

Solution: override getPreferredLocations in the ShowCache and InvalidateCacheRDD to fire tasks at the appropriate location

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

