### PR TITLE
[CARBONDATA-3572] optimize java code checkstyle for LeftCurly rule

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/compression/AbstractCompressor.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/compression/AbstractCompressor.java
@@ -125,5 +125,7 @@ public abstract class AbstractCompressor implements Compressor {
   }
 
   @Override
-  public boolean supportUnsafe() { return false; }
+  public boolean supportUnsafe() {
+    return false;
+  }
 }

--- a/core/src/main/java/org/apache/carbondata/core/keygenerator/mdkey/Bits.java
+++ b/core/src/main/java/org/apache/carbondata/core/keygenerator/mdkey/Bits.java
@@ -139,8 +139,8 @@ public class Bits implements Serializable {
 
       if (nextIndex != idx) {
         int consideredBits = lens[i] - ll & 0x3f;
-        if (consideredBits < lens[i]) //Check for spill over only if all the bits are not considered
-        {
+        //Check for spill over only if all the bits are not considered
+        if (consideredBits < lens[i]) {
           mask = (val >> (lens[i] - ll & 0x3f));//& (0x7fffffffffffffffL >> (0x3f-pos));
           word = words[nextIndex];
           words[nextIndex] = (word | mask);
@@ -176,8 +176,8 @@ public class Bits implements Serializable {
 
       if (nextIndex != index) {
         int consideredBits = lens[i] - ll & 0x3f;
-        if (consideredBits < lens[i]) //Check for spill over only if all the bits are not considered
-        {
+        //Check for spill over only if all the bits are not considered
+        if (consideredBits < lens[i]) {
           // Check for spill over
           mask = (val >> (lens[i] - ll & 0x3f));
           word = words[nextIndex];
@@ -207,8 +207,8 @@ public class Bits implements Serializable {
       int nextIndex = ll >> 6;
       if (nextIndex != index) {
         pos = ll & 0x3f;
-        if (pos != 0) // Number of bits pending for current key is zero, no spill over
-        {
+        // Number of bits pending for current key is zero, no spill over
+        if (pos != 0) {
           mask = (LONG_MAX >>> (MAX_LENGTH - pos));
           val = words[nextIndex];
           vals[i] = vals[i] | ((val & mask) << (lens[i] - pos));

--- a/core/src/main/java/org/apache/carbondata/core/keygenerator/mdkey/NumberCompressor.java
+++ b/core/src/main/java/org/apache/carbondata/core/keygenerator/mdkey/NumberCompressor.java
@@ -89,10 +89,8 @@ public class NumberCompressor {
 
       if (nextIndex != index) {
         int consideredBits = bitsLength - ll & 0x3f;
-        if (consideredBits < bitsLength) // Check for spill over only if
-        // all the bits are not
-        // considered
-        {
+        // Check for spill over only if all the bits are not considered
+        if (consideredBits < bitsLength) {
           // Check for spill over
           mask = (val >> (bitsLength - ll & 0x3f));
           words[nextIndex] |= mask;
@@ -145,8 +143,8 @@ public class NumberCompressor {
       int nextIndex = ll >> 6;
       if (nextIndex != index) {
         pos = ll & 0x3f;
-        if (pos != 0) // Number of bits pending for current key is zero, no spill over
-        {
+        // Number of bits pending for current key is zero, no spill over
+        if (pos != 0) {
           mask = (LONG_MAX >>> (MAX_LENGTH - pos));
           val = words[nextIndex];
           value = value | ((val & mask) << (bitsLength - pos));

--- a/core/src/main/java/org/apache/carbondata/core/scan/collector/impl/DictionaryBasedVectorResultCollector.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/collector/impl/DictionaryBasedVectorResultCollector.java
@@ -206,11 +206,10 @@ public class DictionaryBasedVectorResultCollector extends AbstractScannedResultC
     columnarBatch.setRowCounter(columnarBatch.getRowCounter() + requiredRows);
   }
 
-  void fillColumnVectorDetails(CarbonColumnarBatch columnarBatch, int rowCounter, int requiredRows)
-  {
+  void fillColumnVectorDetails(CarbonColumnarBatch columnarBatch, int rowCount, int requiredRows) {
     for (int i = 0; i < allColumnInfo.length; i++) {
       allColumnInfo[i].size = requiredRows;
-      allColumnInfo[i].offset = rowCounter;
+      allColumnInfo[i].offset = rowCount;
       allColumnInfo[i].vectorOffset = columnarBatch.getRowCounter();
       allColumnInfo[i].vector = columnarBatch.columnVectors[i];
       if (null != allColumnInfo[i].dimension) {

--- a/core/src/main/java/org/apache/carbondata/core/scan/executor/infos/BlockExecutionInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/executor/infos/BlockExecutionInfo.java
@@ -313,9 +313,8 @@ public class BlockExecutionInfo {
   /**
    * @param allSelectedDimensionColumnIndexRange the allSelectedDimensionColumnIndexRange to set
    */
-  public void setAllSelectedDimensionColumnIndexRange(int[][] allSelectedDimensionColumnIndexRange)
-  {
-    this.allSelectedDimensionColumnIndexRange = allSelectedDimensionColumnIndexRange;
+  public void setAllSelectedDimensionColumnIndexRange(int[][] selectedDimensionColumnIndexRange) {
+    this.allSelectedDimensionColumnIndexRange = selectedDimensionColumnIndexRange;
   }
 
   /**

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RowLevelFilterExecuterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RowLevelFilterExecuterImpl.java
@@ -621,8 +621,7 @@ public class RowLevelFilterExecuterImpl implements FilterExecuter {
     for (int i = 0; i < dimColEvaluatorInfoList.size(); i++) {
       DimColumnResolvedFilterInfo dimColumnEvaluatorInfo = dimColEvaluatorInfoList.get(i);
       if (!dimColumnEvaluatorInfo.getDimension().getDataType().isComplexType()) {
-        if (null == rawBlockletColumnChunks.getDimensionRawColumnChunks()[dimensionChunkIndex[i]])
-        {
+        if (null == rawBlockletColumnChunks.getDimensionRawColumnChunks()[dimensionChunkIndex[i]]) {
           rawBlockletColumnChunks.getDimensionRawColumnChunks()[dimensionChunkIndex[i]] =
               rawBlockletColumnChunks.getDataBlock().readDimensionChunk(
                   rawBlockletColumnChunks.getFileReader(), dimensionChunkIndex[i]);

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/vector/impl/CarbonColumnVectorImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/vector/impl/CarbonColumnVectorImpl.java
@@ -368,7 +368,9 @@ public class CarbonColumnVectorImpl implements CarbonColumnVector {
    * Returns true if any of the nulls indicator are set for this column. This can be used
    * as an optimization to prevent setting nulls.
    */
-  public final boolean anyNullsSet() { return anyNullsSet; }
+  public final boolean anyNullsSet() {
+    return anyNullsSet;
+  }
 
   @Override
   public void putFloats(int rowId, int count, float[] src, int srcIndex) {

--- a/core/src/main/java/org/apache/carbondata/events/Event.java
+++ b/core/src/main/java/org/apache/carbondata/events/Event.java
@@ -27,5 +27,7 @@ public abstract class Event {
    *
    * @return
    */
-  String getEventType() { return this.getClass().getName(); }
+  String getEventType() {
+    return this.getClass().getName();
+  }
 }

--- a/core/src/main/java/org/apache/carbondata/hadoop/CarbonInputSplit.java
+++ b/core/src/main/java/org/apache/carbondata/hadoop/CarbonInputSplit.java
@@ -485,7 +485,9 @@ public class CarbonInputSplit extends FileSplit
     return bucketId;
   }
 
-  public String getBlockletId() { return blockletId; }
+  public String getBlockletId() {
+    return blockletId;
+  }
 
   @Override
   public int compareTo(Distributable o) {
@@ -766,7 +768,9 @@ public class CarbonInputSplit extends FileSplit
   }
 
   /** The position of the first byte in the file to process. */
-  public long getStart() { return start; }
+  public long getStart() {
+    return start;
+  }
 
   /**
    * In case of index server detail info won't be present
@@ -800,7 +804,9 @@ public class CarbonInputSplit extends FileSplit
   }
 
   @Override
-  public String toString() { return filePath + ":" + start + "+" + length; }
+  public String toString() {
+    return filePath + ":" + start + "+" + length;
+  }
 
   @Override
   public String[] getLocations() throws IOException {

--- a/dev/javastyle-config.xml
+++ b/dev/javastyle-config.xml
@@ -180,7 +180,7 @@
 
         <!-- Checks for redundant imports. -->
         <module name="RedundantImport">
-            <property name="severity" value="info"/>
+            <property name="severity" value="error"/>
             <message key="import.redundancy" value="Redundant import {0}."/>
         </module>
 
@@ -191,7 +191,7 @@
 
         <!-- Checks for placement of the left curly brace ('{'). -->
         <module name="LeftCurly">
-            <property name="severity" value="info"/>
+            <property name="severity" value="error"/>
         </module>
 
         <!-- Checks for complicated boolean expressions. -->
@@ -201,7 +201,7 @@
 
         <!-- Checks for empty statements. -->
         <module name="EmptyStatement">
-            <property name="severity" value="info"/>
+            <property name="severity" value="error"/>
         </module>
 
         <!-- Checks for consecutive semicolons. -->

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/impl/CarbonTableConfig.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/impl/CarbonTableConfig.java
@@ -61,7 +61,9 @@ public class CarbonTableConfig {
     return this;
   }
 
-  public String getEnableUnsafeColumnPage() { return enableUnsafeColumnPage; }
+  public String getEnableUnsafeColumnPage() {
+    return enableUnsafeColumnPage;
+  }
 
   @Config("enable.unsafe.columnpage")
   public CarbonTableConfig setEnableUnsafeColumnPage(String enableUnsafeColumnPage) {
@@ -69,7 +71,9 @@ public class CarbonTableConfig {
     return this;
   }
 
-  public String getEnableUnsafeSort() { return enableUnsafeSort; }
+  public String getEnableUnsafeSort() {
+    return enableUnsafeSort;
+  }
 
   @Config("enable.unsafe.sort")
   public CarbonTableConfig setEnableUnsafeSort(String enableUnsafeSort) {
@@ -77,7 +81,9 @@ public class CarbonTableConfig {
     return this;
   }
 
-  public String getEnableQueryStatistics() { return enableQueryStatistics; }
+  public String getEnableQueryStatistics() {
+    return enableQueryStatistics;
+  }
 
   @Config("enable.query.statistics")
   public CarbonTableConfig setEnableQueryStatistics(String enableQueryStatistics) {
@@ -85,7 +91,9 @@ public class CarbonTableConfig {
     return this;
   }
 
-  public String getBatchSize() { return batchSize; }
+  public String getBatchSize() {
+    return batchSize;
+  }
 
   @Config("query.vector.batchSize")
   public CarbonTableConfig setBatchSize(String batchSize) {

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/csvinput/BlockDetails.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/csvinput/BlockDetails.java
@@ -72,13 +72,19 @@ public class BlockDetails extends FileSplit implements Serializable {
 
   /** The file containing this split's data. */
   @Override
-  public Path getPath() { return new Path(filePath); }
+  public Path getPath() {
+    return new Path(filePath);
+  }
 
   /** The position of the first byte in the file to process. */
   @Override
-  public long getStart() { return blockOffset; }
+  public long getStart() {
+    return blockOffset;
+  }
 
   /** The number of bytes in the file to process. */
   @Override
-  public long getLength() { return blockLength; }
+  public long getLength() {
+    return blockLength;
+  }
 }

--- a/processing/src/main/java/org/apache/carbondata/processing/merger/CarbonCompactionUtil.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/merger/CarbonCompactionUtil.java
@@ -112,8 +112,7 @@ public class CarbonCompactionUtil {
         groupCorrespodingInfoBasedOnTask(info, taskBlockInfoMapping, taskNo);
         // put the taskBlockInfo with respective segment id
         segmentBlockInfoMapping.put(segId, taskBlockInfoMapping);
-      } else
-      {
+      } else {
         groupCorrespodingInfoBasedOnTask(info, taskBlockInfoMapping, taskNo);
       }
     }

--- a/processing/src/main/java/org/apache/carbondata/processing/merger/RowResultMergerProcessor.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/merger/RowResultMergerProcessor.java
@@ -170,8 +170,7 @@ public class RowResultMergerProcessor extends AbstractResultProcessor {
           }
         }
       }
-      if (isDataPresent)
-      {
+      if (isDataPresent) {
         this.dataHandler.finish();
       }
       mergeStatus = true;

--- a/processing/src/main/java/org/apache/carbondata/processing/partition/spliter/RowResultProcessor.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/partition/spliter/RowResultProcessor.java
@@ -80,8 +80,7 @@ public class RowResultProcessor {
       for (Object[] row: resultList) {
         addRow(row);
       }
-      if (isDataPresent)
-      {
+      if (isDataPresent) {
         this.dataHandler.finish();
       }
       processStatus = true;

--- a/processing/src/main/java/org/apache/carbondata/processing/store/CarbonFactDataHandlerModel.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/CarbonFactDataHandlerModel.java
@@ -659,7 +659,9 @@ public class CarbonFactDataHandlerModel {
     return bucketId;
   }
 
-  public void setBucketId(Integer bucketId) { this.bucketId = bucketId; }
+  public void setBucketId(Integer bucketId) {
+    this.bucketId = bucketId;
+  }
 
   public long getSchemaUpdatedTimeStamp() {
     return schemaUpdatedTimeStamp;


### PR DESCRIPTION
Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed? NO
 
 - [x] Any backward compatibility impacted? NO
 
 - [x] Document update required? NO

 - [x] Testing done YES
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.  NO

Checks for the placement of left curly braces ('{') for code blocks, for a bad style example

#### org.apache.carbondata.core.datastore.compression.AbstractCompressor
``` 
@Override
public boolean supportReusableBuffer() {
  return false;
}

@Override
public boolean supportUnsafe() { return false; }
```


