### PR TITLE
[CARBONDATA-3715]Fix Timeseries Query Rollup failure for timeseries column of Date type

### DIFF
--- a/mv/core/src/main/scala/org/apache/carbondata/mv/extension/MVDataMapProvider.scala
+++ b/mv/core/src/main/scala/org/apache/carbondata/mv/extension/MVDataMapProvider.scala
@@ -23,8 +23,6 @@ import scala.collection.JavaConverters._
 import org.apache.spark.sql.{CarbonUtils, SparkSession}
 import org.apache.spark.sql.execution.command.management.CarbonInsertIntoCommand
 import org.apache.spark.sql.execution.command.table.CarbonDropTableCommand
-import org.apache.spark.sql.parser.CarbonSparkSqlParserUtil
-import org.apache.spark.sql.util.SparkSQLUtil
 
 import org.apache.carbondata.common.annotations.InterfaceAudience
 import org.apache.carbondata.common.exceptions.sql.MalformedMaterializedViewException

--- a/mv/core/src/main/scala/org/apache/carbondata/mv/rewrite/DefaultMatchMaker.scala
+++ b/mv/core/src/main/scala/org/apache/carbondata/mv/rewrite/DefaultMatchMaker.scala
@@ -62,6 +62,8 @@ abstract class DefaultMatchPattern extends MatchPattern[ModularPlan] {
           a.child match {
             case s: ScalaUDF if s.function.isInstanceOf[TimeSeriesFunction] =>
               Utils.getTransformedTimeSeriesUDF(s) -> a.toAttribute
+            case cast: Cast if cast.child.isInstanceOf[AttributeReference] =>
+                Utils.getTransformedCastExpression(cast) -> a.toAttribute
             case _ =>
               a.child -> a.toAttribute
           }
@@ -89,6 +91,8 @@ abstract class DefaultMatchPattern extends MatchPattern[ModularPlan] {
               val newExp = a transform {
                 case s: ScalaUDF if s.function.isInstanceOf[TimeSeriesFunction] =>
                   Utils.getTransformedTimeSeriesUDF(s)
+                case cast: Cast if cast.child.isInstanceOf[AttributeReference] =>
+                  Utils.getTransformedCastExpression(cast)
               }
               attribute = aliasMapExp.get(newExp)
             }

--- a/mv/core/src/main/scala/org/apache/carbondata/mv/rewrite/Utils.scala
+++ b/mv/core/src/main/scala/org/apache/carbondata/mv/rewrite/Utils.scala
@@ -17,6 +17,7 @@
 
 package org.apache.carbondata.mv.rewrite
 
+import org.apache.spark.sql.CarbonToSparkAdapter
 import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeMap, AttributeReference, Cast, Divide, Expression, Literal, Multiply, NamedExpression, PredicateHelper, ScalaUDF}
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, LogicalPlan, Project}
@@ -587,6 +588,22 @@ object Utils extends PredicateHelper {
     s.transform {
       case l: Literal =>
         Literal(l.toString().toLowerCase, l.dataType)
+    }
+  }
+
+  /**
+   * transform cast expression to change it's child attribute reference name to lower case
+   */
+  def getTransformedCastExpression(cast: Cast): Expression = {
+    cast.transform {
+      case attr: AttributeReference =>
+        CarbonToSparkAdapter.createAttributeReference(
+          attr.name.toLowerCase,
+          attr.dataType,
+          attr.nullable,
+          attr.metadata,
+          attr.exprId,
+          attr.qualifier)
     }
   }
 

--- a/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/TestAllOperationsOnMV.scala
+++ b/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/TestAllOperationsOnMV.scala
@@ -423,6 +423,12 @@ class TestAllOperationsOnMV extends QueryTest with BeforeAndAfterEach {
     sql("drop materialized view if exists dm ")
     sql("create materialized view dm  as select max(to_date(dob)) , min(to_date(dob)) from maintable where to_date(dob)='1975-06-11' or to_date(dob)='1975-06-23'")
     checkExistence(sql("select max(to_date(dob)) , min(to_date(dob)) from maintable where to_date(dob)='1975-06-11' or to_date(dob)='1975-06-23'"), true, "1975-06-11 1975-06-11")
+    sql("drop materialized view if exists dm2 ")
+    sql("create materialized view dm2 as select to_date(dob) from maintable where CUST_ID IS NULL or DOB IS NOT NULL or BIGINT_COLUMN1 =120 or DECIMAL_COLUMN1 = 4.34 or Double_COLUMN1 =12345  or INTEGER_COLUMN1 IS NULL")
+    checkExistence(sql("select to_date(DOB) from maintable where CUST_ID IS NULL or DOB IS NOT NULL or BIGINT_COLUMN1 =120 or DECIMAL_COLUMN1 = 4.34 or Double_COLUMN1 =12345  or INTEGER_COLUMN1 IS NULL"), true, "1975-06-11")
+    val df = sql("select to_date(DOB) from maintable where CUST_ID IS NULL or DOB IS NOT NULL or BIGINT_COLUMN1 =120 or DECIMAL_COLUMN1 = 4.34 or Double_COLUMN1 =12345  or INTEGER_COLUMN1 IS NULL")
+    TestUtil.verifyMVDataMap(df.queryExecution.optimizedPlan, "dm2")
+    sql("drop table IF EXISTS maintable")
   }
 
   test("test preagg and mv") {

--- a/mv/plan/src/main/scala/org/apache/carbondata/mv/plans/util/Printers.scala
+++ b/mv/plan/src/main/scala/org/apache/carbondata/mv/plans/util/Printers.scala
@@ -362,6 +362,15 @@ trait Printers {
 
   def formatExpressionsInUDF(exp: Seq[Expression]): String = {
     val result = exp.map {
+      case cast: Cast =>
+        // for rolledUp queries of timeseries column with Date type, make
+        // Cast sql with attribute name
+        cast.child match {
+          case attr: AttributeReference if attr.name.startsWith("gen_subsumer_") =>
+            s"CAST(${ attr.name } AS ${ cast.dataType.sql })"
+          case _ =>
+            cast.sql
+        }
       case attr: AttributeReference =>
         if (attr.name.startsWith("gen_subsumer_")) {
           attr.name


### PR DESCRIPTION
 ### Why is this PR needed?
Issue 1:
 Timeseries query with timeseries column as date,is throwing parsing exception after rollup, because while forming sql for cast expression, it is taking wrong attribute name

Issue 2:
to_date() function has case sensitive issues while rewriting the plan
 
 ### What changes were proposed in this PR?
Issue 1:
If query is rolled up for date, then take attribute name for forming sql for cast expression.

Issue 2:
Convert cast expression child to lower case during rewrite

    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
