### PR TITLE
[Carbondata-3631] StringIndexOutOfBoundsException When Inserting Select From a Parquet Table with Empty array/map

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -890,6 +890,23 @@ public final class CarbonCommonConstants {
   public static final String CARBON_HORIZONTAL_COMPACTION_ENABLE_DEFAULT = "true";
 
   /**
+   * For validating the key to value mapping in case of update.
+   * Update operation should throw exception if one key has more than one value to update.
+   * This validation might have slight degrade in performance of update query.
+   * If user knows that key value mapping is correct.
+   * can disable this validation for better update performance.
+   */
+  @CarbonProperty
+  public static final String CARBON_UPDATE_CHECK_UNIQUE_VALUE =
+      "carbon.update.check.unique.value";
+
+  /**
+   * Default validation of unique value check enabled for the update.
+   */
+  public static final String CARBON_UPDATE_CHECK_UNIQUE_VALUE_DEFAULT = "true";
+
+
+  /**
    * Which storage level to persist dataset when updating data
    * with 'carbon.update.persist.enable'='true'
    */

--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -300,6 +300,9 @@ public final class CarbonCommonConstants {
 
   public static final String CARBON_SKIP_EMPTY_LINE_DEFAULT = "false";
 
+
+  public static final String EMPTY_DATA_RETURN = "!EMPTY_DATA_RETURN!";
+
   /**
    * Currently the segment lock files are not deleted immediately when unlock,
    * this value indicates the number of hours the segment lock files will be preserved.

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/UnsafeFixLengthColumnPage.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/UnsafeFixLengthColumnPage.java
@@ -92,8 +92,8 @@ public class UnsafeFixLengthColumnPage extends ColumnPage {
     this.eachRowSize = eachRowSize;
     totalLength = 0;
     if (columnPageEncoderMeta.getStoreDataType() == DataTypes.BYTE_ARRAY) {
-      memoryBlock =
-          UnsafeMemoryManager.allocateMemoryWithRetry(taskId, (long) pageSize * eachRowSize);
+      capacity = pageSize * eachRowSize;
+      memoryBlock = UnsafeMemoryManager.allocateMemoryWithRetry(taskId, capacity);
       baseAddress = memoryBlock.getBaseObject();
       baseOffset = memoryBlock.getBaseOffset();
     }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/VarLengthColumnPageBase.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/VarLengthColumnPageBase.java
@@ -73,7 +73,7 @@ public abstract class VarLengthColumnPageBase extends ColumnPage {
     try {
       rowOffset = ColumnPage.newPage(
           new ColumnPageEncoderMeta(spec, DataTypes.INT, columnPageEncoderMeta.getCompressorName()),
-          pageSize);
+          pageSize + 1);
     } catch (MemoryException e) {
       throw new RuntimeException(e);
     }

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
@@ -1802,6 +1802,23 @@ public final class CarbonProperties {
   }
 
   /**
+   * Validate and get unique value check enabled
+   *
+   * @return boolean
+   */
+  public static Boolean isUniqueValueCheckEnabled() {
+    String needValidate = CarbonProperties.getInstance()
+        .getProperty(CarbonCommonConstants.CARBON_UPDATE_CHECK_UNIQUE_VALUE);
+    if (needValidate == null) {
+      return Boolean
+          .parseBoolean(CarbonCommonConstants.CARBON_UPDATE_CHECK_UNIQUE_VALUE_DEFAULT);
+    } else {
+      // return false only if false is set. any other case return true
+      return !needValidate.equalsIgnoreCase("false");
+    }
+  }
+
+  /**
    * get local dictionary size threshold in mb.
    */
   private void validateAndGetLocalDictionarySizeThresholdInMB() {

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
@@ -36,7 +36,9 @@ import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
@@ -3341,5 +3343,102 @@ public final class CarbonUtil {
       LOGGER.info("Created index server temp directory" + path);
       return file;
     }
+  }
+
+  /**
+   * For alter table tableProperties of long string, modify ColumnSchema
+   * set operation:
+   * a. reset the current varchar datatype to string
+   * b. reorder back to original order (consider sort column and original schema ordinal)
+   * c. set the new columns to varchar
+   * d. reorder new varchar columns to be after dimensions
+   * <p>
+   * unset operation:
+   * a. reset the current varchar datatype to string
+   * b. reorder back to original order (consider sort column and original schema ordinal)
+   *
+   * @param columns                 list of column schema from thrift
+   * @param longStringColumnsString comma separated long string columns to be set, empty for unset
+   * @return updated columnSchema list
+   */
+  public static List<org.apache.carbondata.format.ColumnSchema> reorderColumnsForLongString(
+      List<org.apache.carbondata.format.ColumnSchema> columns, String longStringColumnsString) {
+    // schema will be like
+    // sortColumns-otherDimensions-varchar-[complexColumns + complex_child - measures]
+    List<org.apache.carbondata.format.ColumnSchema> sortColumns = new ArrayList<>();
+    List<org.apache.carbondata.format.ColumnSchema> dimColumns = new ArrayList<>();
+    List<org.apache.carbondata.format.ColumnSchema> otherColumns = new ArrayList<>();
+    // true if cleared the varchar type in dims to string
+    boolean isResetDone = false;
+    // complex type child also looks like dimension or measure,
+    // so just take all other columns at once.
+    int otherColumnStartIndex = -1;
+    for (int i = 0; i < columns.size(); i++) {
+      if (columns.get(i).getColumnProperties() != null) {
+        String isSortColumn =
+            columns.get(i).getColumnProperties().get(CarbonCommonConstants.SORT_COLUMNS);
+        if ((isSortColumn != null) && (isSortColumn.equalsIgnoreCase("true"))) {
+          // add sort column dimensions
+          sortColumns.add(columns.get(i));
+        }
+      } else if ((columns.get(i).getData_type() == org.apache.carbondata.format.DataType.ARRAY
+          || columns.get(i).getData_type() == org.apache.carbondata.format.DataType.STRUCT
+          || columns.get(i).getData_type() == org.apache.carbondata.format.DataType.MAP || (!columns
+          .get(i).isDimension()))) {
+        // complex type or measure starts here and processed all sort columns and other dimensions
+        otherColumnStartIndex = i;
+        break;
+      } else {
+        // if it is varchar, reset to string as new set and unset needs to be done.
+        // if not, just add it to dimColumns
+        org.apache.carbondata.format.ColumnSchema col = columns.get(i);
+        if (col.data_type == org.apache.carbondata.format.DataType.VARCHAR) {
+          col.data_type = org.apache.carbondata.format.DataType.STRING;
+          isResetDone = true;
+        }
+        dimColumns.add(col);
+      }
+    }
+    if (otherColumnStartIndex != -1) {
+      otherColumns.addAll(columns.subList(otherColumnStartIndex, columns.size()));
+    }
+    if (isResetDone) {
+      // reorder the dims based on original schema ordinal
+      dimColumns.sort(new Comparator<org.apache.carbondata.format.ColumnSchema>() {
+        @Override
+        public int compare(org.apache.carbondata.format.ColumnSchema o1,
+            org.apache.carbondata.format.ColumnSchema o2) {
+          return o1.getSchemaOrdinal() - o2.getSchemaOrdinal();
+        }
+      });
+    }
+    List<org.apache.carbondata.format.ColumnSchema> nonVarCharDims = new ArrayList<>();
+    // for setting long string columns
+    if (!longStringColumnsString.isEmpty()) {
+      String[] inputColumns = longStringColumnsString.split(",");
+      Set<String> longStringSet = new HashSet<>(Arrays.asList(inputColumns));
+      List<org.apache.carbondata.format.ColumnSchema> varCharColumns = new ArrayList<>();
+      // change data type to varchar and extract the varchar columns
+      for (org.apache.carbondata.format.ColumnSchema dim : dimColumns) {
+        if (longStringSet.contains(dim.getColumn_name())) {
+          dim.data_type = org.apache.carbondata.format.DataType.VARCHAR;
+          // extract varchar dimensions
+          varCharColumns.add(dim);
+        } else {
+          // extract non varchar, non sort dimensions
+          nonVarCharDims.add(dim);
+        }
+      }
+      // append varchar in the end of dimensions
+      nonVarCharDims.addAll(varCharColumns);
+    } else {
+      nonVarCharDims = dimColumns;
+    }
+    // combine all columns and return
+    if (otherColumns.size() != 0) {
+      nonVarCharDims.addAll(otherColumns);
+    }
+    sortColumns.addAll(nonVarCharDims);
+    return sortColumns;
   }
 }

--- a/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/TestAllOperationsOnMV.scala
+++ b/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/TestAllOperationsOnMV.scala
@@ -392,7 +392,7 @@ class TestAllOperationsOnMV extends QueryTest with BeforeAndAfterEach {
     sql("insert into table maintable select 'abc',21,2000")
     sql("drop datamap if exists dm ")
     intercept[MalformedCarbonCommandException] {
-      sql("create datamap dm using 'mv' dmproperties('dictionary_include'='name', 'sort_columns'='name') as select name from maintable")
+      sql("create datamap dm using 'mv' dmproperties('sort_columns'='name') as select name from maintable")
     }.getMessage.contains("DMProperties dictionary_include,sort_columns are not allowed for this datamap")
   }
 

--- a/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/timeseries/TestMVTimeSeriesCreateDataMapCommand.scala
+++ b/datamap/mv/core/src/test/scala/org/apache/carbondata/mv/timeseries/TestMVTimeSeriesCreateDataMapCommand.scala
@@ -101,8 +101,17 @@ class TestMVTimeSeriesCreateDataMapCommand extends QueryTest with BeforeAndAfter
       sql(
         "create datamap datamap1 on table maintable_new using 'mv' as " +
         "select timeseries(projectjoindate,'second') from maintable_new")
-    }.getMessage
-      .contains("Granularity should be DAY,MONTH or YEAR, for timeseries column of Date type")
+    }.getMessage.contains("Granularity should be of DAY/WEEK/MONTH/YEAR, for timeseries column of Date type")
+    intercept[MalformedCarbonCommandException] {
+      sql(
+        "create datamap datamap1 on table maintable_new using 'mv' as " +
+        "select timeseries(projectjoindate,'five_minute') from maintable_new")
+    }.getMessage.contains("Granularity should be of DAY/WEEK/MONTH/YEAR, for timeseries column of Date type")
+    intercept[MalformedCarbonCommandException] {
+      sql(
+        "create datamap datamap1 on table maintable_new using 'mv' as " +
+        "select timeseries(projectjoindate,'hour') from maintable_new")
+      }.getMessage.contains("Granularity should be of DAY/WEEK/MONTH/YEAR, for timeseries column of Date type")
     sql("drop table IF EXISTS maintable_new")
   }
 

