### PR TITLE
[CARBONDATA-3494]Fix NullPointerException in drop table and Correct the document formatting

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datamap/DataMapStoreManager.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/DataMapStoreManager.java
@@ -598,6 +598,11 @@ public final class DataMapStoreManager {
    */
   public void deleteDataMap(AbsoluteTableIdentifier identifier, String dataMapName) {
     CarbonTable carbonTable = getCarbonTable(identifier);
+    if (carbonTable == null) {
+      // If carbon table is null then it means table is already deleted, therefore return without
+      // doing any further changes.
+      return;
+    }
     String tableUniqueName = identifier.getCarbonTableIdentifier().getTableUniqueName();
     if (CarbonProperties.getInstance()
         .isDistributedPruningEnabled(identifier.getDatabaseName(), identifier.getTableName())) {
@@ -613,7 +618,7 @@ public final class DataMapStoreManager {
       if (tableIndices != null) {
         int i = 0;
         for (TableDataMap tableDataMap : tableIndices) {
-          if (carbonTable != null && tableDataMap != null && dataMapName
+          if (tableDataMap != null && dataMapName
               .equalsIgnoreCase(tableDataMap.getDataMapSchema().getDataMapName())) {
             try {
               DataMapUtil

--- a/docs/index-server.md
+++ b/docs/index-server.md
@@ -136,11 +136,9 @@ The Index Server is a long running service therefore the 'spark.yarn.keytab' and
 | Name     |      Default Value    |  Description |
 |:----------:|:-------------:|:------:       |
 | carbon.enable.index.server       |  false | Enable the use of index server for pruning for the whole application.       |
-| carbon.index.server.ip |    NA   |   Specify the IP/HOST on which the server is started. Better to
- specify the private IP. |
+| carbon.index.server.ip |    NA   |   Specify the IP/HOST on which the server is started. Better to specify the private IP. |
 | carbon.index.server.port | NA | The port on which the index server is started. |
-| carbon.disable.index.server.fallback | false | Whether to enable/disable fallback for index server
-. Should be used for testing purposes only. Refer: [Fallback](#Fallback)|
+| carbon.disable.index.server.fallback | false | Whether to enable/disable fallback for index server. Should be used for testing purposes only. Refer: [Fallback](#Fallback)|
 |carbon.index.server.max.jobname.length|NA|The max length of the job to show in the index server service UI. For bigger queries this may impact performance as the whole string would be sent from JDBCServer to IndexServer.|
 
 


### PR DESCRIPTION
**Problem:**
1. Fix the formatting of the document in index server md file.
2. drop table is calling drop datamap command with force drop as true. Due to this table is removed from meta and physically. Then when processData is called for drop table, it tried to create carbonTable object by reading schema which causes NullPointerException.

**Solution:**
1. correct the formatting
2. Skip ProcessData if carbonTable is null

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

