### PR TITLE
[CARBONDATA-3579] Support merging index files when adding new partition

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/standardpartition/StandardPartitionTableQueryTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/standardpartition/StandardPartitionTableQueryTestCase.scala
@@ -342,6 +342,16 @@ test("Creation of partition table should fail if the colname in table schema and
     checkAnswer(sql("show partitions partitionTable"), Seq(Row("email=abc"), Row("email=def")))
     checkAnswer(sql("select email from partitionTable"), Seq(Row("abc"), Row("def"), Row("def")))
     checkAnswer(sql("select count(*) from partitionTable"), Seq(Row(3)))
+    checkAnswer(sql("select id from partitionTable where email = 'def'"), Seq(Row(2), Row(3)))
+
+    // do compaction to sort data written by sdk
+    sql("alter table partitionTable compact 'major'")
+    assert(sql("show segments for table partitionTable").collectAsList().get(0).getString(1).contains("Compacted"))
+    checkAnswer(sql("show partitions partitionTable"), Seq(Row("email=abc"), Row("email=def")))
+    checkAnswer(sql("select email from partitionTable"), Seq(Row("abc"), Row("def"), Row("def")))
+    checkAnswer(sql("select count(*) from partitionTable"), Seq(Row(3)))
+    checkAnswer(sql("select id from partitionTable where email = 'def'"), Seq(Row(2), Row(3)))
+
     sql("drop table if exists partitionTable")
     FileFactory.deleteAllCarbonFilesOfDir(FileFactory.getCarbonFile(sdkWritePath))
   }

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/standardpartition/StandardPartitionTableQueryTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/standardpartition/StandardPartitionTableQueryTestCase.scala
@@ -20,7 +20,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.execution.strategy.CarbonDataSourceScan
 import org.apache.spark.sql.test.Spark2TestQueryExecutor
 import org.apache.spark.sql.test.util.QueryTest
-import org.apache.spark.sql.{DataFrame, Row}
+import org.apache.spark.sql.{CarbonEnv, DataFrame, Row}
 import org.apache.spark.util.SparkUtil
 import org.scalatest.BeforeAndAfterAll
 
@@ -28,6 +28,8 @@ import org.apache.carbondata.common.exceptions.sql.MalformedCarbonCommandExcepti
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.datastore.impl.FileFactory
 import org.apache.carbondata.core.util.CarbonProperties
