### PR TITLE
[CARBONDATA-3562] Fix for SDK filter queries not working when schema is given explicitly while Add Segment

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/block/SegmentProperties.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/block/SegmentProperties.java
@@ -628,11 +628,11 @@ public class SegmentProperties {
   /**
    * This method will search for a given measure in the current block measures list
    *
-   * @param columnId
+   * @param measureToBeSearched
    * @return
    */
-  public CarbonMeasure getMeasureFromCurrentBlock(String columnId) {
-    return CarbonUtil.getMeasureFromCurrentBlock(this.measures, columnId);
+  public CarbonMeasure getMeasureFromCurrentBlock(CarbonMeasure measureToBeSearched) {
+    return CarbonUtil.getMeasureFromCurrentBlock(this.measures, measureToBeSearched);
   }
 
   public int getNumberOfSortColumns() {

--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/CarbonTable.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/CarbonTable.java
@@ -1302,7 +1302,7 @@ public class CarbonTable implements Serializable, Writable {
         CarbonMeasure measure = getMeasureByName(tableName, measureColumn);
         if (null != measure) {
           CarbonMeasure measureFromCurrentBlock =
-              segmentProperties.getMeasureFromCurrentBlock(measure.getColumnId());
+              segmentProperties.getMeasureFromCurrentBlock(measure);
           if (null != measureFromCurrentBlock) {
             minMaxCachedColsList.add(measureFromCurrentBlock);
           }

--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/column/CarbonColumn.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/column/CarbonColumn.java
@@ -206,4 +206,10 @@ public class CarbonColumn implements Serializable {
   public void setUseActualData(boolean useActualData) {
     this.useActualData = useActualData;
   }
+
+  public boolean isColmatchBasedOnId(CarbonColumn queryColumn) {
+    return this.getColName().equalsIgnoreCase(this.getColumnId()) && this.getColName()
+        .equalsIgnoreCase(queryColumn.getColName());
+  }
+
 }

--- a/core/src/main/java/org/apache/carbondata/core/scan/executor/impl/AbstractQueryExecutor.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/executor/impl/AbstractQueryExecutor.java
@@ -716,7 +716,7 @@ public abstract class AbstractQueryExecutor<E> implements QueryExecutor<E> {
       Set<CarbonMeasure> updatedFilterMeasures = new HashSet<>(queryFilterMeasures.size());
       for (CarbonMeasure queryMeasure : queryFilterMeasures) {
         CarbonMeasure measureFromCurrentBlock =
-            segmentProperties.getMeasureFromCurrentBlock(queryMeasure.getColumnId());
+            segmentProperties.getMeasureFromCurrentBlock(queryMeasure);
         if (null != measureFromCurrentBlock) {
           updatedFilterMeasures.add(measureFromCurrentBlock);
         }

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/FilterUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/FilterUtil.java
@@ -241,8 +241,8 @@ public final class FilterUtil {
       MeasureColumnResolvedFilterInfo msrColResolvedFilterInfo,
       SegmentProperties segmentProperties) {
     if (null != msrColResolvedFilterInfo && msrColResolvedFilterInfo.getMeasure().isMeasure()) {
-      CarbonMeasure measuresFromCurrentBlock = segmentProperties
-          .getMeasureFromCurrentBlock(msrColResolvedFilterInfo.getMeasure().getColumnId());
+      CarbonMeasure measuresFromCurrentBlock =
+          segmentProperties.getMeasureFromCurrentBlock(msrColResolvedFilterInfo.getMeasure());
       if (null != measuresFromCurrentBlock) {
         // update dimension and column index according to the dimension position in current block
         MeasureColumnResolvedFilterInfo msrColResolvedFilterInfoCopyObject =
@@ -356,8 +356,8 @@ public final class FilterUtil {
     boolean replaceCurrentNodeWithTrueFilter = false;
     CarbonColumn columnFromCurrentBlock = null;
     if (isMeasure) {
-      columnFromCurrentBlock = segmentProperties
-          .getMeasureFromCurrentBlock(columnResolvedFilterInfo.getMeasure().getColumnId());
+      columnFromCurrentBlock =
+          segmentProperties.getMeasureFromCurrentBlock(columnResolvedFilterInfo.getMeasure());
     } else {
       columnFromCurrentBlock =
           segmentProperties.getDimensionFromCurrentBlock(columnResolvedFilterInfo.getDimension());
@@ -422,8 +422,8 @@ public final class FilterUtil {
       SegmentProperties segmentProperties) {
 
     if (null != msrColResolvedFilterInfo && msrColResolvedFilterInfo.getMeasure().isMeasure()) {
-      CarbonMeasure measuresFromCurrentBlock = segmentProperties
-          .getMeasureFromCurrentBlock(msrColResolvedFilterInfo.getMeasure().getColumnId());
+      CarbonMeasure measuresFromCurrentBlock =
+          segmentProperties.getMeasureFromCurrentBlock(msrColResolvedFilterInfo.getMeasure());
       if (null != measuresFromCurrentBlock) {
         // update dimension and column index according to the dimension position in current block
         MeasureColumnResolvedFilterInfo msrColResolvedFilterInfoCopyObject =

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RowLevelFilterExecuterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RowLevelFilterExecuterImpl.java
@@ -181,8 +181,8 @@ public class RowLevelFilterExecuterImpl implements FilterExecuter {
   private void initMeasureChunkIndexes() {
     for (int i = 0; i < msrColEvalutorInfoList.size(); i++) {
       // find the measure in the current block measures list
-      CarbonMeasure measureFromCurrentBlock = segmentProperties.getMeasureFromCurrentBlock(
-          msrColEvalutorInfoList.get(i).getCarbonColumn().getColumnId());
+      CarbonMeasure measureFromCurrentBlock =
+          segmentProperties.getMeasureFromCurrentBlock(msrColEvalutorInfoList.get(i).getMeasure());
       if (null != measureFromCurrentBlock) {
         msrColEvalutorInfoList.get(i).setColumnIndex(measureFromCurrentBlock.getOrdinal());
         this.measureChunkIndex[i] = msrColEvalutorInfoList.get(i).getColumnIndexInMinMaxByteArray();

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
@@ -1142,7 +1142,11 @@ public final class CarbonUtil {
       List<CarbonDimension> blockDimensions, CarbonDimension dimensionToBeSearched) {
     CarbonDimension currentBlockDimension = null;
     for (CarbonDimension blockDimension : blockDimensions) {
-      if (dimensionToBeSearched.getColumnId().equalsIgnoreCase(blockDimension.getColumnId())) {
+      // In case of SDK, columnId is same as columnName therefore the following check will
+      // ensure that if the dimensions columnName is same as the block columnName and the dimension
+      // columnId is the same as dimensions columnName then it's a valid column to be scanned.
+      if (dimensionToBeSearched.getColumnId().equalsIgnoreCase(blockDimension.getColumnId())
+          || blockDimension.isColmatchBasedOnId(dimensionToBeSearched)) {
         currentBlockDimension = blockDimension;
         break;
       }
@@ -1154,14 +1158,18 @@ public final class CarbonUtil {
    * This method will search for a given measure in the current block measures list
    *
    * @param blockMeasures
-   * @param columnId
+   * @param measureToBeSearched
    * @return
    */
   public static CarbonMeasure getMeasureFromCurrentBlock(List<CarbonMeasure> blockMeasures,
-      String columnId) {
+      CarbonMeasure measureToBeSearched) {
     CarbonMeasure currentBlockMeasure = null;
     for (CarbonMeasure blockMeasure : blockMeasures) {
-      if (columnId.equals(blockMeasure.getColumnId())) {
+      // In case of SDK, columnId is same as columnName therefore the following check will
+      // ensure that if the measures columnName is same as the block columnName and the measures
+      // columnId is the same as measures columnName then it's a valid column to be scanned.
+      if (measureToBeSearched.getColumnId().equalsIgnoreCase(blockMeasure.getColumnId())
+          || blockMeasure.isColmatchBasedOnId(measureToBeSearched)) {
         currentBlockMeasure = blockMeasure;
         break;
       }

--- a/core/src/main/java/org/apache/carbondata/core/util/DeleteLoadFolders.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/DeleteLoadFolders.java
@@ -192,8 +192,10 @@ public final class DeleteLoadFolders {
 
   private static boolean checkIfLoadCanBeDeletedPhysically(LoadMetadataDetails oneLoad,
       boolean isForceDelete) {
-    if ((SegmentStatus.MARKED_FOR_DELETE == oneLoad.getSegmentStatus() ||
-        SegmentStatus.COMPACTED == oneLoad.getSegmentStatus())) {
+    // Check if the segment is added externally and path is set then do not delete it
+    if ((SegmentStatus.MARKED_FOR_DELETE == oneLoad.getSegmentStatus()
+        || SegmentStatus.COMPACTED == oneLoad.getSegmentStatus()) && (oneLoad.getPath() == null
+        || oneLoad.getPath().equalsIgnoreCase("NA"))) {
       if (isForceDelete) {
         return true;
       }


### PR DESCRIPTION
Problem1 : Queries will not return correct result from added segment when the schema is given explicitly in case of SDK.

Solution : Handled it by validating based on both column name and column id if it matches for the SDK column.

Problem2 : While deleting added segment, the physical location is also getting deleted.
Solution: Fixed that by adding validation.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

