### PR TITLE
[CARBONDATA-3592] Fix query on bloom in case of multiple data files in one segment

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datamap/DataMapUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/DataMapUtil.java
@@ -152,11 +152,14 @@ public class DataMapUtil {
   /**
    * Prune the segments from the already pruned blocklets.
    */
-  public static void pruneSegments(List<Segment> segments, List<ExtendedBlocklet> prunedBlocklets) {
+  public static void pruneSegments(List<Segment> segments, List<ExtendedBlocklet> prunedBlocklets,
+      boolean clearExistingShards) {
     Set<Segment> validSegments = new HashSet<>();
     for (ExtendedBlocklet blocklet : prunedBlocklets) {
       // Clear the old pruned index files if any present
-      blocklet.getSegment().getFilteredIndexShardNames().clear();
+      if (clearExistingShards) {
+        blocklet.getSegment().getFilteredIndexShardNames().clear();
+      }
       // Set the pruned index file to the segment
       // for further pruning.
       String shardName = CarbonTablePath.getShardName(blocklet.getFilePath());
@@ -174,11 +177,11 @@ public class DataMapUtil {
     if (null == dataMapChooser) {
       return blocklets;
     }
-    pruneSegments(segmentsToLoad, blocklets);
+    pruneSegments(segmentsToLoad, blocklets, false);
     List<ExtendedBlocklet> cgDataMaps = pruneDataMaps(table, filterResolverIntf, segmentsToLoad,
         partitions, blocklets,
         DataMapLevel.CG, dataMapChooser);
-    pruneSegments(segmentsToLoad, cgDataMaps);
+    pruneSegments(segmentsToLoad, cgDataMaps, true);
     return pruneDataMaps(table, filterResolverIntf, segmentsToLoad,
         partitions, cgDataMaps,
         DataMapLevel.FG, dataMapChooser);

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockDataMap.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockDataMap.java
@@ -912,6 +912,9 @@ public class BlockDataMap extends CoarseGrainDataMap
         if (diff < 0) {
           relativeBlockletId = (short) (diff + blockletCount);
           break;
+        } else if (diff == 0) {
+          relativeBlockletId++;
+          break;
         }
         rowIndex++;
       }

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonInputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonInputFormat.java
@@ -604,7 +604,7 @@ m filterExpression
 
       if (cgDataMapExprWrapper != null) {
         // Prune segments from already pruned blocklets
-        DataMapUtil.pruneSegments(segmentIds, prunedBlocklets);
+        DataMapUtil.pruneSegments(segmentIds, prunedBlocklets, false);
         List<ExtendedBlocklet> cgPrunedBlocklets = new ArrayList<>();
         boolean isCGPruneFallback = false;
         // Again prune with CG datamap.
@@ -644,7 +644,7 @@ m filterExpression
         List<ExtendedBlocklet> fgPrunedBlocklets;
         if (fgDataMapExprWrapper != null) {
           // Prune segments from already pruned blocklets
-          DataMapUtil.pruneSegments(segmentIds, prunedBlocklets);
+          DataMapUtil.pruneSegments(segmentIds, prunedBlocklets, true);
           // Prune segments from already pruned blocklets
           fgPrunedBlocklets = DataMapUtil
               .executeDataMapJob(carbonTable, filter.getResolver(), dataMapJob, partitionsToPrune,


### PR DESCRIPTION
**Problem**: Query on bloom datamap fails when there are multiple data files in one segment.
**Solution**: Old pruned index files were cleared from the FilteredIndexSharedNames list. So further pruning was not done on all the valid index files. Hence added a check to clear the index files only in valid scenarios. Also handled the case where wrong blocklet id is passed while creating the blocklet from relative blocklet id.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

