### PR TITLE
[CARBONDATA-3584]Fix Select Query failure for Boolean dictionary column when Codegen is diasbled

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonDictionaryDecoder.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonDictionaryDecoder.scala
@@ -232,7 +232,7 @@ case class CarbonDictionaryDecoder(
            |  return tuple;
            |}""".stripMargin)
       val decodeBool = ctx.freshName("deDictBool")
-      ctx.addNewFunction(decodeStr,
+      ctx.addNewFunction(decodeBool,
         s"""
            |private org.apache.spark.sql.DictTuple $decodeBool(
            |  org.apache.spark.sql.ForwardDictionaryWrapper dict, int surg)


### PR DESCRIPTION
[HOTFIX]Fix Select Query failure for Boolean dictionary column when Codegen is diasbled

Induced because of [https://github.com/apache/carbondata/pull/3463](https://github.com/apache/carbondata/pull/3463)

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
      
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

