### PR TITLE
[CARBONDATA-3548]Polygon expression processing using unknown expression and filtering performance improvement

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/FilterExpressionProcessor.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/FilterExpressionProcessor.java
@@ -168,8 +168,6 @@ public class FilterExpressionProcessor implements FilterProcessor {
       case TRUE:
         return getFilterResolverBasedOnExpressionType(ExpressionType.TRUE, false,
             expressionTree, tableIdentifier, expressionTree);
-      case POLYGON:
-        return createFilterResolverTree(expressionTree.getChildren().get(0), tableIdentifier);
       default:
         return getFilterResolverBasedOnExpressionType(ExpressionType.UNKNOWN, false, expressionTree,
             tableIdentifier, expressionTree);

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/intf/ExpressionType.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/intf/ExpressionType.java
@@ -44,6 +44,5 @@ public enum ExpressionType {
   ENDSWITH,
   CONTAINSWITH,
   TEXT_MATCH,
-  IMPLICIT,
-  POLYGON
+  IMPLICIT
 }

--- a/integration/spark-common-test/src/test/scala/org/apache/carbondata/geo/GeoTest.scala
+++ b/integration/spark-common-test/src/test/scala/org/apache/carbondata/geo/GeoTest.scala
@@ -1,12 +1,13 @@
 package org.apache.carbondata.geo
 
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.test.util.QueryTest
-import org.scalatest.BeforeAndAfterAll
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
 
 import org.apache.carbondata.common.exceptions.sql.MalformedCarbonCommandException
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 
-class GeoTest extends QueryTest with BeforeAndAfterAll {
+class GeoTest extends QueryTest with BeforeAndAfterAll with BeforeAndAfter {
   override def beforeAll(): Unit = {
     drop()
   }
@@ -80,6 +81,23 @@ class GeoTest extends QueryTest with BeforeAndAfterAll {
     }
   }
 
+  test("test polygon query") {
+    createTable()
+    loadData()
+    checkAnswer(
+      sql(s"select longitude, latitude from geotable where IN_POLYGON('116.321011 40.123503, " +
+          s"116.137676 39.947911, 116.560993 39.935276, 116.321011 40.123503')"),
+      Seq(Row(116187332, 39979316),
+        Row(116362699, 39942444),
+        Row(116288955, 39999101),
+        Row(116325378, 39963129),
+        Row(116337069, 39951887),
+        Row(116285807, 40084087)))
+  }
+
+  after {
+    drop()
+  }
   override def afterAll(): Unit = {
     drop()
   }
@@ -98,13 +116,13 @@ class GeoTest extends QueryTest with BeforeAndAfterAll {
            | TBLPROPERTIES ('INDEX_HANDLER'='mygeohash',
            | 'INDEX_HANDLER.mygeohash.type'='geohash',
            | 'INDEX_HANDLER.mygeohash.sourcecolumns'='longitude, latitude',
-           | 'INDEX_HANDLER.mygeohash.originLatitude'='1',
-           | 'INDEX_HANDLER.mygeohash.gridSize'='2',
-           | 'INDEX_HANDLER.mygeohash.minLongitude'='1',
-           | 'INDEX_HANDLER.mygeohash.maxLongitude'='4',
-           | 'INDEX_HANDLER.mygeohash.minLatitude'='1',
-           | 'INDEX_HANDLER.mygeohash.maxLatitude'='4',
-           | 'INDEX_HANDLER.mygeohash.conversionRatio'='1')
+           | 'INDEX_HANDLER.mygeohash.originLatitude'='39.832277',
+           | 'INDEX_HANDLER.mygeohash.gridSize'='50',
+           | 'INDEX_HANDLER.mygeohash.minLongitude'='115.811865',
+           | 'INDEX_HANDLER.mygeohash.maxLongitude'='116.782233',
+           | 'INDEX_HANDLER.mygeohash.minLatitude'='39.832277',
+           | 'INDEX_HANDLER.mygeohash.maxLatitude'='40.225281',
+           | 'INDEX_HANDLER.mygeohash.conversionRatio'='1000000')
        """.stripMargin)
   }
 


### PR DESCRIPTION
 ### Why is this PR needed?
This PR improves the query processing performance of in_polygon UDF.
 
 ### What changes were proposed in this PR?
 At present, PolygonExpression processing leverages the existing InExpression. PolygonExpression internally creates a InExpression as a child to it. InExpression is constructed/build from the result of Quad tree algorithm. Algorithm returns the list of ranges(with each range having min and max Id for that range). And this list is a sorted one.
              InExpression constitute of 2 childs. One child is a columnExpression(for geohash column) and the other is a ListExpression( with List of LiternalExpressions. One LiteralExpression for each Id returned from algo).
**Problems associated with this approach:**
- We expand the list of ranges(with each range having minand max) to all individual Ids. And create LiteralExpression for each Id. Since we can have large ranges(and the numerous ranges), it consumes huge amount of memory in processing.
- Due to same reason, it slows does the filter execution.

**Modifications with this PR:**
Instead we can use UnknownExpression with RowLevelFilterResolverImpl and RowLevelFilterExecuterImpl processing. And override evaluate() method to do the binary  searchon the list of ranges directly. This will significanly inprove the polygon filter query performance. And Polygon filter expression type is not required anymore at Carbon-Core module.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes. Added an end to end test case

    
