### PR TITLE
[CARBONDATA-3547] Delete duplicate data during GLOBAL_SORT compaction

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -440,6 +440,7 @@ public final class CarbonCommonConstants {
   public static final String SORT_COLUMNS = "sort_columns";
   public static final String SORT_SCOPE = "sort_scope";
   public static final String RANGE_COLUMN = "range_column";
+  public static final String DEDUPLICATE_BY = "deduplicate_by";
   public static final String PARTITION_TYPE = "partition_type";
   public static final String NUM_PARTITIONS = "num_partitions";
   public static final String RANGE_INFO = "range_info";

--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/CarbonTable.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/CarbonTable.java
@@ -1026,6 +1026,16 @@ public class CarbonTable implements Serializable, Writable {
     }
   }
 
+  public CarbonColumn getDeduplicateByColumn() {
+    String deduplicateBy =
+        tableInfo.getFactTable().getTableProperties().get(CarbonCommonConstants.DEDUPLICATE_BY);
+    if (deduplicateBy == null) {
+      return null;
+    } else {
+      return getColumnByName(getTableName(), deduplicateBy);
+    }
+  }
+
   public TableInfo getTableInfo() {
     return tableInfo;
   }

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestGlobalSortDeduplicate.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestGlobalSortDeduplicate.scala
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.spark.testsuite.dataload
+
+import org.apache.spark.sql.test.util.QueryTest
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
+import org.scalatest.BeforeAndAfterAll
+
+/**
+ * TestGlobalSortDeduplicate
+ */
+class TestGlobalSortDeduplicate extends QueryTest with BeforeAndAfterAll {
+
+  override def beforeAll(): Unit = {
+    dropTable
+
+    sql(
+      """
+        | CREATE TABLE carbon_deduplicate_1(id INT, name STRING, city STRING, age INT)
+        | STORED AS carbondata TBLPROPERTIES('SORT_SCOPE'='GLOBAL_SORT', 'SORT_COLUMNS' = 'name', 'DEDUPLICATE_BY'='id')
+      """.stripMargin)
+
+    sql(
+      """
+        | CREATE TABLE carbon_deduplicate_2(id INT, name STRING, city STRING, age INT)
+        | STORED AS carbondata TBLPROPERTIES('SORT_SCOPE'='GLOBAL_SORT', 'SORT_COLUMNS' = 'name')
+      """.stripMargin)
+
+    prepareBaseTable("carbon_deduplicate_view_1", 1000, 10)
+    prepareBaseTable("carbon_deduplicate_view_2", 10000, 100)
+  }
+
+  def prepareBaseTable(tableName: String, totalRows: Int, duplicateRows: Int): Unit = {
+    val data1 = (1 to totalRows).map { index =>
+      Row(index, s"name_$index", s"city_$index", index % 100)
+    }
+    val rdd = sqlContext.sparkContext.parallelize(data1 ++ data1.take(duplicateRows), 1)
+    val schema = StructType(
+      StructField("id", IntegerType, nullable = false) ::
+      StructField("name", StringType, nullable = false) ::
+      StructField("city", StringType, nullable = false) ::
+      StructField("age", IntegerType, nullable = false) :: Nil)
+
+    sqlContext.createDataFrame(rdd, schema).createOrReplaceTempView(tableName)
+  }
+
+  override def afterAll(): Unit = {
+    dropTable
+  }
+
+  private def dropTable: Unit = {
+    sql("DROP TABLE IF EXISTS carbon_deduplicate_1")
+    sql("DROP TABLE IF EXISTS carbon_deduplicate_2")
+    sql("DROP VIEW IF EXISTS carbon_deduplicate_view_1")
+    sql("DROP VIEW IF EXISTS carbon_deduplicate_view_2")
+  }
+
+
+  test("deduplicate during data loading") {
+    checkAnswer(
+      sql("select count(*) from carbon_deduplicate_view_1"),
+      Seq(Row(1010))
+    )
+    sql("insert into table carbon_deduplicate_1 select * from carbon_deduplicate_view_1")
+    checkAnswer(
+      sql("select count(*) from carbon_deduplicate_1"),
+      Seq(Row(1000))
+    )
+  }
+
+  test("deduplicate during compaction") {
+    sql("alter table carbon_deduplicate_2 set tblproperties('DEDUPLICATE_BY'='id')")
+
+    sql("insert into table carbon_deduplicate_2 select * from carbon_deduplicate_view_1")
+    sql("insert into table carbon_deduplicate_2 select * from carbon_deduplicate_view_2")
+    sql("insert into table carbon_deduplicate_2 select * from carbon_deduplicate_view_1")
+    checkAnswer(
+      sql("select count(*) from carbon_deduplicate_2"),
+      Seq(Row(1000 + 10000 + 1000))
+    )
+    sql("alter table carbon_deduplicate_2 compact 'custom' where segment.id in (0, 1, 2)")
+    checkAnswer(
+      sql("select count(*) from carbon_deduplicate_2"),
+      Seq(Row(10000))
+    )
+    checkAnswer(
+      sql("select count(distinct id) from carbon_deduplicate_2"),
+      Seq(Row(10000))
+    )
+  }
+
+
+}

