### PR TITLE
[HOTFIX] Change not to use cache when creating CarbonTable from schema file

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/SchemaReader.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/SchemaReader.java
@@ -69,8 +69,7 @@ public class SchemaReader {
   public static CarbonTable readCarbonTableFromSchema(String schemaFilePath, Configuration conf)
       throws IOException {
     TableInfo tableInfo = readTableInfoFromSchema(schemaFilePath, conf);
-    CarbonMetadata.getInstance().loadTableMetadata(tableInfo);
-    return CarbonMetadata.getInstance().getCarbonTable("dummy_dummy");
+    return CarbonTable.buildFromTableInfo(tableInfo);
   }
 
   /**


### PR DESCRIPTION
Using cache will lead to incorrect table path set in SDK writer.
This PR corrects it

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

