### PR TITLE
[HOTFIX] Solve GSON jar dependency conflict with Hadoop

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/statusmanager/LoadMetadataDetails.java
+++ b/core/src/main/java/org/apache/carbondata/core/statusmanager/LoadMetadataDetails.java
@@ -25,7 +25,6 @@ import java.util.Date;
 import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 
-import com.google.gson.annotations.SerializedName;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 
@@ -63,82 +62,65 @@ public class LoadMetadataDetails implements Serializable {
   private static final SimpleDateFormat parser =
       new SimpleDateFormat(CarbonCommonConstants.CARBON_TIMESTAMP_MILLIS);
 
-  @SerializedName(value = "ts", alternate = "timestamp")
   private String timestamp;
 
   // For backward compatibility, this member is required to read from JSON in the table_status file
-  @SerializedName(value = "ls", alternate = "loadStatus")
   private SegmentStatus loadStatus;
 
   // name of the segment
-  @SerializedName(value = "ln", alternate = "loadName")
   private String loadName;
 
-  @SerializedName(value = "ds", alternate = "dataSize")
   private String dataSize;
 
-  @SerializedName(value = "is", alternate = "indexSize")
   private String indexSize;
 
   // update delta end timestamp
-  @SerializedName(value = "ue", alternate = "updateDeltaEndTimestamp")
   private String updateDeltaEndTimestamp;
 
   // update delta start timestamp
-  @SerializedName(value = "us", alternate = "updateDeltaStartTimestamp")
   private String updateDeltaStartTimestamp;
 
   // this will represent the update status file name at that point of time.
-  @SerializedName(value = "uf", alternate = "updateStatusFileName")
   private String updateStatusFileName;
 
   /**
    * Segment modification or deletion time stamp
    */
-  @SerializedName(value = "mt", alternate = "modificationOrdeletionTimesStamp")
   private String modificationOrdeletionTimesStamp;
 
-  @SerializedName(value = "lt", alternate = "loadStartTime")
   private String loadStartTime;
 
-  @SerializedName(value = "mn", alternate = "mergedLoadName")
   private String mergedLoadName;
 
   /**
    * visibility is used to determine whether to the load is visible or not.
    * by default it is true
    */
-  @SerializedName(value = "v", alternate = "visibility")
   private String visibility;
 
   /**
    * To know if the segment is a major compacted segment or not.
    */
-  @SerializedName(value = "mc", alternate = "majorCompacted")
   private String majorCompacted;
 
   /**
    * the file format of this segment, by default it is FileFormat.COLUMNAR_V3
    */
-  @SerializedName(value = "ff", alternate = "fileFormat")
   private String fileFormat;
 
   /**
    * Segment path if the segment is added externally.
    */
-  @SerializedName(value = "p", alternate = "path")
   private String path;
 
   /**
    * Segment file name where it has the information of partition information.
    */
-  @SerializedName(value = "sf", alternate = "segmentFile")
   private String segmentFile;
 
   /**
    * extraInfo will contain segment mapping Information for datamap table
    */
-  @SerializedName(value = "ei", alternate = "extraInfo")
   private String extraInfo;
 
   public String getDataSize() {

--- a/core/src/main/java/org/apache/carbondata/core/statusmanager/SegmentStatus.java
+++ b/core/src/main/java/org/apache/carbondata/core/statusmanager/SegmentStatus.java
@@ -28,7 +28,7 @@ public enum SegmentStatus {
   /**
    * Data load success, it is visible for read
    */
-  @SerializedName(value = "S", alternate = "Success")
+  @SerializedName("Success")
   SUCCESS("Success"),
 
   /**
@@ -58,7 +58,7 @@ public enum SegmentStatus {
   /**
    * Segment is compacted
    */
-  @SerializedName(value = "C", alternate = "Compacted")
+  @SerializedName("Compacted")
   COMPACTED("Compacted"),
 
   /**


### PR DESCRIPTION
Currently CarbonData depends on GSON 2.4 which conflict with the GSON 2.2.4 used in Hadoop. This PR resolve this conflict

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

