### PR TITLE
[CARBONDATA-3692] Support NoneCompression during loading data.

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/compression/CompressorFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/compression/CompressorFactory.java
@@ -35,6 +35,7 @@ public class CompressorFactory {
   private final Map<String, Compressor> allSupportedCompressors = new HashMap<>();
 
   public enum NativeSupportedCompressor {
+    NONE("none",NoneCompressor.class),
     SNAPPY("snappy", SnappyCompressor.class),
     ZSTD("zstd", ZstdCompressor.class),
     GZIP("gzip", GzipCompressor.class);

--- a/core/src/main/java/org/apache/carbondata/core/datastore/compression/NoneCompressor.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/compression/NoneCompressor.java
@@ -1,0 +1,51 @@
+package org.apache.carbondata.core.datastore.compression;
+
+import java.io.IOException;
+
+public class NoneCompressor extends AbstractCompressor {
+
+    @Override
+    public String getName() {
+        return "none";
+    }
+
+    @Override
+    public byte[] compressByte(byte[] unCompInput) {
+        return unCompInput;
+    }
+
+    @Override
+    public byte[] compressByte(byte[] unCompInput, int byteSize) {
+        return unCompInput;
+    }
+
+    @Override
+    public byte[] unCompressByte(byte[] compInput) {
+        return compInput;
+    }
+
+    @Override
+    public byte[] unCompressByte(byte[] compInput, int offset, int length) {
+        return compInput;
+    }
+
+    @Override
+    public long rawUncompress(byte[] input, byte[] output) throws IOException {
+        throw new RuntimeException("Not implemented rawCompress for noneCompressor yet");
+    }
+
+    @Override
+    public long maxCompressedLength(long inputSize) {
+        return inputSize;
+    }
+
+    @Override
+    public int unCompressedLength(byte[] data, int offset, int length) {
+        throw new RuntimeException("Unsupported operation Exception");
+    }
+
+    @Override
+    public int rawUncompress(byte[] data, int offset, int length, byte[] output) {
+        throw new RuntimeException("Not implemented rawCompress for noneCompressor yet");
+    }
+}


### PR DESCRIPTION
### Why is this PR needed?

In some cases, the data need to be uncompressed after loading into Carbondata file.
In the current version, the project do not support loading data without compression.

### What changes were proposed in this PR?

Provide a new Compressor as NoneCompressor implement the AbstractCompressor.
This compressor can be set by calling
CarbonProperties.getInstance().addProperty(CarbonCommonConstants.COMPRESSOR,"none");

### Does this PR introduce any user interface change?
Yes

### Is any new testcase added?
Yes


    
