### PR TITLE
[CARBONDATA-3648] Support Alter Table Compaction Level Threshold

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -842,6 +842,17 @@ public final class CarbonCommonConstants {
    */
   public static final String DEFAULT_SEGMENT_LEVEL_THRESHOLD = "4,3";
 
+
+  /**
+   * Lower limit for the number of segment compacted per time
+   */
+  public static final int NUMBER_OF_SEGMENT_COMPACTED_PERTIME_LOWER_LIMIT = 0;
+
+  /**
+   * Upper limit for the number of segment compacted per time
+   */
+  public static final int NUMBER_OF_SEGMENT_COMPACTED_PERTIME_UPPER_LIMIT = 10000;
+
   /**
    * Number of Update Delta files which is the Threshold for IUD compaction.
    * Only accepted Range is 0 - 10000. Outside this range system will pick default value.

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
@@ -988,8 +988,15 @@ public final class CarbonProperties {
     for (String levelSize : levels) {
       try {
         int size = Integer.parseInt(levelSize.trim());
-        if (validate(size, 100, 0, -1) < 0) {
+        if (validate(size,
+            CarbonCommonConstants.NUMBER_OF_SEGMENT_COMPACTED_PERTIME_UPPER_LIMIT,
+            CarbonCommonConstants.NUMBER_OF_SEGMENT_COMPACTED_PERTIME_LOWER_LIMIT,
+            -1) < 0) {
           // if given size is out of boundary then take default value for all levels.
+          LOGGER.warn(
+              "Given value for property" + size
+                  + " is not proper. Taking the default value "
+                  + CarbonCommonConstants.DEFAULT_SEGMENT_LEVEL_THRESHOLD);
           return new int[0];
         }
         compactionSize[i++] = size;

--- a/core/src/main/java/org/apache/carbondata/core/util/path/CarbonTablePath.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/path/CarbonTablePath.java
@@ -17,6 +17,8 @@
 
 package org.apache.carbondata.core.util.path;
 
+import java.io.File;
+
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.datastore.filesystem.CarbonFile;
 import org.apache.carbondata.core.datastore.filesystem.CarbonFileFilter;
@@ -81,7 +83,7 @@ public class CarbonTablePath {
     int lastIndex = carbonFilePath.lastIndexOf('/');
     // below code for handling windows environment
     if (-1 == lastIndex) {
-      lastIndex = carbonFilePath.lastIndexOf(CarbonCommonConstants.FILE_SEPARATOR);
+      lastIndex = carbonFilePath.lastIndexOf(File.separator);
     }
     return carbonFilePath.substring(0, lastIndex);
   }

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/alterTable/TestAlterTableCompactionLevelThreshold.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/alterTable/TestAlterTableCompactionLevelThreshold.scala
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.spark.testsuite.alterTable
+
+import org.apache.spark.sql.CarbonEnv
+import org.apache.spark.sql.test.util.QueryTest
+import org.scalatest.BeforeAndAfterAll
+
+/**
+ * test class for validating alter table set properties with alter_compaction_level properties
+ */
+class TestAlterTableCompactionLevelThreshold extends QueryTest with BeforeAndAfterAll {
+
+  private def isExpectedValueValid(dbName: String,
+                                   tableName: String,
+                                   key: String,
+                                   expectedValue: String): Boolean = {
+    val carbonTable = CarbonEnv.getCarbonTable(Option(dbName), tableName)(sqlContext.sparkSession)
+    val value = carbonTable.getTableInfo.getFactTable.getTableProperties.get(key)
+    expectedValue.equals(value)
+  }
+
+  private def dropTable = {
+    sql("drop table if exists alter_compaction_level_threshold")
+  }
+
+  override def beforeAll {
+    // drop table
+    dropTable
+    // create table
+    sql("create table alter_compaction_level_threshold(c1 String) stored as carbondata")
+  }
+
+  test("validate alter compaction level_threshold") {
+    sql("ALTER TABLE alter_compaction_level_threshold SET TBLPROPERTIES('COMPACTION_LEVEL_THRESHOLD'='500,0')")
+    assert(isExpectedValueValid("default", "alter_compaction_level_threshold", "compaction_level_threshold", "500,0"))
+  }
+
+  test("validate alter compaction level_threshold with wrong threshold") {
+    var exception = intercept[Exception] {
+      sql("ALTER TABLE alter_compaction_level_threshold SET TBLPROPERTIES('COMPACTION_LEVEL_THRESHOLD'='20000,0')")
+    }
+    assert(exception.getMessage.contains("Alter table newProperties operation failed"))
+
+    exception = intercept[Exception] {
+      sql("ALTER TABLE alter_compaction_level_threshold SET TBLPROPERTIES('COMPACTION_LEVEL_THRESHOLD'='?,?')")
+    }
+    assert(exception.getMessage.contains("Alter table newProperties operation failed"))
+  }
+
+  override def afterAll: Unit = {
+    // drop table
+    dropTable
+  }
+}

--- a/integration/spark2/src/main/scala/org/apache/spark/util/AlterTableUtil.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/util/AlterTableUtil.scala
@@ -45,7 +45,7 @@ import org.apache.carbondata.core.metadata.converter.{SchemaConverter, ThriftWra
 import org.apache.carbondata.core.metadata.datatype.DataTypes
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable
 import org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema
-import org.apache.carbondata.core.util.CarbonUtil
+import org.apache.carbondata.core.util.{CarbonProperties, CarbonUtil}
 import org.apache.carbondata.format.{DataType, SchemaEvolutionEntry, TableInfo}
 import org.apache.carbondata.spark.util.{CarbonScalaUtil, CommonUtil}
 
@@ -451,6 +451,13 @@ object AlterTableUtil {
 
       // validate the Sort Scope and Sort Columns
       validateSortScopeAndSortColumnsProperties(carbonTable, lowerCasePropertiesMap)
+
+      // validate the Sort Scope and Sort Columns
+      validateSortScopeAndSortColumnsProperties(carbonTable, lowerCasePropertiesMap)
+
+      // validate the Compaction Level Threshold
+      validateCompactionLevelThresholdProperties(carbonTable, lowerCasePropertiesMap)
+
       // if SORT_COLUMN is changed, it will move them to the head of column list
       updateSchemaForSortColumns(thriftTable, lowerCasePropertiesMap, schemaConverter)
       // validate long string columns
@@ -542,6 +549,7 @@ object AlterTableUtil {
       "COMMENT",
       "COLUMN_META_CACHE",
       "CACHE_LEVEL",
+      "COMPACTION_LEVEL_THRESHOLD",
       "LOCAL_DICTIONARY_ENABLE",
       "LOCAL_DICTIONARY_THRESHOLD",
       "LOCAL_DICTIONARY_INCLUDE",
@@ -692,6 +700,19 @@ object AlterTableUtil {
           throw new InvalidConfigurationException(
             s"Cannot set SORT_COLUMNS as empty when SORT_SCOPE is ${carbonTable.getSortScope} ")
         }
+      }
+    }
+  }
+
+  def validateCompactionLevelThresholdProperties(carbonTable: CarbonTable,
+      propertiesMap: mutable.Map[String, String]): Unit = {
+    val newCompactionLevelThreshold =
+      propertiesMap.get(CarbonCommonConstants.TABLE_COMPACTION_LEVEL_THRESHOLD)
+    if (newCompactionLevelThreshold.isDefined) {
+      // check compactionlevelthreshold is in the specified range and in the format of number
+      if (CarbonProperties.getInstance().getIntArray(newCompactionLevelThreshold.get).length == 0) {
+        throw new InvalidConfigurationException(
+          s"Cannot set COMPACTION_LEVEL_THRESHOLD as ${newCompactionLevelThreshold.get}")
       }
     }
   }


### PR DESCRIPTION
 ### Why is this PR needed?
(1) The Alter Table sould support Compaction Level Threshold.
(2) The upper limit of Compaction Level Threshold is 100, which is too small to meet the scenario with massive small files
(3) There is a bug to limit alter table in windows env.
 
 ### What changes were proposed in this PR?
(1) AlterTableUtil support alter Compaction_Level_Threshold
(2) CarbonProperties increases the upper limit of Compaction_Level_Threshold to 10000 from 100.
(3) Fix the bug which limit alter table in windows env
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
