### PR TITLE
[CARBONDATA-3485] Data loading is failed from S3 to hdfs table having ~2K carbonfiles

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/scan/result/iterator/AbstractDetailQueryResultIterator.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/iterator/AbstractDetailQueryResultIterator.java
@@ -217,12 +217,12 @@ public abstract class AbstractDetailQueryResultIterator<E> extends CarbonIterato
   }
 
   private DataBlockIterator getDataBlockIterator() {
+    try {
+      fileReader.finish();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
     if (blockExecutionInfos.size() > 0) {
-      try {
-        fileReader.finish();
-      } catch (IOException e) {
-        throw new RuntimeException(e);
-      }
       BlockExecutionInfo executionInfo = blockExecutionInfos.get(0);
       blockExecutionInfos.remove(executionInfo);
       return new DataBlockIterator(executionInfo, fileReader, batchSize, queryStatisticsModel,


### PR DESCRIPTION
Root Cause :- Since opened iterator for carbon files for same Executor and last Filter Channel in each iterator was missed for close. In S3 there is limit of files which can be opened so data loading is failed. 
Solution :- call fileReader.close on each next BlockIterator so that no File Handler is missed. 

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 NO
 - [ ] Any backward compatibility impacted?
 No
 - [ ] Document update required?
NO
 - [ ] Testing done
     Manually
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA
