### PR TITLE
[CARBONDATA-3541]Select queries with Aggregation Functions such as variance, stddev,etc fails with MV datamap

### DIFF
--- a/datamap/mv/core/src/main/scala/org/apache/carbondata/mv/datamap/MVHelper.scala
+++ b/datamap/mv/core/src/main/scala/org/apache/carbondata/mv/datamap/MVHelper.scala
@@ -626,6 +626,33 @@ object MVHelper {
             case Alias(agg@AggregateExpression(fun@Count(Seq(child)), _, _, _), name) =>
               val uFun = Sum(right)
               Alias(agg.copy(aggregateFunction = uFun), left.name)(exprId = left.exprId)
+            case Alias(agg@AggregateExpression(fun@Corr(l, r), _, _, _), name) =>
+              val uFun = Sum(right)
+              Alias(agg.copy(aggregateFunction = uFun), left.name)(exprId = left.exprId)
+            case Alias(agg@AggregateExpression(fun@VariancePop(child), _, _, _), name) =>
+              val uFun = Sum(right)
+              Alias(agg.copy(aggregateFunction = uFun), left.name)(exprId = left.exprId)
+            case Alias(agg@AggregateExpression(fun@VarianceSamp(child), _, _, _), name) =>
+              val uFun = Sum(right)
+              Alias(agg.copy(aggregateFunction = uFun), left.name)(exprId = left.exprId)
+            case Alias(agg@AggregateExpression(fun@StddevSamp(child), _, _, _), name) =>
+              val uFun = Sum(right)
+              Alias(agg.copy(aggregateFunction = uFun), left.name)(exprId = left.exprId)
+            case Alias(agg@AggregateExpression(fun@StddevPop(child), _, _, _), name) =>
+              val uFun = Sum(right)
+              Alias(agg.copy(aggregateFunction = uFun), left.name)(exprId = left.exprId)
+            case Alias(agg@AggregateExpression(fun@CovPopulation(l, r), _, _, _), name) =>
+              val uFun = Sum(right)
+              Alias(agg.copy(aggregateFunction = uFun), left.name)(exprId = left.exprId)
+            case Alias(agg@AggregateExpression(fun@CovSample(l, r), _, _, _), name) =>
+              val uFun = Sum(right)
+              Alias(agg.copy(aggregateFunction = uFun), left.name)(exprId = left.exprId)
+            case Alias(agg@AggregateExpression(fun@Skewness(child), _, _, _), name) =>
+              val uFun = Sum(right)
+              Alias(agg.copy(aggregateFunction = uFun), left.name)(exprId = left.exprId)
+            case Alias(agg@AggregateExpression(fun@Kurtosis(child), _, _, _), name) =>
+              val uFun = Sum(right)
+              Alias(agg.copy(aggregateFunction = uFun), left.name)(exprId = left.exprId)
             case _ =>
               if (left.name != right.name) Alias(right, left.name)(exprId = left.exprId) else right
           }


### PR DESCRIPTION
Problem:
Select queries with Aggregation Functions such as variance, stddev,etc with group by fails with MV datamap after creation.This is because, while querying, aggregation is not added to those columns
Solution:
Add aggregate function to those columns(variance, stddev etc) during rewriting the plan for MV

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [x] Testing done
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

