### PR TITLE
[CARBONDATA-3624] Support creating MV datamap without giving filter columns in projection and bug fixes

### DIFF
--- a/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/MVCreateTestCase.scala
+++ b/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/MVCreateTestCase.scala
@@ -27,6 +27,7 @@ import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.datastore.impl.FileFactory
 import org.apache.carbondata.core.util.CarbonProperties
 import org.apache.carbondata.core.util.path.CarbonTablePath
+import org.apache.carbondata.spark.exception.ProcessMetaDataException
 
 class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
 
@@ -455,9 +456,9 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     sql(s"drop datamap datamap29")
   }
 
-  ignore("test create datamap with join with group by with filter") {
+  test("test create datamap with join with group by with filter") {
     sql("drop datamap if exists datamap30")
-    sql("create datamap datamap30 using 'mv' as select t1.empname, t2.designation, sum(t1.utilization),sum(t2.empname) from fact_table1 t1 inner join fact_table2 t2 on (t1.empname = t2.empname) group by t1.empname, t2.designation")
+    sql("create datamap datamap30 using 'mv' as select t1.empname, t2.designation, sum(t1.utilization) from fact_table1 t1 inner join fact_table2 t2 on (t1.empname = t2.empname) group by t1.empname, t2.designation")
     val frame = sql(
       "select t1.empname, t2.designation, sum(t1.utilization) from fact_table1 t1,fact_table2 t2  " +
       "where t1.empname = t2.empname and t2.designation='SA' group by t1.empname, t2.designation")
@@ -489,7 +490,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     sql(s"drop datamap datamap32")
   }
 
-  ignore("test create datamap with simple and sub group by query and avg agg") {
+  test("test create datamap with simple and sub group by query and avg agg") {
     sql(s"drop datamap if exists datamap33")
     sql("create datamap datamap33 using 'mv' as select empname, avg(utilization) from fact_table1 group by empname")
     val frame = sql("select empname,avg(utilization) from fact_table1 where empname='shivani' group by empname")
@@ -512,7 +513,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     sql(s"drop datamap datamap34")
   }
 
-  ignore("test create datamap with simple and group by query with filter on datamap but not on projection") {
+  test("test create datamap with simple and group by query with filter on datamap but not on projection") {
     sql("create datamap datamap35 using 'mv' as select designation, sum(utilization) from fact_table1 where empname='shivani' group by designation")
     val frame = sql(
       "select designation, sum(utilization) from fact_table1 where empname='shivani' group by designation")
@@ -522,7 +523,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     sql(s"drop datamap datamap35")
   }
 
-  ignore("test create datamap with simple and sub group by query with filter on datamap but not on projection") {
+  test("test create datamap with simple and sub group by query with filter on datamap but not on projection") {
     sql("create datamap datamap36 using 'mv' as select designation, sum(utilization) from fact_table1 where empname='shivani' group by designation")
     val frame = sql(
       "select sum(utilization) from fact_table1 where empname='shivani' group by designation")
@@ -558,7 +559,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     sql(s"drop datamap datamap38")
   }
 
-  ignore("test create datamap with agg push join with group by with filter") {
+  test("test create datamap with agg push join with group by with filter") {
     sql("drop datamap if exists datamap39")
     sql("create datamap datamap39 using 'mv' as select empname, designation, sum(utilization) from fact_table1 group by empname, designation ")
     val frame = sql(
@@ -584,7 +585,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     sql(s"drop datamap datamap40")
   }
 
-  ignore("test create datamap with left join with group by with filter") {
+  test("test create datamap with left join with group by with filter") {
     sql("drop datamap if exists datamap41")
     sql("create datamap datamap41 using 'mv' as select t1.empname, t2.designation, sum(t1.utilization) from fact_table1 t1 left join fact_table2 t2  on t1.empname = t2.empname group by t1.empname, t2.designation")
     val frame = sql(
@@ -597,7 +598,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     sql(s"drop datamap datamap41")
   }
 
-  ignore("test create datamap with left join with sub group by") {
+  test("test create datamap with left join with sub group by") {
     sql("drop datamap if exists datamap42")
     sql("create datamap datamap42 using 'mv' as select t1.empname, t2.designation, sum(t1.utilization) from fact_table1 t1 left join fact_table2 t2  on t1.empname = t2.empname group by t1.empname, t2.designation")
     val frame = sql(
@@ -610,7 +611,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     sql(s"drop datamap datamap42")
   }
 
-  ignore("test create datamap with left join with sub group by with filter") {
+  test("test create datamap with left join with sub group by with filter") {
     sql("drop datamap if exists datamap43")
     sql("create datamap datamap43 using 'mv' as select t1.empname, t2.designation, sum(t1.utilization) from fact_table1 t1 left join fact_table2 t2  on t1.empname = t2.empname group by t1.empname, t2.designation")
     val frame = sql(
@@ -623,7 +624,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     sql(s"drop datamap datamap43")
   }
 
-  ignore("test create datamap with left join with sub group by with filter on mv") {
+  test("test create datamap with left join with sub group by with filter on mv") {
     sql("drop datamap if exists datamap44")
     sql("create datamap datamap44 using 'mv' as select t1.empname, t2.designation, sum(t1.utilization) from fact_table1 t1 left join fact_table2 t2  on t1.empname = t2.empname where t1.empname='shivani' group by t1.empname, t2.designation")
     val frame = sql(
@@ -1054,7 +1055,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     sql(
       "create table mv_like(name string, age int, address string, Country string, id int) stored by 'carbondata'")
     sql(
-      "create datamap mvlikedm1 using 'mv' as select name,address,sum(Country) from mv_like where Country NOT LIKE 'US' group by name,address")
+      "create datamap mvlikedm1 using 'mv' as select name,address from mv_like where Country NOT LIKE 'US' group by name,address")
     sql(
       "create datamap mvlikedm2 using 'mv' as select name,address,Country from mv_like where Country = 'US' or Country = 'China' group by name,address,Country")
     sql("insert into mv_like select 'chandler', 32, 'newYork', 'US', 5")
@@ -1345,7 +1346,25 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     FileFactory.deleteAllFilesOfDir(new File(newPath))
   }
 
-
+  test("test join query with & without filter columns in projection") {
+    sql("drop table if exists t1")
+    sql("drop table if exists t2")
+    sql("drop datamap if exists mv1")
+    sql("create table t1(userId string,score int) stored by 'carbondata'")
+    sql("create table t2(userId string,age int,sex string) stored by 'carbondata'")
+    sql("insert into t1 values(1,100),(2,500)")
+    sql("insert into t2 values(1,20,'f'),(2,30,'m')")
+    val result  = sql("select avg(t1.score),t2.age,t2.sex from t1 join t2 on t1.userId=t2.userId group by t2.age,t2.sex")
+    sql("create datamap mv1 using 'mv' as select avg(t1.score),t2.age,t2.sex from t1 join t2 on t1.userId=t2.userId group by t2.age,t2.sex")
+    val df = sql("select avg(t1.score),t2.age,t2.sex from t1 join t2 on t1.userId=t2.userId group by t2.age,t2.sex")
+    TestUtil.verifyMVDataMap(df.queryExecution.analyzed, "mv1")
+    checkAnswer(df, result)
+    intercept[ProcessMetaDataException] {
+      sql("alter table t1 drop columns(userId)")
+    }.getMessage.contains("Column name cannot be dropped because it exists in mv datamap: mv1")
+    sql("drop table if exists t1")
+    sql("drop table if exists t2")
+  }
 
   def copy(oldLoc: String, newLoc: String): Unit = {
     val oldFolder = FileFactory.getCarbonFile(oldLoc)

--- a/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/SelectAllColumnsSuite.scala
+++ b/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/SelectAllColumnsSuite.scala
@@ -36,15 +36,8 @@ class SelectAllColumnsSuite extends QueryTest {
       Seq(Row(26.0, 177.5, "tom")))
     val frame = sql("select avg(age),avg(height),name from all_table group by name")
     val analyzed = frame.queryExecution.analyzed
-    assert(verifyMVDataMap(analyzed, "all_table_mv"))
+    assert(TestUtil.verifyMVDataMap(analyzed, "all_table_mv"))
     sql("drop table if exists all_table")
-  }
-
-  def verifyMVDataMap(logicalPlan: LogicalPlan, dataMapName: String): Boolean = {
-    val tables = logicalPlan collect {
-      case l: LogicalRelation => l.catalogTable.get
-    }
-    tables.exists(_.identifier.table.equalsIgnoreCase(dataMapName+"_table"))
   }
 
 }

--- a/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/TestAllOperationsOnMV.scala
+++ b/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/TestAllOperationsOnMV.scala
@@ -556,9 +556,9 @@ class TestAllOperationsOnMV extends QueryTest with BeforeAndAfterEach {
     sql("CREATE TABLE maintable (CUST_ID int,CUST_NAME String,ACTIVE_EMUI_VERSION string, DOB date, DOJ timestamp, BIGINT_COLUMN1 bigint,BIGINT_COLUMN2 bigint,DECIMAL_COLUMN1 decimal(30,10), DECIMAL_COLUMN2 decimal(36,10),Double_COLUMN1 double, Double_COLUMN2 double,INTEGER_COLUMN1 int) STORED BY 'org.apache.carbondata.format'")
     sql("insert into maintable values(1, 'abc', 'abc001', '1975-06-11','1975-06-11 02:00:03.0', 120, 1234,4.34,24.56,12345, 2464, 45)")
     sql("drop datamap if exists dm ")
-    intercept[UnsupportedOperationException] {
-      sql("create datamap dm using 'mv' as select dob from maintable where (dob='1975-06-11' or cust_id=2)")
-    }.getMessage.contains("Group by/Filter columns must be present in project columns")
+    sql("create datamap dm using 'mv' as select dob from maintable where (dob='1975-06-11' or cust_id=2)")
+    val df = sql("select dob from maintable where (dob='1975-06-11' or cust_id=2)")
+    TestUtil.verifyMVDataMap(df.queryExecution.analyzed, "dm")
     sql("drop table IF EXISTS maintable")
   }
 

--- a/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/timeseries/TestMVTimeSeriesLoadAndQuery.scala
+++ b/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/timeseries/TestMVTimeSeriesLoadAndQuery.scala
@@ -329,11 +329,11 @@ class TestMVTimeSeriesLoadAndQuery extends QueryTest with BeforeAndAfterAll {
     checkPlan("datamap1", df)
   }
 
-  test("test create datamap with group by & filter columns not present in projection") {
+  test("test create datamap with group by columns not present in projection") {
     sql("drop datamap if exists dm ")
     intercept[UnsupportedOperationException] {
       sql("create datamap dm using 'mv' as select timeseries(projectjoindate,'day') from maintable where empname='chandler' group by timeseries(projectjoindate,'day'),empname")
-    }.getMessage.contains("Group by/Filter columns must be present in project columns")
+    }.getMessage.contains("Group by columns must be present in project columns")
     sql("create datamap dm using 'mv' as select timeseries(projectjoindate,'day'),empname from maintable where empname='chandler' group by timeseries(projectjoindate,'day'),empname")
     var df = sql("select timeseries(projectjoindate,'day'),empname from maintable where empname='chandler' group by timeseries(projectjoindate,'day'),empname")
     checkPlan("dm", df)

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/mv/DataMapListeners.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/mv/DataMapListeners.scala
@@ -221,7 +221,7 @@ object DataMapDropColumnPreListener extends OperationEventListener {
         if (null != dataMapSchema && !dataMapSchema.isIndexDataMap) {
           val listOfColumns = DataMapListeners.getDataMapTableColumns(dataMapSchema, carbonTable)
           val columnExistsInChild = listOfColumns.collectFirst {
-            case parentColumnName if columnsToBeDropped.contains(parentColumnName) =>
+            case parentColumnName if columnsToBeDropped.contains(parentColumnName.toLowerCase) =>
               parentColumnName
           }
           if (columnExistsInChild.isDefined) {
@@ -262,7 +262,7 @@ object DataMapChangeDataTypeorRenameColumnPreListener
       for (dataMapSchema <- dataMapSchemaList) {
         if (null != dataMapSchema && !dataMapSchema.isIndexDataMap) {
           val listOfColumns = DataMapListeners.getDataMapTableColumns(dataMapSchema, carbonTable)
-          if (listOfColumns.contains(columnToBeAltered)) {
+          if (listOfColumns.contains(columnToBeAltered.toLowerCase)) {
             throw new UnsupportedOperationException(
               s"Column $columnToBeAltered exists in a " + dataMapSchema.getProviderName +
               " datamap. Drop " + dataMapSchema.getProviderName + "  datamap to continue")


### PR DESCRIPTION
Problem:
We need to maintain a fieldRelationMap between MV and Parent tables, for inheriting properties from parent table and for restricting alter opeartions on main table columns. Deriving fieldRelationMap from logical Plan should be in a generalised way, hence adding filter columns also to projection check was required. But this check should not restrict user to create datamap, if user query doesnt contain filter columns in projection. 

Solution:
Use Modular Plan instead of Logical plan to form a fieldRelationMap and make it generalised for all type's of queries. By this way, we can avoid restricting user to give filter columns in projection while creating datamap.

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
     
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

