### PR TITLE
[CARBONDATA-3483] Don't require update.lock and compaction.lock again when execute 'IUD_UPDDEL_DELTA' compaction

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/iud/HorizontalCompactionTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/iud/HorizontalCompactionTestCase.scala
@@ -20,7 +20,11 @@ package org.apache.carbondata.spark.testsuite.iud
 import org.apache.spark.sql.Row
 import org.scalatest.BeforeAndAfterAll
 import org.apache.carbondata.core.constants.CarbonCommonConstants
+import org.apache.carbondata.core.datastore.filesystem.{CarbonFile, CarbonFileFilter}
+import org.apache.carbondata.core.datastore.impl.FileFactory
+import org.apache.carbondata.core.metadata.{AbsoluteTableIdentifier, CarbonMetadata}
 import org.apache.carbondata.core.util.CarbonProperties
+import org.apache.carbondata.core.util.path.CarbonTablePath
 import org.apache.spark.sql.test.util.QueryTest
 
 
@@ -383,6 +387,57 @@ class HorizontalCompactionTestCase extends QueryTest with BeforeAndAfterAll {
     checkAnswer(sql("select longfield from customer1"),Seq(Row(9223372036854775807L),Row(9223372036854775807L),Row(9223372036854775807L),Row(9223372036854775807L)))
 
   }
