### PR TITLE
[CARBONDATA-3555] Make move filter related methods under DataMapFilter

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datamap/DataMapStoreManager.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/DataMapStoreManager.java
@@ -37,7 +37,6 @@ import org.apache.carbondata.core.indexstore.SegmentPropertiesFetcher;
 import org.apache.carbondata.core.indexstore.blockletindex.BlockletDataMapFactory;
 import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
 import org.apache.carbondata.core.metadata.CarbonMetadata;
-import org.apache.carbondata.core.metadata.CarbonTableIdentifier;
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
 import org.apache.carbondata.core.metadata.schema.table.DataMapSchema;
 import org.apache.carbondata.core.metadata.schema.table.DataMapSchemaStorageProvider;
@@ -335,7 +334,7 @@ public final class DataMapStoreManager {
     if (allDataMaps.size() > 0 && !CollectionUtils.isEmpty(allDataMaps.get(tableId))
         && !allDataMaps.get(tableId).get(0).getTable().getTableInfo().getFactTable()
         .getListOfColumns().equals(table.getTableInfo().getFactTable().getListOfColumns())) {
-      clearDataMaps(table.getCarbonTableIdentifier());
+      clearDataMaps(tableId);
       tableIndices = null;
     }
     TableDataMap dataMap = null;
@@ -547,7 +546,7 @@ public final class DataMapStoreManager {
       }
     }
     segmentRefreshMap.remove(tableId);
-    clearDataMaps(identifier.getCarbonTableIdentifier());
+    clearDataMaps(tableId);
     allDataMaps.remove(tableId);
     tablePathMap.remove(tableId);
   }
