### PR TITLE
[CARBONDATA-3551] Fix NPE in multi-thread pruning on NonTransactional tables

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datamap/TableDataMap.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/TableDataMap.java
@@ -289,7 +289,7 @@ public final class TableDataMap extends OperationEventListener {
               for (int i = segmentDataMapGroup.getFromIndex();
                    i <= segmentDataMapGroup.getToIndex(); i++) {
                 List<Blocklet> dmPruneBlocklets = dataMapList.get(i).prune(
-                    filter.getExpression(), segmentProperties, partitions, table);
+                    filter.getNewCopyOfExpression(), segmentProperties, partitions, table);
                 pruneBlocklets.addAll(addSegmentId(
                     blockletDetailsFetcher.getExtendedBlocklets(dmPruneBlocklets, segment),
                     segment));

--- a/core/src/main/java/org/apache/carbondata/core/scan/expression/ColumnExpression.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/expression/ColumnExpression.java
@@ -103,6 +103,7 @@ public class ColumnExpression extends LeafExpression {
     measure = null;
     isDimension = false;
     isMeasure = false;
+    carbonColumn = null;
   }
 
   @Override


### PR DESCRIPTION
**problem:** NPE in multi-thread pruning on NonTransactional tables

**Scenario:**
Have a NonTransactional table with more than 0.1 million files and multi thread pruning is used at the driver side. with this query the table with filter condition. 
NPE is observed in below line. 
`DimColumnResolvedFilterInfo.populateFilterInfoBasedOnColumnType`
`this.setColumnIndex(metadata.getColumnExpression().getDimension().getOrdinal());`

here getDimension() is null

**cause:** When multithread pruning is used for nonTransactional table, filter is resolved for each segment again, during which each thread works on same ColumnExpression. Chances that ColumnExpression.reset() is called by other thread, which can impact the current thread

**solution:** For multithread pruning use separate Expression object for each thread. 

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed? NA
 
 - [ ] Any backward compatibility impacted? NA
 
 - [ ] Document update required? NA

 - [ ] Testing done
done. Run CI with new object for single thread and transactional tables also  by always returning resolved flag as false.     
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

