### PR TITLE
[CARBONDATA-3637] Use optimized insert flow for MV and insert stage command

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonInsertFromStageCommand.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonInsertFromStageCommand.scala
@@ -321,18 +321,16 @@ case class CarbonInsertFromStageCommand(
         val header = columns.mkString(",")
         val selectColumns = columns.filter(!partition.contains(_))
         val selectedDataFrame = dataFrame.select(selectColumns.head, selectColumns.tail: _*)
-        CarbonInsertIntoWithDf(
+        CarbonInsertIntoCommand(
           databaseNameOp = Option(table.getDatabaseName),
           tableName = table.getTableName,
           options = scala.collection.immutable.Map("fileheader" -> header,
             "binary_decoder" -> "base64"),
           isOverwriteTable = false,
-          dataFrame = selectedDataFrame,
-          updateModel = None,
-          tableInfoOp = None,
-          internalOptions = Map.empty,
+          logicalPlan = selectedDataFrame.queryExecution.analyzed,
+          tableInfo = table.getTableInfo,
           partition = partition
-        ).process(spark)
+        ).run(spark)
     }
     LOGGER.info(s"finish data loading, time taken ${ System.currentTimeMillis() - start }ms")
   }

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/management/CommonLoadUtils.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/management/CommonLoadUtils.scala
@@ -50,7 +50,7 @@ import org.apache.carbondata.core.constants.{CarbonCommonConstants, CarbonLoadOp
 import org.apache.carbondata.core.datamap.{DataMapStoreManager, TableDataMap}
 import org.apache.carbondata.core.datastore.compression.CompressorFactory
 import org.apache.carbondata.core.indexstore.PartitionSpec
-import org.apache.carbondata.core.keygenerator.directdictionary.timestamp.DateDirectDictionaryGenerator
+import org.apache.carbondata.core.keygenerator.directdictionary.timestamp.{DateDirectDictionaryGenerator, TimeStampGranularityTypeValue}
 import org.apache.carbondata.core.metadata.SegmentFileStore
 import org.apache.carbondata.core.metadata.encoder.Encoding
 import org.apache.carbondata.core.metadata.schema.table.{CarbonTable, TableInfo}
@@ -728,7 +728,13 @@ object CommonLoadUtils {
     }
     val updatedRdd: RDD[InternalRow] = rdd.map { internalRow =>
       for (index <- timeStampIndex) {
-        internalRow.setLong(index, internalRow.getLong(index) / 1000)
+        if (internalRow.getLong(index) == 0) {
+          internalRow.setNullAt(index)
+        } else {
+          internalRow.setLong(
+            index,
+            internalRow.getLong(index) / TimeStampGranularityTypeValue.MILLIS_SECONDS.getValue)
+        }
       }
       var doubleValue: Double = 0
       for (index <- doubleIndex) {

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonCreateTableAsSelectCommand.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonCreateTableAsSelectCommand.scala
@@ -41,7 +41,7 @@ case class CarbonCreateTableAsSelectCommand(
     ifNotExistsSet: Boolean = false,
     tableLocation: Option[String] = None) extends AtomicRunnableCommand {
 
-  var loadCommand: CarbonInsertIntoCommand = _
+  var insertIntoCommand: CarbonInsertIntoCommand = _
 
   override def processMetadata(sparkSession: SparkSession): Seq[Row] = {
     val tableName = tableInfo.getFactTable.getTableName
@@ -76,7 +76,7 @@ case class CarbonCreateTableAsSelectCommand(
         .createCarbonDataSourceHadoopRelation(sparkSession,
           TableIdentifier(tableName, Option(dbName)))
       // execute command to load data into carbon table
-      loadCommand = CarbonInsertIntoCommand(
+      insertIntoCommand = CarbonInsertIntoCommand(
         databaseNameOp = Some(carbonDataSourceHadoopRelation.carbonRelation.databaseName),
         tableName = carbonDataSourceHadoopRelation.carbonRelation.tableName,
         options = scala.collection.immutable
@@ -85,14 +85,14 @@ case class CarbonCreateTableAsSelectCommand(
         isOverwriteTable = false,
         logicalPlan = query,
         tableInfo = tableInfo)
-      loadCommand.processMetadata(sparkSession)
+      insertIntoCommand.processMetadata(sparkSession)
     }
     Seq.empty
   }
 
   override def processData(sparkSession: SparkSession): Seq[Row] = {
-    if (null != loadCommand) {
-      loadCommand.processData(sparkSession)
+    if (null != insertIntoCommand) {
+      insertIntoCommand.processData(sparkSession)
     }
     Seq.empty
   }

--- a/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/MVCreateTestCase.scala
+++ b/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/MVCreateTestCase.scala
@@ -1033,6 +1033,8 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
   }
 
   test("test mv with duplicate columns in query and constant column") {
+    // new optimized insert into flow doesn't support duplicate column names, so send it to old flow
+    CarbonProperties.getInstance().addProperty(CarbonCommonConstants.CARBON_ENABLE_BAD_RECORD_HANDLING_FOR_INSERT, "true")
     sql("drop table if exists maintable")
     sql("create table maintable(name string, age int, add string) STORED AS carbondata")
     sql("create materialized view dupli_mv as select name, sum(age),sum(age) from maintable group by name")
@@ -1051,6 +1053,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     assert(TestUtil.verifyMVDataMap(df4.queryExecution.optimizedPlan, "constant_mv"))
     assert(TestUtil.verifyMVDataMap(df5.queryExecution.optimizedPlan, "dupli_projection"))
     assert(TestUtil.verifyMVDataMap(df6.queryExecution.optimizedPlan, "dupli_projection"))
+    CarbonProperties.getInstance().addProperty(CarbonCommonConstants.CARBON_ENABLE_BAD_RECORD_HANDLING_FOR_INSERT, "false")
   }
 
   test("test mv query when the column names and table name same in join scenario") {

--- a/processing/src/main/java/org/apache/carbondata/processing/store/TablePage.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/TablePage.java
@@ -99,9 +99,13 @@ public class TablePage {
     noDictDimensionPages = new ColumnPage[model.getNoDictionaryCount()];
     int tmpNumDictDimIdx = 0;
     int tmpNumNoDictDimIdx = 0;
-    for (int i = 0; i < dictDimensionPages.length + noDictDimensionPages.length; i++) {
+    for (int i = 0; i < tableSpec.getNumDimensions(); i++) {
       TableSpec.DimensionSpec spec = tableSpec.getDimensionSpec(i);
-      ColumnType columnType = tableSpec.getDimensionSpec(i).getColumnType();
+      if (spec.getSchemaDataType().isComplexType()) {
+        // skip complex columns and go other dimensions.
+        // partition scenario dimensions can present after complex columns.
+        continue;
+      }
       ColumnPage page;
       if (spec.getSchemaDataType() == DataTypes.DATE) {
         page = ColumnPage.newPage(


### PR DESCRIPTION
 ### Why is this PR needed?
MV and insert stage can use the new optimized insert into flow.

Also In the new insert into flow, found one issue with the partition column. Fixed it.
1. If the catalog table schema is already rearranged, don't rearrange again.
2. Timestamp converter was not handled for 0 value.  Need to set it to Null when it is 0.
3. While deriving the index for the convert to 3 step for new insert flow, order was based on internal partition order, instead of internal order.
 
 ### What changes were proposed in this PR?
changed MV and insert stage command to use optimized insert flow.

After this changes,
b. `CarbonInsertIntoCommand` -- insert DML, CTAS DML, MV, insert stage command. 
c. `CarbonInsertIntoWithDf` -- old flow which supports bad record handling with converter step method that process update, compaction, df writer, alter table scenarios [some problem in rearranging now]

    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No

    
