### PR TITLE
[CARBONDATA-3558] Clean up codes for property "autoRefreshDataMap"

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datamap/DataMapProvider.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/DataMapProvider.java
@@ -120,7 +120,7 @@ public abstract class DataMapProvider {
   /**
    * Rebuild the datamap by loading all existing data from mainTable
    * This is called when refreshing the datamap when
-   * 1. after datamap creation and if `autoRefreshDataMap` is set to true
+   * 1. after datamap creation and no "WITH DEFERRED REBUILD" defined
    * 2. user manually trigger REBUILD DATAMAP command
    */
   public boolean rebuild() throws IOException, NoSuchDataMapException {

--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/CarbonTable.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/CarbonTable.java
@@ -1048,14 +1048,6 @@ public class CarbonTable implements Serializable, Writable {
   }
 
   /**
-   * Return true if 'autoRefreshDataMap' is enabled, by default it is enabled
-   */
-  public boolean isAutoRefreshDataMap() {
-    String refresh = getTableInfo().getFactTable().getTableProperties().get("autorefreshdatamap");
-    return refresh == null || refresh.equalsIgnoreCase("true");
-  }
-
-  /**
    * whether this table has aggregation DataMap or not
    */
   public boolean hasAggregationDataMap() {

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/datamap/lucene/LuceneFineGrainDataMapSuite.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/datamap/lucene/LuceneFineGrainDataMapSuite.scala
@@ -167,7 +167,7 @@ class LuceneFineGrainDataMapSuite extends QueryTest with BeforeAndAfterAll {
       """
         | CREATE TABLE datamap_test4(id INT, name STRING, city STRING, age INT)
         | STORED BY 'carbondata'
-        | TBLPROPERTIES('SORT_COLUMNS'='city,name', 'SORT_SCOPE'='LOCAL_SORT', 'autorefreshdatamap' = 'false')
+        | TBLPROPERTIES('SORT_COLUMNS'='city,name', 'SORT_SCOPE'='LOCAL_SORT')
       """.stripMargin)
     sql(s"LOAD DATA LOCAL INPATH '$file2' INTO TABLE datamap_test4 OPTIONS('header'='false')")
 
@@ -829,14 +829,14 @@ class LuceneFineGrainDataMapSuite extends QueryTest with BeforeAndAfterAll {
         | CREATE TABLE datamap_test4(id INT, name STRING, city STRING, age INT)
         | STORED BY 'carbondata'
         | TBLPROPERTIES('SORT_COLUMNS'='city,name', 'SORT_SCOPE'='LOCAL_SORT',
-        | 'autorefreshdatamap' = 'false', 'CACHE_LEVEL'='BLOCKLET')
+        | 'CACHE_LEVEL'='BLOCKLET')
       """.stripMargin)
     sql(
       """
         | CREATE TABLE datamap_copy(id INT, name STRING, city STRING, age INT)
         | STORED BY 'carbondata'
         | TBLPROPERTIES('SORT_COLUMNS'='city,name', 'SORT_SCOPE'='LOCAL_SORT',
-        | 'autorefreshdatamap' = 'false', 'CACHE_LEVEL'='BLOCKLET')
+        | 'CACHE_LEVEL'='BLOCKLET')
       """.stripMargin)
     sql("insert into datamap_test4 select 1,'name','city',20")
     sql("insert into datamap_test4 select 2,'name1','city1',20")


### PR DESCRIPTION
Since PR #2255 support DEFERRED REBUILD when creating DataMap, autoRefreshDataMap property is not used any more.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

