### PR TITLE
[CARBONDATA-3501] Fix update table with varchar column

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/longstring/VarcharDataTypesBasicTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/longstring/VarcharDataTypesBasicTestCase.scala
@@ -389,6 +389,16 @@ class VarcharDataTypesBasicTestCase extends QueryTest with BeforeAndAfterEach wi
 
     sql("DROP TABLE IF EXISTS varchar_complex_table")
   }
+  
+  test("update table with long string column") {
+    prepareTable()
+    // update non-varchar column
+    sql(s"update $longStringTable set(id)=(0) where name is not null").show()
+    // update varchar column
+    sql(s"update $longStringTable set(description)=('empty') where name is not null").show()
+    // update non-varchar&varchar column
+    sql(s"update $longStringTable set(description, id)=('sth.', 1) where name is not null").show()
+  }
 
     // ignore this test in CI, because it will need at least 4GB memory to run successfully
   ignore("Exceed 2GB per column page for varchar datatype") {

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonLoadDataCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonLoadDataCommand.scala
@@ -1060,7 +1060,7 @@ case class CarbonLoadDataCommand(
     val dropAttributes = df.logicalPlan.output.dropRight(1)
     val finalOutput = catalogTable.schema.map { attr =>
       dropAttributes.find { d =>
-        val index = d.name.lastIndexOf("-updatedColumn")
+        val index = d.name.lastIndexOf(CarbonCommonConstants.UPDATED_COL_EXTENSION)
         if (index > 0) {
           d.name.substring(0, index).equalsIgnoreCase(attr.name)
         } else {

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonAnalysisRules.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/hive/CarbonAnalysisRules.scala
@@ -122,9 +122,9 @@ case class CarbonIUDAnalysisRule(sparkSession: SparkSession) extends Rule[Logica
         val renamedProjectList = projectList.zip(columns).map { case (attr, col) =>
           attr match {
             case UnresolvedAlias(child22, _) =>
-              UnresolvedAlias(Alias(child22, col + "-updatedColumn")())
+              UnresolvedAlias(Alias(child22, col + CarbonCommonConstants.UPDATED_COL_EXTENSION)())
             case UnresolvedAttribute(_) =>
-              UnresolvedAlias(Alias(attr, col + "-updatedColumn")())
+              UnresolvedAlias(Alias(attr, col + CarbonCommonConstants.UPDATED_COL_EXTENSION)())
             case _ => attr
           }
         }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/optimizer/CarbonIUDRule.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/optimizer/CarbonIUDRule.scala
@@ -23,6 +23,8 @@ import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, Project}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.command.mutation.CarbonProjectForUpdateCommand
 
+import org.apache.carbondata.core.constants.CarbonCommonConstants
+
 /**
  * Rule specific for IUD operations
  */
@@ -39,7 +41,7 @@ class CarbonIUDRule extends Rule[LogicalPlan] with PredicateHelper {
           case Project(pList, child) if !isTransformed =>
             val (dest: Seq[NamedExpression], source: Seq[NamedExpression]) = pList
               .splitAt(pList.size - cols.size)
-            val diff = cols.diff(dest.map(_.name.toLowerCase))
+            // check complex column
             cols.foreach { col =>
               val complexExists = "\"name\":\"" + col + "\""
               if (dest.exists(m => m.dataType.json.contains(complexExists))) {
@@ -47,11 +49,20 @@ class CarbonIUDRule extends Rule[LogicalPlan] with PredicateHelper {
                   "Unsupported operation on Complex data type")
               }
             }
+            // check updated columns exists in table
+            val diff = cols.diff(dest.map(_.name.toLowerCase))
             if (diff.nonEmpty) {
               sys.error(s"Unknown column(s) ${ diff.mkString(",") } in table ${ table.tableName }")
             }
+            // modify plan for updated column *in place*
             isTransformed = true
-            Project(dest.filter(a => !cols.contains(a.name.toLowerCase)) ++ source, child)
+            source.foreach{ col =>
+              val colName = col.name.substring(0,
+                col.name.lastIndexOf(CarbonCommonConstants.UPDATED_COL_EXTENSION))
+              val updateIdx = dest.indexWhere(_.name.equalsIgnoreCase(colName))
+              dest.updated(updateIdx, col)
+            }
+            Project(dest, child)
         }
         CarbonProjectForUpdateCommand(
           newPlan, table.tableIdentifier.database, table.tableIdentifier.table, cols)

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/optimizer/CarbonIUDRule.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/optimizer/CarbonIUDRule.scala
@@ -39,7 +39,7 @@ class CarbonIUDRule extends Rule[LogicalPlan] with PredicateHelper {
         var isTransformed = false
         val newPlan = updatePlan transform {
           case Project(pList, child) if !isTransformed =>
-            val (dest: Seq[NamedExpression], source: Seq[NamedExpression]) = pList
+            var (dest: Seq[NamedExpression], source: Seq[NamedExpression]) = pList
               .splitAt(pList.size - cols.size)
             // check complex column
             cols.foreach { col =>
@@ -60,7 +60,7 @@ class CarbonIUDRule extends Rule[LogicalPlan] with PredicateHelper {
               val colName = col.name.substring(0,
                 col.name.lastIndexOf(CarbonCommonConstants.UPDATED_COL_EXTENSION))
               val updateIdx = dest.indexWhere(_.name.equalsIgnoreCase(colName))
-              dest.updated(updateIdx, col)
+              dest = dest.updated(updateIdx, col)
             }
             Project(dest, child)
         }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/optimizer/CarbonIUDRule.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/optimizer/CarbonIUDRule.scala
@@ -56,7 +56,7 @@ class CarbonIUDRule extends Rule[LogicalPlan] with PredicateHelper {
             }
             // modify plan for updated column *in place*
             isTransformed = true
-            source.foreach{ col =>
+            source.foreach { col =>
               val colName = col.name.substring(0,
                 col.name.lastIndexOf(CarbonCommonConstants.UPDATED_COL_EXTENSION))
               val updateIdx = dest.indexWhere(_.name.equalsIgnoreCase(colName))


### PR DESCRIPTION
**Problem**
Update on table with varchar column will throw exception:
```
java.lang.Exception: Dataload failed, String length cannot exceed 32000 characters
	at org.apache.carbondata.streaming.parser.FieldConverter$.objectToString(FieldConverter.scala:52)
	at org.apache.carbondata.spark.util.CarbonScalaUtil$.getString(CarbonScalaUtil.scala:70)
	at org.apache.carbondata.spark.rdd.NewRddIterator$$anonfun$next$1.apply$mcVI$sp(NewCarbonDataLoadRDD.scala:357)
	at scala.collection.immutable.Range.foreach$mVc$sp(Range.scala:160)
	at org.apache.carbondata.spark.rdd.NewRddIterator.next(NewCarbonDataLoadRDD.scala:356)
	at org.apache.carbondata.spark.rdd.NewRddIterator.next(NewCarbonDataLoadRDD.scala:333)
	at org.apache.carbondata.processing.loading.steps.InputProcessorStepImpl$InputProcessorIterator.getBatch(InputProcessorStepImpl.java:232)
```

**Analyse**
In the loading part of update operation, it gets the `isVarcharTypeMapping` for each column in the order when table created. And this gives a hint for checking string length. It does not allow to exceeds 32000 char for a column which is not varchar type.

However when changing the plan for updating in `CarbonIUDRule`, it first deletes the old expression and *appends* the new one, which makes the order differ to table created. Such that the string length checking fail.

**Solution**
Keep the order as table created when modify update plan


Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