--- a/integration/spark-common/src/main/java/org/apache/carbondata/spark/util/DeduplicateHelper.java
+++ b/integration/spark-common/src/main/java/org/apache/carbondata/spark/util/DeduplicateHelper.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.spark.util;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * deduplicate base on sort_columns and duplicate_column
+ */
+public class DeduplicateHelper {
+
+  private Object[] oldRow;
+  private Comparator<Object[]> sortComparator;
+  private int duplicateColumn;
+  private Map<Object, Boolean> map;
+
+  public DeduplicateHelper(
+      Comparator<Object[]> sortComparator, int duplicateColumn, int initCapacity) {
+    this.sortComparator = sortComparator;
+    this.duplicateColumn = duplicateColumn;
+    map = new HashMap<>(initCapacity);
+  }
+
+  public boolean isDuplicate(Object[] row) {
+    if (oldRow == null) {
+      map.clear();
+      map.put(row[duplicateColumn], true);
+      oldRow = row;
+      return false;
+    } else {
+      if (sortComparator.compare(oldRow, row) == 0) {
+        if (map.get(row[duplicateColumn]) == null) {
+          map.put(row[duplicateColumn], true);
+          return false;
+        } else {
+          return true;
+        }
+      } else {
+        map.clear();
+        map.put(row[duplicateColumn], true);
+        oldRow = row;
+        return false;
+      }
+    }
+  }
+
+  public void close() {
+    if (map != null) {
+      map.clear();
+      map = null;
+    }
+  }
+}

--- a/integration/spark2/src/main/scala/org/apache/spark/util/AlterTableUtil.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/util/AlterTableUtil.scala
@@ -517,6 +517,7 @@ object AlterTableUtil {
       "LOCAL_DICTIONARY_EXCLUDE",
       "LOAD_MIN_SIZE_INMB",
       "RANGE_COLUMN",
+      "DEDUPLICATE_BY",
       "SORT_SCOPE",
       "SORT_COLUMNS",
       "GLOBAL_SORT_PARTITIONS")

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/CarbonDataLoadConfiguration.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/CarbonDataLoadConfiguration.java
@@ -129,6 +129,11 @@ public class CarbonDataLoadConfiguration {
 
   private int numberOfLoadingCores;
 
+  /**
+   * the index of deduplicateByColumn in dataFields array
+   */
+  private int deduplicateByColumn = -1;
+
   public CarbonDataLoadConfiguration() {
   }
 
@@ -453,5 +458,13 @@ public class CarbonDataLoadConfiguration {
 
   public void setSegmentPath(String segmentPath) {
     this.segmentPath = segmentPath;
+  }
+
+  public int getDeduplicateByColumn() {
+    return deduplicateByColumn;
+  }
+
+  public void setDeduplicateByColumn(int deduplicateByColumn) {
+    this.deduplicateByColumn = deduplicateByColumn;
   }
 }

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/DataLoadProcessBuilder.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/DataLoadProcessBuilder.java
@@ -329,6 +329,17 @@ public final class DataLoadProcessBuilder {
     configuration.setNumberOfLoadingCores(CarbonProperties.getInstance().getNumberOfLoadingCores());
 
     configuration.setColumnCompressor(loadModel.getColumnCompressor());
+
+    CarbonColumn deduplicateBy = carbonTable.getDeduplicateByColumn();
+    if (deduplicateBy != null) {
+      configuration.setDeduplicateByColumn(-1);
+      for (int i = 0; i < dataFields.size(); i++) {
+        if (dataFields.get(i).getColumn() == deduplicateBy) {
+          configuration.setDeduplicateByColumn(i);
+          break;
+        }
+      }
+    }
     return configuration;
   }
 


### PR DESCRIPTION
Delete duplicate data during GLOBAL_SORT compaction
Limitation:
1. only support global_sort
2. duplicate data have the same sort_columns values

 - [x] Any interfaces changed?
   add a table property
 - [x] Any backward compatibility impacted?
   no
 - [ ] Document update required?

 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
            test case added
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
            impact performance of global_sort compaction.
        - Any additional information to help reviewers in testing this change.
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
  small changes
