### PR TITLE
[CARBONDATA-3571] Add table status file read retry for query

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/statusmanager/SegmentStatusManager.java
+++ b/core/src/main/java/org/apache/carbondata/core/statusmanager/SegmentStatusManager.java
@@ -281,8 +281,15 @@ public class SegmentStatusManager {
       } catch (EOFException ex) {
         retry--;
         if (retry == 0) {
+          // we have retried several times, throw this exception to make the execution failed
           LOG.error("Failed to read metadata of load after retry", ex);
           throw ex;
+        }
+        try {
+          // sleep for some time before retry
+          Thread.sleep(10);
+        } catch (InterruptedException e) {
+          // ignored
         }
       } catch (IOException e) {
         LOG.error("Failed to read metadata of load", e);

--- a/core/src/main/java/org/apache/carbondata/core/statusmanager/SegmentStatusManager.java
+++ b/core/src/main/java/org/apache/carbondata/core/statusmanager/SegmentStatusManager.java
@@ -74,7 +74,7 @@ public class SegmentStatusManager {
 
   private Configuration configuration;
 
-  private static final int READ_TABLE_STATUS_RETRY = 3;
+  private static final int READ_TABLE_STATUS_RETRY_COUNT = 3;
 
   public SegmentStatusManager(AbsoluteTableIdentifier identifier) {
     this.identifier = identifier;
@@ -268,7 +268,7 @@ public class SegmentStatusManager {
     // When storing table status file in object store, reading of table status file may
     // fail (receive EOFException) when table status file is being modifying
     // so here we retry multiple times before throwing EOFException
-    int retry = READ_TABLE_STATUS_RETRY;
+    int retry = READ_TABLE_STATUS_RETRY_COUNT;
     while (retry > 0) {
       try {
         if (!FileFactory.isFileExist(tableStatusPath, FileFactory.getFileType(tableStatusPath))) {

--- a/core/src/main/java/org/apache/carbondata/core/statusmanager/SegmentStatusManager.java
+++ b/core/src/main/java/org/apache/carbondata/core/statusmanager/SegmentStatusManager.java
@@ -54,11 +54,12 @@ import org.apache.carbondata.core.util.CarbonUtil;
 import org.apache.carbondata.core.util.DeleteLoadFolders;
 import org.apache.carbondata.core.util.path.CarbonTablePath;
 
+import static org.apache.carbondata.core.constants.CarbonCommonConstants.DEFAULT_CHARSET;
+
 import com.google.gson.Gson;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.log4j.Logger;
 
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.DEFAULT_CHARSET;
 
 /**
  * Manages Load/Segment status

--- a/core/src/main/java/org/apache/carbondata/core/statusmanager/SegmentStatusManager.java
+++ b/core/src/main/java/org/apache/carbondata/core/statusmanager/SegmentStatusManager.java
@@ -30,6 +30,7 @@ import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
@@ -287,7 +288,7 @@ public class SegmentStatusManager {
         }
         try {
           // sleep for some time before retry
-          Thread.sleep(10);
+          TimeUnit.MICROSECONDS.sleep(10);
         } catch (InterruptedException e) {
           // ignored
         }


### PR DESCRIPTION
When storing table status file in object store, reading of table status file may fail (receive EOFException) when table status file is being modifying.

To protect from this scenario, this PR adds retry when reading table status file 

 - [X] Any interfaces changed?
 No
 - [X] Any backward compatibility impacted?
 No
 - [X] Document update required?
No
 - [X] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [X] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA
