### PR TITLE
[CARBONDATA-3506]Fix alter table failures on parition table with hive.metastore.disallow.incompatible.col.type.changes as true

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/standardpartition/StandardPartitionGlobalSortTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/standardpartition/StandardPartitionGlobalSortTestCase.scala
@@ -19,8 +19,7 @@ package org.apache.carbondata.spark.testsuite.standardpartition
 import java.util
 import java.util.concurrent.{Callable, ExecutorService, Executors}
 
-import org.apache.spark.sql.internal.SQLConf
-import org.apache.spark.sql.{AnalysisException, CarbonEnv, Row}
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.test.util.QueryTest
 import org.apache.spark.util.SparkUtil
 import org.scalatest.BeforeAndAfterAll
@@ -1088,6 +1087,5 @@ class StandardPartitionGlobalSortTestCase extends QueryTest with BeforeAndAfterA
     sql("drop table if exists partitiondatadelete")
     sql("drop table if exists comp_dt2")
     sql("drop table if exists partitionNoColumn")
-    sql("drop table if exists part_alter")
   }
 }

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/standardpartition/StandardPartitionGlobalSortTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/standardpartition/StandardPartitionGlobalSortTestCase.scala
@@ -19,7 +19,8 @@ package org.apache.carbondata.spark.testsuite.standardpartition
 import java.util
 import java.util.concurrent.{Callable, ExecutorService, Executors}
 
-import org.apache.spark.sql.Row
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.{AnalysisException, CarbonEnv, Row}
 import org.apache.spark.sql.test.util.QueryTest
 import org.apache.spark.util.SparkUtil
 import org.scalatest.BeforeAndAfterAll
@@ -1087,5 +1088,6 @@ class StandardPartitionGlobalSortTestCase extends QueryTest with BeforeAndAfterA
     sql("drop table if exists partitiondatadelete")
     sql("drop table if exists comp_dt2")
     sql("drop table if exists partitionNoColumn")
+    sql("drop table if exists part_alter")
   }
 }

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/standardpartition/StandardPartitionTableQueryTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/standardpartition/StandardPartitionTableQueryTestCase.scala
@@ -21,6 +21,7 @@ import org.apache.spark.sql.execution.strategy.CarbonDataSourceScan
 import org.apache.spark.sql.test.Spark2TestQueryExecutor
 import org.apache.spark.sql.test.util.QueryTest
 import org.apache.spark.sql.{DataFrame, Row}
+import org.apache.spark.util.SparkUtil
 import org.scalatest.BeforeAndAfterAll
 
 import org.apache.carbondata.common.exceptions.sql.MalformedCarbonCommandException
@@ -458,10 +459,12 @@ test("Creation of partition table should fail if the colname in table schema and
       sql("alter table onlyPart drop columns(name)")
     }
     assert(ex1.getMessage.contains("alter table drop column is failed, cannot have the table with all columns as partition column"))
-    val ex2 = intercept[MalformedCarbonCommandException] {
-      sql("alter table onlyPart change age age bigint")
+    if (SparkUtil.isSparkVersionXandAbove("2.2")) {
+      val ex2 = intercept[MalformedCarbonCommandException] {
+        sql("alter table onlyPart change age age bigint")
+      }
+      assert(ex2.getMessage.contains("Alter datatype of the partition column age is not allowed"))
     }
-    assert(ex2.getMessage.contains("Alter datatype of the partition column age is not allowed"))
     sql("drop table if exists onlyPart")
   }
 

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/standardpartition/StandardPartitionTableQueryTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/standardpartition/StandardPartitionTableQueryTestCase.scala
@@ -450,14 +450,18 @@ test("Creation of partition table should fail if the colname in table schema and
     sql("drop table if exists par")
   }
 
