### PR TITLE
[CARBONDATA-3526]Fix cache issue during update and query

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/mutation/HorizontalCompaction.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/mutation/HorizontalCompaction.scala
@@ -28,7 +28,7 @@ import org.apache.spark.sql.execution.command.management.CarbonAlterTableCompact
 import org.apache.spark.sql.util.SparkSQLUtil
 
 import org.apache.carbondata.common.logging.LogServiceFactory
-import org.apache.carbondata.core.datamap.Segment
+import org.apache.carbondata.core.datamap.{DataMapStoreManager, Segment}
 import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable
 import org.apache.carbondata.core.statusmanager.SegmentUpdateStatusManager
@@ -106,6 +106,13 @@ object HorizontalCompaction {
       segmentUpdateStatusManager,
       deleteTimeStamp,
       segLists)
+
+    // If there are already index and data files are present for old update operation, then the
+    // cache will be loaded for those files during current update, but once after horizontal
+    // compaction is finished, new compacted files are generated, so the segments inside cache are
+    // now invalid, so clear the cache of invalid segment after horizontal compaction.
+    DataMapStoreManager.getInstance()
+      .clearInvalidSegments(carbonTable, segLists.asScala.map(_.getSegmentNo).asJava)
   }
 
   /**


### PR DESCRIPTION
### Problem:
When multiple updates happen on table, cache is loaded during update operation, but since on second update the horizontal compaction happens inside the segment, already loaded into cache are invalid. So if we do clean files, physical deletion of horizontal compacted takes place, but still the cache contains old files.So when select query is fired, query fails with file not found exception.

### Solution:
once after horizontal compaction is finished, new compacted files are generated, so the segments inside cache are now invalid, so clear the cache of invalid segment after horizontal compaction. During drop cache command, clear the cache of segmentMap also.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

