### PR TITLE
[CARBONDATA-3523] Store data file size into index file

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/block/TableBlockInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/block/TableBlockInfo.java
@@ -54,6 +54,11 @@ public class TableBlockInfo implements Distributable, Serializable {
   private String filePath;
 
   /**
+   * file size of the block
+   */
+  private long fileSize;
+
+  /**
    * block offset in the file
    */
   private long blockOffset;
@@ -437,6 +442,14 @@ public class TableBlockInfo implements Distributable, Serializable {
 
   public void setFilePath(String filePath) {
     this.filePath = filePath;
+  }
+
+  public long getFileSize() {
+    return fileSize;
+  }
+
+  public void setFileSize(long fileSize) {
+    this.fileSize = fileSize;
   }
 
   public BlockletDetailInfo getDetailInfo() {

--- a/core/src/main/java/org/apache/carbondata/core/metadata/index/BlockIndexInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/index/BlockIndexInfo.java
@@ -51,6 +51,11 @@ public class BlockIndexInfo {
   private BlockletInfo blockletInfo;
 
   /**
+   * file size
+   */
+  private long fileSize;
+
+  /**
    * Constructor
    *
    * @param numberOfRows  number of rows
@@ -78,6 +83,12 @@ public class BlockIndexInfo {
       BlockletIndex blockletIndex, BlockletInfo blockletInfo) {
     this(numberOfRows, fileName, offset, blockletIndex);
     this.blockletInfo = blockletInfo;
+  }
+
+  public BlockIndexInfo(long numberOfRows, String fileName, long offset,
+      BlockletIndex blockletIndex, BlockletInfo blockletInfo, long fileSize) {
+    this(numberOfRows, fileName, offset, blockletIndex, blockletInfo);
+    this.fileSize = fileSize;
   }
 
   /**
@@ -113,5 +124,12 @@ public class BlockIndexInfo {
    */
   public BlockletInfo getBlockletInfo() {
     return blockletInfo;
+  }
+
+  /**
+   * @return file size
+   */
+  public long getFileSize() {
+    return fileSize;
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/util/AbstractDataFileFooterConverter.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/AbstractDataFileFooterConverter.java
@@ -244,6 +244,9 @@ public abstract class AbstractDataFileFooterConverter {
     }
     fileName = (CarbonCommonConstants.FILE_SEPARATOR + fileName).replaceAll("//", "/");
     tableBlockInfo.setFilePath(parentPath + fileName);
+    if (readBlockIndexInfo.isSetFile_size()) {
+      tableBlockInfo.setFileSize(readBlockIndexInfo.getFile_size());
+    }
     return tableBlockInfo;
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonMetadataUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonMetadataUtil.java
@@ -392,6 +392,7 @@ public class CarbonMetadataUtil {
       if (blockIndexInfo.getBlockletInfo() != null) {
         blockIndex.setBlocklet_info(getBlocletInfo3(blockIndexInfo.getBlockletInfo()));
       }
+      blockIndex.setFile_size(blockIndexInfo.getFileSize());
       thriftBlockIndexList.add(blockIndex);
     }
     return thriftBlockIndexList;

--- a/processing/src/main/java/org/apache/carbondata/processing/store/writer/AbstractFactDataWriter.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/writer/AbstractFactDataWriter.java
@@ -365,10 +365,11 @@ public abstract class AbstractFactDataWriter implements CarbonFactDataWriter {
    *
    * @param numberOfRows    number of rows in file
    * @param carbonDataFileName The name of carbonData file
-   * @param currentPosition current offset
+   * @param footerOffset footer offset
+   * @param fileSize
    */
   protected abstract void fillBlockIndexInfoDetails(long numberOfRows, String carbonDataFileName,
-      long currentPosition);
+      long footerOffset, long fileSize);
 
   public static List<org.apache.carbondata.format.ColumnSchema> getColumnSchemaListAndCardinality(
       List<Integer> cardinality, int[] dictionaryColumnCardinality,


### PR DESCRIPTION
Store data file size into the index file
[Background]
In BlockIndex, the file_size is always zero. We can set the actual value during data loading and use it during the query to improve the scenario of disaggregated compute and storage.
[Benefi]
For cloud and local table, it will help to improve the driver performance of the first query. 
1. avoid invoking listFiles for each segment 
2. avoid invoking getFileStatus for each data file 

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

