### PR TITLE
[CARBONDATA-3351]Block bloom datamap creation on binary datatype column

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/datamap/CarbonCreateDataMapCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/datamap/CarbonCreateDataMapCommand.scala
@@ -27,6 +27,7 @@ import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.core.datamap.{DataMapProvider, DataMapStoreManager}
 import org.apache.carbondata.core.datamap.status.DataMapStatusManager
 import org.apache.carbondata.core.metadata.ColumnarFormatVersion
+import org.apache.carbondata.core.metadata.datatype.DataTypes
 import org.apache.carbondata.core.metadata.schema.datamap.{DataMapClassProvider, DataMapProperty}
 import org.apache.carbondata.core.metadata.schema.table.{CarbonTable, DataMapSchema}
 import org.apache.carbondata.core.util.{CarbonProperties, CarbonUtil}
@@ -145,6 +146,12 @@ case class CarbonCreateDataMapCommand(
               "column '%s' already has %s index datamap created",
               column.getColName, thisDmProviderName))
           } else if (isBloomFilter) {
+            if (column.getDataType == DataTypes.BINARY) {
+              throw new MalformedDataMapCommandException(
+                s"BloomFilter datamap does not support Binary datatype column: ${
+                  column.getColName
+                }")
+            }
             // if datamap provider is bloomfilter,the index column datatype cannot be complex type
             if (column.isComplex) {
               throw new MalformedDataMapCommandException(

--- a/integration/spark2/src/test/scala/org/apache/carbondata/datamap/bloom/BloomCoarseGrainDataMapSuite.scala
+++ b/integration/spark2/src/test/scala/org/apache/carbondata/datamap/bloom/BloomCoarseGrainDataMapSuite.scala
@@ -590,6 +590,25 @@ class BloomCoarseGrainDataMapSuite extends QueryTest with BeforeAndAfterAll with
       "BloomFilter datamap does not support complex datatype column"))
   }
 
+  test("test create bloomfilter datamap which index column datatype is Binary ") {
+    sql("drop table if exists binaryTable")
+    sql(
+      "CREATE TABLE binaryTable (CUST_ID binary,CUST_NAME String,ACTIVE_EMUI_VERSION string, DOB " +
+      "timestamp, DOJ timestamp, BIGINT_COLUMN1 bigint,BIGINT_COLUMN2 bigint,DECIMAL_COLUMN1 " +
+      "decimal(30,10), DECIMAL_COLUMN2 decimal(36,36),Double_COLUMN1 double, Double_COLUMN2 " +
+      "double,INTEGER_COLUMN1 int) STORED BY 'org.apache.carbondata.format'")
+    val exception: MalformedDataMapCommandException = intercept[MalformedDataMapCommandException] {
+      sql(
+        s"""
+           | CREATE DATAMAP binaryBloom ON TABLE binaryTable
+           | USING 'bloomfilter'
+           | DMProperties('INDEX_COLUMNS'='cust_id', 'BLOOM_SIZE'='640000')
+           | """.stripMargin)
+    }
+    assert(exception.getMessage.equalsIgnoreCase(
+      "BloomFilter datamap does not support binary datatype column: cust_id"  ))
+  }
+
   test("test create bloom datamap on newly added column") {
     val datamap1 = "datamap1"
     val datamap2 = "datamap2"


### PR DESCRIPTION
### Why this PR?
As per Binary Datatype design Bloom data-map creation on Binary datatype column is not supported.
Handled the same.


Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

