### PR TITLE
[HOTFIX] Remove unused fields in TableInfo

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/metadata/converter/ThriftWrapperSchemaConverterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/converter/ThriftWrapperSchemaConverterImpl.java
@@ -312,16 +312,7 @@ public class ThriftWrapperSchemaConverterImpl implements SchemaConverter {
       TableInfo wrapperTableInfo, String dbName, String tableName) {
     org.apache.carbondata.format.TableSchema thriftFactTable =
         fromWrapperToExternalTableSchema(wrapperTableInfo.getFactTable());
-    org.apache.carbondata.format.TableInfo tableInfo =
-        new org.apache.carbondata.format.TableInfo(thriftFactTable,
-            new ArrayList<org.apache.carbondata.format.TableSchema>());
-    List<DataMapSchema> wrapperChildSchemaList = wrapperTableInfo.getDataMapSchemaList();
-    if (null != wrapperChildSchemaList) {
-      List<org.apache.carbondata.format.DataMapSchema> thriftChildSchemas =
-          fromWrapperToExternalChildSchemaList(wrapperChildSchemaList);
-      tableInfo.setDataMapSchemas(thriftChildSchemas);
-    }
-    return tableInfo;
+    return new org.apache.carbondata.format.TableInfo(thriftFactTable, new ArrayList<>());
   }
 
   private List<org.apache.carbondata.format.RelationIdentifier> fromWrapperToExternalRI(
@@ -657,10 +648,6 @@ public class ThriftWrapperSchemaConverterImpl implements SchemaConverter {
     wrapperTableInfo.setTableUniqueName(CarbonTable.buildUniqueName(dbName, tableName));
     wrapperTableInfo.setFactTable(
         fromExternalToWrapperTableSchema(externalTableInfo.getFact_table(), tableName));
-    if (null != externalTableInfo.getDataMapSchemas()) {
-      wrapperTableInfo.setDataMapSchemaList(
-          fromExternalToWrapperChildSchemaList(externalTableInfo.getDataMapSchemas()));
-    }
     wrapperTableInfo.setTablePath(tablePath);
     return wrapperTableInfo;
   }

--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/CarbonTableBuilder.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/CarbonTableBuilder.java
@@ -17,7 +17,6 @@
 
 package org.apache.carbondata.core.metadata.schema.table;
 
-import java.util.ArrayList;
 import java.util.Objects;
 
 /**
@@ -72,7 +71,6 @@ public class CarbonTableBuilder {
     tableInfo.setTablePath(tablePath);
     tableInfo.setTransactionalTable(isTransactionalTable);
     tableInfo.setLastUpdatedTime(System.currentTimeMillis());
-    tableInfo.setDataMapSchemaList(new ArrayList<DataMapSchema>(0));
     return CarbonTable.buildFromTableInfo(tableInfo);
   }
 }

--- a/core/src/test/java/org/apache/carbondata/core/metadata/converter/ThriftWrapperSchemaConverterImplTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/metadata/converter/ThriftWrapperSchemaConverterImplTest.java
@@ -1434,7 +1434,6 @@ public class ThriftWrapperSchemaConverterImplTest {
     org.apache.carbondata.format.TableInfo expectedResult =
         new org.apache.carbondata.format.TableInfo(thriftFactTable, new ArrayList<org.apache
             .carbondata.format.TableSchema>());
-    expectedResult.setDataMapSchemas(new ArrayList<DataMapSchema>());
     assertEquals(expectedResult, actualResult);
   }
 

--- a/core/src/test/java/org/apache/carbondata/core/metadata/schema/table/TableInfoTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/metadata/schema/table/TableInfoTest.java
@@ -86,8 +86,7 @@ public class TableInfoTest extends TestCase {
         + "\"tableProperties\":{\"sort_columns\":\"c1\",\"comment\":\"\","
         + "\"local_dictionary_enable\":\"true\"}},\"lastUpdatedTime\":1530534235537,"
         + "\"tablePath\":\"/store/carbonversion_1_1/testinttype1\","
-        + "\"isTransactionalTable\":true,\"dataMapSchemaList\":[],"
-        + "\"parentRelationIdentifiers\":[],\"isSchemaModified\":false}");
+        + "\"isTransactionalTable\":true,\"isSchemaModified\":false}");
     TableInfo tableInfo = CarbonUtil.convertGsonToTableInfo(properties);
     // the schema evolution should not be null
     assertTrue(null != tableInfo.getFactTable().getSchemaEvolution());

--- a/core/src/test/java/org/apache/carbondata/core/metadata/schema/table/TableInfoTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/metadata/schema/table/TableInfoTest.java
@@ -18,7 +18,6 @@
 package org.apache.carbondata.core.metadata.schema.table;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import org.apache.carbondata.core.metadata.converter.ThriftWrapperSchemaConverterImpl;
@@ -204,11 +203,8 @@ public class TableInfoTest extends TestCase {
         + "\"parentRelationIdentifiers\":[],\"isSchemaModified\":false}");
     TableInfo tableInfo = CarbonUtil.convertGsonToTableInfo(properties);
     // the schema evolution should not be null
-    assertTrue(null != tableInfo.getDataMapSchemaList());
-    List<DataMapSchema> dataMapSchemaList = tableInfo.getDataMapSchemaList();
-    for (DataMapSchema dataMapSchema : dataMapSchemaList) {
-      String providerName = dataMapSchema.getProviderName();
-      assertTrue("org.apache.carbondata.core.datamap.AggregateDataMap".equals(providerName));
-    }
+    assertTrue(null != tableInfo.getFactTable());
+    assertTrue(null != tableInfo.getFactTable().getListOfColumns());
+    assertTrue(null != tableInfo.getFactTable().getTableProperties());
   }
 }

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/datamap/CarbonCreateDataMapCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/datamap/CarbonCreateDataMapCommand.scala
@@ -71,14 +71,6 @@ case class CarbonCreateDataMapCommand(
       throw new MalformedCarbonCommandException("Unsupported operation on non transactional table")
     }
 
-    if (mainTable != null && mainTable.getDataMapSchema(dataMapName) != null) {
-      if (!ifNotExistsSet) {
-        throw new MalformedDataMapCommandException(s"DataMap name '$dataMapName' already exist")
-      } else {
-        return Seq.empty
-      }
-    }
-
     if (mainTable != null && CarbonUtil.getFormatVersion(mainTable) != ColumnarFormatVersion.V3) {
       throw new MalformedCarbonCommandException(s"Unsupported operation on table with " +
                                                 s"V1 or V2 format data")

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/datamap/CarbonDataMapShowCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/datamap/CarbonDataMapShowCommand.scala
@@ -32,7 +32,7 @@ import org.apache.spark.sql.types.StringType
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.datamap.{DataMapStoreManager, DataMapUtil}
 import org.apache.carbondata.core.datamap.status.{DataMapSegmentStatusUtil, DataMapStatus, DataMapStatusManager}
-import org.apache.carbondata.core.metadata.schema.datamap.{DataMapClassProvider, DataMapProperty}
+import org.apache.carbondata.core.metadata.schema.datamap.DataMapProperty
 import org.apache.carbondata.core.metadata.schema.table.DataMapSchema
 import org.apache.carbondata.core.statusmanager.{SegmentStatus, SegmentStatusManager}
 import org.apache.carbondata.core.util.path.CarbonTablePath
@@ -68,9 +68,6 @@ case class CarbonDataMapShowCommand(tableIdentifier: Option[TableIdentifier])
         val carbonTable = CarbonEnv.getCarbonTable(table)(sparkSession)
         setAuditTable(carbonTable)
         Checker.validateTableExists(table.database, table.table, sparkSession)
-        if (carbonTable.hasDataMapSchema) {
-          dataMapSchemaList.addAll(carbonTable.getTableInfo.getDataMapSchemaList)
-        }
         val indexSchemas = DataMapStoreManager.getInstance().getDataMapSchemasOfTable(carbonTable)
         if (!indexSchemas.isEmpty) {
           dataMapSchemaList.addAll(indexSchemas)

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/RefreshCarbonTableCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/management/RefreshCarbonTableCommand.scala
@@ -88,24 +88,7 @@ case class RefreshCarbonTableCommand(
         // refresh the column schema in case of store before V3
         refreshColumnSchema(tableInfo)
 
-        // 2.2 register the table with the hive check if the table being registered has
-        // aggregate table then do the below steps
-        // 2.2.1 validate that all the aggregate tables are copied at the store location.
-        val dataMapSchemaList = tableInfo.getDataMapSchemaList
-        if (null != dataMapSchemaList && dataMapSchemaList.size() != 0) {
-          // validate all the aggregate tables are copied at the storeLocation
-          val allExists = validateAllAggregateTablePresent(databaseName,
-            dataMapSchemaList, sparkSession)
-          if (!allExists) {
-            // fail the register operation
-            val msg = s"Table registration with Database name [$databaseName] and Table name " +
-                      s"[$tableName] failed. All the aggregate Tables for table [$tableName] is" +
-                      s" not copied under database [$databaseName]"
-            throwMetadataException(databaseName, tableName, msg)
-          }
-          // 2.2.1 Register the aggregate tables to hive
-          registerAggregates(databaseName, dataMapSchemaList)(sparkSession)
-        }
+        // 2.2 register the table with the hive
         registerTableWithHive(databaseName, tableName, tableInfo, tablePath)(sparkSession)
         // Register partitions to hive metastore in case of hive partitioning carbon table
         if (tableInfo.getFactTable.getPartitionInfo != null &&

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/schema/CarbonAlterTableRenameCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/schema/CarbonAlterTableRenameCommand.scala
@@ -101,9 +101,6 @@ private[sql] case class CarbonAlterTableRenameCommand(
       }
       // get the old table all data map schema
       val dataMapSchemaList: util.List[DataMapSchema] = new util.ArrayList[DataMapSchema]()
-      if (carbonTable.hasDataMapSchema) {
-        dataMapSchemaList.addAll(carbonTable.getTableInfo.getDataMapSchemaList)
-      }
       val indexSchemas = DataMapStoreManager.getInstance().getDataMapSchemasOfTable(carbonTable)
       if (!indexSchemas.isEmpty) {
         dataMapSchemaList.addAll(indexSchemas)

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonDropTableCommand.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonDropTableCommand.scala
@@ -97,11 +97,10 @@ case class CarbonDropTableCommand(
 
       CarbonEnv.getInstance(sparkSession).carbonMetaStore.dropTable(identifier)(sparkSession)
 
-      val indexDatamapSchemas =
-        DataMapStoreManager.getInstance().getDataMapSchemasOfTable(carbonTable)
-      LOGGER.info(s"Dropping DataMaps in table $tableName, size: ${indexDatamapSchemas.size()}")
-      if (!indexDatamapSchemas.isEmpty) {
-        childDropDataMapCommands = indexDatamapSchemas.asScala.map { schema =>
+      val dataMapSchemas = DataMapStoreManager.getInstance().getDataMapSchemasOfTable(carbonTable)
+      LOGGER.info(s"Dropping DataMaps in table $tableName, size: ${dataMapSchemas.size()}")
+      if (!dataMapSchemas.isEmpty) {
+        childDropDataMapCommands = dataMapSchemas.asScala.map { schema =>
           val command = CarbonDropDataMapCommand(schema.getDataMapName,
             ifExistsSet,
             Some(TableIdentifier(tableName, Some(dbName))),

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/listeners/DropCacheEventListeners.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/listeners/DropCacheEventListeners.scala
@@ -52,11 +52,6 @@ object DropCacheDataMapEventListener extends OperationEventListener {
           throw new UnsupportedOperationException("Operation not allowed on child table.")
         }
 
-        if (carbonTable.hasDataMapSchema) {
-          val childrenSchemas = carbonTable.getTableInfo.getDataMapSchemaList.asScala
-            .filter(_.getRelationIdentifier != null)
-          dropCacheForChildTables(sparkSession, childrenSchemas)
-        }
         if (DataMapUtil.hasMVDataMap(carbonTable)) {
           val childrenSchemas = DataMapStoreManager.getInstance
             .getDataMapSchemasOfTable(carbonTable).asScala

--- a/integration/spark2/src/main/scala/org/apache/spark/sql/listeners/ShowCacheEventListeners.scala
+++ b/integration/spark2/src/main/scala/org/apache/spark/sql/listeners/ShowCacheEventListeners.scala
@@ -43,20 +43,6 @@ object ShowCachePreMVEventListener extends OperationEventListener {
         if (carbonTable.isChildTableForMV && !internalCall) {
           throw new UnsupportedOperationException("Operation not allowed on child table.")
         }
-
-        val childTables = operationContext.getProperty(carbonTable.getTableUniqueName)
-          .asInstanceOf[List[(String, String)]]
-
-        if (carbonTable.hasDataMapSchema) {
-          val childrenSchemas = carbonTable.getTableInfo.getDataMapSchemaList.asScala
-            .filter(_.getRelationIdentifier != null)
-          operationContext.setProperty(carbonTable.getTableUniqueName, childrenSchemas.collect {
-            case childSchema if childSchema.getRelationIdentifier != null =>
-              (s"${ childSchema.getRelationIdentifier.getDatabaseName }-${
-                childSchema.getRelationIdentifier.getTableName
-              }", childSchema.getProviderName, childSchema.getRelationIdentifier.getTableId)
-          }.toList ++ childTables)
-        }
     }
   }
 }


### PR DESCRIPTION
 ### Why is this PR needed?
 In TableInfo, dataMapSchemaList and parentRelationIdentifiers are always empty. If user create index or mv, neigher of their schema is stored in TableInfo, but only stored in systemfolder.
 
 ### What changes were proposed in this PR?
This PR removes dataMapSchemaList and parentRelationIdentifiers in TableInfo class
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No


    
