### PR TITLE
[HOTFIX] Fix failing CI test cases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,8 @@
     <module>store/sdk</module>
     <module>assembly</module>
     <module>tools/cli</module>
+    <module>datamap/bloom</module>
+    <module>datamap/lucene</module>
     <module>datamap/mv/plan</module>
     <module>datamap/mv/core</module>
     <module>examples/spark2</module>


### PR DESCRIPTION
Problem: Bloom and lucene dependency was removed due to which mvn was downloaded the old jar.

Solution: Add bloom and lucene dependency to the main pom

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

