### PR TITLE
[CARBONDATA-3512]Index Server Enhancement

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datamap/DataMapUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/DataMapUtil.java
@@ -113,18 +113,10 @@ public class DataMapUtil {
     for (Segment segment : validAndInvalidSegmentsInfo.getInvalidSegments()) {
       invalidSegment.add(segment.getSegmentNo());
     }
-    DistributableDataMapFormat dataMapFormat = new DistributableDataMapFormat(carbonTable,
-        validAndInvalidSegmentsInfo.getValidSegments(), invalidSegment, true,
-        dataMapToClear);
-    try {
-      dataMapJob.execute(dataMapFormat);
-    } catch (Exception e) {
-      if (dataMapJob.getClass().getName().equalsIgnoreCase(DISTRIBUTED_JOB_NAME)) {
-        LOGGER.warn("Failed to clear distributed cache.", e);
-      } else {
-        throw e;
-      }
-    }
+    DistributableDataMapFormat dataMapFormat =
+        new DistributableDataMapFormat(carbonTable, validAndInvalidSegmentsInfo.getValidSegments(),
+            invalidSegment, true, dataMapToClear);
+    dataMapJob.execute(dataMapFormat);
   }
 
   public static void executeClearDataMapJob(CarbonTable carbonTable, String jobClassName)

--- a/docs/index-server.md
+++ b/docs/index-server.md
@@ -119,16 +119,6 @@ be written to file.
 The user can set the location for these file by using 'carbon.indexserver.temp.path'. By default
 table path would be used to write the files.
 
-## Security
-The security for the index server is controlled through 'spark.carbon.indexserver.keytab' and 'spark
-.carbon.indexserver.principal'. These allow the RPC framework to login using the principal. It is
-recommended that the principal should be a super user, and the user should be exclusive for index
-server so that it does not grant access to any other service. Internally the operations would be
-executed  as a Privileged Action using the login user.
-
-The Index Server is a long running service therefore the 'spark.yarn.keytab' and 'spark.yarn
-.principal' should be configured.
-
 ## Configurations
 
 ##### carbon.properties(JDBCServer) 
@@ -160,8 +150,6 @@ The Index Server is a long running service therefore the 'spark.yarn.keytab' and
 
 | Name     |      Default Value    |  Description |
 |:----------:|:-------------:|:------:       |
-| spark.carbon.indexserver.principal |  NA | Used for authentication, whether a valid service is  trying to connect to the server or not. Set in both IndexServer and JDBCServer.     |
-| spark.carbon.indexserver.keytab |    NA   |   Specify the path to the keytab file through which authentication would happen. Set in both IndexServer and JDBCServer. |
 | spark.dynamicAllocation.enabled | true | Set to false, so that spark does not kill the executor, If executors are killed, cache would be lost. Applicable only for Index Server. |
 | spark.yarn.principal | NA | Should be set to the same user used for JDBCServer. Required only for IndexServer.   |
 |spark.yarn.keytab| NA | Should be set to the same as JDBCServer.   |
@@ -180,6 +168,12 @@ that will authenticate the user to access the index server and no other service.
 | Name     |      Default Value    |  Description |
 |:----------:|:-------------:|:------:       |
 | ipc.client.rpc-timeout.ms |  NA | Set the above property to some appropriate value based on your estimated query time. The best option is to set this to the same value as spark.network.timeout. |
+| hadoop.security.authorization |  false | Property to enable the hadoop security which is required only on the server side. |
+| hadoop.proxyuser.<indexserver_user>.users |  NA | Property to set Proxy User list for which IndexServer permission were to be given ,check https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-common/Superusers.html|
+| hadoop.proxyuser.<indexserver_user>.hosts |  NA | Property to set hosts list for which IndexServer permission were to be given ,check https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-common/Superusers.html|
+| hadoop.proxyuser.<indexserver_user>.groups |  NA | Property to set groups list for which IndexServer permission to be given ,check https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-common/Superusers.html|
+| security.indexserver.protocol.acl |  * | Property to set List of User to be Authorized for Other than proxy Spark Application |
+
 
 ##### dynamic-properties(set command)
 
