### PR TITLE
[CARBONDATA-3452] dictionary include udf handle all the scenarios

### DIFF
--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableOutputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableOutputFormat.java
@@ -19,6 +19,7 @@ package org.apache.carbondata.hadoop.api;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -221,8 +222,8 @@ public class CarbonTableOutputFormat extends FileOutputFormat<NullWritable, Obje
       return (String[]) ObjectSerializationUtil.convertStringToObject(encodedString);
     }
     return new String[] {
-        System.getProperty("java.io.tmpdir") + "/" + System.nanoTime() + "_" + taskAttemptContext
-            .getTaskAttemptID().toString() };
+        System.getProperty("java.io.tmpdir") + "/" + UUID.randomUUID().toString().replace("-", "")
+            + "_" + taskAttemptContext.getTaskAttemptID().toString() };
   }
 
   @Override

--- a/integration/spark2/src/test/scala/org/apache/spark/carbondata/query/SubQueryJoinTestSuite.scala
+++ b/integration/spark2/src/test/scala/org/apache/spark/carbondata/query/SubQueryJoinTestSuite.scala
@@ -56,4 +56,23 @@ class SubQueryJoinTestSuite extends Spark2QueryTest with BeforeAndAfterAll {
     sql("drop table t1")
     sql("drop table t2")
   }
+
+  test("test join with dictionary include with udf") {
+    sql("drop table if exists t1")
+    sql("drop table if exists t2")
+    sql(
+      "create table t1 (m_month smallint, hs_code string, country smallint, dollar_value double, " +
+      "quantity double, unit smallint, b_country smallint, imex int, y_year smallint) stored by " +
+      "'carbondata' tblproperties('dictionary_include'='m_month,hs_code,b_country,unit,y_year," +
+      "imex', 'sort_columns'='y_year,m_month,country,b_country,imex')")
+    sql(
+      "create table t2(id bigint, hs string, hs_cn string, hs_en string) stored by 'carbondata' " +
+      "tblproperties ('dictionary_include'='id,hs,hs_cn,hs_en')")
+    checkAnswer(sql(
+      "select a.hs,count(*) tb from (select substring(hs_code,1,2) as hs,count(*) v2000 from t1 " +
+      "group by substring(hs_code,1,2),y_year) a left join t2 h on (a.hs=h.hs) group by a.hs"),
+      Seq())
+    sql("drop table if exists t1")
+    sql("drop table if exists t2")
+  }
 }

--- a/processing/src/main/java/org/apache/carbondata/processing/util/CarbonDataProcessorUtil.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/util/CarbonDataProcessorUtil.java
@@ -94,8 +94,11 @@ public final class CarbonDataProcessorUtil {
       if (dir.exists()) {
         LOGGER.warn("dir already exists, skip dir creation: " + loc);
       } else {
-        if (!dir.mkdirs()) {
+        if (!dir.mkdirs() && !dir.exists()) {
+          // concurrent scenario mkdir may fail, so checking dir
           LOGGER.error("Error occurs while creating dir: " + loc);
+        } else {
+          LOGGER.info("Successfully created dir: " + loc);
         }
       }
     }


### PR DESCRIPTION
problem: select query failure when substring on dictionary column with join.

cause: when dictionary include is present, data type is updated to int from string in plan attribute. so substring was unresolved on int column. Join operation try to reference this attribute which is unresolved.

solution: **Need to handle this for all the scenarios in CarbonLateDecodeRule**

**Also pushed missed files during merge of #3352** 

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed? NA
 
 - [ ] Any backward compatibility impacted? NA
 
 - [ ] Document update required? NA

 - [ ] Testing done. NA
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.  NA

