### PR TITLE
[CARBONDATA-3629] Fix Select query failure on aggregation of same column on MV

### DIFF
--- a/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/timeseries/TestMVTimeSeriesCreateDataMapCommand.scala
+++ b/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/timeseries/TestMVTimeSeriesCreateDataMapCommand.scala
@@ -101,8 +101,17 @@ class TestMVTimeSeriesCreateDataMapCommand extends QueryTest with BeforeAndAfter
       sql(
         "create datamap datamap1 on table maintable_new using 'mv' as " +
         "select timeseries(projectjoindate,'second') from maintable_new")
-    }.getMessage
-      .contains("Granularity should be DAY,MONTH or YEAR, for timeseries column of Date type")
+    }.getMessage.contains("Granularity should be of DAY/WEEK/MONTH/YEAR, for timeseries column of Date type")
+    intercept[MalformedCarbonCommandException] {
+      sql(
+        "create datamap datamap1 on table maintable_new using 'mv' as " +
+        "select timeseries(projectjoindate,'five_minute') from maintable_new")
+    }.getMessage.contains("Granularity should be of DAY/WEEK/MONTH/YEAR, for timeseries column of Date type")
+    intercept[MalformedCarbonCommandException] {
+      sql(
+        "create datamap datamap1 on table maintable_new using 'mv' as " +
+        "select timeseries(projectjoindate,'hour') from maintable_new")
+      }.getMessage.contains("Granularity should be of DAY/WEEK/MONTH/YEAR, for timeseries column of Date type")
     sql("drop table IF EXISTS maintable_new")
   }
 

--- a/docs/datamap/mv-datamap-guide.md
+++ b/docs/datamap/mv-datamap-guide.md
@@ -73,7 +73,7 @@ EXPLAIN SELECT a, sum(b) from maintable group by a;
     GROUP BY country, sex
   ```
  **NOTE**:
- * Group by/Filter columns has to be provided in projection list while creating mv datamap
+ * Group by columns has to be provided in projection list while creating mv datamap
  * If only single parent table is involved in mv datamap creation, then TableProperties of Parent table
    (if not present in a aggregate function like sum(col)) listed below will be
    inherited to datamap table
@@ -91,7 +91,14 @@ EXPLAIN SELECT a, sum(b) from maintable group by a;
    12. NO_INVERTED_INDEX
    13. COLUMN_COMPRESSOR
 
- * All columns of main table at once cannot participate in mv datamap table creation
+ * Creating MV datamap with select query containing only project of all columns of maintable is unsupported 
+      
+   **Example:**
+   If table 'x' contains columns 'a,b,c',
+   then creating MV datamap with below queries is not supported.
+   
+   1. ```select a,b,c from x```
+   2. ```select * from x```
  * TableProperties can be provided in DMProperties excluding LOCAL_DICTIONARY_INCLUDE,
    LOCAL_DICTIONARY_EXCLUDE, DICTIONARY_INCLUDE, DICTIONARY_EXCLUDE, INVERTED_INDEX,
    NO_INVERTED_INDEX, SORT_COLUMNS, LONG_STRING_COLUMNS, RANGE_COLUMN & COLUMN_META_CACHE

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/timeseries/TimeSeriesUtil.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/timeseries/TimeSeriesUtil.scala
@@ -154,10 +154,10 @@ object TimeSeriesUtil {
       timeSeriesFunction: String): Unit = {
     for (granularity <- Granularity.values()) {
       if (timeSeriesFunction.equalsIgnoreCase(granularity.getName
-        .substring(0, granularity.getName.indexOf(CarbonCommonConstants.UNDERSCORE)))) {
+        .substring(0, granularity.getName.lastIndexOf(CarbonCommonConstants.UNDERSCORE)))) {
         if (!supportedGranularitiesForDate.contains(granularity.getName)) {
           throw new MalformedCarbonCommandException(
-            "Granularity should be DAY,MONTH or YEAR, for timeseries column of Date type")
+            "Granularity should be of DAY/WEEK/MONTH/YEAR, for timeseries column of Date type")
         }
       }
     }


### PR DESCRIPTION
Problem:
If MV datamap is created with `SELECT a,sum(a) from maintable group by a` and later queried with `SELECT sum(a) from maintable`, query fails as rewritten plan output list doesn't match  with the table.

Solution:
Check if Aggregation exists in GroupBy Node and copy select node with aliasMap

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
      
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

