### PR TITLE
[HOTFIX]Fixed date filter issue for fileformat

### DIFF
--- a/integration/spark-datasource/src/main/scala/org/apache/spark/sql/carbondata/execution/datasources/CarbonSparkDataSourceUtil.scala
+++ b/integration/spark-datasource/src/main/scala/org/apache/spark/sql/carbondata/execution/datasources/CarbonSparkDataSourceUtil.scala
@@ -19,6 +19,7 @@ package org.apache.spark.sql.carbondata.execution.datasources
 import scala.collection.JavaConverters._
 
 import org.apache.spark.sql._
+import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.types._
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants
@@ -200,6 +201,10 @@ object CarbonSparkDataSourceUtil {
       val dataValue = if (dataTypeOfAttribute.equals(CarbonDataTypes.BINARY)
               && Option(value).isDefined) {
         new String(value.asInstanceOf[Array[Byte]])
+      } else if (dataTypeOfAttribute.equals(CarbonDataTypes.DATE) &&
+                 value.isInstanceOf[java.sql.Date]) {
+        // In case of Date object , convert back to int.
+        DateTimeUtils.fromJavaDate(value.asInstanceOf[java.sql.Date])
       } else {
         value
       }

--- a/integration/spark-datasource/src/test/scala/org/apache/spark/sql/carbondata/datasource/SparkCarbonDataSourceTest.scala
+++ b/integration/spark-datasource/src/test/scala/org/apache/spark/sql/carbondata/datasource/SparkCarbonDataSourceTest.scala
@@ -858,6 +858,19 @@ class SparkCarbonDataSourceTest extends FunSuite with BeforeAndAfterAll {
     spark.sql("drop table if exists date_parquet_table")
   }
 
+  test("test date filter datatype") {
+    spark.sql("drop table if exists date_table")
+    spark.sql("drop table if exists date_parquet_table")
+    spark.sql("create table date_table(empno int, empname string, projdate Date) using carbon")
+    spark.sql("insert into  date_table select 11, 'ravi', '2017-11-11'")
+    spark.sql("select * from date_table where projdate=cast('2017-11-11' as date)").show()
+    spark.sql("create table date_parquet_table(empno int, empname string, projdate Date) using parquet")
+    spark.sql("insert into  date_parquet_table select 11, 'ravi', '2017-11-11'")
+    checkAnswer(spark.sql("select * from date_table where projdate=cast('2017-11-11' as date)"), spark.sql("select * from date_parquet_table where projdate=cast('2017-11-11' as date)"))
+    spark.sql("drop table if exists date_table")
+    spark.sql("drop table if exists date_parquet_table")
+  }
+
   test("test read and write with date datatype with wrong format") {
     spark.sql("drop table if exists date_table")
     spark.sql("drop table if exists date_parquet_table")

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,6 @@
 
   <modules>
     <module>common</module>
-    <module>format</module>
     <module>core</module>
     <module>processing</module>
     <module>hadoop</module>


### PR DESCRIPTION
Problem :
In fileformat spark converts date to date object and sends to the carbon, carbon converts it to string and then generates miliseconds. But there is a milli second gap of spark generated milli and carbon generated milli. This causes date filters are not working properly.

Solution:
Convert the date to millis in spark side before give to carbon. 
Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