@@ -577,8 +576,8 @@ public final class DataMapStoreManager {
   /**
    * this methods clears the datamap of table from memory
    */
-  public void clearDataMaps(CarbonTableIdentifier carbonTableIdentifier) {
-    List<TableDataMap> tableIndices = allDataMaps.get(carbonTableIdentifier.getTableId());
+  public void clearDataMaps(String tableId) {
+    List<TableDataMap> tableIndices = allDataMaps.get(tableId);
     if (tableIndices != null) {
       for (TableDataMap tableDataMap : tableIndices) {
         if (tableDataMap != null) {
@@ -589,8 +588,8 @@ public final class DataMapStoreManager {
         }
       }
     }
-    allDataMaps.remove(carbonTableIdentifier.getTableId());
-    tablePathMap.remove(carbonTableIdentifier.getTableId());
+    allDataMaps.remove(tableId);
+    tablePathMap.remove(tableId);
   }
 
   /**
@@ -775,7 +774,7 @@ public final class DataMapStoreManager {
       }
       allDataMaps.put(carbonTable.getTableId(), remainingDataMaps);
     } else {
-      clearDataMaps(carbonTable.getCarbonTableIdentifier());
+      clearDataMaps(carbonTable.getTableId());
       // clear the segment properties cache from executor
       SegmentPropertiesAndSchemaHolder.getInstance()
           .invalidate(carbonTable.getAbsoluteTableIdentifier());

--- a/core/src/main/java/org/apache/carbondata/core/datamap/Segment.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/Segment.java
@@ -316,6 +316,11 @@ public class Segment implements Serializable, Writable {
   }
 
   public String getSegmentPath() {
+    if (segmentPath == null) {
+      if (loadMetadataDetails != null) {
+        segmentPath = loadMetadataDetails.getPath();
+      }
+    }
     return segmentPath;
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/datamap/TableDataMap.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/TableDataMap.java
@@ -132,7 +132,7 @@ public final class TableDataMap extends OperationEventListener {
       // As 0.1 million files block pruning can take only 1 second.
       // Doing multi-thread for smaller values is not recommended as
       // driver should have minimum threads opened to support multiple concurrent queries.
-      if (filter.isEmpty()) {
+      if (filter == null || filter.isEmpty()) {
         // if filter is not passed, then return all the blocklets.
         return pruneWithoutFilter(segments, partitions, blocklets);
       }

--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/CarbonTable.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/CarbonTable.java
@@ -55,10 +55,7 @@ import org.apache.carbondata.core.metadata.schema.table.column.CarbonMeasure;
 import org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema;
 import org.apache.carbondata.core.scan.expression.Expression;
 import org.apache.carbondata.core.scan.filter.FilterExpressionProcessor;
-import org.apache.carbondata.core.scan.filter.intf.FilterOptimizer;
-import org.apache.carbondata.core.scan.filter.optimizer.RangeFilterOptmizer;
 import org.apache.carbondata.core.scan.filter.resolver.FilterResolverIntf;
-import org.apache.carbondata.core.scan.model.QueryModel;
 import org.apache.carbondata.core.util.CarbonProperties;
 import org.apache.carbondata.core.util.CarbonUtil;
 import org.apache.carbondata.core.util.DataTypeUtil;
@@ -1117,26 +1114,6 @@ public class CarbonTable implements Serializable, Writable {
       indexSize = 0L;
     }
     return dataSize + indexSize;
-  }
-
-  public void processFilterExpression(Expression filterExpression, boolean[] isFilterDimensions,
-      boolean[] isFilterMeasures) {
-    processFilterExpressionWithoutRange(filterExpression, isFilterDimensions, isFilterMeasures);
-    if (null != filterExpression) {
-      // Optimize Filter Expression and fit RANGE filters is conditions apply.
-      FilterOptimizer rangeFilterOptimizer = new RangeFilterOptmizer(filterExpression);
-      rangeFilterOptimizer.optimizeFilter();
-    }
-  }
-
-  public void processFilterExpressionWithoutRange(Expression filterExpression,
-      boolean[] isFilterDimensions, boolean[] isFilterMeasures) {
-    QueryModel.FilterProcessVO processVO =
-        new QueryModel.FilterProcessVO(getDimensionByTableName(getTableName()),
-            getMeasureByTableName(getTableName()), getImplicitDimensionByTableName(getTableName()));
-    QueryModel
-        .processFilterExpression(processVO, filterExpression, isFilterDimensions, isFilterMeasures,
-            this);
   }
 
   public boolean isTransactionalTable() {

--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/TableInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/TableInfo.java
@@ -397,4 +397,8 @@ public class TableInfo implements Serializable, Writable {
   public boolean hasColumnDrift() {
     return hasColumnDrift;
   }
+
+  public String getTablePath() {
+    return tablePath;
+  }
 }

--- a/core/src/main/java/org/apache/carbondata/core/scan/model/QueryModel.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/model/QueryModel.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.carbondata.core.cache.dictionary.Dictionary;
+import org.apache.carbondata.core.datamap.DataMapFilter;
 import org.apache.carbondata.core.datastore.block.TableBlockInfo;
 import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
@@ -32,7 +33,6 @@ import org.apache.carbondata.core.scan.expression.ColumnExpression;
 import org.apache.carbondata.core.scan.expression.Expression;
 import org.apache.carbondata.core.scan.expression.UnknownExpression;
 import org.apache.carbondata.core.scan.expression.conditional.ConditionalExpression;
-import org.apache.carbondata.core.scan.filter.resolver.FilterResolverIntf;
 import org.apache.carbondata.core.stats.QueryStatisticsRecorder;
 import org.apache.carbondata.core.util.CarbonProperties;
 import org.apache.carbondata.core.util.CarbonUtil;
@@ -58,15 +58,11 @@ public class QueryModel {
    * query id
    */
   private String queryId;
-  /**
-   * filter tree
-   */
-  private FilterResolverIntf filterExpressionResolverTree;
 
   /**
    * filter expression tree
    */
-  private Expression filterExpression;
+  private DataMapFilter dataMapFilter;
 
   /**
    * table block information in which query will be executed
@@ -276,23 +272,12 @@ public class QueryModel {
     this.tableBlockInfos = tableBlockInfos;
   }
 
-  /**
-   * @return the filterEvaluatorTree
-   */
-  public FilterResolverIntf getFilterExpressionResolverTree() {
-    return filterExpressionResolverTree;
+  public DataMapFilter getDataMapFilter() {
+    return dataMapFilter;
   }
 
-  public void setFilterExpressionResolverTree(FilterResolverIntf filterExpressionResolverTree) {
-    this.filterExpressionResolverTree = filterExpressionResolverTree;
-  }
-
-  public Expression getFilterExpression() {
-    return filterExpression;
-  }
-
-  public void setFilterExpression(Expression filterExpression) {
-    this.filterExpression = filterExpression;
+  public void setDataMapFilter(DataMapFilter dataMapFilter) {
+    this.dataMapFilter = dataMapFilter;
   }
 
   /**
@@ -416,7 +401,7 @@ public class QueryModel {
     return String.format("scan on table %s.%s, %d projection columns with filter (%s)",
         table.getDatabaseName(), table.getTableName(),
         projection.getDimensions().size() + projection.getMeasures().size(),
-        filterExpressionResolverTree.getFilterExpression().toString());
+        dataMapFilter.getExpression().toString());
   }
 
   public boolean isFreeUnsafeMemory() {

--- a/dev/findbugs-exclude.xml
+++ b/dev/findbugs-exclude.xml
@@ -110,4 +110,12 @@
     <Class name="org.apache.carbondata.core.datamap.Segment"/>
     <Bug pattern="SE_TRANSIENT_FIELD_NOT_RESTORED"/>
   </Match>
+  <Match>
+    <Class name="org.apache.carbondata.core.datamap.DataMapFilter"/>
+    <Bug pattern="SE_TRANSIENT_FIELD_NOT_RESTORED"/>
+  </Match>
+  <Match>
+    <Class name="org.apache.carbondata.core.datamap.DataMapFilter"/>
+    <Bug pattern="SE_BAD_FIELD"/>
+  </Match>
 </FindBugsFilter>

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/stream/StreamRecordReader.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/stream/StreamRecordReader.java
@@ -213,7 +213,7 @@ public class StreamRecordReader extends RecordReader<Void, Object> {
     }
 
     // initialize filter
-    if (null != model.getFilterExpressionResolverTree()) {
+    if (null != model.getDataMapFilter()) {
       initializeFilter();
     } else if (projection.length == 0) {
       skipScanData = true;
@@ -237,7 +237,7 @@ public class StreamRecordReader extends RecordReader<Void, Object> {
         new SegmentProperties(wrapperColumnSchemaList, dictionaryColumnCardinality);
     Map<Integer, GenericQueryType> complexDimensionInfoMap = new HashMap<>();
 
-    FilterResolverIntf resolverIntf = model.getFilterExpressionResolverTree();
+    FilterResolverIntf resolverIntf = model.getDataMapFilter().getResolver();
     filter =
         FilterUtil.getFilterExecuterTree(resolverIntf, segmentProperties, complexDimensionInfoMap);
     // for row filter, we need update column index

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/testutil/StoreCreator.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/testutil/StoreCreator.java
@@ -181,9 +181,10 @@ public class StoreCreator {
   /**
    * Create store without any restructure
    */
-  public void createCarbonStore() throws Exception {
+  public CarbonLoadModel createCarbonStore() throws Exception {
     CarbonLoadModel loadModel = createTableAndLoadModel();
     loadData(loadModel, storePath);
+    return loadModel;
   }
 
   /**

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/util/CarbonInputFormatUtil.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/util/CarbonInputFormatUtil.java
@@ -25,6 +25,7 @@ import java.util.Locale;
 import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.constants.CarbonCommonConstantsInternal;
+import org.apache.carbondata.core.datamap.DataMapFilter;
 import org.apache.carbondata.core.datamap.DataMapJob;
 import org.apache.carbondata.core.datamap.DataMapUtil;
 import org.apache.carbondata.core.exception.InvalidConfigurationException;
@@ -102,13 +103,13 @@ public class CarbonInputFormatUtil {
         .setTransactionalTable(conf, carbonTable.getTableInfo().isTransactionalTable());
     CarbonProjection columnProjection = new CarbonProjection(projectionColumns);
     return createInputFormat(conf, carbonTable.getAbsoluteTableIdentifier(),
-        filterExpression, columnProjection, dataMapJob);
+        new DataMapFilter(carbonTable, filterExpression, true), columnProjection, dataMapJob);
   }
 
   private static <V> CarbonTableInputFormat<V> createInputFormat(
       Configuration conf,
       AbsoluteTableIdentifier identifier,
-      Expression filterExpression,
+      DataMapFilter dataMapFilter,
       CarbonProjection columnProjection,
       DataMapJob dataMapJob) throws InvalidConfigurationException, IOException {
     CarbonTableInputFormat<V> format = new CarbonTableInputFormat<>();
@@ -116,7 +117,7 @@ public class CarbonInputFormatUtil {
         conf,
         identifier.appendWithLocalPrefix(identifier.getTablePath()));
     CarbonInputFormat.setQuerySegment(conf, identifier);
-    CarbonInputFormat.setFilterPredicates(conf, filterExpression);
+    CarbonInputFormat.setFilterPredicates(conf, dataMapFilter);
     CarbonInputFormat.setColumnProjection(conf, columnProjection);
     if (dataMapJob != null) {
       DataMapUtil.setDataMapJob(conf, dataMapJob);

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/impl/CarbonTableReader.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/impl/CarbonTableReader.java
@@ -31,6 +31,7 @@ import java.util.stream.Collectors;
 
 import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
+import org.apache.carbondata.core.datamap.DataMapFilter;
 import org.apache.carbondata.core.datamap.DataMapStoreManager;
 import org.apache.carbondata.core.datastore.filesystem.CarbonFile;
 import org.apache.carbondata.core.datastore.impl.FileFactory;
@@ -273,8 +274,8 @@ public class CarbonTableReader {
     try {
       CarbonTableInputFormat.setTableInfo(config, tableInfo);
       CarbonTableInputFormat carbonTableInputFormat =
-          createInputFormat(jobConf, carbonTable.getAbsoluteTableIdentifier(), filters,
-              filteredPartitions);
+          createInputFormat(jobConf, carbonTable.getAbsoluteTableIdentifier(),
+              new DataMapFilter(carbonTable, filters, true), filteredPartitions);
       Job job = Job.getInstance(jobConf);
       List<InputSplit> splits = carbonTableInputFormat.getSplits(job);
       Gson gson = new Gson();
@@ -356,12 +357,12 @@ public class CarbonTableReader {
   }
 
   private CarbonTableInputFormat<Object> createInputFormat(Configuration conf,
-      AbsoluteTableIdentifier identifier, Expression filterExpression,
+      AbsoluteTableIdentifier identifier, DataMapFilter dataMapFilter,
       List<PartitionSpec> filteredPartitions) throws IOException {
     CarbonTableInputFormat format = new CarbonTableInputFormat<Object>();
     CarbonTableInputFormat
         .setTablePath(conf, identifier.appendWithLocalPrefix(identifier.getTablePath()));
-    CarbonTableInputFormat.setFilterPredicates(conf, filterExpression);
+    CarbonTableInputFormat.setFilterPredicates(conf, dataMapFilter);
     if (filteredPartitions.size() != 0) {
       CarbonTableInputFormat.setPartitionsToPrune(conf, filteredPartitions);
     }

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/allqueries/TestQueryWithColumnMetCacheAndCacheLevelProperty.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/allqueries/TestQueryWithColumnMetCacheAndCacheLevelProperty.scala
@@ -27,13 +27,11 @@ import org.scalatest.BeforeAndAfterAll
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.datamap.dev.DataMap
-import org.apache.carbondata.core.datamap.{DataMapChooser, DataMapStoreManager, Segment, TableDataMap}
-import org.apache.carbondata.core.datastore.block.SegmentPropertiesAndSchemaHolder
+import org.apache.carbondata.core.datamap.{DataMapChooser, DataMapFilter, DataMapStoreManager, Segment, TableDataMap}
 import org.apache.carbondata.core.indexstore.Blocklet
 import org.apache.carbondata.core.indexstore.blockletindex.{BlockDataMap, BlockletDataMap, BlockletDataMapRowIndexes}
 import org.apache.carbondata.core.indexstore.schema.CarbonRowSchema
 import org.apache.carbondata.core.metadata.datatype.DataTypes
-import org.apache.carbondata.core.metadata.schema.table.CarbonTable
 import org.apache.carbondata.core.metadata.schema.table.column.CarbonDimension
 import org.apache.carbondata.core.readcommitter.TableStatusReadCommittedScope
 import org.apache.carbondata.core.scan.expression.conditional.NotEqualsExpression
@@ -282,8 +280,7 @@ class TestQueryWithColumnMetCacheAndCacheLevelProperty extends QueryTest with Be
     val notEqualsExpression = new NotEqualsExpression(columnExpression, literalNullExpression)
     val equalsExpression = new NotEqualsExpression(columnExpression, literalValueExpression)
     val andExpression = new AndExpression(notEqualsExpression, equalsExpression)
-    val resolveFilter: FilterResolverIntf =
-      CarbonTable.resolveFilter(andExpression, carbonTable.getAbsoluteTableIdentifier)
+    val resolveFilter: FilterResolverIntf = new DataMapFilter(carbonTable, andExpression).getResolver()
     val exprWrapper = DataMapChooser.getDefaultDataMap(carbonTable, resolveFilter)
     val segment = new Segment("0", new TableStatusReadCommittedScope(carbonTable
       .getAbsoluteTableIdentifier, new Configuration(false)))

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/filterexpr/FilterProcessorTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/filterexpr/FilterProcessorTestCase.scala
@@ -392,4 +392,11 @@ class FilterProcessorTestCase extends QueryTest with BeforeAndAfterAll {
     CarbonProperties.getInstance()
       .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, "dd-MM-yyyy")
   }
+
+  test("test if query is giving empty results for table with no segments") {
+    sql("drop table if exists q1")
+    sql("create table q1(a string) stored by 'carbondata' TBLPROPERTIES('DICTIONARY_INCLUDE'='a')")
+    assert(sql("select * from q1 where a > 10").count() == 0)
+    sql("drop table if exists q1")
+  }
 }

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/filterexpr/TestImplicitFilterExpression.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/filterexpr/TestImplicitFilterExpression.scala
@@ -25,6 +25,7 @@ import org.apache.spark.sql.hive.CarbonRelation
 import org.apache.spark.sql.test.util.QueryTest
 import org.scalatest.BeforeAndAfterAll
 
+import org.apache.carbondata.core.datamap.DataMapFilter
 import org.apache.carbondata.core.datastore.filesystem.{CarbonFile, CarbonFileFilter}
 import org.apache.carbondata.core.datastore.impl.FileFactory
 import org.apache.carbondata.core.scan.expression.logical.{AndExpression, TrueExpression}
@@ -101,11 +102,11 @@ class TestImplicitFilterExpression extends QueryTest with BeforeAndAfterAll {
     blockletList.add(blockletId)
     blockToBlockletMap.put(carbondataFileShortName, blockletList)
     // create a new AND expression with True expression as right child
-    val filterExpression = new AndExpression(scanRDD.filterExpression, new TrueExpression(null))
+    val filterExpression = new AndExpression(scanRDD.dataMapFilter.getExpression, new TrueExpression(null))
     // create implicit expression which will replace the right child (True expression)
     FilterUtil.createImplicitExpressionAndSetAsRightChild(filterExpression, blockToBlockletMap)
     // update the filter expression
-    scanRDD.filterExpression = filterExpression
+    scanRDD.dataMapFilter = new DataMapFilter(carbonTable, filterExpression)
     // execute the query and get the result count
     checkAnswer(query.toDF(), Seq(Row(expectedResultCount)))
   }

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchemaCommon.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchemaCommon.scala
@@ -40,7 +40,7 @@ import org.apache.carbondata.core.metadata.schema.table.{CarbonTable, RelationId
 import org.apache.carbondata.core.metadata.schema.table.column.{ColumnSchema, ParentColumnTableRelation}
 import org.apache.carbondata.core.service.impl.ColumnUniqueIdGenerator
 import org.apache.carbondata.core.statusmanager.{LoadMetadataDetails, SegmentUpdateStatusManager}
-import org.apache.carbondata.core.util.{CarbonProperties, CarbonUtil, DataTypeUtil}
+import org.apache.carbondata.core.util.{CarbonUtil, DataTypeUtil}
 import org.apache.carbondata.processing.loading.FailureCauses
 import org.apache.carbondata.processing.loading.model.CarbonLoadModel
 import org.apache.carbondata.processing.merger.CompactionType
@@ -650,6 +650,9 @@ class TableNewProcessor(cm: TableModel) {
             columnRelation.parentDatabaseName,
             columnRelation.parentTableName,
             columnRelation.parentTableId)
+          if (cm.parentTable.isDefined) {
+            relationIdentifier.setTablePath(cm.parentTable.get.getTablePath)
+          }
           val parentColumnTableRelation = new ParentColumnTableRelation(
             relationIdentifier,
             columnRelation.parentColumnId,

--- a/integration/spark-datasource/src/main/scala/org/apache/carbondata/spark/vectorreader/VectorizedCarbonRecordReader.java
+++ b/integration/spark-datasource/src/main/scala/org/apache/carbondata/spark/vectorreader/VectorizedCarbonRecordReader.java
@@ -328,9 +328,9 @@ public class VectorizedCarbonRecordReader extends AbstractRecordReader<Object> {
    */
   private boolean isUseLazyLoad() {
     boolean useLazyLoad = false;
-    if (queryModel.getFilterExpressionResolverTree() != null) {
+    if (queryModel.getDataMapFilter() != null) {
       Expression expression =
-          queryModel.getFilterExpressionResolverTree().getFilterExpression();
+          queryModel.getDataMapFilter().getExpression();
       useLazyLoad = true;
       // In case of join queries only not null filter would e pushed down so check and disable the
       // lazy load in that case.

--- a/integration/spark-datasource/src/main/scala/org/apache/spark/sql/carbondata/execution/datasources/CarbonFileIndex.scala
+++ b/integration/spark-datasource/src/main/scala/org/apache/spark/sql/carbondata/execution/datasources/CarbonFileIndex.scala
@@ -16,7 +16,6 @@
  */
 package org.apache.spark.sql.carbondata.execution.datasources
 
-import java.io.IOException
 import java.util
 
 import scala.collection.JavaConverters._
@@ -31,6 +30,7 @@ import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.types.{AtomicType, StructType}
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants
+import org.apache.carbondata.core.datamap.DataMapFilter
 import org.apache.carbondata.core.datastore.filesystem.{CarbonFile, HDFSCarbonFile}
 import org.apache.carbondata.core.readcommitter.LatestFilesReadCommittedScope
 import org.apache.carbondata.core.scan.expression.{Expression => CarbonExpression}
@@ -127,7 +127,9 @@ class CarbonFileIndex(
         hadoopConf,
         new LatestFilesReadCommittedScope(indexFiles, hadoopConf))
       filter match {
-        case Some(c) => CarbonInputFormat.setFilterPredicates(hadoopConf, c)
+        case Some(c) => CarbonInputFormat
+          .setFilterPredicates(hadoopConf,
+            new DataMapFilter(model.getCarbonDataLoadSchema.getCarbonTable, c, true))
         case None => None
       }
       val format: CarbonFileInputFormat[Object] = new CarbonFileInputFormat[Object]

--- a/integration/spark-datasource/src/main/scala/org/apache/spark/sql/carbondata/execution/datasources/SparkCarbonFileFormat.scala
+++ b/integration/spark-datasource/src/main/scala/org/apache/spark/sql/carbondata/execution/datasources/SparkCarbonFileFormat.scala
@@ -21,7 +21,6 @@ import java.net.URI
 import java.util.UUID
 
 import scala.collection.JavaConverters._
-import scala.collection.mutable.ArrayBuffer
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileStatus, Path}
@@ -34,7 +33,7 @@ import org.apache.spark.internal.io.FileCommitProtocol
 import org.apache.spark.memory.MemoryMode
 import org.apache.spark.sql._
 import org.apache.spark.sql.carbondata.execution.datasources.readsupport.SparkUnsafeRowReadSuport
-import org.apache.spark.sql.carbondata.execution.datasources.tasklisteners.{CarbonLoadTaskCompletionListener, CarbonLoadTaskCompletionListenerImpl, CarbonQueryTaskCompletionListener, CarbonQueryTaskCompletionListenerImpl}
+import org.apache.spark.sql.carbondata.execution.datasources.tasklisteners.{CarbonLoadTaskCompletionListenerImpl, CarbonQueryTaskCompletionListenerImpl}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.JoinedRow
 import org.apache.spark.sql.catalyst.expressions.codegen.GenerateUnsafeProjection
@@ -43,12 +42,13 @@ import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.sources.{DataSourceRegister, Filter}
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.util.SparkTypeConverter
-import org.apache.spark.util.{SerializableConfiguration, TaskCompletionListener}
+import org.apache.spark.util.SerializableConfiguration
 
 import org.apache.carbondata.common.annotations.{InterfaceAudience, InterfaceStability}
 import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.converter.SparkDataTypeConverterImpl
-import org.apache.carbondata.core.constants.{CarbonCommonConstants, CarbonVersionConstants}
+import org.apache.carbondata.core.constants.CarbonCommonConstants
+import org.apache.carbondata.core.datamap.DataMapFilter
 import org.apache.carbondata.core.datastore.impl.FileFactory
 import org.apache.carbondata.core.indexstore.BlockletDetailInfo
 import org.apache.carbondata.core.metadata.{AbsoluteTableIdentifier, ColumnarFormatVersion}
@@ -376,7 +376,9 @@ class SparkCarbonFileFormat extends FileFormat
     CarbonInputFormat.setTransactionalTable(hadoopConf, false)
     CarbonInputFormat.setColumnProjection(hadoopConf, carbonProjection)
     filter match {
-      case Some(c) => CarbonInputFormat.setFilterPredicates(hadoopConf, c)
+      case Some(c) => CarbonInputFormat
+        .setFilterPredicates(hadoopConf,
+          new DataMapFilter(model.getCarbonDataLoadSchema.getCarbonTable, c, true))
       case None => None
     }
     val format: CarbonFileInputFormat[Object] = new CarbonFileInputFormat[Object]

--- a/integration/spark2/src/main/scala/org/apache/carbondata/store/SparkCarbonStore.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/store/SparkCarbonStore.scala
@@ -26,6 +26,7 @@ import org.apache.spark.sql.{CarbonEnv, SparkSession}
 import org.apache.spark.sql.CarbonSession._
 
 import org.apache.carbondata.common.annotations.InterfaceAudience
+import org.apache.carbondata.core.datamap.DataMapFilter
 import org.apache.carbondata.core.datastore.row.CarbonRow
 import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier
 import org.apache.carbondata.core.scan.expression.Expression
@@ -78,10 +79,11 @@ class SparkCarbonStore extends MetaCachedCarbonStore {
     require(projectColumns != null)
     val table = CarbonEnv
       .getCarbonTable(Some(tableIdentifier.getDatabaseName), tableIdentifier.getTableName)(session)
+    val dataMapFilter = if (filter == null) null else new DataMapFilter(table, filter)
     val rdd = new CarbonScanRDD[CarbonRow](
       spark = session,
       columnProjection = new CarbonProjection(projectColumns),
-      filterExpression = filter,
+      dataMapFilter = dataMapFilter,
       identifier = table.getAbsoluteTableIdentifier,
       serializedTableInfo = table.getTableInfo.serialize,
       tableInfo = table.getTableInfo,

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonDatasourceHadoopRelation.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonDatasourceHadoopRelation.scala
@@ -29,10 +29,11 @@ import org.apache.spark.sql.execution.command.management.CarbonInsertIntoCommand
 import org.apache.spark.sql.hive.CarbonRelation
 import org.apache.spark.sql.optimizer.CarbonFilters
 import org.apache.spark.sql.sources.{BaseRelation, Filter, InsertableRelation}
-import org.apache.spark.sql.types.{ArrayType, StructType}
+import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CarbonException
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants
+import org.apache.carbondata.core.datamap.DataMapFilter
 import org.apache.carbondata.core.indexstore.PartitionSpec
 import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable
@@ -40,7 +41,7 @@ import org.apache.carbondata.core.metadata.schema.table.column.CarbonDimension
 import org.apache.carbondata.core.scan.expression.Expression
 import org.apache.carbondata.core.scan.expression.logical.AndExpression
 import org.apache.carbondata.hadoop.CarbonProjection
-import org.apache.carbondata.spark.rdd.{CarbonScanRDD, SparkReadSupport}
+import org.apache.carbondata.spark.rdd.CarbonScanRDD
 
 case class CarbonDatasourceHadoopRelation(
     sparkSession: SparkSession,
@@ -184,7 +185,7 @@ case class CarbonDatasourceHadoopRelation(
     new CarbonScanRDD(
       sparkSession,
       projection,
-      filterExpression.orNull,
+      filterExpression.map(new DataMapFilter(carbonTable, _, true)).orNull,
       identifier,
       carbonTable.getTableInfo.serialize(),
       carbonTable.getTableInfo,

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonAddLoadCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonAddLoadCommand.scala
@@ -227,6 +227,7 @@ case class CarbonAddLoadCommand(
     model.setDatabaseName(carbonTable.getDatabaseName)
     model.setTableName(carbonTable.getTableName)
     val operationContext = new OperationContext
+    operationContext.setProperty("isLoadOrCompaction", false)
     val loadTablePreExecutionEvent: LoadTablePreExecutionEvent =
       new LoadTablePreExecutionEvent(
         carbonTable.getCarbonTableIdentifier,

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/strategy/CarbonLateDecodeStrategy.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/strategy/CarbonLateDecodeStrategy.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.execution.strategy
 
+import java.util
+
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer

--- a/processing/src/main/java/org/apache/carbondata/processing/merger/CarbonCompactionExecutor.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/merger/CarbonCompactionExecutor.java
@@ -28,6 +28,7 @@ import org.apache.carbondata.common.CarbonIterator;
 import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.cache.dictionary.Dictionary;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
+import org.apache.carbondata.core.datamap.DataMapFilter;
 import org.apache.carbondata.core.datastore.block.SegmentProperties;
 import org.apache.carbondata.core.datastore.block.TableBlockInfo;
 import org.apache.carbondata.core.datastore.block.TaskBlockInfo;
@@ -129,7 +130,8 @@ public class CarbonCompactionExecutor {
           new QueryModelBuilder(carbonTable).projectAllColumns().dataConverter(dataTypeConverter)
               .enableForcedDetailRawQuery();
     } else {
-      builder = new QueryModelBuilder(carbonTable).projectAllColumns().filterExpression(filterExpr)
+      builder = new QueryModelBuilder(carbonTable).projectAllColumns()
+          .filterExpression(new DataMapFilter(carbonTable, filterExpr))
           .dataConverter(dataTypeConverter).enableForcedDetailRawQuery()
           .convertToRangeFilter(false);
     }

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonReaderBuilder.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonReaderBuilder.java
@@ -27,6 +27,7 @@ import java.util.UUID;
 import org.apache.carbondata.common.annotations.InterfaceAudience;
 import org.apache.carbondata.common.annotations.InterfaceStability;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
+import org.apache.carbondata.core.datamap.DataMapFilter;
 import org.apache.carbondata.core.datamap.DataMapStoreManager;
 import org.apache.carbondata.core.datastore.impl.FileFactory;
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
@@ -287,7 +288,8 @@ public class CarbonReaderBuilder {
     format.setTableName(job.getConfiguration(), table.getTableName());
     format.setDatabaseName(job.getConfiguration(), table.getDatabaseName());
     if (filterExpression != null) {
-      format.setFilterPredicates(job.getConfiguration(), filterExpression);
+      format.setFilterPredicates(job.getConfiguration(),
+          new DataMapFilter(table, filterExpression, true));
     }
     if (null != this.fileLists) {
       format.setFileLists(this.fileLists);

--- a/store/sdk/src/main/java/org/apache/carbondata/store/LocalCarbonStore.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/store/LocalCarbonStore.java
@@ -25,6 +25,7 @@ import java.util.Objects;
 
 import org.apache.carbondata.common.annotations.InterfaceAudience;
 import org.apache.carbondata.common.logging.LogServiceFactory;
+import org.apache.carbondata.core.datamap.DataMapFilter;
 import org.apache.carbondata.core.datastore.row.CarbonRow;
 import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
@@ -83,7 +84,8 @@ class LocalCarbonStore extends MetaCachedCarbonStore {
     CarbonInputFormat
         .setColumnProjection(job.getConfiguration(), new CarbonProjection(projectColumns));
     if (filter != null) {
-      CarbonInputFormat.setFilterPredicates(job.getConfiguration(), filter);
+      CarbonInputFormat
+          .setFilterPredicates(job.getConfiguration(), new DataMapFilter(table, filter));
     }
 
     final List<InputSplit> splits =


### PR DESCRIPTION
1. This PR will make DataMapFilter as a filter holder for the filter expression and the FilterResolver objects so that all the major API's can accept dataMapFilter as an argument.
2. Moved all the filter resolving methods inside DataMapFilter for ease of use

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

