### PR TITLE
[CARBONDATA-3559] Support adding carbon files into CarbonData table

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -1610,7 +1610,7 @@ public final class CarbonCommonConstants {
 
   public static final String HDFSURL_PREFIX = "hdfs://";
 
-  public static final String LOCAL_FILE_PREFIX = "file://";
+  public static final String LOCAL_FILE_PREFIX = "file:";
 
   public static final String VIEWFSURL_PREFIX = "viewfs://";
 

--- a/core/src/main/java/org/apache/carbondata/core/datastore/impl/FileFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/impl/FileFactory.java
@@ -587,12 +587,13 @@ public final class FileFactory {
     }
     String defaultFs = conf.get(CarbonCommonConstants.FS_DEFAULT_FS);
     String lowerPath = path.toLowerCase();
-    if (lowerPath.startsWith(CarbonCommonConstants.HDFSURL_PREFIX) || lowerPath
-        .startsWith(CarbonCommonConstants.ALLUXIOURL_PREFIX) || lowerPath
-        .startsWith(CarbonCommonConstants.VIEWFSURL_PREFIX) || lowerPath
-        .startsWith(CarbonCommonConstants.S3N_PREFIX) || lowerPath
-        .startsWith(CarbonCommonConstants.S3A_PREFIX) || lowerPath
-        .startsWith(CarbonCommonConstants.S3_PREFIX)) {
+    if (lowerPath.startsWith(CarbonCommonConstants.HDFSURL_PREFIX) ||
+        lowerPath.startsWith(CarbonCommonConstants.ALLUXIOURL_PREFIX) ||
+        lowerPath.startsWith(CarbonCommonConstants.VIEWFSURL_PREFIX) ||
+        lowerPath.startsWith(CarbonCommonConstants.LOCAL_FILE_PREFIX) ||
+        lowerPath.startsWith(CarbonCommonConstants.S3N_PREFIX) ||
+        lowerPath.startsWith(CarbonCommonConstants.S3A_PREFIX) ||
+        lowerPath.startsWith(CarbonCommonConstants.S3_PREFIX)) {
       return path;
     } else if (defaultFs != null) {
       return defaultFs + CarbonCommonConstants.FILE_SEPARATOR + path;

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonAddLoadCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonAddLoadCommand.scala
@@ -143,7 +143,7 @@ case class CarbonAddLoadCommand(
       false)
     newLoadMetaEntry.setPath(segmentPath)
     val format = options.getOrElse("format", "carbondata")
-    val isCarbonFormat = format.equals("carbondata") || format.equals("carbon")
+    val isCarbonFormat = format.equals("carbondata")
     if (!isCarbonFormat) {
       newLoadMetaEntry.setFileFormat(new FileFormat(format))
     }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/strategy/MixedFormatHandler.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/strategy/MixedFormatHandler.scala
@@ -144,7 +144,9 @@ object MixedFormatHandler {
       new CSVFileFormat
     } else if (fileFormat.equals(new FileFormatName("text"))) {
       new TextFileFormat
-    } else {
+    } else if (fileFormat.equals(new FileFormatName("carbon")))
+      new SparkCarbonFileFormat
+    else {
       throw new UnsupportedOperationException("Format not supported " + fileFormat)
     }
   }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/strategy/MixedFormatHandler.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/strategy/MixedFormatHandler.scala
@@ -144,9 +144,9 @@ object MixedFormatHandler {
       new CSVFileFormat
     } else if (fileFormat.equals(new FileFormatName("text"))) {
       new TextFileFormat
-    } else if (fileFormat.equals(new FileFormatName("carbon")))
+    } else if (fileFormat.equals(new FileFormatName("carbon"))) {
       new SparkCarbonFileFormat
-    else {
+    } else {
       throw new UnsupportedOperationException("Format not supported " + fileFormat)
     }
   }


### PR DESCRIPTION
Since adding parquet/orc files into CarbonData table are supported now, adding carbon files should be supported as well

This PR supports usage as below:
```
CREATE TABLE source (
  userId string,
  message string
) USING carbon/parquet/orc;

# bulk loading into source table for many times
INSERT INTO source ...
INSERT INTO source ...

CREATE TABLE target (
  userId string,
  message string
) USING carbondata;

# bulk loading into target table, creating internal segments
INSERT INTO target ...
INSERT INTO target ...

# add files from source table as external segments to target table
ALTER TABLE target ADD SEGMENT 
OPTIONS (path='path_from_source_table', format='carbon/parquet/orc');

# query target table will read files from both internal segment and external segment
SELECT * FROM target;

```

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

