### PR TITLE
[CARBONDATA-3519]Made optimizations in write step to avoid unnecessary memory blk allocation/free

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/UnsafeFixLengthColumnPage.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/UnsafeFixLengthColumnPage.java
@@ -92,8 +92,8 @@ public class UnsafeFixLengthColumnPage extends ColumnPage {
     this.eachRowSize = eachRowSize;
     totalLength = 0;
     if (columnPageEncoderMeta.getStoreDataType() == DataTypes.BYTE_ARRAY) {
-      memoryBlock =
-          UnsafeMemoryManager.allocateMemoryWithRetry(taskId, (long) pageSize * eachRowSize);
+      capacity = pageSize * eachRowSize;
+      memoryBlock = UnsafeMemoryManager.allocateMemoryWithRetry(taskId, capacity);
       baseAddress = memoryBlock.getBaseObject();
       baseOffset = memoryBlock.getBaseOffset();
     }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/VarLengthColumnPageBase.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/VarLengthColumnPageBase.java
@@ -73,7 +73,7 @@ public abstract class VarLengthColumnPageBase extends ColumnPage {
     try {
       rowOffset = ColumnPage.newPage(
           new ColumnPageEncoderMeta(spec, DataTypes.INT, columnPageEncoderMeta.getCompressorName()),
-          pageSize);
+          pageSize + 1);
     } catch (MemoryException e) {
       throw new RuntimeException(e);
     }


### PR DESCRIPTION
**Issue-1:**
**Context:**
For a string column with local dictionary enabled, a column page of `UnsafeFixLengthColumnPage` with datatype `DataTypes.BYTE_ARRAY` is created for `encodedPage` along with regular `actualPage` of `UnsafeVarLengthColumnPage`.  We have `capacity` field in the `UnsafeFixLengthColumnPage`. And this field indicates the capacity of  allocated
`memoryBlock` for the page. `ensureMemory()` method gets called while adding rows to check if  `totalLength + requestSize > capacity` to allocate a new memoryBlock. If there is no room to add the next row, allocates a new block, copy the old context(prev rows) and free the old memoryBlock.
 **Problem:**
While, `UnsafeFixLengthColumnPage` with with datatype `DataTypes.BYTE_ARRAY` is created for `encodedPage`, we have not assigned the `capacity` field with allocated memory block size. **Hence, for each add row to tablePage, ensureMemory() check always fails, allocates a new column page memoryBlock, copy the old context(prev rows) and free the old memoryBlock.** 
**This allocation of new memoryBlock and free of old memoryBlock happens for each row row addition for the string columns with local dictionary.**
**Solution:**
We can set the capacity to allocated size.

**Issue-2:**
**Context:**
In`VarLengthColumnPageBase`, we have a `rowOffset` column page of `UnsafeFixLengthColumnPage` of datatype `INT` to maintain the data offset to each row of variable length columns. This `rowOffset` page allocates to be size of page. 
 **Problem:**
If we have 10 rows in the page, we need 11 rows for its rowOffset page. Because we always keep 0 as offset to 1st row. So an additional row is required for rowOffset page. Otherwise, **`ensureMemory()` check always fails for the last row(10th row in this case) of data and allocates a new rowOffset page memoryBlock, copy the old context(prev rows) and free the old memoryBlock**. This can happen for the string columns with local dictionary, direct dictionary columns, global disctionary columns.
**Solution:**
We can allocate for 1 additional row of rowOffset page.

 - [ ] Any interfaces changed?
 No
 - [ ] Any backward compatibility impacted?
 No
 - [ ] Document update required?
No
 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
          No. Base test cases already cover it.
        - How it is tested? Please attach test report.
          It is a base function. Created a table with dictionary and direct dictionary columns. Loaded a segment and verified.
        - Is it a performance related change? Please attach the performance test report.
          Yes. It is a performance optimization. It avoids unnecessary memory block allocations in the above mentioned cases.
        - Any additional information to help reviewers in testing this change.
          Description above and code changes are self explanatory.
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

