### PR TITLE
[CARBONDATA-3669] Delete Physical Partition When Drop Partition

### DIFF
--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/partition/CarbonAlterTableDropHivePartitionCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/partition/CarbonAlterTableDropHivePartitionCommand.scala
@@ -190,7 +190,7 @@ case class CarbonAlterTableDropHivePartitionCommand(
       DataMapStoreManager.getInstance().clearDataMaps(table.getAbsoluteTableIdentifier)
     } finally {
       AlterTableUtil.releaseLocks(locks)
-      SegmentFileStore.cleanSegments(table, null, false)
+      SegmentFileStore.cleanSegments(table, null, true)
     }
     Seq.empty[Row]
   }


### PR DESCRIPTION
 ### Why is this PR needed?
 When drop partition, hive will clean the dictory and data, but carbondata won't, the customers confuse about that. Maybe we should keep same with hive in carbondata.

 ### What changes were proposed in this PR?
When drop partition, set force delete physical partition to true.

    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No

    
