### PR TITLE
[CARBONDATA-3575] optimize java code checkstyle for OperatorWrap rule

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonLoadOptionConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonLoadOptionConstants.java
@@ -138,8 +138,8 @@ public final class CarbonLoadOptionConstants {
    * data. This option is especially useful when you encounter skewed data.
    */
   @CarbonProperty
-  public static final String ENABLE_CARBON_LOAD_SKEWED_DATA_OPTIMIZATION
-      = "carbon.load.skewedDataOptimization.enabled";
+  public static final String ENABLE_CARBON_LOAD_SKEWED_DATA_OPTIMIZATION =
+      "carbon.load.skewedDataOptimization.enabled";
 
   public static final String ENABLE_CARBON_LOAD_SKEWED_DATA_OPTIMIZATION_DEFAULT = "false";
 
@@ -154,8 +154,8 @@ public final class CarbonLoadOptionConstants {
   public static final String SORT_COLUMN_BOUNDS_ROW_DELIMITER = ";";
 
   @CarbonProperty
-  public static final String ENABLE_CARBON_LOAD_DIRECT_WRITE_TO_STORE_PATH
-      = "carbon.load.directWriteToStorePath.enabled";
+  public static final String ENABLE_CARBON_LOAD_DIRECT_WRITE_TO_STORE_PATH =
+      "carbon.load.directWriteToStorePath.enabled";
 
   public static final String ENABLE_CARBON_LOAD_DIRECT_WRITE_TO_STORE_PATH_DEFAULT = "false";
 
@@ -167,11 +167,10 @@ public final class CarbonLoadOptionConstants {
    * into sort memory, valid value is from 0 to 100.
    */
   @CarbonProperty
-  public static final String CARBON_LOAD_SORT_MEMORY_SPILL_PERCENTAGE
-      = "carbon.load.sortmemory.spill.percentage";
+  public static final String CARBON_LOAD_SORT_MEMORY_SPILL_PERCENTAGE =
+      "carbon.load.sortmemory.spill.percentage";
 
   public static final String CARBON_LOAD_SORT_MEMORY_SPILL_PERCENTAGE_DEFAULT = "0";
-
 
   /**
    * carbon binary decoder when writing string data to binary, like decode base64, Hex

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/BlockletDataMapIndexStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/BlockletDataMapIndexStore.java
@@ -162,8 +162,8 @@ public class BlockletDataMapIndexStore
   public List<BlockletDataMapIndexWrapper> getAll(
       List<TableBlockIndexUniqueIdentifierWrapper> tableSegmentUniqueIdentifiers)
       throws IOException {
-    Map<String, Map<String, BlockMetaInfo>> segInfoCache
-        = new HashMap<String, Map<String, BlockMetaInfo>>();
+    Map<String, Map<String, BlockMetaInfo>> segInfoCache =
+        new HashMap<String, Map<String, BlockMetaInfo>>();
 
     List<BlockletDataMapIndexWrapper> blockletDataMapIndexWrappers =
         new ArrayList<>(tableSegmentUniqueIdentifiers.size());

--- a/dev/javastyle-config.xml
+++ b/dev/javastyle-config.xml
@@ -242,7 +242,7 @@
 
         <!-- Checks for assign operators are at the end of the line. -->
         <module name="OperatorWrap">
-            <property name="severity" value="info"/>
+            <property name="severity" value="error"/>
             <property name="option" value="eol"/>
             <property name="tokens" value="ASSIGN"/>
         </module>

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/sort/SortStepRowHandler.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/sort/SortStepRowHandler.java
@@ -133,8 +133,7 @@ public class SortStepRowHandler implements Serializable {
   public Object[] convertRawRowTo3Parts(Object[] row) {
     Object[] holder = new Object[3];
     try {
-      int[] dictDims
-          = new int[this.dictSortDimCnt + this.dictNoSortDimCnt];
+      int[] dictDims = new int[this.dictSortDimCnt + this.dictNoSortDimCnt];
       Object[] nonDictArray = new Object[this.noDictSortDimCnt + this.noDictNoSortDimCnt
                                        + this.varcharDimCnt + this.complexDimCnt];
       Object[] measures = new Object[this.measureCnt];

--- a/processing/src/main/java/org/apache/carbondata/processing/partition/spliter/CarbonSplitExecutor.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/partition/spliter/CarbonSplitExecutor.java
@@ -58,8 +58,8 @@ public class CarbonSplitExecutor extends AbstractCarbonQueryExecutor {
         .dataConverter(converter)
         .enableForcedDetailRawQuery()
         .build();
-    List<PartitionSpliterRawResultIterator> resultList
-        = new ArrayList<>(CarbonCommonConstants.DEFAULT_COLLECTION_SIZE);
+    List<PartitionSpliterRawResultIterator> resultList =
+        new ArrayList<>(CarbonCommonConstants.DEFAULT_COLLECTION_SIZE);
     TaskBlockInfo taskBlockInfo = segmentMapping.get(segmentId);
     Set<String> taskBlockListMapping = taskBlockInfo.getTaskSet();
     for (String task : taskBlockListMapping) {


### PR DESCRIPTION
Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed? NO
 
 - [x] Any backward compatibility impacted? NO
 
 - [x] Document update required? NO

 - [x] Testing done YES
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.  NO

optimize java code checkstyle for OperatorWrap rule, for a bad style example

#### org.apache.carbondata.processing.loading.sort.SortStepRowHandler#convertRawRowTo3Parts
``` 
int[] dictDims
     = new int[this.dictSortDimCnt + this.dictNoSortDimCnt];
```


