### PR TITLE
[CARBONDATA-3664]Add SchemaEvolutionEntry after alter set sort columns

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/schema/CarbonAlterTableColRenameDataTypeChangeCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/schema/CarbonAlterTableColRenameDataTypeChangeCommand.scala
@@ -181,7 +181,7 @@ private[sql] case class CarbonAlterTableColRenameDataTypeChangeCommand(
       // maintain the added column for schema evolution history
       var addColumnSchema: ColumnSchema = null
       var deletedColumnSchema: ColumnSchema = null
-      val schemaEvolutionEntry: SchemaEvolutionEntry = null
+      var schemaEvolutionEntry: SchemaEvolutionEntry = null
       val columnSchemaList = tableInfo.fact_table.table_columns.asScala.filter(!_.isInvisible)
 
       columnSchemaList.foreach { columnSchema =>
@@ -208,9 +208,8 @@ private[sql] case class CarbonAlterTableColRenameDataTypeChangeCommand(
           addColumnSchema = columnSchema
           timeStamp = System.currentTimeMillis()
           // make a new schema evolution entry after column rename or datatype change
-          AlterTableUtil
-            .addNewSchemaEvolutionEntry(schemaEvolutionEntry, timeStamp, addColumnSchema,
-              deletedColumnSchema)
+          schemaEvolutionEntry = AlterTableUtil
+            .addNewSchemaEvolutionEntry(timeStamp, addColumnSchema, deletedColumnSchema)
         }
       }
 


### PR DESCRIPTION
 ### Why is this PR needed?
Alter set sort columns is changing schema but evolution entry is not made 
 
 ### What changes were proposed in this PR?
Once we do set sort columns, we change the schema which changes the column order, so make an
evolution entry for it.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No(Not required as this will help in track of operations on schema)

    
