### PR TITLE
[HOTFIX] Fix task id in FileFormat write

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonThreadFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonThreadFactory.java
@@ -49,7 +49,7 @@ public class CarbonThreadFactory implements ThreadFactory {
   @Override public Thread newThread(Runnable r) {
     final Thread thread = defaultFactory.newThread(r);
     if (withTime) {
-      thread.setName(name + "_" + System.currentTimeMillis());
+      thread.setName(name + "_" + System.nanoTime());
     } else {
       thread.setName(name);
     }


### PR DESCRIPTION
problem : In FIleFormat write, carbon is using task id as System.nanoTime()

cause :  when multiple tasks launched concurrently, there is a chance that two task can have same id  very rarely. Due to this, two spark task launched for one insert will have same carbondata file name.
so, when both tasks write to one file, chances are more to corrupt the file. which leads in query failure

solution: use own unique task id instead of nano seconds.
here use spark task id  + global counter to generate unique task id across jobs.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed? NA
 
 - [ ] Any backward compatibility impacted? NA
 
 - [ ] Document update required? NA

 - [ ] Testing done
done. Attached the report
[testReport.txt](https://github.com/apache/carbondata/files/3388501/testReport.txt)

 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.  [NA]