+import org.apache.carbondata.core.util.path.CarbonTablePath
+import org.apache.carbondata.sdk.file.{CarbonWriter, Field, Schema}
 import org.apache.carbondata.spark.rdd.CarbonScanRDD
 
 class StandardPartitionTableQueryTestCase extends QueryTest with BeforeAndAfterAll {
@@ -312,6 +314,36 @@ test("Creation of partition table should fail if the colname in table schema and
     sql("insert into partitionTable select 1,'huawei','def'")
     checkAnswer(sql("select email from partitionTable"), Seq(Row("def"), Row("abc")))
     FileFactory.deleteAllCarbonFilesOfDir(FileFactory.getCarbonFile(location))
+  }
+
+  test("sdk write and add partition based on location on partition table"){
+    sql("drop table if exists partitionTable")
+    sql("create table partitionTable (id int,name String) partitioned by(email string) stored as carbondata")
+    sql("insert into partitionTable select 1,'blue','abc'")
+    val schemaFile =
+      CarbonTablePath.getSchemaFilePath(
+        CarbonEnv.getCarbonTable(None, "partitionTable")(sqlContext.sparkSession).getTablePath)
+
+    val sdkWritePath = metaStoreDB +"/" +"def"
+    FileFactory.deleteAllCarbonFilesOfDir(FileFactory.getCarbonFile(sdkWritePath))
+
+    val writer = CarbonWriter.builder()
+      .outputPath(sdkWritePath)
+      .writtenBy("test")
+      .withSchemaFile(schemaFile)
+      .withCsvInput()
+      .build()
+    writer.write(Seq("2", "red", "def").toArray)
+    writer.write(Seq("3", "black", "def").toArray)
+    writer.close()
+
+    sql(s"alter table partitionTable add partition (email='def') location '$sdkWritePath'")
+    sql("show partitions partitionTable").show(false)
+    checkAnswer(sql("show partitions partitionTable"), Seq(Row("email=abc"), Row("email=def")))
+    checkAnswer(sql("select email from partitionTable"), Seq(Row("abc"), Row("def"), Row("def")))
+    checkAnswer(sql("select count(*) from partitionTable"), Seq(Row(3)))
+    sql("drop table if exists partitionTable")
+    FileFactory.deleteAllCarbonFilesOfDir(FileFactory.getCarbonFile(sdkWritePath))
   }
 
   test("add partition with static column partition with load command") {

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/events/AlterTableEvents.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/events/AlterTableEvents.scala
@@ -205,9 +205,9 @@ case class AlterTableCompactionAbortEvent(sparkSession: SparkSession,
 /**
  * Compaction Event for handling merge index in alter DDL
  *
- * @param sparkSession
- * @param carbonTable
- * @param alterTableModel
+ * @param sparkSession spark session
+ * @param carbonTable carbon table
+ * @param alterTableModel alter request
  */
 case class AlterTableMergeIndexEvent(sparkSession: SparkSession,
     carbonTable: CarbonTable,

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/partition/CarbonAlterTableAddHivePartitionCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/partition/CarbonAlterTableAddHivePartitionCommand.scala
@@ -154,6 +154,12 @@ case class CarbonAlterTableAddHivePartitionCommand(
         // Make the load as success in table status
         CarbonLoaderUtil.recordNewLoadMetadata(newMetaEntry, loadModel, false, false)
 
+        // Normally, application will use Carbon SDK to write files into a partition folder, then
+        // add the folder to partitioned carbon table.
+        // If there are many threads writes to the same partition folder, there will be many
+        // carbon index files, and it is not good for query performance since all index files
+        // need to be read to spark driver.
+        // So, here trigger to merge the index files by sending an event
         val alterTableModel = AlterTableModel(
           dbName = Some(table.getDatabaseName),
           tableName = table.getTableName,

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/partition/CarbonAlterTableAddHivePartitionCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/partition/CarbonAlterTableAddHivePartitionCommand.scala
@@ -116,7 +116,7 @@ case class CarbonAlterTableAddHivePartitionCommand(
       if (segmentFile != null) {
         val indexToSchemas = SegmentFileStore.getSchemaFiles(segmentFile, table.getTablePath)
         val tableColums = table.getTableInfo.getFactTable.getListOfColumns.asScala
-        var isSameSchema = indexToSchemas.asScala.exists{ case(key, columnSchemas) =>
+        val isSameSchema = indexToSchemas.asScala.exists{ case(key, columnSchemas) =>
           columnSchemas.asScala.exists { col =>
             tableColums.exists(p => p.getColumnUniqueId.equals(col.getColumnUniqueId))
           } && columnSchemas.size() == tableColums.length
@@ -167,7 +167,7 @@ case class CarbonAlterTableAddHivePartitionCommand(
           compactionType = "", // to trigger index merge, this is not required
           factTimeStamp = Some(System.currentTimeMillis()),
           alterSql = null,
-          customSegmentIds = None)
+          customSegmentIds = Some(Seq(loadModel.getSegmentId).toList))
         val mergeIndexEvent = AlterTableMergeIndexEvent(sparkSession, table, alterTableModel)
         OperationListenerBus.getInstance.fireEvent(mergeIndexEvent, new OperationContext)
       }


### PR DESCRIPTION
Normally, application will use Carbon SDK to write files into a partition folder, then add the folder to partitioned carbon table. 
If there are many threads writes to the same partition folder, there will be many carbon index files, and it is not good for query performance since all index files need to be read to spark driver.

So, a better way is to merge the index files when adding new partition to carbon table.
This PR supports it.

 - [X] Any interfaces changed?
 No
 - [X] Any backward compatibility impacted?
 No
 - [X] Document update required?
No
 - [X] Testing done
   A new testcase added    
 - [X] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 
NA
