### PR TITLE
[CARBONDATA-3615]: Show metacache shows the index server index-dictionary files when data loaded after index server disabled using set command

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
@@ -1664,17 +1664,29 @@ public final class CarbonProperties {
   public boolean isDistributedPruningEnabled(String dbName, String tableName) {
     // Check if user has enabled/disabled the use of index server for the current session using
     // the set command
-    String configuredValue = getSessionPropertyValue(
-        CarbonCommonConstants.CARBON_ENABLE_INDEX_SERVER + "." + dbName + "." + tableName);
-    if (configuredValue == null) {
-      // if not set in session properties then check carbon.properties for the same.
-      configuredValue = getProperty(CarbonCommonConstants.CARBON_ENABLE_INDEX_SERVER);
+    String configuredValueForTable = getSessionPropertyValue(
+            CarbonCommonConstants.CARBON_ENABLE_INDEX_SERVER + "." + dbName + "." + tableName);
+    String configuredValue = getProperty(CarbonCommonConstants.CARBON_ENABLE_INDEX_SERVER);
+
+    /**
+     * Carbon.enable.index.server | carbon.enable.index.server.dbname.tablename | Output
+     *  False                         False                                         False
+     *  False                         True                                          False
+     *  True                          False                                         False
+     *  True                          True                                          True
+     *  True                          NULL                                          True
+     *  False                         NULL                                          False
+     */
+
+    if (!Boolean.parseBoolean(configuredValue)) {
+      return false;
+    } else if (Boolean.parseBoolean(configuredValue) && configuredValueForTable != null
+            && !Boolean.parseBoolean(configuredValueForTable)) {
+      return false;
+    } else {
+      LOGGER.info("Distributed Index Server is enabled for " + dbName + "." + tableName);
+      return true;
     }
-    boolean isServerEnabledByUser = Boolean.parseBoolean(configuredValue);
-    if (isServerEnabledByUser) {
-      LOGGER.info("Distributed Index server is enabled for " + dbName + "." + tableName);
-    }
-    return isServerEnabledByUser;
   }
 
   /**


### PR DESCRIPTION
Modification_Reason: isDistributedPruningEnabled function does not consider value of CARBON_ENABLE_INDEX_SERVER when CARBON_ENABLE_INDEX_SERVER.dbName.tableName is true.
Modification_Content: isDistributedPruningEnabled function rewritten with new logic. Logic mentioned in the comments.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

