### PR TITLE
[HOTFIX] Fix INSERT STAGE footer read error

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/reader/CarbonFooterReaderV3.java
+++ b/core/src/main/java/org/apache/carbondata/core/reader/CarbonFooterReaderV3.java
@@ -19,12 +19,8 @@ package org.apache.carbondata.core.reader;
 
 import java.io.IOException;
 
-import org.apache.carbondata.core.constants.CarbonCommonConstants;
-import org.apache.carbondata.core.datastore.impl.FileFactory;
-import org.apache.carbondata.core.util.path.CarbonTablePath;
 import org.apache.carbondata.format.FileFooter3;
 
-import org.apache.hadoop.conf.Configuration;
 import org.apache.thrift.TBase;
 
 /**

--- a/core/src/main/java/org/apache/carbondata/core/reader/CarbonFooterReaderV3.java
+++ b/core/src/main/java/org/apache/carbondata/core/reader/CarbonFooterReaderV3.java
@@ -17,11 +17,11 @@
 
 package org.apache.carbondata.core.reader;
 
-import java.io.DataInputStream;
 import java.io.IOException;
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.datastore.impl.FileFactory;
+import org.apache.carbondata.core.util.path.CarbonTablePath;
 import org.apache.carbondata.format.FileFooter3;
 
 import org.apache.hadoop.conf.Configuration;
@@ -36,15 +36,11 @@ public class CarbonFooterReaderV3 {
   //Fact file path
   private String filePath;
 
-  // size of the file
-  private long fileSize;
-
   //start offset of the file footer
   private long footerOffset;
 
-  public CarbonFooterReaderV3(String filePath, long fileSize, long offset) {
+  public CarbonFooterReaderV3(String filePath, long offset) {
     this.filePath = filePath;
-    this.fileSize = fileSize;
     this.footerOffset = offset;
   }
 
@@ -57,21 +53,6 @@ public class CarbonFooterReaderV3 {
   public FileFooter3 readFooterVersion3() throws IOException {
     ThriftReader thriftReader = openThriftReader(filePath);
     thriftReader.open();
-
-    // If footer offset is 0, means caller does not set it,
-    // so we read it from the end of the file
-    if (footerOffset == 0) {
-      Configuration conf = FileFactory.getConfiguration();
-      try (DataInputStream reader = FileFactory.getDataInputStream(filePath, conf)) {
-        long skipBytes = fileSize - CarbonCommonConstants.LONG_SIZE_IN_BYTE;
-        long skipped = reader.skip(skipBytes);
-        if (skipped != skipBytes) {
-          throw new IOException(String.format(
-              "expect skip %d bytes, but actually skipped %d bytes", skipBytes, skipped));
-        }
-        footerOffset = reader.readLong();
-      }
-    }
 
     // Set the offset from where it should read
     thriftReader.setReadOffset(footerOffset);

--- a/core/src/main/java/org/apache/carbondata/core/reader/CarbonIndexFileReader.java
+++ b/core/src/main/java/org/apache/carbondata/core/reader/CarbonIndexFileReader.java
@@ -112,5 +112,4 @@ public class CarbonIndexFileReader {
   public boolean hasNext() throws IOException {
     return thriftReader.hasNext();
   }
-
 }

--- a/core/src/main/java/org/apache/carbondata/core/reader/CarbonIndexFileReader.java
+++ b/core/src/main/java/org/apache/carbondata/core/reader/CarbonIndexFileReader.java
@@ -113,33 +113,4 @@ public class CarbonIndexFileReader {
     return thriftReader.hasNext();
   }
 
-  /**
-   * Return the footer offset of the given dataFileName in the index file
-   *
-   * @param indexFilePath path of the index file
-   * @param dataFileName file name of the data file to match in the index file
-   * @param conf hadoop configuration
-   * @return footer offset of the data file
-   * @throws IOException
-   */
-  public static long readFooterOffsetFromIndexFile(String indexFilePath, String dataFileName,
-      Configuration conf) throws IOException {
-    CarbonIndexFileReader indexReader = new CarbonIndexFileReader(conf);
-    try {
-      // open the reader
-      indexReader.openThriftReader(indexFilePath);
-      // read the index header and ignore it
-      indexReader.readIndexHeader();
-      // read the block info from file and find the footer offset
-      while (indexReader.hasNext()) {
-        BlockIndex blockIndex = indexReader.readBlockIndexInfo();
-        if (blockIndex.getFile_name().equals(dataFileName)) {
-          return blockIndex.getOffset();
-        }
-      }
-    } finally {
-      indexReader.closeThriftReader();
-    }
-    return -1;
-  }
 }

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
@@ -40,13 +40,11 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.cache.dictionary.Dictionary;
@@ -110,13 +108,11 @@ import org.apache.carbondata.core.statusmanager.SegmentStatus;
 import org.apache.carbondata.core.statusmanager.SegmentStatusManager;
 import org.apache.carbondata.core.statusmanager.SegmentUpdateStatusManager;
 import org.apache.carbondata.core.util.path.CarbonTablePath;
