### PR TITLE
[HOTFIX] CLI test case failed during release because of space differences

### DIFF
--- a/tools/cli/src/test/java/org/apache/carbondata/tool/CarbonCliTest.java
+++ b/tools/cli/src/test/java/org/apache/carbondata/tool/CarbonCliTest.java
@@ -241,12 +241,9 @@ public class CarbonCliTest {
         "2    0      3.36KB     4.06MB     false      0            0.0B      93.76KB      0.0   100.0  7    2999998  " ,
         "2    1      2.04KB     1.49MB     false      0            0.0B      89.62KB      0.0   100.0  9    2999999  ");
     Assert.assertTrue(output.contains(expectedOutput));
-
-    expectedOutput = buildLines(
-        "## version Details",
-        "written_by  Version         ",
-        "TestUtil    "+ CarbonVersionConstants.CARBONDATA_VERSION+"  ");
-    Assert.assertTrue(output.contains(expectedOutput));
+    Assert.assertTrue(output.contains("## version Details"));
+    Assert.assertTrue(output.contains("written_by  Version"));
+    Assert.assertTrue(output.contains("TestUtil    "+ CarbonVersionConstants.CARBONDATA_VERSION));
   }
 
   @Test


### PR DESCRIPTION
CLI test case is failed if the release name is short and without snapshot, it adds more space . 
That's why changed test check the individual contains instead of a batch of lines


Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

