### PR TITLE
[CARBONDATA-3513] fix 'taskNo' exceeding Long.MAX_VALUE issue when execute major compaction

### DIFF
--- a/processing/src/main/java/org/apache/carbondata/processing/merger/AbstractResultProcessor.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/merger/AbstractResultProcessor.java
@@ -61,7 +61,7 @@ public abstract class AbstractResultProcessor {
       carbonDataFileAttributes = new CarbonDataFileAttributes(index, loadModel.getFactTimeStamp());
     } else {
       carbonDataFileAttributes =
-          new CarbonDataFileAttributes(Long.parseLong(loadModel.getTaskNo()),
+          new CarbonDataFileAttributes(loadModel.getTaskNo(),
               loadModel.getFactTimeStamp());
     }
     carbonFactDataHandlerModel.setCarbonDataFileAttributes(carbonDataFileAttributes);


### PR DESCRIPTION
Probelm:
Major compaction command runs error.
java.lang.NumberFormatException is thrown.java.lang.NumberFormatException: For input string: "32881200100001100000"
Through code analysis it was found that taskno is "long" type. taskno generate algorithm may generate a number bigger than "Long.MAX_VALUE". carbondata-3325 change taskno type to string. But in some places it still using long. 

Solution:
Change taskno type to string.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

