### PR TITLE
[CARBONDATA-3714] Support specify order type when list stage files

### DIFF
--- a/docs/dml-of-carbondata.md
+++ b/docs/dml-of-carbondata.md
@@ -323,6 +323,7 @@ CarbonData DML statements are documented here,which includes:
 | Property                                                | Description                                                  |
 | ------------------------------------------------------- | ------------------------------------------------------------ |
 | [BATCH_FILE_COUNT](#batch_file_count)                   | The number of stage files per processing                     |
+| [BATCH_FILE_ORDER](#batch_file_order)                   | The order type of stage files in per processing                     |
 
 -
   You can use the following options to load data:
@@ -334,11 +335,24 @@ CarbonData DML statements are documented here,which includes:
     OPTIONS('batch_file_count'='5')
     ```
 
+  - ##### BATCH_FILE_ORDER: 
+    The order type of stage files in per processing, choices: ASC, DESC.
+    The default is ASC.
+    Stage files will order by the last modified time with the specified order type.
+
+    ``` 
+    OPTIONS('batch_file_order'='DESC')
+    ```
+
   Examples:
   ```
   INSERT INTO table1 STAGE
 
   INSERT INTO table1 STAGE OPTIONS('batch_file_count' = '5')
+  Note: This command use the default file order, will insert the earliest stage files into the table.
+
+  INSERT INTO table1 STAGE OPTIONS('batch_file_count' = '5', 'batch_file_order'='DESC')
+  Note: This command will insert the latest stage files into the table.
   ```
 
 ### Load Data Using Static Partition 

--- a/integration/flink/src/test/scala/org/apache/carbon/flink/TestCarbonWriter.scala
+++ b/integration/flink/src/test/scala/org/apache/carbon/flink/TestCarbonWriter.scala
@@ -27,6 +27,7 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink
 import org.apache.spark.sql.{CarbonEnv, Row}
 import org.apache.spark.sql.test.util.QueryTest
+
 import org.apache.carbondata.core.datastore.impl.FileFactory
 import org.apache.carbondata.core.util.CarbonProperties
 import org.apache.carbondata.core.util.path.CarbonTablePath
@@ -36,7 +37,6 @@ class TestCarbonWriter extends QueryTest {
 
   val tableName = "test_flink"
   val bucketTableName = "insert_bucket_table"
-
 
   test("Writing flink data to local carbon table") {
     sql(s"DROP TABLE IF EXISTS $tableName").collect()
@@ -281,9 +281,9 @@ class TestCarbonWriter extends QueryTest {
 
       val plan = sql(
         s"""
-          |select t1.*, t2.*
-          |from $tableName t1, $bucketTableName t2
-          |where t1.stringField = t2.stringField
+           |select t1.*, t2.*
+           |from $tableName t1, $bucketTableName t2
+           |where t1.stringField = t2.stringField
       """.stripMargin).queryExecution.executedPlan
       var shuffleExists = false
       plan.collect {
@@ -297,15 +297,16 @@ class TestCarbonWriter extends QueryTest {
 
       checkAnswer(sql(
         s"""select count(*) from
-          |(select t1.*, t2.*
-          |from $tableName t1, $bucketTableName t2
-          |where t1.stringField = t2.stringField) temp
+           |(select t1.*, t2.*
+           |from $tableName t1, $bucketTableName t2
+           |where t1.stringField = t2.stringField) temp
       """.stripMargin), Row(1000))
     } finally {
       sql(s"DROP TABLE IF EXISTS $tableName").collect()
       sql(s"DROP TABLE IF EXISTS $bucketTableName").collect()
     }
   }
+
 
   private def newWriterProperties(
     dataTempPath: String,


### PR DESCRIPTION
 ### Why is this PR needed?
 Sometimes, user want load the lastest data to table first.
 
 ### What changes were proposed in this PR?
Add "batch_file_order" option for CarbonInsertFromStagesCommand.
    
 ### Does this PR introduce any user interface change?
 - Yes. (One option "batch_file_order" is added for CarbonInsertFromStageCommand, document added)

 ### Is any new testcase added?
 - Yes

    