+
+  def getDeltaFiles(carbonFile: CarbonFile, fileSuffix: String): Array[CarbonFile] = {
+    return carbonFile.listFiles(new CarbonFileFilter {
+      override def accept(file: CarbonFile): Boolean = {
+        file.getName.endsWith(fileSuffix)
+      }
+    })
+  }
+
+  test("[CARBONDATA-3483] Don't require update.lock and compaction.lock again when execute 'IUD_UPDDEL_DELTA' compaction") {
+    sql("""drop database if exists iud4 cascade""")
+    sql("""create database iud4""")
+    sql("""use iud4""")
+
+    sql(
+      """create table dest2 (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""")
+    sql(s"""load data local inpath '$resourcesPath/IUD/comp1.csv' INTO table dest2""")
+
+    val carbonTable = CarbonMetadata.getInstance().getCarbonTable("iud4_dest2")
+    val identifier = carbonTable.getAbsoluteTableIdentifier()
+    val dataFilesDir = CarbonTablePath.getSegmentPath(identifier.getTablePath, "0")
+    val carbonFile =
+        FileFactory.getCarbonFile(dataFilesDir, FileFactory.getFileType(dataFilesDir))
+
+    var updateDeltaFiles = getDeltaFiles(carbonFile, CarbonCommonConstants.UPDATE_INDEX_FILE_EXT)
+    var deletaDeltaFiles = getDeltaFiles(carbonFile, CarbonCommonConstants.DELETE_DELTA_FILE_EXT)
+    assert(updateDeltaFiles.length == 0)
+    assert(deletaDeltaFiles.length == 0)
+
+    sql("""update dest2 set (c1, c3) = ('update_a', 'update_aa') where c2 = 3 or c2 = 6""").show()
+
+    updateDeltaFiles = getDeltaFiles(carbonFile, CarbonCommonConstants.UPDATE_INDEX_FILE_EXT)
+    deletaDeltaFiles = getDeltaFiles(carbonFile, CarbonCommonConstants.DELETE_DELTA_FILE_EXT)
+    // just update once, there is no horizontal compaction at this time
+    assert(updateDeltaFiles.length == 1)
+    assert(deletaDeltaFiles.length == 1)
+
+    sql("""update dest2 set (c1, c3) = ('update_a', 'update_aa') where c2 = 5 or c2 = 8""").show()
+
+    updateDeltaFiles = getDeltaFiles(carbonFile, CarbonCommonConstants.UPDATE_INDEX_FILE_EXT)
+    deletaDeltaFiles = getDeltaFiles(carbonFile, CarbonCommonConstants.DELETE_DELTA_FILE_EXT)
+    // one '.carbonindex' file for last update operation
+    // one '.carbonindex' file for update operation this time
+    // one '.carbonindex' file for horizontal compaction
+    // so there must be three '.carbonindex' files and three '.deletedelta' files
+    assert(updateDeltaFiles.length == 3)
+    assert(deletaDeltaFiles.length == 3)
+
+    sql("""drop table dest2""")
+  }
+
   override def afterAll {
     CarbonProperties.getInstance()
       .addProperty(CarbonCommonConstants.ENABLE_VECTOR_READER , "true")

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/iud/HorizontalCompactionTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/iud/HorizontalCompactionTestCase.scala
@@ -22,11 +22,11 @@ import org.scalatest.BeforeAndAfterAll
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.datastore.filesystem.{CarbonFile, CarbonFileFilter}
 import org.apache.carbondata.core.datastore.impl.FileFactory
-import org.apache.carbondata.core.metadata.{AbsoluteTableIdentifier, CarbonMetadata}
+import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier
 import org.apache.carbondata.core.util.CarbonProperties
 import org.apache.carbondata.core.util.path.CarbonTablePath
+import org.apache.spark.sql.CarbonEnv
 import org.apache.spark.sql.test.util.QueryTest
-
 
 class HorizontalCompactionTestCase extends QueryTest with BeforeAndAfterAll {
   override def beforeAll {
@@ -407,7 +407,7 @@ class HorizontalCompactionTestCase extends QueryTest with BeforeAndAfterAll {
       """create table dest10 (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""")
     sql(s"""load data local inpath '$resourcesPath/IUD/comp1.csv' INTO table dest10""")
 
-    val carbonTable = CarbonMetadata.getInstance().getCarbonTable("iud10_dest10")
+    val carbonTable = CarbonEnv.getCarbonTable(Some("iud10"), "dest10")(sqlContext.sparkSession)
     val identifier = carbonTable.getAbsoluteTableIdentifier()
     val dataFilesDir = CarbonTablePath.getSegmentPath(identifier.getTablePath, "0")
     val carbonFile =

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/iud/HorizontalCompactionTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/iud/HorizontalCompactionTestCase.scala
@@ -399,6 +399,8 @@ class HorizontalCompactionTestCase extends QueryTest with BeforeAndAfterAll {
   test("[CARBONDATA-3483] Don't require update.lock and compaction.lock again when execute 'IUD_UPDDEL_DELTA' compaction") {
     CarbonProperties.getInstance()
       .addProperty(CarbonCommonConstants.ENABLE_VECTOR_READER , "true")
+    CarbonProperties.getInstance().addProperty(
+      CarbonCommonConstants.CARBON_UPDATE_SEGMENT_PARALLELISM, "1")
     sql("""drop database if exists iud10 cascade""")
     sql("""create database iud10""")
     sql("""use iud10""")

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/iud/HorizontalCompactionTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/iud/HorizontalCompactionTestCase.scala
@@ -397,15 +397,17 @@ class HorizontalCompactionTestCase extends QueryTest with BeforeAndAfterAll {
   }
 
   test("[CARBONDATA-3483] Don't require update.lock and compaction.lock again when execute 'IUD_UPDDEL_DELTA' compaction") {
-    sql("""drop database if exists iud4 cascade""")
-    sql("""create database iud4""")
-    sql("""use iud4""")
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.ENABLE_VECTOR_READER , "true")
+    sql("""drop database if exists iud10 cascade""")
+    sql("""create database iud10""")
+    sql("""use iud10""")
 
     sql(
-      """create table dest2 (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""")
-    sql(s"""load data local inpath '$resourcesPath/IUD/comp1.csv' INTO table dest2""")
+      """create table dest10 (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""")
+    sql(s"""load data local inpath '$resourcesPath/IUD/comp1.csv' INTO table dest10""")
 
-    val carbonTable = CarbonMetadata.getInstance().getCarbonTable("iud4_dest2")
+    val carbonTable = CarbonMetadata.getInstance().getCarbonTable("iud10_dest10")
     val identifier = carbonTable.getAbsoluteTableIdentifier()
     val dataFilesDir = CarbonTablePath.getSegmentPath(identifier.getTablePath, "0")
     val carbonFile =
@@ -416,7 +418,7 @@ class HorizontalCompactionTestCase extends QueryTest with BeforeAndAfterAll {
     assert(updateDeltaFiles.length == 0)
     assert(deletaDeltaFiles.length == 0)
 
-    sql("""update dest2 set (c1, c3) = ('update_a', 'update_aa') where c2 = 3 or c2 = 6""").show()
+    sql("""update dest10 set (c1, c3) = ('update_a', 'update_aa') where c2 = 3 or c2 = 6""").show()
 
     updateDeltaFiles = getDeltaFiles(carbonFile, CarbonCommonConstants.UPDATE_INDEX_FILE_EXT)
     deletaDeltaFiles = getDeltaFiles(carbonFile, CarbonCommonConstants.DELETE_DELTA_FILE_EXT)
@@ -424,7 +426,7 @@ class HorizontalCompactionTestCase extends QueryTest with BeforeAndAfterAll {
     assert(updateDeltaFiles.length == 1)
     assert(deletaDeltaFiles.length == 1)
 
-    sql("""update dest2 set (c1, c3) = ('update_a', 'update_aa') where c2 = 5 or c2 = 8""").show()
+    sql("""update dest10 set (c1, c3) = ('update_a', 'update_aa') where c2 = 5 or c2 = 8""").show()
 
     updateDeltaFiles = getDeltaFiles(carbonFile, CarbonCommonConstants.UPDATE_INDEX_FILE_EXT)
     deletaDeltaFiles = getDeltaFiles(carbonFile, CarbonCommonConstants.DELETE_DELTA_FILE_EXT)
@@ -435,7 +437,10 @@ class HorizontalCompactionTestCase extends QueryTest with BeforeAndAfterAll {
     assert(updateDeltaFiles.length == 3)
     assert(deletaDeltaFiles.length == 3)
 
-    sql("""drop table dest2""")
+    sql("""drop table dest10""")
+    sql("""drop database if exists iud10 cascade""")
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.ENABLE_VECTOR_READER , "false")
   }
 
   override def afterAll {

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/iud/UpdateCarbonTableTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/iud/UpdateCarbonTableTestCase.scala
@@ -795,5 +795,7 @@ class UpdateCarbonTableTestCase extends QueryTest with BeforeAndAfterAll {
       .addProperty(CarbonCommonConstants.CARBON_HORIZONTAL_COMPACTION_ENABLE , "true")
     CarbonProperties.getInstance()
       .addProperty(CarbonCommonConstants.ENABLE_VECTOR_READER , "true")
+    CarbonProperties.getInstance().addProperty(
+      CarbonCommonConstants.CARBON_UPDATE_SEGMENT_PARALLELISM, "1")
   }
 }

--- a/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -276,7 +276,9 @@ object CarbonDataRDDFactory {
         } finally {
           executor.shutdownNow()
           compactor.deletePartialLoadsInCompaction()
-          compactionLock.unlock()
+          if (compactionModel.compactionType != CompactionType.IUD_UPDDEL_DELTA) {
+            compactionLock.unlock()
+          }
         }
       }
     }


### PR DESCRIPTION
**Problem:**
After #3166 , horizontal compaction will not actually run when execute update sql.
When it runs update sql and will run horizontal compaction if needs, it will require update.lock and compaction.lock when execute CarbonAlterTableCompactionCommand.alterTableForCompaction, but these two locks already are locked when it starts to execute update sql. so it will require locks failed and can't execute compaction.

**Solution:**
Don't require update.lock and compaction.lock again when execute 'IUD_UPDDEL_DELTA' compaction

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed? No
 
 - [ ] Any backward compatibility impacted? No
 
 - [ ] Document update required? No

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

Test manually