### PR TITLE
[HOTFIX] Remove ‘hive-service’ from carbondata assembly jar

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -107,6 +107,7 @@
               <exclude>org.apache.spark:*</exclude>
               <exclude>org.apache.zookeeper:*</exclude>
               <exclude>org.apache.avro:*</exclude>
+              <exclude>org.apache.hive:*</exclude>
               <exclude>com.google.guava:guava</exclude>
               <exclude>org.xerial.snappy:snappy-java</exclude>
               <!--add more items to be excluded from the assembly-->


### PR DESCRIPTION
**Problem**: In some environments, there will occur 'No Such Method: registerCurrentOperationLog' exception while execute sql on carbon thrift server.

**Cause**: spark hive thrift module rewrite class 'org.apache.hive.service.cli.operation.ExecuteStatementOperation' and add method 'registerCurrentOperationLog' in it, but when start carbon thrift server, it maybe load class 'ExecuteStatementOperation' first from carbondata assembly jar (includes 'org.apache.hive:hive-service'), this class 'ExecuteStatementOperation' which is from hive-service jar doesn't have method 'registerCurrentOperationLog', so it throws NoSuchMethodException.

**Solution**: remove all artifacts of 'org.apache.hive' when assemble carbondata jar.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed? No
 
 - [ ] Any backward compatibility impacted?  No
 
 - [ ] Document update required?  No

 - [ ] Testing done  No need
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

