### PR TITLE
[CARBONDATA-3532] Support Query Rollup for MV TimeSeries Queries

### DIFF
--- a/datamap/mv/core/src/main/scala/org/apache/carbondata/mv/rewrite/DefaultMatchMaker.scala
+++ b/datamap/mv/core/src/main/scala/org/apache/carbondata/mv/rewrite/DefaultMatchMaker.scala
@@ -544,14 +544,19 @@ object GroupbyGroupbySelectOnlyChildDelta extends DefaultMatchPattern with Predi
    */
   private def isDerivableForUDF(exprE: Expression, exprListR: Seq[Expression]): Boolean = {
     var canBeDerived = false
-    exprListR.forall {
-      case a: ScalaUDF =>
-        a.references.foreach { a =>
-          canBeDerived = exprE.sql.contains(a.name)
-        }
-        canBeDerived
+    exprE match {
+      case f: ScalaUDF =>
+        canEvaluate(f, exprListR)
       case _ =>
-        canBeDerived
+        exprListR.forall {
+          case a: ScalaUDF =>
+            a.references.foreach { a =>
+              canBeDerived = exprE.sql.contains(a.name)
+            }
+            canBeDerived
+          case _ =>
+            canBeDerived
+        }
     }
   }
 

--- a/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/timeseries/TestMVTimeSeriesQueryRollUp.scala
+++ b/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/timeseries/TestMVTimeSeriesQueryRollUp.scala
@@ -1,0 +1,279 @@
+  /*
+  * Licensed to the Apache Software Foundation (ASF) under one or more
+  * contributor license agreements.  See the NOTICE file distributed with
+  * this work for additional information regarding copyright ownership.
+  * The ASF licenses this file to You under the Apache License, Version 2.0
+  * (the "License"); you may not use this file except in compliance with
+  * the License.  You may obtain a copy of the License at
+  *
+  *    http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+
+  package org.apache.carbondata.mv.timeseries
+
+  import org.apache.spark.sql.test.util.QueryTest
+  import org.scalatest.BeforeAndAfterAll
+
+  import org.apache.carbondata.mv.rewrite.TestUtil
+
+  class TestMVTimeSeriesQueryRollUp extends QueryTest with BeforeAndAfterAll {
+
+    override def beforeAll(): Unit = {
+      drop()
+      createTable()
+      loadData("maintable")
+    }
+
+    override def afterAll(): Unit = {
+      drop()
+    }
+
+    test("test timeseries query rollup with simple projection") {
+      val result  = sql("select timeseries(projectjoindate,'day'),projectcode from maintable")
+      sql("drop datamap if exists datamap1")
+      sql("drop datamap if exists datamap2")
+      sql(
+        "create datamap datamap1 on table maintable using 'mv' as " +
+        "select timeseries(projectjoindate,'second'),projectcode from maintable")
+      sql(
+        "create datamap datamap2 on table maintable using 'mv' as " +
+        "select timeseries(projectjoindate,'hour'),projectcode from maintable")
+      val df = sql("select timeseries(projectjoindate,'day'),projectcode from maintable")
+      assert(TestUtil.verifyMVDataMap(df.queryExecution.optimizedPlan, "datamap2"))
+      checkAnswer(result,df)
+      sql("drop datamap if exists datamap1")
+      sql("drop datamap if exists datamap2")
+    }
+
+    test("test timeseries query rollup with simple projection with group by - scenario-1") {
+      val result  = sql("select timeseries(projectjoindate,'day'),projectcode from maintable group by timeseries(projectjoindate,'day'),projectcode")
+      sql("drop datamap if exists datamap1")
+      sql("drop datamap if exists datamap2")
+      sql(
+        "create datamap datamap1 on table maintable using 'mv' as " +
+        "select timeseries(projectjoindate,'second'),projectcode from maintable group by timeseries(projectjoindate,'second'),projectcode")
+      sql(
+        "create datamap datamap2 on table maintable using 'mv' as " +
+        "select timeseries(projectjoindate,'hour'),projectcode from maintable group by timeseries(projectjoindate,'hour'),projectcode")
+      var df = sql("select timeseries(projectjoindate,'day'),projectcode from maintable group by timeseries(projectjoindate,'day'),projectcode")
+      assert(TestUtil.verifyMVDataMap(df.queryExecution.optimizedPlan, "datamap2"))
+      checkAnswer(result,df)
+      df = sql("select timeseries(projectjoindate,'second'),projectcode from maintable group by timeseries(projectjoindate,'second'),projectcode")
+      assert(TestUtil.verifyMVDataMap(df.queryExecution.optimizedPlan, "datamap1"))
+      df = sql("select timeseries(projectjoindate,'second') from maintable group by timeseries(projectjoindate,'second')")
+      assert(TestUtil.verifyMVDataMap(df.queryExecution.optimizedPlan, "datamap1"))
+      sql("drop datamap if exists datamap1")
+      sql("drop datamap if exists datamap2")
+    }
+
+    test("test timeseries query rollup with simple projection with group by - scenario-1 with single datamap") {
+      val result  = sql("select timeseries(projectjoindate,'day'),projectcode from maintable group by timeseries(projectjoindate,'day'),projectcode")
+      sql("drop datamap if exists datamap1")
+      sql(
+        "create datamap datamap1 on table maintable using 'mv' as " +
+        "select timeseries(projectjoindate,'second'),projectcode from maintable group by timeseries(projectjoindate,'second'),projectcode")
+      var df = sql("select timeseries(projectjoindate,'day'),projectcode from maintable group by timeseries(projectjoindate,'day'),projectcode")
+      assert(TestUtil.verifyMVDataMap(df.queryExecution.optimizedPlan, "datamap1"))
+      checkAnswer(result,df)
+      df = sql("select timeseries(projectjoindate,'second'),projectcode from maintable group by timeseries(projectjoindate,'second'),projectcode")
+      assert(TestUtil.verifyMVDataMap(df.queryExecution.optimizedPlan, "datamap1"))
+      df = sql("select timeseries(projectjoindate,'second') from maintable group by timeseries(projectjoindate,'second')")
+      assert(TestUtil.verifyMVDataMap(df.queryExecution.optimizedPlan, "datamap1"))
+      sql("drop datamap if exists datamap1")
+    }
+
+    test("test timeseries query rollup with simple projection with group by - scenario-2") {
+      val result  = sql("select timeseries(projectjoindate,'day'),sum(projectcode) from maintable group by timeseries(projectjoindate,'day')")
+      sql("drop datamap if exists datamap1")
+      sql("drop datamap if exists datamap2")
+      sql(
+        "create datamap datamap1 on table maintable using 'mv' as " +
+        "select timeseries(projectjoindate,'second'),sum(projectcode) from maintable group by timeseries(projectjoindate,'second')")
+      sql(
+        "create datamap datamap2 on table maintable using 'mv' as " +
+        "select timeseries(projectjoindate,'hour'),sum(projectcode) from maintable group by timeseries(projectjoindate,'hour')")
+      val df =sql("select timeseries(projectjoindate,'day'),sum(projectcode) from maintable group by timeseries(projectjoindate,'day')")
+      assert(TestUtil.verifyMVDataMap(df.queryExecution.optimizedPlan, "datamap2"))
+      checkAnswer(result,df)
+      sql("drop datamap if exists datamap1")
+      sql("drop datamap if exists datamap2")
+    }
+
+    test("test timeseries query rollup with simple projection with filter") {
+      val result  = sql("select timeseries(projectjoindate,'day'),projectcode from maintable where projectcode=8")
+      sql("drop datamap if exists datamap1")
+      sql("drop datamap if exists datamap2")
+      sql(
+        "create datamap datamap1 on table maintable using 'mv' as " +
+        "select timeseries(projectjoindate,'second'),projectcode from maintable")
+      sql(
+        "create datamap datamap2 on table maintable using 'mv' as " +
+        "select timeseries(projectjoindate,'hour'),projectcode from maintable")
+      val df = sql("select timeseries(projectjoindate,'day'),projectcode from maintable where projectcode=8")
+      assert(TestUtil.verifyMVDataMap(df.queryExecution.optimizedPlan, "datamap2"))
+      checkAnswer(result,df)
+      sql("drop datamap if exists datamap1")
+      sql("drop datamap if exists datamap2")
+    }
+
+    test("test timeseries query rollup with simple projection with group by & filter - scenario 1") {
+      val result = sql("select timeseries(projectjoindate,'day'),projectcode from maintable where projectcode=8 " +
+                       "group by timeseries(projectjoindate,'day'),projectcode")
+      sql("drop datamap if exists datamap1")
+      sql("drop datamap if exists datamap2")
+      sql("create datamap datamap1 on table maintable using 'mv' as " +
+          "select timeseries(projectjoindate,'second'),projectcode from maintable group by " +
+          "timeseries(projectjoindate,'second'),projectcode")
+      sql("create datamap datamap2 on table maintable using 'mv' as " +
+          "select timeseries(projectjoindate,'hour'),projectcode from maintable group by timeseries" +
+          "(projectjoindate,'hour'),projectcode")
+      val df = sql("select timeseries(projectjoindate,'day'),projectcode from maintable where projectcode=8 " +
+                   "group by timeseries(projectjoindate,'day'),projectcode")
+      assert(TestUtil.verifyMVDataMap(df.queryExecution.optimizedPlan, "datamap2"))
+      checkAnswer(result, df)
+      sql("drop datamap if exists datamap1")
+      sql("drop datamap if exists datamap2")
+    }
+
+    test("test timeseries query rollup with simple projection with group by & filter - scenario 2") {
+      val result  = sql("select timeseries(projectjoindate,'day'),projectcode from maintable where projectcode=8 group by timeseries(projectjoindate,'day'),projectcode")
+      sql("drop datamap if exists datamap1")
+      sql(
+        "create datamap datamap1 on table maintable using 'mv' as " +
+        "select timeseries(projectjoindate,'second'),projectcode from maintable where projectcode=1 group by timeseries(projectjoindate,'second'),projectcode")
+      val df = sql("select timeseries(projectjoindate,'day'),projectcode from maintable where projectcode=8 group by timeseries(projectjoindate,'day'),projectcode")
+      assert(!TestUtil.verifyMVDataMap(df.queryExecution.optimizedPlan, "datamap1"))
+      checkAnswer(result,df)
+      sql("drop datamap if exists datamap1")
+    }
+
+    test("test timeseries query rollup with simple projection with alias- scenario 1") {
+      val result  = sql("select timeseries(projectjoindate,'day') as a,projectcode as b from maintable")
+      sql("drop datamap if exists datamap1")
+      sql("drop datamap if exists datamap2")
+      sql(
+        "create datamap datamap1 on table maintable using 'mv' as " +
+        "select timeseries(projectjoindate,'second'),projectcode from maintable")
+      sql(
+        "create datamap datamap2 on table maintable using 'mv' as " +
+        "select timeseries(projectjoindate,'hour'),projectcode from maintable")
+      val df = sql("select timeseries(projectjoindate,'day') as a,projectcode as b from maintable")
+      assert(TestUtil.verifyMVDataMap(df.queryExecution.optimizedPlan, "datamap2"))
+      checkAnswer(result,df)
+      sql("drop datamap if exists datamap1")
+      sql("drop datamap if exists datamap2")
+    }
+
+    test("test timeseries query rollup with simple projection with alias- scenario 2") {
+      val result  = sql("select timeseries(projectjoindate,'day'),projectcode from maintable")
+      sql("drop datamap if exists datamap1")
+      sql("drop datamap if exists datamap2")
+      sql(
+        "create datamap datamap1 on table maintable using 'mv' as " +
+        "select timeseries(projectjoindate,'second') as a,projectcode as b from maintable")
+      sql(
+        "create datamap datamap2 on table maintable using 'mv' as " +
+        "select timeseries(projectjoindate,'hour') as a,projectcode as b from maintable")
+      val df = sql("select timeseries(projectjoindate,'day'),projectcode from maintable")
+      assert(TestUtil.verifyMVDataMap(df.queryExecution.optimizedPlan, "datamap2"))
+      checkAnswer(result,df)
+      sql("drop datamap if exists datamap1")
+      sql("drop datamap if exists datamap2")
+    }
+
+    test("test timeseries query rollup with projection with alias and group by- scenario 1") {
+      val result  = sql("select timeseries(projectjoindate,'day') as a,sum(projectcode) as b from maintable group by timeseries(projectjoindate,'day')")
+      sql("drop datamap if exists datamap1")
+      sql("drop datamap if exists datamap2")
+      sql(
+        "create datamap datamap1 on table maintable using 'mv' as " +
+        "select timeseries(projectjoindate,'second'),sum(projectcode) from maintable group by timeseries(projectjoindate,'second')")
+      sql(
+        "create datamap datamap2 on table maintable using 'mv' as " +
+        "select timeseries(projectjoindate,'hour'),sum(projectcode) from maintable group by timeseries(projectjoindate,'hour')")
+      val df = sql("select timeseries(projectjoindate,'day') as a,sum(projectcode) as b from maintable group by timeseries(projectjoindate,'day')")
+      assert(TestUtil.verifyMVDataMap(df.queryExecution.optimizedPlan, "datamap2"))
+      checkAnswer(result,df)
+      sql("drop datamap if exists datamap1")
+      sql("drop datamap if exists datamap2")
+    }
+
+    test("test timeseries query rollup with projection with alias and group by- scenario 2") {
+      val result  = sql("select timeseries(projectjoindate,'day'),sum(projectcode) from maintable group by timeseries(projectjoindate,'day')")
+      sql("drop datamap if exists datamap1")
+      sql("drop datamap if exists datamap2")
+      sql(
+        "create datamap datamap1 on table maintable using 'mv' as " +
+        "select timeseries(projectjoindate,'second') as a,sum(projectcode) as b from maintable group by timeseries(projectjoindate,'second')")
+      sql(
+        "create datamap datamap2 on table maintable using 'mv' as " +
+        "select timeseries(projectjoindate,'hour') as a,sum(projectcode) as b from maintable group by timeseries(projectjoindate,'hour')")
+      val df = sql("select timeseries(projectjoindate,'day'),sum(projectcode) from maintable group by timeseries(projectjoindate,'day')")
+      assert(TestUtil.verifyMVDataMap(df.queryExecution.optimizedPlan, "datamap2"))
+      checkAnswer(result,df)
+      sql("drop datamap if exists datamap1")
+      sql("drop datamap if exists datamap2")
+    }
+
+    test("rollup not supported for join queries") {
+      sql("drop table if exists maintable1")
+      sql("CREATE TABLE maintable1 (empno int,empname string, projectcode int, projectjoindate " +
+        "Timestamp,salary double) STORED AS CARBONDATA")
+      loadData("maintable1")
+      val result = sql("select timeseries(t1.projectjoindate,'day'),count(timeseries(t2.projectjoindate,'day')),sum(t2.projectcode) from maintable t1 inner join maintable1 t2 " +
+          "on (timeseries(t1.projectjoindate,'day')=timeseries(t2.projectjoindate,'day')) group by timeseries(t1.projectjoindate,'day')")
+      sql("drop datamap if exists datamap1")
+      sql("drop datamap if exists datamap2")
+      sql("create datamap datamap1 on table maintable using 'mv' as " +
+        "select timeseries(t1.projectjoindate,'second'),count(timeseries(t2.projectjoindate,'second')),sum(t2.projectcode) from maintable t1 inner join maintable1 t2 " +
+        "on (timeseries(t1.projectjoindate,'second')=timeseries(t2.projectjoindate,'second')) group by timeseries(t1.projectjoindate,'second')")
+      sql("create datamap datamap2 on table maintable using 'mv' as " +
+        "select timeseries(t1.projectjoindate,'hour'),count(timeseries(t2.projectjoindate,'hour')),sum(t2.projectcode) from maintable t1 inner join maintable1 t2 " +
+        "on (timeseries(t1.projectjoindate,'hour')=timeseries(t2.projectjoindate,'hour')) group by timeseries(t1.projectjoindate,'hour')")
+      val df = sql("select timeseries(t1.projectjoindate,'day'),count(timeseries(t2.projectjoindate,'day')),sum(t2.projectcode) from maintable t1 inner join maintable1 t2 " +
+          "on (timeseries(t1.projectjoindate,'day')=timeseries(t2.projectjoindate,'day')) group by timeseries(t1.projectjoindate,'day')")
+      assert(!TestUtil.verifyMVDataMap(df.queryExecution.optimizedPlan, "datamap2"))
+      checkAnswer(result,df)
+      sql("drop datamap if exists datamap1")
+      sql("drop datamap if exists datamap2")
+    }
+
+    test("rollup not supported for timeseries udf in filter") {
+      val result  = sql("select timeseries(projectjoindate,'day'),sum(projectcode) from maintable where timeseries(projectjoindate,'day')='2016-02-23 00:00:00' group by timeseries(projectjoindate,'day')")
+      sql("drop datamap if exists datamap1")
+      sql("drop datamap if exists datamap2")
+      sql(
+        "create datamap datamap1 on table maintable using 'mv' as " +
+        "select timeseries(projectjoindate,'second'),sum(projectcode) from maintable group by timeseries(projectjoindate,'second')")
+      sql(
+        "create datamap datamap2 on table maintable using 'mv' as " +
+        "select timeseries(projectjoindate,'hour'),sum(projectcode) from maintable group by timeseries(projectjoindate,'hour')")
+      val df = sql("select timeseries(projectjoindate,'day'),sum(projectcode) from maintable where timeseries(projectjoindate,'day')='2016-02-23 00:00:00' group by timeseries(projectjoindate,'day')")
+      assert(!TestUtil.verifyMVDataMap(df.queryExecution.optimizedPlan, "datamap2"))
+      checkAnswer(result,df)
+      sql("drop datamap if exists datamap1")
+      sql("drop datamap if exists datamap2")
+    }
+
+    def drop(): Unit = {
+      sql("drop table if exists maintable")
+    }
+
+    def createTable(): Unit = {
+      sql(
+        "CREATE TABLE maintable (empno int,empname string, projectcode int, projectjoindate " +
+        "Timestamp,salary double) STORED AS CARBONDATA")
+    }
+
+    def loadData(table: String): Unit = {
+      sql(
+        s"""LOAD DATA local inpath '$resourcesPath/mv_sampledata.csv' INTO TABLE $table  OPTIONS
+           |('DELIMITER'= ',', 'QUOTECHAR'= '"')""".stripMargin)
+    }
+}

--- a/datamap/mv/plan/src/main/scala/org/apache/carbondata/mv/plans/modular/ModularPlan.scala
+++ b/datamap/mv/plan/src/main/scala/org/apache/carbondata/mv/plans/modular/ModularPlan.scala
@@ -96,6 +96,24 @@ abstract class ModularPlan
     _rewritten
   }
 
+  private var rolledUp: Boolean = false
+
+  /**
+   * Marks this plan as rolledup plan
+   */
+  private[mv] def setRolledUp(): ModularPlan = {
+    rolledUp = true
+    children.foreach(_.setRolledUp())
+    this
+  }
+
+  /**
+   * Returns true if plan is rolledup
+   */
+  def isRolledUp: Boolean = {
+    rolledUp
+  }
+
   private var _skip: Boolean = false
 
   private[mv] def setSkip(): ModularPlan = {

--- a/docs/datamap/mv-datamap-guide.md
+++ b/docs/datamap/mv-datamap-guide.md
@@ -24,6 +24,7 @@
 * [Compaction](#compacting-mv-datamap)
 * [Data Management](#data-management-with-mv-tables)
 * [MV TimeSeries Support](#mv-timeseries-support)
+* [MV TimeSeries RollUp Support](#mv-timeseries-rollup-support)
 
 ## Quick example
 
@@ -236,3 +237,35 @@ Timeseries queries with Date type support's only year, month, day and week granu
  **NOTE**:
  1. Single select statement cannot contain timeseries udf(s) neither with different granularity nor
  with different timestamp/date columns.
+ 
+ ## MV TimeSeries RollUp Support
+  MV Timeseries queries can be rolledUp from existing mv datamaps.
+  ### Query RollUp
+ Consider an example where the query is on hour level granularity, but the datamap
+ of hour is not present but  minute level datamap is present, then we can get the data
+ from minute level and the aggregate the hour level data and give output.
+ This is called query rollup.
+ 
+ Consider if user create's below timeseries datamap,
+   ```
+   CREATE DATAMAP agg_sales
+   ON TABLE sales
+   USING "MV"
+   AS
+     SELECT timeseries(order_time,'minute'),avg(price)
+     FROM sales
+     GROUP BY timeseries(order_time,'minute')
+   ```
+ and fires the below query with hour level granularity.
+   ```
+    SELECT timeseries(order_time,'hour'),avg(price)
+    FROM sales
+    GROUP BY timeseries(order_time,'hour')
+   ```
+ Then, the above query can be rolled up from 'agg_sales' mv datamap, by adding hour
+ level timeseries aggregation on minute level datamap. Users can fire explain command
+ to check if query is rolled up from existing mv datamaps.
+ 
+  **NOTE**:
+  1. Queries cannot be rolled up, if filter contains timeseries function.
+  2. RollUp is not yet supported for queries having join clause or order by functions.

--- a/integration/spark2/src/main/spark2.3/org/apache/spark/sql/CarbonToSparkAdapter.scala
+++ b/integration/spark2/src/main/spark2.3/org/apache/spark/sql/CarbonToSparkAdapter.scala
@@ -52,6 +52,14 @@ object CarbonToSparkAdapter {
       metadata)(exprId, qualifier)
   }
 
+  def createAttributeReference(attr: AttributeReference,
+      attrName: String,
+      newSubsume: String): AttributeReference = {
+    AttributeReference(attrName, attr.dataType)(
+      exprId = attr.exprId,
+      qualifier = Some(newSubsume))
+  }
+
   def createScalaUDF(s: ScalaUDF, reference: AttributeReference): ScalaUDF = {
     ScalaUDF(s.function, s.dataType, Seq(reference), s.inputTypes)
   }

--- a/integration/spark2/src/main/spark2.4/org/apache/spark/sql/CarbonToSparkAdapter.scala
+++ b/integration/spark2/src/main/spark2.4/org/apache/spark/sql/CarbonToSparkAdapter.scala
@@ -73,6 +73,14 @@ object CarbonToSparkAdapter {
       metadata)(exprId, qualifier)
   }
 
+  def createAttributeReference(attr: AttributeReference,
+      attrName: String,
+      newSubsume: String): AttributeReference = {
+    AttributeReference(attrName, attr.dataType)(
+      exprId = attr.exprId,
+      qualifier = newSubsume.split("\n").map(_.trim))
+  }
+
   def createScalaUDF(s: ScalaUDF, reference: AttributeReference) = {
     ScalaUDF(s.function, s.dataType, Seq(reference), s.inputsNullSafe, s.inputTypes)
   }


### PR DESCRIPTION
Supported Query RollUp for MV TimeSeries queries.
How it is supported?
For each timeseries query, check if query can be rolled up from the existing datasets, by replacing the granularity in given user query. If query is rewritten and rolledUp, then add Select and Group by nodes on the rewritten query.

User Query:
`SELECT timeseries(col,'day') from maintable group by timeseries(col,'day')` 

Available datasets,
datamap1 => `SELECT timeseries(col,'hour') from maintable group by timeseries(col,'hour')`
datamap2 => `SELECT timeseries(col,'second') from maintable group by timeseries(col,'second')`

Rewritten Query For datamap1:
```
`SELECT datamap1_table.`UDF:timeseries_projectjoindate_hour` AS `UDF:timeseries (projectjoindate,hour)`
 FROM
 default.datamap1_table
 GROUP BY datamap1_table.`UDF:timeseries_projectjoindate_hour``
```

RolledUp Query:
```
`SELECT timeseries(gen_subsumer_0.`UDF:timeseries(projectjoindate, hour)`,'day' ) AS
`UDF:timeseries(projectjoindate, day)`
FROM
 
( SELECT datamap2_table.`UDF:timeseries_projectjoindate_hour` AS 
 `UDF:timeseries(projectjoindate,hour)`
  FROM
  default.datamap2_table
  GROUP BY datamap2_table.`UDF:timeseries_projectjoindate_hour` )    gen_subsumer_0

GROUP BY timeseries(gen_subsumer_0.`UDF:timeseries(projectjoindate, hour)`,'day' )`
```
**Performance report:**
**MainTable schema:** 88 columns
Tested on 3 node cluster
Data size - 4.8GB

**DataMaps :** 
**DM1 =>** created with query `SELECT timeseries(timecolumn,'hour'), sum(intcolumn) from mainTable group by timeseries(timecolumn,'hour')`
**DM2 =>** created with query `SELECT timeseries(timecolumn,'second'), sum(intcolumn) from mainTable group by timeseries(timecolumn,'second')`

**Query:** `SELECT timeseries(timecolumn,'day'), sum(intcolumn) from mainTable group by timeseries(timecolumn,'day')`

| MainTable(time in seconds)| DataMap(Rolledup (DM1)) table(time in seconds) |
| ------------- | ------------- |
| 5.458| 2.002|



 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [x] Document update required?

 - [x] Testing done
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

