### PR TITLE
[CARBONDATA-3623]: Fixed global sort compaction failure on timestamp column

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestGlobalSortDataLoad.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestGlobalSortDataLoad.scala
@@ -141,7 +141,7 @@ class TestGlobalSortDataLoad extends QueryTest with BeforeAndAfterEach with Befo
 
   // ----------------------------------- Compaction -----------------------------------
   test("compaction major: timestamp and long data type confliction")
-  {sptc
+  {
     sql("drop table if exists compactionTable")
     sql("create table compactionTable (DOJ timestamp, DOB date) STORED BY 'org.apache.carbondata.format'")
     sql("alter table compactionTable set tblproperties('sort_columns'='doj, dob', 'sort_scope'='global_sort')")
@@ -159,7 +159,6 @@ class TestGlobalSortDataLoad extends QueryTest with BeforeAndAfterEach with Befo
       case Some(row) => assert(row.get(1).toString.equalsIgnoreCase("Compacted"))
     }
   }
-
   test("Compaction GLOBAL_SORT * 2") {
     sql("DROP TABLE IF EXISTS carbon_localsort_twice")
     sql(

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/load/DataLoadProcessBuilderOnSpark.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/load/DataLoadProcessBuilderOnSpark.scala
@@ -27,7 +27,7 @@ import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.sql.execution.command.ExecutionErrors
-import org.apache.spark.sql.util.{SparkSQLUtil, SparkTypeConverter}
+import org.apache.spark.sql.util.SparkSQLUtil
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.unsafe.types.UTF8String
 
@@ -422,23 +422,6 @@ object DataLoadProcessBuilderOnSpark {
       loadModel.setGlobalSortPartitions(globalSortPartitions)
     }
     loadModel
-  }
-
-  /**
-   * create DataFrame basing on specified splits
-   */
-  def createInputDataFrame(
-      sparkSession: SparkSession,
-      carbonTable: CarbonTable
-  ): DataFrame = {
-    /**
-     * [[org.apache.spark.sql.catalyst.expressions.objects.ValidateExternalType]] validates the
-     * datatype of column data and corresponding datatype in schema provided to create dataframe.
-     * Since carbonScanRDD gives Long data for timestamp column and corresponding column datatype in
-     * schema is Timestamp, this validation fails if we use createDataFrame API which takes rdd as
-     * input. Hence, using below API which creates dataframe from tablename.
-     */
-    sparkSession.sqlContext.table(carbonTable.getTableName)
   }
 }
 

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/util/SparkSQLUtil.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/util/SparkSQLUtil.scala
@@ -35,6 +35,8 @@ import org.apache.spark.sql.internal.{SessionState, SQLConf}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.{CarbonReflectionUtils, SerializableConfiguration, SparkUtil, Utils}
 
+import org.apache.carbondata.core.metadata.schema.table.CarbonTable
+
 object SparkSQLUtil {
   def sessionState(sparkSession: SparkSession): SessionState = sparkSession.sessionState
 
@@ -257,4 +259,19 @@ object SparkSQLUtil {
     taskGroupDesc
   }
 
+  /**
+   * create DataFrame based on carbonTable
+   */
+  def createInputDataFrame(
+      sparkSession: SparkSession,
+      carbonTable: CarbonTable): DataFrame = {
+    /**
+     * [[org.apache.spark.sql.catalyst.expressions.objects.ValidateExternalType]] validates the
+     * datatype of column data and corresponding datatype in schema provided to create dataframe.
+     * Since carbonScanRDD gives Long data for timestamp column and corresponding column datatype in
+     * schema is Timestamp, this validation fails if we use createDataFrame API which takes rdd as
+     * input. Hence, using below API which creates dataframe from tablename.
+     */
+    sparkSession.sqlContext.table(carbonTable.getTableName)
+  }
 }

