### PR TITLE
[CARBONDATA-3653] Support huge data for complex child columns

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/LazyColumnPage.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/LazyColumnPage.java
@@ -179,7 +179,7 @@ public class LazyColumnPage extends ColumnPage {
   }
 
   @Override
-  public byte[] getComplexChildrenLVFlattenedBytePage() {
+  public byte[] getComplexChildrenLVFlattenedBytePage(DataType dataType) {
     throw new UnsupportedOperationException("internal error");
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/LocalDictColumnPage.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/LocalDictColumnPage.java
@@ -28,6 +28,7 @@ import org.apache.carbondata.core.keygenerator.factory.KeyGeneratorFactory;
 import org.apache.carbondata.core.localdictionary.PageLevelDictionary;
 import org.apache.carbondata.core.localdictionary.exception.DictionaryThresholdReachedException;
 import org.apache.carbondata.core.localdictionary.generator.LocalDictionaryGenerator;
+import org.apache.carbondata.core.metadata.datatype.DataType;
 
 import org.apache.log4j.Logger;
 
@@ -364,11 +365,11 @@ public class LocalDictColumnPage extends ColumnPage {
   }
 
   @Override
-  public byte[] getComplexChildrenLVFlattenedBytePage() throws IOException {
+  public byte[] getComplexChildrenLVFlattenedBytePage(DataType dataType) throws IOException {
     if (null != encodedDataColumnPage) {
-      return encodedDataColumnPage.getComplexChildrenLVFlattenedBytePage();
+      return encodedDataColumnPage.getComplexChildrenLVFlattenedBytePage(dataType);
     } else {
-      return actualDataColumnPage.getComplexChildrenLVFlattenedBytePage();
+      return actualDataColumnPage.getComplexChildrenLVFlattenedBytePage(dataType);
     }
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/SafeFixLengthColumnPage.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/SafeFixLengthColumnPage.java
@@ -296,7 +296,7 @@ public class SafeFixLengthColumnPage extends ColumnPage {
   }
 
   @Override
-  public byte[] getComplexChildrenLVFlattenedBytePage() throws IOException {
+  public byte[] getComplexChildrenLVFlattenedBytePage(DataType dataType) throws IOException {
     ByteArrayOutputStream stream = new ByteArrayOutputStream();
     DataOutputStream out = new DataOutputStream(stream);
     for (int i = 0; i < arrayElementCount; i++) {

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/SafeVarLengthColumnPage.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/SafeVarLengthColumnPage.java
@@ -25,6 +25,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.carbondata.core.datastore.page.encoding.ColumnPageEncoderMeta;
+import org.apache.carbondata.core.metadata.datatype.DataType;
+import org.apache.carbondata.core.util.DataTypeUtil;
 
 public class SafeVarLengthColumnPage extends VarLengthColumnPageBase {
 
@@ -88,11 +90,15 @@ public class SafeVarLengthColumnPage extends VarLengthColumnPageBase {
   }
 
   @Override
-  public byte[] getComplexChildrenLVFlattenedBytePage() throws IOException {
+  public byte[] getComplexChildrenLVFlattenedBytePage(DataType dataType) throws IOException {
     ByteArrayOutputStream stream = new ByteArrayOutputStream();
     DataOutputStream out = new DataOutputStream(stream);
     for (byte[] byteArrayDatum : byteArrayData) {
-      out.writeShort((short)byteArrayDatum.length);
+      if (DataTypeUtil.isByteArrayComplexChildColumn(dataType)) {
+        out.writeInt(byteArrayDatum.length);
+      } else {
+        out.writeShort((short) byteArrayDatum.length);
+      }
       out.write(byteArrayDatum);
     }
     return stream.toByteArray();

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/UnsafeFixLengthColumnPage.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/UnsafeFixLengthColumnPage.java
@@ -24,6 +24,7 @@ import org.apache.carbondata.core.memory.CarbonUnsafe;
 import org.apache.carbondata.core.memory.MemoryBlock;
 import org.apache.carbondata.core.memory.MemoryException;
 import org.apache.carbondata.core.memory.UnsafeMemoryManager;
+import org.apache.carbondata.core.metadata.datatype.DataType;
 import org.apache.carbondata.core.metadata.datatype.DataTypes;
 import org.apache.carbondata.core.util.ByteUtil;
 import org.apache.carbondata.core.util.ThreadLocalTaskInfo;
@@ -396,7 +397,7 @@ public class UnsafeFixLengthColumnPage extends ColumnPage {
   }
 
   @Override
-  public byte[] getComplexChildrenLVFlattenedBytePage() {
+  public byte[] getComplexChildrenLVFlattenedBytePage(DataType dataType) {
     byte[] data = new byte[totalLength];
     CarbonUnsafe.getUnsafe()
         .copyMemory(baseAddress, baseOffset, data, CarbonUnsafe.BYTE_ARRAY_OFFSET, totalLength);

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/ColumnPageEncoder.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/ColumnPageEncoder.java
@@ -194,6 +194,11 @@ public abstract class ColumnPageEncoder {
     while (index < input.getComplexColumnIndex()) {
       ColumnPage subColumnPage = input.getColumnPage(index);
       encodedPages[index] = encodedColumn(subColumnPage);
+      // by default add this encoding,
+      // it is used for checking length of
+      // complex child byte array columns (short and int)
+      encodedPages[index].getPageMetadata().getEncoders()
+          .add(Encoding.INT_LENGTH_COMPLEX_CHILD_BYTE_ARRAY);
       index++;
     }
     return encodedPages;

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/EncodingFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/EncodingFactory.java
@@ -83,6 +83,8 @@ public abstract class EncodingFactory {
       String compressor, boolean fullVectorFill) throws IOException {
     assert (encodings.size() >= 1);
     assert (encoderMetas.size() == 1);
+    boolean isComplexPrimitiveIntLengthEncoding =
+        encodings.contains(Encoding.INT_LENGTH_COMPLEX_CHILD_BYTE_ARRAY);
     Encoding encoding = encodings.get(0);
     byte[] encoderMeta = encoderMetas.get(0).array();
     ByteArrayInputStream stream = new ByteArrayInputStream(encoderMeta);
@@ -91,7 +93,10 @@ public abstract class EncodingFactory {
       ColumnPageEncoderMeta metadata = new ColumnPageEncoderMeta();
       metadata.setFillCompleteVector(fullVectorFill);
       metadata.readFields(in);
-      return new DirectCompressCodec(metadata.getStoreDataType()).createDecoder(metadata);
+      DirectCompressCodec directCompressCodec =
+          new DirectCompressCodec(metadata.getStoreDataType());
+      directCompressCodec.setComplexPrimitiveIntLengthEncoding(isComplexPrimitiveIntLengthEncoding);
+      return directCompressCodec.createDecoder(metadata);
     } else if (encoding == ADAPTIVE_INTEGRAL) {
       ColumnPageEncoderMeta metadata = new ColumnPageEncoderMeta();
       metadata.setFillCompleteVector(fullVectorFill);

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/adaptive/AdaptiveDeltaFloatingCodec.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/adaptive/AdaptiveDeltaFloatingCodec.java
@@ -128,7 +128,7 @@ public class AdaptiveDeltaFloatingCodec extends AdaptiveCodec {
       @Override
       public ColumnPage decode(byte[] input, int offset, int length)
           throws MemoryException, IOException {
-        ColumnPage page = ColumnPage.decompress(meta, input, offset, length, false);
+        ColumnPage page = ColumnPage.decompress(meta, input, offset, length, false, false);
         return LazyColumnPage.newPage(page, converter);
       }
 

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/adaptive/AdaptiveDeltaIntegralCodec.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/adaptive/AdaptiveDeltaIntegralCodec.java
@@ -139,7 +139,7 @@ public class AdaptiveDeltaIntegralCodec extends AdaptiveCodec {
         if (DataTypes.isDecimal(meta.getSchemaDataType())) {
           page = ColumnPage.decompressDecimalPage(meta, input, offset, length);
         } else {
-          page = ColumnPage.decompress(meta, input, offset, length, false);
+          page = ColumnPage.decompress(meta, input, offset, length, false, false);
         }
         return LazyColumnPage.newPage(page, converter);
       }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/adaptive/AdaptiveFloatingCodec.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/adaptive/AdaptiveFloatingCodec.java
@@ -116,7 +116,7 @@ public class AdaptiveFloatingCodec extends AdaptiveCodec {
       @Override
       public ColumnPage decode(byte[] input, int offset, int length)
           throws MemoryException, IOException {
-        ColumnPage page = ColumnPage.decompress(meta, input, offset, length, false);
+        ColumnPage page = ColumnPage.decompress(meta, input, offset, length, false, false);
         return LazyColumnPage.newPage(page, converter);
       }
 

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/adaptive/AdaptiveIntegralCodec.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/adaptive/AdaptiveIntegralCodec.java
@@ -116,7 +116,7 @@ public class AdaptiveIntegralCodec extends AdaptiveCodec {
         if (DataTypes.isDecimal(meta.getSchemaDataType())) {
           page = ColumnPage.decompressDecimalPage(meta, input, offset, length);
         } else {
-          page = ColumnPage.decompress(meta, input, offset, length, false);
+          page = ColumnPage.decompress(meta, input, offset, length, false, false);
         }
         return LazyColumnPage.newPage(page, converter);
       }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/compress/DirectCompressCodec.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/compress/DirectCompressCodec.java
@@ -58,6 +58,12 @@ public class DirectCompressCodec implements ColumnPageCodec {
     this.dataType = dataType;
   }
 
+  boolean isComplexPrimitiveIntLengthEncoding = false;
+
+  public void setComplexPrimitiveIntLengthEncoding(boolean complexPrimitiveIntLengthEncoding) {
+    isComplexPrimitiveIntLengthEncoding = complexPrimitiveIntLengthEncoding;
+  }
+
   @Override
   public String getName() {
     return "DirectCompressCodec";
@@ -102,7 +108,8 @@ public class DirectCompressCodec implements ColumnPageCodec {
         if (DataTypes.isDecimal(dataType)) {
           decodedPage = ColumnPage.decompressDecimalPage(meta, input, offset, length);
         } else {
-          decodedPage = ColumnPage.decompress(meta, input, offset, length, false);
+          decodedPage = ColumnPage
+              .decompress(meta, input, offset, length, false, isComplexPrimitiveIntLengthEncoding);
         }
         return LazyColumnPage.newPage(decodedPage, converter);
       }
@@ -150,8 +157,9 @@ public class DirectCompressCodec implements ColumnPageCodec {
       @Override
       public ColumnPage decode(byte[] input, int offset, int length, boolean isLVEncoded)
           throws MemoryException, IOException {
-        return LazyColumnPage
-            .newPage(ColumnPage.decompress(meta, input, offset, length, isLVEncoded), converter);
+        return LazyColumnPage.newPage(ColumnPage
+            .decompress(meta, input, offset, length, isLVEncoded,
+                isComplexPrimitiveIntLengthEncoding), converter);
       }
     };
   }

--- a/core/src/main/java/org/apache/carbondata/core/metadata/converter/ThriftWrapperSchemaConverterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/converter/ThriftWrapperSchemaConverterImpl.java
@@ -120,6 +120,8 @@ public class ThriftWrapperSchemaConverterImpl implements SchemaConverter {
         return org.apache.carbondata.format.Encoding.BIT_PACKED;
       case DIRECT_DICTIONARY:
         return org.apache.carbondata.format.Encoding.DIRECT_DICTIONARY;
+      case INT_LENGTH_COMPLEX_CHILD_BYTE_ARRAY:
+        return org.apache.carbondata.format.Encoding.INT_LENGTH_COMPLEX_CHILD_BYTE_ARRAY;
       default:
         return org.apache.carbondata.format.Encoding.DICTIONARY;
     }
@@ -457,6 +459,8 @@ public class ThriftWrapperSchemaConverterImpl implements SchemaConverter {
         return Encoding.DIRECT_COMPRESS_VARCHAR;
       case BIT_PACKED:
         return Encoding.BIT_PACKED;
+      case INT_LENGTH_COMPLEX_CHILD_BYTE_ARRAY:
+        return Encoding.INT_LENGTH_COMPLEX_CHILD_BYTE_ARRAY;
       case DIRECT_DICTIONARY:
         return Encoding.DIRECT_DICTIONARY;
       default:

--- a/core/src/main/java/org/apache/carbondata/core/metadata/encoder/Encoding.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/encoder/Encoding.java
@@ -38,7 +38,8 @@ public enum Encoding {
   ADAPTIVE_FLOATING,
   BOOL_BYTE,
   ADAPTIVE_DELTA_FLOATING,
-  DIRECT_COMPRESS_VARCHAR;
+  DIRECT_COMPRESS_VARCHAR,
+  INT_LENGTH_COMPLEX_CHILD_BYTE_ARRAY;
 
   public static Encoding valueOf(int ordinal) {
     if (ordinal == DICTIONARY.ordinal()) {
@@ -73,6 +74,8 @@ public enum Encoding {
       return ADAPTIVE_DELTA_FLOATING;
     } else if (ordinal == DIRECT_COMPRESS_VARCHAR.ordinal()) {
       return DIRECT_COMPRESS_VARCHAR;
+    } else if (ordinal == INT_LENGTH_COMPLEX_CHILD_BYTE_ARRAY.ordinal()) {
+      return INT_LENGTH_COMPLEX_CHILD_BYTE_ARRAY;
     } else {
       throw new RuntimeException("create Encoding with invalid ordinal: " + ordinal);
     }

--- a/core/src/main/java/org/apache/carbondata/core/scan/complextypes/PrimitiveQueryType.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/complextypes/PrimitiveQueryType.java
@@ -107,7 +107,11 @@ public class PrimitiveQueryType extends ComplexQueryType implements GenericQuery
     byte[] currentVal =
         copyBlockDataChunk(rawColumnChunks, dimensionColumnPages, rowNumber, pageNumber);
     if (!this.isDictionary && !this.isDirectDictionary) {
-      dataOutputStream.writeShort(currentVal.length);
+      if (DataTypeUtil.isByteArrayComplexChildColumn(dataType)) {
+        dataOutputStream.writeInt(currentVal.length);
+      } else {
+        dataOutputStream.writeShort(currentVal.length);
+      }
     }
     dataOutputStream.write(currentVal);
   }
@@ -158,7 +162,12 @@ public class PrimitiveQueryType extends ComplexQueryType implements GenericQuery
       actualData = directDictionaryGenerator.getValueFromSurrogate(surrgateValue);
     } else if (!isDictionary) {
       if (size == -1) {
-        size = dataBuffer.getShort();
+        if (DataTypeUtil.isByteArrayComplexChildColumn(dataType)) {
+          size = dataBuffer.getInt();
+        } else {
+          size = dataBuffer.getShort();
+        }
+
       }
       byte[] value = new byte[size];
       dataBuffer.get(value, 0, size);

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
@@ -3225,6 +3225,7 @@ public final class CarbonUtil {
         case ADAPTIVE_DELTA_INTEGRAL:
         case ADAPTIVE_FLOATING:
         case ADAPTIVE_DELTA_FLOATING:
+        case INT_LENGTH_COMPLEX_CHILD_BYTE_ARRAY:
           return true;
       }
     }

--- a/core/src/main/java/org/apache/carbondata/core/util/DataTypeUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/DataTypeUtil.java
@@ -1125,4 +1125,18 @@ public final class DataTypeUtil {
     return false;
   }
 
+  /**
+   * utility function to check complex column child columns that can exceed 32000 length
+   *
+   * @param dataType
+   * @return
+   */
+  public static boolean isByteArrayComplexChildColumn(DataType dataType) {
+    return ((dataType == DataTypes.STRING) ||
+        (dataType == DataTypes.VARCHAR) ||
+        (dataType == DataTypes.BINARY) ||
+        (dataType == DataTypes.DATE) ||
+        DataTypes.isDecimal(dataType) ||
+        (dataType == DataTypes.BYTE_ARRAY));
+  }
 }

--- a/format/src/main/thrift/schema.thrift
+++ b/format/src/main/thrift/schema.thrift
@@ -62,6 +62,7 @@ enum Encoding{
 	BOOL_BYTE = 12;   // Identifies that a column is encoded using BooleanPageCodec
 	ADAPTIVE_DELTA_FLOATING = 13; // Identifies that a column is encoded using AdaptiveDeltaFloatingCodec
 	DIRECT_COMPRESS_VARCHAR = 14;  // Identifies that a columm is encoded using DirectCompressCodec, it is used for long string columns
+	INT_LENGTH_COMPLEX_CHILD_BYTE_ARRAY = 15;  // Identifies that a complex column child stored as INT length or SHORT length
 }
 
 // Only NATIVE_HIVE is supported, others are deprecated since CarbonData 2.0

--- a/store/sdk/src/test/java/org/apache/carbondata/sdk/file/ImageTest.java
+++ b/store/sdk/src/test/java/org/apache/carbondata/sdk/file/ImageTest.java
@@ -33,6 +33,7 @@ import org.apache.carbondata.util.BinaryUtil;
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.mapreduce.InputSplit;
 import org.junit.Assert;
 import org.junit.Test;
@@ -1164,6 +1165,46 @@ public class ImageTest extends TestCase {
       Object[] structResult = (Object[]) row[2];
       assert (new String((byte[]) arrayResult[0]).equalsIgnoreCase("binary1"));
       assert (new String((byte[]) structResult[0]).equalsIgnoreCase("binary2"));
+    }
+    reader.close();
+  }
+
+  @Test public void testHugeBinaryWithComplexType()
+      throws IOException, InvalidLoadOptionException, InterruptedException {
+    int num = 1;
+    int rows = 1;
+    String path = "./target/binary";
+    try {
+      FileUtils.deleteDirectory(new File(path));
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+    Field[] fields = new Field[2];
+    fields[0] = new Field("arrayField", DataTypes.createArrayType(DataTypes.BINARY));
+    ArrayList<StructField> structFields = new ArrayList<>();
+    structFields.add(new StructField("b", DataTypes.BINARY));
+    fields[1] = new Field("structField", DataTypes.createStructType(structFields));
+
+    String description = RandomStringUtils.randomAlphabetic(33000);
+
+    // read and write image data
+    for (int j = 0; j < num; j++) {
+      CarbonWriter writer = CarbonWriter.builder().outputPath(path).withCsvInput(new Schema(fields))
+          .writtenBy("BinaryExample").withPageSizeInMb(5).build();
+
+      for (int i = 0; i < rows; i++) {
+        // write data
+        writer.write(new String[] { description, description });
+      }
+      writer.close();
+    }
+    CarbonReader reader = CarbonReader.builder(path, "_temp").build();
+    while (reader.hasNext()) {
+      Object[] row = (Object[]) reader.readNextRow();
+      Object[] arrayResult = (Object[]) row[0];
+      Object[] structResult = (Object[]) row[1];
+      assert (new String((byte[]) arrayResult[0]).equalsIgnoreCase(description));
+      assert (new String((byte[]) structResult[0]).equalsIgnoreCase(description));
     }
     reader.close();
   }


### PR DESCRIPTION
 ### Why is this PR needed?
 Currently complex child columns string and binary is stored as short length. So, if the data is more than 32000 characters. Data load will fail for binary and long string columns.

 ### What changes were proposed in this PR?
complex child columns string, binary, decimal, date is stored as byte_array page with short length. Changed it to int length. [Just separating string and binary is hard now, to do in future]
Handled compatibility by introducing the new encoding type for complex child columns

 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
