### PR TITLE
[CARBONDATA-3584] Fix Select Query failure for Boolean dictionary column when Codegen is diasbled

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/util/DataTypeUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/DataTypeUtil.java
@@ -715,6 +715,12 @@ public final class DataTypeUtil {
           javaDecVal = javaDecVal.setScale(dimension.getColumnSchema().getScale());
         }
         return getDataTypeConverter().convertFromBigDecimalToDecimal(javaDecVal);
+      } else if (dataType == DataTypes.BOOLEAN) {
+        String data8 = new String(dataInBytes, CarbonCommonConstants.DEFAULT_CHARSET_CLASS);
+        if (data8.isEmpty()) {
+          return null;
+        }
+        return BooleanConvert.parseBoolean(data8);
       } else {
         return getDataTypeConverter().convertFromByteToUTF8String(dataInBytes);
       }

--- a/integration/spark2/src/test/scala/org/apache/carbondata/spark/testsuite/booleantype/BooleanDataTypesBaseTest.scala
+++ b/integration/spark2/src/test/scala/org/apache/carbondata/spark/testsuite/booleantype/BooleanDataTypesBaseTest.scala
@@ -154,4 +154,21 @@ class BooleanDataTypesBaseTest extends QueryTest with BeforeAndAfterEach with Be
     sql("delete from carbon_table where cc=true")
     checkAnswer(sql("select COUNT(*) from carbon_table"), Row(0))
   }
+
+  test("test boolean as dictionary include column and codegen=false"){
+    sql("drop table if exists carbon_table")
+    sql("create table carbon_table(a1 boolean,a2 string,a3 int) stored by 'carbondata' tblproperties('dictionary_include'='a1')")
+    sql("insert into carbon_table select false,'a',1")
+    sql("set spark.sql.codegen.wholestage=false")
+    checkAnswer(sql("select a1 from carbon_table"), Seq(Row(false)))
+    sql("set spark.sql.codegen.wholestage=true")
+    checkAnswer(sql("select a1 from carbon_table"), Seq(Row(false)))
+    sql("insert into carbon_table select true,'a',1")
+    sql("set spark.sql.codegen.wholestage=false")
+    checkAnswer(sql("select a1 from carbon_table"), Seq(Row(false), Row(true)))
+    sql("set spark.sql.codegen.wholestage=true")
+    checkAnswer(sql("select a1 from carbon_table"), Seq(Row(false), Row(true)))
+    sql("reset")
+    sql("drop table if exists carbon_table")
+  }
 }


### PR DESCRIPTION
Problem:
Select query fails for boolean dictionary column with CastException when codegen is disabled.

Solution:
Added Boolean case in getDataBasedOnDataType and  decode Boolean in CodegenContext

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

