### PR TITLE
[CARBONDATA-3589]: Adding NULL segments check and empty segments check before prepriming

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -28,6 +28,7 @@ import scala.collection.mutable.ListBuffer
 import scala.util.Random
 import scala.util.control.Breaks._
 
+import org.apache.commons.lang3.StringUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.io.NullWritable
@@ -594,7 +595,7 @@ object CarbonDataRDDFactory {
 
       // code to handle Pre-Priming cache for loading
 
-      if (carbonLoadModel.getSegmentId != null) {
+      if (!StringUtils.isEmpty(carbonLoadModel.getSegmentId)) {
         DistributedRDDUtils.triggerPrepriming(sqlContext.sparkSession, carbonTable, Seq(),
           operationContext, hadoopConf, List(carbonLoadModel.getSegmentId))
       }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonLoadDataCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonLoadDataCommand.scala
@@ -870,7 +870,7 @@ case class CarbonLoadDataCommand(
       }
 
       // Prepriming for Partition table here
-      if (carbonLoadModel.getSegmentId != null) {
+      if (!StringUtils.isEmpty(carbonLoadModel.getSegmentId)) {
         DistributedRDDUtils.triggerPrepriming(sparkSession,
           table,
           Seq(),


### PR DESCRIPTION
Insert into select from hive table into carbon table having partition fails with index server running because of the fact that empty segments were being sent for prepriming. Added a check for the same.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

