### PR TITLE
[CARBONDATA-3709] Move stage_data directory to the $tablePath/ from $tablePath/Metadata/

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/util/path/CarbonTablePath.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/path/CarbonTablePath.java
@@ -71,7 +71,7 @@ public class CarbonTablePath {
   }
 
   public static String getStageDataDir(String tablePath) {
-    return getMetadataPath(tablePath) + CarbonCommonConstants.FILE_SEPARATOR + STAGE_DATA_DIR;
+    return tablePath + CarbonCommonConstants.FILE_SEPARATOR + STAGE_DATA_DIR;
   }
 
   public static String getStageSnapshotFile(String tablePath) {


### PR DESCRIPTION
 ### Why is this PR needed?
 The stage_data directory is data directory, but under the $tablePath/Metadata/ directory, it cause the metadata directory is not clean.
 
 ### What changes were proposed in this PR?
Move stage_data directory to the $tablePath/ from $tablePath/Metadata/, and keep the $tablePath/Metadata/ directory not include any data.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No

    
