### PR TITLE
[CARBONDATA-3495] Fix Insert into Complex data type of Binary failure with Carbon & SparkFileFormat

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/ComplexColumnPage.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/ComplexColumnPage.java
@@ -124,6 +124,7 @@ public class ComplexColumnPage {
             DataTypes.isMapType(dataType) ||
             (dataType == DataTypes.STRING) ||
             (dataType == DataTypes.VARCHAR) ||
+            (dataType == DataTypes.BINARY) ||
             (dataType == DataTypes.DATE) ||
             DataTypes.isDecimal(dataType))))) {
       // For all these above condition the ColumnPage should be Taken as BYTE_ARRAY

--- a/core/src/main/java/org/apache/carbondata/core/util/DataTypeUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/DataTypeUtil.java
@@ -530,6 +530,7 @@ public final class DataTypeUtil {
   public static boolean isFixedSizeDataType(DataType dataType) {
     if (dataType == DataTypes.STRING ||
         dataType == DataTypes.VARCHAR ||
+        dataType == DataTypes.BINARY ||
         DataTypes.isDecimal(dataType)) {
       return false;
     } else {
@@ -1019,6 +1020,8 @@ public final class DataTypeUtil {
       return DataTypes.BYTE_ARRAY;
     } else if (DataTypes.BYTE_ARRAY.getName().equalsIgnoreCase(name)) {
       return DataTypes.BYTE_ARRAY;
+    } else if (DataTypes.BINARY.getName().equalsIgnoreCase(name)) {
+      return DataTypes.BINARY;
     } else if (name.equalsIgnoreCase("decimal")) {
       return DataTypes.createDefaultDecimalType();
     } else if (name.equalsIgnoreCase("array")) {

--- a/integration/spark-common-test/src/test/resources/complexbinary.csv
+++ b/integration/spark-common-test/src/test/resources/complexbinary.csv
@@ -1,0 +1,3 @@
+1,true,abc,binary1$binary2,binary1,1&binary1
+2,false,abcd,binary11$binary12,binary11,1&binary2
+3,true,abcde,binary13$binary13,binary13,1&binary3

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
@@ -1511,6 +1511,8 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
     field.dataType.getOrElse("NIL") match {
       case "String" => Field(parentName + "." + field.column, Some("String"),
         Some(parentName + "." + field.name.getOrElse(None)), Some(null), parentName)
+      case "binary" => Field(parentName + "." + field.column, Some("Binary"),
+        Some(parentName + "." + field.name.getOrElse(None)), Some(null), parentName)
       case "SmallInt" => Field(parentName + "." + field.column, Some("SmallInt"),
         Some(parentName + "." + field.name.getOrElse(None)), Some(null), parentName)
       case "Integer" => Field(parentName + "." + field.column, Some("Integer"),

--- a/processing/src/main/java/org/apache/carbondata/processing/datatypes/PrimitiveDataType.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/datatypes/PrimitiveDataType.java
@@ -378,6 +378,9 @@ public class PrimitiveDataType implements GenericDataType<Object> {
                 } else {
                   value = ByteUtil.toXorBytes(Long.parseLong(parsedValue));
                 }
+              } else if (this.carbonDimension.getDataType().equals(DataTypes.BINARY)) {
+                value = DataTypeUtil.getBytesDataDataTypeForNoDictionaryColumn(input,
+                    this.carbonDimension.getDataType());
               } else {
                 value = DataTypeUtil.getBytesBasedOnDataTypeForNoDictionaryColumn(parsedValue,
                     this.carbonDimension.getDataType(), dateFormat);


### PR DESCRIPTION
Problem:
Insert into Complex data type(Array/Struct/Map) of binary data type fails with Invalid data type name, because Binary with complex data types is not handled

Solution:
Handle Binary data type to work with complex data types

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [x] Testing done
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