--- a/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonTableCompactor.scala
+++ b/integration/spark2/src/main/scala/org/apache/carbondata/spark/rdd/CarbonTableCompactor.scala
@@ -67,8 +67,8 @@ class CarbonTableCompactor(carbonLoadModel: CarbonLoadModel,
       loadsToMerge: java.util.List[LoadMetadataDetails]): Boolean = {
     // support to resort old segment with old sort_columns
     if (CompactionType.CUSTOM == compactionModel.compactionType &&
-      loadsToMerge.size() == 1 &&
-      SortScope.NO_SORT != compactionModel.carbonTable.getSortScope) {
+        loadsToMerge.size() == 1 &&
+        SortScope.NO_SORT != compactionModel.carbonTable.getSortScope) {
       !CarbonCompactionUtil.isSortedByCurrentSortColumns(
         carbonLoadModel.getCarbonDataLoadSchema.getCarbonTable,
         loadsToMerge.get(0),
@@ -87,8 +87,8 @@ class CarbonTableCompactor(carbonLoadModel: CarbonLoadModel,
     var loadsToMerge = identifySegmentsToBeMerged()
 
     while (loadsToMerge.size() > 1 || needSortSingleSegment(loadsToMerge) ||
-      (CompactionType.IUD_UPDDEL_DELTA == compactionModel.compactionType &&
-        loadsToMerge.size() > 0)) {
+           (CompactionType.IUD_UPDDEL_DELTA == compactionModel.compactionType &&
+            loadsToMerge.size() > 0)) {
       val lastSegment = sortedSegments.get(sortedSegments.size() - 1)
       deletePartialLoadsInCompaction()
 
@@ -207,9 +207,9 @@ class CarbonTableCompactor(carbonLoadModel: CarbonLoadModel,
           carbonMergerMapping
         ).collect
       } else if (SortScope.GLOBAL_SORT == carbonTable.getSortScope &&
-        !carbonTable.getSortColumns.isEmpty &&
-        carbonTable.getRangeColumn == null &&
-        CarbonUtil.isStandardCarbonTable(carbonTable)) {
+                 !carbonTable.getSortColumns.isEmpty &&
+                 carbonTable.getRangeColumn == null &&
+                 CarbonUtil.isStandardCarbonTable(carbonTable)) {
         compactSegmentsByGlobalSort(sc.sparkSession, carbonLoadModel, carbonMergerMapping)
       } else {
         new CarbonMergerRDD(
@@ -233,7 +233,7 @@ class CarbonTableCompactor(carbonLoadModel: CarbonLoadModel,
       if (carbonTable.isHivePartitionTable) {
         val readPath =
           CarbonTablePath.getSegmentFilesLocation(carbonLoadModel.getTablePath) +
-            CarbonCommonConstants.FILE_SEPARATOR + carbonLoadModel.getFactTimeStamp + ".tmp"
+          CarbonCommonConstants.FILE_SEPARATOR + carbonLoadModel.getFactTimeStamp + ".tmp"
         // Merge all partition files into a single file.
         segmentFileName =
           mergedLoadNumber + "_" + carbonLoadModel.getFactTimeStamp
@@ -270,11 +270,11 @@ class CarbonTableCompactor(carbonLoadModel: CarbonLoadModel,
       operationContext.setProperty("isCompaction", "true")
       // trigger event for compaction
       val alterTableCompactionPreStatusUpdateEvent =
-        AlterTableCompactionPreStatusUpdateEvent(sc.sparkSession,
-          carbonTable,
-          carbonMergerMapping,
-          carbonLoadModel,
-          mergedLoadName)
+      AlterTableCompactionPreStatusUpdateEvent(sc.sparkSession,
+        carbonTable,
+        carbonMergerMapping,
+        carbonLoadModel,
+        mergedLoadName)
       OperationListenerBus.getInstance
         .fireEvent(alterTableCompactionPreStatusUpdateEvent, operationContext)
 
@@ -282,21 +282,21 @@ class CarbonTableCompactor(carbonLoadModel: CarbonLoadModel,
       LOGGER.info(s"time taken to merge $mergedLoadName is ${ endTime - startTime }")
       val statusFileUpdation =
         ((compactionType == CompactionType.IUD_UPDDEL_DELTA) &&
-          CarbonDataMergerUtil
-            .updateLoadMetadataIUDUpdateDeltaMergeStatus(loadsToMerge,
-              carbonTable.getMetadataPath,
-              carbonLoadModel,
-              segmentFilesForIUDCompact)) ||
-          CarbonDataMergerUtil.updateLoadMetadataWithMergeStatus(
-            loadsToMerge,
-            carbonTable.getMetadataPath,
-            mergedLoadNumber,
-            carbonLoadModel,
-            compactionType,
-            segmentFileName)
+         CarbonDataMergerUtil
+           .updateLoadMetadataIUDUpdateDeltaMergeStatus(loadsToMerge,
+             carbonTable.getMetadataPath,
+             carbonLoadModel,
+             segmentFilesForIUDCompact)) ||
+        CarbonDataMergerUtil.updateLoadMetadataWithMergeStatus(
+          loadsToMerge,
+          carbonTable.getMetadataPath,
+          mergedLoadNumber,
+          carbonLoadModel,
+          compactionType,
+          segmentFileName)
 
       if (compactionType != CompactionType.IUD_DELETE_DELTA &&
-        compactionType != CompactionType.IUD_UPDDEL_DELTA) {
+          compactionType != CompactionType.IUD_UPDDEL_DELTA) {
         MergeIndexUtil.mergeIndexFilesOnCompaction(compactionCallableModel)
       }
 
@@ -326,22 +326,22 @@ class CarbonTableCompactor(carbonLoadModel: CarbonLoadModel,
       // possible (level 1, 2 etc). so we need to check for either condition
       if (!statusFileUpdation || !commitComplete) {
         LOGGER.error(s"Compaction request failed for table ${ carbonLoadModel.getDatabaseName }." +
-          s"${ carbonLoadModel.getTableName }")
+                     s"${ carbonLoadModel.getTableName }")
         throw new Exception(s"Compaction failed to update metadata for table" +
-          s" ${ carbonLoadModel.getDatabaseName }." +
-          s"${ carbonLoadModel.getTableName }")
+                            s" ${ carbonLoadModel.getDatabaseName }." +
+                            s"${ carbonLoadModel.getTableName }")
       } else {
         LOGGER.info(s"Compaction request completed for table " +
-          s"${ carbonLoadModel.getDatabaseName }.${ carbonLoadModel.getTableName }")
+                    s"${ carbonLoadModel.getDatabaseName }.${ carbonLoadModel.getTableName }")
 
         // Prepriming index for compaction
         val segmentsForPriming = if (compactionType.equals(CompactionType.IUD_DELETE_DELTA) ||
-          compactionType.equals(CompactionType.IUD_UPDDEL_DELTA)) {
-          validSegments.asScala.map(_.getSegmentNo).toList
+            compactionType.equals(CompactionType.IUD_UPDDEL_DELTA)) {
+            validSegments.asScala.map(_.getSegmentNo).toList
         } else if (compactionType.equals(CompactionType.MAJOR) ||
-          compactionType.equals(CompactionType.MINOR) ||
-          compactionType.equals(CompactionType.CUSTOM)) {
-          scala.List(mergedLoadNumber)
+                   compactionType.equals(CompactionType.MINOR) ||
+                   compactionType.equals(CompactionType.CUSTOM)) {
+            scala.List(mergedLoadNumber)
         } else {
           scala.List()
         }
@@ -354,7 +354,7 @@ class CarbonTableCompactor(carbonLoadModel: CarbonLoadModel,
       }
     } else {
       LOGGER.error(s"Compaction request failed for table " +
-        s"${ carbonLoadModel.getDatabaseName }.${ carbonLoadModel.getTableName }")
+                   s"${ carbonLoadModel.getDatabaseName }.${ carbonLoadModel.getTableName }")
       throw new Exception("Compaction Failure in Merger Rdd.")
     }
   }
@@ -363,9 +363,9 @@ class CarbonTableCompactor(carbonLoadModel: CarbonLoadModel,
    * compact segments by global sort
    */
   def compactSegmentsByGlobalSort(
-   sparkSession: SparkSession,
-   carbonLoadModel: CarbonLoadModel,
-   carbonMergerMapping: CarbonMergerMapping): Array[(String, Boolean)] = {
+      sparkSession: SparkSession,
+      carbonLoadModel: CarbonLoadModel,
+      carbonMergerMapping: CarbonMergerMapping): Array[(String, Boolean)] = {
     val table = carbonLoadModel.getCarbonDataLoadSchema.getCarbonTable
     val splits = splitsOfSegments(
       sparkSession,
@@ -377,7 +377,7 @@ class CarbonTableCompactor(carbonLoadModel: CarbonLoadModel,
         .threadSet(CarbonCommonConstants.CARBON_INPUT_SEGMENTS +
           table.getDatabaseName + CarbonCommonConstants.POINT + table.getTableName,
           splits.asScala.map(s => s.asInstanceOf[CarbonInputSplit].getSegmentId).mkString(","))
-      val dataFrame = DataLoadProcessBuilderOnSpark.createInputDataFrame(
+      val dataFrame = SparkSQLUtil.createInputDataFrame(
         sparkSession,
         table)
 

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonInsertFromStageCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonInsertFromStageCommand.scala
@@ -28,16 +28,12 @@ import com.google.gson.Gson
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.mapreduce.InputSplit
 import org.apache.log4j.Logger
-import org.apache.spark.CarbonInputMetrics
-import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.{CarbonEnv, DataFrame, Row, SparkSession}
-import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.{CarbonEnv, CarbonUtils, DataFrame, Row, SparkSession}
 import org.apache.spark.sql.execution.command.{Checker, DataCommand}
-import org.apache.spark.sql.util.{SparkSQLUtil, SparkTypeConverter}
+import org.apache.spark.sql.util.SparkSQLUtil
 
 import org.apache.carbondata.common.exceptions.sql.MalformedCarbonCommandException
 import org.apache.carbondata.common.logging.LogServiceFactory
-import org.apache.carbondata.converter.SparkDataTypeConverterImpl
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.datastore.filesystem.CarbonFile
 import org.apache.carbondata.core.datastore.impl.FileFactory
@@ -46,13 +42,11 @@ import org.apache.carbondata.core.metadata.{ColumnarFormatVersion, SegmentFileSt
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable
 import org.apache.carbondata.core.statusmanager.{SegmentStatus, SegmentStatusManager, StageInput}
 import org.apache.carbondata.core.util.path.CarbonTablePath
-import org.apache.carbondata.hadoop.{CarbonInputSplit, CarbonProjection}
+import org.apache.carbondata.hadoop.CarbonInputSplit
 import org.apache.carbondata.processing.loading.FailureCauses
 import org.apache.carbondata.processing.loading.model.CarbonLoadModel
 import org.apache.carbondata.processing.util.CarbonLoaderUtil
 import org.apache.carbondata.spark.load.DataLoadProcessBuilderOnSpark
-import org.apache.carbondata.spark.rdd.CarbonScanRDD
-import org.apache.carbondata.spark.readsupport.SparkRowReadSupportImpl
 
 /**
  * Collect stage input files and trigger a loading into carbon table.
@@ -185,7 +179,7 @@ case class CarbonInsertFromStageCommand(
       table.getAbsoluteTableIdentifier, LockUsage.TABLE_STATUS_LOCK)
     if (!lock.lockWithRetries()) {
       throw new RuntimeException(s"Failed to lock table status for " +
-                                 s"${table.getDatabaseName}.${table.getTableName}")
+        s"${table.getDatabaseName}.${table.getTableName}")
     }
     try {
       val segments = SegmentStatusManager.readTableStatusFile(
@@ -201,7 +195,7 @@ case class CarbonInsertFromStageCommand(
           lock.unlock()
           lock = null
           LOGGER.info(s"Segment $segmentId is in SUCCESS state, about to delete " +
-                      s"${stageFileNames.length} stage files")
+            s"${stageFileNames.length} stage files")
           val numThreads = Math.min(Math.max(stageFileNames.length, 1), 10)
           val executorService = Executors.newFixedThreadPool(numThreads)
           stageFileNames.map { fileName =>
@@ -219,7 +213,7 @@ case class CarbonInsertFromStageCommand(
         case SegmentStatus.INSERT_IN_PROGRESS =>
           // delete entry in table status and load again
           LOGGER.info(s"Segment $segmentId is in INSERT_IN_PROGRESS state, about to delete the " +
-                      s"segment entry and load again")
+            s"segment entry and load again")
           val segmentToWrite = segments.filterNot(_.getLoadName.equals(segmentId))
           SegmentStatusManager.writeLoadDetailsIntoFile(
             CarbonTablePath.getTableStatusFilePath(table.getTablePath),
@@ -262,16 +256,27 @@ case class CarbonInsertFromStageCommand(
       // 3) do loading.
       val splits = stageInput.flatMap(_.createSplits().asScala)
       LOGGER.info(s"start to load ${splits.size} files into " +
-                  s"${table.getDatabaseName}.${table.getTableName}")
+        s"${table.getDatabaseName}.${table.getTableName}")
       val start = System.currentTimeMillis()
-      val dataFrame = DataLoadProcessBuilderOnSpark.createInputDataFrame(spark, table, splits)
-      DataLoadProcessBuilderOnSpark.loadDataUsingGlobalSort(
-        spark,
-        Option(dataFrame),
-        loadModel,
-        SparkSQLUtil.sessionState(spark).newHadoopConf()
-      ).map { row =>
+      try {
+        CarbonUtils
+          .threadSet(CarbonCommonConstants.CARBON_INPUT_SEGMENTS +
+            table.getDatabaseName + CarbonCommonConstants.POINT + table.getTableName,
+            splits.map(s => s.asInstanceOf[CarbonInputSplit].getSegmentId).mkString(","))
+        val dataFrame = DataLoadProcessBuilderOnSpark.createInputDataFrame(spark, table)
+        DataLoadProcessBuilderOnSpark.loadDataUsingGlobalSort(
+          spark,
+          Option(dataFrame),
+          loadModel,
+          SparkSQLUtil.sessionState(spark).newHadoopConf()
+        ).map { row =>
           (row._1, FailureCauses.NONE == row._2._2.failureCauses)
+        }
+      } finally {
+        CarbonUtils
+          .threadUnset(CarbonCommonConstants.CARBON_INPUT_SEGMENTS +
+            table.getDatabaseName + "." +
+            table.getTableName)
       }
       LOGGER.info(s"finish data loading, time taken ${System.currentTimeMillis() - start}ms")
 
@@ -311,15 +316,30 @@ case class CarbonInsertFromStageCommand(
     val start = System.currentTimeMillis()
     partitionDataList.map {
       case (partition, splits) =>
-        LOGGER.info(s"start to load ${splits.size} files into " +
-          s"${table.getDatabaseName}.${table.getTableName}. " +
-          s"Partition information: ${partition.mkString(",")}")
-        val dataFrame = createInputDataFrameOfInternalRow(spark, table, splits)
+        LOGGER.info(s"start to load ${ splits.size } files into " +
+          s"${ table.getDatabaseName }.${ table.getTableName }. " +
+          s"Partition information: ${ partition.mkString(",") }")
+        val dataFrame = try {
+          // Segments should be set for query here, because consider a scenario where custom
+          // compaction is triggered, so it can happen that all the segments might be taken into
+          // consideration instead of custom segments if we do not set, leading to duplicate data in
+          // compacted segment. To avoid this, segments to be considered are to be set in threadset.
+          CarbonUtils
+            .threadSet(CarbonCommonConstants.CARBON_INPUT_SEGMENTS +
+              table.getDatabaseName + CarbonCommonConstants.POINT +
+              table.getTableName,
+              splits.map(split => split.asInstanceOf[CarbonInputSplit].getSegmentId).mkString(","))
+          createInputDataFrameOfInternalRow(spark, table, splits)
+        } finally {
+          CarbonUtils.threadUnset(
+            CarbonCommonConstants.CARBON_INPUT_SEGMENTS + table.getDatabaseName +
+              CarbonCommonConstants.POINT +
+              table.getTableName)
+        }
         val columns = dataFrame.columns
         val header = columns.mkString(",")
         val selectColumns = columns.filter(!partition.contains(_))
         val selectedDataFrame = dataFrame.select(selectColumns.head, selectColumns.tail: _*)
-
         val loadCommand = CarbonLoadDataCommand(
           databaseNameOp = Option(table.getDatabaseName),
           tableName = table.getTableName,
@@ -337,7 +357,7 @@ case class CarbonInsertFromStageCommand(
         )
         loadCommand.run(spark)
     }
-    LOGGER.info(s"finish data loading, time taken ${System.currentTimeMillis() - start}ms")
+    LOGGER.info(s"finish data loading, time taken ${ System.currentTimeMillis() - start }ms")
   }
 
   /**
@@ -428,7 +448,7 @@ case class CarbonInsertFromStageCommand(
       future.get()
     }
     LOGGER.info(s"finished to delete stage files, time taken: " +
-                s"${System.currentTimeMillis() - startTime}ms")
+      s"${System.currentTimeMillis() - startTime}ms")
   }
 
   /*
@@ -494,21 +514,7 @@ case class CarbonInsertFromStageCommand(
       .asScala
       .map(_.getColName)
       .toArray
-    val schema = SparkTypeConverter.createSparkSchema(carbonTable, columns)
-    val rdd: RDD[InternalRow] = new CarbonScanRDD[InternalRow](
-      sparkSession,
-      columnProjection = new CarbonProjection(columns),
-      null,
-      carbonTable.getAbsoluteTableIdentifier,
-      carbonTable.getTableInfo.serialize,
-      carbonTable.getTableInfo,
-      new CarbonInputMetrics,
-      null,
-      classOf[SparkDataTypeConverterImpl],
-      classOf[SparkRowReadSupportImpl],
-      splits.asJava
-    )
-    SparkSQLUtil.execute(rdd, schema, sparkSession)
+    sparkSession.sqlContext.table(carbonTable.getTableName)
   }
 
   override protected def opName: String = "INSERT STAGE"


### PR DESCRIPTION
**Problem**:
In Carbondata the timestamp is converted into long and stored in RDD.
While collect(action) is applied on dataframe it gives an error due to the confliction between data types that is - long in carbonScanRDD(from which dataframe is created) and Timestamp in schema.

**Solution**:
Called Dataset.ofRows(LogicalPlan) which returns the dataframe. Used Set command which sets all segments to be compacted. And Unset once the compaction is finished.

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

