### PR TITLE
[CARBONDATA-3601] Show Segments displays wrong Index size for Partition table with Merge Index Enabled

### DIFF
--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonOutputCommitter.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonOutputCommitter.java
@@ -39,6 +39,7 @@ import org.apache.carbondata.core.mutate.CarbonUpdateUtil;
 import org.apache.carbondata.core.statusmanager.LoadMetadataDetails;
 import org.apache.carbondata.core.statusmanager.SegmentStatus;
 import org.apache.carbondata.core.statusmanager.SegmentStatusManager;
+import org.apache.carbondata.core.util.CarbonProperties;
 import org.apache.carbondata.core.util.CarbonSessionInfo;
 import org.apache.carbondata.core.util.ThreadLocalSessionInfo;
 import org.apache.carbondata.core.util.path.CarbonTablePath;
@@ -167,6 +168,14 @@ public class CarbonOutputCommitter extends FileOutputCommitter {
         } catch (Exception e) {
           throw new IOException(e);
         }
+      }
+      // After merging index, update newMetaEntry with updated merge index size
+      boolean isMergeIndexEnabled = Boolean.parseBoolean(CarbonProperties.getInstance()
+          .getProperty(CarbonCommonConstants.CARBON_MERGE_INDEX_IN_SEGMENT,
+              CarbonCommonConstants.CARBON_MERGE_INDEX_IN_SEGMENT_DEFAULT));
+      if (isMergeIndexEnabled) {
+        CarbonLoaderUtil
+            .addIndexSizeIntoMetaEntry(newMetaEntry, loadModel.getSegmentId(), carbonTable);
       }
       String uniqueId = null;
       if (overwriteSet) {

--- a/processing/src/main/java/org/apache/carbondata/processing/util/CarbonLoaderUtil.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/util/CarbonLoaderUtil.java
@@ -47,6 +47,7 @@ import org.apache.carbondata.core.locks.CarbonLockUtil;
 import org.apache.carbondata.core.locks.ICarbonLock;
 import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
 import org.apache.carbondata.core.metadata.ColumnIdentifier;
+import org.apache.carbondata.core.metadata.SegmentFileStore;
 import org.apache.carbondata.core.metadata.datatype.DataType;
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
 import org.apache.carbondata.core.mutate.CarbonUpdateUtil;
@@ -1168,6 +1169,20 @@ public final class CarbonLoaderUtil {
     Long indexSize = dataIndexSize.get(CarbonCommonConstants.CARBON_TOTAL_INDEX_SIZE);
     loadMetadataDetails.setIndexSize(String.valueOf(indexSize));
     return dataSize + indexSize;
+  }
+
+  public static void addIndexSizeIntoMetaEntry(LoadMetadataDetails loadMetadataDetails,
+      String segmentId, CarbonTable carbonTable) throws IOException {
+    Segment segment = new Segment(segmentId, loadMetadataDetails.getSegmentFile());
+    if (segment.getSegmentFileName() != null) {
+      SegmentFileStore fileStore =
+          new SegmentFileStore(carbonTable.getTablePath(), segment.getSegmentFileName());
+      if (fileStore.getLocationMap() != null) {
+        fileStore.readIndexFiles(FileFactory.getConfiguration());
+        long carbonIndexSize = CarbonUtil.getCarbonIndexSize(fileStore, fileStore.getLocationMap());
+        loadMetadataDetails.setIndexSize(String.valueOf(carbonIndexSize));
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
Problem:
After merging index for partition table, new LoadMetaData entry is not updated with merge index file data size.

Solution:
Update index size on new LoadMetaDataEntry after merge index on partitioned table

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
      
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