-import org.apache.carbondata.format.BlockIndex;
 import org.apache.carbondata.format.BlockletHeader;
 import org.apache.carbondata.format.DataChunk2;
 import org.apache.carbondata.format.DataChunk3;
 import org.apache.carbondata.format.IndexHeader;
 
-import com.google.common.collect.Lists;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import org.apache.commons.codec.binary.Base64;

--- a/core/src/main/java/org/apache/carbondata/core/util/DataFileFooterConverterV3.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/DataFileFooterConverterV3.java
@@ -64,8 +64,7 @@ public class DataFileFooterConverterV3 extends AbstractDataFileFooterConverter {
     CarbonHeaderReader carbonHeaderReader = new CarbonHeaderReader(tableBlockInfo.getFilePath());
     FileHeader fileHeader = carbonHeaderReader.readHeader();
     CarbonFooterReaderV3 reader =
-        new CarbonFooterReaderV3(tableBlockInfo.getFilePath(), tableBlockInfo.getBlockLength(),
-            tableBlockInfo.getBlockOffset());
+        new CarbonFooterReaderV3(tableBlockInfo.getFilePath(), tableBlockInfo.getBlockOffset());
     FileFooter3 footer = reader.readFooterVersion3();
     return convertDataFileFooter(fileHeader, footer);
   }

--- a/core/src/main/java/org/apache/carbondata/core/util/path/CarbonTablePath.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/path/CarbonTablePath.java
@@ -714,4 +714,16 @@ public class CarbonTablePath {
           CarbonCommonConstants.FILE_SEPARATOR + taskNo;
     }
   }
+
+  /**
+   * Return the parent path of the input file
+   */
+  public static String getParentPath(String dataFilePath) {
+    int endIndex = dataFilePath.lastIndexOf(CarbonCommonConstants.FILE_SEPARATOR);
+    if (endIndex > -1) {
+      return dataFilePath.substring(0, endIndex);
+    } else {
+      return dataFilePath;
+    }
+  }
 }

