### PR TITLE
[CARBONDATA-3467] Fix count(*) with filter on string column

### DIFF
--- a/datamap/mv/core/src/main/scala/org/apache/carbondata/mv/datamap/MVAnalyzerRule.scala
+++ b/datamap/mv/core/src/main/scala/org/apache/carbondata/mv/datamap/MVAnalyzerRule.scala
@@ -70,7 +70,14 @@ class MVAnalyzerRule(sparkSession: SparkSession) extends Rule[LogicalPlan] {
     plan.transform {
       case aggregate@Aggregate(grp, aExp, child) =>
         // check for if plan is for dataload for preaggregate table, then skip applying mv
-        if (aExp.exists(p => p.name.equals("preAggLoad") || p.name.equals("preAgg"))) {
+        val isPreAggLoad = aExp.exists { p =>
+          if (p.isInstanceOf[UnresolvedAlias]) {
+            false
+          } else {
+            p.name.equals("preAggLoad") || p.name.equals("preAgg")
+          }
+        }
+        if (isPreAggLoad) {
           needAnalysis = false
         }
         Aggregate(grp, aExp, child)

--- a/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/TestAllOperationsOnMV.scala
+++ b/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/TestAllOperationsOnMV.scala
@@ -540,6 +540,17 @@ class TestAllOperationsOnMV extends QueryTest with BeforeAndAfterEach {
     }.getMessage.contains("Operation not allowed on child table.")
   }
 
+  test("test count(*) with filter") {
+    sql("drop table if exists maintable")
+    sql("create table maintable(id int, name string, id1 string, id2 string, dob timestamp, doj " +
+        "timestamp, v1 bigint, v2 bigint, v3 decimal(30,10), v4 decimal(20,10), v5 double, v6 " +
+        "double ) stored by 'carbondata'")
+    sql("insert into maintable values(1, 'abc', 'id001', 'id002', '2017-01-01 00:00:00','2017-01-01 " +
+        "00:00:00', 234, 2242,12.4,23.4,2323,455 )")
+    checkAnswer(sql("select count(*) from maintable where  id1 < id2"), Seq(Row(1)))
+    sql("drop table if exists maintable")
+  }
+
   test("drop meta cache on mv datamap table") {
     sql("drop table IF EXISTS maintable")
     sql("create table maintable(name string, c_code int, price int) stored by 'carbondata'")
@@ -580,6 +591,6 @@ class TestAllOperationsOnMV extends QueryTest with BeforeAndAfterEach {
     newSet.addAll(oldSet)
     newSet
   }
-
+  
 }
 


### PR DESCRIPTION
Problem:
count(*) with filter on string column throws Unresolved Exception
Solution:
Added check for UnresolvedAlias in MVAnalyzer

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

