### PR TITLE
[CARBONDATA-3678] optimize list files in insert stage

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/AbstractDFSCarbonFile.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/AbstractDFSCarbonFile.java
@@ -514,6 +514,24 @@ public abstract class AbstractDFSCarbonFile implements CarbonFile {
   }
 
   @Override
+  public CarbonFile[] listFiles(boolean recursive, int maxCount)
+      throws IOException {
+    List<CarbonFile> carbonFiles = new ArrayList<>();
+    FileStatus fileStatus = fileSystem.getFileStatus(path);
+    if (null != fileStatus && fileStatus.isDirectory()) {
+      RemoteIterator<LocatedFileStatus> listStatus = fileSystem.listFiles(path, recursive);
+      int counter = 0;
+      while (counter < maxCount && listStatus.hasNext()) {
+        LocatedFileStatus locatedFileStatus = listStatus.next();
+        CarbonFile carbonFile = FileFactory.getCarbonFile(locatedFileStatus.getPath().toString());
+        carbonFiles.add(carbonFile);
+        counter++;
+      }
+    }
+    return carbonFiles.toArray(new CarbonFile[0]);
+  }
+
+  @Override
   public String[] getLocations() throws IOException {
     BlockLocation[] blkLocations;
     FileStatus fileStatus = fileSystem.getFileStatus(path);

--- a/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/CarbonFile.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/CarbonFile.java
@@ -33,6 +33,8 @@ public interface CarbonFile {
 
   CarbonFile[] listFiles();
 
+  CarbonFile[] listFiles(boolean recursive, int maxCount) throws IOException;
+
   List<CarbonFile> listFiles(Boolean recursive) throws IOException;
 
   List<CarbonFile> listFiles(boolean recursive, CarbonFileFilter fileFilter) throws IOException;

--- a/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/LocalCarbonFile.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/LocalCarbonFile.java
@@ -163,6 +163,13 @@ public class LocalCarbonFile implements CarbonFile {
   }
 
   @Override
+  public CarbonFile[] listFiles(boolean recursive, int maxCount)
+      throws IOException {
+    // ignore the maxCount for local filesystem
+    return listFiles();
+  }
+
+  @Override
   public List<CarbonFile> listFiles(Boolean recursive) {
     if (!isDirectory()) {
       return new ArrayList<>();

--- a/integration/flink/src/main/java/org/apache/carbon/flink/CarbonLocalWriter.java
+++ b/integration/flink/src/main/java/org/apache/carbon/flink/CarbonLocalWriter.java
@@ -166,9 +166,10 @@ final class CarbonLocalWriter extends CarbonWriter {
         return;
       }
       try {
+        // make it ordered by time in case the files ordered by file name.
         String stageInputPath = CarbonTablePath.getStageDir(
             table.getAbsoluteTableIdentifier().getTablePath()) +
-            CarbonCommonConstants.FILE_SEPARATOR + UUID.randomUUID();
+            CarbonCommonConstants.FILE_SEPARATOR + System.currentTimeMillis() + UUID.randomUUID();
         tryCreateLocalDirectory(new File(stageInputPath));
         StageManager.writeStageInput(stageInputPath, stageInput);
       } catch (Throwable exception) {

--- a/integration/flink/src/main/java/org/apache/carbon/flink/CarbonS3Writer.java
+++ b/integration/flink/src/main/java/org/apache/carbon/flink/CarbonS3Writer.java
@@ -180,9 +180,10 @@ final class CarbonS3Writer extends CarbonWriter {
         return;
       }
       try {
+        // make it ordered by time in case the files ordered by file name.
         String stageInputPath = CarbonTablePath.getStageDir(
             table.getAbsoluteTableIdentifier().getTablePath()) +
-            CarbonCommonConstants.FILE_SEPARATOR + UUID.randomUUID();
+            CarbonCommonConstants.FILE_SEPARATOR + System.currentTimeMillis() + UUID.randomUUID();
         StageManager.writeStageInput(stageInputPath, stageInput);
       } catch (Throwable exception) {
         this.deleteSegmentDataFilesQuietly(dataPath);


### PR DESCRIPTION
 ### Why is this PR needed?
 To optimize the insert stage files using iterator which can avoid listing all files under dir in case file_count is set in command, especially for s3/obs cases and this can reduce the time cost of driver.
 
 ### What changes were proposed in this PR?
Use iterator to get limited num of stage files.
    
 ### Does this PR introduce any user interface change?
 - No
 - Yes. (please explain the change and update document)

 ### Is any new testcase added?
 - No
 - Yes

    
