### PR TITLE
 [CARBONDATA-3516] Fixed compilation issue for mixed formats in Spark-2.1

### DIFF
--- a/integration/spark2/src/main/commonTo2.2And2.3/org/apache/spark/sql/MixedFomatHandlerUtil.scala
+++ b/integration/spark2/src/main/commonTo2.2And2.3/org/apache/spark/sql/MixedFomatHandlerUtil.scala
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql
+
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
+import org.apache.spark.sql.execution.FileSourceScanExec
+import org.apache.spark.sql.execution.datasources.HadoopFsRelation
+import org.apache.spark.sql.types.StructType
+
+object MixedFormatHandlerUtil {
+
+  def getScanForSegments(
+      @transient relation: HadoopFsRelation,
+      output: Seq[Attribute],
+      outputSchema: StructType,
+      partitionFilters: Seq[Expression],
+      dataFilters: Seq[Expression],
+      tableIdentifier: Option[TableIdentifier]
+  ): FileSourceScanExec = {
+    FileSourceScanExec(
+      relation,
+      output,
+      outputSchema,
+      partitionFilters,
+      dataFilters,
+      tableIdentifier)
+  }
+}

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/strategy/MixedFormatHandler.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/strategy/MixedFormatHandler.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.{execution, MixedFormatHandlerUtil, SparkSession}
 import org.apache.spark.sql.carbondata.execution.datasources.SparkCarbonFileFormat
 import org.apache.spark.sql.catalyst.expressions
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, AttributeSet, Expression, ExpressionSet, NamedExpression, SubqueryExpression}
+import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeReference, AttributeSet, Cast, Expression, ExpressionSet, NamedExpression, SubqueryExpression}
 import org.apache.spark.sql.execution.datasources.{FileFormat, HadoopFsRelation, InMemoryFileIndex, LogicalRelation}
 import org.apache.spark.sql.execution.datasources.csv.CSVFileFormat
 import org.apache.spark.sql.execution.datasources.json.JsonFileFormat
@@ -234,8 +234,8 @@ object MixedFormatHandler {
     LOGGER.info(s"Post-Scan Filters: ${ afterScanFilters.mkString(",") }")
     val filterAttributes = AttributeSet(afterScanFilters)
     val requiredExpressions = new util.LinkedHashSet[NamedExpression](
-        (projects.map(p => dataColumns.find(_.exprId == p.exprId).get) ++
-         filterAttributes.map(p => dataColumns.find(_.exprId == p.exprId).get)).asJava
+      (projects.flatMap(p => findAttribute(dataColumns, p)) ++
+       filterAttributes.map(p => dataColumns.find(_.exprId.equals(p.exprId)).get)).asJava
     ).asScala.toSeq
     val readDataColumns =
       requiredExpressions.filterNot(partitionColumns.contains).asInstanceOf[Seq[Attribute]]
@@ -260,6 +260,33 @@ object MixedFormatHandler {
       execution.ProjectExec(projects, withFilter)
     }
     (withProjections.inputRDDs().head, fileFormat.supportBatch(sparkSession, outputSchema))
+  }
+
+  // This function is used to get the unique columns based on expression Id from
+  // filters and the projections list
+  def findAttribute(dataColumns: Seq[Attribute], p: Expression): Seq[Attribute] = {
+    dataColumns.find {
+      x =>
+        val attr = findAttributeReference(p)
+        attr.isDefined && x.exprId.equals(attr.get.exprId)
+    } match {
+      case Some(c) => Seq(c)
+      case None => Seq()
+    }
+  }
+
+  private def findAttributeReference(p: Expression): Option[NamedExpression] = {
+    p match {
+      case a: AttributeReference =>
+        Some(a)
+      case al =>
+        if (al.children.nonEmpty) {
+          al.children.map(findAttributeReference).head
+        } else {
+          None
+        }
+      case _ => None
+    }
   }
 
   def getSegmentsToAccess(identifier: AbsoluteTableIdentifier): Seq[String] = {

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/strategy/MixedFormatHandler.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/strategy/MixedFormatHandler.scala
@@ -22,13 +22,11 @@ import scala.collection.JavaConverters._
 
 import org.apache.hadoop.fs.{Path, PathFilter}
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.execution
-import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.{execution, MixedFormatHandlerUtil, SparkSession}
 import org.apache.spark.sql.carbondata.execution.datasources.SparkCarbonFileFormat
 import org.apache.spark.sql.catalyst.expressions
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, AttributeSet, Expression, ExpressionSet, NamedExpression}
-import org.apache.spark.sql.execution.FileSourceScanExec
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, AttributeSet, Expression, ExpressionSet, NamedExpression, SubqueryExpression}
 import org.apache.spark.sql.execution.datasources.{FileFormat, HadoopFsRelation, InMemoryFileIndex, LogicalRelation}
 import org.apache.spark.sql.execution.datasources.csv.CSVFileFormat
 import org.apache.spark.sql.execution.datasources.json.JsonFileFormat
@@ -247,7 +245,7 @@ object MixedFormatHandler {
     val outputAttributes = readDataColumns ++ partitionColumns
 
     val scan =
-      FileSourceScanExec(
+      MixedFormatHandlerUtil.getScanForSegments(
         fsRelation,
         outputAttributes,
         outputSchema,

--- a/integration/spark2/src/main/spark2.1/org/apache/spark/sql/MixedFormatHandlerUtil.scala
+++ b/integration/spark2/src/main/spark2.1/org/apache/spark/sql/MixedFormatHandlerUtil.scala
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql
+
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
+import org.apache.spark.sql.execution.FileSourceScanExec
+import org.apache.spark.sql.execution.datasources.{DataSourceStrategy, HadoopFsRelation}
+import org.apache.spark.sql.types.StructType
+
+object MixedFormatHandlerUtil {
+
+  def getScanForSegments(
+      @transient relation: HadoopFsRelation,
+      output: Seq[Attribute],
+      outputSchema: StructType,
+      partitionFilters: Seq[Expression],
+      dataFilters: Seq[Expression],
+      tableIdentifier: Option[TableIdentifier]
+  ): FileSourceScanExec = {
+    val pushedDownFilters = dataFilters.flatMap(DataSourceStrategy.translateFilter)
+    FileSourceScanExec(
+      relation,
+      output,
+      outputSchema,
+      partitionFilters,
+      pushedDownFilters,
+      tableIdentifier)
+  }
+}


### PR DESCRIPTION
This PR depends on [#3392](https://github.com/apache/carbondata/pull/3392)

Problem: Compilation issue with Spark-2.1 as FileSourceScanExec takes different parameters in Spark-2.1 and Spark-2.3. 

Solution: Decoupled the code for Spark-2.1 and Spark-2.2/2.3.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

