### PR TITLE
[CARBONDATA-3505] Drop database cascade fix

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/cache/CarbonShowCacheCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/cache/CarbonShowCacheCommand.scala
@@ -443,9 +443,9 @@ case class CarbonShowCacheCommand(tableIdentifier: Option[TableIdentifier],
       case (_, _, sum, provider) =>
         provider.toLowerCase match {
           case `bloomFilterIdentifier` =>
-            allIndexSize += sum
-          case _ =>
             allDatamapSize += sum
+          case _ =>
+            allIndexSize += sum
         }
     }
     (allIndexSize, allDatamapSize)

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/strategy/DDLStrategy.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/strategy/DDLStrategy.scala
@@ -37,6 +37,7 @@ import org.apache.spark.util.{CarbonReflectionUtils, DataMapUtil, FileUtils, Spa
 
 import org.apache.carbondata.common.exceptions.sql.MalformedCarbonCommandException
 import org.apache.carbondata.common.logging.LogServiceFactory
+import org.apache.carbondata.core.datastore.impl.FileFactory
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable
 import org.apache.carbondata.core.util.{CarbonProperties, DataTypeUtil, ThreadLocalSessionInfo}
 import org.apache.carbondata.spark.util.Util
@@ -115,7 +116,8 @@ class DDLStrategy(sparkSession: SparkSession) extends SparkStrategy {
           .setConfigurationToCurrentThread(sparkSession.sessionState.newHadoopConf())
         FileUtils.createDatabaseDirectory(dbName, dbLocation, sparkSession.sparkContext)
         ExecutedCommandExec(createDb) :: Nil
-      case drop@DropDatabaseCommand(dbName, ifExists, isCascade) =>
+      case drop@DropDatabaseCommand(dbName,
+      ifExists, isCascade) if CarbonEnv.databaseLocationExists(dbName, sparkSession, ifExists) =>
         ExecutedCommandExec(CarbonDropDatabaseCommand(drop)) :: Nil
       case alterTable@CarbonAlterTableCompactionCommand(altertablemodel, _, _) =>
         val isCarbonTable = CarbonEnv.getInstance(sparkSession).carbonMetaStore

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonFileMetastore.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonFileMetastore.scala
@@ -288,13 +288,13 @@ class CarbonFileMetastore extends CarbonMetaStore {
         Some(wrapperTableInfo)
       } else {
         val tableMetadataFile = CarbonTablePath.getSchemaFilePath(tablePath)
-        schemaRefreshTime = FileFactory
-          .getCarbonFile(CarbonTablePath.getSchemaFilePath(tablePath)).getLastModifiedTime
         val fileType = FileFactory.getFileType(tableMetadataFile)
         if (FileFactory.isFileExist(tableMetadataFile, fileType)) {
           val tableInfo: TableInfo = CarbonUtil.readSchemaFile(tableMetadataFile)
           val wrapperTableInfo =
             schemaConverter.fromExternalToWrapperTableInfo(tableInfo, dbName, tableName, tablePath)
+          schemaRefreshTime = FileFactory
+            .getCarbonFile(tableMetadataFile).getLastModifiedTime
           Some(wrapperTableInfo)
         } else {
           None


### PR DESCRIPTION
**Problem:** When 2 databases are created on same location and one of them is dropped then the folder is also deleted from backend. If we try to drop the 2nd database then it would try to lookup the other table, but the schema file would not exist in the backend and the drop will fail.

**Solution:** Add a check to call CarbonDropDatabaseCommand only if the database location exists in the backend.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

