### PR TITLE
[CARBONDATA-3616]: Load and drop table operations fail when index server is stopped with indexserver and prepriming property enabled

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datamap/DataMapUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/DataMapUtil.java
@@ -119,6 +119,10 @@ public class DataMapUtil {
     try {
       dataMapJob.execute(dataMapFormat);
     } catch (Exception e) {
+      /*
+       * Consider a scenario where clear datamap job is called from drop table and index server
+       *  crashes, in this no exception should be thrown and drop table should complete.
+       */
       LOGGER.error("Failed to execute Datamap clear Job", e);
     }
   }

--- a/core/src/main/java/org/apache/carbondata/core/datamap/DataMapUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/DataMapUtil.java
@@ -116,7 +116,11 @@ public class DataMapUtil {
     DistributableDataMapFormat dataMapFormat =
         new DistributableDataMapFormat(carbonTable, validAndInvalidSegmentsInfo.getValidSegments(),
             invalidSegment, true, dataMapToClear);
-    dataMapJob.execute(dataMapFormat);
+    try {
+      dataMapJob.execute(dataMapFormat);
+    } catch (Exception e) {
+      LOGGER.error("Failed to execute Datamap clear Job", e);
+    }
   }
 
   public static void executeClearDataMapJob(CarbonTable carbonTable, String jobClassName)

--- a/core/src/main/java/org/apache/carbondata/core/datamap/DataMapUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/DataMapUtil.java
@@ -119,10 +119,9 @@ public class DataMapUtil {
     try {
       dataMapJob.execute(dataMapFormat);
     } catch (Exception e) {
-      /*
-       * Consider a scenario where clear datamap job is called from drop table and index server
-       *  crashes, in this no exception should be thrown and drop table should complete.
-       */
+      // Consider a scenario where clear datamap job is called from drop table
+      // and index server crashes, in this no exception should be thrown and
+      // drop table should complete.
       LOGGER.error("Failed to execute Datamap clear Job", e);
     }
   }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/indexserver/PrePrimingListener.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/indexserver/PrePrimingListener.scala
@@ -21,7 +21,8 @@ import scala.collection.JavaConverters._
 
 import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.core.datamap.{DistributableDataMapFormat, Segment}
-import org.apache.carbondata.events.{Event, IndexServerLoadEvent, OperationContext, OperationEventListener}
+import org.apache.carbondata.events.{Event, IndexServerLoadEvent,
+  OperationContext, OperationEventListener}
 import org.apache.carbondata.indexserver.IndexServer
 
 // Listener for the PrePriming Event. This listener calls the index server using an Asynccall
@@ -47,12 +48,10 @@ object PrePrimingEventListener extends OperationEventListener {
         IndexServer.getClient.getCount(dataMapFormat)
       }
       catch {
-        /*
-         * Consider a scenario where prepriming is in progress and the index server crashes, in
-         * this case since we should not fail the corresponding operation where pre-priming is triggered.
-         *  Because prepriming is an optimization for cache loading prior to query, so no exception
-         *  should be thrown.
-         */
+        // Consider a scenario where prepriming is in progress and the index server crashes, in
+        // this case since we should not fail the corresponding operation where pre-priming is
+        // triggered. Because prepriming is an optimization for cache loading prior to query,
+        // so no exception should be thrown.
         case ex: Exception =>
           LOGGER.error(s"Prepriming failed for table ${carbonTable.getTableName} ", ex)
       }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/indexserver/PrePrimingListener.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/indexserver/PrePrimingListener.scala
@@ -48,10 +48,10 @@ object PrePrimingEventListener extends OperationEventListener {
       }
       catch {
         /*
-         * A scenario where prepriming fails is when index server crashes or has not been
-         *  started but "carbon.indexserver.enable.prepriming" property and
-         * "carbon.enable.index.server" property is set to true in the
-         *  carbon properties.
+         * Consider a scenario where prepriming is in progress and the index server crashes, in
+         * this case since we should not fail the corresponding operation where pre-priming is triggered.
+         *  Because prepriming is an optimization for cache loading prior to query, so no exception
+         *  should be thrown.
          */
         case ex: Exception =>
           LOGGER.error(s"Prepriming failed for table ${carbonTable.getTableName} ", ex)


### PR DESCRIPTION
**Modification Reason:** If index server is stopped and all it's properties are enabled, then it tries to connect to the index Server.
**Modification Content:** Added try catch while prpriming and trying to clear datamaps.
Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

