### PR TITLE
[CARBONDATA-3598] Throw java.util.ConcurrentModifitcationException when close carbon fact data writer.

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/util/DataFileFooterConverter2.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/DataFileFooterConverter2.java
@@ -100,10 +100,15 @@ public class DataFileFooterConverter2 extends AbstractDataFileFooterConverter {
       org.apache.carbondata.format.BlockletInfo2 blockletInfoThrift, int numberOfDimensionColumns) {
     BlockletInfo blockletInfo = new BlockletInfo();
     List<Long> dimensionColumnChunkOffsets =
-        blockletInfoThrift.getColumn_data_chunks_offsets().subList(0, numberOfDimensionColumns);
-    List<Long> measureColumnChunksOffsets = blockletInfoThrift.getColumn_data_chunks_offsets()
-        .subList(numberOfDimensionColumns,
-            blockletInfoThrift.getColumn_data_chunks_offsets().size());
+        new ArrayList<>(
+            blockletInfoThrift.getColumn_data_chunks_offsets().subList(0, numberOfDimensionColumns)
+        );
+    List<Long> measureColumnChunksOffsets =
+        new ArrayList<>(
+            blockletInfoThrift.getColumn_data_chunks_offsets()
+                .subList(numberOfDimensionColumns,
+                    blockletInfoThrift.getColumn_data_chunks_offsets().size())
+        );
     List<Short> dimensionColumnChunkLength =
         blockletInfoThrift.getColumn_data_chunks_length().subList(0, numberOfDimensionColumns);
     List<Short> measureColumnChunksLength = blockletInfoThrift.getColumn_data_chunks_length()

--- a/core/src/main/java/org/apache/carbondata/core/util/DataFileFooterConverterV3.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/DataFileFooterConverterV3.java
@@ -130,10 +130,15 @@ public class DataFileFooterConverterV3 extends AbstractDataFileFooterConverter {
       org.apache.carbondata.format.BlockletInfo3 blockletInfoThrift, int numberOfDimensionColumns) {
     BlockletInfo blockletInfo = new BlockletInfo();
     List<Long> dimensionColumnChunkOffsets =
-        blockletInfoThrift.getColumn_data_chunks_offsets().subList(0, numberOfDimensionColumns);
-    List<Long> measureColumnChunksOffsets = blockletInfoThrift.getColumn_data_chunks_offsets()
-        .subList(numberOfDimensionColumns,
-            blockletInfoThrift.getColumn_data_chunks_offsets().size());
+        new ArrayList<>(
+            blockletInfoThrift.getColumn_data_chunks_offsets().subList(0, numberOfDimensionColumns)
+        );
+    List<Long> measureColumnChunksOffsets =
+        new ArrayList<>(
+            blockletInfoThrift.getColumn_data_chunks_offsets()
+                .subList(numberOfDimensionColumns,
+                    blockletInfoThrift.getColumn_data_chunks_offsets().size())
+        );
     List<Integer> dimensionColumnChunkLength =
         blockletInfoThrift.getColumn_data_chunks_length().subList(0, numberOfDimensionColumns);
     List<Integer> measureColumnChunksLength = blockletInfoThrift.getColumn_data_chunks_length()


### PR DESCRIPTION
Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 NA
 - [ ] Any backward compatibility impacted?
 NA
 - [ ] Document update required?
NA
 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

