### PR TITLE
[CARBONDATA-3593] Add BLOCKLET_SCANNED_NUM and fix TOTAL_BLOCKLET_NUM not right when blocklet filtered

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/scan/result/iterator/AbstractDetailQueryResultIterator.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/iterator/AbstractDetailQueryResultIterator.java
@@ -245,6 +245,11 @@ public abstract class AbstractDetailQueryResultIterator<E> extends CarbonIterato
         .put(QueryStatisticsConstants.VALID_SCAN_BLOCKLET_NUM, queryStatisticValidScanBlocklet);
     queryStatisticsModel.getRecorder().recordStatistics(queryStatisticValidScanBlocklet);
 
+    QueryStatistic scannedBlocklets = new QueryStatistic();
+    queryStatisticsModel.getStatisticsTypeAndObjMap()
+        .put(QueryStatisticsConstants.BLOCKLET_SCANNED_NUM, scannedBlocklets);
+    queryStatisticsModel.getRecorder().recordStatistics(scannedBlocklets);
+
     QueryStatistic totalNumberOfPages = new QueryStatistic();
     queryStatisticsModel.getStatisticsTypeAndObjMap()
         .put(QueryStatisticsConstants.TOTAL_PAGE_SCANNED, totalNumberOfPages);

--- a/core/src/main/java/org/apache/carbondata/core/scan/scanner/impl/BlockletFilterScanner.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/scanner/impl/BlockletFilterScanner.java
@@ -113,6 +113,10 @@ public class BlockletFilterScanner extends BlockletFullScanner {
         .get(QueryStatisticsConstants.TOTAL_PAGE_SCANNED);
     totalPagesScanned.addCountStatistic(QueryStatisticsConstants.TOTAL_PAGE_SCANNED,
         totalPagesScanned.getCount() + dataBlock.numberOfPages());
+    QueryStatistic totalBlockletStatistic = queryStatisticsModel.getStatisticsTypeAndObjMap()
+        .get(QueryStatisticsConstants.TOTAL_BLOCKLET_NUM);
+    totalBlockletStatistic.addCountStatistic(QueryStatisticsConstants.TOTAL_BLOCKLET_NUM,
+        totalBlockletStatistic.getCount() + 1);
     // apply min max
     if (isMinMaxEnabled) {
       if (null == dataBlock.getColumnsMaxValue()
@@ -168,10 +172,6 @@ public class BlockletFilterScanner extends BlockletFullScanner {
   private BlockletScannedResult executeFilter(RawBlockletColumnChunks rawBlockletColumnChunks)
       throws FilterUnsupportedException, IOException {
     long startTime = System.currentTimeMillis();
-    QueryStatistic totalBlockletStatistic = queryStatisticsModel.getStatisticsTypeAndObjMap()
-        .get(QueryStatisticsConstants.TOTAL_BLOCKLET_NUM);
-    totalBlockletStatistic.addCountStatistic(QueryStatisticsConstants.TOTAL_BLOCKLET_NUM,
-        totalBlockletStatistic.getCount() + 1);
     // set the indexed data if it has any during fgdatamap pruning.
     BitSetGroup fgBitSetGroup = rawBlockletColumnChunks.getDataBlock().getIndexedData();
     rawBlockletColumnChunks.setBitSetGroup(fgBitSetGroup);
@@ -187,6 +187,11 @@ public class BlockletFilterScanner extends BlockletFullScanner {
           .get(QueryStatisticsConstants.SCAN_BLOCKlET_TIME);
       scanTime.addCountStatistic(QueryStatisticsConstants.SCAN_BLOCKlET_TIME,
           scanTime.getCount() + (System.currentTimeMillis() - startTime));
+
+      QueryStatistic scannedBlocklets = queryStatisticsModel.getStatisticsTypeAndObjMap()
+          .get(QueryStatisticsConstants.BLOCKLET_SCANNED_NUM);
+      scannedBlocklets.addCountStatistic(QueryStatisticsConstants.BLOCKLET_SCANNED_NUM,
+          scannedBlocklets.getCount() + 1);
 
       QueryStatistic scannedPages = queryStatisticsModel.getStatisticsTypeAndObjMap()
           .get(QueryStatisticsConstants.PAGE_SCANNED);
@@ -211,6 +216,12 @@ public class BlockletFilterScanner extends BlockletFullScanner {
         .get(QueryStatisticsConstants.VALID_PAGE_SCANNED);
     validPages.addCountStatistic(QueryStatisticsConstants.VALID_PAGE_SCANNED,
         validPages.getCount() + bitSetGroup.getValidPages());
+
+    QueryStatistic scannedBlocklets = queryStatisticsModel.getStatisticsTypeAndObjMap()
+        .get(QueryStatisticsConstants.BLOCKLET_SCANNED_NUM);
+    scannedBlocklets.addCountStatistic(QueryStatisticsConstants.BLOCKLET_SCANNED_NUM,
+        scannedBlocklets.getCount() + 1);
+
     QueryStatistic scannedPages = queryStatisticsModel.getStatisticsTypeAndObjMap()
         .get(QueryStatisticsConstants.PAGE_SCANNED);
     scannedPages.addCountStatistic(QueryStatisticsConstants.PAGE_SCANNED,
@@ -351,10 +362,6 @@ public class BlockletFilterScanner extends BlockletFullScanner {
       RawBlockletColumnChunks rawBlockletColumnChunks)
       throws FilterUnsupportedException, IOException {
     long startTime = System.currentTimeMillis();
-    QueryStatistic totalBlockletStatistic = queryStatisticsModel.getStatisticsTypeAndObjMap()
-        .get(QueryStatisticsConstants.TOTAL_BLOCKLET_NUM);
-    totalBlockletStatistic.addCountStatistic(QueryStatisticsConstants.TOTAL_BLOCKLET_NUM,
-        totalBlockletStatistic.getCount() + 1);
     // apply filter on actual data, for each page
     BitSet pages = this.filterExecuter.prunePages(rawBlockletColumnChunks);
     // if filter result is empty then return with empty result
@@ -366,6 +373,11 @@ public class BlockletFilterScanner extends BlockletFullScanner {
           .get(QueryStatisticsConstants.SCAN_BLOCKlET_TIME);
       scanTime.addCountStatistic(QueryStatisticsConstants.SCAN_BLOCKlET_TIME,
           scanTime.getCount() + (System.currentTimeMillis() - startTime));
+
+      QueryStatistic scannedBlocklets = queryStatisticsModel.getStatisticsTypeAndObjMap()
+          .get(QueryStatisticsConstants.BLOCKLET_SCANNED_NUM);
+      scannedBlocklets.addCountStatistic(QueryStatisticsConstants.BLOCKLET_SCANNED_NUM,
+          scannedBlocklets.getCount() + 1);
 
       QueryStatistic scannedPages = queryStatisticsModel.getStatisticsTypeAndObjMap()
           .get(QueryStatisticsConstants.PAGE_SCANNED);
@@ -388,6 +400,12 @@ public class BlockletFilterScanner extends BlockletFullScanner {
         .get(QueryStatisticsConstants.VALID_PAGE_SCANNED);
     validPages.addCountStatistic(QueryStatisticsConstants.VALID_PAGE_SCANNED,
         validPages.getCount() + pages.cardinality());
+
+    QueryStatistic scannedBlocklets = queryStatisticsModel.getStatisticsTypeAndObjMap()
+        .get(QueryStatisticsConstants.BLOCKLET_SCANNED_NUM);
+    scannedBlocklets.addCountStatistic(QueryStatisticsConstants.BLOCKLET_SCANNED_NUM,
+        scannedBlocklets.getCount() + 1);
+
     QueryStatistic scannedPages = queryStatisticsModel.getStatisticsTypeAndObjMap()
         .get(QueryStatisticsConstants.PAGE_SCANNED);
     scannedPages.addCountStatistic(QueryStatisticsConstants.PAGE_SCANNED,

--- a/core/src/main/java/org/apache/carbondata/core/stats/QueryStatisticsConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/stats/QueryStatisticsConstants.java
@@ -52,6 +52,8 @@ public interface QueryStatisticsConstants {
 
   String VALID_SCAN_BLOCKLET_NUM = "The num of valid scanned blocklet";
 
+  String BLOCKLET_SCANNED_NUM = "The num of blocklet scanned";
+
   String VALID_PAGE_SCANNED = "The number of valid page scanned";
 
   String TOTAL_PAGE_SCANNED = "The number of total page scanned";

--- a/core/src/main/java/org/apache/carbondata/core/stats/TaskStatistics.java
+++ b/core/src/main/java/org/apache/carbondata/core/stats/TaskStatistics.java
@@ -41,6 +41,7 @@ public class TaskStatistics implements Serializable {
       new Column("carbon_IO_time", QueryStatisticsConstants.READ_BLOCKlET_TIME),
       new Column("scan_blocks_num", QueryStatisticsConstants.SCAN_BLOCKS_NUM),
       new Column("total_blocklets", QueryStatisticsConstants.TOTAL_BLOCKLET_NUM),
+      new Column("scanned_blocklets", QueryStatisticsConstants.BLOCKLET_SCANNED_NUM),
       new Column("valid_blocklets", QueryStatisticsConstants.VALID_SCAN_BLOCKLET_NUM),
       new Column("total_pages", QueryStatisticsConstants.TOTAL_PAGE_SCANNED),
       new Column("scanned_pages", QueryStatisticsConstants.PAGE_SCANNED),


### PR DESCRIPTION
Add BLOCKLET_SCANNED_NUM and fix TOTAL_BLOCKLET_NUM not right when blocklet filtered.

Here is the comparison:
scala> carbon.sql("select * from test_table_hdfs_sort where  city_name='city1'").show
 * Before  change, statistics printing:  

|scan_blocks_num|total_blocklets|valid_blocklets|total_pages|scanned_pages|valid_pages|
-|-|-|-|-|-
|1|1|1|193|4|4|

 * After  change, statistics printing:

|scan_blocks_num|total_blocklets|scanned_blocklets|valid_blocklets|total_pages|scanned_pages|valid_pages|
-|-|-|-|-|-|-
|              1|              3|              1| 1 |        193|            4|          4|

    |query_id         |task_id|start


Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed? No
 
 - [x] Any backward compatibility impacted? No
 
 - [x] Document update required? No

 - [x] Testing done Yes
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. OK

