### PR TITLE
[CARBONDATA-3461] Carbon SDK support filter equal values set.

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/FilterUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/FilterUtil.java
@@ -49,13 +49,11 @@ import org.apache.carbondata.core.metadata.schema.table.column.CarbonMeasure;
 import org.apache.carbondata.core.scan.expression.ColumnExpression;
 import org.apache.carbondata.core.scan.expression.Expression;
 import org.apache.carbondata.core.scan.expression.LiteralExpression;
-import org.apache.carbondata.core.scan.expression.conditional.ConditionalExpression;
-import org.apache.carbondata.core.scan.expression.conditional.ImplicitExpression;
-import org.apache.carbondata.core.scan.expression.conditional.InExpression;
-import org.apache.carbondata.core.scan.expression.conditional.ListExpression;
+import org.apache.carbondata.core.scan.expression.conditional.*;
 import org.apache.carbondata.core.scan.expression.exception.FilterIllegalMemberException;
 import org.apache.carbondata.core.scan.expression.exception.FilterUnsupportedException;
 import org.apache.carbondata.core.scan.expression.logical.AndExpression;
+import org.apache.carbondata.core.scan.expression.logical.OrExpression;
 import org.apache.carbondata.core.scan.expression.logical.TrueExpression;
 import org.apache.carbondata.core.scan.filter.executer.AndFilterExecuterImpl;
 import org.apache.carbondata.core.scan.filter.executer.DimColumnExecuterFilterInfo;
