### PR TITLE
[CARBONDATA-3499] Fix insert failure with customFileProvider

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/impl/DefaultFileTypeProvider.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/impl/DefaultFileTypeProvider.java
@@ -43,7 +43,9 @@ public class DefaultFileTypeProvider implements FileTypeInterface {
    */
   protected FileTypeInterface customFileTypeProvider = null;
 
-  protected boolean customFileTypeProviderInitialized = false;
+  protected Boolean customFileTypeProviderInitialized = false;
+
+  private final Object lock = new Object();
 
   public DefaultFileTypeProvider() {
   }
@@ -52,17 +54,22 @@ public class DefaultFileTypeProvider implements FileTypeInterface {
    * This method is required apart from Constructor to handle the below circular dependency.
    * CarbonProperties-->FileFactory-->DefaultTypeProvider-->CarbonProperties
    */
-  private void initializeCustomFileprovider() {
+  private void initializeCustomFileProvider() {
     if (!customFileTypeProviderInitialized) {
-      customFileTypeProviderInitialized = true;
-      String customFileProvider =
-          CarbonProperties.getInstance().getProperty(CarbonCommonConstants.CUSTOM_FILE_PROVIDER);
-      if (customFileProvider != null && !customFileProvider.trim().isEmpty()) {
-        try {
-          customFileTypeProvider =
-              (FileTypeInterface) Class.forName(customFileProvider).newInstance();
-        } catch (Exception e) {
-          LOGGER.error("Unable load configured FileTypeInterface class. Ignored.", e);
+      // This initialization can happen in concurrent threads.
+      synchronized (lock) {
+        if (!customFileTypeProviderInitialized) {
+          String customFileProvider = CarbonProperties.getInstance()
+              .getProperty(CarbonCommonConstants.CUSTOM_FILE_PROVIDER);
+          if (customFileProvider != null && !customFileProvider.trim().isEmpty()) {
+            try {
+              customFileTypeProvider =
+                  (FileTypeInterface) Class.forName(customFileProvider).newInstance();
+            } catch (Exception e) {
+              LOGGER.error("Unable load configured FileTypeInterface class. Ignored.", e);
+            }
+            customFileTypeProviderInitialized = true;
+          }
         }
       }
     }
@@ -77,7 +84,7 @@ public class DefaultFileTypeProvider implements FileTypeInterface {
    * @return true if supported by the custom
    */
   @Override public boolean isPathSupported(String path) {
-    initializeCustomFileprovider();
+    initializeCustomFileProvider();
     if (customFileTypeProvider != null) {
       return customFileTypeProvider.isPathSupported(path);
     }


### PR DESCRIPTION
problem: 
Below exception is thrown when the custom file system is used with first time insert randomly.
IllegalArgumentException("Path belongs to unsupported file system") from FileFactory.getFileType() 

cause:
DefaultFileTypeProvider.initializeCustomFileProvider is called concurrently during insert. Hence one thread got the provider and other thread didn't get as flag is set to true.
so other thread failed as it tried with default provider.

solution:
synchronize the initialization of custom file provider.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed? NA
 
 - [ ] Any backward compatibility impacted? NA
 
 - [ ] Document update required? NA

 - [ ] Testing done. done
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. NA

