### PR TITLE
[CARBONDATA-3563] optimize java code checkstyle for RedundantImport rule

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/DataMapSchemaStorageProvider.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/DataMapSchemaStorageProvider.java
@@ -22,7 +22,6 @@ import java.util.List;
 
 import org.apache.carbondata.common.annotations.InterfaceAudience;
 import org.apache.carbondata.common.exceptions.sql.NoSuchDataMapException;
-import org.apache.carbondata.core.metadata.schema.table.DataMapSchema;
 
 /**
  *It is used to save/retreive/drop datamap schema from storage medium like disk or DB.

--- a/core/src/main/java/org/apache/carbondata/core/scan/expression/MatchExpression.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/expression/MatchExpression.java
@@ -19,8 +19,6 @@ package org.apache.carbondata.core.scan.expression;
 
 import org.apache.carbondata.common.annotations.InterfaceAudience;
 import org.apache.carbondata.core.metadata.datatype.DataTypes;
-import org.apache.carbondata.core.scan.expression.Expression;
-import org.apache.carbondata.core.scan.expression.ExpressionResult;
 import org.apache.carbondata.core.scan.expression.exception.FilterIllegalMemberException;
 import org.apache.carbondata.core.scan.expression.exception.FilterUnsupportedException;
 import org.apache.carbondata.core.scan.filter.intf.ExpressionType;

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/InputMetricsStats.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/InputMetricsStats.java
@@ -18,7 +18,6 @@
 package org.apache.carbondata.hadoop;
 
 import java.io.Serializable;
-import java.lang.Long;
 
 /**
  * It gives statistics of number of bytes and record read


### PR DESCRIPTION
Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed? NO
 
 - [x] Any backward compatibility impacted? NO
 
 - [x] Document update required? NO

 - [x] Testing done YES
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.  NO

Checks for redundant import statements. An import statement is considered redundant if:

- It is a duplicate of another import.
- The class non-statically imported is from the java.lang package, e.g. importing java.lang.String.
- The class non-statically imported is from the same package as the current package.


