### PR TITLE
[CARBONDATA-3473] Fix data size calcution of the last column in CarbonCli

### DIFF
--- a/tools/cli/src/test/java/org/apache/carbondata/tool/CarbonCliTest.java
+++ b/tools/cli/src/test/java/org/apache/carbondata/tool/CarbonCliTest.java
@@ -234,11 +234,11 @@ public class CarbonCliTest {
 
     expectedOutput = buildLines(
         "BLK  BLKLT  Meta Size  Data Size  LocalDict  DictEntries  DictSize  AvgPageSize  Min%  Max%   Min  Max      " ,
-        "0    0      3.36KB     5.14MB     false      0            0.0B      93.76KB      0.0   100.0  0    2999990  " ,
+        "0    0      3.36KB     2.57MB     false      0            0.0B      93.76KB      0.0   100.0  0    2999990  " ,
         "0    1      3.36KB     2.57MB     false      0            0.0B      93.76KB      0.0   100.0  1    2999992  " ,
-        "1    0      3.36KB     5.14MB     false      0            0.0B      93.76KB      0.0   100.0  3    2999994  " ,
+        "1    0      3.36KB     2.57MB     false      0            0.0B      93.76KB      0.0   100.0  3    2999994  " ,
         "1    1      3.36KB     2.57MB     false      0            0.0B      93.76KB      0.0   100.0  5    2999996  " ,
-        "2    0      3.36KB     4.06MB     false      0            0.0B      93.76KB      0.0   100.0  7    2999998  " ,
+        "2    0      3.36KB     2.57MB     false      0            0.0B      93.76KB      0.0   100.0  7    2999998  " ,
         "2    1      2.04KB     1.49MB     false      0            0.0B      89.62KB      0.0   100.0  9    2999999  ");
     Assert.assertTrue(output.contains(expectedOutput));
     Assert.assertTrue(output.contains("## version Details"));


### PR DESCRIPTION
when update last column chunk data size, current code use `columnDataSize.add(fileSizeInBytes - footerSizeInBytes - previousChunkOffset)` for every blocklet. This leads to wrong result for calculting the data size of the last column, especially when a carbon data file has multiple blocklet.
```
Scan column 'batchno'                                                                             |
| Blocklet#0: total size 109.77MB, 21 pages, 672,000 rows                                            |
|       ColumnChunk IO takes 510 us                                                                       |
|       Decompress Pages takes 1,018 us                                                                   |
| Blocklet#1: total size 53.96MB, 21 pages, 672,000 rows                                             |
|       ColumnChunk IO takes 1,570 us                                                                     |
|       Decompress Pages takes 1,226 us                                                                   |
| Blocklet#2: total size 37.51KB, 21 pages, 672,000 rows                                             |
|       ColumnChunk IO takes 584 us                                                                       |
|       Decompress Pages takes 1,222 us                                                                   |

```
In this PR, we fix this problem and modify the calcultion by remarking the end offset of blocklet.



Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

