### PR TITLE
[CARBONDATA-3602]Fix MV issues with session level operations

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datamap/DataMapStoreManager.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/DataMapStoreManager.java
@@ -277,6 +277,14 @@ public final class DataMapStoreManager {
   }
 
   /**
+   * This method removes the datamapCatalog for the corresponding provider if the session gets
+   * refreshed or updated
+   */
+  public void clearDataMapCatalog() {
+    dataMapCatalogs = null;
+  }
+
+  /**
    * Initialize by reading all datamaps from store and re register it
    * @param dataMapProvider
    */

--- a/datamap/mv/core/src/main/scala/org/apache/carbondata/mv/datamap/MVAnalyzerRule.scala
+++ b/datamap/mv/core/src/main/scala/org/apache/carbondata/mv/datamap/MVAnalyzerRule.scala
@@ -83,8 +83,16 @@ class MVAnalyzerRule(sparkSession: SparkSession) extends Rule[LogicalPlan] {
         }
         Aggregate(grp, aExp, child)
     }
-    val catalog = DataMapStoreManager.getInstance().getDataMapCatalog(dataMapProvider,
+    var catalog = DataMapStoreManager.getInstance().getDataMapCatalog(dataMapProvider,
       DataMapClassProvider.MV.getShortName).asInstanceOf[SummaryDatasetCatalog]
+    // when first time DataMapCatalogs are initialized, it stores session info also, but when carbon
+    // session is newly created, catalog map will not be cleared, so if session info is different,
+    // remove the entry from map.
+    if (catalog != null && !catalog.mvSession.sparkSession.equals(sparkSession)) {
+      DataMapStoreManager.getInstance().clearDataMapCatalog()
+      catalog = DataMapStoreManager.getInstance().getDataMapCatalog(dataMapProvider,
+        DataMapClassProvider.MV.getShortName).asInstanceOf[SummaryDatasetCatalog]
+    }
     if (needAnalysis && catalog != null && isValidPlan(plan, catalog)) {
       val modularPlan = catalog.mvSession.sessionState.rewritePlan(plan).withMVTable
       if (modularPlan.find(_.rewritten).isDefined) {

--- a/datamap/mv/core/src/main/scala/org/apache/carbondata/mv/rewrite/SummaryDatasetCatalog.scala
+++ b/datamap/mv/core/src/main/scala/org/apache/carbondata/mv/rewrite/SummaryDatasetCatalog.scala
@@ -108,25 +108,22 @@ private[mv] class SummaryDatasetCatalog(sparkSession: SparkSession)
   private[mv] def registerSchema(dataMapSchema: DataMapSchema): Unit = {
     writeLock {
       val updatedQuery = parser.addMVSkipFunction(dataMapSchema.getCtasQuery)
-      val currentDatabase = sparkSession
-        .asInstanceOf[CarbonSession]
-        .sessionState
-        .catalog
-        .getCurrentDatabase
+      val currentDatabase = sparkSession match {
+        case carbonSession: CarbonSession =>
+          carbonSession.sessionState.catalog.getCurrentDatabase
+        case _ =>
+          sparkSession.catalog.currentDatabase
+      }
       // This is required because datamap schemas are across databases, so while loading the
       // catalog, if the datamap is in database other than sparkSession.currentDataBase(), then it
       // fails to register, so set the database present in the dataMapSchema Object
-      sparkSession.asInstanceOf[CarbonSession].sessionState.catalog
-        .setCurrentDatabase(dataMapSchema.getRelationIdentifier.getDatabaseName)
+      setCurrentDataBase(dataMapSchema.getRelationIdentifier.getDatabaseName)
       val query = sparkSession.sql(updatedQuery)
       // here setting back to current database of current session, because if the actual query
       // contains db name in query like, select db1.column1 from table and current database is
       // default and if we drop the db1, still the session has current db as db1.
       // So setting back to current database.
-      sparkSession.asInstanceOf[CarbonSession]
-        .sessionState
-        .catalog
-        .setCurrentDatabase(currentDatabase)
+      setCurrentDataBase(currentDatabase)
       val planToRegister = MVHelper.dropDummFuc(query.queryExecution.analyzed)
       val modularPlan =
         mvSession.sessionState.modularizer.modularize(
@@ -158,6 +155,15 @@ private[mv] class SummaryDatasetCatalog(sparkSession: SparkSession)
         planToRegister,
         dataMapSchema,
         MVPlanWrapper(select, dataMapSchema))
+    }
+  }
+
+  private def setCurrentDataBase(dataBaseName: String): Unit = {
+    sparkSession match {
+      case carbonSession: CarbonSession =>
+        carbonSession.sessionState.catalog.setCurrentDatabase(dataBaseName)
+      case _ =>
+        sparkSession.catalog.setCurrentDatabase(dataBaseName)
     }
   }
 

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/timeseries/TimeSeriesFunction.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/timeseries/TimeSeriesFunction.scala
@@ -24,7 +24,7 @@ import org.apache.carbondata.core.preagg.TimeSeriesUDF
  * Time series udf class
  */
 
-class TimeSeriesFunction extends ((Timestamp, String) => Timestamp) with Serializable{
+case class TimeSeriesFunction() extends ((Timestamp, String) => Timestamp) with Serializable{
 
   override def apply(v1: Timestamp, v2: String): Timestamp = {
     TimeSeriesUDF.INSTANCE.applyUDF(v1, v2)


### PR DESCRIPTION
### Problems:
1. when the same timeseries query is being executed from different session, one session query is not being hit to datamap table. When the query executed from different session, the semantic equals of ScalaUDF expression fails, as object reference is different, when the object equals is checked for that.

2. When same datamap on same table, but in some other database is executed, fails with table not found error. This is because, when first time the datamap catalog map is initialized, it contains the session info, which wont be cleared when session get refreshed.

### Solution:
1. make the TimeSeriesFunction as case class, as during run time scala generates the equals method, which will check the other equality when the object reference are not equal.

2. when the session info gets updated, clear the entry in map and put again with new session info.


Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

