### PR TITLE
[CARBONDATA-3588]: Table id taken as key generated from table path for non-transactional table

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datamap/DataMapStoreManager.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/DataMapStoreManager.java
@@ -322,7 +322,7 @@ public final class DataMapStoreManager {
     String tableId =
         table.getAbsoluteTableIdentifier().getCarbonTableIdentifier().getTableId();
     List<TableDataMap> tableIndices = allDataMaps.get(table.getTableId());
-    if (tableIndices == null) {
+    if (tableIndices == null && !table.isTransactionalTable()) {
       String keyUsingTablePath = getKeyUsingTablePath(table.getTablePath());
       if (keyUsingTablePath != null) {
         tableId = keyUsingTablePath;


### PR DESCRIPTION
Modification reason: Show cache command on table with index server enabled displays the index size incorrectly for table that was created with index server disabled

Modification content: In case of non transactional table, the table id is now taken as the key generated from the table path


Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

