### PR TITLE
[CARBONDATA-3540] Delete all external segments when dropping table

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/CarbonTable.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/CarbonTable.java
@@ -43,6 +43,7 @@ import org.apache.carbondata.core.datastore.block.SegmentProperties;
 import org.apache.carbondata.core.features.TableOperation;
 import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
 import org.apache.carbondata.core.metadata.CarbonTableIdentifier;
+import org.apache.carbondata.core.metadata.SegmentFileStore;
 import org.apache.carbondata.core.metadata.encoder.Encoding;
 import org.apache.carbondata.core.metadata.schema.BucketingInfo;
 import org.apache.carbondata.core.metadata.schema.PartitionInfo;
@@ -59,6 +60,8 @@ import org.apache.carbondata.core.scan.filter.intf.FilterOptimizer;
 import org.apache.carbondata.core.scan.filter.optimizer.RangeFilterOptmizer;
 import org.apache.carbondata.core.scan.filter.resolver.FilterResolverIntf;
 import org.apache.carbondata.core.scan.model.QueryModel;
+import org.apache.carbondata.core.statusmanager.LoadMetadataDetails;
+import org.apache.carbondata.core.statusmanager.SegmentStatusManager;
 import org.apache.carbondata.core.util.CarbonProperties;
 import org.apache.carbondata.core.util.CarbonUtil;
 import org.apache.carbondata.core.util.DataTypeUtil;
@@ -1373,4 +1376,25 @@ public class CarbonTable implements Serializable, Writable {
     tableInfo.readFields(in);
     updateTableByTableInfo(this, tableInfo);
   }
+
+  /**
+   * Return all external segment folders in this table
+   */
+  public List<String> getAllExternalSegmentFolders() throws IOException {
+    LoadMetadataDetails[] loads = SegmentStatusManager.readTableStatusFile(
+        CarbonTablePath.getTableStatusFilePath(getTablePath()));
+    List<String> folders = new LinkedList<>();
+    for (LoadMetadataDetails load : loads) {
+      SegmentFileStore.SegmentFile segment = SegmentFileStore.readSegmentFile(
+          CarbonTablePath.getSegmentFilePath(getTablePath(), load.getSegmentFile()));
+      if (segment != null) {
+        if (!segment.getLocationMap().values().toArray(
+            new SegmentFileStore.FolderDetails[0])[0].isRelative()) {
+          folders.add(segment.getOptions().get("path"));
+        }
+      }
+    }
+    return folders;
+  }
+
 }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonDropTableCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonDropTableCommand.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql.execution.command.table
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
 
+import org.apache.hadoop.conf.Configuration
 import org.apache.spark.sql.{CarbonEnv, Row, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException
@@ -36,6 +37,7 @@ import org.apache.carbondata.core.exception.ConcurrentOperationException
 import org.apache.carbondata.core.locks.{CarbonLockFactory, CarbonLockUtil, ICarbonLock, LockUsage}
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable
 import org.apache.carbondata.core.statusmanager.SegmentStatusManager
+import org.apache.carbondata.core.util.path.CarbonTablePath
 import org.apache.carbondata.core.util.{CarbonProperties, CarbonUtil}
 import org.apache.carbondata.events._
 
@@ -232,6 +234,10 @@ case class CarbonDropTableCommand(
       // delete table data only if it is not external table
       if (FileFactory.isFileExist(tablePath, fileType) &&
           !(carbonTable.isExternalTable || carbonTable.isFileLevelFormat)) {
+
+        // if it is managed table, we should delete all external segment folders
+        deleteExternalSegments(carbonTable, sparkSession.sessionState.newHadoopConf())
+
         val file = FileFactory.getCarbonFile(tablePath, fileType)
         CarbonUtil.deleteFoldersAndFilesSilent(file)
       }
@@ -251,6 +257,13 @@ case class CarbonDropTableCommand(
       childDropDataMapCommands.foreach(_.processData(sparkSession))
     }
     Seq.empty
+  }
+
+  private def deleteExternalSegments(table: CarbonTable, conf: Configuration): Unit = {
+    val externalSegmentFolders = table.getAllExternalSegmentFolders
+    externalSegmentFolders.asScala.foreach { folder =>
+      CarbonUtil.deleteFoldersAndFilesSilent(FileFactory.getCarbonFile(folder, conf))
+    }
   }
 
   override protected def opName: String = "DROP TABLE"

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonDropTableCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonDropTableCommand.scala
@@ -37,8 +37,8 @@ import org.apache.carbondata.core.exception.ConcurrentOperationException
 import org.apache.carbondata.core.locks.{CarbonLockFactory, CarbonLockUtil, ICarbonLock, LockUsage}
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable
 import org.apache.carbondata.core.statusmanager.SegmentStatusManager
-import org.apache.carbondata.core.util.path.CarbonTablePath
 import org.apache.carbondata.core.util.{CarbonProperties, CarbonUtil}
+import org.apache.carbondata.core.util.path.CarbonTablePath
 import org.apache.carbondata.events._
 
 case class CarbonDropTableCommand(


### PR DESCRIPTION
For managed table, DROP TABLE command should delete all external segments automatically

 - [X] Any interfaces changed?
 No
 - [X] Any backward compatibility impacted?
 No
 - [X] Document update required?
No
 - [X] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
   Test case added    
 - [X] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
No
