### PR TITLE
[CARBONDATA-3553] Support SDK Writer using existing schema file

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/metadata/converter/SchemaConverter.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/converter/SchemaConverter.java
@@ -94,16 +94,19 @@ public interface SchemaConverter {
       org.apache.carbondata.format.TableSchema externalTableSchema, String tableNam);
 
   /**
-   * @param externalTableInfo
-   * @param dbName
-   * @param tableName
-   * @return
+   * method to convert thrift table info object to wrapper table info
+   *
+   * @param externalTableInfo thrift table info object
+   * @param dbName database name
+   * @param tableName table name
+   * @param tablePath table path
+   * @return TableInfo
    */
   TableInfo fromExternalToWrapperTableInfo(
       org.apache.carbondata.format.TableInfo externalTableInfo,
       String dbName,
       String tableName,
-      String storePath);
+      String tablePath);
 
   /**
    * method to convert thrift datamap schema object to wrapper

--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/SchemaReader.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/SchemaReader.java
@@ -59,6 +59,45 @@ public class SchemaReader {
   }
 
   /**
+   * Read specified schema file as CarbonTable
+   * @param schemaFilePath schema file path
+   * @param conf hadoop configuration
+   * @return CarbonTable object
+   * @throws IOException if IO error occurs
+   */
+  public static CarbonTable readCarbonTableFromSchema(String schemaFilePath, Configuration conf)
+      throws IOException {
+    TableInfo tableInfo = readTableInfoFromSchema(schemaFilePath, conf);
+    CarbonMetadata.getInstance().loadTableMetadata(tableInfo);
+    return CarbonMetadata.getInstance().getCarbonTable("dummy_dummy");
+  }
+
+  /**
+   * Read specified schema file as TableInfo
+   * @param schemaFilePath schema file path
+   * @param conf hadoop configuration
+   * @return TableInfo object
+   * @throws IOException if IO error occurs
+   */
+  private static TableInfo readTableInfoFromSchema(String schemaFilePath, Configuration conf)
+      throws IOException {
+    if (FileFactory.isFileExist(schemaFilePath)) {
+      String tableName = "dummy";
+
+      org.apache.carbondata.format.TableInfo tableInfo = CarbonUtil.readSchemaFile(schemaFilePath);
+      SchemaConverter schemaConverter = new ThriftWrapperSchemaConverterImpl();
+      TableInfo wrapperTableInfo = schemaConverter.fromExternalToWrapperTableInfo(
+          tableInfo,
+          "dummy",
+          tableName,
+          "dummy");
+      return wrapperTableInfo;
+    } else {
+      throw new IOException("File does not exist: " + schemaFilePath);
+    }
+  }
+
+  /**
    * the method returns the Wrapper TableInfo
    *
    * @param identifier

--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/CarbonTable.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/CarbonTable.java
@@ -1152,6 +1152,7 @@ public class CarbonTable implements Serializable, Writable {
 
   public void setTransactionalTable(boolean transactionalTable) {
     isTransactionalTable = transactionalTable;
+    getTableInfo().setTransactionalTable(transactionalTable);
   }
 
   /**

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
@@ -2040,13 +2040,19 @@ public final class CarbonUtil {
    */
   public static org.apache.carbondata.format.TableInfo readSchemaFile(String schemaFilePath)
       throws IOException {
+    return readSchemaFile(schemaFilePath, FileFactory.getConfiguration());
+  }
+
+  public static org.apache.carbondata.format.TableInfo readSchemaFile(String schemaFilePath,
+      Configuration conf)
+      throws IOException {
     TBaseCreator createTBase = new ThriftReader.TBaseCreator() {
       public org.apache.thrift.TBase<org.apache.carbondata.format.TableInfo,
           org.apache.carbondata.format.TableInfo._Fields> create() {
         return new org.apache.carbondata.format.TableInfo();
       }
     };
-    ThriftReader thriftReader = new ThriftReader(schemaFilePath, createTBase);
+    ThriftReader thriftReader = new ThriftReader(schemaFilePath, createTBase, conf);
     thriftReader.open();
     org.apache.carbondata.format.TableInfo tableInfo =
         (org.apache.carbondata.format.TableInfo) thriftReader.read();
@@ -2541,12 +2547,14 @@ public final class CarbonUtil {
   }
 
   // Get the total size of carbon data and the total size of carbon index
-  private static HashMap<String, Long> getDataSizeAndIndexSize(String tablePath,
-      String segmentId) throws IOException {
+  public static HashMap<String, Long> getDataSizeAndIndexSize(
+      String segmentPath) throws IOException {
+    if (segmentPath == null) {
+      throw new IllegalArgumentException("Argument [segmentPath] is null.");
+    }
     long carbonDataSize = 0L;
     long carbonIndexSize = 0L;
     HashMap<String, Long> dataAndIndexSize = new HashMap<String, Long>();
-    String segmentPath = CarbonTablePath.getSegmentPath(tablePath, segmentId);
     FileFactory.FileType fileType = FileFactory.getFileType(segmentPath);
     switch (fileType) {
       case HDFS:
@@ -2592,6 +2600,12 @@ public final class CarbonUtil {
     dataAndIndexSize.put(CarbonCommonConstants.CARBON_TOTAL_DATA_SIZE, carbonDataSize);
     dataAndIndexSize.put(CarbonCommonConstants.CARBON_TOTAL_INDEX_SIZE, carbonIndexSize);
     return dataAndIndexSize;
+  }
+
+  // Get the total size of carbon data and the total size of carbon index
+  private static HashMap<String, Long> getDataSizeAndIndexSize(String tablePath,
+      String segmentId) throws IOException {
+    return getDataSizeAndIndexSize(CarbonTablePath.getSegmentPath(tablePath, segmentId));
   }
 
   // Get the total size of carbon data and the total size of carbon index

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonInputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonInputFormat.java
@@ -310,7 +310,7 @@ m filterExpression
   public static void setQuerySegment(Configuration conf, AbsoluteTableIdentifier identifier) {
     String dbName = identifier.getCarbonTableIdentifier().getDatabaseName().toLowerCase();
     String tbName = identifier.getCarbonTableIdentifier().getTableName().toLowerCase();
-    getQuerySegmentToAccess(conf, dbName, tbName);
+    setQuerySegmentToAccess(conf, dbName, tbName);
   }
 
   /**
@@ -898,7 +898,7 @@ m filterExpression
     return projectColumns.toArray(new String[projectColumns.size()]);
   }
 
-  private static void getQuerySegmentToAccess(Configuration conf, String dbName, String tableName) {
+  private static void setQuerySegmentToAccess(Configuration conf, String dbName, String tableName) {
     String segmentNumbersFromProperty = CarbonProperties.getInstance()
         .getProperty(CarbonCommonConstants.CARBON_INPUT_SEGMENTS + dbName + "." + tableName, "*");
     if (!segmentNumbersFromProperty.trim().equals("*")) {
@@ -912,7 +912,7 @@ m filterExpression
    */
   public static void setQuerySegment(Configuration conf, CarbonTable carbonTable) {
     String tableName = carbonTable.getTableName();
-    getQuerySegmentToAccess(conf, carbonTable.getDatabaseName(), tableName);
+    setQuerySegmentToAccess(conf, carbonTable.getDatabaseName(), tableName);
   }
 
 }

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/readsupport/impl/CarbonRowReadSupport.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/readsupport/impl/CarbonRowReadSupport.java
@@ -41,6 +41,7 @@ public class CarbonRowReadSupport extends DictionaryDecodeReadSupport<CarbonRow>
         Calendar c = Calendar.getInstance();
         c.setTime(new Date(0));
         c.add(Calendar.DAY_OF_YEAR, (Integer) data[i]);
+        c.add(Calendar.DATE, 1);
         data[i] = new Date(c.getTime().getTime());
       } else if (dataTypes[i] == DataTypes.TIMESTAMP) {
         data[i] = new Timestamp((long) data[i] / 1000);

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/sdk/TestSDKWithTransactionalTable.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/sdk/TestSDKWithTransactionalTable.scala
@@ -1,0 +1,114 @@
+package org.apache.carbondata.spark.testsuite.sdk
+
+import java.io.{BufferedWriter, File, FileWriter}
+
+import org.apache.carbondata.core.constants.CarbonCommonConstants
+import org.apache.carbondata.core.util.CarbonProperties
+import org.apache.carbondata.sdk.file.{ArrowCarbonReader, CarbonReader, CarbonSchemaReader}
+import org.apache.spark.sql.{CarbonEnv, Row}
+import org.apache.spark.sql.test.util.QueryTest
+import org.scalatest.BeforeAndAfterAll
+
+class TestSDKWithTransactionalTable extends QueryTest with BeforeAndAfterAll {
+  var filePath: String = _
+
+  def buildTestData() =  {
+    filePath = s"${integrationPath}/spark-common-test/target/big.csv"
+    val file = new File(filePath)
+    val writer = new BufferedWriter(new FileWriter(file))
+    writer.write("c1, c2, c3, c4, c5, c6, c7, c8, c9, c10")
+    writer.newLine()
+    for (i <- 0 until 10) {
+      writer.write("a" + 1%1000 + "," +
+                   "b" + 1%1000 + "," +
+                   "c" + 1%1000 + "," +
+                   "d" + 1%1000 + "," +
+                   "e" + 1%1000 + "," +
+                   "f" + 1%1000 + "," +
+                   1%1000 + "," +
+                   1%1000 + "," +
+                   1%1000 + "," +
+                   1%1000 + "\n")
+      if ( i % 10000 == 0) {
+        writer.flush()
+      }
+    }
+    writer.close()
+  }
+
+  def dropTable() = {
+    sql("DROP TABLE IF EXISTS carbon_load1")
+    sql("DROP TABLE IF EXISTS train")
+    sql("DROP TABLE IF EXISTS test")
+  }
+
+  override def beforeAll {
+    dropTable
+    buildTestData
+  }
+
+  test("test sdk with transactional table, read as arrow") {
+
+    sql(
+      """
+        | CREATE TABLE carbon_load1(
+        |    c1 string, c2 string, c3 string, c4 string, c5 string,
+        |    c6 string, c7 int, c8 int, c9 int, c10 int)
+        | STORED AS carbondata
+      """.stripMargin)
+
+    sql(s"LOAD DATA LOCAL INPATH '$filePath' into table carbon_load1")
+    sql(s"LOAD DATA LOCAL INPATH '$filePath' into table carbon_load1")
+    sql(s"LOAD DATA LOCAL INPATH '$filePath' into table carbon_load1")
+
+    val table = CarbonEnv.getCarbonTable(None, "carbon_load1")(sqlContext.sparkSession)
+
+    val reader:ArrowCarbonReader[Array[Object]] =
+      CarbonReader.builder(table.getTablePath, table.getTableName).buildArrowReader()
+
+    var count = 0
+    while(reader.hasNext) {
+      reader.readNextRow()
+      count += 1
+    }
+    reader.close()
+    checkAnswer(sql("select count(*) from carbon_load1"), Seq(Row(count)))
+    sql("DROP TABLE carbon_load1")
+  }
+
+  test("test sdk with transactional table, read as row") {
+
+    sql(
+      """
+        | CREATE TABLE carbon_load1(
+        |    c1 string, c2 string, c3 string, c4 string, c5 string,
+        |    c6 string, c7 int, c8 int, c9 int, c10 int)
+        | STORED AS carbondata
+      """.stripMargin)
+
+    sql(s"LOAD DATA LOCAL INPATH '$filePath' into table carbon_load1")
+    sql(s"LOAD DATA LOCAL INPATH '$filePath' into table carbon_load1")
+    sql(s"LOAD DATA LOCAL INPATH '$filePath' into table carbon_load1")
+
+    val table = CarbonEnv.getCarbonTable(None, "carbon_load1")(sqlContext.sparkSession)
+    val reader = CarbonReader.builder(table.getTablePath, table.getTableName).build()
+
+    var count = 0
+    while ( { reader.hasNext }) {
+      var row = reader.readNextRow.asInstanceOf[Array[AnyRef]]
+      count += 1
+    }
+    reader.close()
+
+    checkAnswer(sql("select count(*) from carbon_load1"), Seq(Row(count)))
+    sql("DROP TABLE carbon_load1")
+  }
+
+  override def afterAll {
+    new File(filePath).delete()
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.LOAD_SORT_SCOPE,
+        CarbonCommonConstants.LOAD_SORT_SCOPE_DEFAULT)
+  }
+
+}

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/model/CarbonLoadModelBuilder.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/model/CarbonLoadModelBuilder.java
@@ -79,6 +79,8 @@ public class CarbonLoadModelBuilder {
         columns[i] = csvHeader.get(i).getColName();
       }
       optionsFinal.put("fileheader", Strings.mkString(columns, ","));
+    } else {
+      optionsFinal.put("fileheader", options.get("fileheader"));
     }
     optionsFinal.put("bad_record_path", CarbonBadRecordUtil.getBadRecordsPath(options, table));
     optionsFinal.put("sort_scope",

--- a/store/sdk/pom.xml
+++ b/store/sdk/pom.xml
@@ -169,13 +169,6 @@
   <build>
     <plugins>
       <plugin>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <configuration>
@@ -209,6 +202,14 @@
             </goals>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>8</source>
+          <target>8</target>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonSchemaReader.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonSchemaReader.java
@@ -30,11 +30,13 @@ import org.apache.carbondata.core.datastore.filesystem.CarbonFileFilter;
 import org.apache.carbondata.core.datastore.impl.FileFactory;
 import org.apache.carbondata.core.metadata.converter.SchemaConverter;
 import org.apache.carbondata.core.metadata.converter.ThriftWrapperSchemaConverterImpl;
+import org.apache.carbondata.core.metadata.schema.table.TableSchema;
 import org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema;
 import org.apache.carbondata.core.reader.CarbonFooterReaderV3;
 import org.apache.carbondata.core.reader.CarbonHeaderReader;
 import org.apache.carbondata.core.reader.CarbonIndexFileReader;
 import org.apache.carbondata.core.util.CarbonUtil;
+import org.apache.carbondata.core.util.path.CarbonTablePath;
 import org.apache.carbondata.format.FileFooter3;
 import org.apache.carbondata.processing.loading.exception.CarbonDataLoadingException;
 import org.apache.carbondata.sdk.file.arrow.ArrowConverter;
@@ -159,6 +161,11 @@ public class CarbonSchemaReader {
    */
   public static Schema readSchema(String path, boolean validateSchema, Configuration conf)
       throws IOException {
+    // Check whether it is transational table reads the schema
+    String schemaFilePath = CarbonTablePath.getSchemaFilePath(path);
+    if (FileFactory.getCarbonFile(schemaFilePath, conf).exists()) {
+      return readSchemaInSchemaFile(schemaFilePath, conf);
+    }
     if (path.endsWith(INDEX_FILE_EXT)) {
       return readSchemaFromIndexFile(path, conf);
     } else if (path.endsWith(CARBON_DATA_EXT)) {
@@ -189,6 +196,17 @@ public class CarbonSchemaReader {
       String indexFilePath = getCarbonFile(path, INDEX_FILE_EXT, conf)[0].getAbsolutePath();
       return readSchemaFromIndexFile(indexFilePath, conf);
     }
+  }
+
+  private static Schema readSchemaInSchemaFile(String schemaFilePath, Configuration conf)
+      throws IOException {
+    org.apache.carbondata.format.TableInfo tableInfo =
+        CarbonUtil.readSchemaFile(schemaFilePath, conf);
+    SchemaConverter schemaConverter = new ThriftWrapperSchemaConverterImpl();
+    TableSchema factTable =
+        schemaConverter.fromExternalToWrapperTableInfo(tableInfo, "", "", "").getFactTable();
+    List<ColumnSchema> schemaList = factTable.getListOfColumns();
+    return new Schema(schemaList, factTable.getTableProperties());
   }
 
   /**

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/Schema.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/Schema.java
@@ -20,7 +20,9 @@ package org.apache.carbondata.sdk.file;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.carbondata.common.annotations.InterfaceAudience;
 import org.apache.carbondata.common.annotations.InterfaceStability;
@@ -41,12 +43,23 @@ public class Schema {
 
   private Field[] fields;
 
+  private Map<String, String> properties;
+
   /**
    * construct a schema with fields
    * @param fields
    */
   public Schema(Field[] fields) {
+    this(fields, new HashMap<String, String>());
+  }
+
+  /**
+   * construct a schema with fields
+   * @param fields
+   */
+  public Schema(Field[] fields, Map<String, String> properties) {
     this.fields = fields;
+    this.properties = properties;
   }
 
   /**
@@ -55,10 +68,20 @@ public class Schema {
    * @param columnSchemaList column schema list
    */
   public Schema(List<ColumnSchema> columnSchemaList) {
+    this(columnSchemaList, new HashMap<String, String>());
+  }
+
+  /**
+   * construct a schema with List<ColumnSchema>
+   *
+   * @param columnSchemaList column schema list
+   */
+  public Schema(List<ColumnSchema> columnSchemaList, Map<String, String> properties) {
     fields = new Field[columnSchemaList.size()];
     for (int i = 0; i < columnSchemaList.size(); i++) {
       fields[i] = new Field(columnSchemaList.get(i));
     }
+    this.properties = properties;
   }
 
   /**
@@ -150,6 +173,10 @@ public class Schema {
       }
     });
     return this;
+  }
+
+  public Map<String, String> getProperties() {
+    return properties;
   }
 
   @Override


### PR DESCRIPTION
Sometimes, user need to build SDK writer with schema file, rather than with scheme object. It's will be easier to use.

```java
val writer = CarbonWriter.builder.outputPath(...).withSchemaFile("/default/test/Metadata/schema").withCsvInput().build()
```

 - [ ] Any interfaces changed?
 NA
 - [ ] Any backward compatibility impacted?
 NA
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
 NA
