### PR TITLE
[HOTFIX] Fix json to carbon writer

### DIFF
--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonWriterBuilder.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonWriterBuilder.java
@@ -65,7 +65,10 @@ public class CarbonWriterBuilder {
   private int pageSizeInMb;
   private int blockSize;
   private long timestamp;
-  private Map<String, String> options;
+
+  // use TreeMap as keys need to be case insensitive
+  private Map<String, String> options = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+
   private String taskNo;
   private int localDictionaryThreshold;
   private boolean isLocalDictionaryEnabled = Boolean.parseBoolean(
@@ -239,10 +242,6 @@ public class CarbonWriterBuilder {
       }
     }
 
-    if (this.options == null) {
-      // convert it to treeMap as keys need to be case insensitive
-      this.options = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
-    }
     this.options.putAll(options);
     return this;
   }


### PR DESCRIPTION
When using SDK to write carbon files with json input, there is a NullPointerException.
This PR fixed this bug.

 - [X] Any interfaces changed?
 No
 - [X] Any backward compatibility impacted?
 No
 - [X] Document update required?
No
 - [Y] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [X] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA