### PR TITLE
[HOTFIX]Fix listing both old and new index files while writing segment file

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/metadata/SegmentFileStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/SegmentFileStore.java
@@ -173,20 +173,6 @@ public class SegmentFileStore {
   }
 
   /**
-   * Write segment file to the metadata folder of the table
-   *
-   * @param carbonTable CarbonTable
-   * @param segmentId segment id
-   * @param UUID      a UUID string used to construct the segment file name
-   * @return segment file name
-   */
-  public static String writeSegmentFile(CarbonTable carbonTable, String segmentId, String UUID,
-      String segPath)
-      throws IOException {
-    return writeSegmentFile(carbonTable, segmentId, UUID, null, segPath);
-  }
-
-  /**
    * Returns the list of index files
    *
    * @param segmentPath
@@ -299,7 +285,7 @@ public class SegmentFileStore {
    * @return
    * @throws IOException
    */
-  public static String writeSegmentFile(CarbonTable carbonTable, String segmentId, String UUID,
+  public static String writeSegmentFile(CarbonTable carbonTable, String segmentId,
       final String currentLoadTimeStamp, String absSegPath) throws IOException {
     String tablePath = carbonTable.getTablePath();
     boolean supportFlatFolder = carbonTable.isSupportFlatFolder();
@@ -346,7 +332,8 @@ public class SegmentFileStore {
       if (!carbonFile.exists()) {
         carbonFile.mkdirs(segmentFileFolder);
       }
-      String segmentFileName = genSegmentFileName(segmentId, UUID) + CarbonTablePath.SEGMENT_EXT;
+      String segmentFileName =
+          genSegmentFileName(segmentId, currentLoadTimeStamp) + CarbonTablePath.SEGMENT_EXT;
       // write segment info to new file.
       writeSegmentFile(segmentFile, segmentFileFolder + File.separator + segmentFileName);
 


### PR DESCRIPTION
### Why this PR?
In segment file store, we were passing two arguments to writeSegmentfile which will be same values as load start time, so remove unnecessary method.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