@@ -1289,6 +1287,107 @@ public final class FilterUtil {
         .getDirectDictionaryGenerator(currentBlockDimension.getDataType());
     int key = directDictionaryGenerator.generateDirectSurrogateKey(null);
     return ByteUtil.convertIntToBytes(key);
+  }
+
+  public static Expression prepareEqualToExpression(String columnName, String dataType,
+      Object value) {
+    if (DataTypes.STRING.getName().equalsIgnoreCase(dataType)) {
+      return new EqualToExpression(
+          new ColumnExpression(columnName, DataTypes.STRING),
+          new LiteralExpression(value, DataTypes.STRING));
+    } else if (DataTypes.INT.getName().equalsIgnoreCase(dataType)) {
+      return new EqualToExpression(
+          new ColumnExpression(columnName, DataTypes.INT),
+          new LiteralExpression(value, DataTypes.INT));
+    } else if (DataTypes.DOUBLE.getName().equalsIgnoreCase(dataType)) {
+      return new EqualToExpression(
+          new ColumnExpression(columnName, DataTypes.DOUBLE),
+          new LiteralExpression(value, DataTypes.DOUBLE));
+    } else if (DataTypes.FLOAT.getName().equalsIgnoreCase(dataType)) {
+      return new EqualToExpression(
+          new ColumnExpression(columnName, DataTypes.FLOAT),
+          new LiteralExpression(value, DataTypes.FLOAT));
+    } else if (DataTypes.SHORT.getName().equalsIgnoreCase(dataType)) {
+      return new EqualToExpression(
+          new ColumnExpression(columnName, DataTypes.SHORT),
+          new LiteralExpression(value, DataTypes.SHORT));
+    } else if (DataTypes.BINARY.getName().equalsIgnoreCase(dataType)) {
+      return new EqualToExpression(
+          new ColumnExpression(columnName, DataTypes.BINARY),
+          new LiteralExpression(value, DataTypes.BINARY));
+    } else if (DataTypes.DATE.getName().equalsIgnoreCase(dataType)) {
+      return new EqualToExpression(
+          new ColumnExpression(columnName, DataTypes.DATE),
+          new LiteralExpression(value, DataTypes.DATE));
+    } else if (DataTypes.LONG.getName().equalsIgnoreCase(dataType)) {
+      return new EqualToExpression(
+          new ColumnExpression(columnName, DataTypes.LONG),
+          new LiteralExpression(value, DataTypes.LONG));
+    } else if (DataTypes.TIMESTAMP.getName().equalsIgnoreCase(dataType)) {
+      return new EqualToExpression(
+          new ColumnExpression(columnName, DataTypes.TIMESTAMP),
+          new LiteralExpression(value, DataTypes.TIMESTAMP));
+    } else if (DataTypes.BYTE.getName().equalsIgnoreCase(dataType)) {
+      return new EqualToExpression(
+          new ColumnExpression(columnName, DataTypes.BYTE),
+          new LiteralExpression(value, DataTypes.BYTE));
+    } else {
+      throw new IllegalArgumentException("Unsupported data type: " + dataType);
+    }
+  }
+
+  public static Expression prepareOrExpression(List<Expression> expressions) {
+    if (expressions.size() < 2) {
+      throw new RuntimeException("Please input at least two expressions");
+    }
+    Expression expression = expressions.get(0);
+    for (int i = 1; i < expressions.size(); i++) {
+      expression = new OrExpression(expression, expressions.get(i));
+    }
+    return expression;
+  }
+
+  private static Expression prepareEqualToExpressionSet(String columnName, DataType dataType,
+      List<Object> values) {
+    Expression expression = null;
+    if (0 == values.size()) {
+      expression = prepareEqualToExpression(columnName, dataType.getName(), null);
+    } else {
+      expression = prepareEqualToExpression(columnName, dataType.getName(), values.get(0));
+    }
+    for (int i = 1; i < values.size(); i++) {
+      Expression expression2 = prepareEqualToExpression(columnName,
+          dataType.getName(), values.get(i));
+      expression = new OrExpression(expression, expression2);
+    }
+    return expression;
+  }
+
+  public static Expression prepareEqualToExpressionSet(String columnName, String dataType,
+      List<Object> values) {
+    if (DataTypes.STRING.getName().equalsIgnoreCase(dataType)) {
+      return prepareEqualToExpressionSet(columnName, DataTypes.STRING, values);
+    } else if (DataTypes.INT.getName().equalsIgnoreCase(dataType)) {
+      return prepareEqualToExpressionSet(columnName, DataTypes.INT, values);
+    } else if (DataTypes.DOUBLE.getName().equalsIgnoreCase(dataType)) {
+      return prepareEqualToExpressionSet(columnName, DataTypes.DOUBLE, values);
+    } else if (DataTypes.FLOAT.getName().equalsIgnoreCase(dataType)) {
+      return prepareEqualToExpressionSet(columnName, DataTypes.FLOAT, values);
+    } else if (DataTypes.SHORT.getName().equalsIgnoreCase(dataType)) {
+      return prepareEqualToExpressionSet(columnName, DataTypes.SHORT, values);
+    } else if (DataTypes.BINARY.getName().equalsIgnoreCase(dataType)) {
+      return prepareEqualToExpressionSet(columnName, DataTypes.BINARY, values);
+    } else if (DataTypes.DATE.getName().equalsIgnoreCase(dataType)) {
+      return prepareEqualToExpressionSet(columnName, DataTypes.DATE, values);
+    } else if (DataTypes.LONG.getName().equalsIgnoreCase(dataType)) {
+      return prepareEqualToExpressionSet(columnName, DataTypes.LONG, values);
+    } else if (DataTypes.TIMESTAMP.getName().equalsIgnoreCase(dataType)) {
+      return prepareEqualToExpressionSet(columnName, DataTypes.TIMESTAMP, values);
+    } else if (DataTypes.BYTE.getName().equalsIgnoreCase(dataType)) {
+      return prepareEqualToExpressionSet(columnName, DataTypes.BYTE, values);
+    } else {
+      throw new IllegalArgumentException("Unsupported data type: " + dataType);
+    }
   }
 
 }

