### PR TITLE
[CARBONDATA-3489] Optimized the comparator instances in sort

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/util/comparator/Comparator.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/comparator/Comparator.java
@@ -26,33 +26,20 @@ import org.apache.carbondata.core.util.ByteUtil;
 public final class Comparator {
 
   //Comparators are made static so that only one instance is generated
-  private static SerializableComparator Boolean  = new BooleanSerializableComparator();
-  private static SerializableComparator Int = new IntSerializableComparator();
-  private static SerializableComparator Short = new ShortSerializableComparator();
-  private static SerializableComparator Double = new DoubleSerializableComparator();
-  private static SerializableComparator Float = new FloatSerializableComparator();
-  private static SerializableComparator Long = new LongSerializableComparator();
-  private static SerializableComparator Decimal  = new BigDecimalSerializableComparator();
-  private static SerializableComparator Byte = new ByteArraySerializableComparator();
+  private static final SerializableComparator BOOLEAN  = new BooleanSerializableComparator();
+  private static final SerializableComparator INT = new IntSerializableComparator();
+  private static final SerializableComparator SHORT = new ShortSerializableComparator();
+  private static final SerializableComparator DOUBLE = new DoubleSerializableComparator();
+  private static final SerializableComparator FLOAT = new FloatSerializableComparator();
+  private static final SerializableComparator LONG = new LongSerializableComparator();
+  private static final SerializableComparator DECIMAL  = new BigDecimalSerializableComparator();
+  private static final SerializableComparator BYTE = new ByteArraySerializableComparator();
 
   public static SerializableComparator getComparator(DataType dataType) {
-    if (dataType == DataTypes.BOOLEAN) {
-      return Boolean;
-    } else if (dataType == DataTypes.INT) {
-      return Int;
-    } else if (dataType == DataTypes.SHORT) {
-      return Short;
-    } else if (dataType == DataTypes.DOUBLE) {
-      return Double;
-    } else if (dataType == DataTypes.FLOAT) {
-      return Float;
-    } else if (dataType == DataTypes.LONG || dataType == DataTypes.DATE
-        || dataType == DataTypes.TIMESTAMP) {
-      return Long;
-    } else if (DataTypes.isDecimal(dataType)) {
-      return Decimal;
+    if (dataType == DataTypes.DATE || dataType == DataTypes.TIMESTAMP) {
+      return LONG;
     } else {
-      return Byte;
+      return getComparatorByDataTypeForMeasure(dataType);
     }
   }
 
@@ -64,21 +51,21 @@ public final class Comparator {
    */
   public static SerializableComparator getComparatorByDataTypeForMeasure(DataType dataType) {
     if (dataType == DataTypes.BOOLEAN) {
-      return Boolean;
+      return BOOLEAN;
     } else if (dataType == DataTypes.INT) {
-      return Int;
+      return INT;
     } else if (dataType == DataTypes.SHORT) {
-      return Short;
+      return SHORT;
     } else if (dataType == DataTypes.LONG) {
-      return Long;
+      return LONG;
     } else if (dataType == DataTypes.DOUBLE) {
-      return Double;
+      return DOUBLE;
     } else if (dataType == DataTypes.FLOAT) {
-      return Float;
+      return FLOAT;
     } else if (DataTypes.isDecimal(dataType)) {
-      return Decimal;
+      return DECIMAL;
     } else if (dataType == DataTypes.BYTE) {
-      return Byte;
+      return BYTE;
     } else {
       throw new IllegalArgumentException("Unsupported data type: " + dataType.getName());
     }

--- a/core/src/main/java/org/apache/carbondata/core/util/comparator/Comparator.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/comparator/Comparator.java
@@ -38,6 +38,8 @@ public final class Comparator {
   public static SerializableComparator getComparator(DataType dataType) {
     if (dataType == DataTypes.DATE || dataType == DataTypes.TIMESTAMP) {
       return LONG;
+    } else if(dataType == DataTypes.STRING){
+      return BYTE;
     } else {
       return getComparatorByDataTypeForMeasure(dataType);
     }

--- a/core/src/main/java/org/apache/carbondata/core/util/comparator/Comparator.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/comparator/Comparator.java
@@ -38,7 +38,7 @@ public final class Comparator {
   public static SerializableComparator getComparator(DataType dataType) {
     if (dataType == DataTypes.DATE || dataType == DataTypes.TIMESTAMP) {
       return LONG;
-    } else if(dataType == DataTypes.STRING){
+    } else if (dataType == DataTypes.STRING) {
       return BYTE;
     } else {
       return getComparatorByDataTypeForMeasure(dataType);

--- a/core/src/main/java/org/apache/carbondata/core/util/comparator/Comparator.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/comparator/Comparator.java
@@ -25,24 +25,34 @@ import org.apache.carbondata.core.util.ByteUtil;
 
 public final class Comparator {
 
+  //Comparators are made static so that only one instance is generated
+  private static SerializableComparator Boolean  = new BooleanSerializableComparator();
+  private static SerializableComparator Int = new IntSerializableComparator();
+  private static SerializableComparator Short = new ShortSerializableComparator();
+  private static SerializableComparator Double = new DoubleSerializableComparator();
+  private static SerializableComparator Float = new FloatSerializableComparator();
+  private static SerializableComparator Long = new LongSerializableComparator();
+  private static SerializableComparator Decimal  = new BigDecimalSerializableComparator();
+  private static SerializableComparator Byte = new ByteArraySerializableComparator();
+
   public static SerializableComparator getComparator(DataType dataType) {
     if (dataType == DataTypes.BOOLEAN) {
-      return new BooleanSerializableComparator();
+      return Boolean;
     } else if (dataType == DataTypes.INT) {
-      return new IntSerializableComparator();
+      return Int;
     } else if (dataType == DataTypes.SHORT) {
-      return new ShortSerializableComparator();
+      return Short;
     } else if (dataType == DataTypes.DOUBLE) {
-      return new DoubleSerializableComparator();
+      return Double;
     } else if (dataType == DataTypes.FLOAT) {
-      return new FloatSerializableComparator();
+      return Float;
     } else if (dataType == DataTypes.LONG || dataType == DataTypes.DATE
         || dataType == DataTypes.TIMESTAMP) {
-      return new LongSerializableComparator();
+      return Long;
     } else if (DataTypes.isDecimal(dataType)) {
-      return new BigDecimalSerializableComparator();
+      return Decimal;
     } else {
-      return new ByteArraySerializableComparator();
+      return Byte;
     }
   }
 
@@ -54,21 +64,21 @@ public final class Comparator {
    */
   public static SerializableComparator getComparatorByDataTypeForMeasure(DataType dataType) {
     if (dataType == DataTypes.BOOLEAN) {
-      return new BooleanSerializableComparator();
+      return Boolean;
     } else if (dataType == DataTypes.INT) {
-      return new IntSerializableComparator();
+      return Int;
     } else if (dataType == DataTypes.SHORT) {
-      return new ShortSerializableComparator();
+      return Short;
     } else if (dataType == DataTypes.LONG) {
-      return new LongSerializableComparator();
+      return Long;
     } else if (dataType == DataTypes.DOUBLE) {
-      return new DoubleSerializableComparator();
+      return Double;
     } else if (dataType == DataTypes.FLOAT) {
-      return new FloatSerializableComparator();
+      return Float;
     } else if (DataTypes.isDecimal(dataType)) {
-      return new BigDecimalSerializableComparator();
+      return Decimal;
     } else if (dataType == DataTypes.BYTE) {
-      return new ByteArraySerializableComparator();
+      return Byte;
     } else {
       throw new IllegalArgumentException("Unsupported data type: " + dataType.getName());
     }

--- a/processing/src/test/java/org/apache/carbondata/processing/loading/partition/impl/RawRowComparatorTest.java
+++ b/processing/src/test/java/org/apache/carbondata/processing/loading/partition/impl/RawRowComparatorTest.java
@@ -29,14 +29,18 @@ public class RawRowComparatorTest {
   private RawRowComparator new_comparator;
 
   @Test public void checkTypes() {
-    DataType noDicDataTypes[] = { DataTypes.INT };
-    SerializableComparator comparator = org.apache.carbondata.core.util.comparator.Comparator
-        .getComparator(noDicDataTypes[0]);
-    SerializableComparator comparator1 = org.apache.carbondata.core.util.comparator.Comparator
-        .getComparator(noDicDataTypes[0]);
-    Assert.assertTrue(comparator1==comparator);
+    DataType noDicDataTypes[] =
+        { DataTypes.INT, DataTypes.SHORT, DataTypes.LONG, DataTypes.BOOLEAN, DataTypes.BYTE,
+            DataTypes.FLOAT };
+    for (int i = 0; i < noDicDataTypes.length; i++) {
+      SerializableComparator comparator = org.apache.carbondata.core.util.comparator.Comparator
+          .getComparator(noDicDataTypes[i]);
+      SerializableComparator comparator1 = org.apache.carbondata.core.util.comparator.Comparator
+          .getComparator(noDicDataTypes[i]);
+      Assert.assertTrue(comparator1==comparator);
+    }
   }
- 
+
   @Test public void compareint() {
     DataType noDicDataTypes[] = { DataTypes.INT };
     boolean noDicSortColumnMapping[] = { true };

--- a/processing/src/test/java/org/apache/carbondata/processing/loading/partition/impl/RawRowComparatorTest.java
+++ b/processing/src/test/java/org/apache/carbondata/processing/loading/partition/impl/RawRowComparatorTest.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.processing.loading.partition.impl;
+
+import org.apache.carbondata.core.datastore.row.CarbonRow;
+import org.apache.carbondata.core.metadata.datatype.DataType;
+import org.apache.carbondata.core.metadata.datatype.DataTypes;
+import org.apache.carbondata.core.util.comparator.SerializableComparator;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class RawRowComparatorTest {
+  private RawRowComparator new_comparator;
+
+  @Test public void checkTypes() {
+    DataType noDicDataTypes[] = { DataTypes.INT };
+    SerializableComparator comparator = org.apache.carbondata.core.util.comparator.Comparator
+        .getComparator(noDicDataTypes[0]);
+    SerializableComparator comparator1 = org.apache.carbondata.core.util.comparator.Comparator
+        .getComparator(noDicDataTypes[0]);
+    Assert.assertTrue(comparator1==comparator);
+  }
+ 
+  @Test public void compareint() {
+    DataType noDicDataTypes[] = { DataTypes.INT };
+    boolean noDicSortColumnMapping[] = { true };
+    int sortColumnIndices[] = { 1 };
+    new_comparator =
+        new RawRowComparator(sortColumnIndices, noDicSortColumnMapping, noDicDataTypes);
+
+    Integer arr[] = { 1, 7, 5 };
+    Integer arr1[] = { 2, 4, 6 };
+    int res = new_comparator.compare(new CarbonRow(arr), new CarbonRow(arr1));
+    Assert.assertTrue(res > 0);
+  }
+
+  @Test public void compareintreverse() {
+    DataType noDicDataTypes[] = { DataTypes.INT };
+    boolean noDicSortColumnMapping[] = { true };
+    int sortColumnIndices[] = { 1 };
+    new_comparator =
+        new RawRowComparator(sortColumnIndices, noDicSortColumnMapping, noDicDataTypes);
+    
+    Integer arr[] = { 2, 7, 5 };
+    Integer arr1[] = { 1, 4, 6 };
+    int res = new_comparator.compare(new CarbonRow(arr1), new CarbonRow(arr));
+    Assert.assertTrue(res < 0);
+  }
+
+  @Test public void compareshort() {
+    DataType noDicDataTypes[] = { DataTypes.SHORT };
+    boolean noDicSortColumnMapping[] = { true };
+    int sortColumnIndices[] = { 1 };
+    new_comparator =
+        new RawRowComparator(sortColumnIndices, noDicSortColumnMapping, noDicDataTypes);
+
+    Short arr[] = { 1, 7, 5 };
+    Short arr1[] = { 2, 4, 6 };
+    int res = new_comparator.compare(new CarbonRow(arr), new CarbonRow(arr1));
+    Assert.assertTrue(res > 0);
+  }
+
+  @Test public void comparelong() {
+    DataType noDicDataTypes[] = { DataTypes.LONG };
+    boolean noDicSortColumnMapping[] = { true };
+    int sortColumnIndices[] = { 1 };
+    new_comparator =
+        new RawRowComparator(sortColumnIndices, noDicSortColumnMapping, noDicDataTypes);
+    Long arr[] = { 1L, 7L, 5L };
+    Long arr1[] = { 2L, 4L, 6L };
+    int res = new_comparator.compare(new CarbonRow(arr), new CarbonRow(arr1));
+    Assert.assertTrue(res > 0);
+  }
+
+  @Test public void comparefloat() {
+    DataType noDicDataTypes[] = { DataTypes.FLOAT };
+    boolean noDicSortColumnMapping[] = { true };
+    int sortColumnIndices[] = { 1 };
+    new_comparator =
+        new RawRowComparator(sortColumnIndices, noDicSortColumnMapping, noDicDataTypes);
+    Float arr[] = { 1F, 7F, 5F };
+    Float arr1[] = { 2F, 4F, 6F };
+    int res = new_comparator.compare(new CarbonRow(arr), new CarbonRow(arr1));
+    Assert.assertTrue(res > 0);
+  }
+
+  @Test public void compareboolean() {
+    DataType noDicDataTypes[] = { DataTypes.BOOLEAN };
+    boolean noDicSortColumnMapping[] = { true };
+    int sortColumnIndices[] = { 1 };
+    new_comparator =
+        new RawRowComparator(sortColumnIndices, noDicSortColumnMapping, noDicDataTypes);
+    Boolean arr[] = { false, false };
+    Boolean arr1[] = { true, true };
+    int res = new_comparator.compare(new CarbonRow(arr), new CarbonRow(arr1));
+    Assert.assertTrue(res < 0);
+  }
+
+   @Test public void comparebyte() {
+    DataType noDicDataTypes[] = { DataTypes.BYTE };
+    boolean noDicSortColumnMapping[] = { true };
+    int sortColumnIndices[] = { 1 };
+    new_comparator =
+        new RawRowComparator(sortColumnIndices, noDicSortColumnMapping, noDicDataTypes);
+    Byte arr[] = { 1, 2, 3 };
+    Byte arr1[] = { 4, 5, 6 };
+    int res = new_comparator.compare(new CarbonRow(arr), new CarbonRow(arr1));
+    Assert.assertTrue(res < 0);
+  }
+
+  @Test public void comparemixed() {
+    DataType noDicDataTypes[] = { DataTypes.INT, DataTypes.SHORT, DataTypes.BOOLEAN };
+    boolean noDicSortColumnMapping[] = { true, true, true };
+    int sortColumnIndices[] = { 1, 2, 3 };
+    new_comparator =
+        new RawRowComparator(sortColumnIndices, noDicSortColumnMapping, noDicDataTypes);
+    Object arr[] = { 1, 2, false };
+    Object arr1[] = { 4, 5, true };
+    int res = new_comparator.compare(new CarbonRow(arr), new CarbonRow(arr1));
+    Assert.assertTrue(res < 0);
+  }
+}

--- a/processing/src/test/java/org/apache/carbondata/processing/sort/sortdata/IntermediateSortTempRowComparatorTest.java
+++ b/processing/src/test/java/org/apache/carbondata/processing/sort/sortdata/IntermediateSortTempRowComparatorTest.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.processing.sort.sortdata;
+
+import org.apache.carbondata.core.metadata.datatype.DataType;
+import org.apache.carbondata.core.metadata.datatype.DataTypes;
+import org.apache.carbondata.processing.loading.row.IntermediateSortTempRow;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class IntermediateSortTempRowComparatorTest {
+  private IntermediateSortTempRowComparator new_comparator;
+
+  @Test public void compareint() {
+    DataType noDicDataTypes[] = { DataTypes.INT };
+    boolean noDicSortColumnMapping[] = { true };
+    new_comparator = new IntermediateSortTempRowComparator(noDicSortColumnMapping, noDicDataTypes);
+
+    int[] dictSortDims1 = {1,2,3};
+    Object[] noDictSortDims1 = {1,2,3};
+    byte[] noSortDimsAndMeasures1 = {1,2,3};
+    IntermediateSortTempRow a1 = new IntermediateSortTempRow(dictSortDims1, noDictSortDims1, noSortDimsAndMeasures1);
+
+    int[] dictSortDims = {1,2,3};
+    Object[] noDictSortDims = {4,5,6};
+    byte[] noSortDimsAndMeasures = {1,2,3};
+    IntermediateSortTempRow a = new IntermediateSortTempRow(dictSortDims, noDictSortDims, noSortDimsAndMeasures);
+
+    int res = new_comparator.compare( a, a1);
+    Assert.assertTrue(res > 0);
+  }
+
+  @Test public void compareintreverse() {
+    DataType noDicDataTypes[] = { DataTypes.INT };
+    boolean noDicSortColumnMapping[] = { true };
+    new_comparator = new IntermediateSortTempRowComparator(noDicSortColumnMapping, noDicDataTypes);
+
+    int[] dictSortDims1 = {1,2,3};
+    Object[] noDictSortDims1 = {1,2,3};
+    byte[] noSortDimsAndMeasures1 = {1,2,3};
+    IntermediateSortTempRow a1 = new IntermediateSortTempRow(dictSortDims1, noDictSortDims1, noSortDimsAndMeasures1);
+
+    int[] dictSortDims = {1,2,3};
+    Object[] noDictSortDims = {4,5,6};
+    byte[] noSortDimsAndMeasures = {1,2,3};
+    IntermediateSortTempRow a = new IntermediateSortTempRow(dictSortDims, noDictSortDims, noSortDimsAndMeasures);
+
+    int res = new_comparator.compare( a1, a);
+    Assert.assertTrue(res < 0);
+  }
+
+  @Test public void comparelong() {
+    DataType noDicDataTypes[] = { DataTypes.LONG };
+    boolean noDicSortColumnMapping[] = { true };
+    new_comparator = new IntermediateSortTempRowComparator(noDicSortColumnMapping, noDicDataTypes);
+
+    int[] dictSortDims1 = {1,2,3};
+    Object[] noDictSortDims1 = {1L,2L,3L};
+    byte[] noSortDimsAndMeasures1 = {1,2,3};
+    IntermediateSortTempRow a1 = new IntermediateSortTempRow(dictSortDims1, noDictSortDims1, noSortDimsAndMeasures1);
+
+    int[] dictSortDims = {1,2,3};
+    Object[] noDictSortDims = {4L,5L,6L};
+    byte[] noSortDimsAndMeasures = {1,2,3};
+    IntermediateSortTempRow a = new IntermediateSortTempRow(dictSortDims, noDictSortDims, noSortDimsAndMeasures);
+
+    int res = new_comparator.compare( a1, a);
+    Assert.assertTrue(res < 0);
+  }
+
+  @Test public void comparefloat() {
+    DataType noDicDataTypes[] = { DataTypes.FLOAT };
+    boolean noDicSortColumnMapping[] = { true };
+    new_comparator = new IntermediateSortTempRowComparator(noDicSortColumnMapping, noDicDataTypes);
+
+    int[] dictSortDims1 = {1,2,3};
+    Object[] noDictSortDims1 = {1F,2F,3F};
+    byte[] noSortDimsAndMeasures1 = {1,2,3};
+    IntermediateSortTempRow a1 = new IntermediateSortTempRow(dictSortDims1, noDictSortDims1, noSortDimsAndMeasures1);
+
+    int[] dictSortDims = {1,2,3};
+    Object[] noDictSortDims = {4F,5F,6F};
+    byte[] noSortDimsAndMeasures = {1,2,3};
+    IntermediateSortTempRow a = new IntermediateSortTempRow(dictSortDims, noDictSortDims, noSortDimsAndMeasures);
+
+    int res = new_comparator.compare( a1, a);
+    Assert.assertTrue(res < 0);
+  }
+
+  @Test public void compareboolean() {
+    DataType noDicDataTypes[] = { DataTypes.BOOLEAN};
+    boolean noDicSortColumnMapping[] = { true };
+    new_comparator = new IntermediateSortTempRowComparator(noDicSortColumnMapping, noDicDataTypes);
+
+    int[] dictSortDims1 = {1,2,3};
+    Object[] noDictSortDims1 = {true};
+    byte[] noSortDimsAndMeasures1 = {1,2,3};
+    IntermediateSortTempRow a1 = new IntermediateSortTempRow(dictSortDims1, noDictSortDims1, noSortDimsAndMeasures1);
+
+    int[] dictSortDims = {1,2,3};
+    Object[] noDictSortDims = {false};
+    byte[] noSortDimsAndMeasures = {1,2,3};
+    IntermediateSortTempRow a = new IntermediateSortTempRow(dictSortDims, noDictSortDims, noSortDimsAndMeasures);
+    int res = new_comparator.compare( a1, a);
+    Assert.assertTrue(res> 0);
+  }
+
+  @Test public void comparebyte() {
+    DataType noDicDataTypes[] = { DataTypes.BYTE};
+    boolean noDicSortColumnMapping[] = { true };
+    new_comparator = new IntermediateSortTempRowComparator(noDicSortColumnMapping, noDicDataTypes);
+
+    int[] dictSortDims1 = {1,2,3};
+    Byte[] noDictSortDims1 = {1,2,3};
+    byte[] noSortDimsAndMeasures1 = {1,2,3};
+    IntermediateSortTempRow a1 = new IntermediateSortTempRow(dictSortDims1, noDictSortDims1, noSortDimsAndMeasures1);
+
+    int[] dictSortDims = {1,2,3};
+    Byte[] noDictSortDims = {3,4,5};
+    byte[] noSortDimsAndMeasures = {1,2,3};
+    IntermediateSortTempRow a = new IntermediateSortTempRow(dictSortDims, noDictSortDims, noSortDimsAndMeasures);
+    int res = new_comparator.compare( a1, a);
+    Assert.assertTrue(res < 0);
+  }
+
+  @Test public void comparemixed() {
+    DataType noDicDataTypes[] = { DataTypes.BOOLEAN, DataTypes.INT, DataTypes.LONG};
+    boolean noDicSortColumnMapping[] = { true };
+    new_comparator = new IntermediateSortTempRowComparator(noDicSortColumnMapping, noDicDataTypes);
+
+    int[] dictSortDims1 = {1,2,3};
+    Object[] noDictSortDims1 = {true, 1, 2L};
+    byte[] noSortDimsAndMeasures1 = {1,2,3};
+    IntermediateSortTempRow a1 = new IntermediateSortTempRow(dictSortDims1, noDictSortDims1, noSortDimsAndMeasures1);
+
+    int[] dictSortDims = {1,2,3};
+    Object[] noDictSortDims = {false, 3, 5L};
+    byte[] noSortDimsAndMeasures = {1,2,3};
+    IntermediateSortTempRow a = new IntermediateSortTempRow(dictSortDims, noDictSortDims, noSortDimsAndMeasures);
+    int res = new_comparator.compare( a1, a);
+    Assert.assertTrue(res > 0);
+  }
+
+  @Test public void compareshort() {
+    DataType noDicDataTypes[] = { DataTypes.SHORT};
+    boolean noDicSortColumnMapping[] = { true };
+    new_comparator = new IntermediateSortTempRowComparator(noDicSortColumnMapping, noDicDataTypes);
+
+    int[] dictSortDims1 = {1,2,3};
+    Short[] noDictSortDims1 = {2};
+    byte[] noSortDimsAndMeasures1 = {1,2,3};
+    IntermediateSortTempRow a1 = new IntermediateSortTempRow(dictSortDims1, noDictSortDims1, noSortDimsAndMeasures1);
+
+    int[] dictSortDims = {1,2,3};
+    Short[] noDictSortDims = {1};
+    byte[] noSortDimsAndMeasures = {1,2,3};
+    IntermediateSortTempRow a = new IntermediateSortTempRow(dictSortDims, noDictSortDims, noSortDimsAndMeasures);
+
+    int res = new_comparator.compare( a1, a);
+    Assert.assertTrue(res > 0);
+  }
+} 

--- a/processing/src/test/java/org/apache/carbondata/processing/sort/sortdata/NewRowComparatorTest.java
+++ b/processing/src/test/java/org/apache/carbondata/processing/sort/sortdata/NewRowComparatorTest.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.processing.sort.sortdata;
+
+import org.apache.carbondata.core.metadata.datatype.DataType;
+import org.apache.carbondata.core.metadata.datatype.DataTypes;
+import org.apache.carbondata.core.util.comparator.SerializableComparator;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class NewRowComparatorTest {
+  private NewRowComparator new_comparator;
+
+  @Test public void compareint() {
+    DataType noDicDataTypes[] = { DataTypes.INT };
+    boolean noDicSortColumnMapping[] = { true };
+    new_comparator = new NewRowComparator(noDicSortColumnMapping, noDicDataTypes);
+    Integer arr[] = { 1, 7, 5 };
+    Integer arr1[] = { 2, 4, 6 };
+    int res = new_comparator.compare(arr, arr1);
+    Assert.assertTrue(res < 0);
+  }
+
+  @Test public void compareintreverse() {
+    DataType noDicDataTypes[] = { DataTypes.INT };
+    boolean noDicSortColumnMapping[] = { true };
+    new_comparator = new NewRowComparator(noDicSortColumnMapping, noDicDataTypes);
+    Integer arr[] = { 1, 2, 3 };
+    Integer arr1[] = { 4, 5, 6 };
+    int res = new_comparator.compare(arr1, arr);
+    Assert.assertTrue(res > 0);
+  }
+
+  @Test public void compareshort() {
+    DataType noDicDataTypes[] = { DataTypes.SHORT };
+    boolean noDicSortColumnMapping[] = { true };
+    new_comparator = new NewRowComparator(noDicSortColumnMapping, noDicDataTypes);
+    Short arr[] = { 1, 2, 3 };
+    Short arr1[] = { 4, 5, 6 };
+    int res = new_comparator.compare(arr, arr1);
+    Assert.assertTrue(res < 0);
+  }
+
+  @Test public void comparelong() {
+    DataType noDicDataTypes[] = { DataTypes.LONG };
+    boolean noDicSortColumnMapping[] = { true };
+    new_comparator = new NewRowComparator(noDicSortColumnMapping, noDicDataTypes);
+    Long arr[] = { 1L, 2L, 3L };
+    Long arr1[] = { 4L, 5L, 6L };
+    int res = new_comparator.compare(arr, arr1);
+    Assert.assertTrue(res < 0);
+  }
+
+  @Test public void comparefloat() {
+    DataType noDicDataTypes[] = { DataTypes.FLOAT };
+    boolean noDicSortColumnMapping[] = { true };
+    new_comparator = new NewRowComparator(noDicSortColumnMapping, noDicDataTypes);
+    Float arr[] = { 1F, 2F, 3F };
+    Float arr1[] = { 4F, 5F, 6F };
+    int res = new_comparator.compare(arr, arr1);
+    Assert.assertTrue(res < 0);
+  }
+
+  @Test public void compareboolean() {
+    DataType noDicDataTypes[] = { DataTypes.BOOLEAN };
+    boolean noDicSortColumnMapping[] = { true };
+    new_comparator = new NewRowComparator(noDicSortColumnMapping, noDicDataTypes);
+    Boolean arr[] = { false };
+    Boolean arr1[] = { true };
+    int res = new_comparator.compare(arr, arr1);
+    Assert.assertTrue(res < 0);
+  }
+
+  @Test public void comparebyte() {
+    DataType noDicDataTypes[] = { DataTypes.BYTE };
+    boolean noDicSortColumnMapping[] = { true };
+    new_comparator = new NewRowComparator(noDicSortColumnMapping, noDicDataTypes);
+    Byte arr[] = { 1, 2, 3 };
+    Byte arr1[] = { 4, 5, 6 };
+    int res = new_comparator.compare(arr, arr1);
+    Assert.assertTrue(res < 0);
+  }
+ 
+  @Test public void comparemixed() {
+    DataType noDicDataTypes[] = { DataTypes.INT, DataTypes.FLOAT, DataTypes.BOOLEAN };
+    boolean noDicSortColumnMapping[] = { true, true, true };
+    new_comparator = new NewRowComparator(noDicSortColumnMapping, noDicDataTypes);
+    Object arr[] = { 1, 2F, false };
+    Object arr1[] = { 4, 5F, true };
+    int res = new_comparator.compare(arr, arr1);
+    Assert.assertTrue(res < 0);
+  }
+}


### PR DESCRIPTION
[CARBONDATA-3489] Optimized the comparator instances in sort

Root cause: In case of sorting in the comparator classes(NewRowComparator, RawRowComparator, IntermediateSortTempRowComparator and  UnsafeRowComparator) a new SerializableComparator object is been created in the compare method everytime two objects are passed for comparison.

Solution: We can reduce the number of SerializeableComparator objects that are been created by storing the SerializeableComparators of primitive datatypes  in a map and getting it from the map instead of creating a new SerializeableComparator everytime.

Tested on: 1 TB data on a 10 node cluster.
Sort Configuration: Global Sort with 400 global sort partitions
Reduced load time from 6241 seconds to 6230 seconds (11 seconds improvement)

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed? NA
 
 - [ ] Any backward compatibility impacted? NA
 
 - [ ] Document update required? NA

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

