### PR TITLE
[CARBONDATA-3657]Support alter hive table add columns with complex types

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/util/DataTypeUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/DataTypeUtil.java
@@ -1044,47 +1044,10 @@ public final class DataTypeUtil {
    * @return returns the datatype based on the input string from json to deserialize the tableInfo
    */
   public static DataType valueOf(DataType dataType, int precision, int scale) {
-    if (DataTypes.STRING.getName().equalsIgnoreCase(dataType.getName())) {
-      return DataTypes.STRING;
-    } else if (DataTypes.DATE.getName().equalsIgnoreCase(dataType.getName())) {
-      return DataTypes.DATE;
-    } else if (DataTypes.TIMESTAMP.getName().equalsIgnoreCase(dataType.getName())) {
-      return DataTypes.TIMESTAMP;
-    } else if (DataTypes.BOOLEAN.getName().equalsIgnoreCase(dataType.getName())) {
-      return DataTypes.BOOLEAN;
-    } else if (DataTypes.BYTE.getName().equalsIgnoreCase(dataType.getName())) {
-      return DataTypes.BYTE;
-    } else if (DataTypes.SHORT.getName().equalsIgnoreCase(dataType.getName())) {
-      return DataTypes.SHORT;
-    } else if (DataTypes.SHORT_INT.getName().equalsIgnoreCase(dataType.getName())) {
-      return DataTypes.SHORT_INT;
-    } else if (DataTypes.INT.getName().equalsIgnoreCase(dataType.getName())) {
-      return DataTypes.INT;
-    } else if (DataTypes.LONG.getName().equalsIgnoreCase(dataType.getName())) {
-      return DataTypes.LONG;
-    } else if (DataTypes.FLOAT.getName().equalsIgnoreCase(dataType.getName())) {
-      return DataTypes.FLOAT;
-    } else if (DataTypes.DOUBLE.getName().equalsIgnoreCase(dataType.getName())) {
-      return DataTypes.DOUBLE;
-    } else if (DataTypes.VARCHAR.getName().equalsIgnoreCase(dataType.getName())) {
-      return DataTypes.VARCHAR;
-    } else if (DataTypes.NULL.getName().equalsIgnoreCase(dataType.getName())) {
-      return DataTypes.NULL;
-    } else if (DataTypes.BYTE_ARRAY.getName().equalsIgnoreCase(dataType.getName())) {
-      return DataTypes.BYTE_ARRAY;
-    } else if (DataTypes.BINARY.getName().equalsIgnoreCase(dataType.getName())) {
-      return DataTypes.BINARY;
-    } else if (dataType.getName().equalsIgnoreCase("decimal")) {
+    if (DataTypes.isDecimal(dataType)) {
       return DataTypes.createDecimalType(precision, scale);
-    } else if (dataType.getName().equalsIgnoreCase("array")) {
-      return DataTypes.createDefaultArrayType();
-    } else if (dataType.getName().equalsIgnoreCase("struct")) {
-      return DataTypes.createDefaultStructType();
-    } else if (dataType.getName().equalsIgnoreCase("map")) {
-      return DataTypes.createDefaultMapType();
     } else {
-      throw new RuntimeException(
-          "create DataType with invalid dataType.getName(): " + dataType.getName());
+      return valueOf(dataType.getName());
     }
   }
 

--- a/integration/spark-common-cluster-test/src/test/scala/org/apache/carbondata/cluster/sdv/suite/SDVSuites.scala
+++ b/integration/spark-common-cluster-test/src/test/scala/org/apache/carbondata/cluster/sdv/suite/SDVSuites.scala
@@ -168,8 +168,7 @@ class SDVSuites4 extends Suites with BeforeAndAfterAll {
 class SDVSuites5 extends Suites with BeforeAndAfterAll {
 
   val suites = new CreateTableUsingSparkCarbonFileFormatTestCase ::
-               new SparkCarbonDataSourceTestCase ::
-               new CarbonV1toV3CompatabilityTestCase :: Nil
+               new SparkCarbonDataSourceTestCase :: Nil
 
   override val nestedSuites = suites.toIndexedSeq
 

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/DataTypeConverterUtil.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/DataTypeConverterUtil.scala
@@ -17,12 +17,13 @@
 
 package org.apache.carbondata.spark.util
 
+import scala.collection.JavaConverters._
+
 import org.apache.spark.sql.execution.command.Field
 import org.apache.spark.sql.util.CarbonException
+
 import org.apache.carbondata.core.metadata.datatype.{ArrayType, DataType, DataTypes, DecimalType, MapType, StructField, StructType}
 import org.apache.carbondata.format.{DataType => ThriftDataType}
-
-import scala.collection.JavaConverters._
 
 object DataTypeConverterUtil {
   val FIXED_DECIMAL = """decimal\(\s*(\d+)\s*,\s*(\-?\d+)\s*\)""".r
@@ -128,7 +129,8 @@ object DataTypeConverterUtil {
     }
   }
 
-  private def convertSubFields(name: String, dataType: DataType, children: List[Field]): StructField = {
+  private def convertSubFields(name: String, dataType: DataType,
+      children: List[Field]): StructField = {
     val actualName = name.split("\\.").last
     children match {
       case null | Nil =>

--- a/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/DataTypeConverterUtil.scala
+++ b/integration/spark-common/src/main/scala/org/apache/carbondata/spark/util/DataTypeConverterUtil.scala
@@ -17,10 +17,12 @@
 
 package org.apache.carbondata.spark.util
 
+import org.apache.spark.sql.execution.command.Field
 import org.apache.spark.sql.util.CarbonException
-
-import org.apache.carbondata.core.metadata.datatype.{DataType, DataTypes}
+import org.apache.carbondata.core.metadata.datatype.{ArrayType, DataType, DataTypes, DecimalType, MapType, StructField, StructType}
 import org.apache.carbondata.format.{DataType => ThriftDataType}
+
+import scala.collection.JavaConverters._
 
 object DataTypeConverterUtil {
   val FIXED_DECIMAL = """decimal\(\s*(\d+)\s*,\s*(\-?\d+)\s*\)""".r
@@ -84,6 +86,58 @@ object DataTypeConverterUtil {
         } else {
           CarbonException.analysisException(s"Unsupported data type: $dataType")
         }
+    }
+  }
+
+  def convertToCarbonType(field: Field): DataType = {
+    this.convertToCarbonType(field.dataType.get) match {
+      case _: DecimalType =>
+        if (field.scale == 0) {
+          DataTypes.createDefaultDecimalType()
+        } else {
+          DataTypes.createDecimalType(field.precision, field.scale)
+        }
+      case _: MapType =>
+        field.children match {
+          case Some(List(kv)) =>
+            kv.children match {
+              case Some(List(k, v)) =>
+                DataTypes.createMapType(this.convertToCarbonType(k), this.convertToCarbonType(v))
+            }
+          case _ =>
+            CarbonException.analysisException(s"Unsupported map data type: ${field.column}")
+        }
+      case _: ArrayType =>
+        field.children match {
+          case Some(List(v)) =>
+            DataTypes.createArrayType(this.convertToCarbonType(v))
+          case None =>
+            CarbonException.analysisException(s"Unsupported array data type: ${field.column}")
+        }
+      case _: StructType =>
+        field.children match {
+          case Some(fs) =>
+            val subFields = fs.map(f =>
+              this.convertSubFields(f.column, this.convertToCarbonType(f), f.children.orNull)
+            )
+            DataTypes.createStructType(subFields.asJava)
+          case None =>
+            CarbonException.analysisException(s"Unsupported struct data type: ${field.column}")
+        }
+      case other: DataType => other
+    }
+  }
+
+  private def convertSubFields(name: String, dataType: DataType, children: List[Field]): StructField = {
+    val actualName = name.split("\\.").last
+    children match {
+      case null | Nil =>
+        new StructField(actualName, dataType)
+      case other =>
+        val subFields = other.map(f =>
+          this.convertSubFields(f.column, this.convertToCarbonType(f), f.children.orNull)
+        )
+        new StructField(actualName, dataType, subFields.asJava)
     }
   }
 

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/strategy/DDLStrategy.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/strategy/DDLStrategy.scala
@@ -16,6 +16,7 @@
  */
 package org.apache.spark.sql.execution.strategy
 
+import org.apache.commons.lang3.StringUtils
 import org.apache.spark.sql._
 import org.apache.spark.sql.carbondata.execution.datasources.CarbonSparkDataSourceUtil
 import org.apache.spark.sql.catalyst.TableIdentifier
@@ -35,11 +36,11 @@ import org.apache.spark.sql.hive.{CarbonRelation, CreateCarbonSourceTableAsSelec
 import org.apache.spark.sql.parser.CarbonSpark2SqlParser
 import org.apache.spark.sql.types.StructField
 import org.apache.spark.util.{CarbonReflectionUtils, DataMapUtil, FileUtils, SparkUtil}
+
 import org.apache.carbondata.common.exceptions.sql.MalformedCarbonCommandException
 import org.apache.carbondata.common.logging.LogServiceFactory
-import org.apache.carbondata.core.util.{CarbonProperties, DataTypeUtil, ThreadLocalSessionInfo}
+import org.apache.carbondata.core.util.{CarbonProperties, ThreadLocalSessionInfo}
 import org.apache.carbondata.spark.util.DataTypeConverterUtil
-import org.apache.commons.lang3.StringUtils
 
   /**
    * Carbon strategies for ddl commands


### PR DESCRIPTION
Follow up CARBONDATA-3628 

Alter hive add columns has some problems in carbon, this PR will support:
* Map type
* Array type
* Struct type
* Decimal type with precision and scale
* Add columns with comments

### Why is this PR needed?
 
 
 ### What changes were proposed in this PR?

    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new test case added?
 - Yes

    