@@ -205,11 +199,6 @@ Q. **Index Server is throwing Large response size exception.**
 A. The exception would show the size of response it is trying to send over the
 network. Use ipc.maximum.response.length to a value bigger than the
 response size.
-
-Q. **Index server is throwing Kerberos principal not set exception**
-
-A. Set spark.carbon.indexserver.principal to the correct principal in both IndexServer and
-JDBCServer configurations.
 
 Q. **Unable to connect to index server**
 

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/events/IndexServerEvents.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/events/IndexServerEvents.scala
@@ -25,5 +25,9 @@ import org.apache.carbondata.core.metadata.schema.table.CarbonTable
 case class IndexServerLoadEvent(sparkSession: SparkSession,
     carbonTable: CarbonTable,
     segment: List[Segment],
-    invalidsegment: List[String])
+    invalidsegment: List[String]) extends Event with IndexServerEventInfo
+
+case class IndexServerEvent(sparkSession: SparkSession,
+    carbonTable: CarbonTable,
+    username: String)
   extends Event with IndexServerEventInfo

--- a/integration/spark2/src/main/scala/org/apache/carbondata/indexserver/DataMapJobs.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/indexserver/DataMapJobs.scala
@@ -130,7 +130,7 @@ class EmbeddedDataMapJob extends AbstractDataMapJob {
       .getCarbonTable.getTablePath, dataMapFormat.getQueryId, dataMapFormat.isCountStarJob)
     // Fire a job to clear the cache from executors as Embedded mode does not maintain the cache.
     IndexServer.invalidateSegmentCache(dataMapFormat.getCarbonTable, dataMapFormat
-      .getValidSegmentIds.asScala.toArray)
+      .getValidSegmentIds.asScala.toArray, isFallBack = true)
     spark.sparkContext.setLocalProperty("spark.job.description", originalJobDesc)
     splits
   }


### PR DESCRIPTION
### What changes are proposed 

1. Remove the keytab dependency for IndexServer 
  	Currently IndexServer needs to configure keytab and prinicipal for both Client side and Server Side.But indexServer is super user and having super user's keytab and principal in client is not correct(specialy spark-submit).
  	Since IndexServer is wrapped around spark application so no need to ask Keytab from User for IndexServer. 
  2. Authentication :- This happens in org.apache.hadoop.security.SaslRpcClient#createSaslClient .it checks  getServerPrincipal(spark.carbon.indexserver.principal) and Server protocol (UGI of IndexServer). User need to configure spark.carbon.indexserver.principal properly.

  3. Authorization(ACL):- Support User who can access the IndexServer. 
  	Authorization is controlled by hadoop.security.authorization parameter.  	 
  	IndexServer has below scenarios.
  	1. Spark-submit,spark-shell,spark-Sql :-> These type of spark Application has UGI where LoginUser and LoginUser will be same either based on kinit or based on spark.yarn.principal. 
  		Authorization is done in org.apache.hadoop.ipc.Server#authorize using IndexServer ProtocolClass and  ACL list which is prepared  by org.apache.hadoop.security.authorize.PolicyProvider(generally hadoop-policy.xml with key security.indexserver.protocol.acl , by default *). 
  	2. Spark JDBCServer :- It has UGI based on ProxyUser like  user1(auth:PROXY)via spark/<DOMAIN>/<REALM>. where user1 is currentUser and spark is LoginUser (JDBCServer started UGI).
  		This type of  Authorization happens in org.apache.hadoop.security.authorize.ProxyUsers#authorize with proxyUserAcl list prepared by  hadoop.proxyuser.<INDEXSERVER_UGI>.users ,hadoop.proxyuser.<INDEXSERVER_UGI>.hosts ,hadoop.proxyuser.<INDEXSERVER_UGI>.groups. 
  		check IndexServer document for detail about configuration.

4. TokenRenewer:- IndexServer is NOT Token based Hadoop Service. It does not required Delegation Token as IndexServer does not connect to KDC since it is inside SparkApplication(both, Indexclient and IndexServer) so take advantage of it. 

![image](https://user-images.githubusercontent.com/12861989/64279552-f37d3f00-cf6c-11e9-9fb0-f2e91ccb9611.png)

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

