### PR TITLE
[CARBONDATA-3692] Support NoneCompression during loading data.

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/compression/CompressorFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/compression/CompressorFactory.java
@@ -35,7 +35,7 @@ public class CompressorFactory {
   private final Map<String, Compressor> allSupportedCompressors = new HashMap<>();
 
   public enum NativeSupportedCompressor {
-    NONE("none",NoneCompressor.class),
+    NONE("none", NoneCompressor.class),
     SNAPPY("snappy", SnappyCompressor.class),
     ZSTD("zstd", ZstdCompressor.class),
     GZIP("gzip", GzipCompressor.class);

--- a/core/src/main/java/org/apache/carbondata/core/datastore/compression/CompressorFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/compression/CompressorFactory.java
@@ -35,6 +35,7 @@ public class CompressorFactory {
   private final Map<String, Compressor> allSupportedCompressors = new HashMap<>();
 
   public enum NativeSupportedCompressor {
+    NONE("none",NoneCompressor.class),
     SNAPPY("snappy", SnappyCompressor.class),
     ZSTD("zstd", ZstdCompressor.class),
     GZIP("gzip", GzipCompressor.class);

--- a/core/src/main/java/org/apache/carbondata/core/datastore/compression/NoneCompressor.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/compression/NoneCompressor.java
@@ -1,0 +1,51 @@
+package org.apache.carbondata.core.datastore.compression;
+
+import java.io.IOException;
+
+public class NoneCompressor extends AbstractCompressor {
+
+    @Override
+    public String getName() {
+        return "none";
+    }
+
+    @Override
+    public byte[] compressByte(byte[] unCompInput) {
+        return unCompInput;
+    }
+
+    @Override
+    public byte[] compressByte(byte[] unCompInput, int byteSize) {
+        return unCompInput;
+    }
+
+    @Override
+    public byte[] unCompressByte(byte[] compInput) {
+        return compInput;
+    }
+
+    @Override
+    public byte[] unCompressByte(byte[] compInput, int offset, int length) {
+        return compInput;
+    }
+
+    @Override
+    public long rawUncompress(byte[] input, byte[] output) throws IOException {
+        throw new RuntimeException("Not implemented rawCompress for noneCompressor yet");
+    }
+
+    @Override
+    public long maxCompressedLength(long inputSize) {
+        return inputSize;
+    }
+
+    @Override
+    public int unCompressedLength(byte[] data, int offset, int length) {
+        throw new RuntimeException("Unsupported operation Exception");
+    }
+
+    @Override
+    public int rawUncompress(byte[] data, int offset, int length, byte[] output) {
+        throw new RuntimeException("Not implemented rawCompress for noneCompressor yet");
+    }
+}

--- a/core/src/main/java/org/apache/carbondata/core/datastore/compression/NoneCompressor.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/compression/NoneCompressor.java
@@ -1,6 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.carbondata.core.datastore.compression;
 
 import java.io.IOException;
+
+/**
+ * This compressor actually will not compress or decompress anything.
+ * It is used for speed up the data loading by skip the compression.
+ */
 
 public class NoneCompressor extends AbstractCompressor {
 


### PR DESCRIPTION
 ### Why is this PR needed?
 In some cases, the data need to be uncompressed after loading into Carbondata file.
In the current version, the project does not support loading data without compression.
It could speed up data loading form Flink to OBS by skipping compress and uncompress data.

 
 ### What changes were proposed in this PR?
Provide a new Compressor as NoneCompressor implements the AbstractCompressor which will actually not compress and uncompress anything.
This compressor can be set by calling
CarbonProperties.getInstance().addProperty(CarbonCommonConstants.COMPRESSOR,"none");
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
- Yes

    