--- a/docs/configuration-parameters.md
+++ b/docs/configuration-parameters.md
@@ -153,6 +153,7 @@ This section provides the details of all the configurations required for the Car
 | carbon.insert.storage.level | MEMORY_AND_DISK | Storage level to persist dataset of a RDD/dataframe. Applicable when ***carbon.insert.persist.enable*** is **true**, if user's executor has less memory, set this parameter to 'MEMORY_AND_DISK_SER' or other storage level to correspond to different environment. [See detail](http://spark.apache.org/docs/latest/rdd-programming-guide.html#rdd-persistence). |
 | carbon.update.persist.enable | true | Configuration to enable the dataset of RDD/dataframe to persist data. Enabling this will reduce the execution time of UPDATE operation. |
 | carbon.update.storage.level | MEMORY_AND_DISK | Storage level to persist dataset of a RDD/dataframe. Applicable when ***carbon.update.persist.enable*** is **true**, if user's executor has less memory, set this parameter to 'MEMORY_AND_DISK_SER' or other storage level to correspond to different environment. [See detail](http://spark.apache.org/docs/latest/rdd-programming-guide.html#rdd-persistence). |
+| carbon.update.check.unique.value | true | By default this property is true, so update will validate key value mapping. This validation might have slight degrade in performance of update query. If user knows that key value mapping is correct, can disable this validation for better update performance by setting this property to false. |
 
 
 ##  Dynamic Configuration In CarbonData Using SET-RESET

