### PR TITLE
[CARBONDATA-3466] Fix NPE for carboncli command

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/alterTable/TestAlterTableSortColumnsProperty.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/alterTable/TestAlterTableSortColumnsProperty.scala
@@ -601,7 +601,6 @@ class TestAlterTableSortColumnsProperty extends QueryTest with BeforeAndAfterAll
       val out: ByteArrayOutputStream = new ByteArrayOutputStream
       val stream: PrintStream = new PrintStream(out)
       CarbonCli.run(args, stream)
-      CarbonCli.cleanOutPuts()
       val output: String = new String(out.toByteArray)
       if (segmentId == 2) {
         assertResult(s"Input Folder: $segmentPath\nsorted by intfield,stringfield\n")(output)

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonCliCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonCliCommand.scala
@@ -56,7 +56,7 @@ case class CarbonCliCommand(
       case x => Seq(x.trim)
     }.flatten
     val summaryOutput = new util.ArrayList[String]()
-    CarbonCli.run(finalCommands.toArray, summaryOutput)
+    CarbonCli.run(finalCommands.toArray, summaryOutput, false)
     summaryOutput.asScala.map(x =>
       Row(x)
     )

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSpark2SqlParser.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSpark2SqlParser.scala
@@ -522,14 +522,9 @@ class CarbonSpark2SqlParser extends CarbonDDLSqlParser {
     }
 
   protected lazy val cli: Parser[LogicalPlan] =
-    (CARBONCLI ~> FOR ~> TABLE) ~> (ident <~ ".").? ~ ident ~
-    (OPTIONS ~> "(" ~> commandOptions <~ ")").? <~
-    opt(";") ^^ {
-      case databaseName ~ tableName ~ commandList =>
-        var commandOptions: String = null
-        if (commandList.isDefined) {
-          commandOptions = commandList.get
-        }
+    CARBONCLI ~> FOR ~> TABLE ~> (ident <~ ".").? ~ ident ~
+    (OPTIONS ~> "(" ~> commandOptions <~ ")") <~ opt(";") ^^ {
+      case databaseName ~ tableName ~ commandOptions =>
         CarbonCliCommand(
           convertDbNameToLowerCase(databaseName),
           tableName.toLowerCase(),

--- a/integration/spark2/src/test/scala/org/apache/carbondata/spark/testsuite/TestCarbonCli.scala
+++ b/integration/spark2/src/test/scala/org/apache/carbondata/spark/testsuite/TestCarbonCli.scala
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.spark.testsuite
+
+import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.common.util.Spark2QueryTest
+import org.scalatest.BeforeAndAfterAll
+
+class TestCarbonCli extends Spark2QueryTest with BeforeAndAfterAll{
+
+  override protected def beforeAll(): Unit = {
+    sql("drop table if exists OneRowTable")
+    sql("create table OneRowTable(col1 string, col2 string, col3 int, col4 double) stored by 'carbondata'")
+    sql("insert into OneRowTable select '0.1', 'a.b', 1, 1.2")
+  }
+
+  test("CarbonCli table summary") {
+    checkExistence(
+      sql("carboncli for table OneRowTable options('-cmd summary -a')"),
+      true, "## Summary")
+
+    checkExistence(
+      sql("carboncli for table OneRowTable options('-cmd summary -v')"),
+      true, "## version Details")
+
+    checkExistence(
+      sql("carboncli for table OneRowTable options('-cmd summary -s')"),
+      true, "## Schema")
+
+    checkExistence(
+      sql("carboncli for table OneRowTable options('-cmd summary -t')"),
+      true, "## Table Properties")
+
+    checkExistence(
+      sql("carboncli for table OneRowTable options('-cmd summary -m')"),
+      true, "## Segment")
+  }
+
+  test("CarbonCli column details") {
+    checkExistence(
+      sql("carboncli for table OneRowTable options('-cmd summary -c col1')"),
+      true, "## Column Statistics for 'col1'")
+  }
+
+  test("CarbonCli benchmark") {
+    checkExistence(
+      sql("carboncli for table OneRowTable options('-cmd benchmark -c col1')"),
+      true, "## Benchmark")
+  }
+
+  test("CarbonCli invalid cmd"){
+
+    assert(intercept[AnalysisException] {
+      sql("carboncli for table OneRowTable").show()
+    }.getMessage().contains("mismatched input 'carboncli'"))
+
+    assert(intercept[Exception] {
+      sql("carboncli for table OneRowTable options('')")
+    }.getMessage().contains("Missing required option: cmd"))
+
+    checkExistence(sql("carboncli for table OneRowTable options('-cmd test')"),
+      true, "command test is not supported")
+  }
+
+  override protected def afterAll(): Unit = {
+    sql("drop table if exists OneRowTable")
+  }
+}

--- a/tools/cli/src/main/java/org/apache/carbondata/tool/CarbonCli.java
+++ b/tools/cli/src/main/java/org/apache/carbondata/tool/CarbonCli.java
@@ -205,8 +205,6 @@ public class CarbonCli {
       out.flush();
     } catch (IOException | MemoryException e) {
       e.printStackTrace();
-    } finally {
-      out.close();
     }
   }
 


### PR DESCRIPTION
*What is changed:*
1. require option for carboncli command when parsing
2. unify to fill result in array when running carbon cli , use adapter to print to stream on demand

*Problem details:*
if no options specified, like `"carboncli for table source"`, NPE will occur when running `commandOptions.split("\\s+")` in `CarbonCliCommand#processData`. 
Since option, as a role of command, is a must in `CarbonCli`, we require it when parsing command in this PR.

FYI, if user give `options('')`, carboncli can check and throw like this:
```
0: jdbc:hive2://127.0.0.1:10000> carboncli  for table testtbl options('');
Error: java.lang.RuntimeException: Parsing failed. Reason: Missing required option: cmd (state=,code=0)
```

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

