### PR TITLE
[CARBONDATA-3585] Handle Range Compaction failure in case of Kryo Serializer

### DIFF
--- a/core/src/main/java/org/apache/carbondata/hadoop/CarbonInputSplitWrapper.java
+++ b/core/src/main/java/org/apache/carbondata/hadoop/CarbonInputSplitWrapper.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.hadoop;
+
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.carbondata.core.stream.ExtendedByteArrayOutputStream;
+import org.apache.carbondata.core.util.CarbonUtil;
+
+public class CarbonInputSplitWrapper implements Serializable {
+  private byte[] data;
+  private int size;
+
+  public CarbonInputSplitWrapper(List<CarbonInputSplit> inputSplitList) {
+    ExtendedByteArrayOutputStream stream = new ExtendedByteArrayOutputStream();
+    DataOutputStream dos = new DataOutputStream(stream);
+    try {
+      for (CarbonInputSplit carbonInputSplit : inputSplitList) {
+        carbonInputSplit.write(dos);
+      }
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    } finally {
+      CarbonUtil.closeStreams(dos);
+    }
+    this.data = stream.getBuffer();
+    this.size = inputSplitList.size();
+  }
+
+  public List<CarbonInputSplit> getInputSplit() {
+    ByteArrayInputStream stream = new ByteArrayInputStream(data);
+    DataInputStream dis = new DataInputStream(stream);
+    List<CarbonInputSplit> splits = new ArrayList<>();
+    try {
+      for (int i = 0; i < size; i++) {
+        CarbonInputSplit split = new CarbonInputSplit();
+        split.readFields(dis);
+        splits.add(split);
+      }
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    } finally {
+      CarbonUtil.closeStreams(dis);
+    }
+    return splits;
+  }
+}

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonMergerRDD.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonMergerRDD.scala
@@ -56,7 +56,7 @@ import org.apache.carbondata.core.scan.result.iterator.RawResultIterator
 import org.apache.carbondata.core.statusmanager.{FileFormat, LoadMetadataDetails, SegmentStatusManager, SegmentUpdateStatusManager}
 import org.apache.carbondata.core.util.{CarbonProperties, CarbonUtil, DataTypeUtil}
 import org.apache.carbondata.core.util.path.CarbonTablePath
-import org.apache.carbondata.hadoop.{CarbonInputSplit, CarbonMultiBlockSplit, CarbonProjection}
+import org.apache.carbondata.hadoop.{CarbonInputSplit, CarbonInputSplitWrapper, CarbonMultiBlockSplit, CarbonProjection}
 import org.apache.carbondata.hadoop.api.{CarbonInputFormat, CarbonTableInputFormat}
 import org.apache.carbondata.hadoop.util.{CarbonInputFormatUtil, CarbonInputSplitTaskInfo}
 import org.apache.carbondata.processing.loading.TableProcessingOperations
@@ -89,10 +89,10 @@ class CarbonMergerRDD[K, V](
   var rangeColumn: CarbonColumn = null
   var singleRange = false
   var expressionMapForRangeCol: util.Map[Integer, Expression] = null
-  var broadCastSplits: Broadcast[util.List[CarbonInputSplit]] = null
+  var broadCastSplits: Broadcast[CarbonInputSplitWrapper] = null
 
   def makeBroadCast(splits: util.List[CarbonInputSplit]): Unit = {
-    broadCastSplits = sparkContext.broadcast(splits)
+    broadCastSplits = sparkContext.broadcast(new CarbonInputSplitWrapper(splits))
   }
 
   override def internalCompute(theSplit: Partition, context: TaskContext): Iterator[(K, V)] = {
@@ -125,7 +125,7 @@ class CarbonMergerRDD[K, V](
           // all the splits)
           carbonSparkPartition.split.value.getAllSplits
         } else {
-          broadCastSplits.value
+          broadCastSplits.value.getInputSplit
         }
         val tableBlockInfoList = CarbonInputSplit.createBlocks(splitList)
 


### PR DESCRIPTION
Problem : Range Compaction fails in case of Kryo Serializer.
Solution : Fixed it by converting splits into Byte-Array and then broadcasting them to all the executors in case of Range Column.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