--- a/sdk/sdk/src/test/java/org/apache/carbondata/sdk/file/AvroCarbonWriterTest.java
+++ b/sdk/sdk/src/test/java/org/apache/carbondata/sdk/file/AvroCarbonWriterTest.java
@@ -337,6 +337,71 @@ public class AvroCarbonWriterTest {
     }
   }
 
+  private void WriteAvroComplexDataAndRead(String mySchema)
+      throws IOException, InvalidLoadOptionException, InterruptedException {
+
+    // conversion to GenericData.Record
+    Schema nn = new Schema.Parser().parse(mySchema);
+    try {
+      CarbonWriter writer =
+          CarbonWriter.builder()
+              .outputPath(path)
+              .withAvroInput(mySchema)
+              .writtenBy("AvroCarbonWriterTest")
+              .build();
+      int numOfRows = 100000/100;
+      int numOfWrite = 20000;
+      int arrayLength = 300;
+      for (int i = 0; i < numOfRows; i++) {
+        StringBuffer aa1 = new StringBuffer();
+        StringBuffer bb1 = new StringBuffer();
+        StringBuffer cc1 = new StringBuffer();
+        aa1.append("[0.1234567,0.2,-0.3,0.4]");
+        bb1.append("[0.2123456]");
+        cc1.append("[0.3123456]");
+        for (int j = 1; j < arrayLength; j++) {
+          aa1.append(",[1" + i + "" + j + ".1234567,1" + i + "" + j + ".2,-1" + i + "" + j + ".3,1" + i + "" + j + ".4]");
+          bb1.append(",[2" + i + "" + j + ".2123456,-2" + i + "" + j + ".2]");
+          cc1.append(",[3" + i + "" + j + ".3123456]");
+        }
+        String json = "{\"fileName\":\"bob\", \"id\":10, "
+            + "   \"aa1\" : [" + aa1 + "], "
+            + "\"bb1\" : [" + bb1 + "], " +
+            "\"cc1\" : [" + cc1 + "]}";
+
+        writer.write(json);
+        if (i > 0 && i % numOfWrite == 0) {
+          writer.close();
+          writer =
+              CarbonWriter.builder()
+                  .outputPath(path)
+                  .withAvroInput(mySchema)
+                  .writtenBy("AvroCarbonWriterTest")
+                  .build();
+        }
+      }
+      writer.close();
+      String[] projection = new String[nn.getFields().size()];
+      for (int j = 0; j < nn.getFields().size(); j++) {
+        projection[j] = nn.getFields().get(j).name();
+      }
+      CarbonReader carbonReader = CarbonReader.builder().projection(projection).withFolder(path).build();
+      int sum = 0;
+      while (carbonReader.hasNext()) {
+        sum++;
+        Object[] row = (Object[]) carbonReader.readNextRow();
+        Assert.assertTrue(row.length == 5);
+        Object[] aa1 = (Object[]) row[2];
+        Assert.assertTrue(aa1.length == arrayLength);
+        Object[] aa2 = (Object[]) aa1[1];
+        Assert.assertTrue(aa2.length == 4 || aa2.length == 2 || aa2.length == 1);
+      }
+      Assert.assertTrue(sum == numOfRows);
+    } catch (Exception e) {
+      e.printStackTrace();
+      throw e;
+    }
+  }
 
   @Test
   public void testWriteComplexRecord() throws IOException, InvalidLoadOptionException {
@@ -428,6 +493,60 @@ public class AvroCarbonWriterTest {
       Assert.fail();
     } catch (Exception e) {
       Assert.assertTrue(true);
+    }
+    FileUtils.deleteDirectory(new File(path));
+  }
+
+  @Test
+  public void testWriteArrayArrayFloat() throws IOException {
+    FileUtils.deleteDirectory(new File(path));
+
+    String mySchema =
+        "{" +
+            "  \"name\": \"address\", " +
+            "   \"type\": \"record\", " +
+            "    \"fields\": [  " +
+            "  { \"name\": \"fileName\", \"type\": \"string\"}, " +
+            "  { \"name\": \"id\", \"type\": \"int\"}, " +
+            "  {\"name\" :\"aa1\", " +
+            "   \"type\" : { " +
+            "   \"type\" :\"array\", " +
+            "   \"items\":{ " +
+            "   \"name\" :\"aa2\", " +
+            "   \"type\" :\"array\", " +
+            "   \"items\":{ " +
+            "   \"name\" :\"f1\", " +
+            "   \"type\" : \"float\", " +
+            "   \"default\":-1}}}}," +
+            "  {\"name\" :\"bb1\", " +
+            "   \"type\" : { " +
+            "   \"type\" :\"array\", " +
+            "   \"items\":{ " +
+            "   \"name\" :\"bb2\", " +
+            "   \"type\" :\"array\", " +
+            "   \"items\":{ " +
+            "   \"name\" :\"f2\", " +
+            "   \"type\" : \"float\", " +
+            "   \"default\":-1}}}}," +
+            "  {\"name\" :\"cc1\", " +
+            "   \"type\" : { " +
+            "   \"type\" :\"array\", " +
+            "   \"items\":{ " +
+            "   \"name\" :\"cc2\", " +
+            "   \"type\" :\"array\", " +
+            "   \"items\":{ " +
+            "   \"name\" :\"f3\", " +
+            "   \"type\" : \"float\", " +
+            "   \"default\":-1}}}}" +
+            "] " +
+            "}";
+
+    try {
+      WriteAvroComplexDataAndRead(mySchema);
+      Assert.assertTrue(true);
+    } catch (Exception e) {
+      e.printStackTrace();
+      Assert.fail();
     }
     FileUtils.deleteDirectory(new File(path));
   }

