### PR TITLE
[CARBONDATA-3705] Support create and load MV for spark datasource table

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datamap/DataMapProvider.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/DataMapProvider.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.apache.carbondata.common.annotations.InterfaceAudience;
 import org.apache.carbondata.common.exceptions.sql.MalformedDataMapCommandException;
@@ -189,7 +190,11 @@ public abstract class DataMapProvider {
             return false;
           }
         } else {
-          List<RelationIdentifier> relationIdentifiers = dataMapSchema.getParentTables();
+          // set segment mapping only for carbondata table
+          List<RelationIdentifier> relationIdentifiers = dataMapSchema.getParentTables()
+              .stream()
+              .filter(RelationIdentifier::isCarbonDataTable)
+              .collect(Collectors.toList());
           for (RelationIdentifier relationIdentifier : relationIdentifiers) {
             List<String> mainTableSegmentList =
                 DataMapUtil.getMainTableValidSegmentList(relationIdentifier);

--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/RelationIdentifier.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/RelationIdentifier.java
@@ -21,6 +21,7 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.Objects;
 
 /**
  * class to maintain the relation between parent and child
@@ -34,6 +35,8 @@ public class RelationIdentifier implements Serializable, Writable {
   private String tableId;
 
   private String tablePath = "";
+
+  private String provider = "carbondata";
 
   public RelationIdentifier(String databaseName, String tableName, String tableId) {
     this.databaseName = databaseName;
@@ -61,12 +64,25 @@ public class RelationIdentifier implements Serializable, Writable {
     this.tablePath = tablePath;
   }
 
+  public String getProvider() {
+    return provider;
+  }
+
+  public void setProvider(String provider) {
+    this.provider = provider;
+  }
+
+  public boolean isCarbonDataTable() {
+    return provider.equalsIgnoreCase("carbondata");
+  }
+
   @Override
   public void write(DataOutput out) throws IOException {
     out.writeUTF(databaseName);
     out.writeUTF(tableName);
     out.writeUTF(tableId);
     out.writeUTF(tablePath);
+    out.writeUTF(provider);
   }
 
   @Override
@@ -75,6 +91,7 @@ public class RelationIdentifier implements Serializable, Writable {
     this.tableName = in.readUTF();
     this.tableId = in.readUTF();
     this.tablePath = in.readUTF();
+    this.provider = in.readUTF();
   }
 
   @Override
@@ -84,15 +101,16 @@ public class RelationIdentifier implements Serializable, Writable {
 
     RelationIdentifier that = (RelationIdentifier) o;
 
-    if (databaseName != null ?
-        !databaseName.equals(that.databaseName) :
-        that.databaseName != null) {
+    if (!Objects.equals(databaseName, that.databaseName)) {
       return false;
     }
-    if (tableName != null ? !tableName.equals(that.tableName) : that.tableName != null) {
+    if (!Objects.equals(tableName, that.tableName)) {
       return false;
     }
-    return tableId != null ? tableId.equals(that.tableId) : that.tableId == null;
+    if (!Objects.equals(provider, that.provider)) {
+      return false;
+    }
+    return Objects.equals(tableId, that.tableId);
   }
 
   @Override
@@ -100,6 +118,7 @@ public class RelationIdentifier implements Serializable, Writable {
     int result = databaseName != null ? databaseName.hashCode() : 0;
     result = 31 * result + (tableName != null ? tableName.hashCode() : 0);
     result = 31 * result + (tableId != null ? tableId.hashCode() : 0);
+    result = 31 * result + (provider != null ? provider.hashCode() : 0);
     return result;
   }
 

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
@@ -288,6 +288,20 @@ object CarbonEnv {
   }
 
   /**
+   * Return any kinds of table including non-carbon table
+   */
+  def getAnyTable(
+      databaseNameOp: Option[String],
+      tableName: String)
+    (sparkSession: SparkSession): CarbonTable = {
+    val catalog = getInstance(sparkSession).carbonMetaStore
+    catalog
+      .lookupAnyRelation(databaseNameOp, tableName)(sparkSession)
+      .asInstanceOf[CarbonRelation]
+      .carbonTable
+  }
+
+  /**
    *
    * @return true is the relation was changes and was removed from cache. false is there is no
    *         change in the relation.

--- a/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonMetaStore.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonMetaStore.scala
@@ -35,9 +35,12 @@ import org.apache.carbondata.format.SchemaEvolutionEntry
 trait CarbonMetaStore {
 
   def lookupRelation(dbName: Option[String], tableName: String)
-    (sparkSession: SparkSession): LogicalPlan
+    (sparkSession: SparkSession): CarbonRelation
 
   def lookupRelation(tableIdentifier: TableIdentifier)
+    (sparkSession: SparkSession): CarbonRelation
+
+  def lookupAnyRelation(dbName: Option[String], tableName: String)
     (sparkSession: SparkSession): LogicalPlan
 
   /**

--- a/integration/spark/src/main/scala/org/apache/spark/sql/parser/CarbonSparkSqlParserUtil.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/parser/CarbonSparkSqlParserUtil.scala
@@ -460,6 +460,7 @@ object CarbonSparkSqlParserUtil {
       )
       TableNewProcessor(tableModel)
     }
+    tableInfo.setTablePath(identifier.getTablePath)
     tableInfo.setTransactionalTable(isTransactionalTable)
     tableInfo
   }

--- a/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/MVCreateTestCase.scala
+++ b/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/MVCreateTestCase.scala
@@ -109,9 +109,16 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     sql("drop table if exists source")
     sql("create table source using parquet as select * from fact_table1")
     sql("create materialized view mv1 as select empname, deptname, avg(salary) from source group by empname, deptname")
-    val df = sql("select empname, avg(salary) from source group by empname")
+    var df = sql("select empname, avg(salary) from source group by empname")
     assert(TestUtil.verifyMVDataMap(df.queryExecution.optimizedPlan, "mv1"))
     checkAnswer(df, sql("select empname, avg(salary) from fact_table2 group by empname"))
+
+    // load to parquet table and check again
+    sql("insert into source select * from fact_table1")
+    df = sql("select empname, avg(salary) from source group by empname")
+    assert(TestUtil.verifyMVDataMap(df.queryExecution.optimizedPlan, "mv1"))
+    checkAnswer(df, sql("select empname, avg(salary) from fact_table2 group by empname"))
+
     sql(s"drop materialized view mv1")
     sql("drop table source")
   }
@@ -121,9 +128,16 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     sql("drop table if exists source")
     sql("create table source using orc as select * from fact_table1")
     sql("create materialized view mv1 as select empname, deptname, avg(salary) from source group by empname, deptname")
-    val df = sql("select empname, avg(salary) from source group by empname")
+    var df = sql("select empname, avg(salary) from source group by empname")
     assert(TestUtil.verifyMVDataMap(df.queryExecution.optimizedPlan, "mv1"))
     checkAnswer(df, sql("select empname, avg(salary) from fact_table2 group by empname"))
+
+    // load to orc table and check again
+    sql("insert into source select * from fact_table1")
+    df = sql("select empname, avg(salary) from source group by empname")
+    assert(TestUtil.verifyMVDataMap(df.queryExecution.optimizedPlan, "mv1"))
+    checkAnswer(df, sql("select empname, avg(salary) from fact_table2 group by empname"))
+
     sql(s"drop materialized view mv1")
     sql("drop table source")
   }
@@ -133,9 +147,16 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     sql("drop table if exists source")
     sql("create table source stored as parquet as select * from fact_table1")
     sql("create materialized view mv1 as select empname, deptname, avg(salary) from source group by empname, deptname")
-    val df = sql("select empname, avg(salary) from source group by empname")
+    var df = sql("select empname, avg(salary) from source group by empname")
     assert(TestUtil.verifyMVDataMap(df.queryExecution.optimizedPlan, "mv1"))
     checkAnswer(df, sql("select empname, avg(salary) from fact_table2 group by empname"))
+
+    // load to parquet table and check again
+    sql("insert into source select * from fact_table1")
+    df = sql("select empname, avg(salary) from source group by empname")
+    assert(TestUtil.verifyMVDataMap(df.queryExecution.optimizedPlan, "mv1"))
+    checkAnswer(df, sql("select empname, avg(salary) from fact_table2 group by empname"))
+
     sql(s"drop materialized view mv1")
     sql("drop table source")
   }

--- a/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/MVCreateTestCase.scala
+++ b/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/MVCreateTestCase.scala
@@ -104,6 +104,58 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     sql(s"""LOAD DATA local inpath '$resourcesPath/data_big.csv' INTO TABLE fact_table6 OPTIONS('DELIMITER'= ',', 'QUOTECHAR'= '"')""")
   }
 
+  test("test create mv on parquet spark table") {
+    sql("drop materialized view if exists mv1")
+    sql("drop table if exists source")
+    sql("create table source using parquet as select * from fact_table1")
+    sql("create materialized view mv1 as select empname, deptname, avg(salary) from source group by empname, deptname")
+    val df = sql("select empname, avg(salary) from source group by empname")
+    assert(TestUtil.verifyMVDataMap(df.queryExecution.optimizedPlan, "mv1"))
+    checkAnswer(df, sql("select empname, avg(salary) from fact_table2 group by empname"))
+    sql(s"drop materialized view mv1")
+    sql("drop table source")
+  }
+
+  test("test create mv on orc spark table") {
+    sql("drop materialized view if exists mv1")
+    sql("drop table if exists source")
+    sql("create table source using orc as select * from fact_table1")
+    sql("create materialized view mv1 as select empname, deptname, avg(salary) from source group by empname, deptname")
+    val df = sql("select empname, avg(salary) from source group by empname")
+    assert(TestUtil.verifyMVDataMap(df.queryExecution.optimizedPlan, "mv1"))
+    checkAnswer(df, sql("select empname, avg(salary) from fact_table2 group by empname"))
+    sql(s"drop materialized view mv1")
+    sql("drop table source")
+  }
+
+  test("test create mv on parquet hive table") {
+    sql("drop materialized view if exists mv1")
+    sql("drop table if exists source")
+    sql("create table source stored as parquet as select * from fact_table1")
+    sql("create materialized view mv1 as select empname, deptname, avg(salary) from source group by empname, deptname")
+    val df = sql("select empname, avg(salary) from source group by empname")
+    assert(TestUtil.verifyMVDataMap(df.queryExecution.optimizedPlan, "mv1"))
+    checkAnswer(df, sql("select empname, avg(salary) from fact_table2 group by empname"))
+    sql(s"drop materialized view mv1")
+    sql("drop table source")
+  }
+
+  // TODO: orc hive table is not supported since MV rewrite does not handle HiveTableRelation
+  ignore("test create mv on orc hive table") {
+    sql("drop materialized view if exists mv2")
+    sql("drop table if exists source")
+    sql("create table source stored as orc as select * from fact_table1")
+    sql("explain extended select empname, avg(salary) from source group by empname").show(false)
+    sql("create materialized view mv2 as select empname, deptname, avg(salary) from source group by empname, deptname")
+    sql("select * from mv2_table").show
+    val df = sql("select empname, avg(salary) from source group by empname")
+    sql("explain extended select empname, avg(salary) from source group by empname").show(false)
+    assert(TestUtil.verifyMVDataMap(df.queryExecution.optimizedPlan, "mv2"))
+    checkAnswer(df, sql("select empname, avg(salary) from fact_table2 group by empname"))
+    sql(s"drop materialized view mv2")
+    sql("drop table source")
+  }
+
   test("test create mv with simple and same projection") {
     sql("drop materialized view if exists mv1")
     sql("create materialized view mv1 as select empname, designation from fact_table1")

--- a/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/TestAllOperationsOnMV.scala
+++ b/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/TestAllOperationsOnMV.scala
@@ -235,12 +235,11 @@ class TestAllOperationsOnMV extends QueryTest with BeforeAndAfterEach {
 
   test("test mv with non-carbon table") {
     sql("drop table if exists noncarbon")
-    sql("create table noncarbon (product string,amount int)")
+    sql("create table noncarbon (product string,amount int) stored as parquet")
     sql("insert into noncarbon values('Mobile',2000)")
     sql("drop materialized view if exists p")
-    intercept[MalformedCarbonCommandException] {
-      sql("Create materialized view p  as Select product from noncarbon")
-    }.getMessage.contains("Non-Carbon table does not support creating MV materialized view")
+    sql("Create materialized view p as Select product from noncarbon")
+    sql("drop materialized view p")
     sql("drop table if exists noncarbon")
   }
 


### PR DESCRIPTION
This PR is based on #3612 

 ### Why is this PR needed?
Materialized View is a feature built on top of Spark, it should support not only carbondata format but also other formats.
 
 ### What changes were proposed in this PR?
1. Added an API in CarbonMetaStore to lookup any relation, not just carbon relation
2. When creating MV, use newly added lookup relation to get all parent table relations. Use CatalogTable instead of CarbonTable whenever possible
3. Skip the segment handling when loading MV
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes 

    
