### PR TITLE
[CARBONDATA-3663] Support loading stage files in batches

### DIFF
--- a/docs/dml-of-carbondata.md
+++ b/docs/dml-of-carbondata.md
@@ -316,12 +316,29 @@ CarbonData DML statements are documented here,which includes:
   You can use this command to insert them into the table, so that making them visible for query.
   
   ```
-  INSERT INTO <CARBONDATA TABLE> STAGE
+  INSERT INTO <CARBONDATA TABLE> STAGE OPTIONS(property_name=property_value, ...)
   ```
+  **Supported Properties:**
+
+| Property                                                | Description                                                  |
+| ------------------------------------------------------- | ------------------------------------------------------------ |
+| [BATCH_FILE_COUNT](#batch_file_count)                   | The number of stage files per processing                     |
+
+-
+  You can use the following options to load data:
+
+  - ##### BATCH_FILE_COUNT: 
+    The number of stage files per processing.
+
+    ``` 
+    OPTIONS('batch_file_count'=',')
+    ```
 
   Examples:
   ```
   INSERT INTO table1 STAGE
+
+  INSERT INTO table1 STAGE OPTIONS('batch_file_count' = '5')
   ```
 
 ### Load Data Using Static Partition 

--- a/integration/flink/src/test/scala/org/apache/carbon/flink/TestCarbonPartitionWriter.scala
+++ b/integration/flink/src/test/scala/org/apache/carbon/flink/TestCarbonPartitionWriter.scala
@@ -34,7 +34,6 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.test.util.QueryTest
-import org.junit.Test
 import scala.collection.JavaConverters._
 
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
@@ -43,9 +42,8 @@ class TestCarbonPartitionWriter extends QueryTest {
 
   val tableName = "test_flink_partition"
 
-  @Test
-  def testLocal(): Unit = {
-    sql(s"drop table if exists $tableName").collect()
+  test("Writing flink data to local partition carbon table") {
+    sql(s"DROP TABLE IF EXISTS $tableName").collect()
     sql(
       s"""
          | CREATE TABLE $tableName (stringField string, intField int, shortField short)
@@ -122,17 +120,16 @@ class TestCarbonPartitionWriter extends QueryTest {
 
       sql(s"INSERT INTO $tableName STAGE")
 
-      checkAnswer(sql(s"select count(1) from $tableName"), Seq(Row(1000)))
+      checkAnswer(sql(s"SELECT count(1) FROM $tableName"), Seq(Row(1000)))
 
     } finally {
-      sql(s"drop table if exists $tableName").collect()
+      sql(s"DROP TABLE IF EXISTS $tableName").collect()
       delDir(new File(dataPath))
     }
   }
 
-  @Test
-  def testComplexType(): Unit = {
-    sql(s"drop table if exists $tableName").collect()
+  test("Test complex type") {
+    sql(s"DROP TABLE IF EXISTS $tableName").collect()
     sql(
       s"""
          | CREATE TABLE $tableName (stringField string, intField int, shortField short,
@@ -212,14 +209,14 @@ class TestCarbonPartitionWriter extends QueryTest {
 
       sql(s"INSERT INTO $tableName STAGE")
 
-      checkAnswer(sql(s"select count(1) from $tableName"), Seq(Row(1000)))
+      checkAnswer(sql(s"SELECT count(1) FROM $tableName"), Seq(Row(1000)))
 
-      val rows = sql(s"select * from $tableName limit 1").collect()
+      val rows = sql(s"SELECT * FROM $tableName limit 1").collect()
       assertResult(1)(rows.length)
       assertResult(Array[Byte](2, 3, 4))(rows(0).get(rows(0).fieldIndex("binaryfield")).asInstanceOf[GenericRowWithSchema](0))
 
     } finally {
-      sql(s"drop table if exists $tableName").collect()
+      sql(s"DROP TABLE IF EXISTS $tableName").collect()
       delDir(new File(dataPath))
     }
   }
@@ -231,7 +228,6 @@ class TestCarbonPartitionWriter extends QueryTest {
     val properties = new Properties
     properties.setProperty(CarbonLocalProperty.DATA_TEMP_PATH, dataTempPath)
     properties.setProperty(CarbonLocalProperty.DATA_PATH, dataPath)
-    properties.setProperty(CarbonLocalProperty.COMMIT_THRESHOLD, "100")
     properties
   }
 

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSpark2SqlParser.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/parser/CarbonSpark2SqlParser.scala
@@ -523,12 +523,14 @@ class CarbonSpark2SqlParser extends CarbonDDLSqlParser {
     }
 
   /**
-   * INSERT INTO [dbName.]tableName STAGE
+   * INSERT INTO [dbName.]tableName STAGE [OPTIONS (key1=value1, key2=value2, ...)]
    */
   protected lazy val insertStageData: Parser[LogicalPlan] =
-    INSERT ~ INTO ~> (ident <~ ".").? ~ ident <~ STAGE <~ opt(";") ^^ {
-      case dbName ~ tableName =>
-        CarbonInsertFromStageCommand(dbName, tableName)
+    INSERT ~ INTO ~> (ident <~ ".").? ~ ident ~ STAGE ~
+    (OPTIONS ~> "(" ~> repsep(loadOptions, ",") <~ ")").? <~ opt(";") ^^ {
+      case dbName ~ tableName ~ stage ~ options =>
+        CarbonInsertFromStageCommand(dbName, tableName,
+          options.getOrElse(List[(String, String)]()).toMap[String, String])
     }
 
   protected lazy val cleanFiles: Parser[LogicalPlan] =


### PR DESCRIPTION
 ### Why is this PR needed?
 When there are a lots of stage files in the stage directory,  if load all of them in once time, the loading time will can not be control.
There need a way for users to specify the number of stage files per processing, to control the execution time of commands.
 
 ### What changes were proposed in this PR?
Add a load option batch_file_count for users to specify the number of stage files per processing.
    
 ### Does this PR introduce any user interface change?
 - Yes

 ### Is any new testcase added?
 - Yes

    
