### PR TITLE
[CARBONDATA-3486] Fix Serialization/Deserialization issue with DataType

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/FilterUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/FilterUtil.java
@@ -1524,17 +1524,18 @@ public final class FilterUtil {
       DimColumnExecuterFilterInfo dimColumnExecuterInfo, CarbonMeasure measures,
       MeasureColumnExecuterFilterInfo msrColumnExecuterInfo) {
     if (null != measures) {
+      DataType filterColumnDataType = DataTypes.valueOf(measures.getDataType().getId());
       DataTypeConverterImpl converter = new DataTypeConverterImpl();
       Object[] keysBasedOnFilter = filterValues.getMeasuresFilterValuesList()
           .toArray((new Object[filterValues.getMeasuresFilterValuesList().size()]));
       for (int i = 0; i < keysBasedOnFilter.length; i++) {
         if (keysBasedOnFilter[i] != null) {
           keysBasedOnFilter[i] = DataTypeUtil
-              .getDataBasedOnDataType(keysBasedOnFilter[i].toString(), measures.getDataType(),
+              .getDataBasedOnDataType(keysBasedOnFilter[i].toString(), filterColumnDataType,
                   converter);
         }
       }
-      msrColumnExecuterInfo.setFilterKeys(keysBasedOnFilter,  measures.getDataType());
+      msrColumnExecuterInfo.setFilterKeys(keysBasedOnFilter, filterColumnDataType);
     } else {
       if (filterValues == null) {
         dimColumnExecuterInfo.setFilterKeys(new byte[0][]);

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/resolver/resolverinfo/MeasureColumnResolvedFilterInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/resolver/resolverinfo/MeasureColumnResolvedFilterInfo.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.carbondata.core.metadata.datatype.DataTypes;
 import org.apache.carbondata.core.metadata.schema.table.column.CarbonColumn;
 import org.apache.carbondata.core.metadata.schema.table.column.CarbonDimension;
 import org.apache.carbondata.core.metadata.schema.table.column.CarbonMeasure;
@@ -101,7 +102,7 @@ public class MeasureColumnResolvedFilterInfo extends ColumnResolvedFilterInfo
   }
 
   public void setType(org.apache.carbondata.core.metadata.datatype.DataType dataType) {
-    this.type = dataType;
+    this.type = DataTypes.valueOf(dataType.getId());
   }
 
   public CarbonColumn getCarbonColumn() {


### PR DESCRIPTION
Problem: When we use old store and do alter add sort columns on it then query on the old segment, serialization/de-serialization issue comes for Filter Column of Measure type which has been changed in Sort Column as it is being de-serialized by ObjectSerialization. This fails the check and the query.

Solution: Checked the datatype based on Datatype ID and not on the object.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