--- a/docs/datamap/mv-datamap-guide.md
+++ b/docs/datamap/mv-datamap-guide.md
@@ -73,7 +73,7 @@ EXPLAIN SELECT a, sum(b) from maintable group by a;
     GROUP BY country, sex
   ```
  **NOTE**:
- * Group by/Filter columns has to be provided in projection list while creating mv datamap
+ * Group by columns has to be provided in projection list while creating mv datamap
  * If only single parent table is involved in mv datamap creation, then TableProperties of Parent table
    (if not present in a aggregate function like sum(col)) listed below will be
    inherited to datamap table
@@ -91,7 +91,14 @@ EXPLAIN SELECT a, sum(b) from maintable group by a;
    12. NO_INVERTED_INDEX
    13. COLUMN_COMPRESSOR
 
- * All columns of main table at once cannot participate in mv datamap table creation
+ * Creating MV datamap with select query containing only project of all columns of maintable is unsupported 
+      
+   **Example:**
+   If table 'x' contains columns 'a,b,c',
+   then creating MV datamap with below queries is not supported.
+   
+   1. ```select a,b,c from x```
+   2. ```select * from x```
  * TableProperties can be provided in DMProperties excluding LOCAL_DICTIONARY_INCLUDE,
    LOCAL_DICTIONARY_EXCLUDE, DICTIONARY_INCLUDE, DICTIONARY_EXCLUDE, INVERTED_INDEX,
    NO_INVERTED_INDEX, SORT_COLUMNS, LONG_STRING_COLUMNS, RANGE_COLUMN & COLUMN_META_CACHE

--- a/integration/spark-common-cluster-test/src/test/scala/org/apache/carbondata/cluster/sdv/generated/AlterTableTestCase.scala
+++ b/integration/spark-common-cluster-test/src/test/scala/org/apache/carbondata/cluster/sdv/generated/AlterTableTestCase.scala
@@ -1022,7 +1022,31 @@ class AlterTableTestCase extends QueryTest with BeforeAndAfterAll {
       assert(exception.getMessage.contains("Unsupported alter operation on hive table"))
     } else if (SparkUtil.isSparkVersionXandAbove("2.2")) {
       sql("alter table alter_hive add columns(add string)")
-      sql("insert into alter_hive select 'abc','banglore'")
+      sql("alter table alter_hive add columns (var map<string, string>)")
+      sql("insert into alter_hive select 'abc','banglore',map('age','10','birth','2020')")
+      checkAnswer(
+        sql("select * from alter_hive"),
+        Seq(Row("abc", "banglore", Map("age" -> "10", "birth" -> "2020")))
+      )
+    }
+  }
+
+  test("Alter table add column for hive partitioned table for spark version above 2.1") {
+    sql("drop table if exists alter_hive")
+    sql("create table alter_hive(name string) stored as rcfile partitioned by (dt string)")
+    if (SparkUtil.isSparkVersionXandAbove("2.2")) {
+      sql("alter table alter_hive add columns(add string)")
+      sql("alter table alter_hive add columns (var map<string, string>)")
+      sql("alter table alter_hive add columns (loves array<string>)")
+      sql(
+        s"""
+           |insert into alter_hive partition(dt='par')
+           |select 'abc', 'banglore', map('age', '10', 'birth', '2020'), array('a', 'b', 'c')
+         """.stripMargin)
+      checkAnswer(
+        sql("select * from alter_hive where dt='par'"),
+        Seq(Row("abc", "banglore", Map("age" -> "10", "birth" -> "2020"), Seq("a", "b", "c"), "par"))
+      )
     }
   }
 

--- a/integration/spark-common-cluster-test/src/test/scala/org/apache/carbondata/cluster/sdv/generated/SDKwriterTestCase.scala
+++ b/integration/spark-common-cluster-test/src/test/scala/org/apache/carbondata/cluster/sdv/generated/SDKwriterTestCase.scala
@@ -146,8 +146,7 @@ class SDKwriterTestCase extends QueryTest with BeforeAndAfterEach {
   }
 
   def deleteFile(path: String, extension: String): Unit = {
-    val file: CarbonFile = FileFactory
-      .getCarbonFile(path, FileFactory.getFileType(path))
+    val file: CarbonFile = FileFactory.getCarbonFile(path)
 
     for (eachDir <- file.listFiles) {
       if (!eachDir.isDirectory) {

--- a/integration/spark-common-cluster-test/src/test/scala/org/apache/spark/sql/common/util/QueryTest.scala
+++ b/integration/spark-common-cluster-test/src/test/scala/org/apache/spark/sql/common/util/QueryTest.scala
@@ -88,14 +88,13 @@ class QueryTest extends PlanTest with Suite {
 
   protected def checkAnswer(carbon: String, hive: String, uniqueIdentifier: String): Unit = {
     val path = TestQueryExecutor.hiveresultpath + "/" + uniqueIdentifier
-    if (FileFactory.isFileExist(path, FileFactory.getFileType(path))) {
-      val objinp = new ObjectInputStream(FileFactory
-        .getDataInputStream(path, FileFactory.getFileType(path)))
+    if (FileFactory.isFileExist(path)) {
+      val objinp = new ObjectInputStream(FileFactory.getDataInputStream(path))
       val rows = objinp.readObject().asInstanceOf[Array[Row]]
       objinp.close()
       QueryTest.checkAnswer(sql(carbon), rows) match {
         case Some(errorMessage) => {
-          FileFactory.deleteFile(path, FileFactory.getFileType(path))
+          FileFactory.deleteFile(path)
           writeAndCheckAnswer(carbon, hive, path)
         }
         case None =>
@@ -107,8 +106,7 @@ class QueryTest extends PlanTest with Suite {
 
   private def writeAndCheckAnswer(carbon: String, hive: String, path: String): Unit = {
     val rows = sql(hive).collect()
-    val obj = new ObjectOutputStream(FileFactory.getDataOutputStream(path, FileFactory
-      .getFileType(path)))
+    val obj = new ObjectOutputStream(FileFactory.getDataOutputStream(path))
     obj.writeObject(rows)
     obj.close()
     checkAnswer(sql(carbon), rows)

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/complexType/TestCreateTableWithDouble.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/complexType/TestCreateTableWithDouble.scala
@@ -64,8 +64,7 @@ class TestCreateTableWithDouble extends QueryTest with BeforeAndAfterAll {
     try {
       sql("CREATE TABLE doubleComplex2 (Id int, number double, name string, " +
         "gamePoint array<double>, mac struct<num:double>) " +
-        "STORED BY 'org.apache.carbondata.format' " +
-        "TBLPROPERTIES('DICTIONARY_INCLUDE'='number,gamePoint,mac')")
+        "STORED BY 'org.apache.carbondata.format' ")
       sql(s"LOAD DATA LOCAL INPATH '$dataPath' INTO TABLE doubleComplex2")
       countNum = sql(s"SELECT COUNT(*) FROM doubleComplex2").collect
       doubleField = sql(s"SELECT number FROM doubleComplex2 SORT BY Id").collect

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/primitiveTypes/ArrayDataTypeTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/primitiveTypes/ArrayDataTypeTestCase.scala
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.integration.spark.testsuite.primitiveTypes
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.test.util.QueryTest
+import org.scalatest.BeforeAndAfterAll
+
+/**
+ * Test Class for filter query on Float datatypes
+ */
+class ArrayDataTypeTestCase extends QueryTest with BeforeAndAfterAll {
+
+  override def beforeAll {
+    sql("DROP TABLE IF EXISTS datatype_array_parquet")
+    sql("DROP TABLE IF EXISTS datatype_array_carbondata")
+  }
+
+  test("test when insert select from a parquet table with an array with empty string") {
+    sql("create table datatype_array_parquet(col array<string>) stored as parquet")
+    sql("create table datatype_array_carbondata(col array<string>) stored as carbondata")
+    sql("insert into datatype_array_parquet values(array(''))")
+    sql("insert into datatype_array_carbondata select * from datatype_array_parquet")
+    checkAnswer(
+      sql("SELECT * FROM datatype_array_carbondata"),
+      sql("SELECT * FROM datatype_array_parquet"))
+    sql("DROP TABLE IF EXISTS datatype_array_carbondata")
+    sql("DROP TABLE IF EXISTS datatype_array_parquet")
+  }
+
+  test("test when insert select from a parquet table with empty array") {
+    sql("create table datatype_array_parquet(col array<string>) stored as parquet")
+    sql("create table datatype_array_carbondata(col array<string>) stored as carbondata")
+    sql("insert into datatype_array_parquet values(array())")
+    sql("insert into datatype_array_carbondata select * from datatype_array_parquet")
+    checkAnswer(
+      sql("SELECT * FROM datatype_array_carbondata"),
+      sql("SELECT * FROM datatype_array_parquet"))
+    sql("DROP TABLE IF EXISTS datatype_array_carbondata")
+    sql("DROP TABLE IF EXISTS datatype_array_parquet")
+  }
+
+  override def afterAll {
+    sql("DROP TABLE IF EXISTS datatype_array_carbondata")
+    sql("DROP TABLE IF EXISTS datatype_array_parquet")
+  }
+}

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/primitiveTypes/MapDataTypeTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/primitiveTypes/MapDataTypeTestCase.scala
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.integration.spark.testsuite.primitiveTypes
+
+import org.apache.spark.sql.test.util.QueryTest
+import org.scalatest.BeforeAndAfterAll
+
+/**
+ * Test Class for filter query on Float datatypes
+ */
+class MapDataTypeTestCase extends QueryTest with BeforeAndAfterAll {
+
+  override def beforeAll {
+    sql("DROP TABLE IF EXISTS datatype_map_parquet")
+    sql("DROP TABLE IF EXISTS datatype_map_carbondata")
+  }
+
+  test("test when insert select from a parquet table with an map with empty key and value") {
+    sql("create table datatype_map_parquet(col map<string,string>) stored as parquet")
+    sql("create table datatype_map_carbondata(col map<string,string>) stored as carbondata")
+    sql("insert into datatype_map_parquet values(map('',''))")
+    sql("insert into datatype_map_carbondata select * from datatype_map_parquet")
+    checkAnswer(
+      sql("SELECT * FROM datatype_map_carbondata"),
+      sql("SELECT * FROM datatype_map_parquet"))
+    sql("DROP TABLE IF EXISTS datatype_map_carbondata")
+    sql("DROP TABLE IF EXISTS datatype_map_parquet")
+  }
+
+  test("test when insert select from a parquet table with an map with empty key") {
+    sql("create table datatype_map_parquet(col map<string,string>) stored as parquet")
+    sql("create table datatype_map_carbondata(col map<string,string>) stored as carbondata")
+    sql("insert into datatype_map_parquet values(map('','value'))")
+    sql("insert into datatype_map_carbondata select * from datatype_map_parquet")
+    checkAnswer(
+      sql("SELECT * FROM datatype_map_carbondata"),
+      sql("SELECT * FROM datatype_map_parquet"))
+    sql("DROP TABLE IF EXISTS datatype_map_carbondata")
+    sql("DROP TABLE IF EXISTS datatype_map_parquet")
+  }
+
+  test("test when insert select from a parquet table with an map with empty value") {
+    sql("create table datatype_map_parquet(col map<string,string>) stored as parquet")
+    sql("create table datatype_map_carbondata(col map<string,string>) stored as carbondata")
+    sql("insert into datatype_map_parquet values(map('key',''))")
+    sql("insert into datatype_map_carbondata select * from datatype_map_parquet")
+    checkAnswer(
+      sql("SELECT * FROM datatype_map_carbondata"),
+      sql("SELECT * FROM datatype_map_parquet"))
+    sql("DROP TABLE IF EXISTS datatype_map_carbondata")
+    sql("DROP TABLE IF EXISTS datatype_map_parquet")
+  }
+
+  test("test when insert select from a parquet table with empty map") {
+    sql("create table datatype_map_parquet(col map<string,string>) stored as parquet")
+    sql("create table datatype_map_carbondata(col map<string,string>) stored as carbondata")
+    sql("insert into datatype_map_parquet values(map())")
+    sql("insert into datatype_map_carbondata select * from datatype_map_parquet")
+    checkAnswer(
+      sql("SELECT * FROM datatype_map_carbondata"),
+      sql("SELECT * FROM datatype_map_parquet"))
+    sql("DROP TABLE IF EXISTS datatype_map_carbondata")
+    sql("DROP TABLE IF EXISTS datatype_map_parquet")
+  }
+
+  override def afterAll {
+    sql("DROP TABLE IF EXISTS datatype_map_carbondata")
+    sql("DROP TABLE IF EXISTS datatype_map_parquet")
+  }
+}

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/primitiveTypes/StructDataTypeTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/integration/spark/testsuite/primitiveTypes/StructDataTypeTestCase.scala
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.integration.spark.testsuite.primitiveTypes
+
+import org.apache.spark.sql.test.util.QueryTest
+import org.scalatest.BeforeAndAfterAll
+
+/**
+ * Test Class for filter query on Float datatypes
+ */
+class StructDataTypeTestCase extends QueryTest with BeforeAndAfterAll {
+
+  override def beforeAll {
+    sql("DROP TABLE IF EXISTS datatype_struct_parquet")
+    sql("DROP TABLE IF EXISTS datatype_struct_carbondata")
+  }
+
+  test("test when insert select from a parquet table with an struct with empty string") {
+    sql("create table datatype_struct_parquet(price struct<b:string>) stored as parquet")
+    sql("insert into table datatype_struct_parquet values(named_struct('b', ''))")
+    sql("create table datatype_struct_carbondata(price struct<b:string>) stored as carbondata")
+    sql("insert into datatype_struct_carbondata select * from datatype_struct_parquet")
+    checkAnswer(
+      sql("SELECT * FROM datatype_struct_carbondata"),
+      sql("SELECT * FROM datatype_struct_parquet"))
+    sql("DROP TABLE IF EXISTS datatype_struct_carbondata")
+    sql("DROP TABLE IF EXISTS datatype_struct_parquet")
+  }
+
+  override def afterAll {
+    sql("DROP TABLE IF EXISTS datatype_struct_carbondata")
+    sql("DROP TABLE IF EXISTS datatype_struct_parquet")
+  }
+}

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestCreateTableAsSelect.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestCreateTableAsSelect.scala
@@ -145,25 +145,6 @@ class TestCreateTableAsSelect extends QueryTest with BeforeAndAfterAll {
     checkAnswer(sql("select * from ctas_select_direct_data"), Seq(Row(300, "carbondata")))
   }
 
-  test("test create table as select with TBLPROPERTIES") {
-    sql("DROP TABLE IF EXISTS ctas_tblproperties_testt")
-    sql(
-      "create table ctas_tblproperties_testt stored by 'carbondata' TBLPROPERTIES" +
-        "('DICTIONARY_INCLUDE'='key', 'sort_scope'='global_sort') as select * from carbon_ctas_test")
-    checkAnswer(sql("select * from ctas_tblproperties_testt"), sql("select * from carbon_ctas_test"))
-    val carbonTable = CarbonEnv.getInstance(Spark2TestQueryExecutor.spark).carbonMetaStore
-      .lookupRelation(Option("default"), "ctas_tblproperties_testt")(Spark2TestQueryExecutor.spark)
-      .asInstanceOf[CarbonRelation].carbonTable
-    val metadataFolderPath: CarbonFile = FileFactory.getCarbonFile(carbonTable.getMetadataPath)
-    assert(metadataFolderPath.exists())
-    val dictFiles: Array[CarbonFile] = metadataFolderPath.listFiles(new CarbonFileFilter {
-      override def accept(file: CarbonFile): Boolean = {
-        file.getName.contains(".dict") || file.getName.contains(".sortindex")
-      }
-    })
-    assert(dictFiles.length == 3)
-  }
-
   test("test create table as select with column name as tupleid") {
     intercept[Exception] {
       sql("create table t2 stored by 'carbondata' as select count(value) AS tupleid from carbon_ctas_test")

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/iud/UpdateCarbonTableTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/iud/UpdateCarbonTableTestCase.scala
@@ -96,6 +96,39 @@ class UpdateCarbonTableTestCase extends QueryTest with BeforeAndAfterAll {
     sql("""drop table if exists iud.dest22""")
   }
 
+  test("update with subquery with more than one value for key") {
+    sql("drop table if exists t1")
+    sql("drop table if exists t2")
+    sql("create table t1 (age int, name string) stored by 'carbondata'")
+    sql("insert into t1 select 1, 'aa'")
+    sql("insert into t1 select 2, 'aa'")
+    sql("create table t2 (age int, name string) stored by 'carbondata'")
+    sql("insert into t2 select 1, 'Andy'")
+    sql("insert into t2 select 2, 'Andy'")
+    sql("insert into t2 select 1, 'aa'")
+    sql("insert into t2 select 3, 'aa'")
+    val exception = intercept[RuntimeException] {
+      sql("update t1 set (age) = (select t2.age from t2 where t2.name = 'Andy') where t1.age = 1 ").show(false)
+    }
+    assertResult(
+      "Update operation failed.  update cannot be supported for 1 to N mapping, as more than one " +
+      "value present for the update key")(exception.getMessage)
+    // Test carbon property
+    CarbonProperties.getInstance().addProperty(CarbonCommonConstants.CARBON_UPDATE_CHECK_UNIQUE_VALUE, "false")
+    // update  should not throw exception
+    sql("update t1 set (age) = (select t2.age from t2 where t2.name = 'Andy') where t1.age = 1 ").show(false)
+    CarbonProperties.getInstance().addProperty(CarbonCommonConstants.CARBON_UPDATE_CHECK_UNIQUE_VALUE, "true")
+    // test join scenario
+    val exception1 = intercept[RuntimeException] {
+      sql("update t1 set (age) = (select t2.age from t2 where t2.name = t1.name) ").show(false)
+    }
+    assertResult(
+      "Update operation failed.  update cannot be supported for 1 to N mapping, as more than one " +
+      "value present for the update key")(exception1.getMessage)
+    sql("drop table if exists t1")
+    sql("drop table if exists t2")
+  }
+
   test("update carbon table without alias in set columns") {
     sql("""drop table if exists iud.dest33""")
     sql("""create table iud.dest33 (c1 string,c2 int,c3 string,c5 string) STORED BY 'org.apache.carbondata.format'""")

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonMergerRDD.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/CarbonMergerRDD.scala
@@ -19,7 +19,7 @@ package org.apache.carbondata.spark.rdd
 
 import java.io.IOException
 import java.util
-import java.util.{Collections, List, Map}
+import java.util.{Collections, List}
 import java.util.concurrent.atomic.AtomicInteger
 
 import scala.collection.mutable
@@ -32,10 +32,11 @@ import org.apache.spark._
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.deploy.SparkHadoopUtil
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.carbondata.execution.datasources.CarbonSparkDataSourceUtil
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.execution.command.{CarbonMergerMapping, NodeInfo}
 import org.apache.spark.sql.hive.DistributionUtil
-import org.apache.spark.sql.util.{CarbonException, SparkTypeConverter}
+import org.apache.spark.sql.util.CarbonException
 
 import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.converter.SparkDataTypeConverterImpl
@@ -64,8 +65,8 @@ import org.apache.carbondata.processing.loading.model.CarbonLoadModel
 import org.apache.carbondata.processing.merger._
 import org.apache.carbondata.processing.util.{CarbonDataProcessorUtil, CarbonLoaderUtil}
 import org.apache.carbondata.spark.MergeResult
-import org.apache.carbondata.spark.load.{ByteArrayOrdering, DataLoadProcessBuilderOnSpark, PrimtiveOrdering, StringOrdering}
-import org.apache.carbondata.spark.util.{CarbonScalaUtil, CommonUtil, Util}
+import org.apache.carbondata.spark.load.{DataLoadProcessBuilderOnSpark, PrimtiveOrdering, StringOrdering}
+import org.apache.carbondata.spark.util.{CarbonScalaUtil, CommonUtil}
 
 class CarbonMergerRDD[K, V](
     @transient private val ss: SparkSession,
@@ -680,7 +681,7 @@ class CarbonMergerRDD[K, V](
       partitionNames = null,
       splits = allSplits)
     val objectOrdering: Ordering[Object] = createOrderingForColumn(rangeColumn)
-    val sparkDataType = Util.convertCarbonToSparkDataType(dataType)
+    val sparkDataType = CarbonSparkDataSourceUtil.convertCarbonToSparkDataType(dataType)
     // Change string type to support all types
     val sampleRdd = scanRdd
       .map(row => (row.get(0, sparkDataType), null))

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/timeseries/TimeSeriesUtil.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/timeseries/TimeSeriesUtil.scala
@@ -154,10 +154,10 @@ object TimeSeriesUtil {
       timeSeriesFunction: String): Unit = {
     for (granularity <- Granularity.values()) {
       if (timeSeriesFunction.equalsIgnoreCase(granularity.getName
-        .substring(0, granularity.getName.indexOf(CarbonCommonConstants.UNDERSCORE)))) {
+        .substring(0, granularity.getName.lastIndexOf(CarbonCommonConstants.UNDERSCORE)))) {
         if (!supportedGranularitiesForDate.contains(granularity.getName)) {
           throw new MalformedCarbonCommandException(
-            "Granularity should be DAY,MONTH or YEAR, for timeseries column of Date type")
+            "Granularity should be of DAY/WEEK/MONTH/YEAR, for timeseries column of Date type")
         }
       }
     }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/datasources/SparkCarbonTableFormat.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/datasources/SparkCarbonTableFormat.scala
@@ -353,7 +353,8 @@ private class CarbonOutputWriter(path: String,
   def writeCarbon(row: InternalRow): Unit = {
     val data = new Array[AnyRef](fieldTypes.length + partitionData.length)
     var i = 0
-    while (i < fieldTypes.length) {
+    val fieldTypesLen = fieldTypes.length
+    while (i < fieldTypesLen) {
       if (!row.isNullAt(i)) {
         fieldTypes(i) match {
           case StringType =>
@@ -367,7 +368,7 @@ private class CarbonOutputWriter(path: String,
       i += 1
     }
     if (partitionData.length > 0) {
-      System.arraycopy(partitionData, 0, data, fieldTypes.length, partitionData.length)
+      System.arraycopy(partitionData, 0, data, fieldTypesLen, partitionData.length)
     }
     writable.set(data)
     recordWriter.write(NullWritable.get(), writable)

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/strategy/DDLStrategy.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/strategy/DDLStrategy.scala
@@ -17,6 +17,7 @@
 package org.apache.spark.sql.execution.strategy
 
 import org.apache.spark.sql._
+import org.apache.spark.sql.carbondata.execution.datasources.CarbonSparkDataSourceUtil
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.{NoSuchDatabaseException, UnresolvedRelation}
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
@@ -35,11 +36,9 @@ import org.apache.spark.sql.parser.CarbonSpark2SqlParser
 import org.apache.spark.sql.types.StructField
 import org.apache.spark.util.{CarbonReflectionUtils, DataMapUtil, FileUtils, SparkUtil}
 
-import org.apache.carbondata.common.exceptions.DeprecatedFeatureException
 import org.apache.carbondata.common.exceptions.sql.MalformedCarbonCommandException
 import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.core.util.{CarbonProperties, DataTypeUtil, ThreadLocalSessionInfo}
-import org.apache.carbondata.spark.util.Util
 
   /**
    * Carbon strategies for ddl commands
@@ -176,8 +175,8 @@ class DDLStrategy(sparkSession: SparkSession) extends SparkStrategy {
           val structField = (alterTableAddColumnsModel.dimCols ++ alterTableAddColumnsModel.msrCols)
             .map {
               a =>
-                StructField(a.column,
-                  Util.convertCarbonToSparkDataType(DataTypeUtil.valueOf(a.dataType.get)))
+                StructField(a.column, CarbonSparkDataSourceUtil.convertCarbonToSparkDataType(
+                  DataTypeUtil.valueOf(a.dataType.get)))
             }
           val identifier = TableIdentifier(
             alterTableAddColumnsModel.tableName,

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSparkSqlParserUtil.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSparkSqlParserUtil.scala
@@ -30,6 +30,7 @@ import org.apache.spark.sql.execution.command.{PartitionerField, TableModel, Tab
 import org.apache.spark.sql.execution.command.table.{CarbonCreateTableAsSelectCommand, CarbonCreateTableCommand}
 import org.apache.spark.sql.types.StructField
 
+import org.apache.carbondata.common.exceptions.DeprecatedFeatureException
 import org.apache.carbondata.common.exceptions.sql.MalformedCarbonCommandException
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.datastore.impl.FileFactory
@@ -135,6 +136,11 @@ object CarbonSparkSqlParserUtil {
     }
 
     // validate tblProperties
+    if (tableProperties.contains(CarbonCommonConstants.DICTIONARY_INCLUDE) ||
+        tableProperties.contains(CarbonCommonConstants.DICTIONARY_EXCLUDE)) {
+      throw new DeprecatedFeatureException("global dictionary")
+    }
+
     val bucketFields = parser.getBucketFields(tableProperties, fields, options)
     var isTransactionalTable: Boolean = true
 

--- a/integration/spark2/src/main/scala/org/apache/spark/util/AlterTableUtil.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/util/AlterTableUtil.scala
@@ -45,7 +45,7 @@ import org.apache.carbondata.core.metadata.datatype.DataTypes
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable
 import org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema
 import org.apache.carbondata.core.util.CarbonUtil
-import org.apache.carbondata.format.{SchemaEvolutionEntry, TableInfo}
+import org.apache.carbondata.format.{DataType, SchemaEvolutionEntry, TableInfo}
 import org.apache.carbondata.spark.util.{CarbonScalaUtil, CommonUtil}
 
 
@@ -170,6 +170,20 @@ object AlterTableUtil {
         columns.addAll(newColumns)
       }
     }
+  }
+
+  /**
+   * update schema when LONG_STRING_COLUMNS are changed
+   */
+  private def updateSchemaForLongStringColumns(
+      thriftTable: TableInfo,
+      longStringColumns: String) = {
+    val longStringColumnsString = CarbonUtil.unquoteChar(longStringColumns).trim
+    val newColumns = CarbonUtil.reorderColumnsForLongString(thriftTable
+      .getFact_table
+      .getTable_columns,
+      longStringColumnsString)
+    thriftTable.getFact_table.setTable_columns(newColumns)
   }
 
   /**
@@ -436,6 +450,15 @@ object AlterTableUtil {
       validateSortScopeAndSortColumnsProperties(carbonTable, lowerCasePropertiesMap)
       // if SORT_COLUMN is changed, it will move them to the head of column list
       updateSchemaForSortColumns(thriftTable, lowerCasePropertiesMap, schemaConverter)
+      // validate long string columns
+      val longStringColumns = lowerCasePropertiesMap.get("long_string_columns");
+      if (longStringColumns.isDefined) {
+        validateLongStringColumns(longStringColumns.get, carbonTable)
+        // update schema for long string columns
+        updateSchemaForLongStringColumns(thriftTable, longStringColumns.get)
+      } else if (propKeys.exists(_.equalsIgnoreCase("long_string_columns") && !set)) {
+        updateSchemaForLongStringColumns(thriftTable, "")
+      }
       // below map will be used for cache invalidation. As tblProperties map is getting modified
       // in the next few steps the original map need to be retained for any decision making
       val existingTablePropertiesMap = mutable.Map(tblPropertiesMap.toSeq: _*)
@@ -518,7 +541,8 @@ object AlterTableUtil {
       "RANGE_COLUMN",
       "SORT_SCOPE",
       "SORT_COLUMNS",
-      "GLOBAL_SORT_PARTITIONS")
+      "GLOBAL_SORT_PARTITIONS",
+      "LONG_STRING_COLUMNS")
     supportedOptions.contains(propKey.toUpperCase)
   }
 
@@ -810,6 +834,52 @@ object AlterTableUtil {
       false
     }
     allColumnsMatch
+  }
+
+  /**
+   * Validate LONG_STRING_COLUMNS property specified in Alter command
+   *
+   * @param longStringColumns
+   * @param carbonTable
+   */
+  def validateLongStringColumns(longStringColumns: String,
+      carbonTable: CarbonTable): Unit = {
+    // don't allow duplicate column names
+    val longStringCols = longStringColumns.split(",")
+    if (longStringCols.distinct.lengthCompare(longStringCols.size) != 0) {
+      val duplicateColumns = longStringCols
+        .diff(longStringCols.distinct).distinct
+      val errMsg =
+        "LONG_STRING_COLUMNS contains Duplicate Columns: " +
+        duplicateColumns.mkString(",") + ". Please check the DDL."
+      throw new MalformedCarbonCommandException(errMsg)
+    }
+    // check if the column specified exists in table schema and must be of string data type
+    val colSchemas = carbonTable.getTableInfo.getFactTable.getListOfColumns.asScala
+    longStringCols.foreach { col =>
+      if (!colSchemas.exists(x => x.getColumnName.equalsIgnoreCase(col.trim))) {
+        val errorMsg = "LONG_STRING_COLUMNS column: " + col.trim +
+                       " does not exist in table. Please check the DDL."
+        throw new MalformedCarbonCommandException(errorMsg)
+      } else if (colSchemas.exists(x => x.getColumnName.equalsIgnoreCase(col.trim) &&
+                                          !x.getDataType.toString
+                                            .equalsIgnoreCase("STRING"))) {
+        val errMsg = "LONG_STRING_COLUMNS column: " + col.trim +
+                     " is not a string datatype column"
+        throw new MalformedCarbonCommandException(errMsg)
+      }
+    }
+    // should not be present in sort columns
+    val sortCols = carbonTable.getSortColumns
+    if (sortCols != null) {
+      for (col <- longStringCols) {
+        if (sortCols.contains(col)) {
+          val errMsg =
+            "LONG_STRING_COLUMNS cannot be present in sort columns: " + col
+          throw new MalformedCarbonCommandException(errMsg)
+        }
+      }
+    }
   }
 
   /**

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/parser/impl/ArrayParserImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/parser/impl/ArrayParserImpl.java
@@ -19,6 +19,7 @@ package org.apache.carbondata.processing.loading.parser.impl;
 
 import java.util.regex.Pattern;
 
+import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.util.CarbonUtil;
 import org.apache.carbondata.processing.loading.complexobjects.ArrayObject;
 import org.apache.carbondata.processing.loading.parser.ComplexParser;
@@ -48,7 +49,8 @@ public class ArrayParserImpl implements ComplexParser<ArrayObject> {
   public ArrayObject parse(Object data) {
     if (data != null) {
       String value = data.toString();
-      if (!value.isEmpty() && !value.equals(nullFormat)) {
+      if (!value.isEmpty() && !value.equals(nullFormat)
+          && !value.equals(CarbonCommonConstants.EMPTY_DATA_RETURN)) {
         String[] split = pattern.split(value, -1);
         if (ArrayUtils.isNotEmpty(split)) {
           Object[] array = new Object[split.length];
@@ -60,6 +62,9 @@ public class ArrayParserImpl implements ComplexParser<ArrayObject> {
       } else if (value.isEmpty()) {
         Object[] array = new Object[1];
         array[0] = child.parse(value);
+        return new ArrayObject(array);
+      } else if (value.equals(CarbonCommonConstants.EMPTY_DATA_RETURN)) {
+        Object[] array = new Object[0];
         return new ArrayObject(array);
       }
     }

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/parser/impl/MapParserImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/parser/impl/MapParserImpl.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.processing.loading.complexobjects.ArrayObject;
 
 import org.apache.commons.lang.ArrayUtils;
@@ -40,7 +41,9 @@ public class MapParserImpl extends ArrayParserImpl {
   public ArrayObject parse(Object data) {
     if (data != null) {
       String value = data.toString();
-      if (!value.isEmpty() && !value.equals(nullFormat)) {
+      if (!value.isEmpty() && !value.equals(nullFormat)
+          && !value.equals(keyValueDelimiter)
+          && !value.equals(CarbonCommonConstants.EMPTY_DATA_RETURN)) {
         String[] split = pattern.split(value, -1);
         if (ArrayUtils.isNotEmpty(split)) {
           ArrayList<Object> array = new ArrayList<>();
@@ -54,6 +57,13 @@ public class MapParserImpl extends ArrayParserImpl {
           }
           return new ArrayObject(array.toArray());
         }
+      } else if (value.equals(keyValueDelimiter)) {
+        Object[] array = new Object[1];
+        array[0] = child.parse(value);
+        return new ArrayObject(array);
+      } else if (value.equals(CarbonCommonConstants.EMPTY_DATA_RETURN)) {
+        Object[] array = new Object[0];
+        return new ArrayObject(array);
       }
     }
     return null;

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/parser/impl/StructParserImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/parser/impl/StructParserImpl.java
@@ -59,6 +59,12 @@ public class StructParserImpl implements ComplexParser<StructObject> {
           }
           return new StructObject(array);
         }
+      } else if (value.isEmpty()) {
+        Object[] array = new Object[1];
+        if (children.size() > 0) {
+          array[0] = children.get(0).parse(value);
+          return new StructObject(array);
+        }
       }
     }
     return null;

--- a/streaming/src/main/scala/org/apache/carbondata/streaming/parser/FieldConverter.scala
+++ b/streaming/src/main/scala/org/apache/carbondata/streaming/parser/FieldConverter.scala
@@ -66,31 +66,39 @@ object FieldConverter {
         case bs: Array[Byte] => new String(bs,
           Charset.forName(CarbonCommonConstants.DEFAULT_CHARSET))
         case s: scala.collection.Seq[Any] =>
-          val delimiter = complexDelimiters.get(level)
-          val builder = new StringBuilder()
-          s.foreach { x =>
-            val nextLevel = level + 1
-            builder.append(objectToString(x, serializationNullFormat, complexDelimiters,
-              timeStampFormat, dateFormat, isVarcharType, level = nextLevel))
-              .append(delimiter)
+          if (s.nonEmpty) {
+            val delimiter = complexDelimiters.get(level)
+            val builder = new StringBuilder()
+            s.foreach { x =>
+              val nextLevel = level + 1
+              builder.append(objectToString(x, serializationNullFormat, complexDelimiters,
+                timeStampFormat, dateFormat, isVarcharType, level = nextLevel))
+                .append(delimiter)
+            }
+            builder.substring(0, builder.length - delimiter.length())
+          } else {
+            CarbonCommonConstants.EMPTY_DATA_RETURN
           }
-          builder.substring(0, builder.length - delimiter.length())
         // First convert the 'key' of Map and then append the keyValueDelimiter and then convert
         // the 'value of the map and append delimiter
         case m: scala.collection.Map[_, _] =>
-          val nextLevel = level + 2
-          val delimiter = complexDelimiters.get(level)
-          val keyValueDelimiter = complexDelimiters.get(level + 1)
-          val builder = new StringBuilder()
-          m.foreach { x =>
-            builder.append(objectToString(x._1, serializationNullFormat, complexDelimiters,
-              timeStampFormat, dateFormat, isVarcharType, level = nextLevel))
-              .append(keyValueDelimiter)
-            builder.append(objectToString(x._2, serializationNullFormat, complexDelimiters,
-              timeStampFormat, dateFormat, isVarcharType, level = nextLevel))
-              .append(delimiter)
+          if (m.nonEmpty) {
+            val nextLevel = level + 2
+            val delimiter = complexDelimiters.get(level)
+            val keyValueDelimiter = complexDelimiters.get(level + 1)
+            val builder = new StringBuilder()
+            m.foreach { x =>
+              builder.append(objectToString(x._1, serializationNullFormat, complexDelimiters,
+                timeStampFormat, dateFormat, isVarcharType, level = nextLevel))
+                .append(keyValueDelimiter)
+              builder.append(objectToString(x._2, serializationNullFormat, complexDelimiters,
+                timeStampFormat, dateFormat, isVarcharType, level = nextLevel))
+                .append(delimiter)
+            }
+            builder.substring(0, builder.length - delimiter.length())
+          } else {
+            CarbonCommonConstants.EMPTY_DATA_RETURN
           }
-          builder.substring(0, builder.length - delimiter.length())
         case r: org.apache.spark.sql.Row =>
           val delimiter = complexDelimiters.get(level)
           val builder = new StringBuilder()


### PR DESCRIPTION
Modification reason:
(1) StringIndexOutOfBoundsException When Inserting Select From a Parquet Table with Empty array/map.
(2) ArrayIndexOutOfBuoundsException When Inserting Select From a Parquet Table with a map with empty key and empty value
(3) Result is incorrect when Inserting Select From a Parquet Table with a Struct with Empty String, The result will be null while the correct result is "".

Modification content:
(1) When the input value is ARRAY(), return EMPTY_DATA_RETURN in the FieldConverter.scala, ArrayParserImpl handle it.
(2) When the input value is ARRAY(""), return EMPTY STRING ->"" in the FieldConverter.scala, ArrayParserImpl handle it.
(3) When the input value is MAP("",""), return EMPTY STRING ->"" in the FieldConverter.scala, MapParserImpl handle it.
(4) When the input value is MAP(), return EMPTY_DATA_RETURN ->"" in the FieldConverter.scala, MapParserImpl handle it.
(5) When the input value is Struct(""), the StructParserImpl handle the EMPTY STRING


Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [ ] Any interfaces changed?
 
 - [ ] Any backward compatibility impacted?
 
 - [ ] Document update required?

 - [ ] Testing done
        Please provide details on 
        - Whether new unit test cases have been added or why no new tests are required?
        - How it is tested? Please attach test report.
        - Is it a performance related change? Please attach the performance test report.
        - Any additional information to help reviewers in testing this change.
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

