### PR TITLE
[CARBONDATA-3530] Support Create timeseries MV Datamap with the supported granularity levels.

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/DataMapSchema.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/DataMapSchema.java
@@ -91,6 +91,11 @@ public class DataMapSchema implements Serializable, Writable {
    */
   private Map<Integer, String> columnsOrderMap;
 
+  /**
+   * timeseries query
+   */
+  private boolean isTimeSeries;
+
   public DataMapSchema(String dataMapName, String providerName) {
     this.dataMapName = dataMapName;
     this.providerName = providerName;
@@ -278,5 +283,13 @@ public class DataMapSchema implements Serializable, Writable {
 
   public void setColumnsOrderMap(Map<Integer, String> columnsOrderMap) {
     this.columnsOrderMap = columnsOrderMap;
+  }
+
+  public boolean isTimeSeries() {
+    return isTimeSeries;
+  }
+
+  public void setTimeSeries(boolean timeSeries) {
+    isTimeSeries = timeSeries;
   }
 }

--- a/datamap/mv/core/src/main/scala/org/apache/carbondata/mv/datamap/MVDataMapProvider.scala
+++ b/datamap/mv/core/src/main/scala/org/apache/carbondata/mv/datamap/MVDataMapProvider.scala
@@ -58,7 +58,11 @@ class MVDataMapProvider(
       throw new MalformedDataMapCommandException(
         "select statement is mandatory")
     }
-    MVHelper.createMVDataMap(sparkSession, dataMapSchema, ctasSqlStatement, true)
+    MVHelper.createMVDataMap(sparkSession,
+      dataMapSchema,
+      ctasSqlStatement,
+      true,
+      mainTable)
     try {
       DataMapStoreManager.getInstance.registerDataMapCatalog(this, dataMapSchema)
       if (dataMapSchema.isLazy) {

--- a/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/timeseries/TestMVTimeSeriesCreateDataMapCommand.scala
+++ b/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/timeseries/TestMVTimeSeriesCreateDataMapCommand.scala
@@ -1,0 +1,224 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package org.apache.carbondata.mv.timeseries
+
+import java.util.concurrent.{Callable, Executors, TimeUnit}
+
+import org.apache.spark.sql.test.util.QueryTest
+import org.scalatest.BeforeAndAfterAll
+
+import org.apache.carbondata.common.exceptions.sql.MalformedCarbonCommandException
+import org.apache.carbondata.core.constants.CarbonCommonConstants
+import org.apache.carbondata.core.util.CarbonProperties
+import org.apache.carbondata.mv.rewrite.TestUtil
+
+class TestMVTimeSeriesCreateDataMapCommand extends QueryTest with BeforeAndAfterAll {
+
+  private val timestampFormat = CarbonProperties.getInstance()
+    .getProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT)
+
+  override def beforeAll(): Unit = {
+    CarbonProperties.getInstance().addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, "dd-MM-yyyy")
+    drop()
+    sql("CREATE TABLE maintable (empname String, designation String, doj Timestamp, workgroupcategory int, workgroupcategoryname String, deptno int, " +
+        "deptname String, projectcode int, projectjoindate Timestamp, projectenddate Timestamp,attendance int, utilization int,salary int) STORED BY 'org.apache.carbondata.format'")
+    sql(s"""LOAD DATA local inpath '$resourcesPath/data_big.csv' INTO TABLE maintable  OPTIONS
+         |('DELIMITER'= ',', 'QUOTECHAR'= '"')""".stripMargin)
+  }
+
+  def drop(): Unit = {
+    sql("drop table if exists products")
+    sql("drop table IF EXISTS main_table")
+    sql("drop table IF EXISTS maintable")
+  }
+
+  test("test mv_timeseries create datamap") {
+    sql("drop datamap if exists datamap1")
+    sql(
+      "create datamap datamap1 on table maintable using 'mv'" +
+      " as select timeseries(projectjoindate,'second'), sum(projectcode) from maintable group by timeseries(projectjoindate,'second')")
+    val result = sql("show datamap on table maintable").collectAsList()
+    assert(result.get(0).get(0).toString.equalsIgnoreCase("datamap1"))
+    assert(result.get(0).get(4).toString.equalsIgnoreCase("ENABLED"))
+    val df = sql("select timeseries(projectjoindate,'second'), sum(projectcode) from maintable group by timeseries(projectjoindate,'second')")
+    assert(TestUtil.verifyMVDataMap(df.queryExecution.analyzed, "datamap1"))
+    sql("drop datamap if exists datamap1")
+  }
+
+  test("test mv_timeseries create lazy datamap") {
+    sql("drop datamap if exists datamap1")
+    intercept[MalformedCarbonCommandException] {
+      sql(
+        "create datamap datamap1 on table maintable using 'mv' with deferred rebuild as " +
+        "select timeseries(projectjoindate,'second') from maintable group by timeseries(projectjoindate,'second')")
+    }.getMessage.contains("MV TimeSeries queries does not support Lazy Rebuild")
+  }
+
+  test("test mv_timeseries create datamap with multiple granularity") {
+    sql("drop datamap if exists datamap1")
+    intercept[MalformedCarbonCommandException] {
+      sql(
+        "create datamap datamap1 on table maintable using 'mv'  as " +
+        "select timeseries(projectjoindate,'second'), timeseries(projectjoindate,'hour') from maintable")
+    }.getMessage.contains("Multiple timeseries udf functions are defined in Select statement with different granularities")
+  }
+
+  test("test mv_timeseries create datamap with date type as timeseries_column") {
+    sql("drop table IF EXISTS maintable_new")
+    sql("CREATE TABLE maintable_new (projectcode int, projectjoindate date, projectenddate Timestamp,attendance int) " +
+        "STORED BY 'org.apache.carbondata.format'")
+    sql("drop datamap if exists datamap1")
+    sql(
+      "create datamap datamap1 on table maintable_new using 'mv' as " +
+      "select timeseries(projectjoindate,'day') from maintable_new")
+    val result = sql("show datamap on table maintable_new").collectAsList()
+    assert(result.get(0).get(0).toString.equalsIgnoreCase("datamap1"))
+    assert(result.get(0).get(4).toString.equalsIgnoreCase("ENABLED"))
+    sql("drop table IF EXISTS maintable_new")
+  }
+
+  test("test mv_timeseries create datamap with date type as timeseries_column with incorrect granularity") {
+    sql("drop table IF EXISTS maintable_new")
+    sql("CREATE TABLE maintable_new (projectcode int, projectjoindate date, projectenddate Timestamp,attendance int) " +
+        "STORED BY 'org.apache.carbondata.format'")
+    sql("drop datamap if exists datamap1")
+    intercept[MalformedCarbonCommandException] {
+      sql(
+        "create datamap datamap1 on table maintable_new using 'mv' as " +
+        "select timeseries(projectjoindate,'second') from maintable_new")
+    }.getMessage
+      .contains("Granularity should be DAY,MONTH or YEAR, for timeseries column of Date type")
+    sql("drop table IF EXISTS maintable_new")
+  }
+
+  test("test mv_timeseries create datamap - Parent table name is different in Create and Select Statement") {
+    sql("drop table if exists main_table")
+    sql("CREATE TABLE main_table (empname String, designation String, doj Timestamp, workgroupcategory int, workgroupcategoryname String, deptno int, " +
+        "deptname String, projectcode int, projectjoindate Timestamp, projectenddate Timestamp,attendance int, utilization int,salary int) STORED BY 'org.apache.carbondata.format'")
+    sql("drop datamap if exists datamap1")
+    intercept[MalformedCarbonCommandException] {
+      sql(
+        "create datamap datamap1 on table main_table using 'mv' as " +
+        "select timeseries(projectjoindate,'second'), sum(projectcode) from maintable group by timeseries(projectjoindate,'second')")
+    }.getMessage.contains("Parent table name is different in Create and Select Statement")
+    sql("drop table if exists main_table")
+  }
+
+  test("test mv_timeseries for same event_column with different granularities") {
+    def dropDataMaps = {
+      sql("drop datamap if exists datamap1")
+      sql("drop datamap if exists datamap2")
+      sql("drop datamap if exists datamap3")
+      sql("drop datamap if exists datamap4")
+      sql("drop datamap if exists datamap5")
+    }
+    dropDataMaps
+    sql(
+      "create datamap datamap1 on table maintable using 'mv' as " +
+      "select timeseries(projectjoindate,'second'), sum(projectcode) from maintable group by timeseries(projectjoindate,'second')")
+    sql(
+      "create datamap datamap2 on table maintable using 'mv' as " +
+      "select timeseries(projectjoindate,'hour'), sum(projectcode) from maintable group by timeseries(projectjoindate,'hour')")
+    sql(
+      "create datamap datamap3 on table maintable using 'mv' as " +
+      "select timeseries(projectjoindate,'minute'), sum(projectcode) from maintable group by timeseries(projectjoindate,'minute')")
+    sql(
+      "create datamap datamap4 on table maintable using 'mv' as " +
+      "select timeseries(projectjoindate,'day'), sum(projectcode) from maintable group by timeseries(projectjoindate,'day')")
+    sql(
+      "create datamap datamap5 on table maintable using 'mv' as " +
+      "select timeseries(projectjoindate,'year'), sum(projectcode) from maintable group by timeseries(projectjoindate,'year')")
+    dropDataMaps
+  }
+
+  test("test mv_timeseries create datamap with more event_columns") {
+    sql("drop datamap if exists datamap1")
+    intercept[MalformedCarbonCommandException] {
+      sql(
+        "create datamap datamap1 on table maintable using 'mv' as " +
+        "select timeseries(projectjoindate,'hour'), timeseries(projectenddate,'hour') from maintable")
+    }.getMessage.contains(
+        "Multiple timeseries udf functions are defined in Select statement with different timestamp columns")
+  }
+
+  test("test mv_timeseries create datamap with same granularity and different ctas") {
+    sql("drop datamap if exists datamap1")
+    sql(
+      "create datamap datamap1 on table maintable using 'mv' as " +
+      "select timeseries(projectjoindate,'second'), sum(projectcode) from maintable group by timeseries(projectjoindate,'second')")
+    sql("drop datamap if exists datamap2")
+    sql(
+      "create datamap datamap2 on table maintable using 'mv' as " +
+      "select timeseries(projectjoindate,'second'), sum(projectcode) from maintable where projectjoindate='29-06-2008 00:00:00.0' " +
+      "group by timeseries(projectjoindate,'second')")
+    sql("drop datamap if exists datamap1")
+    sql("drop datamap if exists datamap2")
+  }
+
+  test("insert and create datamap in progress") {
+    sql("drop datamap if exists datamap1")
+    val query = s"LOAD DATA local inpath '$resourcesPath/data_big.csv' INTO TABLE maintable  " +
+                s"OPTIONS('DELIMITER'= ',')"
+    val executorService = Executors.newFixedThreadPool(4)
+    executorService.submit(new QueryTask(query))
+    intercept[UnsupportedOperationException] {
+      sql(
+        "create datamap datamap1 on table maintable using 'mv' as " +
+        "select timeseries(projectjoindate,'year'), sum(projectcode) from maintable group by timeseries(projectjoindate,'year')")
+    }.getMessage
+      .contains("Cannot create mv datamap table when insert is in progress on parent table: maintable")
+    executorService.shutdown()
+    executorService.awaitTermination(2, TimeUnit.HOURS)
+    sql("drop datamap if exists datamap1")
+  }
+
+  test("test create datamap with incorrect timeseries_column and granularity") {
+    sql("drop datamap if exists datamap2")
+    intercept[MalformedCarbonCommandException] {
+      sql(
+        "create datamap datamap2 on table maintable using 'mv' as " +
+        "select timeseries(projectjoindate,'time'), sum(projectcode) from maintable group by timeseries(projectjoindate,'time')")
+    }.getMessage.contains("Granularity time is invalid")
+    intercept[MalformedCarbonCommandException] {
+      sql(
+        "create datamap datamap2 on table maintable using 'mv' as " +
+        "select timeseries(empname,'second'), sum(projectcode) from maintable group by timeseries(empname,'second')")
+    }.getMessage.contains("MV Timeseries is only supported on Timestamp/Date column")
+  }
+
+  class QueryTask(query: String) extends Callable[String] {
+    override def call(): String = {
+      var result = "PASS"
+      try {
+        sql(query).collect()
+      } catch {
+        case exception: Exception => LOGGER.error(exception.getMessage)
+          result = "FAIL"
+      }
+      result
+    }
+  }
+
+  override def afterAll(): Unit = {
+    drop()
+    if (null != timestampFormat) {
+      CarbonProperties.getInstance()
+        .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT, timestampFormat)
+    }
+  }
+}

--- a/docs/datamap/mv-datamap-guide.md
+++ b/docs/datamap/mv-datamap-guide.md
@@ -23,6 +23,7 @@
 * [Querying Data](#querying-data)
 * [Compaction](#compacting-mv-datamap)
 * [Data Management](#data-management-with-mv-tables)
+* [MV TimeSeries Support](#mv-timeseries-support)
 
 ## Quick example
 
@@ -208,3 +209,25 @@ release, user can do as following:
 2. Carry out the data management operation on main table
 3. Create the mv datamap table again by `CREATE DATAMAP` command
 Basically, user can manually trigger the operation by re-building the datamap.
+
+## MV TimeSeries Support
+MV non-lazy datamap support's TimeSeries queries. Supported granularities strings are: year, month, day, week,
+hour,thirty_minute, fifteen_minute, minute and second.
+
+ User can create MV datamap with timeseries queries like the below example:
+
+  ```
+  CREATE DATAMAP agg_sales
+  ON TABLE sales
+  USING "MV"
+  AS
+    SELECT timeseries(order_time,'second'),avg(price)
+    FROM sales
+    GROUP BY timeseries(order_time,'second')
+  ```
+Supported columns that can be provided in timeseries udf should be of TimeStamp/Date type.
+Timeseries queries with Date type support's only year, month, day and week granularities.
+
+ **NOTE**:
+ 1. Multiple timeseries udf functions cannot be defined in Select statement with different timestamp 
+ columns or different granularities.


### PR DESCRIPTION
Use existing mv datamapProvider to create datamap with timeseries queries with the supported granularity levels

This PR supports,
1. Creating MV datamap with timeseries queries
    Syntax for creating mv-timeseries datamap:
    `CREATE datamap <datamap_name> on <table_name> using
    'mv' as Select timeseries(time_column,'granularity'), ... from
     <table_name> group by  timeseries(time_column,'granularity')`
   Queries having timeseries udf of timestamp/date column can be created as a mv datamap.
2. Added Validations for providing time stamp column and granularity.

Please refer design document attached in https://issues.apache.org/jira/browse/CARBONDATA-3525 for more info.

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

