### PR TITLE
[CARBONDATA-3487] wrong Input metrics (size/record) displayed in spark UI during insert into

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -1307,6 +1307,16 @@ public final class CarbonCommonConstants {
   public static final String IS_DRIVER_INSTANCE_DEFAULT = "false";
 
   /**
+   * property to set input metrics update interval (in records count), after every interval,
+   * input metrics will be updated to spark, else will be update in the end of query
+   */
+  @CarbonProperty(dynamicConfigurable = true)
+  public static final String INPUT_METRICS_UPDATE_INTERVAL = "carbon.input.metrics.update.interval";
+
+  public static final Long INPUT_METRICS_UPDATE_INTERVAL_DEFAULT = 500000L;
+
+
+  /**
    * property for enabling unsafe based query processing
    */
   @CarbonProperty(dynamicConfigurable = true)

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
@@ -1749,4 +1749,28 @@ public final class CarbonProperties {
     }
     return numOfThreadsForPruning;
   }
+
+  /**
+   * Validate and get the input metrics interval
+   *
+   * @return input metrics interval
+   */
+  public static Long getInputMetricsInterval() {
+    String metrics = CarbonProperties.getInstance()
+        .getProperty(CarbonCommonConstants.INPUT_METRICS_UPDATE_INTERVAL);
+    if (metrics == null) {
+      return CarbonCommonConstants.INPUT_METRICS_UPDATE_INTERVAL_DEFAULT;
+    } else {
+      try {
+        long configuredValue = Long.parseLong(metrics);
+        if (configuredValue < 0) {
+          return CarbonCommonConstants.INPUT_METRICS_UPDATE_INTERVAL_DEFAULT;
+        } else {
+          return configuredValue;
+        }
+      } catch (Exception ex) {
+        return CarbonCommonConstants.INPUT_METRICS_UPDATE_INTERVAL_DEFAULT;
+      }
+    }
+  }
 }

