### PR TITLE
[CARBONDATA-3636]Timeseries query is not hitting datamap if granularity in query is given case insensitive

### DIFF
--- a/datamap/mv/core/src/main/scala/org/apache/carbondata/mv/datamap/MVAnalyzerRule.scala
+++ b/datamap/mv/core/src/main/scala/org/apache/carbondata/mv/datamap/MVAnalyzerRule.scala
@@ -149,7 +149,7 @@ class MVAnalyzerRule(sparkSession: SparkSession) extends Rule[LogicalPlan] {
         if (!outPutUDFColumn.equalsIgnoreCase("") && compactSQL.contains("WHERE")) {
           queryArray = compactSQL.split("\n")
           queryArray(queryArray.indexOf("WHERE") + 1) = queryArray(
-            queryArray.indexOf("WHERE") + 1).replace(outPutUDFColumn,
+            queryArray.indexOf("WHERE") + 1).toLowerCase.replace(outPutUDFColumn.toLowerCase,
             s"gen_subsumer_0.`$outPutUDFColumn`")
           reWrittenQuery = queryArray.mkString("\n")
         }

--- a/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/timeseries/TestMVTimeSeriesLoadAndQuery.scala
+++ b/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/timeseries/TestMVTimeSeriesLoadAndQuery.scala
@@ -48,6 +48,8 @@ class TestMVTimeSeriesLoadAndQuery extends QueryTest with BeforeAndAfterAll {
     val df1 = sql("select timeseries(projectjoindate,'minute'),sum(projectcode) from maintable where timeseries(projectjoindate,'minute') = '2016-02-23 09:17:00'" +
                   "group by timeseries(projectjoindate,'minute')")
     assert(TestUtil.verifyMVDataMap(df1.queryExecution.optimizedPlan, "datamap1"))
+    val df2 = sql("select timeseries(projectjoindate,'MINUTE'), sum(projectcode) from maintable where timeseries(projectjoindate,'MINute') = '2016-02-23 09:17:00' group by timeseries(projectjoindate,'MINUTE')")
+    TestUtil.verifyMVDataMap(df2.queryExecution.optimizedPlan, "datamap1")
     dropDataMap("datamap1")
   }
 
@@ -181,8 +183,10 @@ class TestMVTimeSeriesLoadAndQuery extends QueryTest with BeforeAndAfterAll {
       "create datamap datamap1 on table maintable using 'mv' as " +
       "select timeseries(projectjoindate,'month'), max(salary) from maintable where timeseries(projectjoindate,'month') = '2016-03-01 00:00:00' or  timeseries(projectjoindate,'month') = '2016-02-01 00:00:00' group by timeseries(projectjoindate,'month')")
     loadData("maintable")
-    val df1 = sql("select timeseries(projectjoindate,'month'), max(salary) from maintable where timeseries(projectjoindate,'month') = '2016-03-01 00:00:00' or  timeseries(projectjoindate,'month') = '2016-02-01 00:00:00' group by timeseries(projectjoindate,'month')")
+    var df1 = sql("select timeseries(projectjoindate,'month'), max(salary) from maintable where timeseries(projectjoindate,'month') = '2016-03-01 00:00:00' or  timeseries(projectjoindate,'month') = '2016-02-01 00:00:00' group by timeseries(projectjoindate,'month')")
     checkPlan("datamap1", df1)
+    df1 = sql("select timeseries(projectjoindate,'MONth'), max(salary) from maintable where timeseries(projectjoindate,'MoNtH') = '2016-03-01 00:00:00' or  timeseries(projectjoinDATE,'MONth') = '2016-02-01 00:00:00' group by timeseries(projectjoindate,'MONth')")
+    TestUtil.verifyMVDataMap(df1.queryExecution.optimizedPlan, "datamap1")
     sql(
       "create datamap datamap2 on table maintable using 'mv' as " +
       "select timeseries(projectjoindate,'month'), max(salary) from maintable where timeseries(projectjoindate,'month') = '2016-03-01 00:00:00' and  timeseries(projectjoindate,'month') = '2016-02-01 00:00:00' group by timeseries(projectjoindate,'month')")


### PR DESCRIPTION
Problem:
TimeSeriesUDF function has two parameters:
1. Column -> AttributeReference
2. Granularity -> Literal
For timeseries function having granularity with different case letters in Create datamap and actual query, select query is not hitting the datamap. This is because, since we store granularity as Literal, semanticEquals returns false, if granularity is of different case.

Solution:
For TimeSeriesFunction, check Literal value case insensitive

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
    
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