--- a/sdk/sdk/src/test/java/org/apache/carbondata/sdk/file/CarbonReaderTest.java
+++ b/sdk/sdk/src/test/java/org/apache/carbondata/sdk/file/CarbonReaderTest.java
@@ -445,8 +445,6 @@ public class CarbonReaderTest extends TestCase {
   public void testReadWithFilterEqualSet() throws IOException, InterruptedException {
     String path = "./testWriteFiles";
     FileUtils.deleteDirectory(new File(path));
-    DataMapStoreManager.getInstance()
-        .clearDataMaps(AbsoluteTableIdentifier.from(path));
     Field[] fields = new Field[3];
     fields[0] = new Field("name", DataTypes.STRING);
     fields[1] = new Field("age", DataTypes.INT);

--- a/sdk/sdk/src/test/java/org/apache/carbondata/sdk/file/ImageTest.java
+++ b/sdk/sdk/src/test/java/org/apache/carbondata/sdk/file/ImageTest.java
@@ -18,7 +18,6 @@
 package org.apache.carbondata.sdk.file;
 
 import junit.framework.TestCase;
-
 import org.apache.carbondata.common.exceptions.sql.InvalidLoadOptionException;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.metadata.datatype.DataTypes;
@@ -30,7 +29,6 @@ import org.apache.carbondata.core.scan.expression.conditional.EqualToExpression;
 import org.apache.carbondata.core.util.CarbonProperties;
 import org.apache.carbondata.core.util.path.CarbonTablePath;
 import org.apache.carbondata.util.BinaryUtil;
-
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.io.FileUtils;
@@ -47,11 +45,18 @@ import javax.imageio.stream.FileImageInputStream;
 import javax.imageio.stream.ImageInputStream;
 import java.awt.color.ColorSpace;
 import java.awt.image.BufferedImage;
-import java.io.*;
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.FilenameFilter;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+import static org.apache.carbondata.core.scan.filter.FilterUtil.prepareEqualToExpression;
 import static org.apache.carbondata.sdk.file.utils.SDKUtil.listFiles;
 
 public class ImageTest extends TestCase {
@@ -322,6 +327,7 @@ public class ImageTest extends TestCase {
     byte[] originBinary = null;
 
     // read and write image data
+    String binaryValue = null;
     for (int j = 0; j < num; j++) {
       CarbonWriter writer = CarbonWriter
           .builder()
@@ -340,7 +346,8 @@ public class ImageTest extends TestCase {
           hexValue = Hex.encodeHex(originBinary);
         }
         // write data
-        writer.write(new String[]{"robot" + (i % 10), String.valueOf(i), String.valueOf(hexValue)});
+        binaryValue = String.valueOf(hexValue);
+        writer.write(new String[]{"robot" + (i % 10), String.valueOf(i), binaryValue});
         bis.close();
       }
       writer.close();
@@ -407,6 +414,56 @@ public class ImageTest extends TestCase {
       i++;
     }
     reader2.close();
+
+
+    // Read data with filter for binary
+
+    CarbonReader reader3 = CarbonReader
+        .builder(path, "_temp")
+        .filter(prepareEqualToExpression("image", "binary", binaryValue))
+        .build();
+
+    System.out.println("\nData:");
+    i = 0;
+    while (i < 20 && reader3.hasNext()) {
+      Object[] row = (Object[]) reader3.readNextRow();
+
+      byte[] outputBinary = Hex.decodeHex(new String((byte[]) row[1]).toCharArray());
+      System.out.println(row[0] + " " + row[2] + " image size:" + outputBinary.length);
+
+      // validate output binary data and origin binary data
+      assert (originBinary.length == outputBinary.length);
+      for (int j = 0; j < originBinary.length; j++) {
+        assert (originBinary[j] == outputBinary[j]);
+      }
+      String value = new String(outputBinary);
+      Assert.assertTrue(value.startsWith("�PNG"));
+      // save image, user can compare the save image and original image
+      String destString = "./target/binary/image" + i + ".jpg";
+      BufferedOutputStream bos = new BufferedOutputStream(new FileOutputStream(destString));
+      bos.write(outputBinary);
+      bos.close();
+      i++;
+    }
+    assert (1 == i);
+    System.out.println("\nFinished");
+    reader3.close();
+
+
+    CarbonReader reader4 = CarbonReader
+        .builder(path, "_temp")
+        .filter(prepareEqualToExpression("image", "binary", "hello"))
+        .build();
+
+    System.out.println("\nData:");
+    i = 0;
+    while (i < 20 && reader4.hasNext()) {
+      Object[] row = (Object[]) reader4.readNextRow();
+      assert (null == row[1]);
+    }
+    System.out.println("\nFinished");
+    reader4.close();
+
     try {
       FileUtils.deleteDirectory(new File(path));
     } catch (IOException e) {


### PR DESCRIPTION
Carbon SDK support filter equal values set. Support:    

1. prepareEqualToExpression(String columnName, String dataType, Object value)
2. prepareOrExpression(List<Expression> expressions).  
3.prepareEqualToExpressionSet(String columnName, DataType dataType, List<Object> values)    
4.prepareEqualToExpressionSet(String columnName, String dataType, List<Object> values).  

      
usage:

```
  CarbonReader reader = CarbonReader
        .builder(path, "_temp")
        .projection(new String[]{"name", "age", "doubleField"})
        .filter(prepareEqualToExpressionSet("name", "String", values))
        .build();
```

or:

```
    List<Expression> expressions = new ArrayList<>();
    expressions.add(prepareEqualToExpression("name", "String", "robot1"));
    expressions.add(prepareEqualToExpression("name", "String", "robot7"));
    expressions.add(prepareEqualToExpression("age", "int", "2"));

    CarbonReader reader5 = CarbonReader
        .builder(path, "_temp")
        .projection(new String[]{"name", "age", "doubleField"})
        .filter(prepareOrExpression(expressions))
        .build();
```
Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 Add new interfaces
 - [x] Any backward compatibility impacted?
 No
 - [x] Document update required?
No
 - [x] Testing done
     added
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NO