--- a/core/src/main/java/org/apache/carbondata/core/util/TaskMetricsMap.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/TaskMetricsMap.java
@@ -36,7 +36,7 @@ public class TaskMetricsMap {
   private static final Logger LOGGER =
       LogServiceFactory.getLogService(TaskMetricsMap.class.getName());
 
-  public static final InheritableThreadLocal<Long> threadLocal = new InheritableThreadLocal<>();
+  private static final InheritableThreadLocal<Long> threadLocal = new InheritableThreadLocal<>();
   /**
    * In this map we are maintaining all spawned child threads callback info for each parent thread
    * here key = parent thread id & values =  list of spawned child threads callbacks
@@ -48,6 +48,25 @@ public class TaskMetricsMap {
 
   public static TaskMetricsMap getInstance() {
     return taskMetricsMap;
+  }
+
+  public static InheritableThreadLocal<Long> getThreadLocal() {
+    return threadLocal;
+  }
+
+
+  /**
+   * initializes thread local to current thread id
+   *
+   * @return
+   */
+  public static void initializeThreadLocal() {
+    // In case of multi level RDD (say insert into scenario, where DataFrameRDD calling ScanRDD)
+    // parent thread id should not be overwritten by child thread id.
+    // so don't set if it is already set.
+    if (threadLocal.get() == null) {
+      threadLocal.set(Thread.currentThread().getId());
+    }
   }
 
   /**

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/InitInputMetrics.java
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/InitInputMetrics.java
@@ -28,5 +28,5 @@ import org.apache.spark.TaskContext;
  */
 public interface InitInputMetrics extends InputMetricsStats {
 
-  void initBytesReadCallback(TaskContext context, CarbonMultiBlockSplit carbonMultiBlockSplit);
+  void initBytesReadCallback(TaskContext context, CarbonMultiBlockSplit carbonMultiBlockSplit, Long inputMetricsInterval);
 }

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/load/DataLoadProcessBuilderOnSpark.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/load/DataLoadProcessBuilderOnSpark.scala
@@ -364,7 +364,7 @@ object DataLoadProcessBuilderOnSpark {
     TaskContext.get.addTaskCompletionListener { _ =>
       CommonUtil.clearUnsafeMemory(ThreadLocalTaskInfo.getCarbonTaskInfo.getTaskId)
     }
-    TaskMetricsMap.threadLocal.set(Thread.currentThread().getId)
+    TaskMetricsMap.initializeThreadLocal()
     val carbonTaskInfo = new CarbonTaskInfo
     carbonTaskInfo.setTaskId(CarbonUtil.generateUUID())
     ThreadLocalTaskInfo.setCarbonTaskInfo(carbonTaskInfo)

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonRDD.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonRDD.scala
@@ -51,6 +51,8 @@ abstract class CarbonRDD[T: ClassTag](
     info
   }
 
+  val inputMetricsInterval: Long = CarbonProperties.getInputMetricsInterval
+
   @transient val hadoopConf = SparkSQLUtil.sessionState(ss).newHadoopConf()
 
   val config = SparkSQLUtil.broadCastHadoopConf(sparkContext, hadoopConf)
@@ -73,7 +75,7 @@ abstract class CarbonRDD[T: ClassTag](
     TaskContext.get.addTaskCompletionListener(_ => ThreadLocalSessionInfo.unsetAll())
     carbonSessionInfo.getNonSerializableExtraInfo.put("carbonConf", getConf)
     ThreadLocalSessionInfo.setCarbonSessionInfo(carbonSessionInfo)
-    TaskMetricsMap.threadLocal.set(Thread.currentThread().getId)
+    TaskMetricsMap.initializeThreadLocal()
     val carbonTaskInfo = new CarbonTaskInfo
     carbonTaskInfo.setTaskId(CarbonUtil.generateUUID())
     ThreadLocalTaskInfo.setCarbonTaskInfo(carbonTaskInfo)

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
@@ -422,7 +422,7 @@ class CarbonScanRDD[T: ClassTag](
     val format = prepareInputFormatForExecutor(attemptContext.getConfiguration)
     val inputSplit = split.asInstanceOf[CarbonSparkPartition].split.value
     TaskMetricsMap.getInstance().registerThreadCallback()
-    inputMetricsStats.initBytesReadCallback(context, inputSplit)
+    inputMetricsStats.initBytesReadCallback(context, inputSplit, inputMetricsInterval)
     val iterator = if (inputSplit.getAllSplits.size() > 0) {
       val model = format.createQueryModel(inputSplit, attemptContext, filterExpression)
       // one query id per table

--- a/integration/spark2/src/main/scala/org/apache/carbondata/datamap/IndexDataMapRebuildRDD.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/datamap/IndexDataMapRebuildRDD.scala
@@ -338,7 +338,7 @@ class IndexDataMapRebuildRDD[K, V](
     val segmentId = inputSplit.getAllSplits.get(0).getSegment.getSegmentNo
     val segment = segments.find(p => p.getSegmentNo.equals(segmentId))
     if (segment.isDefined) {
-      inputMetrics.initBytesReadCallback(context, inputSplit)
+      inputMetrics.initBytesReadCallback(context, inputSplit, inputMetricsInterval)
 
       val attemptId = new TaskAttemptID(jobTrackerId, id, TaskType.MAP, split.index, 0)
       val attemptContext = new TaskAttemptContextImpl(FileFactory.getConfiguration, attemptId)


### PR DESCRIPTION
**Problem:** wrong Input metrics (size/record) displayed in spark UI during insert into

**cause:** 
a) size metrics was wrong as the update didn't happen to spark input metrics because of below problem
NewDataFrameRDD was setting thread local id, which was override by ScanRDD thread local id
due to multi level RDD.
b) Record metrics was not proper because, during insert into scanRDD will be called by multiple threads. Hence synchronisation was not there as one spark input metric (task level) is used by all the concurrent scanRDD.

**solution:**
a) To fix the size, set threadlocal for parent RDD and don't set threadlocal for child RDD If it is already registered. 

b) To fix record, add synchronisation for record metrics (decrease the frequency by checking after interval)

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed? NA
 
 - [ ] Any backward compatibility impacted? NA
 
 - [ ] Document update required? NA

 - [ ] Testing done. 
done. tested in cluster with huge data.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. NA