-  test("test drop column when after dropping only partition column remains") {
+  test("test drop column when after dropping only partition column remains and datatype change on partition column") {
     sql("drop table if exists onlyPart")
-    sql("create table onlyPart(name string) partitioned by (age double) stored by " +
+    sql("create table onlyPart(name string) partitioned by (age int) stored by " +
         "'carbondata' TBLPROPERTIES('cache_level'='blocklet')")
-    val ex = intercept[MalformedCarbonCommandException] {
+    val ex1 = intercept[MalformedCarbonCommandException] {
       sql("alter table onlyPart drop columns(name)")
     }
-    assert(ex.getMessage.contains("alter table drop column is failed, cannot have the table with all columns as partition column"))
+    assert(ex1.getMessage.contains("alter table drop column is failed, cannot have the table with all columns as partition column"))
+    val ex2 = intercept[MalformedCarbonCommandException] {
+      sql("alter table onlyPart change age age bigint")
+    }
+    assert(ex2.getMessage.contains("Alter datatype of the partition column age is not allowed"))
     sql("drop table if exists onlyPart")
   }
 

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/schema/CarbonAlterTableColRenameDataTypeChangeCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/schema/CarbonAlterTableColRenameDataTypeChangeCommand.scala
@@ -21,10 +21,9 @@ import scala.collection.JavaConverters._
 import scala.collection.mutable
 
 import org.apache.spark.sql.{CarbonEnv, Row, SparkSession}
-import org.apache.spark.sql.execution.command.{AlterTableDataTypeChangeModel, DataTypeInfo,
-  MetadataCommand}
+import org.apache.spark.sql.execution.command.{AlterTableDataTypeChangeModel, DataTypeInfo, MetadataCommand}
 import org.apache.spark.sql.hive.CarbonSessionCatalog
-import org.apache.spark.util.AlterTableUtil
+import org.apache.spark.util.{AlterTableUtil, SparkUtil}
 
 import org.apache.carbondata.common.exceptions.sql.MalformedCarbonCommandException
 import org.apache.carbondata.common.logging.LogServiceFactory
@@ -257,7 +256,7 @@ private[sql] case class CarbonAlterTableColRenameDataTypeChangeCommand(
    * @param carbonTable              carbonTable
    * @param tableInfo                tableInfo
    * @param addColumnSchema          added column schema
-   * @param schemaEvolutionEntryList new SchemaEvolutionEntry
+   * @param schemaEvolutionEntry     new SchemaEvolutionEntry
    */
   private def updateSchemaAndRefreshTable(sparkSession: SparkSession,
       carbonTable: CarbonTable,
@@ -275,12 +274,27 @@ private[sql] case class CarbonAlterTableColRenameDataTypeChangeCommand(
     // update the schema changed column at the specific index in carbonColumns based on schema order
     carbonColumns
       .update(schemaOrdinal, schemaConverter.fromExternalToWrapperColumnSchema(addColumnSchema))
+    // In case of spark2.2 and above and , when we call
+    // alterExternalCatalogForTableWithUpdatedSchema to update the new schema to external catalog
+    // in case of rename column or change datatype, spark gets the catalog table and then it itself
+    // adds the partition columns if the table is partition table for all the new data schema sent
+    // by carbon, so there will be duplicate partition columns, so send the columns without
+    // partition columns
+    val columns = if (SparkUtil.isSparkVersionXandAbove("2.2") &&
+                      carbonTable.isHivePartitionTable) {
+      val partitionColumns = carbonTable.getPartitionInfo.getColumnSchemaList.asScala
+      val carbonColumnsWithoutPartition = carbonColumns.filterNot(col => partitionColumns.contains(
+        col))
+      Some(carbonColumnsWithoutPartition)
+    } else {
+      Some(carbonColumns)
+    }
     val (tableIdentifier, schemaParts) = AlterTableUtil.updateSchemaInfo(
       carbonTable,
       schemaEvolutionEntry,
       tableInfo)(sparkSession)
     sparkSession.sessionState.catalog.asInstanceOf[CarbonSessionCatalog]
-      .alterColumnChangeDataTypeOrRename(tableIdentifier, schemaParts, Some(carbonColumns))
+      .alterColumnChangeDataTypeOrRename(tableIdentifier, schemaParts, columns)
     sparkSession.catalog.refreshTable(tableIdentifier.quotedString)
   }
 


### PR DESCRIPTION
### Problem:
1. In case of spark2.2 and above and , when we call alterExternalCatalogForTableWithUpdatedSchema to update the new schema to external catalog in case of add column, spark gets the catalog table and then it itself adds the partition columns if the table is partition table for all the new data schema sent by carbon, so there will be duplicate partition columns, so validation fails in hive
2. When the table has only two columns and one of them is partition column, then dropping non partition column is invalid because, if we allow it is like table with all columns as partition columns. So with the above property as true, drop column will fail to update the hive metastore.
3. in spark2.2 and above if the datatype change is done on partition column, with the above property as true, it also fails, as we are not sending partition column for schema alter in hive

### Solution:
1. when sending the new schema to spark to update in catalog, do not send the partition columns in case of spark2.2 and above, as spark will take care of adding parition columns to new schema sent by us.
2. In the above scenario of drop, do not allow drop column, if after dropping the specific column, if table has only partition columns.
3. Block the operation on datatype change on partition column on spark2.2 and above.


Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed?
 NA
 - [x] Any backward compatibility impacted?
 NA
 - [x] Document update required?
NA
 - [x] Testing done
Added UT and tested in cluster.
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA

