### PR TITLE
[CARBONDATA-3665] Support TimeBased Cache expiration using Guava Cache

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -51,6 +51,17 @@
       <version>2.4</version>
     </dependency>
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>23.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava-testlib</artifactId>
+      <version>23.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
     </dependency>

--- a/core/src/main/java/org/apache/carbondata/core/cache/CarbonLRUCache.java
+++ b/core/src/main/java/org/apache/carbondata/core/cache/CarbonLRUCache.java
@@ -18,15 +18,17 @@
 package org.apache.carbondata.core.cache;
 
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.util.CarbonProperties;
 
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import org.apache.log4j.Logger;
 
 /**
@@ -43,10 +45,11 @@ public final class CarbonLRUCache {
   private static final Logger LOGGER =
       LogServiceFactory.getLogService(CarbonLRUCache.class.getName());
   /**
-   * Map that will contain key as table unique name and value as cache Holder
+   * Guava cache that holds key as table unique name and value as cache Holder
    * object
    */
-  private Map<String, Cacheable> lruCacheMap;
+  private Cache<String, Cacheable> lruCache;
+
   /**
    * lruCacheSize
    */
@@ -95,9 +98,17 @@ public final class CarbonLRUCache {
    * initialize lru cache
    */
   private void initCache() {
-    lruCacheMap =
-        new LinkedHashMap<String, Cacheable>(CarbonCommonConstants.DEFAULT_COLLECTION_SIZE, 1.0f,
-            true);
+    // get duration for cache expiration if configured
+    long duration = CarbonCommonConstants.CARBON_LRU_CACHE_EXPIRATION_DURATION_IN_MINUTES_DEFAULT;
+    String timeBasedExpiration = CarbonProperties.getInstance()
+        .getProperty(CarbonCommonConstants.CARBON_LRU_CACHE_EXPIRATION_DURATION_IN_MINUTES);
+    if (null != timeBasedExpiration) {
+      duration = Long.parseLong(timeBasedExpiration);
+    }
+    // initialise guava cache with time based expiration
+    lruCache =
+        CacheBuilder.newBuilder().initialCapacity(CarbonCommonConstants.DEFAULT_COLLECTION_SIZE)
+            .expireAfterWrite(duration, TimeUnit.MINUTES).build();
   }
 
   /**
@@ -108,7 +119,7 @@ public final class CarbonLRUCache {
     List<String> toBeDeletedKeys =
         new ArrayList<String>(CarbonCommonConstants.DEFAULT_COLLECTION_SIZE);
     long removedSize = 0;
-    for (Entry<String, Cacheable> entry : lruCacheMap.entrySet()) {
+    for (Entry<String, Cacheable> entry : lruCache.asMap().entrySet()) {
       String key = entry.getKey();
       Cacheable cacheInfo = entry.getValue();
       long memorySize = cacheInfo.getMemorySize();
@@ -156,7 +167,7 @@ public final class CarbonLRUCache {
    * @param key
    */
   public void remove(String key) {
-    synchronized (lruCacheMap) {
+    synchronized (lruCache) {
       removeKey(key);
     }
   }
@@ -165,7 +176,7 @@ public final class CarbonLRUCache {
    * @param keys
    */
   public void removeAll(List<String> keys) {
-    synchronized (lruCacheMap) {
+    synchronized (lruCache) {
       for (String key : keys) {
         removeKey(key);
       }
@@ -178,11 +189,11 @@ public final class CarbonLRUCache {
    * @param key
    */
   private void removeKey(String key) {
-    Cacheable cacheable = lruCacheMap.get(key);
+    Cacheable cacheable = lruCache.getIfPresent(key);
     if (null != cacheable) {
       long memorySize = cacheable.getMemorySize();
       cacheable.invalidate();
-      lruCacheMap.remove(key);
+      lruCache.invalidate(key);
       currentSize = currentSize - memorySize;
       LOGGER.info("Removed entry from InMemory lru cache :: " + key);
     }
@@ -202,7 +213,7 @@ public final class CarbonLRUCache {
     }
     boolean columnKeyAddedSuccessfully = false;
     if (isLRUCacheSizeConfigured()) {
-      synchronized (lruCacheMap) {
+      synchronized (lruCache) {
         if (freeMemorySizeForAddingCache(requiredSize)) {
           currentSize = currentSize + requiredSize;
           addEntryToLRUCacheMap(columnIdentifier, cacheInfo);
@@ -215,7 +226,7 @@ public final class CarbonLRUCache {
         }
       }
     } else {
-      synchronized (lruCacheMap) {
+      synchronized (lruCache) {
         addEntryToLRUCacheMap(columnIdentifier, cacheInfo);
         currentSize = currentSize + requiredSize;
       }
@@ -225,43 +236,14 @@ public final class CarbonLRUCache {
   }
 
   /**
-   * This method will check if required size is available in the memory
-   * @param columnIdentifier
-   * @param requiredSize
-   * @return
-   */
-  public boolean tryPut(String columnIdentifier, long requiredSize) {
-    if (LOGGER.isDebugEnabled()) {
-      LOGGER.debug("checking Required size for entry " + columnIdentifier + " :: " + requiredSize
-          + " Current cache size :: " + currentSize);
-    }
-    boolean columnKeyCanBeAdded = false;
-    if (isLRUCacheSizeConfigured()) {
-      synchronized (lruCacheMap) {
-        if (freeMemorySizeForAddingCache(requiredSize)) {
-          columnKeyCanBeAdded = true;
-        } else {
-          LOGGER.error(
-              "Size check failed.Size not available. Entry cannot be added to lru cache :: "
-                  + columnIdentifier + " .Required Size = " + requiredSize + " Size available " + (
-                  lruCacheMemorySize - currentSize));
-        }
-      }
-    } else {
-      columnKeyCanBeAdded = true;
-    }
-    return columnKeyCanBeAdded;
-  }
-
-  /**
    * The method will add the cache entry to LRU cache map
    *
    * @param columnIdentifier
    * @param cacheInfo
    */
   private void addEntryToLRUCacheMap(String columnIdentifier, Cacheable cacheInfo) {
-    if (null == lruCacheMap.get(columnIdentifier)) {
-      lruCacheMap.put(columnIdentifier, cacheInfo);
+    if (null == lruCache.asMap().get(columnIdentifier)) {
+      lruCache.put(columnIdentifier, cacheInfo);
     }
     if (LOGGER.isDebugEnabled()) {
       LOGGER.debug("Added entry to InMemory lru cache :: " + columnIdentifier);
@@ -317,8 +299,8 @@ public final class CarbonLRUCache {
    * @return
    */
   public Cacheable get(String key) {
-    synchronized (lruCacheMap) {
-      return lruCacheMap.get(key);
+    synchronized (lruCache) {
+      return lruCache.getIfPresent(key);
     }
   }
 
@@ -326,16 +308,16 @@ public final class CarbonLRUCache {
    * This method will empty the level cache
    */
   public void clear() {
-    synchronized (lruCacheMap) {
-      for (Cacheable cachebleObj : lruCacheMap.values()) {
+    synchronized (lruCache) {
+      for (Cacheable cachebleObj : lruCache.asMap().values()) {
         cachebleObj.invalidate();
       }
-      lruCacheMap.clear();
+      lruCache.cleanUp();
     }
   }
 
   public Map<String, Cacheable> getCacheMap() {
-    return lruCacheMap;
+    return lruCache.asMap();
   }
 
   /**

--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -1314,6 +1314,17 @@ public final class CarbonCommonConstants {
   public static final double CARBON_LRU_CACHE_PERCENT_OVER_MAX_SIZE = 0.6d;
 
   /**
+   * lruCache can be cleared based on time-based expiration using guava cache
+   */
+  public static final String CARBON_LRU_CACHE_EXPIRATION_DURATION_IN_MINUTES =
+      "carbon.lru.cache.expiration.duration.in.minutes";
+
+  /**
+   * Default time-based expiration for guava cache
+   */
+  public static final long CARBON_LRU_CACHE_EXPIRATION_DURATION_IN_MINUTES_DEFAULT = Long.MAX_VALUE;
+
+  /**
    * property to enable min max during filter query
    */
   @CarbonProperty

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
@@ -42,6 +42,7 @@ import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_
 import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_DATA_FILE_VERSION;
 import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_DATE_FORMAT;
 import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_DYNAMIC_ALLOCATION_SCHEDULER_TIMEOUT;
+import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_LRU_CACHE_EXPIRATION_DURATION_IN_MINUTES;
 import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_MINMAX_ALLOWED_BYTE_COUNT;
 import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_PREFETCH_BUFFERSIZE;
 import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_SCHEDULER_MIN_REGISTERED_RESOURCES_RATIO;
@@ -207,6 +208,9 @@ public final class CarbonProperties {
         break;
       case CarbonCommonConstants.CARBON_DATAMAP_SCHEMA_STORAGE:
         validateDMSchemaStorageProvider();
+        break;
+      case CarbonCommonConstants.CARBON_LRU_CACHE_EXPIRATION_DURATION_IN_MINUTES:
+        validateDurationForCacheExpiration();
         break;
       // TODO : Validation for carbon.lock.type should be handled for addProperty flow
       default:
@@ -1893,5 +1897,36 @@ public final class CarbonProperties {
       return CarbonCommonConstants.CARBON_DATAMAP_SCHEMA_STORAGE_DEFAULT;
     }
     return provider.toUpperCase();
+  }
+
+  /**
+   * This method validates the duration for carbon cache expiration
+   */
+  private void validateDurationForCacheExpiration() {
+    String defaultValue = Long.toString(
+        CarbonCommonConstants.CARBON_LRU_CACHE_EXPIRATION_DURATION_IN_MINUTES_DEFAULT);
+    long duration;
+    try {
+      duration = Long.parseLong(
+          carbonProperties.getProperty(CARBON_LRU_CACHE_EXPIRATION_DURATION_IN_MINUTES));
+      if (duration < 0 || duration == 0) {
+        LOGGER.info("using default value of carbon.lru.cache.expiration.duration.in.minutes = "
+            + CarbonCommonConstants.CARBON_LRU_CACHE_EXPIRATION_DURATION_IN_MINUTES_DEFAULT);
+        carbonProperties
+            .setProperty(CarbonCommonConstants.CARBON_LOCAL_DICTIONARY_SIZE_THRESHOLD_IN_MB,
+                defaultValue);
+      } else {
+        LOGGER.info("using carbon.lru.cache.expiration.duration.in.minutes = " + duration);
+        carbonProperties
+            .setProperty(CARBON_LRU_CACHE_EXPIRATION_DURATION_IN_MINUTES,
+                Long.toString(duration));
+      }
+    } catch (Exception e) {
+      LOGGER.info(String.format(
+          "The cache expiration duration for long type value \"%s\" is invalid. "
+              + "Using the default value \"%s\"", defaultValue,
+          CarbonCommonConstants.CARBON_LRU_CACHE_EXPIRATION_DURATION_IN_MINUTES_DEFAULT));
+      carbonProperties.setProperty(CARBON_LRU_CACHE_EXPIRATION_DURATION_IN_MINUTES, defaultValue);
+    }
   }
 }

--- a/docs/configuration-parameters.md
+++ b/docs/configuration-parameters.md
@@ -51,6 +51,7 @@ This section provides the details of all the configurations required for the Car
 | carbon.fs.custom.file.provider | None | To support FileTypeInterface for configuring custom CarbonFile implementation to work with custom FileSystem. |
 | carbon.timeseries.first.day.of.week | SUNDAY | This parameter configures which day of the week to be considered as first day of the week. Because first day of the week will be different in different parts of the world. |
 | carbon.enable.tablestatus.backup | false | In cloud object store scenario, overwriting table status file is not an atomic operation since it uses rename API. Thus, it is possible that table status is corrupted if process crashed when overwriting the table status file. To protect from file corruption, user can enable this property. |
+| carbon.lru.cache.expiration.duration.in.minutes | Long.MAX_VALUE | This property configures the value for time-based cache expiration. It takes long value(in minutes) as input. Cache entries expires after the specified duration has passed since the entry was created, or the most recent replacement of the value. |
 
 ## Data Loading Configuration
 


### PR DESCRIPTION
 ### Why is this PR needed?
 Currently, in Carbon, we follow LRU cache based mechanism. An least-recently used entry will be removed from the cache when it is full. There is no time-based cache expiration supported in carbon.  In cloud, all vm's may not have enough memory to cache everything we could cache.
In that case, we can clear cache after a specified duration. This can be achieved by using cache libraries available. 

One of the caching library is **Guava Cache**, which provides flexible and powerful caching features. Please refer [GuavaCache](https://github.com/google/guava) for more info.
 
 ### What changes were proposed in this PR?
1. Replaced LinkedHashMap with Guava Cache
2. Added Carbon property to allow user to specify cache expiration duration in minutes, to clear cache.
   Newly added carbon property:
 `carbon.lru.cache.expiration.duration.in.minutes` which takes long value.
 For example:
 `carbon.lru.cache.expiration.duration.in.minutes="5"` -> After 5 minutes, cache will be cleared.
    
 ### Does this PR introduce any user interface change?
 - Yes.  Added new property. Document is updated

 ### Is any new testcase added?
 
 - Yes

    
