### PR TITLE
[CARBONDATA-3496] Maintain the list of TableDataMap based on tableId instead of tableName

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/util/SessionParams.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/SessionParams.java
@@ -28,7 +28,6 @@ import org.apache.carbondata.core.cache.CacheProvider;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.constants.CarbonCommonConstantsInternal;
 import org.apache.carbondata.core.constants.CarbonLoadOptionConstants;
-import org.apache.carbondata.core.datamap.DataMapStoreManager;
 import org.apache.carbondata.core.exception.InvalidConfigurationException;
 
 import static org.apache.carbondata.core.constants.CarbonCommonConstants.*;
@@ -218,15 +217,7 @@ public class SessionParams implements Serializable, Cloneable {
         } else if (key.startsWith(CarbonCommonConstantsInternal.QUERY_ON_PRE_AGG_STREAMING)) {
           isValid = true;
         } else if (key.startsWith(CarbonCommonConstants.CARBON_DATAMAP_VISIBLE)) {
-          String[] keyArray = key.split("\\.");
-          isValid = DataMapStoreManager.getInstance().isDataMapExist(
-              keyArray[keyArray.length - 3],
-              keyArray[keyArray.length - 2],
-              keyArray[keyArray.length - 1]);
-          if (!isValid) {
-            throw new InvalidConfigurationException(
-                String.format("Invalid configuration of %s, datamap does not exist", key));
-          }
+          isValid = true;
         } else if (key.startsWith(CarbonCommonConstants.CARBON_LOAD_DATAMAPS_PARALLEL)) {
           isValid = CarbonUtil.validateBoolean(value);
           if (!isValid) {

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/cache/ShowCacheEventListeners.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/cache/ShowCacheEventListeners.scala
@@ -54,7 +54,7 @@ object ShowCachePreAggEventListener extends OperationEventListener {
             case childSchema if childSchema.getRelationIdentifier != null =>
               (s"${ childSchema.getRelationIdentifier.getDatabaseName }-${
                 childSchema.getRelationIdentifier.getTableName
-              }", childSchema.getProviderName)
+              }", childSchema.getProviderName, childSchema.getRelationIdentifier.getTableId)
           }.toList ++ childTables)
         }
     }
@@ -92,16 +92,18 @@ object ShowCacheDataMapEventListener extends OperationEventListener {
   }
 
   private def filterDataMaps(dataMaps: List[DataMapSchema],
-      filter: String): List[(String, String)] = {
+      filter: String): List[(String, String, String)] = {
     dataMaps.collect {
       case dataMap if dataMap.getProviderName
         .equalsIgnoreCase(filter) =>
         if (filter.equalsIgnoreCase(DataMapClassProvider.BLOOMFILTER.getShortName)) {
           (s"${ dataMap.getRelationIdentifier.getDatabaseName }-${
-            dataMap.getDataMapName}", dataMap.getProviderName)
+            dataMap.getDataMapName}", dataMap.getProviderName,
+            dataMap.getRelationIdentifier.getTableId)
         } else {
           (s"${ dataMap.getRelationIdentifier.getDatabaseName }-${
-            dataMap.getRelationIdentifier.getTableName}", dataMap.getProviderName)
+            dataMap.getRelationIdentifier.getTableName}", dataMap.getProviderName,
+            dataMap.getRelationIdentifier.getTableId)
         }
     }
   }

--- a/processing/src/main/java/org/apache/carbondata/processing/datamap/DataMapWriterListener.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/datamap/DataMapWriterListener.java
@@ -64,7 +64,7 @@ public class DataMapWriterListener {
       String taskNo, SegmentProperties segmentProperties) {
     // clear cache in executor side
     DataMapStoreManager.getInstance()
-        .clearDataMaps(carbonTable.getCarbonTableIdentifier().getTableUniqueName());
+        .clearDataMaps(carbonTable.getCarbonTableIdentifier());
     List<TableDataMap> tableIndices;
     try {
       tableIndices = DataMapStoreManager.getInstance().getAllDataMap(carbonTable);


### PR DESCRIPTION
**Problem:** 
TableNotFoundException is thrown from index server randomly for various file like schema & .carbondata.
Through code analysis it was found that if table cache is stale in the index executors and a query is fired then the cache can return a TableDataMap objetc which is old and the carbondata file would not exist for the same.
**Solution:**
Make the cache based on tableId instead of tableUniqueName to avoid stale cache access.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