--- a/core/src/main/java/org/apache/carbondata/core/util/path/CarbonTablePath.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/path/CarbonTablePath.java
@@ -716,7 +716,9 @@ public class CarbonTablePath {
   }
 
   /**
-   * Return the parent path of the input file
+   * Return the parent path of the input file.
+   * For example, if input file path is /user/warehouse/t1/file.carbondata
+   * then return will be /user/warehouse/t1
    */
   public static String getParentPath(String dataFilePath) {
     int endIndex = dataFilePath.lastIndexOf(CarbonCommonConstants.FILE_SEPARATOR);

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestCreateTableWithBlockletSize.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestCreateTableWithBlockletSize.scala
@@ -61,8 +61,7 @@ class TestCreateTableWithBlockletSize extends QueryTest with BeforeAndAfterAll {
         .getFileHolder(FileFactory.getFileType(dataFile.getPath))
       val buffer = fileReader
         .readByteBuffer(FileFactory.getUpdatedFilePath(dataFile.getPath), dataFile.getSize - 8, 8)
-      val footerReader = new CarbonFooterReaderV3(
-        dataFile.getAbsolutePath, dataFile.getSize, buffer.getLong)
+      val footerReader = new CarbonFooterReaderV3(dataFile.getAbsolutePath, buffer.getLong)
       val footer = footerReader.readFooterVersion3
       assertResult(2)(footer.blocklet_index_list.size)
       assertResult(2)(footer.blocklet_info_list3.size)

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestNonTransactionalCarbonTable.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestNonTransactionalCarbonTable.scala
@@ -2575,8 +2575,7 @@ class TestNonTransactionalCarbonTable extends QueryTest with BeforeAndAfterAll {
         .getFileHolder(FileFactory.getFileType(dataFile.getPath))
       val buffer = fileReader
         .readByteBuffer(FileFactory.getUpdatedFilePath(dataFile.getPath), dataFile.getSize - 8, 8)
-      val footerReader = new CarbonFooterReaderV3(
-        dataFile.getAbsolutePath, dataFile.getSize, buffer.getLong)
+      val footerReader = new CarbonFooterReaderV3(dataFile.getAbsolutePath, buffer.getLong)
       val footer = footerReader.readFooterVersion3
       // without page_size configuration there will be only 1 page, now it will be more.
       assert(footer.getBlocklet_info_list3.get(0).number_number_of_pages != 1)

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonInsertFromStageCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonInsertFromStageCommand.scala
@@ -216,16 +216,14 @@ case class CarbonInsertFromStageCommand(
           }.map { future =>
             future.get()
           }
-        case SegmentStatus.INSERT_IN_PROGRESS =>
+        case other =>
           // delete entry in table status and load again
-          LOGGER.info(s"Segment $segmentId is in INSERT_IN_PROGRESS state, about to delete the " +
+          LOGGER.warn(s"Segment $segmentId is in $other state, about to delete the " +
                       s"segment entry and load again")
           val segmentToWrite = segments.filterNot(_.getLoadName.equals(segmentId))
           SegmentStatusManager.writeLoadDetailsIntoFile(
             CarbonTablePath.getTableStatusFilePath(table.getTablePath),
             segmentToWrite)
-        case other =>
-          throw new RuntimeException(s"Segment $segmentId is in unexpected state: $other")
       }
     } finally {
       if (lock != null) {

--- a/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonSchemaReader.java
+++ b/store/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonSchemaReader.java
@@ -320,7 +320,7 @@ public class CarbonSchemaReader {
         fileReader.readByteBuffer(FileFactory.getUpdatedFilePath(dataFilePath), fileSize - 8, 8);
     fileReader.finish();
     CarbonFooterReaderV3 footerReader =
-        new CarbonFooterReaderV3(dataFilePath, fileSize, buffer.getLong());
+        new CarbonFooterReaderV3(dataFilePath, buffer.getLong());
     FileFooter3 footer = footerReader.readFooterVersion3();
     if (null != footer.getExtra_info()) {
       return footer.getExtra_info().get(CarbonCommonConstants.CARBON_WRITTEN_BY_FOOTER_INFO)

--- a/store/sdk/src/test/java/org/apache/carbondata/sdk/file/CSVCarbonWriterTest.java
+++ b/store/sdk/src/test/java/org/apache/carbondata/sdk/file/CSVCarbonWriterTest.java
@@ -428,7 +428,7 @@ public class CSVCarbonWriterTest {
           dataFile.getPath()), dataFile.getSize() - 8, 8);
       fileReader.finish();
       CarbonFooterReaderV3 footerReader =
-          new CarbonFooterReaderV3(dataFile.getAbsolutePath(), dataFile.getSize(), buffer.getLong());
+          new CarbonFooterReaderV3(dataFile.getAbsolutePath(), buffer.getLong());
       FileFooter3 footer = footerReader.readFooterVersion3();
       Assert.assertEquals(2, footer.blocklet_index_list.size());
       Assert.assertEquals(2, footer.blocklet_info_list3.size());

--- a/tools/cli/src/main/java/org/apache/carbondata/tool/DataFile.java
+++ b/tools/cli/src/main/java/org/apache/carbondata/tool/DataFile.java
@@ -170,7 +170,7 @@ class DataFile {
     this.footerOffset = buffer.getLong();
     this.footerSizeInBytes = this.fileSizeInBytes - footerOffset;
     CarbonFooterReaderV3 footerReader =
-        new CarbonFooterReaderV3(dataFile.getAbsolutePath(), dataFile.getSize(), footerOffset);
+        new CarbonFooterReaderV3(dataFile.getAbsolutePath(), footerOffset);
     return footerReader.readFooterVersion3();
   }
 


### PR DESCRIPTION
 ### Why is this PR needed?
 There are 2 issues:
1. INSERT STAGE will skip bytes to read the last long in the carbondata file as the offset to the footer, but sometimes DFS is not skipping the right byte size
2. When error occurs, segment status is not in SUCCESS state, but recovery handling is not doing correctly in  INSERT STAGE command
 
 ### What changes were proposed in this PR?
1. In CarbonFooterReaderV3.readFooterVersion3, if offset is not set by caller, read it from corresponding index file.
2. In CarbonInsertFromStageCommand, when recovery is required, delete the segment entry if the entry is not in SUCESS state.
    
 ### Does this PR introduce any user interface change?
No


 ### Is any new testcase added?
No


    
