### PR TITLE
[CARBONDATA-3577] Use Spark 2.3 as default version and upgrade Spark 2.3.2 to 2.3.4

### DIFF
--- a/integration/spark-datasource/pom.xml
+++ b/integration/spark-datasource/pom.xml
@@ -180,7 +180,7 @@
     <profile>
       <id>build-all</id>
       <properties>
-        <spark.version>2.2.1</spark.version>
+        <spark.version>2.3.4</spark.version>
         <scala.binary.version>2.11</scala.binary.version>
         <scala.version>2.11.8</scala.version>
       </properties>
@@ -233,9 +233,6 @@
     </profile>
     <profile>
       <id>spark-2.2</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
       <properties>
         <spark.version>2.2.1</spark.version>
         <scala.binary.version>2.11</scala.binary.version>
@@ -276,8 +273,11 @@
     </profile>
     <profile>
       <id>spark-2.3</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
       <properties>
-        <spark.version>2.3.2</spark.version>
+        <spark.version>2.3.4</spark.version>
         <scala.binary.version>2.11</scala.binary.version>
         <scala.version>2.11.8</scala.version>
       </properties>

--- a/integration/spark2/pom.xml
+++ b/integration/spark2/pom.xml
@@ -236,7 +236,7 @@
     <profile>
       <id>build-all</id>
       <properties>
-        <spark.version>2.2.1</spark.version>
+        <spark.version>2.3.4</spark.version>
         <scala.binary.version>2.11</scala.binary.version>
         <scala.version>2.11.8</scala.version>
       </properties>
@@ -292,9 +292,6 @@
     </profile>
     <profile>
       <id>spark-2.2</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
       <properties>
         <spark.version>2.2.1</spark.version>
         <scala.binary.version>2.11</scala.binary.version>
@@ -338,8 +335,11 @@
     </profile>
     <profile>
       <id>spark-2.3</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
       <properties>
-        <spark.version>2.3.2</spark.version>
+        <spark.version>2.3.4</spark.version>
         <scala.binary.version>2.11</scala.binary.version>
         <scala.version>2.11.8</scala.version>
       </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,7 @@
     <scala.binary.version>2.11</scala.binary.version>
     <scala.version>2.11.8</scala.version>
     <hadoop.deps.scope>compile</hadoop.deps.scope>
+    <spark.version>2.3.4</spark.version>
     <spark.deps.scope>compile</spark.deps.scope>
     <scala.deps.scope>compile</scala.deps.scope>
     <dev.path>${basedir}/dev</dev.path>
@@ -546,9 +547,6 @@
     </profile>
     <profile>
       <id>spark-2.2</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
       <properties>
         <spark.version>2.2.1</spark.version>
         <scala.binary.version>2.11</scala.binary.version>
@@ -598,8 +596,11 @@
     </profile>
     <profile>
       <id>spark-2.3</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
       <properties>
-        <spark.version>2.3.2</spark.version>
+        <spark.version>2.3.4</spark.version>
         <scala.binary.version>2.11</scala.binary.version>
         <scala.version>2.11.8</scala.version>
       </properties>


### PR DESCRIPTION
Use Spark 2.3 as default version and upgrade Spark 2.3.2 to 2.3.4

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

