### PR TITLE
[CARBONDATA-3581] Support page level bloom filter

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/bloom/BloomFilterUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/bloom/BloomFilterUtil.java
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.carbondata.core.bloom;
 
 import java.io.IOException;
@@ -45,6 +46,9 @@ public class BloomFilterUtil {
   }
 
   public static int[] getPageBloomParameters() {
+    // Use maximum page size(not quite large) to reduce number of bloom parameter to set.
+    // And same parameters of bloom has same hash functions, so hashing the filter value one time
+    // then we can check all pages in blocklet when query
     return getBloomParameters(
             CarbonV3DataFormatConstants.NUMBER_OF_ROWS_PER_BLOCKLET_COLUMN_PAGE_DEFAULT,
             CarbonCommonConstants.DEFAULT_PAGE_BLOOM_FPP);
@@ -81,11 +85,8 @@ public class BloomFilterUtil {
 
   public static RoaringBitmap convertBitSetToRoaringBitmap(BitSet bits) {
     RoaringBitmap bitmap = new RoaringBitmap();
-    int length = bits.cardinality();
-    int nextSetBit = bits.nextSetBit(0);
-    for (int i = 0; i < length; ++i) {
-      bitmap.add(nextSetBit);
-      nextSetBit = bits.nextSetBit(nextSetBit + 1);
+    for (int i = bits.nextSetBit(0); i >= 0; i = bits.nextSetBit(i + 1)) {
+      bitmap.add(i);
     }
     return bitmap;
   }

--- a/core/src/main/java/org/apache/carbondata/core/bloom/BloomFilterUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/bloom/BloomFilterUtil.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.core.bloom;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.BitSet;
+
+import org.apache.carbondata.core.constants.CarbonCommonConstants;
+import org.apache.carbondata.core.constants.CarbonV3DataFormatConstants;
+
+import org.apache.hadoop.util.bloom.BloomFilter;
+import org.roaringbitmap.RoaringBitmap;
+
+public class BloomFilterUtil {
+
+  /**
+   *  Calculate page bloom parameters by item size and fpp
+   *  Formula:
+   *     Number of bits (m) = -n*ln(p) / (ln(2)^2)
+   *     Number of hashes(k) = m/n * ln(2)
+   *
+   * @param n Number of items in the filter
+   * @param p False positive probability
+   *
+   */
+  public static int[] getBloomParameters(int n, double p) {
+    double numOfBit = -n * Math.log(p) / (Math.pow(Math.log(2), 2));
+    double numOfHash = numOfBit / n * Math.log(2);
+    return new int[]{(int) Math.ceil(numOfBit), (int) Math.ceil(numOfHash)};
+  }
+
+  public static int[] getPageBloomParameters() {
+    return getBloomParameters(
+            CarbonV3DataFormatConstants.NUMBER_OF_ROWS_PER_BLOCKLET_COLUMN_PAGE_DEFAULT,
+            CarbonCommonConstants.DEFAULT_PAGE_BLOOM_FPP);
+  }
+
+  /**
+   * Get bitset from super class using reflection, in some cases java cannot access
+   * the fields if jars are loaded in separate class loaders.
+   *
+   */
+  public static BitSet getBitSet(BloomFilter bf) throws IOException {
+    try {
+      Field field = BloomFilter.class.getDeclaredField("bits");
+      field.setAccessible(true);
+      return (BitSet)field.get(bf);
+    } catch (Exception e) {
+      throw new IOException(e);
+    }
+  }
+
+  /**
+   * Set bitset from super class using reflection, in some cases java cannot access
+   * the fields if jars are loaded in separte class loaders.
+   */
+  public static void setBitSet(BitSet bitSet, BloomFilter bf) throws IOException {
+    try {
+      Field field = BloomFilter.class.getDeclaredField("bits");
+      field.setAccessible(true);
+      field.set(bf, bitSet);
+    } catch (Exception e) {
+      throw new IOException(e);
+    }
+  }
+
+  public static RoaringBitmap convertBitSetToRoaringBitmap(BitSet bits) {
+    RoaringBitmap bitmap = new RoaringBitmap();
+    int length = bits.cardinality();
+    int nextSetBit = bits.nextSetBit(0);
+    for (int i = 0; i < length; ++i) {
+      bitmap.add(nextSetBit);
+      nextSetBit = bits.nextSetBit(nextSetBit + 1);
+    }
+    return bitmap;
+  }
+
+  public static RoaringBitmap convertBloomFilterToRoaringBitmap(BloomFilter bf)
+          throws IOException {
+    return convertBitSetToRoaringBitmap(getBitSet(bf));
+  }
+}

--- a/core/src/main/java/org/apache/carbondata/core/bloom/ColumnPagesBloomFilter.java
+++ b/core/src/main/java/org/apache/carbondata/core/bloom/ColumnPagesBloomFilter.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.core.bloom;
+
+import java.io.*;
+import java.nio.ByteBuffer;
+import java.util.*;
+
+import org.apache.carbondata.common.logging.LogServiceFactory;
+import org.apache.carbondata.format.PageBloomChunk;
+
+import org.apache.hadoop.util.bloom.BloomFilter;
+import org.apache.hadoop.util.bloom.HashFunction;
+import org.apache.hadoop.util.bloom.Key;
+import org.apache.hadoop.util.hash.Hash;
+import org.apache.log4j.Logger;
+import org.roaringbitmap.RoaringBitmap;
+
+/**
+ * Store hash function parameters and bitmaps of each page for a column.
+ */
+public class ColumnPagesBloomFilter {
+
+  private static final Logger LOGGER =
+          LogServiceFactory.getLogService(ColumnPagesBloomFilter.class.getName());
+
+  /** The vector size of page bloom filter. */
+  private int vectorSize;
+
+  /** The number of hash function to consider. */
+  private short nbHash;
+
+  /** Type of hashing function to use. */
+  private short hashType;
+
+  /** The hash function used to map a key to several positions in the vector. */
+  protected HashFunction hash;
+
+  private List<RoaringBitmap> pageBitmaps;
+
+  private List<ByteBuffer> bloomByteBuffers;
+
+  /**
+   * This constructor is used for building page blooms.
+   */
+  public ColumnPagesBloomFilter() {
+    int[] bloomParas = BloomFilterUtil.getPageBloomParameters();
+    this.vectorSize = bloomParas[0];
+    this.nbHash = (short) bloomParas[1];
+    this.hashType = Hash.MURMUR_HASH;
+    this.hash = new HashFunction(vectorSize, nbHash, hashType);
+  }
+
+  /**
+   * This constructor is used for query.
+   * Only recover the bitmaps for necessary pages
+   */
+  public ColumnPagesBloomFilter(PageBloomChunk pageBloomChunk) {
+    this.vectorSize = pageBloomChunk.getVector_size();
+    this.nbHash = pageBloomChunk.getNum_hash();
+    this.hashType = pageBloomChunk.getHash_type();
+    this.hash = new HashFunction(vectorSize, nbHash, hashType);
+    this.bloomByteBuffers = pageBloomChunk.getPagebloom_list();
+  }
+
+
+  public void addPageBloomFilter(BloomFilter bloomFilter) {
+    if (null == pageBitmaps) {
+      pageBitmaps = new ArrayList<>();
+    }
+    try {
+      RoaringBitmap bitmap = BloomFilterUtil.convertBloomFilterToRoaringBitmap(bloomFilter);
+      pageBitmaps.add(bitmap);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+
+  /**
+   * prune pages based on minmax result bitset
+   */
+  public BitSet prunePages(byte[][] filterValues, BitSet minMaxBitSet) throws IOException {
+    // decode pages which is set to TRUE in minMaxBitSet
+    RoaringBitmap[] candidatePageBitmaps = new RoaringBitmap[minMaxBitSet.length()];
+    int length = minMaxBitSet.cardinality();
+    int nextSetBit = minMaxBitSet.nextSetBit(0);
+    for (int i = 0; i < length; ++i) {
+      byte[] bloomFilterInBytes = bloomByteBuffers.get(nextSetBit).array();
+      DataInputStream dis = new DataInputStream(new ByteArrayInputStream(bloomFilterInBytes));
+      RoaringBitmap bitmap = new RoaringBitmap();
+      bitmap.deserialize(dis);
+      candidatePageBitmaps[nextSetBit] = bitmap;
+      nextSetBit = minMaxBitSet.nextSetBit(nextSetBit + 1);
+    }
+
+    // check if page is hit in bloom
+    BitSet pageBitSet = new BitSet(minMaxBitSet.length());
+    for (byte[] filterValue : filterValues) {
+      int[] ret = hash.hash(new Key(filterValue)); // only hash once
+      for (int pageId = 0; pageId < minMaxBitSet.length(); pageId++) {
+        if (pageBitSet.get(pageId) // skip if bloom believed any filter in this page
+            || !minMaxBitSet.get(pageId)) { // skip if minmax set this page false
+          continue;
+        }
+        RoaringBitmap bitmap = candidatePageBitmaps[pageId];
+        boolean pageNeedCheck = true;
+        for (int k : ret) {
+          if (!bitmap.contains(k)) {
+            pageNeedCheck = false;
+            break;
+          }
+        }
+        if (pageNeedCheck) {
+          // all bit check pass
+          pageBitSet.set(pageId);
+        }
+      }
+    }
+    return pageBitSet;
+  }
+
+  public PageBloomChunk toPageBloomChunk() {
+    PageBloomChunk pageBloomChunk = new PageBloomChunk();
+    pageBloomChunk.setVector_size(this.vectorSize);
+    pageBloomChunk.setNum_hash(this.nbHash);
+    pageBloomChunk.setHash_type(this.hashType);
+    List<ByteBuffer> bitmaps = new ArrayList<>();
+
+    try {
+      for (RoaringBitmap page : pageBitmaps) {
+        ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(stream);
+        page.serialize(out);
+        out.close();
+        bitmaps.add(ByteBuffer.wrap(stream.toByteArray()));
+      }
+      pageBloomChunk.setPagebloom_list(bitmaps);
+      return pageBloomChunk;
+    } catch (IOException e) {
+      LOGGER.debug("Failed while converting to PageBloomChunk. " +
+              "Disable page bloom for current blocklet.", e);
+      // null can be taken as bloom is disabled
+      return null;
+    }
+  }
+}

--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -203,6 +203,16 @@ public final class CarbonCommonConstants {
   public static final String LOCAL_DICTIONARY_DECODER_BASED_FALLBACK_DEFAULT = "true";
 
   /**
+   * table properties for page level bloom filter to specify which columns needs to build
+   */
+  public static final String PAGE_BLOOM_INCLUDE = "page_bloom_include";
+
+  /**
+   * default value of page bloom's false positive probability parameter
+   */
+  public static final double DEFAULT_PAGE_BLOOM_FPP = 0.0005;
+
+  /**
    * zookeeper url key
    */
   @CarbonProperty

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/AbstractRawColumnChunk.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/AbstractRawColumnChunk.java
@@ -57,11 +57,11 @@ public abstract class AbstractRawColumnChunk {
   }
 
   public ColumnPagesBloomFilter getPageBloomFilter() {
-    if (!dataChunkV3.isSetPage_bloom_chunk()) {
-      // page bloom is disabled for current column in this blocklet
-      return null;
+    if (dataChunkV3.isSetPage_bloom_chunk()) {
+      return new ColumnPagesBloomFilter(dataChunkV3.page_bloom_chunk);
     }
-    return new ColumnPagesBloomFilter(dataChunkV3.page_bloom_chunk);
+    // page bloom is not available for current column
+    return null;
   }
 
   public byte[][] getMinValues() {

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/AbstractRawColumnChunk.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/AbstractRawColumnChunk.java
@@ -57,12 +57,11 @@ public abstract class AbstractRawColumnChunk {
   }
 
   public ColumnPagesBloomFilter getPageBloomFilter() {
-    // page bloom is disabled for current column in this blocklet
     if (!dataChunkV3.isSetPage_bloom_chunk()) {
+      // page bloom is disabled for current column in this blocklet
       return null;
-    } else {
-      return new ColumnPagesBloomFilter(dataChunkV3.page_bloom_chunk);
     }
+    return new ColumnPagesBloomFilter(dataChunkV3.page_bloom_chunk);
   }
 
   public byte[][] getMinValues() {

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/AbstractRawColumnChunk.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/AbstractRawColumnChunk.java
@@ -19,6 +19,7 @@ package org.apache.carbondata.core.datastore.chunk;
 
 import java.nio.ByteBuffer;
 
+import org.apache.carbondata.core.bloom.ColumnPagesBloomFilter;
 import org.apache.carbondata.format.DataChunk3;
 
 /**
@@ -53,6 +54,15 @@ public abstract class AbstractRawColumnChunk {
     this.rawData = rawData;
     this.offSet = offSet;
     this.length = length;
+  }
+
+  public ColumnPagesBloomFilter getPageBloomFilter() {
+    // page bloom is disabled for current column in this blocklet
+    if (!dataChunkV3.isSetPage_bloom_chunk()) {
+      return null;
+    } else {
+      return new ColumnPagesBloomFilter(dataChunkV3.page_bloom_chunk);
+    }
   }
 
   public byte[][] getMinValues() {

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/ColumnPage.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/ColumnPage.java
@@ -45,6 +45,8 @@ import static org.apache.carbondata.core.metadata.datatype.DataTypes.INT;
 import static org.apache.carbondata.core.metadata.datatype.DataTypes.LONG;
 import static org.apache.carbondata.core.metadata.datatype.DataTypes.SHORT;
 
+import org.apache.hadoop.util.bloom.BloomFilter;
+
 public abstract class ColumnPage {
 
   // number of row in this page
@@ -81,6 +83,18 @@ public abstract class ColumnPage {
 
   public int getPageSize() {
     return pageSize;
+  }
+
+  public void initBloom() {
+    statsCollector.initBloom();
+  }
+
+  public BloomFilter getBloomFilter() {
+    return statsCollector.getBloomFilter();
+  }
+
+  public boolean isBloomEnable() {
+    return null != statsCollector.getBloomFilter();
   }
 
   public void setStatsCollector(ColumnPageStatsCollector statsCollector) {

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/statistics/ColumnPageStatsCollector.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/statistics/ColumnPageStatsCollector.java
@@ -19,28 +19,54 @@ package org.apache.carbondata.core.datastore.page.statistics;
 
 import java.math.BigDecimal;
 
-public interface ColumnPageStatsCollector {
+import org.apache.carbondata.core.bloom.BloomFilterUtil;
+import org.apache.carbondata.core.constants.CarbonCommonConstants;
 
-  void updateNull(int rowId);
+import org.apache.hadoop.util.bloom.BloomFilter;
+import org.apache.hadoop.util.bloom.Key;
+import org.apache.hadoop.util.hash.Hash;
 
-  void update(byte value);
+public abstract class ColumnPageStatsCollector {
 
-  void update(short value);
+  protected BloomFilter bloomFilter;
 
-  void update(int value);
+  public abstract void updateNull(int rowId);
 
-  void update(long value);
+  public abstract void update(byte value);
 
-  void update(double value);
+  public abstract void update(short value);
 
-  void update(float value);
+  public abstract void update(int value);
 
-  void update(BigDecimal value);
+  public abstract void update(long value);
 
-  void update(byte[] value);
+  public abstract void update(double value);
+
+  public abstract void update(float value);
+
+  public abstract void update(BigDecimal value);
+
+  public abstract void update(byte[] value);
 
   /**
    * return the collected statistics
    */
-  SimpleStatsResult getPageStats();
+  public abstract SimpleStatsResult getPageStats();
+
+  public void initBloom() {
+    int[] bloomParas = BloomFilterUtil.getPageBloomParameters();
+    bloomFilter = new BloomFilter(bloomParas[0], bloomParas[1], Hash.MURMUR_HASH);
+  }
+
+  public BloomFilter getBloomFilter() {
+    return bloomFilter;
+  }
+
+  void addValueToBloom(byte[] value) {
+    if (value.length == 0) {
+      bloomFilter.add(new Key(CarbonCommonConstants.MEMBER_DEFAULT_VAL_ARRAY));
+    } else {
+      bloomFilter.add(new Key(value));
+    }
+  }
 }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/statistics/DummyStatsCollector.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/statistics/DummyStatsCollector.java
@@ -27,7 +27,7 @@ import static org.apache.carbondata.core.metadata.datatype.DataTypes.BYTE_ARRAY;
  * Column Page dummy stats collector. This will be used for which stats generation
  * is not required for example complex type column
  */
-public class DummyStatsCollector implements ColumnPageStatsCollector {
+public class DummyStatsCollector extends ColumnPageStatsCollector {
 
   /**
    * dummy stats used to sync with encoder

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/statistics/KeyPageStatsCollector.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/statistics/KeyPageStatsCollector.java
@@ -22,7 +22,7 @@ import java.math.BigDecimal;
 import org.apache.carbondata.core.metadata.datatype.DataType;
 import org.apache.carbondata.core.util.ByteUtil;
 
-public class KeyPageStatsCollector implements ColumnPageStatsCollector {
+public class KeyPageStatsCollector extends ColumnPageStatsCollector {
 
   private DataType dataType;
 

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/statistics/LVStringStatsCollector.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/statistics/LVStringStatsCollector.java
@@ -25,7 +25,7 @@ import org.apache.carbondata.core.metadata.datatype.DataTypes;
 import org.apache.carbondata.core.util.ByteUtil;
 import org.apache.carbondata.core.util.CarbonProperties;
 
-public abstract class LVStringStatsCollector implements ColumnPageStatsCollector {
+public abstract class LVStringStatsCollector extends ColumnPageStatsCollector {
 
   /**
    * allowed character limit for to be considered for storing min max
@@ -94,7 +94,14 @@ public abstract class LVStringStatsCollector implements ColumnPageStatsCollector
     }
     // input value is LV encoded
     byte[] newValue = getActualValue(value);
-    if (min == null) {
+
+    // add value to page bloom
+    if (null != bloomFilter) {
+      addValueToBloom(newValue);
+    }
+
+    // update min max
+    if (null == min) {
       min = newValue;
     }
     if (null == max) {

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/statistics/PrimitivePageStatsCollector.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/statistics/PrimitivePageStatsCollector.java
@@ -24,12 +24,14 @@ import org.apache.carbondata.core.datastore.page.encoding.bool.BooleanConvert;
 import org.apache.carbondata.core.metadata.ValueEncoderMeta;
 import org.apache.carbondata.core.metadata.datatype.DataType;
 import org.apache.carbondata.core.metadata.datatype.DataTypes;
+import org.apache.carbondata.core.util.CarbonUtil;
 
 import static org.apache.carbondata.core.datastore.page.encoding.bool.BooleanConvert.FALSE_VALUE;
 import static org.apache.carbondata.core.datastore.page.encoding.bool.BooleanConvert.TRUE_VALUE;
 
 /** statics for primitive column page */
-public class PrimitivePageStatsCollector implements ColumnPageStatsCollector, SimpleStatsResult {
+public class PrimitivePageStatsCollector extends ColumnPageStatsCollector
+        implements SimpleStatsResult {
   private static final String ZERO_STRING = "0";
   private DataType dataType;
   private byte minByte, maxByte;
@@ -221,6 +223,9 @@ public class PrimitivePageStatsCollector implements ColumnPageStatsCollector, Si
     if (maxInt < value) {
       maxInt = value;
     }
+    if (null != bloomFilter) {
+      addValueToBloom(CarbonUtil.getValueAsBytes(DataTypes.INT, value));
+    }
   }
 
   @Override
@@ -230,6 +235,9 @@ public class PrimitivePageStatsCollector implements ColumnPageStatsCollector, Si
     }
     if (maxLong < value) {
       maxLong = value;
+    }
+    if (null != bloomFilter) {
+      addValueToBloom(CarbonUtil.getValueAsBytes(DataTypes.LONG, value));
     }
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/metadata/converter/ThriftWrapperSchemaConverterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/converter/ThriftWrapperSchemaConverterImpl.java
@@ -606,6 +606,8 @@ public class ThriftWrapperSchemaConverterImpl implements SchemaConverter {
           .setLocalDictColumnsToWrapperSchema(listOfColumns, externalTableSchema.tableProperties,
               externalTableSchema.tableProperties
                   .get(CarbonCommonConstants.LOCAL_DICTIONARY_ENABLE));
+      CarbonUtil.setPageBloomColumnsToWrapperSchema(
+              listOfColumns, externalTableSchema.tableProperties);
     }
     wrapperTableSchema.setListOfColumns(listOfColumns);
     wrapperTableSchema.setSchemaEvolution(

--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/CarbonTable.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/CarbonTable.java
@@ -386,6 +386,8 @@ public class CarbonTable implements Serializable, Writable {
     CarbonUtil.setLocalDictColumnsToWrapperSchema(tableSchema.getListOfColumns(),
         tableSchema.getTableProperties(),
         tableSchema.getTableProperties().get(CarbonCommonConstants.LOCAL_DICTIONARY_ENABLE));
+    CarbonUtil.setPageBloomColumnsToWrapperSchema(tableSchema.getListOfColumns(),
+            tableSchema.getTableProperties());
     dimensionOrdinalMax = dimensionOrdinal;
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/column/CarbonColumn.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/column/CarbonColumn.java
@@ -184,6 +184,10 @@ public class CarbonColumn implements Serializable {
     return this.schemaOrdinal;
   }
 
+  public boolean isBloomPageColumn() {
+    return this.columnSchema.isPageBloomColumn();
+  }
+
   public String getDateFormat() {
     return dateFormat;
   }

--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/column/ColumnSchema.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/column/ColumnSchema.java
@@ -133,6 +133,11 @@ public class ColumnSchema implements Serializable, Writable {
   private String timeSeriesFunction = "";
 
   /**
+   * set whether the column enables page bloom or not.
+   */
+  private boolean isPageBloomColumn = false;
+
+  /**
    * set whether the column is local dictionary column or not.
    */
   private boolean isLocalDictColumn = false;
@@ -149,6 +154,14 @@ public class ColumnSchema implements Serializable, Writable {
    */
   public void setLocalDictColumn(boolean localDictColumn) {
     isLocalDictColumn = localDictColumn;
+  }
+
+  public boolean isPageBloomColumn() {
+    return isPageBloomColumn;
+  }
+
+  public void setPageBloomColumn(boolean pageBloomColumn) {
+    isPageBloomColumn = pageBloomColumn;
   }
 
   /**

--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/column/ColumnSchema.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/column/ColumnSchema.java
@@ -542,6 +542,7 @@ public class ColumnSchema implements Serializable, Writable {
       }
     }
     out.writeBoolean(isLocalDictColumn);
+    out.writeBoolean(isPageBloomColumn);
   }
 
   @Override
@@ -591,6 +592,7 @@ public class ColumnSchema implements Serializable, Writable {
       }
     }
     this.isLocalDictColumn = in.readBoolean();
+    this.isPageBloomColumn = in.readBoolean();
   }
 
   /**

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/IncludeFilterExecuterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/IncludeFilterExecuterImpl.java
@@ -275,7 +275,7 @@ public class IncludeFilterExecuterImpl implements FilterExecuter {
   public boolean applyFilter(RowIntf value, int dimOrdinalMax) {
     if (isDimensionPresentInCurrentBlock) {
       byte[][] filterValues = dimColumnExecuterInfo.getFilterKeys();
-      byte[] col = (byte[]) value.getVal(dimColumnEvaluatorInfo.getDimension().getOrdinal());
+      byte[] col = (byte[])value.getVal(dimColumnEvaluatorInfo.getDimension().getOrdinal());
       for (int i = 0; i < filterValues.length; i++) {
         if (0 == ByteUtil.UnsafeComparer.INSTANCE.compareTo(col, 0, col.length,
             filterValues[i], 0, filterValues[i].length)) {

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonMetadataUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonMetadataUtil.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.apache.carbondata.common.logging.LogServiceFactory;
+import org.apache.carbondata.core.bloom.ColumnPagesBloomFilter;
 import org.apache.carbondata.core.datastore.blocklet.BlockletEncodedColumnPage;
 import org.apache.carbondata.core.datastore.blocklet.EncodedBlocklet;
 import org.apache.carbondata.core.datastore.compression.CompressorFactory;
@@ -425,7 +426,7 @@ public class CarbonMetadataUtil {
    * return DataChunk3 that contains the input DataChunk2 list
    */
   public static DataChunk3 getDataChunk3(List<DataChunk2> dataChunksList,
-      LocalDictionaryChunk encodedDictionary) {
+      LocalDictionaryChunk encodedDictionary, ColumnPagesBloomFilter bloomFilter) {
     int offset = 0;
     DataChunk3 dataChunk = new DataChunk3();
     List<Integer> pageOffsets = new ArrayList<>();
@@ -442,6 +443,9 @@ public class CarbonMetadataUtil {
     dataChunk.setData_chunk_list(dataChunksList);
     dataChunk.setPage_length(pageLengths);
     dataChunk.setPage_offset(pageOffsets);
+    if (null != bloomFilter) {
+      dataChunk.setPage_bloom_chunk(bloomFilter.toPageBloomChunk());
+    }
     return dataChunk;
   }
 
@@ -458,8 +462,10 @@ public class CarbonMetadataUtil {
         .getEncodedColumnPageList()) {
       dataChunksList.add(encodedColumnPage.getPageMetadata());
     }
+    // get and set PageBloomChunk from blocklet. null means page bloom is disabled
     return CarbonMetadataUtil
-        .getDataChunk3(dataChunksList, blockletEncodedColumnPage.getEncodedDictionary());
+        .getDataChunk3(dataChunksList, blockletEncodedColumnPage.getEncodedDictionary(),
+                blockletEncodedColumnPage.getColumnPagesBloomFilter());
   }
 
   /**
@@ -474,7 +480,9 @@ public class CarbonMetadataUtil {
         .getEncodedColumnPageList()) {
       dataChunksList.add(encodedColumnPage.getPageMetadata());
     }
-    return CarbonMetadataUtil.getDataChunk3(dataChunksList, null);
+    // get and set PageBloomChunk from blocklet. null means page bloom is disabled
+    return CarbonMetadataUtil.getDataChunk3(dataChunksList, null,
+            blockletEncodedColumnPage.getColumnPagesBloomFilter());
   }
 
   private static int compareMeasureData(byte[] first, byte[] second, DataType dataType) {

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
@@ -3161,17 +3161,18 @@ public final class CarbonUtil {
     return columnLocalDictGenMap;
   }
 
-
+  /**
+   * sets the page bloom columns to wrapper schema, if the table property
+   * page_bloom_include is defined
+   * @param columns
+   * @param mainTableProperties
+   */
   public static void setPageBloomColumnsToWrapperSchema(List<ColumnSchema> columns,
         Map<String, String> mainTableProperties) {
-    if (!mainTableProperties.containsKey(CarbonCommonConstants.PAGE_BLOOM_INCLUDE)) {
-      return;
-    }
-    String[] pageBloomCols = null;
     String pageBloomIncludeColumns =
             mainTableProperties.get(CarbonCommonConstants.PAGE_BLOOM_INCLUDE);
     if (null != pageBloomIncludeColumns) {
-      pageBloomCols = pageBloomIncludeColumns.trim().split("\\s*,\\s*");
+      String[] pageBloomCols = pageBloomIncludeColumns.trim().split("\\s*,\\s*");
       for (String bloomColumn : pageBloomCols) {
         for (ColumnSchema column: columns) {
           if (bloomColumn.trim().equalsIgnoreCase(column.getColumnName())) {
@@ -3181,8 +3182,8 @@ public final class CarbonUtil {
         }
       }
     }
-
   }
+
   /**
    * This method get the carbon file format version
    *

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
@@ -3161,6 +3161,28 @@ public final class CarbonUtil {
     return columnLocalDictGenMap;
   }
 
+
+  public static void setPageBloomColumnsToWrapperSchema(List<ColumnSchema> columns,
+        Map<String, String> mainTableProperties) {
+    if (!mainTableProperties.containsKey(CarbonCommonConstants.PAGE_BLOOM_INCLUDE)) {
+      return;
+    }
+    String[] pageBloomCols = null;
+    String pageBloomIncludeColumns =
+            mainTableProperties.get(CarbonCommonConstants.PAGE_BLOOM_INCLUDE);
+    if (null != pageBloomIncludeColumns) {
+      pageBloomCols = pageBloomIncludeColumns.trim().split("\\s*,\\s*");
+      for (String bloomColumn : pageBloomCols) {
+        for (ColumnSchema column: columns) {
+          if (bloomColumn.trim().equalsIgnoreCase(column.getColumnName())) {
+            column.setPageBloomColumn(true);
+            break;
+          }
+        }
+      }
+    }
+
+  }
   /**
    * This method get the carbon file format version
    *

--- a/core/src/test/java/org/apache/carbondata/core/pagebloom/ColumnPagesBloomFilterTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/pagebloom/ColumnPagesBloomFilterTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.core.pagebloom;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.List;
+
+import org.apache.carbondata.core.bloom.BloomFilterUtil;
+import org.apache.carbondata.core.bloom.ColumnPagesBloomFilter;
+import org.apache.carbondata.core.metadata.datatype.DataTypes;
+import org.apache.carbondata.core.util.CarbonUtil;
+import org.apache.carbondata.format.PageBloomChunk;
+
+import org.apache.hadoop.util.bloom.BloomFilter;
+import org.apache.hadoop.util.bloom.Key;
+import org.apache.hadoop.util.hash.Hash;
+import org.junit.Test;
+
+public class ColumnPagesBloomFilterTest {
+
+  @Test
+  public void testColumnPagesBloomFilter() throws IOException {
+    // use same parameters as query
+    int[] bloomParas = BloomFilterUtil.getPageBloomParameters();
+    // build bloom filter
+    ColumnPagesBloomFilter pagesBloomFilter = new ColumnPagesBloomFilter();
+    for (int i = 0; i < 10; i++) {
+      // as bloom filter of a column page
+      BloomFilter bloomFilter = new BloomFilter(bloomParas[0], bloomParas[1], Hash.MURMUR_HASH);
+      for (int j = 0; j < 10; j++) {
+        bloomFilter.add(new Key(CarbonUtil.getValueAsBytes(DataTypes.INT, i * 10 + j)));
+      }
+      pagesBloomFilter.addPageBloomFilter(bloomFilter);
+    }
+    PageBloomChunk pageBloomChunk = pagesBloomFilter.toPageBloomChunk();
+
+    // simulate query recover the filter from file
+    ColumnPagesBloomFilter pagesBloomFilterRecovered = new ColumnPagesBloomFilter(pageBloomChunk);
+    // make minmax hit all pages
+    BitSet bitset = new BitSet(10);
+    bitset.flip(0, 10);
+    // can only check True Positive value since bloom has False Positive cases
+    List<byte[]> filterKeyBytes = new ArrayList<>();
+    filterKeyBytes.add(CarbonUtil.getValueAsBytes(DataTypes.INT, 0));
+    filterKeyBytes.add(CarbonUtil.getValueAsBytes(DataTypes.INT, 33));
+    filterKeyBytes.add(CarbonUtil.getValueAsBytes(DataTypes.INT, 71));
+    // check result
+    BitSet result = pagesBloomFilterRecovered.prunePages(filterKeyBytes.toArray(new byte[0][0]), bitset);
+    assert result.get(0);
+    assert result.get(3);
+    assert result.get(7);
+  }
+}

--- a/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/AbstractBloomDataMapWriter.java
+++ b/datamap/bloom/src/main/java/org/apache/carbondata/datamap/bloom/AbstractBloomDataMapWriter.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.carbondata.common.annotations.InterfaceAudience;
+import org.apache.carbondata.core.bloom.BloomFilterUtil;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.datamap.Segment;
 import org.apache.carbondata.core.datamap.dev.DataMapWriter;
@@ -78,29 +79,11 @@ public abstract class AbstractBloomDataMapWriter extends DataMapWriter {
 
   protected void resetBloomFilters() {
     indexBloomFilters.clear();
-    int[] stats = calculateBloomStats();
+    int[] stats = BloomFilterUtil.getBloomParameters(bloomFilterSize, bloomFilterFpp);
     for (int i = 0; i < indexColumns.size(); i++) {
       indexBloomFilters
           .add(new CarbonBloomFilter(stats[0], stats[1], Hash.MURMUR_HASH, compressBloom));
     }
-  }
-
-  /**
-   * It calculates the bits size and number of hash functions to calculate bloom.
-   */
-  private int[] calculateBloomStats() {
-    /*
-     * n: how many items you expect to have in your filter
-     * p: your acceptable false positive rate
-     * Number of bits (m) = -n*ln(p) / (ln(2)^2)
-     * Number of hashes(k) = m/n * ln(2)
-     */
-    double sizeinBits = -bloomFilterSize * Math.log(bloomFilterFpp) / (Math.pow(Math.log(2), 2));
-    double numberOfHashes = sizeinBits / bloomFilterSize * Math.log(2);
-    int[] stats = new int[2];
-    stats[0] = (int) Math.ceil(sizeinBits);
-    stats[1] = (int) Math.ceil(numberOfHashes);
-    return stats;
   }
 
   @Override

--- a/docs/ddl-of-carbondata.md
+++ b/docs/ddl-of-carbondata.md
@@ -25,6 +25,7 @@ CarbonData DDL statements are documented here,which includes:
   * [Inverted Index](#inverted-index-configuration)
   * [Sort Columns](#sort-columns-configuration)
   * [Sort Scope](#sort-scope-configuration)
+  * [Page Bloom](#page-bloom-configuration)
   * [Table Block Size](#table-block-size-configuration)
   * [Table Compaction](#table-compaction-configuration)
   * [Streaming](#streaming)
@@ -88,6 +89,7 @@ CarbonData DDL statements are documented here,which includes:
 | [INVERTED_INDEX](#inverted-index-configuration)              | Columns to include for inverted index generation             |
 | [SORT_COLUMNS](#sort-columns-configuration)                  | Columns to include in sort and its order of sort             |
 | [SORT_SCOPE](#sort-scope-configuration)                      | Sort scope of the load.Options include no sort, local sort ,batch sort and global sort |
+| [PAGE_BLOOM_INCLUDE](#page-bloom-configuration)      | Columns to include for page bloom generation |
 | [TABLE_BLOCKSIZE](#table-block-size-configuration)           | Size of blocks to write onto hdfs                            |
 | [TABLE_BLOCKLET_SIZE](#table-blocklet-size-configuration)    | Size of blocklet to write in the file                        |
 | [TABLE_PAGE_SIZE_INMB](#table-page-size-configuration)       | Size of page in MB; if page size crosses this value before 32000 rows, page will be cut to this many rows and remaining rows are processed in the subsequent pages. This helps in keeping page size to fit in cpu cache size|
@@ -259,6 +261,17 @@ CarbonData DDL statements are documented here,which includes:
    ```
 
    **NOTE:** CarbonData also supports "using carbondata". Find example code at [SparkSessionExample](https://github.com/apache/carbondata/blob/master/examples/spark2/src/main/scala/org/apache/carbondata/examples/SparkSessionExample.scala) in the CarbonData repo.
+
+   - ##### Page Bloom Configuration
+
+     Page bloom acts as supplement to min-max index to optimize query by skipping pages to scan.
+     It will take effect when configured columns take place in Equal/In filter. A typical example is point query for phone number.
+     Please note that page bloom will  increase the storage size of carbondata file.
+     This property is for setting which columns need to build bloom filter for values at page level. 
+
+     ```
+     TBLPROPERTIES ('PAGE_BLOOM_INCLUDE'='column1, column2')
+     ```
 
    - ##### Table Block Size Configuration
 

--- a/format/src/main/thrift/carbondata.thrift
+++ b/format/src/main/thrift/carbondata.thrift
@@ -151,8 +151,16 @@ struct DataChunk3{
     2: optional list<i32> page_offset; // Offset of each chunk
     3: optional list<i32> page_length; // Length of each chunk
     4: optional LocalDictionaryChunk local_dictionary; // to store blocklet local dictionary values
-   
+    5: optional PageBloomChunk page_bloom_chunk; // data of hash function and bitmaps of each page
  }
+
+ struct PageBloomChunk{
+    1: required i32 vector_size;
+    2: required i16 num_hash;
+    3: required i16 hash_type;
+    4: required list<binary> pagebloom_list;
+ }
+
 /**
  * Information about a blocklet for V1 format
  */

--- a/format/src/main/thrift/carbondata.thrift
+++ b/format/src/main/thrift/carbondata.thrift
@@ -155,10 +155,10 @@ struct DataChunk3{
  }
 
  struct PageBloomChunk{
-    1: required i32 vector_size;
-    2: required i16 num_hash;
-    3: required i16 hash_type;
-    4: required list<binary> pagebloom_list;
+    1: required i32 vector_size; // vector size of page bloom filter
+    2: required i16 num_hash; // number of resulting hashed values
+    3: required i16 hash_type; // type of hash function
+    4: required list<binary> pagebloom_list; // list of compressed bitmap of page bloom filter, one for a page
  }
 
 /**

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
@@ -518,8 +518,10 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
     pageBloomFields.foreach { column =>
       val bloomFiled = fields.find(_.column.equalsIgnoreCase(column))
       if (bloomFiled.isDefined) {
-        // check if data type is supported
         val datatypeStr = bloomFiled.get.dataType.getOrElse("");
+        // here we only allow following data types
+        // because they are more reasonable to have discrete values for filters
+        // applicable for bloom like `col = 1` or `col in (1,2)`
         val supportedType = Array("string", "int", "bigint")
         if (!supportedType.exists(_.equalsIgnoreCase(datatypeStr))) {
           val errorMsg = datatypeStr.toUpperCase +" data type is not supported in property " +

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
@@ -317,6 +317,11 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
     // column properties
     val colProps = extractColumnProperties(fields, tableProperties)
 
+    // validata the page level bloom property if defined
+    if (tableProperties.get(CarbonCommonConstants.PAGE_BLOOM_INCLUDE).isDefined) {
+      validatePageBloomColumns(fields, tableProperties)
+    }
+
     // validate the local dictionary property if defined
     if (tableProperties.get(CarbonCommonConstants.LOCAL_DICTIONARY_ENABLE).isDefined) {
       if (!CarbonScalaUtil
@@ -501,6 +506,32 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
       bucketFields: Option[BucketFields],
       partitionInfo,
       tableComment)
+  }
+
+  def validatePageBloomColumns(fields: Seq[Field], tableProperties: Map[String, String]): Unit = {
+    val pageBloomFields = tableProperties(CarbonCommonConstants.PAGE_BLOOM_INCLUDE)
+      .split(",").map(_.trim.toLowerCase)
+    if (pageBloomFields.length != pageBloomFields.distinct.length) {
+      throw new MalformedCarbonCommandException(
+        CarbonCommonConstants.PAGE_BLOOM_INCLUDE.toUpperCase() + " have duplicate columns")
+    }
+    pageBloomFields.foreach { column =>
+      val bloomFiled = fields.find(_.column.equalsIgnoreCase(column))
+      if (bloomFiled.isDefined) {
+        // check if data type is supported
+        val datatypeStr = bloomFiled.get.dataType.getOrElse("");
+        val supportedType = Array("string", "int", "bigint")
+        if (!supportedType.exists(_.equalsIgnoreCase(datatypeStr))) {
+          val errorMsg = datatypeStr.toUpperCase +" data type is not supported in property " +
+            CarbonCommonConstants.PAGE_BLOOM_INCLUDE.toUpperCase()
+          throw new MalformedCarbonCommandException(errorMsg)
+        }
+      } else {
+        val errorMsg = column + " set in property " +
+          CarbonCommonConstants.PAGE_BLOOM_INCLUDE.toUpperCase() + " does not exist in table."
+        throw new MalformedCarbonCommandException(errorMsg)
+      }
+    }
   }
 
   /**

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchemaCommon.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchemaCommon.scala
@@ -763,12 +763,15 @@ class TableNewProcessor(cm: TableModel) {
     // add all dimensions
     cm.dimCols.foreach(addDimensionCol(_))
 
-    // check whether the column is a local dictionary column and set in column schema
     if (null != cm.tableProperties) {
+      // check whether the column is a local dictionary column and set in column schema
       CarbonUtil
         .setLocalDictColumnsToWrapperSchema(allColumns.asJava,
           cm.tableProperties.asJava,
           cm.tableProperties(CarbonCommonConstants.LOCAL_DICTIONARY_ENABLE))
+      // set page level bloom info to column schema
+      CarbonUtil.setPageBloomColumnsToWrapperSchema(allColumns.asJava,
+          cm.tableProperties.asJava)
     }
     cm.msrCols.foreach { field =>
       // if aggregate function is defined in case of preaggregate and agg function is sum or avg

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonDescribeFormattedCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonDescribeFormattedCommand.scala
@@ -151,6 +151,10 @@ private[sql] case class CarbonDescribeFormattedCommand(
       results ++= Seq((CarbonCommonConstants.LONG_STRING_COLUMNS.toUpperCase,
         tblProps.getOrElse(CarbonCommonConstants.LONG_STRING_COLUMNS, ""), ""))
     }
+    if (tblProps.contains(CarbonCommonConstants.PAGE_BLOOM_INCLUDE)) {
+      results ++= Seq(("Page Bloom Include",
+        tblProps.getOrElse(CarbonCommonConstants.PAGE_BLOOM_INCLUDE, ""), ""))
+    }
 
     //////////////////////////////////////////////////////////////////////////////
     // Compaction Information

--- a/processing/src/main/java/org/apache/carbondata/processing/store/TablePage.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/TablePage.java
@@ -49,7 +49,6 @@ import org.apache.carbondata.core.localdictionary.generator.LocalDictionaryGener
 import org.apache.carbondata.core.memory.MemoryException;
 import org.apache.carbondata.core.metadata.datatype.DataType;
 import org.apache.carbondata.core.metadata.datatype.DataTypes;
-import org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema;
 import org.apache.carbondata.core.util.DataTypeUtil;
 import org.apache.carbondata.processing.datatypes.GenericDataType;
 
@@ -105,14 +104,6 @@ public class TablePage {
     noDictDimensionPages = new ColumnPage[model.getNoDictionaryCount()];
     int tmpNumDictDimIdx = 0;
     int tmpNumNoDictDimIdx = 0;
-
-    // find columns config to build page bloom
-    List<String> pageBloomColumns = new ArrayList<>();
-    for (ColumnSchema columnSchema : model.getWrapperColumnSchema()) {
-      if (columnSchema.isPageBloomColumn()) {
-        pageBloomColumns.add(columnSchema.getColumnName().toLowerCase());
-      }
-    }
 
     // create page for each column
     for (int i = 0; i < dictDimensionPages.length + noDictDimensionPages.length; i++) {
@@ -175,7 +166,7 @@ public class TablePage {
         noDictDimensionPages[tmpNumNoDictDimIdx++] = page;
       }
       // init to build page bloom
-      if (pageBloomColumns.contains(page.getColumnSpec().getFieldName().toLowerCase())) {
+      if (page.getColumnSpec().isPageBloomColumn()) {
         page.initBloom();
       }
     }
@@ -200,7 +191,7 @@ public class TablePage {
       measurePages[i] = page;
 
       // init to build page bloom
-      if (pageBloomColumns.contains(page.getColumnSpec().getFieldName().toLowerCase())) {
+      if (page.getColumnSpec().isPageBloomColumn()) {
         page.initBloom();
       }
     }
@@ -348,7 +339,7 @@ public class TablePage {
     }
     byte[] output = new byte[input.length + 2];
     ByteBuffer buffer = ByteBuffer.wrap(output);
-    buffer.putShort((short)input.length);
+    buffer.putShort((short) input.length);
     buffer.put(input, 0, input.length);
     return output;
   }


### PR DESCRIPTION
**Target Scenario**
Data of column page: `1 2 3 4 99` => min is 1 and max is 99
Point Query: `column_value = 11` => minmax will tell you to scan this page, but actually no need.

This pr is introducing Page Level Bloom Filter when filter is applied on *column with discrete values*, which helps to skip scanning data for better performance. Page pruning runs in executor side.

**Support Datatype**
Currently only allow to build page bloom on column with datatype `int`, `bigint` or `string`, which resonable to have discrete values.

**Usage**
Specify columns in table property `page_bloom_include`. 
Page bloom filter will build for those columns when loading. 
Query will use the filter if filter columns has page bloom data and the filter is EQUAL or IN.

## Test
**Load time & Storage size for different table property**
`≈88 million rows`
`Property 1: 'page_bloom_include'='str1,bigint1'  `
`Property 2: 'sort_scope'='local_sort','sort_column'='str1,bigint1'  ` 

table property| loadTime(seconds) |  dataSize(GB)
-|-|-
nosort|2157.345|24.10
nosort + page bloom|2178.867|24.35
sort|4435.986 / 4281.805|16.65
sort + page bloom|4388.571 / 4220.84|16.93

Query: avg time cost of 10 times each case

type | 1 filter 1 project(seconds) |  1 filter 100 project(seconds)
-|-|-
nosort|2.1978 | 3.4139
nosort_bloom|1.1871 | 2.1172
sort|0.3114 | 0.5209
sort_bloom|0.3151 | 0.5164

cpu usage with same order as the form above
![image](https://user-images.githubusercontent.com/3809732/69596352-45e66d00-103d-11ea-83ed-180b187130ca.png)


**Load time & Storage size for different number of page bloom column**

`no sort; ≈2.7 million rows;`

number of page bloom column | loadTime(seconds) |  dataSize(MB)
-|-|-
 1 | 58.998 | 777.92
 2 | 58.424 | 783.37
 3 | 58.197 | 785.14
 4 | 58.646 | 786.74
 5 | 58.621 | 788.67
 6 | 58.235 | 789.52
 7 | 58.954 | 791.29
 8 | 59.904 | 796.73
 9 | 58.785 | 802.17
 10 | 59.518 | 802.21
 11 | 59.051 | 802.23
 12 | 58.689 | 802.45
 13 | 59.06 | 802.66
 14 | 58.625 | 802.69
 15 | 59.973 | 808.13
 16 | 59.294 | 813.57
 17 | 59.08 | 813.58
 18 | 60.669 | 819.03
 19 | 59.484 | 824.46
 20 | 60.051 | 829.9
 21 | 59.728 | 830.98
 22 | 58.75 | 831.02
 23 | 59.612 | 831.03
 24 | 60.257 | 831.03
 25 | 59.42 | 831.78
 26 | 60.261 | 832.22
 27 | 59.843 | 832.23
 28 | 59.515 | 832.24
 29 | 61.135 | 833.27
 30 | 60.129 | 833.32
 31 | 60.393 | 833.5
 32 | 60.345 | 835.05
 33 | 59.882 | 840.49
 34 | 60.342 | 845.94
 35 | 60.656 | 851.38
 36 | 60.26 | 856.82
 37 | 60.764 | 862.27
 38 | 60.684 | 867.71
 39 | 60.539 | 869.84
 40 | 60.818 | 872.13
 41 | 60.743 | 872.14
 42 | 60.408 | 872.15
 43 | 61.21 | 872.15
 44 | 60.849 | 872.16
 45 | 63.1 | 873.6
 46 | 60.52 | 879.05
 47 | 60.701 | 879.05
 48 | 60.842 | 879.22
 49 | 62.261 | 879.52
 50 | 62.293 | 879.53


Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

