### PR TITLE
[CARBONDATA-3662]: Changes to show metacache command

### DIFF
--- a/docs/ddl-of-carbondata.md
+++ b/docs/ddl-of-carbondata.md
@@ -1027,6 +1027,14 @@ Users can specify which columns to include and exclude for local dictionary gene
   datamaps. This also shows the cache usage by all the tables and children tables in the current 
   database.
   
+   ```sql
+    SHOW EXECUTOR METACACHE
+   ``` 
+    
+   This shows the overall memory consumed by the cache in each executor of the Index
+   Server. This command is only allowed when the carbon property `carbon.enable.index.server` 
+   is set to true.
+  
   ```sql
   SHOW METACACHE ON TABLE tableName
   ```

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/sql/commands/TestCarbonShowCacheCommand.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/sql/commands/TestCarbonShowCacheCommand.scala
@@ -179,13 +179,12 @@ class TestCarbonShowCacheCommand extends QueryTest with BeforeAndAfterAll {
     // Empty database
     sql("use cache_empty_db").collect()
     val result1 = sql("show metacache").collect()
-    assertResult(2)(result1.length)
-    assertResult(Row("cache_empty_db", "ALL", "0 B", "0 B", "0 B", "DRIVER"))(result1(1))
+    assertResult(0)(result1.length)
 
     // Database with 3 tables but only 2 are in cache
     sql("use cache_db").collect()
     val result2 = sql("show metacache").collect()
-    assertResult(4)(result2.length)
+    assertResult(3)(result2.length)
 
     // Make sure PreAgg tables are not in SHOW METADATA
     sql("use default").collect()

--- a/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
+++ b/integration/spark-common/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
@@ -119,6 +119,7 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
   protected val WITH = carbonKeyWord("WITH")
   protected val AGGREGATETABLE = carbonKeyWord("AGGREGATETABLE")
   protected val ABS = carbonKeyWord("abs")
+  protected val EXECUTOR = carbonKeyWord("EXECUTOR")
 
   protected val FOR = carbonKeyWord("FOR")
   protected val SCRIPTS = carbonKeyWord("SCRIPTS")

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSpark2SqlParser.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSpark2SqlParser.scala
@@ -549,9 +549,9 @@ class CarbonSpark2SqlParser extends CarbonDDLSqlParser {
     }
 
   protected lazy val showCache: Parser[LogicalPlan] =
-    SHOW ~> METACACHE ~> opt(ontable) <~ opt(";") ^^ {
-      case table =>
-        CarbonShowCacheCommand(table)
+    (SHOW ~> opt(EXECUTOR) <~ METACACHE) ~ opt(ontable) <~ opt(";") ^^ {
+      case (executor ~ table) =>
+        CarbonShowCacheCommand(executor.isDefined, table)
     }
 
   protected lazy val dropCache: Parser[LogicalPlan] =


### PR DESCRIPTION
 ### Why is this PR needed?
1. There is no command to show the cache occupied by each of the executors(only applicable for index server). 
This command will not show per table, only per node
Example:
Driver - X bytes
Executor1 - Y bytes
Executor2 - Z bytes
  
2. Show metacache command does not show the complete cache used used by IndexServer side and Driver side. It just shows the total of both of them.
 
 ### What changes were proposed in this PR?
 1. To change *show metacache* command to *show executor metacache*, where the "executor" keyword is optional.
2.  Added TOTAL cache value separately for Index Server and Driver.
    
 ### Does this PR introduce any user interface change?
 - No
 - Yes. (please explain the change and update document)

 ### Is any new testcase added?
 - No
 - Yes

    
