### PR TITLE
[CARBONDATA-3567] Added validation for compacting mixed format segments

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -1701,6 +1701,11 @@ public final class CarbonCommonConstants {
   public static final String FACT_FILE_EXT = ".carbondata";
 
   /**
+   * PARQUET_FILE_EXT
+   */
+  public static final String PARQUET_FILE_EXT = ".parquet";
+
+  /**
    * DELETE_DELTA_FILE_EXT
    */
   public static final String DELETE_DELTA_FILE_EXT = ".deletedelta";

--- a/core/src/main/java/org/apache/carbondata/core/statusmanager/FileFormat.java
+++ b/core/src/main/java/org/apache/carbondata/core/statusmanager/FileFormat.java
@@ -56,6 +56,11 @@ public class FileFormat implements Serializable {
     return COLUMNAR_V3;
   }
 
+  public boolean isCarbonFormat() {
+    return (this.format.equalsIgnoreCase("COLUMNAR_V3") ||
+        this.format.equalsIgnoreCase("ROW_V1"));
+  }
+
   @Override public boolean equals(Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/api/CarbonStore.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/api/CarbonStore.scala
@@ -120,9 +120,14 @@ object CarbonStore {
               (-1L, -1L)
             }
           } else {
-            // for batch segment, we can get the data size from table status file directly
-            (if (load.getDataSize == null) -1L else load.getDataSize.toLong,
-              if (load.getIndexSize == null) -1L else load.getIndexSize.toLong)
+            // If the added segment is other than carbon segment then we can only display the data
+            // size and not index size, we can get the data size from table status file directly
+            if (!load.getFileFormat.isCarbonFormat) {
+              (if (load.getIndexSize == null) -1L else load.getIndexSize.toLong, -1L)
+            } else {
+              (if (load.getDataSize == null) -1L else load.getDataSize.toLong,
+                if (load.getIndexSize == null) -1L else load.getIndexSize.toLong)
+            }
           }
 
           if (showHistory) {


### PR DESCRIPTION
1) Custom compaction with ids containing non carbon formats gave error. Custom compaction with segment ids containing mixed format segments blocked.

2) Data size and Index size is not displayed correctly for other format segments. Data-size is displayed as the size of files of the other segments and Index-size displayed as NA during show segments for external segments.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

