### PR TITLE
[CARBONDATA-3502] Select query with UDF having Match expression inside IN expression Fails

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/optimizer/CarbonFilters.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/optimizer/CarbonFilters.scala
@@ -425,8 +425,6 @@ object CarbonFilters {
         new AndExpression(l, r)
       case strTrim: StringTrim if isStringTrimCompatibleWithCarbon(strTrim) =>
         transformExpression(strTrim)
-      case s: ScalaUDF =>
-        new MatchExpression(s.children.head.toString())
       case _ =>
         new SparkUnknownExpression(expr.transform {
           case AttributeReference(name, dataType, _, _) =>


### PR DESCRIPTION
Problem: Select query with UDF having Match expression inside IN expression Fails with ArrayIndexOutOfBounds exception.

Cause: The expression should not be treated as Match expression, instead should be treated as SparkUnknownExpression.

Solution: Removed the check for Match Expression as it was only added for Lucene Search mode, which is no longer present.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

