### PR TITLE
[CARBONDATA-3696] Avoid list db's all Tables to check table exists in the db

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonCreateTableAsSelectCommand.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonCreateTableAsSelectCommand.scala
@@ -54,7 +54,7 @@ case class CarbonCreateTableAsSelectCommand(
     setAuditTable(dbName, tableName)
     setAuditInfo(Map("query" -> query.simpleString))
     // check if table already exists
-    if (!sparkSession.sessionState.catalog
+    if (sparkSession.sessionState.catalog
       .tableExists(TableIdentifier(tableName, Some(dbName)))) {
       if (!ifNotExistsSet) {
         throw new TableAlreadyExistsException(dbName, tableName)

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonCreateTableAsSelectCommand.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonCreateTableAsSelectCommand.scala
@@ -54,8 +54,8 @@ case class CarbonCreateTableAsSelectCommand(
     setAuditTable(dbName, tableName)
     setAuditInfo(Map("query" -> query.simpleString))
     // check if table already exists
-    if (sparkSession.sessionState.catalog.listTables(dbName)
-      .exists(_.table.equalsIgnoreCase(tableName))) {
+    if (!sparkSession.sessionState.catalog
+      .tableExists(TableIdentifier(tableName, Some(dbName)))) {
       if (!ifNotExistsSet) {
         throw new TableAlreadyExistsException(dbName, tableName)
       }

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonCreateTableCommand.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonCreateTableCommand.scala
@@ -62,8 +62,8 @@ case class CarbonCreateTableCommand(
     tableInfo.setDatabaseName(dbName)
     tableInfo.setTableUniqueName(CarbonTable.buildUniqueName(dbName, tableName))
     val isTransactionalTable = tableInfo.isTransactionalTable
-    if (sparkSession.sessionState.catalog.listTables(dbName)
-      .exists(_.table.equalsIgnoreCase(tableName))) {
+    if (sparkSession.sessionState.catalog
+      .tableExists(TableIdentifier(tableName, Some(dbName)))) {
       if (!ifNotExistsSet) {
         throw new TableAlreadyExistsException(dbName, tableName)
       }


### PR DESCRIPTION


 ### Why is this PR needed?
 
 I found a lot of `listTables` of the db to check if table exists like this:
```
sparkSession.sessionState.catalog.listTables(databaseName)
  .exists(_.table.equalsIgnoreCase(tableName)
```
This may affect performances if there are lots of tables in one database. In `spark`, we can check this by `tableExists` function. 

 ### What changes were proposed in this PR?
use `exits(db, table)` to replace `iterate tables in a db`.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No

    
