### PR TITLE
[CARBONDATA-3642] Add column name in error msg when string length exceed 32000

### DIFF
--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/longstring/VarcharDataTypesBasicTestCase.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/longstring/VarcharDataTypesBasicTestCase.scala
@@ -196,7 +196,7 @@ class VarcharDataTypesBasicTestCase extends QueryTest with BeforeAndAfterEach wi
     val e = intercept[Exception] {
       sql(s""" insert into testlongstring select 1, 'abc', '$longChar'""")
     }
-    assert(e.getMessage.contains("Dataload failed, String length cannot exceed 32000 characters"))
+    assert(e.getMessage.contains("DataLoad failure: Column description is too long"))
     sql("ALTER TABLE testlongstring SET TBLPROPERTIES('long_String_columns'='description')")
     sql(s""" insert into testlongstring select 1, 'ab1', '$longChar'""")
     sql("drop table if exists testlongstring")

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/NewCarbonDataLoadRDD.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/rdd/NewCarbonDataLoadRDD.scala
@@ -357,7 +357,7 @@ class NewRddIterator(rddIter: Iterator[Row],
     val len = columns.length
     var i = 0
     while (i < len) {
-      columns(i) = CarbonScalaUtil.getString(row.get(i), serializationNullFormat,
+      columns(i) = CarbonScalaUtil.getString(row, i, carbonLoadModel, serializationNullFormat,
         complexDelimiters, timeStampFormat, dateFormat,
         isVarcharType = i < isVarcharTypeMapping.size && isVarcharTypeMapping(i),
         isComplexType = i < isComplexTypeMapping.size && isComplexTypeMapping(i))
@@ -431,7 +431,7 @@ class LazyRddIterator(serializer: SerializerInstance,
     val row = rddIter.next()
     val columns = new Array[AnyRef](row.length)
     for (i <- 0 until columns.length) {
-      columns(i) = CarbonScalaUtil.getString(row.get(i), serializationNullFormat,
+      columns(i) = CarbonScalaUtil.getString(row, i, carbonLoadModel, serializationNullFormat,
         complexDelimiters, timeStampFormat, dateFormat,
         isVarcharType = i < isVarcharTypeMapping.size && isVarcharTypeMapping(i))
     }

--- a/streaming/src/main/scala/org/apache/carbondata/streaming/parser/FieldConverter.scala
+++ b/streaming/src/main/scala/org/apache/carbondata/streaming/parser/FieldConverter.scala
@@ -24,6 +24,7 @@ import java.util
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 
 object FieldConverter {
+  val stringLengthExceedErrorMsg = "Dataload failed, String length cannot exceed "
 
   /**
    * Return a String representation of the input value
@@ -50,8 +51,8 @@ object FieldConverter {
       value match {
         case s: String => if (!isVarcharType && !isComplexType &&
                               s.length > CarbonCommonConstants.MAX_CHARS_PER_COLUMN_DEFAULT) {
-          throw new Exception("Dataload failed, String length cannot exceed " +
-                              CarbonCommonConstants.MAX_CHARS_PER_COLUMN_DEFAULT + " characters")
+          throw new IllegalArgumentException(stringLengthExceedErrorMsg +
+            CarbonCommonConstants.MAX_CHARS_PER_COLUMN_DEFAULT + " characters")
         } else {
           s
         }


### PR DESCRIPTION
Before change, when string length exceed 32000, the error message is
```
Previous exception in task: Dataload failed, String length cannot exceed 32000 characters
	org.apache.carbondata.streaming.parser.FieldConverter$.objectToString(FieldConverter.scala:53)
	org.apache.carbondata.spark.util.CarbonScalaUtil$.getString(CarbonScalaUtil.scala:71)
	org.apache.carbondata.spark.rdd.NewRddIterator$$anonfun$next$1.apply$mcVI$sp(NewCarbonDataLoadRDD.scala:360)
	scala.collection.immutable.Range.foreach$mVc$sp(Range.scala:160)
	org.apache.carbondata.spark.rdd.NewRddIterator.next(NewCarbonDataLoadRDD.scala:359)
	org.apache.carbondata.spark.load.DataLoadProcessorStepOnSpark$$anon$1.next(DataLoadProcessorStepOnSpark.scala:66)
... ...
```

After change,  when string length exceed 32000, the error message is
```
  Previous exception in task: Column base_exinfo too long, consider to use 'long_string_columns' table property.
	org.apache.carbondata.spark.util.CarbonScalaUtil$.getString(CarbonScalaUtil.scala:81)
	org.apache.carbondata.spark.rdd.NewRddIterator$$anonfun$next$1.apply$mcVI$sp(NewCarbonDataLoadRDD.scala:360)
	scala.collection.immutable.Range.foreach$mVc$sp(Range.scala:160)
	org.apache.carbondata.spark.rdd.NewRddIterator.next(NewCarbonDataLoadRDD.scala:359)
	org.apache.carbondata.spark.load.DataLoadProcessorStepOnSpark$$anon$1.next(DataLoadProcessorStepOnSpark.scala:66)
	org.apache.carbondata.spark.load.DataLoadProcessorStepOnSpark$$anon$1.next(DataLoadProcessorStepOnSpark.scala:61)
	org.apache.carbondata.spark.load.DataLoadProcessorStepOnSpark$$anon$4.next(DataLoadProcessorStepOnSpark.scala:179)
	org.apache.carbondata.spark.load.DataLoadProcessorStepOnSpark$$anon$4.next(DataLoadProcessorStepOnSpark.scala:170)
	scala.collection.Iterator$$anon$13.hasNext(Iterator.scala:462)
	scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:408)
	scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:408)
	org.apache.spark.sql.catalyst.expressions.GeneratedClass$GeneratedIteratorForCodegenStage1.processNext(Unknown Source)
	org.apache.spark.sql.execution.BufferedRowIterator.hasNext(BufferedRowIterator.java:43)
	org.apache.spark.sql.execution.WholeStageCodegenExec$$anonfun$10$$anon$1.hasNext(WholeStageCodegenExec.scala:614)
	org.apache.spark.sql.execution.UnsafeExternalRowSorter.sort(UnsafeExternalRowSorter.java:216)
	org.apache.spark.sql.execution.SortExec$$anonfun$1.apply(SortExec.scala:109)
	org.apache.spark.sql.execution.SortExec$$anonfun$1.apply(SortExec.scala:102)
	org.apache.spark.rdd.RDD$$anonfun$mapPartitionsInternal$1$$anonfun$apply$26.apply(RDD.scala:830)
	org.apache.spark.rdd.RDD$$anonfun$mapPartitionsInternal$1$$anonfun$apply$26.apply(RDD.scala:830)
	org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:38)
	org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:324)
	org.apache.spark.rdd.RDD.iterator(RDD.scala:288)
	org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:87)
	org.apache.spark.scheduler.Task.run(Task.scala:109)
	org.apache.spark.executor.Executor$TaskRunner$$anon$2.run(Executor.scala:379)
	java.security.AccessController.doPrivileged(Native Method)
	javax.security.auth.Subject.doAs(Subject.java:360)
	org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1787)
	org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:376)
	java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1146)
	java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:621)
	java.lang.Thread.run(Thread.java:849)
		at org.apache.spark.TaskContextImpl.invokeListeners(TaskContextImpl.scala:139)
		at org.apache.spark.TaskContextImpl.markTaskFailed(TaskContextImpl.scala:107)
		at org.apache.spark.scheduler.Task.run(Task.scala:114)
		... 8 more
Caused by: java.lang.IllegalArgumentException: Dataload failed, String length cannot exceed 32000 characters
	at org.apache.carbondata.streaming.parser.FieldConverter$.objectToString(FieldConverter.scala:54)
	at org.apache.carbondata.spark.util.CarbonScalaUtil$.getString(CarbonScalaUtil.scala:75)
	... 31 more
```

Be sure to do all of the following checklist to help us incorporate 
your contribution quickly and easily:

 - [x] Any interfaces changed? No
 
 - [x] Any backward compatibility impacted? No
 
 - [x] Document update required? No

 - [x] Testing done Yes
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA. 

