### PR TITLE
[CARBONDATA-3561] Fix incorrect results after execute delete/update operation if there are null values

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/LocalDictDimensionDataChunkStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/LocalDictDimensionDataChunkStore.java
@@ -81,6 +81,9 @@ public class LocalDictDimensionDataChunkStore implements DimensionDataChunkStore
         vector.putNull(i);
         dictionaryVector.putNull(i);
       } else {
+        // if vector is 'ColumnarVectorWrapperDirectWithDeleteDelta', it needs to call 'putNotNull'
+        // to increase 'counter', otherwise it will set the null value to the wrong index.
+        vector.putNotNull(i);
         dictionaryVector.putInt(i, surrogate);
       }
     }

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/vector/impl/directread/ColumnarVectorWrapperDirectWithDeleteDelta.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/vector/impl/directread/ColumnarVectorWrapperDirectWithDeleteDelta.java
@@ -159,6 +159,13 @@ class ColumnarVectorWrapperDirectWithDeleteDelta extends AbstractCarbonColumnarV
   }
 
   @Override
+  public void putNotNull(int rowId) {
+    if (!deletedRows.get(rowId)) {
+      counter++;
+    }
+  }
+
+  @Override
   public void putFloats(int rowId, int count, float[] src, int srcIndex) {
     for (int i = srcIndex; i < count; i++) {
       if (!deletedRows.get(rowId++)) {

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/vector/impl/directread/ColumnarVectorWrapperDirectWithInvertedIndex.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/vector/impl/directread/ColumnarVectorWrapperDirectWithInvertedIndex.java
@@ -101,6 +101,11 @@ public class ColumnarVectorWrapperDirectWithInvertedIndex extends AbstractCarbon
   }
 
   @Override
+  public void putNotNull(int rowId) {
+    // nothing to do
+  }
+
+  @Override
   public void putFloats(int rowId, int count, float[] src, int srcIndex) {
     for (int i = srcIndex; i < count; i++) {
       columnVector.putFloat(invertedIndex[rowId++], src[i]);

--- a/datamap/examples/src/minmaxdatamap/main/java/org/apache/carbondata/datamap/examples/MinMaxIndexDataMapFactory.java
+++ b/datamap/examples/src/minmaxdatamap/main/java/org/apache/carbondata/datamap/examples/MinMaxIndexDataMapFactory.java
@@ -21,7 +21,10 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.log4j.Logger;
+
 import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.datamap.DataMapDistributable;
 import org.apache.carbondata.core.datamap.DataMapMeta;
@@ -41,9 +44,6 @@ import org.apache.carbondata.core.metadata.schema.table.column.CarbonColumn;
 import org.apache.carbondata.core.scan.filter.intf.ExpressionType;
 import org.apache.carbondata.core.util.path.CarbonTablePath;
 import org.apache.carbondata.events.Event;
-
-import org.apache.commons.lang3.StringUtils;
-import org.apache.hadoop.conf.Configuration;
 
 /**
  * Min Max DataMap Factory
@@ -137,7 +137,7 @@ public class MinMaxIndexDataMapFactory extends CoarseGrainDataMapFactory {
    * @param segment
    */
   @Override
-  public void clear(Segment segment) {
+  public void clear(String segmentNo) {
   }
 
   /**


### PR DESCRIPTION
**Problem:**
If there are null values in table, after execute delete/update sql, the results are incorrect when query with vector mode

**Root cause:**
In method 'fillVector' of 'LocalDictDimensionDataChunkStore', if the type of 'vector' is 'ColumnarVectorWrapperDirectWithDeleteDelta', the parameter 'counter' of 'ColumnarVectorWrapperDirectWithDeleteDelta' does not increase when the data is not null, so it will set the null value to the wrong index.

**Solution:**
Increase 'counter' of 'ColumnarVectorWrapperDirectWithDeleteDelta' when the data is not null.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?  No
 
 - [ ] Any backward compatibility impacted?  No
 
 - [ ] Document update required?  No

 - [x] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

