### PR TITLE
[CARBONDATA-3474]Fix validate mvQuery having filter expression and correct error message

### DIFF
--- a/datamap/mv/core/src/main/scala/org/apache/carbondata/mv/datamap/MVUtil.scala
+++ b/datamap/mv/core/src/main/scala/org/apache/carbondata/mv/datamap/MVUtil.scala
@@ -314,7 +314,8 @@ class MVUtil {
     if (a.child.isInstanceOf[GetMapValue] || a.child.isInstanceOf[GetStructField] ||
         a.child.isInstanceOf[GetArrayItem]) {
       throw new UnsupportedOperationException(
-        s"MV datamap is unsupported for ComplexData type child column: " + a.child.simpleString)
+        s"MV datamap is not supported for complex datatype child columns and complex datatype " +
+        s"return types of function :" + a.child.simpleString)
     }
   }
 

--- a/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/MVCreateTestCase.scala
+++ b/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/MVCreateTestCase.scala
@@ -1051,7 +1051,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     sql(
       "create table mv_like(name string, age int, address string, Country string, id int) stored by 'carbondata'")
     sql(
-      "create datamap mvlikedm1 using 'mv' as select name,address from mv_like where Country NOT LIKE 'US' group by name,address")
+      "create datamap mvlikedm1 using 'mv' as select name,address,sum(Country) from mv_like where Country NOT LIKE 'US' group by name,address")
     sql(
       "create datamap mvlikedm2 using 'mv' as select name,address,Country from mv_like where Country = 'US' or Country = 'China' group by name,address,Country")
     sql("insert into mv_like select 'chandler', 32, 'newYork', 'US', 5")

--- a/integration/spark2/src/main/scala/org/apache/spark/util/DataMapUtil.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/util/DataMapUtil.scala
@@ -45,7 +45,7 @@ object DataMapUtil {
     parentOrder.foreach(parentcol =>
       fields.filter(col => fieldRelationMap(col).aggregateFunction.isEmpty &&
                            fieldRelationMap(col).columnTableRelationList.size == 1 &&
-                           parentcol.equals(fieldRelationMap(col).
+                           parentcol.equalsIgnoreCase(fieldRelationMap(col).
                              columnTableRelationList.get(0).parentColumnName))
         .map(cols => neworder :+= cols.column))
     if (neworder.nonEmpty) {


### PR DESCRIPTION
Problem:
1. Create mv datamap with select query having predicate expression like &&, AND, OR with predicate not present in projection. Executing the same query throws exception
2. For UDF functions like histogram_numeric, collect_set, collect_list etc., return type is complex type. Creating mv with above functions throws improper exception

Solution:
1. Validate mv queries having predicate as expression and throw exception on create datamap if predicate is not given in projection
2. Correct unsupported error message for functions like histogram_numeric, collect_set, collect_list etc., whose return type is of complex data type with mv

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
  
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

