### PR TITLE
[HOTFIX] Fix dictionary include issue with codegen failure

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/optimizer/CarbonLateDecodeRule.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/optimizer/CarbonLateDecodeRule.scala
@@ -713,9 +713,10 @@ class CarbonLateDecodeRule extends Rule[LogicalPlan] with PredicateHelper {
             prExp.transform {
               case attr: AttributeReference =>
                 updateDataType(attr, attrMap, allAttrsNotDecode, aliasMap)
-            }
+            }.asInstanceOf[NamedExpression]
+          } else {
+            prExp
           }
-          prExp
         }
         Project(prExps, p.child)
       case wd: Window if relations.nonEmpty =>


### PR DESCRIPTION
**problem:** when whole codegen is false, query on dictionary include column fails.

**cause**: This is because, the data type is not updated for dictionary include column.

**solution:** return the updated expression when data type is changed for the dictionary include column

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed? NA
 
 - [ ] Any backward compatibility impacted? NA
 
 - [ ] Document update required? NA

 - [ ] Testing done. yes.

 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. NA

