### PR TITLE
[HOTFIX] Fix NPE on windows

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonFileMetastore.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonFileMetastore.scala
@@ -151,8 +151,8 @@ class CarbonFileMetastore extends CarbonMetaStore {
     val tables = Option(CarbonMetadata.getInstance.getCarbonTable(database, tableName))
     tables match {
       case Some(t) =>
-        if (isSchemaRefreshed(absIdentifier, sparkSession)) {
-          readCarbonSchema(absIdentifier, parameters)
+        if (isSchemaRefreshed(t.getAbsoluteTableIdentifier, sparkSession)) {
+          readCarbonSchema(t.getAbsoluteTableIdentifier, parameters)
         } else {
           CarbonRelation(database, tableName, CarbonSparkUtil.createSparkMeta(t), t)
         }


### PR DESCRIPTION
*Problem*

#3339 has some changes in `CarbonFileMetastore.createCarbonRelation`, running query on windows will fail as follow:
```
Exception in thread "main" java.lang.NullPointerException
	at org.apache.carbondata.core.datamap.TableDataMap.prune(TableDataMap.java:122)
	at org.apache.carbondata.hadoop.api.CarbonInputFormat.getPrunedBlocklets(CarbonInputFormat.java:558)
	at org.apache.carbondata.hadoop.api.CarbonInputFormat.getDataBlocksOfSegment(CarbonInputFormat.java:471)
	at org.apache.carbondata.hadoop.api.CarbonTableInputFormat.getSplits(CarbonTableInputFormat.java:460)
	at org.apache.carbondata.hadoop.api.CarbonTableInputFormat.getSplits(CarbonTableInputFormat.java:196)
	at org.apache.carbondata.spark.rdd.CarbonScanRDD.internalGetPartitions(CarbonScanRDD.scala:131)
```

*Analyse*

carbon index files are merged but `SegmentFile` did not update, so it fails to get any default datamap for pruning. 

The reason for no updated is about path comparison like `/[your_path_here]/examples/spark2/target/store/default/source/\Fact\Part0\Segment_0` 

vs

 `D:/[your_path_here]/examples/spark2/target/store/default/source/Fact/Part0/Segment_0`

the main different is disk symbol

*Solution*

use the `AbsoluteTableIdentifier` of table from `CarbonMetadata` instead of the newly created object, keep the path style same

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

