### PR TITLE
[CARBONDATA-3600] Fix creating mv timeseries UDF column as partition column

### DIFF
--- a/datamap/mv/core/src/main/scala/org/apache/carbondata/mv/datamap/MVDataMapProvider.scala
+++ b/datamap/mv/core/src/main/scala/org/apache/carbondata/mv/datamap/MVDataMapProvider.scala
@@ -95,8 +95,8 @@ class MVDataMapProvider(
       dataMapSchema.getRelationIdentifier.getTableName,
       true)
     dropTableCommand.processMetadata(sparkSession)
-    DataMapStoreManager.getInstance.unRegisterDataMapCatalog(dataMapSchema)
     DataMapStoreManager.getInstance().dropDataMapSchema(dataMapSchema.getDataMapName)
+    DataMapStoreManager.getInstance.unRegisterDataMapCatalog(dataMapSchema)
   }
 
   override def cleanData(): Unit = {

--- a/datamap/mv/core/src/main/scala/org/apache/carbondata/mv/datamap/MVDataMapProvider.scala
+++ b/datamap/mv/core/src/main/scala/org/apache/carbondata/mv/datamap/MVDataMapProvider.scala
@@ -95,8 +95,17 @@ class MVDataMapProvider(
       dataMapSchema.getRelationIdentifier.getTableName,
       true)
     dropTableCommand.processMetadata(sparkSession)
-    DataMapStoreManager.getInstance().dropDataMapSchema(dataMapSchema.getDataMapName)
-    DataMapStoreManager.getInstance.unRegisterDataMapCatalog(dataMapSchema)
+    // First, drop datamapschema and unregister datamap from catalog, because if in
+    // case, unregister fails, datamapschema will not be deleted from system and cannot
+    // create datamap also again
+    try {
+      DataMapStoreManager.getInstance().dropDataMapSchema(dataMapSchema.getDataMapName)
+    } catch {
+      case e: IOException =>
+        throw e
+    } finally {
+      DataMapStoreManager.getInstance.unRegisterDataMapCatalog(dataMapSchema)
+    }
   }
 
   override def cleanData(): Unit = {

--- a/datamap/mv/core/src/main/scala/org/apache/carbondata/mv/datamap/MVUtil.scala
+++ b/datamap/mv/core/src/main/scala/org/apache/carbondata/mv/datamap/MVUtil.scala
@@ -204,27 +204,27 @@ class MVUtil {
           "")
       }
     }
-    groupByExp map { grp =>
-      grp.collect {
-        case attr: AttributeReference =>
-          val carbonTable: CarbonTable = getCarbonTable(logicalRelation, attr)
-          if (null != carbonTable) {
-            val arrayBuffer: ArrayBuffer[ColumnTableRelation] = new
-                ArrayBuffer[ColumnTableRelation]()
-            arrayBuffer += getColumnRelation(attr.name,
-              carbonTable.getAbsoluteTableIdentifier.getCarbonTableIdentifier.getTableId,
-              carbonTable.getAbsoluteTableIdentifier.getCarbonTableIdentifier.getTableName,
-              carbonTable.getAbsoluteTableIdentifier.getCarbonTableIdentifier.getDatabaseName,
-              carbonTable)
-            fieldToDataMapFieldMap +=
-            getFieldToDataMapFields(attr.name,
-              attr.dataType,
-              attr.qualifier,
-              "",
-              arrayBuffer,
-              carbonTable.getTableName)
-          }
-      }
+    groupByExp map {
+      case attr: AttributeReference =>
+        val carbonTable: CarbonTable = getCarbonTable(logicalRelation, attr)
+        if (null != carbonTable) {
+          val arrayBuffer: ArrayBuffer[ColumnTableRelation] = new
+              ArrayBuffer[ColumnTableRelation]()
+          arrayBuffer += getColumnRelation(attr.name,
+            carbonTable.getAbsoluteTableIdentifier.getCarbonTableIdentifier.getTableId,
+            carbonTable.getAbsoluteTableIdentifier.getCarbonTableIdentifier.getTableName,
+            carbonTable.getAbsoluteTableIdentifier.getCarbonTableIdentifier.getDatabaseName,
+            carbonTable)
+          fieldToDataMapFieldMap +=
+          getFieldToDataMapFields(attr.name,
+            attr.dataType,
+            attr.qualifier,
+            "",
+            arrayBuffer,
+            carbonTable.getTableName)
+        }
+        attr
+      case _ =>
     }
     fieldToDataMapFieldMap
   }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
@@ -17,7 +17,10 @@
 
 package org.apache.spark.sql
 
+import java.io.IOException
 import java.util.concurrent.ConcurrentHashMap
+
+import scala.collection.JavaConverters._
 
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.{NoSuchDatabaseException, NoSuchTableException}
@@ -121,10 +124,43 @@ class CarbonEnv {
         CarbonProperties.getInstance
           .addNonSerializableProperty(CarbonCommonConstants.IS_DRIVER_INSTANCE, "true")
         initialized = true
+        cleanChildTablesNotRegisteredInHive(sparkSession)
       }
     }
     Profiler.initialize(sparkSession.sparkContext)
     LOGGER.info("Initialize CarbonEnv completed...")
+  }
+
+  private def cleanChildTablesNotRegisteredInHive(sparkSession: SparkSession): Unit = {
+    // If in case JDBC application is killed/stopped, when create datamap was in progress, datamap
+    // table was created and datampschema was saved to the system, but table was not registered to
+    // metastore. So, when we restart JDBC application, we need to clean up
+    // stale tables and datamapschema's.
+    val dataMapSchemas = DataMapStoreManager.getInstance().getAllDataMapSchemas
+    dataMapSchemas.asScala.foreach {
+      dataMapSchema =>
+        if (null != dataMapSchema.getRelationIdentifier &&
+            !dataMapSchema.isIndexDataMap) {
+          if (!sparkSession.sessionState
+            .catalog
+            .tableExists(TableIdentifier(dataMapSchema.getRelationIdentifier.getTableName,
+              Some(dataMapSchema.getRelationIdentifier.getDatabaseName)))) {
+            try {
+              DataMapStoreManager.getInstance().dropDataMapSchema(dataMapSchema.getDataMapName)
+            } catch {
+              case e: IOException =>
+                throw e
+            } finally {
+              DataMapStoreManager.getInstance.unRegisterDataMapCatalog(dataMapSchema)
+              if (FileFactory.isFileExist(dataMapSchema.getRelationIdentifier.getTablePath)) {
+                CarbonUtil.deleteFoldersAndFilesSilent(FileFactory.getCarbonFile(dataMapSchema
+                  .getRelationIdentifier
+                  .getTablePath))
+              }
+            }
+          }
+        }
+    }
   }
 }
 


### PR DESCRIPTION
Problem:
Issue 1:
When trying to create datamap with partition column in timeseries udf, throws Exception.
Issue 2:
When Create datamap was in progress, Jdbc application is killed. When restarting, datamap table not found exception is thrown.

Solution:
Issue 1:
While adding fields to FieldRelationMap, in case of group by, no need to add UDF expressions.
If partition column is present in timeseries UDF, child table will not inherit partition fields from parent table
Issue 2:
Clean up the invalid table and schema from the store

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

