### PR TITLE
[CARBONDATA-3619] NoSuchMethodError(registerCurrentOperationLog) Whil…

### DIFF
--- a/integration/spark-common/pom.xml
+++ b/integration/spark-common/pom.xml
@@ -48,6 +48,10 @@
           <groupId>org.apache.hive</groupId>
           <artifactId>hive-exec</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.apache.hive</groupId>
+          <artifactId>hive-service</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
…e Creating Table

Modification reason: ExecuteStatementOperation.java exists in both hive-service model and spark-hive-thriftserver model, Leading "NoSuchMethodError: org.apache.spark.sql.hive.thriftserver.SparkExecuteStatementOperation.registerCurrentOperationLog()V"

Modification content: Excludes the dependence on hive-service in the spark-hive-thriftserver

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

