### PR TITLE
[CARBONDATA-3529]Block Add Partition directly on MV datamap partitioned  table

### DIFF
--- a/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/TestPartitionWithMV.scala
+++ b/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/TestPartitionWithMV.scala
@@ -502,6 +502,13 @@ class TestPartitionWithMV extends QueryTest with BeforeAndAfterAll {
     assert(intercept[Exception] {
       sql("alter table p1_table add partition(c=1)")
     }.getMessage.equals("Cannot add partition directly on non partitioned table"))
+    sql("drop datamap if exists p1")
+    sql(
+      "create datamap p1 on table partitionone using 'mv' as select empname, year from " +
+      "partitionone")
+    assert(intercept[Exception] {
+      sql("alter table p1_table add partition(partitionone_year=1)")
+    }.getMessage.equals("Cannot add partition directly on child tables"))
   }
 
   test("test if alter rename is blocked on partition table with mv") {

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/partition/CarbonAlterTableAddHivePartitionCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/partition/CarbonAlterTableAddHivePartitionCommand.scala
@@ -58,8 +58,8 @@ case class CarbonAlterTableAddHivePartitionCommand(
     setAuditTable(table)
     setAuditInfo(Map("partition" -> partitionSpecsAndLocs.mkString(", ")))
     if (table.isHivePartitionTable) {
-      if (table.isChildDataMap) {
-        throw new UnsupportedOperationException("Cannot add partition directly on aggregate tables")
+      if (table.isChildDataMap || table.isChildTable) {
+        throw new UnsupportedOperationException("Cannot add partition directly on child tables")
       }
       val partitionWithLoc = partitionSpecsAndLocs.filter(_._2.isDefined)
       if (partitionWithLoc.nonEmpty) {


### PR DESCRIPTION
Problem:
Add Partition directly on mv datamap table is not blocked
Solution:
Blocked Add Partition directly on MV datamap partitioned  table

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

