### PR TITLE
[HOTFIX]: Making maven repo changes in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
       <id>central</id>
       <!-- This should be at top, it makes maven try the central repo first and then others and hence faster dep resolution -->
       <name>Maven Repository</name>
-      <url>http://repo1.maven.org/maven2</url>
+      <url>https://repo1.maven.org/maven2</url>
       <releases>
         <enabled>true</enabled>
       </releases>


### PR DESCRIPTION
 ### Why is this PR needed?
 To use https instead of http to connect central maven repo
 
 ### What changes were proposed in this PR?
Changes made to use https instead of http to connect central maven repo that is https://repo.maven.apache.org/maven2 instead of http://repo.maven.apache.org/maven2 

Link for clarification : https://stackoverflow.com/questions/59763531/maven-dependencies-are-failing-with-501-error
    
 ### Does this PR introduce any user interface change?
 - No
  ### Is any new testcase added?
 - No


    
