### PR TITLE
[CARBONDATA-3488] Check the file size after move local file to carbon path

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
@@ -2739,28 +2739,28 @@ public final class CarbonUtil {
     LOGGER.info(String.format("Copying %s to %s, operation id %d", localFilePath,
         carbonDataDirectoryPath, copyStartTime));
     try {
-      CarbonFile localCarbonFile =
-          FileFactory.getCarbonFile(localFilePath, FileFactory.getFileType(localFilePath));
+      CarbonFile localCarbonFile = FileFactory.getCarbonFile(localFilePath);
+      // the size of local carbon file must be greater than 0
       if (localCarbonFile.getSize() == 0L) {
-        LOGGER.error("The file size of local carbon file: " + localFilePath + " is 0.");
-        throw new CarbonDataWriterException(
-            "The file size of local carbon file is 0.");
+        LOGGER.error("The size of local carbon file: " + localFilePath + " is 0.");
+        throw new CarbonDataWriterException("The size of local carbon file is 0.");
       }
       String carbonFilePath = carbonDataDirectoryPath + localFilePath
           .substring(localFilePath.lastIndexOf(File.separator));
       copyLocalFileToCarbonStore(carbonFilePath, localFilePath,
           CarbonCommonConstants.BYTEBUFFER_SIZE,
           getMaxOfBlockAndFileSize(fileSizeInBytes, localCarbonFile.getSize()));
-      CarbonFile targetCarbonFile =
-          FileFactory.getCarbonFile(carbonFilePath, FileFactory.getFileType(carbonFilePath));
-      if (targetCarbonFile.getSize() == 0L
-          || (targetCarbonFile.getSize() != localCarbonFile.getSize())) {
-        LOGGER.error("The file size of carbon file: " + carbonFilePath + " is 0 "
-            + "or is not the same as the file size of local carbon file: ("
+      CarbonFile targetCarbonFile = FileFactory.getCarbonFile(carbonFilePath);
+      // the size of carbon file must be greater than 0
+      // and the same as the size of local carbon file
+      if (targetCarbonFile.getSize() == 0L ||
+          (targetCarbonFile.getSize() != localCarbonFile.getSize())) {
+        LOGGER.error("The size of carbon file: " + carbonFilePath + " is 0 "
+            + "or is not the same as the size of local carbon file: ("
             + "carbon file size=" + targetCarbonFile.getSize()
             + ", local carbon file size=" + localCarbonFile.getSize() + ")");
-        throw new CarbonDataWriterException("The file size of carbon file is 0 "
-            + "or is not the same as the file size of local carbon file.");
+        throw new CarbonDataWriterException("The size of carbon file is 0 "
+            + "or is not the same as the size of local carbon file.");
       }
     } catch (Exception e) {
       throw new CarbonDataWriterException(

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
@@ -2741,12 +2741,28 @@ public final class CarbonUtil {
     try {
       CarbonFile localCarbonFile =
           FileFactory.getCarbonFile(localFilePath, FileFactory.getFileType(localFilePath));
+      if (localCarbonFile.getSize() == 0l) {
+        LOGGER.error("The file size of local carbon file: " + localFilePath + " is 0.");
+        throw new CarbonDataWriterException(
+            "The file size of local carbon file is 0.");
+      }
       String carbonFilePath = carbonDataDirectoryPath + localFilePath
           .substring(localFilePath.lastIndexOf(File.separator));
       copyLocalFileToCarbonStore(carbonFilePath, localFilePath,
           CarbonCommonConstants.BYTEBUFFER_SIZE,
           getMaxOfBlockAndFileSize(fileSizeInBytes, localCarbonFile.getSize()));
-    } catch (IOException e) {
+      CarbonFile targetCarbonFile =
+          FileFactory.getCarbonFile(carbonFilePath, FileFactory.getFileType(carbonFilePath));
+      if (targetCarbonFile.getSize() == 0l
+          || (targetCarbonFile.getSize() != localCarbonFile.getSize())) {
+        LOGGER.error("The file size of carbon file: " + carbonFilePath + " is 0 "
+            + "or is not the same as the file size of local carbon file: ("
+            + "carbon file size=" + targetCarbonFile.getSize()
+            + ", local carbon file size=" + localCarbonFile.getSize() + ")");
+        throw new CarbonDataWriterException("The file size of carbon file is 0 "
+            + "or is not the same as the file size of local carbon file.");
+      }
+    } catch (Exception e) {
       throw new CarbonDataWriterException(
           "Problem while copying file from local store to carbon store", e);
     }

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
@@ -2741,7 +2741,7 @@ public final class CarbonUtil {
     try {
       CarbonFile localCarbonFile =
           FileFactory.getCarbonFile(localFilePath, FileFactory.getFileType(localFilePath));
-      if (localCarbonFile.getSize() == 0l) {
+      if (localCarbonFile.getSize() == 0L) {
         LOGGER.error("The file size of local carbon file: " + localFilePath + " is 0.");
         throw new CarbonDataWriterException(
             "The file size of local carbon file is 0.");
@@ -2753,7 +2753,7 @@ public final class CarbonUtil {
           getMaxOfBlockAndFileSize(fileSizeInBytes, localCarbonFile.getSize()));
       CarbonFile targetCarbonFile =
           FileFactory.getCarbonFile(carbonFilePath, FileFactory.getFileType(carbonFilePath));
-      if (targetCarbonFile.getSize() == 0l
+      if (targetCarbonFile.getSize() == 0L
           || (targetCarbonFile.getSize() != localCarbonFile.getSize())) {
         LOGGER.error("The file size of carbon file: " + carbonFilePath + " is 0 "
             + "or is not the same as the file size of local carbon file: ("


### PR DESCRIPTION
**Problem:**
the row num saved in carbonindex file is non zero but the file size of relevant carbondata file is 0.

**Solution:**
In CarbonUtil.copyCarbonDataFileToCarbonStorePath, check the file size of carbon file whether is the same as the size fo local file after move local file to carbon path.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?  No
 
 - [ ] Any backward compatibility impacted?  No
 
 - [ ] Document update required?  No

 - [ ] Testing done  No
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

