### PR TITLE
[CARBONDATA-3644] Support Configuration of Complex Delimiters in Carbon…

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -146,6 +146,30 @@ public final class CarbonCommonConstants {
   public static final String DEFAULT_COMPRESSOR = "snappy";
 
   /**
+   * the level 1 complex delimiter
+   */
+  @CarbonProperty
+  public static final String COMPLEX_DELIMITERS_LEVEL_1 = "carbon.complex.delimiter.level.1";
+
+  /**
+   * the level 2 complex delimiter
+   */
+  @CarbonProperty
+  public static final String COMPLEX_DELIMITERS_LEVEL_2 = "carbon.complex.delimiter.level.2";
+
+  /**
+   * the level 3 complex delimiter
+   */
+  @CarbonProperty
+  public static final String COMPLEX_DELIMITERS_LEVEL_3 = "carbon.complex.delimiter.level.3";
+
+  /**
+   * the level 4 complex delimiter
+   */
+  @CarbonProperty
+  public static final String COMPLEX_DELIMITERS_LEVEL_4 = "carbon.complex.delimiter.level.4";
+
+  /**
    * ZOOKEEPER_ENABLE_LOCK if this is set to true then zookeeper
    * will be used to handle locking
    * mechanism of carbon

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonLoadDataCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonLoadDataCommand.scala
@@ -169,9 +169,6 @@ case class CarbonLoadDataCommand(
     val carbonLoadModel = new CarbonLoadModel()
     val tableProperties = table.getTableInfo.getFactTable.getTableProperties
     val optionsFinal = LoadOption.fillOptionWithDefaultValue(options.asJava)
-    optionsFinal
-      .put("complex_delimiter_level_4",
-        ComplexDelimitersEnum.COMPLEX_DELIMITERS_LEVEL_4.value())
 
     /**
     * Priority of sort_scope assignment :

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/model/LoadOption.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/model/LoadOption.java
@@ -107,15 +107,27 @@ public class LoadOption {
 
     optionsFinal.put("complex_delimiter_level_1",
         Maps.getOrDefault(options, "complex_delimiter_level_1",
-            ComplexDelimitersEnum.COMPLEX_DELIMITERS_LEVEL_1.value()));
+            CarbonProperties.getInstance().getProperty(
+                CarbonCommonConstants.COMPLEX_DELIMITERS_LEVEL_1,
+                ComplexDelimitersEnum.COMPLEX_DELIMITERS_LEVEL_1.value())));
 
     optionsFinal.put("complex_delimiter_level_2",
         Maps.getOrDefault(options, "complex_delimiter_level_2",
-            ComplexDelimitersEnum.COMPLEX_DELIMITERS_LEVEL_2.value()));
+            CarbonProperties.getInstance().getProperty(
+                CarbonCommonConstants.COMPLEX_DELIMITERS_LEVEL_2,
+                ComplexDelimitersEnum.COMPLEX_DELIMITERS_LEVEL_2.value())));
 
     optionsFinal.put("complex_delimiter_level_3",
         Maps.getOrDefault(options, "complex_delimiter_level_3",
-            ComplexDelimitersEnum.COMPLEX_DELIMITERS_LEVEL_3.value()));
+            CarbonProperties.getInstance().getProperty(
+                CarbonCommonConstants.COMPLEX_DELIMITERS_LEVEL_3,
+                ComplexDelimitersEnum.COMPLEX_DELIMITERS_LEVEL_3.value())));
+
+    optionsFinal.put("complex_delimiter_level_4",
+        Maps.getOrDefault(options, "complex_delimiter_level_4",
+            CarbonProperties.getInstance().getProperty(
+                CarbonCommonConstants.COMPLEX_DELIMITERS_LEVEL_4,
+                ComplexDelimitersEnum.COMPLEX_DELIMITERS_LEVEL_4.value())));
 
     optionsFinal.put(
         "dateformat",


### PR DESCRIPTION
… Properties

 ### Why is this PR needed?
 Modification reason: In the insert carbontable select from a parquet table processing, if the binary column has the content '\001', like 'col1\001col2', the content before '\001' will be truncated as '\001' is the Complex Delimiter. The problem is that Complex Delimiter can't be configured in the insert flow, which needs to improve.
 
 ### What changes were proposed in this PR?
Modification content: We add the configuration of complex delimiters in the CarbonProperties, which will be loaded in the LoadOption.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
