### PR TITLE
[CARBONDATA-3688] Add compressor name in data file name

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockDataMap.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockDataMap.java
@@ -396,7 +396,8 @@ public class BlockDataMap extends CoarseGrainDataMap
     row.setInt((int) fileFooter.getNumberOfRows(), ordinal++);
     // add file name
     byte[] filePathBytes =
-        getFileNameFromPath(filePath).getBytes(CarbonCommonConstants.DEFAULT_CHARSET_CLASS);
+        CarbonTablePath.getCarbonDataFileName(filePath)
+            .getBytes(CarbonCommonConstants.DEFAULT_CHARSET_CLASS);
     row.setByteArray(filePathBytes, ordinal++);
     // add version number
     row.setShort(fileFooter.getVersionId().number(), ordinal++);
@@ -430,10 +431,6 @@ public class BlockDataMap extends CoarseGrainDataMap
       minMaxFlagRow.setBoolean(minMaxFlag[i], flagOrdinal++);
     }
     row.setRow(minMaxFlagRow, ordinal);
-  }
-
-  protected String getFileNameFromPath(String filePath) {
-    return CarbonTablePath.getCarbonDataFileName(filePath);
   }
 
   protected String getFilePath() {

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMap.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletDataMap.java
@@ -41,6 +41,7 @@ import org.apache.carbondata.core.metadata.blocklet.index.BlockletMinMaxIndex;
 import org.apache.carbondata.core.metadata.schema.table.column.CarbonColumn;
 import org.apache.carbondata.core.scan.filter.resolver.FilterResolverIntf;
 import org.apache.carbondata.core.util.BlockletDataMapUtil;
+import org.apache.carbondata.core.util.path.CarbonTablePath;
 
 /**
  * Datamap implementation for blocklet.
@@ -168,7 +169,8 @@ public class BlockletDataMap extends BlockDataMap implements Serializable {
       row.setInt(blockletInfo.getNumberOfRows(), ordinal++);
       // add file name
       byte[] filePathBytes =
-          getFileNameFromPath(filePath).getBytes(CarbonCommonConstants.DEFAULT_CHARSET_CLASS);
+          CarbonTablePath.getCarbonDataFileName(filePath)
+              .getBytes(CarbonCommonConstants.DEFAULT_CHARSET_CLASS);
       row.setByteArray(filePathBytes, ordinal++);
       // add version number
       row.setShort(fileFooter.getVersionId().number(), ordinal++);

--- a/core/src/main/java/org/apache/carbondata/core/readcommitter/LatestFilesReadCommittedScope.java
+++ b/core/src/main/java/org/apache/carbondata/core/readcommitter/LatestFilesReadCommittedScope.java
@@ -213,19 +213,19 @@ public class LatestFilesReadCommittedScope implements ReadCommittedScope {
         // Get Segment Name from the IndexFile.
         String indexFilePath =
             FileFactory.getUpdatedFilePath(carbonIndexFiles[i].getAbsolutePath());
-        String segId = getSegmentID(carbonIndexFiles[i].getName(), indexFilePath);
+        String timestamp = getSegmentID(carbonIndexFiles[i].getName(), indexFilePath);
         // TODO. During Partition table handling, place Segment File Name.
         List<String> indexList;
         SegmentRefreshInfo segmentRefreshInfo;
-        if (indexFileStore.get(segId) == null) {
+        if (indexFileStore.get(timestamp) == null) {
           indexList = new ArrayList<>(1);
           segmentRefreshInfo =
               new SegmentRefreshInfo(carbonIndexFiles[i].getLastModifiedTime(), 0);
-          segmentTimestampUpdaterMap.put(segId, segmentRefreshInfo);
+          segmentTimestampUpdaterMap.put(timestamp, segmentRefreshInfo);
         } else {
           // Entry is already present.
-          indexList = indexFileStore.get(segId);
-          segmentRefreshInfo = segmentTimestampUpdaterMap.get(segId);
+          indexList = indexFileStore.get(timestamp);
+          segmentRefreshInfo = segmentTimestampUpdaterMap.get(timestamp);
         }
         indexList.add(indexFilePath);
         if (segmentRefreshInfo.getSegmentUpdatedTimestamp() < carbonIndexFiles[i]
@@ -233,7 +233,7 @@ public class LatestFilesReadCommittedScope implements ReadCommittedScope {
           segmentRefreshInfo
               .setSegmentUpdatedTimestamp(carbonIndexFiles[i].getLastModifiedTime());
         }
-        indexFileStore.put(segId, indexList);
+        indexFileStore.put(timestamp, indexList);
         segmentRefreshInfo.setCountOfFileInSegment(indexList.size());
       }
     }

--- a/core/src/main/java/org/apache/carbondata/core/statusmanager/SegmentUpdateStatusManager.java
+++ b/core/src/main/java/org/apache/carbondata/core/statusmanager/SegmentUpdateStatusManager.java
@@ -405,8 +405,8 @@ public class SegmentUpdateStatusManager {
       String firstPart = deltaFilePathName.substring(0, deltaFilePathName.lastIndexOf('.'));
       String blockName =
           firstPart.substring(0, firstPart.lastIndexOf(CarbonCommonConstants.HYPHEN));
-      long timestamp = Long.parseLong(firstPart
-          .substring(firstPart.lastIndexOf(CarbonCommonConstants.HYPHEN) + 1, firstPart.length()));
+      long timestamp =
+          Long.parseLong(CarbonTablePath.DataFileUtil.getTimeStampFromFileName(deltaFilePathName));
       // It compares whether this delta file belongs to this block or not. And also checks that
       // corresponding delta file is valid or not by considering its load start and end time with
       // the file timestamp.
@@ -450,8 +450,8 @@ public class SegmentUpdateStatusManager {
                 && pathName.getSize() > 0) {
               String firstPart = fileName.substring(0, fileName.indexOf('.'));
               String blkName = firstPart.substring(0, firstPart.lastIndexOf("-"));
-              long timestamp = Long.parseLong(
-                  firstPart.substring(firstPart.lastIndexOf("-") + 1, firstPart.length()));
+              long timestamp =
+                  Long.parseLong(CarbonTablePath.DataFileUtil.getTimeStampFromFileName(fileName));
               if (blockName.equals(blkName) && (Long.compare(timestamp, deltaEndTimeStamp) <= 0)
                   && (Long.compare(timestamp, deltaStartTimestamp) >= 0)) {
                 return true;
@@ -503,11 +503,8 @@ public class SegmentUpdateStatusManager {
 
       String fileName = eachFile.getName();
       if (fileName.endsWith(fileExtension)) {
-        String firstPart = fileName.substring(0, fileName.lastIndexOf('.'));
-
-        long timestamp = Long.parseLong(firstPart
-            .substring(firstPart.lastIndexOf(CarbonCommonConstants.HYPHEN) + 1,
-                firstPart.length()));
+        long timestamp =
+            Long.parseLong(CarbonTablePath.DataFileUtil.getTimeStampFromFileName(fileName));
 
         if (excludeOriginalFact) {
           if (Long.compare(factTimeStampFinal, timestamp) == 0) {

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
@@ -1962,4 +1962,8 @@ public final class CarbonProperties {
       return badRecordHandling.equalsIgnoreCase("true");
     }
   }
+
+  public String getDefaultCompressor() {
+    return getProperty(CarbonCommonConstants.COMPRESSOR, CarbonCommonConstants.DEFAULT_COMPRESSOR);
+  }
 }

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
@@ -1586,17 +1586,16 @@ public final class CarbonUtil {
       UpdateVO invalidBlockVOForSegmentId, SegmentUpdateStatusManager updateStatusMngr) {
 
     if (!updateStatusMngr.isBlockValid(segmentId,
-        CarbonTablePath.getCarbonDataFileName(filePath) + CarbonTablePath
-            .getCarbonDataExtension())) {
+        CarbonTablePath.getCarbonDataFileName(filePath) +
+            CarbonTablePath.getCarbonDataExtension())) {
       return true;
     }
     // in case of compaction over si table the factTimeStamp will be null for the
     // main table's compacted segments in that case no need to validate the block
     if (null != invalidBlockVOForSegmentId &&
         null != invalidBlockVOForSegmentId.getFactTimestamp()) {
-      Long blockTimeStamp = Long.parseLong(filePath
-          .substring(filePath.lastIndexOf('-') + 1,
-              filePath.lastIndexOf('.')));
+      long blockTimeStamp =
+          Long.parseLong(CarbonTablePath.DataFileUtil.getTimeStampFromFileName(filePath));
       if ((blockTimeStamp > invalidBlockVOForSegmentId.getFactTimestamp() && (
           invalidBlockVOForSegmentId.getUpdateDeltaStartTimestamp() != null
               && blockTimeStamp < invalidBlockVOForSegmentId.getUpdateDeltaStartTimestamp()))) {

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonFileInputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonFileInputFormat.java
@@ -146,8 +146,9 @@ public class CarbonFileInputFormat<T> extends CarbonInputFormat<T> implements Se
         seg = new Segment(load.getLoadName(), null, readCommittedScope);
         if (fileLists != null) {
           for (int i = 0; i < fileLists.size(); i++) {
-            if (fileLists.get(i).toString().endsWith(seg.getSegmentNo()
-                + CarbonTablePath.CARBON_DATA_EXT)) {
+            String timestamp =
+                CarbonTablePath.DataFileUtil.getTimeStampFromFileName(fileLists.get(i).toString());
+            if (timestamp.equals(seg.getSegmentNo())) {
               externalTableSegments.add(seg);
               break;
             }

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableOutputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableOutputFormat.java
@@ -474,7 +474,7 @@ public class CarbonTableOutputFormat extends FileOutputFormat<NullWritable, Obje
           future.get();
         } catch (ExecutionException e) {
           LOG.error("Error while loading data", e);
-          throw new InterruptedException(e.getMessage());
+          throw new RuntimeException(e);
         } finally {
           executorService.shutdownNow();
           dataLoadExecutor.close();

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/describeTable/TestDescribeTable.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/spark/testsuite/describeTable/TestDescribeTable.scala
@@ -68,15 +68,6 @@ class TestDescribeTable extends QueryTest with BeforeAndAfterAll {
     assert(descPar.exists(_.toString().contains("Partition Parameters:")))
   }
 
-  test(testName = "Compressor Type update from carbon properties") {
-    sql("drop table if exists b")
-    sql(sqlText = "create table b(a int,b string) STORED AS carbondata")
-    CarbonProperties.getInstance().addProperty(CarbonCommonConstants.COMPRESSOR, "gzip")
-    val result = sql(sqlText = "desc formatted b").collect()
-    assert(result.filter(row => row.getString(0).contains("Data File Compressor")).head.getString
-    (1).equalsIgnoreCase("gzip"))
-  }
-
   override def afterAll: Unit = {
     sql("DROP TABLE Desc1")
     sql("DROP TABLE Desc2")

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonDescribeFormattedCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonDescribeFormattedCommand.scala
@@ -141,11 +141,6 @@ private[sql] case class CarbonDescribeFormattedCommand(
         Strings.formatSize(
           tblProps.getOrElse(CarbonCommonConstants.CARBON_LOAD_MIN_SIZE_INMB,
             CarbonCommonConstants.CARBON_LOAD_MIN_SIZE_INMB_DEFAULT).toFloat), ""),
-      ("Data File Compressor ", tblProps
-        .getOrElse(CarbonCommonConstants.COMPRESSOR,
-          CarbonProperties.getInstance()
-            .getProperty(CarbonCommonConstants.COMPRESSOR,
-          CarbonCommonConstants.DEFAULT_COMPRESSOR)), ""),
       //////////////////////////////////////////////////////////////////////////////
       //  Index Information
       //////////////////////////////////////////////////////////////////////////////

--- a/processing/src/main/java/org/apache/carbondata/processing/store/writer/AbstractFactDataWriter.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/writer/AbstractFactDataWriter.java
@@ -308,7 +308,8 @@ public abstract class AbstractFactDataWriter implements CarbonFactDataWriter {
     this.carbonDataFileName = CarbonTablePath
         .getCarbonDataFileName(fileCount, model.getCarbonDataFileAttributes().getTaskId(),
             model.getBucketId(), model.getTaskExtension(),
-            "" + model.getCarbonDataFileAttributes().getFactTimeStamp(), model.getSegmentId());
+            "" + model.getCarbonDataFileAttributes().getFactTimeStamp(), model.getSegmentId(),
+            model.getColumnCompressor());
     this.carbonDataFileStorePath = model.getCarbonDataDirectoryPath() + File.separator
         + carbonDataFileName;
     try {

--- a/store/sdk/src/test/java/org/apache/carbondata/sdk/file/CSVCarbonWriterTest.java
+++ b/store/sdk/src/test/java/org/apache/carbondata/sdk/file/CSVCarbonWriterTest.java
@@ -89,6 +89,31 @@ public class CSVCarbonWriterTest {
     FileUtils.deleteDirectory(new File(path));
   }
 
+  // [CARBONDATA-3688]: compressor name is added in data file name
+  @Test
+  public void testFileName() throws IOException {
+    String path = "./testWriteFiles";
+    FileUtils.deleteDirectory(new File(path));
+
+    Field[] fields = new Field[2];
+    fields[0] = new Field("name", DataTypes.STRING);
+    fields[1] = new Field("age", DataTypes.INT);
+
+    TestUtil.writeFilesAndVerify(new Schema(fields), path);
+
+    File[] dataFiles = new File(path).listFiles(new FileFilter() {
+      @Override
+      public boolean accept(File pathname) {
+        return pathname.getName().endsWith(
+            CarbonCommonConstants.DEFAULT_COMPRESSOR + CarbonCommonConstants.FACT_FILE_EXT);
+      }
+    });
+
+    Assert.assertTrue(dataFiles.length > 0);
+
+    FileUtils.deleteDirectory(new File(path));
+  }
+
   @Test
   public void testWriteFilesJsonSchema() throws IOException {
     String path = "./testWriteFilesJsonSchema";

--- a/store/sdk/src/test/java/org/apache/carbondata/sdk/file/ImageTest.java
+++ b/store/sdk/src/test/java/org/apache/carbondata/sdk/file/ImageTest.java
@@ -1066,7 +1066,7 @@ public class ImageTest extends TestCase {
         .builder()
         .withFileLists(fileLists)
         .getSplits(true);
-    Assert.assertTrue(5 == splits.length);
+    Assert.assertEquals(5, splits.length);
     for (int j = 0; j < splits.length; j++) {
       ArrowCarbonReader.builder(splits[j]).build();
     }

--- a/streaming/src/main/java/org/apache/carbondata/streaming/CarbonStreamRecordWriter.java
+++ b/streaming/src/main/java/org/apache/carbondata/streaming/CarbonStreamRecordWriter.java
@@ -139,7 +139,9 @@ public class CarbonStreamRecordWriter extends RecordWriter<Void, Object> {
 
     segmentDir = CarbonTablePath.getSegmentPath(
         carbonTable.getAbsoluteTableIdentifier().getTablePath(), segmentId);
-    fileName = CarbonTablePath.getCarbonDataFileName(0, taskNo + "", 0, 0, "0", segmentId);
+    fileName = CarbonTablePath.getCarbonDataFileName(
+        0, taskNo + "", 0, 0, "0",
+        segmentId, CompressorFactory.NativeSupportedCompressor.SNAPPY.getName());
 
     // initialize metadata
     isNoDictionaryDimensionColumn =
@@ -186,7 +188,7 @@ public class CarbonStreamRecordWriter extends RecordWriter<Void, Object> {
       compressorName = carbonTable.getTableInfo().getFactTable().getTableProperties().get(
           CarbonCommonConstants.COMPRESSOR);
       if (null == compressorName) {
-        compressorName = CompressorFactory.getInstance().getCompressor().getName();
+        compressorName = CompressorFactory.NativeSupportedCompressor.SNAPPY.getName();
       }
       writeFileHeader();
     }

--- a/streaming/src/main/java/org/apache/carbondata/streaming/CarbonStreamRecordWriter.java
+++ b/streaming/src/main/java/org/apache/carbondata/streaming/CarbonStreamRecordWriter.java
@@ -26,7 +26,6 @@ import java.util.List;
 
 import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
-import org.apache.carbondata.core.datastore.compression.CompressorFactory;
 import org.apache.carbondata.core.datastore.filesystem.CarbonFile;
 import org.apache.carbondata.core.datastore.impl.FileFactory;
 import org.apache.carbondata.core.datastore.row.CarbonRow;
@@ -38,6 +37,7 @@ import org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema;
 import org.apache.carbondata.core.reader.CarbonHeaderReader;
 import org.apache.carbondata.core.util.ByteUtil;
 import org.apache.carbondata.core.util.CarbonMetadataUtil;
+import org.apache.carbondata.core.util.CarbonProperties;
 import org.apache.carbondata.core.util.CarbonUtil;
 import org.apache.carbondata.core.util.DataTypeUtil;
 import org.apache.carbondata.core.util.path.CarbonTablePath;
@@ -141,7 +141,7 @@ public class CarbonStreamRecordWriter extends RecordWriter<Void, Object> {
         carbonTable.getAbsoluteTableIdentifier().getTablePath(), segmentId);
     fileName = CarbonTablePath.getCarbonDataFileName(
         0, taskNo + "", 0, 0, "0",
-        segmentId, CompressorFactory.NativeSupportedCompressor.SNAPPY.getName());
+        segmentId, CarbonProperties.getInstance().getDefaultCompressor());
 
     // initialize metadata
     isNoDictionaryDimensionColumn =
@@ -180,7 +180,7 @@ public class CarbonStreamRecordWriter extends RecordWriter<Void, Object> {
       if (header.isSetCompressor_name()) {
         compressorName = header.getCompressor_name();
       } else {
-        compressorName = CompressorFactory.NativeSupportedCompressor.SNAPPY.getName();
+        compressorName = CarbonProperties.getInstance().getDefaultCompressor();
       }
     } else {
       // IF the file is not existed, use the create api
@@ -188,7 +188,7 @@ public class CarbonStreamRecordWriter extends RecordWriter<Void, Object> {
       compressorName = carbonTable.getTableInfo().getFactTable().getTableProperties().get(
           CarbonCommonConstants.COMPRESSOR);
       if (null == compressorName) {
-        compressorName = CompressorFactory.NativeSupportedCompressor.SNAPPY.getName();
+        compressorName = CarbonProperties.getInstance().getDefaultCompressor();
       }
       writeFileHeader();
     }


### PR DESCRIPTION
 ### Why is this PR needed?
Currently there is no easy way to tell what compressor is used given one carbondata file unless to read the FileFooter in the file.
 
 ### What changes were proposed in this PR?
Added compressor name in the carbondata file name, now the file name pattern is 
partNo-taskNo-batchNo-bucketNo-segmentNo-timestamp.compressorName.carbondata

    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes


    
