### PR TITLE
[CARBONDATA-3507] Fix Create Table As Select Failure in Spark-2.3

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonFileMetastore.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonFileMetastore.scala
@@ -567,9 +567,7 @@ class CarbonFileMetastore extends CarbonMetaStore {
         }
         val tableLocation = catalogTable.storage.locationUri match {
           case tableLoc@Some(uri) =>
-            if (tableLoc.get.isInstanceOf[URI]) {
-              FileFactory.getUpdatedFilePath(tableLoc.get.asInstanceOf[URI].getPath)
-            }
+            FileFactory.getUpdatedFilePath(tableLoc.get.toString)
           case None =>
             CarbonEnv.getTablePath(tableIdentifier.database, tableIdentifier.table)(sparkSession)
         }


### PR DESCRIPTION
Problem: Create table as select fails with Spark-2.3.

Cause: When creating the table location path the function removes the "hdfs://" part from the path and then stores it, due to which in later stages the file is treated as a Local Carbon File.

Solution: Get the original table path without removing the prefix.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

