### PR TITLE
[CARBONDATA-3724] Secondary Index enable on partition Table

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -2102,6 +2102,11 @@ public final class CarbonCommonConstants {
   // As due to SnappyCompressor.MAX_BYTE_TO_COMPRESS is 1.75 GB
   public static final int TABLE_PAGE_SIZE_MAX_INMB = 1755;
 
+  /**
+   * Current segment file
+   */
+  public static final String CURRENT_SEGMENTFILE = "current.segmentfile";
+
   //////////////////////////////////////////////////////////////////////////////////////////
   // Unused constants and parameters start here
   //////////////////////////////////////////////////////////////////////////////////////////

--- a/core/src/main/java/org/apache/carbondata/core/datamap/Segment.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/Segment.java
@@ -130,6 +130,10 @@ public class Segment implements Serializable, Writable {
     this.options = options;
   }
 
+  public void setSegmentFileName(String segmentFileName) {
+    this.segmentFileName = segmentFileName;
+  }
+
   /**
    *
    * @param segmentNo

--- a/core/src/main/java/org/apache/carbondata/core/datastore/block/SegmentPropertiesAndSchemaHolder.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/block/SegmentPropertiesAndSchemaHolder.java
@@ -302,6 +302,10 @@ public class SegmentPropertiesAndSchemaHolder {
       this.columnsInTable = columnsInTable;
     }
 
+    public CarbonTable getCarbonTable() {
+      return this.carbonTable;
+    }
+
     public void initSegmentProperties() {
       segmentProperties = new SegmentProperties(columnsInTable);
     }

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockIndex.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockIndex.java
@@ -789,9 +789,13 @@ public class BlockIndex extends CoarseGrainIndex
       byte[][] minValue, boolean[] minMaxFlag, String filePath, int blockletId) {
     BitSet bitSet = null;
     if (filterExecuter instanceof ImplicitColumnFilterExecutor) {
-      String uniqueBlockPath = !isPartitionTable ?
-                filePath.substring(filePath.lastIndexOf("/Part") + 1) :
-                filePath;
+      String uniqueBlockPath;
+      if (segmentPropertiesWrapper.getCarbonTable().isHivePartitionTable()) {
+        uniqueBlockPath = filePath
+            .substring(segmentPropertiesWrapper.getCarbonTable().getTablePath().length() + 1);
+      } else {
+        uniqueBlockPath = filePath.substring(filePath.lastIndexOf("/Part") + 1);
+      }
       // this case will come in case of old store where index file does not contain the
       // blocklet information
       if (blockletId != -1) {

--- a/core/src/main/java/org/apache/carbondata/core/mutate/CarbonUpdateUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/mutate/CarbonUpdateUtil.java
@@ -63,7 +63,7 @@ public class CarbonUpdateUtil {
    *
    */
   public static String getRequiredFieldFromTID(String Tid, int index) {
-    return Tid.split("/")[index];
+    return Tid.split(CarbonCommonConstants.FILE_SEPARATOR)[index];
   }
 
   /**

--- a/core/src/main/java/org/apache/carbondata/core/mutate/CarbonUpdateUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/mutate/CarbonUpdateUtil.java
@@ -61,6 +61,14 @@ public class CarbonUpdateUtil {
   /**
    * returns required filed from tuple id
    *
+   */
+  public static String getRequiredFieldFromTID(String Tid, int index) {
+    return Tid.split("/")[index];
+  }
+
+  /**
+   * returns required filed from tuple id
+   *
    * @param Tid
    * @param tid
    * @return
@@ -74,7 +82,10 @@ public class CarbonUpdateUtil {
    * @param Tid
    * @return
    */
-  public static String getSegmentWithBlockFromTID(String Tid) {
+  public static String getSegmentWithBlockFromTID(String Tid, boolean isPartitionTable) {
+    if (isPartitionTable) {
+      return getRequiredFieldFromTID(Tid, TupleIdEnum.SEGMENT_ID);
+    }
     return getRequiredFieldFromTID(Tid, TupleIdEnum.SEGMENT_ID)
         + CarbonCommonConstants.FILE_SEPARATOR + getRequiredFieldFromTID(Tid, TupleIdEnum.BLOCK_ID);
   }
@@ -916,14 +927,15 @@ public class CarbonUpdateUtil {
    * @param blockName
    * @return
    */
-  public static String getSegmentBlockNameKey(String segID, String blockName) {
-
+  public static String getSegmentBlockNameKey(String segID, String blockName,
+      boolean isPartitionTable) {
     String blockNameWithOutPart = blockName
-            .substring(blockName.indexOf(CarbonCommonConstants.HYPHEN) + 1,
-                    blockName.lastIndexOf(CarbonTablePath.getCarbonDataExtension()));
-
+        .substring(blockName.indexOf(CarbonCommonConstants.HYPHEN) + 1,
+            blockName.lastIndexOf(CarbonTablePath.getCarbonDataExtension()));
+    if (isPartitionTable) {
+      return blockNameWithOutPart;
+    }
     return segID + CarbonCommonConstants.FILE_SEPARATOR + blockNameWithOutPart;
-
   }
 
   /**

--- a/core/src/main/java/org/apache/carbondata/core/mutate/data/BlockMappingVO.java
+++ b/core/src/main/java/org/apache/carbondata/core/mutate/data/BlockMappingVO.java
@@ -30,6 +30,8 @@ public class BlockMappingVO {
 
   private Map<String, RowCountDetailsVO> completeBlockRowDetailVO;
 
+  private Map<String, String> blockToSegmentMapping;
+
   public void setCompleteBlockRowDetailVO(Map<String, RowCountDetailsVO> completeBlockRowDetailVO) {
     this.completeBlockRowDetailVO = completeBlockRowDetailVO;
   }
@@ -50,5 +52,13 @@ public class BlockMappingVO {
       Map<String, Long> segmentNumberOfBlockMapping) {
     this.blockRowCountMapping = blockRowCountMapping;
     this.segmentNumberOfBlockMapping = segmentNumberOfBlockMapping;
+  }
+
+  public void setBlockToSegmentMapping(Map<String, String> blockToSegmentMapping) {
+    this.blockToSegmentMapping = blockToSegmentMapping;
+  }
+
+  public Map<String, String> getBlockToSegmentMapping() {
+    return blockToSegmentMapping;
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/mutate/data/BlockMappingVO.java
+++ b/core/src/main/java/org/apache/carbondata/core/mutate/data/BlockMappingVO.java
@@ -30,6 +30,8 @@ public class BlockMappingVO {
 
   private Map<String, RowCountDetailsVO> completeBlockRowDetailVO;
 
+  // This map will help us to finding the segment id from the block path.
+  // key is 'blockpath' and value is 'segmentId'
   private Map<String, String> blockToSegmentMapping;
 
   public void setCompleteBlockRowDetailVO(Map<String, RowCountDetailsVO> completeBlockRowDetailVO) {

--- a/core/src/main/java/org/apache/carbondata/core/scan/executor/impl/AbstractQueryExecutor.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/executor/impl/AbstractQueryExecutor.java
@@ -433,7 +433,7 @@ public abstract class AbstractQueryExecutor<E> implements QueryExecutor<E> {
         .getBlockId(queryModel.getAbsoluteTableIdentifier(), filePath, segment.getSegmentNo(),
             queryModel.getTable().getTableInfo().isTransactionalTable(),
             isStandardTable, queryModel.getTable().isHivePartitionTable());
-    if (!isStandardTable || queryModel.getTable().isHivePartitionTable()) {
+    if (!isStandardTable) {
       blockExecutionInfo.setBlockId(CarbonTablePath.getShortBlockIdForPartitionTable(blockId));
     } else {
       blockExecutionInfo.setBlockId(CarbonTablePath.getShortBlockId(blockId));

--- a/core/src/main/java/org/apache/carbondata/core/scan/executor/impl/AbstractQueryExecutor.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/executor/impl/AbstractQueryExecutor.java
@@ -432,8 +432,8 @@ public abstract class AbstractQueryExecutor<E> implements QueryExecutor<E> {
     String blockId = CarbonUtil
         .getBlockId(queryModel.getAbsoluteTableIdentifier(), filePath, segment.getSegmentNo(),
             queryModel.getTable().getTableInfo().isTransactionalTable(),
-            isStandardTable);
-    if (!isStandardTable) {
+            isStandardTable, queryModel.getTable().isHivePartitionTable());
+    if (!isStandardTable || queryModel.getTable().isHivePartitionTable()) {
       blockExecutionInfo.setBlockId(CarbonTablePath.getShortBlockIdForPartitionTable(blockId));
     } else {
       blockExecutionInfo.setBlockId(CarbonTablePath.getShortBlockId(blockId));

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/BlockletScannedResult.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/BlockletScannedResult.java
@@ -32,9 +32,7 @@ import org.apache.carbondata.core.datastore.chunk.DimensionColumnPage;
 import org.apache.carbondata.core.datastore.chunk.impl.DimensionRawColumnChunk;
 import org.apache.carbondata.core.datastore.chunk.impl.MeasureRawColumnChunk;
 import org.apache.carbondata.core.datastore.page.ColumnPage;
-import org.apache.carbondata.core.mutate.CarbonUpdateUtil;
 import org.apache.carbondata.core.mutate.DeleteDeltaVo;
-import org.apache.carbondata.core.mutate.TupleIdEnum;
 import org.apache.carbondata.core.scan.executor.infos.BlockExecutionInfo;
 import org.apache.carbondata.core.scan.filter.GenericQueryType;
 import org.apache.carbondata.core.scan.result.vector.CarbonColumnVector;
@@ -572,17 +570,17 @@ public abstract class BlockletScannedResult {
    * Set blocklet id, which looks like
    * "Part0/Segment_0/part-0-0_batchno0-0-1517155583332.carbondata/0"
    */
-  public void setBlockletId(String blockletId) {
-    this.blockletId = blockletId;
-    blockletNumber = CarbonUpdateUtil.getRequiredFieldFromTID(blockletId, TupleIdEnum.BLOCKLET_ID);
+  public void setBlockletId(String blockletId, String blockletNumber) {
+    this.blockletId = blockletId + CarbonCommonConstants.FILE_SEPARATOR + blockletNumber;
+    this.blockletNumber = blockletNumber;
     // if deleted recors map is present for this block
     // then get the first page deleted vo
     if (null != deletedRecordMap) {
       String key;
       if (pageIdFiltered != null) {
-        key = blockletNumber + '_' + pageIdFiltered[pageCounter];
+        key = this.blockletNumber + '_' + pageIdFiltered[pageCounter];
       } else {
-        key = blockletNumber + '_' + pageCounter;
+        key = this.blockletNumber + '_' + pageCounter;
       }
       currentDeleteDeltaVo = deletedRecordMap.get(key);
     }

--- a/core/src/main/java/org/apache/carbondata/core/scan/scanner/impl/BlockletFilterScanner.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/scanner/impl/BlockletFilterScanner.java
@@ -202,9 +202,8 @@ public class BlockletFilterScanner extends BlockletFullScanner {
 
     BlockletScannedResult scannedResult =
         new FilterQueryScannedResult(blockExecutionInfo, queryStatisticsModel);
-    scannedResult.setBlockletId(
-        blockExecutionInfo.getBlockIdString(),
-            "" + rawBlockletColumnChunks.getDataBlock().blockletIndex());
+    scannedResult.setBlockletId(blockExecutionInfo.getBlockIdString(),
+        String.valueOf(rawBlockletColumnChunks.getDataBlock().blockletIndex()));
     // valid scanned blocklet
     QueryStatistic validScannedBlockletStatistic = queryStatisticsModel.getStatisticsTypeAndObjMap()
         .get(QueryStatisticsConstants.VALID_SCAN_BLOCKLET_NUM);
@@ -452,9 +451,8 @@ public class BlockletFilterScanner extends BlockletFullScanner {
     scannedResult.setPageFilteredRowCount(numberOfRows);
     scannedResult.setPageIdFiltered(pageFilteredPages);
     scannedResult.setLazyBlockletLoader(lazyBlocklet);
-    scannedResult.setBlockletId(
-        blockExecutionInfo.getBlockIdString(),
-            "" + rawBlockletColumnChunks.getDataBlock().blockletIndex());
+    scannedResult.setBlockletId(blockExecutionInfo.getBlockIdString(),
+        String.valueOf(rawBlockletColumnChunks.getDataBlock().blockletIndex()));
     // adding statistics for carbon scan time
     QueryStatistic scanTime = queryStatisticsModel.getStatisticsTypeAndObjMap()
         .get(QueryStatisticsConstants.SCAN_BLOCKlET_TIME);

--- a/core/src/main/java/org/apache/carbondata/core/scan/scanner/impl/BlockletFilterScanner.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/scanner/impl/BlockletFilterScanner.java
@@ -203,8 +203,8 @@ public class BlockletFilterScanner extends BlockletFullScanner {
     BlockletScannedResult scannedResult =
         new FilterQueryScannedResult(blockExecutionInfo, queryStatisticsModel);
     scannedResult.setBlockletId(
-        blockExecutionInfo.getBlockIdString() + CarbonCommonConstants.FILE_SEPARATOR +
-            rawBlockletColumnChunks.getDataBlock().blockletIndex());
+        blockExecutionInfo.getBlockIdString(),
+            "" + rawBlockletColumnChunks.getDataBlock().blockletIndex());
     // valid scanned blocklet
     QueryStatistic validScannedBlockletStatistic = queryStatisticsModel.getStatisticsTypeAndObjMap()
         .get(QueryStatisticsConstants.VALID_SCAN_BLOCKLET_NUM);
@@ -453,8 +453,8 @@ public class BlockletFilterScanner extends BlockletFullScanner {
     scannedResult.setPageIdFiltered(pageFilteredPages);
     scannedResult.setLazyBlockletLoader(lazyBlocklet);
     scannedResult.setBlockletId(
-        blockExecutionInfo.getBlockIdString() + CarbonCommonConstants.FILE_SEPARATOR
-            + rawBlockletColumnChunks.getDataBlock().blockletIndex());
+        blockExecutionInfo.getBlockIdString(),
+            "" + rawBlockletColumnChunks.getDataBlock().blockletIndex());
     // adding statistics for carbon scan time
     QueryStatistic scanTime = queryStatisticsModel.getStatisticsTypeAndObjMap()
         .get(QueryStatisticsConstants.SCAN_BLOCKlET_TIME);

--- a/core/src/main/java/org/apache/carbondata/core/scan/scanner/impl/BlockletFullScanner.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/scanner/impl/BlockletFullScanner.java
@@ -83,7 +83,7 @@ public class BlockletFullScanner implements BlockletScanner {
     totalPagesScanned.addCountStatistic(QueryStatisticsConstants.TOTAL_PAGE_SCANNED,
         totalPagesScanned.getCount() + rawBlockletColumnChunks.getDataBlock().numberOfPages());
     scannedResult.setBlockletId(blockExecutionInfo.getBlockIdString(),
-        "" + rawBlockletColumnChunks.getDataBlock().blockletIndex());
+        String.valueOf(rawBlockletColumnChunks.getDataBlock().blockletIndex()));
     DimensionRawColumnChunk[] dimensionRawColumnChunks =
         rawBlockletColumnChunks.getDimensionRawColumnChunks();
     DimensionColumnPage[][] dimensionColumnDataChunks =

--- a/core/src/main/java/org/apache/carbondata/core/scan/scanner/impl/BlockletFullScanner.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/scanner/impl/BlockletFullScanner.java
@@ -19,7 +19,6 @@ package org.apache.carbondata.core.scan.scanner.impl;
 
 import java.io.IOException;
 
-import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.datastore.DataRefNode;
 import org.apache.carbondata.core.datastore.chunk.DimensionColumnPage;
 import org.apache.carbondata.core.datastore.chunk.impl.DimensionRawColumnChunk;
@@ -83,9 +82,8 @@ public class BlockletFullScanner implements BlockletScanner {
         .get(QueryStatisticsConstants.TOTAL_PAGE_SCANNED);
     totalPagesScanned.addCountStatistic(QueryStatisticsConstants.TOTAL_PAGE_SCANNED,
         totalPagesScanned.getCount() + rawBlockletColumnChunks.getDataBlock().numberOfPages());
-    String blockletId = blockExecutionInfo.getBlockIdString() + CarbonCommonConstants.FILE_SEPARATOR
-        + rawBlockletColumnChunks.getDataBlock().blockletIndex();
-    scannedResult.setBlockletId(blockletId);
+    scannedResult.setBlockletId(blockExecutionInfo.getBlockIdString(),
+        "" + rawBlockletColumnChunks.getDataBlock().blockletIndex());
     DimensionRawColumnChunk[] dimensionRawColumnChunks =
         rawBlockletColumnChunks.getDimensionRawColumnChunks();
     DimensionColumnPage[][] dimensionColumnDataChunks =

--- a/core/src/main/java/org/apache/carbondata/core/statusmanager/SegmentUpdateStatusManager.java
+++ b/core/src/main/java/org/apache/carbondata/core/statusmanager/SegmentUpdateStatusManager.java
@@ -176,10 +176,6 @@ public class SegmentUpdateStatusManager {
 
   }
 
-  public Map<String, SegmentUpdateDetails> getBlockAndDetailsMap() {
-    return blockAndDetailsMap;
-  }
-
   /**
    * Returns the LoadMetadata Details
    * @return

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
@@ -2777,11 +2777,6 @@ public final class CarbonUtil {
   /**
    * Generate the blockid as per the block path
    *
-   * @param identifier
-   * @param filePath
-   * @param segmentId
-   * @param isStandardTable
-   * @param isPartitionTable
    * @return
    */
   public static String getBlockId(AbsoluteTableIdentifier identifier, String filePath,
@@ -2807,13 +2802,13 @@ public final class CarbonUtil {
         }
         if (isPartitionTable) {
           blockId =
-              partitionDir.replace("/", "#")
+              partitionDir.replace(CarbonCommonConstants.FILE_SEPARATOR, "#")
                   + CarbonCommonConstants.FILE_SEPARATOR + blockName;
         } else {
           // Replace / with # on partition director to support multi level partitioning. And access
           // them all as a single entity.
           blockId =
-              partitionDir.replace("/", "#")
+              partitionDir.replace(CarbonCommonConstants.FILE_SEPARATOR, "#")
                   + CarbonCommonConstants.FILE_SEPARATOR + segmentId
                   + CarbonCommonConstants.FILE_SEPARATOR + blockName;
         }

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
@@ -2764,11 +2764,29 @@ public final class CarbonUtil {
    * @param identifier
    * @param filePath
    * @param segmentId
+   * @param isTransactionalTable
    * @param isStandardTable
    * @return
    */
   public static String getBlockId(AbsoluteTableIdentifier identifier, String filePath,
       String segmentId, boolean isTransactionalTable, boolean isStandardTable) {
+    return getBlockId(identifier, filePath, segmentId, isTransactionalTable, isStandardTable,
+        false);
+  }
+
+  /**
+   * Generate the blockid as per the block path
+   *
+   * @param identifier
+   * @param filePath
+   * @param segmentId
+   * @param isStandardTable
+   * @param isPartitionTable
+   * @return
+   */
+  public static String getBlockId(AbsoluteTableIdentifier identifier, String filePath,
+      String segmentId, boolean isTransactionalTable, boolean isStandardTable,
+      boolean isPartitionTable) {
     String blockId;
     String blockName = filePath.substring(filePath.lastIndexOf("/") + 1, filePath.length());
     String tablePath = identifier.getTablePath();
@@ -2787,10 +2805,18 @@ public final class CarbonUtil {
         } else {
           partitionDir = "";
         }
-        // Replace / with # on partition director to support multi level partitioning. And access
-        // them all as a single entity.
-        blockId = partitionDir.replace("/", "#") + CarbonCommonConstants.FILE_SEPARATOR
-            + segmentId + CarbonCommonConstants.FILE_SEPARATOR + blockName;
+        if (isPartitionTable) {
+          blockId =
+              partitionDir.replace("/", "#")
+                  + CarbonCommonConstants.FILE_SEPARATOR + blockName;
+        } else {
+          // Replace / with # on partition director to support multi level partitioning. And access
+          // them all as a single entity.
+          blockId =
+              partitionDir.replace("/", "#")
+                  + CarbonCommonConstants.FILE_SEPARATOR + segmentId
+                  + CarbonCommonConstants.FILE_SEPARATOR + blockName;
+        }
       }
     } else {
       blockId = filePath.substring(0, filePath.length() - blockName.length()).replace("/", "#")

--- a/core/src/test/java/org/apache/carbondata/core/indexstore/blockletindex/TestBlockletIndex.java
+++ b/core/src/test/java/org/apache/carbondata/core/indexstore/blockletindex/TestBlockletIndex.java
@@ -18,9 +18,12 @@
 package org.apache.carbondata.core.indexstore.blockletindex;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.BitSet;
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
+import org.apache.carbondata.core.datastore.block.SegmentPropertiesAndSchemaHolder;
+import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
 import org.apache.carbondata.core.metadata.schema.table.column.CarbonImplicitDimension;
 import org.apache.carbondata.core.scan.filter.executer.FilterExecuter;
 import org.apache.carbondata.core.scan.filter.executer.ImplicitIncludeFilterExecutorImpl;
@@ -59,6 +62,16 @@ public class TestBlockletIndex {
     };
 
     BlockIndex blockletDataMap = new BlockletIndex();
+
+    new MockUp<CarbonTable>() {
+      @Mock public boolean isHivePartitionTable() {
+        return false;
+      }
+    };
+
+    blockletDataMap.setSegmentPropertiesWrapper(
+        new SegmentPropertiesAndSchemaHolder.SegmentPropertiesWrapper(new CarbonTable(),
+            new ArrayList<>()));
     Method method = BlockIndex.class
         .getDeclaredMethod("addBlockBasedOnMinMaxValue", FilterExecuter.class, byte[][].class,
             byte[][].class, boolean[].class, String.class, int.class);

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonOutputCommitter.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonOutputCommitter.java
@@ -175,7 +175,7 @@ public class CarbonOutputCommitter extends FileOutputCommitter {
     if (segmentSize > 0 || overwriteSet) {
       if (operationContext != null) {
         operationContext
-            .setProperty("current.segmentfile", newMetaEntry.getSegmentFile());
+            .setProperty(CarbonCommonConstants.CURRENT_SEGMENTFILE, newMetaEntry.getSegmentFile());
         LoadEvents.LoadTablePreStatusUpdateEvent event =
             new LoadEvents.LoadTablePreStatusUpdateEvent(carbonTable.getCarbonTableIdentifier(),
                 loadModel);
@@ -298,7 +298,8 @@ public class CarbonOutputCommitter extends FileOutputCommitter {
       CarbonLoaderUtil.recordNewLoadMetadata(newMetaEntry, loadModel, false, false, uuid);
     }
     if (operationContext != null) {
-      operationContext.setProperty("current.segmentfile", newMetaEntry.getSegmentFile());
+      operationContext
+          .setProperty(CarbonCommonConstants.CURRENT_SEGMENTFILE, newMetaEntry.getSegmentFile());
     }
     commitJobFinal(context, loadModel, operationContext, carbonTable, uniqueId);
   }

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableInputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableInputFormat.java
@@ -189,8 +189,9 @@ public class CarbonTableInputFormat<T> extends CarbonInputFormat<T> {
 
     List<Segment> segmentToAccess =
         getFilteredSegment(job, validAndInProgressSegments, false, readCommittedScope);
-    String segmentFileName = job.getConfiguration().get("current.segmentfile");
+    String segmentFileName = job.getConfiguration().get(CarbonCommonConstants.CURRENT_SEGMENTFILE);
     if (segmentFileName != null) {
+      //per segment it has only one file("current.segment")
       segmentToAccess.get(0).setSegmentFileName(segmentFileName + CarbonTablePath.SEGMENT_EXT);
     }
     // process and resolve the expression

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableInputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableInputFormat.java
@@ -61,6 +61,7 @@ import org.apache.carbondata.core.stream.StreamFile;
 import org.apache.carbondata.core.stream.StreamPruner;
 import org.apache.carbondata.core.util.CarbonProperties;
 import org.apache.carbondata.core.util.CarbonUtil;
+import org.apache.carbondata.core.util.path.CarbonTablePath;
 import org.apache.carbondata.hadoop.CarbonInputSplit;
 
 import org.apache.hadoop.fs.BlockLocation;
@@ -188,7 +189,10 @@ public class CarbonTableInputFormat<T> extends CarbonInputFormat<T> {
 
     List<Segment> segmentToAccess =
         getFilteredSegment(job, validAndInProgressSegments, false, readCommittedScope);
-
+    String segmentFileName = job.getConfiguration().get("current.segmentfile");
+    if (segmentFileName != null) {
+      segmentToAccess.get(0).setSegmentFileName(segmentFileName + CarbonTablePath.SEGMENT_EXT);
+    }
     // process and resolve the expression
     IndexFilter indexFilter = getFilterPredicates(job.getConfiguration());
 

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/util/CarbonInputFormatUtil.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/util/CarbonInputFormatUtil.java
@@ -25,6 +25,7 @@ import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.datamap.IndexUtil;
 import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
 import org.apache.carbondata.core.util.CarbonProperties;
+import org.apache.carbondata.hadoop.api.CarbonFileInputFormat;
 import org.apache.carbondata.hadoop.api.CarbonTableInputFormat;
 
 import org.apache.hadoop.conf.Configuration;
@@ -44,6 +45,18 @@ public class CarbonInputFormatUtil {
    */
   private static final Logger LOGGER =
       LogServiceFactory.getLogService(CarbonProperties.class.getName());
+
+  public static <V> CarbonFileInputFormat<V> createCarbonFileInputFormat(
+      AbsoluteTableIdentifier identifier, Job job) throws IOException {
+    CarbonFileInputFormat<V> carbonInputFormat = new CarbonFileInputFormat<V>();
+    CarbonTableInputFormat.setDatabaseName(job.getConfiguration(),
+        identifier.getCarbonTableIdentifier().getDatabaseName());
+    CarbonTableInputFormat
+        .setTableName(job.getConfiguration(), identifier.getCarbonTableIdentifier().getTableName());
+    FileInputFormat.addInputPath(job, new Path(identifier.getTablePath()));
+    setDataMapJobIfConfigured(job.getConfiguration());
+    return carbonInputFormat;
+  }
 
   public static <V> CarbonTableInputFormat<V> createCarbonInputFormat(
       AbsoluteTableIdentifier identifier,

--- a/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/TestAlterTableColumnRenameWithIndex.scala
+++ b/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/TestAlterTableColumnRenameWithIndex.scala
@@ -16,10 +16,10 @@
  */
 package org.apache.carbondata.spark.testsuite.secondaryindex
 
+import org.apache.carbondata.spark.testsuite.secondaryindex.TestSecondaryIndexUtils
+.isFilterPushedDownToSI;
 import org.apache.carbondata.core.metadata.CarbonMetadata
 import org.apache.carbondata.spark.exception.ProcessMetaDataException
-import org.apache.spark.sql.execution.SparkPlan
-import org.apache.spark.sql.secondaryindex.joins.BroadCastSIFilterPushJoin
 import org.apache.spark.sql.test.util.QueryTest
 import org.scalatest.BeforeAndAfterAll
 
@@ -93,21 +93,5 @@ class TestAlterTableColumnRenameWithIndex extends QueryTest with BeforeAndAfterA
 
   private def createTable(): Unit = {
     sql("create table si_rename (a string,b int, c string, d string) STORED AS carbondata")
-  }
-
-  /**
-    * Method to check whether the filter is push down to SI table or not
-    *
-    * @param sparkPlan
-    * @return
-    */
-  private def isFilterPushedDownToSI(sparkPlan: SparkPlan): Boolean = {
-    var isValidPlan = false
-    sparkPlan.transform {
-      case broadCastSIFilterPushDown: BroadCastSIFilterPushJoin =>
-        isValidPlan = true
-        broadCastSIFilterPushDown
-    }
-    isValidPlan
   }
 }

--- a/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/TestBroadCastSIFilterPushJoinWithUDF.scala
+++ b/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/TestBroadCastSIFilterPushJoinWithUDF.scala
@@ -16,6 +16,8 @@
  */
 package org.apache.carbondata.spark.testsuite.secondaryindex
 
+import org.apache.carbondata.spark.testsuite.secondaryindex.TestSecondaryIndexUtils
+.isFilterPushedDownToSI;
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.test.util.QueryTest
 import org.apache.spark.util.SparkUtil
@@ -62,7 +64,7 @@ class TestBroadCastSIFilterPushJoinWithUDF extends QueryTest with BeforeAndAfter
     // approx_count_distinct udf
     carbonQuery = sql("select approx_count_distinct(empname), approx_count_distinct(deptname) from udfValidation where empname = 'pramod' or deptname = 'network'")
     hiveQuery = sql("select approx_count_distinct(empname), approx_count_distinct(deptname) from udfHive where empname = 'pramod' or deptname = 'network'")
-    if (testSecondaryIndexForORFilterPushDown.isFilterPushedDownToSI(carbonQuery.queryExecution.executedPlan)) {
+    if (isFilterPushedDownToSI(carbonQuery.queryExecution.executedPlan)) {
       assert(true)
     } else {
       assert(false)
@@ -74,7 +76,7 @@ class TestBroadCastSIFilterPushJoinWithUDF extends QueryTest with BeforeAndAfter
     // collect_list udf
     carbonQuery = sql("select collect_list(empname) from udfValidation where empname = 'pramod' or deptname = 'network' or designation='TL'")
     hiveQuery = sql("select collect_list(empname) from udfHive where empname = 'pramod' or deptname = 'network' or designation='TL'")
-    if (testSecondaryIndexForORFilterPushDown.isFilterPushedDownToSI(carbonQuery.queryExecution.executedPlan)) {
+    if (isFilterPushedDownToSI(carbonQuery.queryExecution.executedPlan)) {
       assert(true)
     } else {
       assert(false)
@@ -86,7 +88,7 @@ class TestBroadCastSIFilterPushJoinWithUDF extends QueryTest with BeforeAndAfter
     // collect_set udf
     carbonQuery = sql("select collect_set(deptname) from udfValidation where empname = 'pramod' or deptname = 'network' or designation='TL'")
     hiveQuery = sql("select collect_set(deptname) from udfHive where empname = 'pramod' or deptname = 'network' or designation='TL'")
-    if (testSecondaryIndexForORFilterPushDown.isFilterPushedDownToSI(carbonQuery.queryExecution.executedPlan)) {
+    if (isFilterPushedDownToSI(carbonQuery.queryExecution.executedPlan)) {
       assert(true)
     } else {
       assert(false)
@@ -98,7 +100,7 @@ class TestBroadCastSIFilterPushJoinWithUDF extends QueryTest with BeforeAndAfter
     // corr udf
     carbonQuery = sql("select corr(deptno, empno) from udfValidation where empname = 'pramod' or deptname = 'network' or designation='TL'")
     hiveQuery = sql("select corr(deptno, empno) from udfHive where empname = 'pramod' or deptname = 'network' or designation='TL'")
-    if (testSecondaryIndexForORFilterPushDown.isFilterPushedDownToSI(carbonQuery.queryExecution.executedPlan)) {
+    if (isFilterPushedDownToSI(carbonQuery.queryExecution.executedPlan)) {
       assert(true)
     } else {
       assert(false)
@@ -110,7 +112,7 @@ class TestBroadCastSIFilterPushJoinWithUDF extends QueryTest with BeforeAndAfter
     // covar_pop udf
     carbonQuery = sql("select covar_pop(deptno, empno) from udfValidation where empname = 'pramod' or deptname = 'network' or designation='TL'")
     hiveQuery = sql("select covar_pop(deptno, empno) from udfHive where empname = 'pramod' or deptname = 'network' or designation='TL'")
-    if (testSecondaryIndexForORFilterPushDown.isFilterPushedDownToSI(carbonQuery.queryExecution.executedPlan)) {
+    if (isFilterPushedDownToSI(carbonQuery.queryExecution.executedPlan)) {
       assert(true)
     } else {
       assert(false)
@@ -122,7 +124,7 @@ class TestBroadCastSIFilterPushJoinWithUDF extends QueryTest with BeforeAndAfter
     // covar_samp udf
     carbonQuery = sql("select covar_samp(deptno, empno) from udfValidation where empname = 'pramod' or deptname = 'network' or designation='TL'")
     hiveQuery = sql("select covar_samp(deptno, empno) from udfHive where empname = 'pramod' or deptname = 'network' or designation='TL'")
-    if (testSecondaryIndexForORFilterPushDown.isFilterPushedDownToSI(carbonQuery.queryExecution.executedPlan)) {
+    if (isFilterPushedDownToSI(carbonQuery.queryExecution.executedPlan)) {
       assert(true)
     } else {
       assert(false)
@@ -134,7 +136,7 @@ class TestBroadCastSIFilterPushJoinWithUDF extends QueryTest with BeforeAndAfter
     // grouping udf
     carbonQuery = sql("select grouping(designation), grouping(deptname) from udfValidation where empname = 'pramod' or deptname = 'network' or designation='TL' group by designation, deptname with ROLLUP")
     hiveQuery = sql("select grouping(designation), grouping(deptname) from udfHive where empname = 'pramod' or deptname = 'network' or designation='TL' group by designation, deptname with ROLLUP")
-    if (testSecondaryIndexForORFilterPushDown.isFilterPushedDownToSI(carbonQuery.queryExecution.executedPlan)) {
+    if (isFilterPushedDownToSI(carbonQuery.queryExecution.executedPlan)) {
       assert(true)
     } else {
       assert(false)
@@ -146,7 +148,7 @@ class TestBroadCastSIFilterPushJoinWithUDF extends QueryTest with BeforeAndAfter
     // mean udf
     carbonQuery = sql("select mean(deptno), mean(empno) from udfValidation where empname = 'pramod' or deptname = 'network' or designation='TL'")
     hiveQuery = sql("select mean(deptno), mean(empno) from udfHive where empname = 'pramod' or deptname = 'network' or designation='TL'")
-    if (testSecondaryIndexForORFilterPushDown.isFilterPushedDownToSI(carbonQuery.queryExecution.executedPlan)) {
+    if (isFilterPushedDownToSI(carbonQuery.queryExecution.executedPlan)) {
       assert(true)
     } else {
       assert(false)
@@ -158,7 +160,7 @@ class TestBroadCastSIFilterPushJoinWithUDF extends QueryTest with BeforeAndAfter
     // skewness udf
     carbonQuery = sql("select skewness(deptno), skewness(empno) from udfValidation where empname = 'pramod' or deptname = 'network' or designation='TL'")
     hiveQuery = sql("select skewness(deptno), skewness(empno) from udfHive where empname = 'pramod' or deptname = 'network' or designation='TL'")
-    if (testSecondaryIndexForORFilterPushDown.isFilterPushedDownToSI(carbonQuery.queryExecution.executedPlan)) {
+    if (isFilterPushedDownToSI(carbonQuery.queryExecution.executedPlan)) {
       assert(true)
     } else {
       assert(false)
@@ -170,7 +172,7 @@ class TestBroadCastSIFilterPushJoinWithUDF extends QueryTest with BeforeAndAfter
     // stddev udf
     carbonQuery = sql("select stddev(deptno), stddev(empno) from udfValidation where empname = 'pramod' or deptname = 'network' or designation='TL'")
     hiveQuery = sql("select stddev(deptno), stddev(empno) from udfHive where empname = 'pramod' or deptname = 'network' or designation='TL'")
-    if (testSecondaryIndexForORFilterPushDown.isFilterPushedDownToSI(carbonQuery.queryExecution.executedPlan)) {
+    if (isFilterPushedDownToSI(carbonQuery.queryExecution.executedPlan)) {
       assert(true)
     } else {
       assert(false)
@@ -182,7 +184,7 @@ class TestBroadCastSIFilterPushJoinWithUDF extends QueryTest with BeforeAndAfter
     // stddev_pop udf
     carbonQuery = sql("select stddev_pop(deptno), stddev_pop(empno) from udfValidation where empname = 'pramod' or deptname = 'network' or designation='TL'")
     hiveQuery = sql("select stddev_pop(deptno), stddev_pop(empno) from udfHive where empname = 'pramod' or deptname = 'network' or designation='TL'")
-    if (testSecondaryIndexForORFilterPushDown.isFilterPushedDownToSI(carbonQuery.queryExecution.executedPlan)) {
+    if (isFilterPushedDownToSI(carbonQuery.queryExecution.executedPlan)) {
       assert(true)
     } else {
       assert(false)
@@ -194,7 +196,7 @@ class TestBroadCastSIFilterPushJoinWithUDF extends QueryTest with BeforeAndAfter
     // stddev_samp udf
     carbonQuery = sql("select stddev_samp(deptno), stddev_samp(empno) from udfValidation where empname = 'pramod' or deptname = 'network' or designation='TL'")
     hiveQuery = sql("select stddev_samp(deptno), stddev_samp(empno) from udfHive where empname = 'pramod' or deptname = 'network' or designation='TL'")
-    if (testSecondaryIndexForORFilterPushDown.isFilterPushedDownToSI(carbonQuery.queryExecution.executedPlan)) {
+    if (isFilterPushedDownToSI(carbonQuery.queryExecution.executedPlan)) {
       assert(true)
     } else {
       assert(false)
@@ -206,7 +208,7 @@ class TestBroadCastSIFilterPushJoinWithUDF extends QueryTest with BeforeAndAfter
     // var_pop udf
     carbonQuery = sql("select var_pop(deptno), var_pop(empno) from udfValidation where empname = 'pramod' or deptname = 'network' or designation='TL'")
     hiveQuery = sql("select var_pop(deptno), var_pop(empno) from udfHive where empname = 'pramod' or deptname = 'network' or designation='TL'")
-    if (testSecondaryIndexForORFilterPushDown.isFilterPushedDownToSI(carbonQuery.queryExecution.executedPlan)) {
+    if (isFilterPushedDownToSI(carbonQuery.queryExecution.executedPlan)) {
       assert(true)
     } else {
       assert(false)
@@ -218,7 +220,7 @@ class TestBroadCastSIFilterPushJoinWithUDF extends QueryTest with BeforeAndAfter
     // var_samp udf
     carbonQuery = sql("select var_samp(deptno), var_samp(empno) from udfValidation where empname = 'pramod' or deptname = 'network' or designation='TL'")
     hiveQuery = sql("select var_samp(deptno), var_samp(empno) from udfHive where empname = 'pramod' or deptname = 'network' or designation='TL'")
-    if (testSecondaryIndexForORFilterPushDown.isFilterPushedDownToSI(carbonQuery.queryExecution.executedPlan)) {
+    if (isFilterPushedDownToSI(carbonQuery.queryExecution.executedPlan)) {
       assert(true)
     } else {
       assert(false)
@@ -230,7 +232,7 @@ class TestBroadCastSIFilterPushJoinWithUDF extends QueryTest with BeforeAndAfter
     // variance udf
     carbonQuery = sql("select variance(deptno), variance(empno) from udfValidation where empname = 'pramod' or deptname = 'network' or designation='TL'")
     hiveQuery = sql("select variance(deptno), variance(empno) from udfHive where empname = 'pramod' or deptname = 'network' or designation='TL'")
-    if (testSecondaryIndexForORFilterPushDown.isFilterPushedDownToSI(carbonQuery.queryExecution.executedPlan)) {
+    if (isFilterPushedDownToSI(carbonQuery.queryExecution.executedPlan)) {
       assert(true)
     } else {
       assert(false)
@@ -242,7 +244,7 @@ class TestBroadCastSIFilterPushJoinWithUDF extends QueryTest with BeforeAndAfter
     // COALESCE, CONV and SUBSTRING udf
     carbonQuery = sql("select COALESCE(CONV(substring(empname, 3, 2), 16, 10), ''), COALESCE(CONV(substring(deptname, 3, 2), 16, 10), '') from udfValidation where empname = 'pramod' or deptname = 'network' or designation='TL'")
     hiveQuery = sql("select COALESCE(CONV(substring(empname, 3, 2), 16, 10), ''), COALESCE(CONV(substring(deptname, 3, 2), 16, 10), '') from udfHive where empname = 'pramod' or deptname = 'network' or designation='TL'")
-    if (testSecondaryIndexForORFilterPushDown.isFilterPushedDownToSI(carbonQuery.queryExecution.executedPlan)) {
+    if (isFilterPushedDownToSI(carbonQuery.queryExecution.executedPlan)) {
       assert(true)
     } else {
       assert(false)
@@ -275,7 +277,7 @@ class TestBroadCastSIFilterPushJoinWithUDF extends QueryTest with BeforeAndAfter
           "COALESCE(CONV(substring(empname, 3, 2), 16, 10), ''), COALESCE(CONV(substring(deptname, 3," +
           " 2), 16, 10), '') from udfHive where empname = 'pramod' or deptname = 'network' or " +
           "designation='TL' group by designation, deptname, empname with ROLLUP")
-        if (testSecondaryIndexForORFilterPushDown.isFilterPushedDownToSI(carbonQuery.queryExecution.executedPlan)) {
+        if (isFilterPushedDownToSI(carbonQuery.queryExecution.executedPlan)) {
           assert(true)
         } else {
           assert(false)
@@ -310,7 +312,7 @@ class TestBroadCastSIFilterPushJoinWithUDF extends QueryTest with BeforeAndAfter
           "COALESCE(CONV(substring(empname, 3, 2), 16, 10), '') as c25, COALESCE(CONV(substring(deptname, 3," +
           " 2), 16, 10), '') as c26 from udfHive where empname = 'pramod' or deptname = 'network' or " +
           "designation='TL' group by designation, deptname, empname with ROLLUP")
-        if (testSecondaryIndexForORFilterPushDown.isFilterPushedDownToSI(carbonQuery.queryExecution.executedPlan)) {
+        if (isFilterPushedDownToSI(carbonQuery.queryExecution.executedPlan)) {
           assert(true)
         } else {
           assert(false)
@@ -345,7 +347,7 @@ class TestBroadCastSIFilterPushJoinWithUDF extends QueryTest with BeforeAndAfter
           "COALESCE(CONV(substring(empname, 3, 2), 16, 10), ''), COALESCE(CONV(substring(deptname, 3," +
           " 2), 16, 10), '') from udfHive where empname = 'pramod' or deptname = 'network' or " +
           "designation='TL' group by designation, deptname, empname with ROLLUP")
-        if (testSecondaryIndexForORFilterPushDown.isFilterPushedDownToSI(carbonQuery.queryExecution.executedPlan)) {
+        if (isFilterPushedDownToSI(carbonQuery.queryExecution.executedPlan)) {
           assert(true)
         } else {
           assert(false)
@@ -380,7 +382,7 @@ class TestBroadCastSIFilterPushJoinWithUDF extends QueryTest with BeforeAndAfter
           "COALESCE(CONV(substring(empname, 3, 2), 16, 10), '') as c26, COALESCE(CONV(substring(deptname, 3," +
           " 2), 16, 10), '') as c27 from udfHive where empname = 'pramod' or deptname = 'network' or " +
           "designation='TL' group by designation, deptname, empname with ROLLUP")
-        if (testSecondaryIndexForORFilterPushDown.isFilterPushedDownToSI(carbonQuery.queryExecution.executedPlan)) {
+        if (isFilterPushedDownToSI(carbonQuery.queryExecution.executedPlan)) {
           assert(true)
         } else {
           assert(false)
@@ -393,7 +395,7 @@ class TestBroadCastSIFilterPushJoinWithUDF extends QueryTest with BeforeAndAfter
   test("test udf on filter - concat") {
     carbonQuery = sql("select concat_ws(deptname)from udfValidation where concat_ws(deptname) IS NOT NULL or concat_ws(deptname) is null")
     hiveQuery = sql("select concat_ws(deptname)from udfHive where concat_ws(deptname) IS NOT NULL or concat_ws(deptname) is null")
-    if (testSecondaryIndexForORFilterPushDown.isFilterPushedDownToSI(carbonQuery.queryExecution.executedPlan)) {
+    if (isFilterPushedDownToSI(carbonQuery.queryExecution.executedPlan)) {
       assert(true)
     } else {
       assert(false)
@@ -404,7 +406,7 @@ class TestBroadCastSIFilterPushJoinWithUDF extends QueryTest with BeforeAndAfter
   test("test udf on filter - find_in_set") {
     carbonQuery = sql("select find_in_set(deptname,'o')from udfValidation where find_in_set(deptname,'o') =0 or find_in_set(deptname,'a') is null")
     hiveQuery = sql("select find_in_set(deptname,'o')from udfHive where find_in_set(deptname,'o') =0 or find_in_set(deptname,'a') is null")
-    if (testSecondaryIndexForORFilterPushDown.isFilterPushedDownToSI(carbonQuery.queryExecution.executedPlan)) {
+    if (isFilterPushedDownToSI(carbonQuery.queryExecution.executedPlan)) {
       assert(true)
     } else {
       assert(false)
@@ -415,7 +417,7 @@ class TestBroadCastSIFilterPushJoinWithUDF extends QueryTest with BeforeAndAfter
   test("test udf on filter - agg") {
     carbonQuery = sql("select max(length(deptname)),min(length(designation)),avg(length(empname)),count(length(empname)),sum(length(deptname)),variance(length(designation)) from udfValidation where length(empname)=6 or length(empname) is NULL")
     hiveQuery = sql("select max(length(deptname)),min(length(designation)),avg(length(empname)),count(length(empname)),sum(length(deptname)),variance(length(designation)) from udfHive where length(empname)=6 or length(empname) is NULL")
-    if (testSecondaryIndexForORFilterPushDown.isFilterPushedDownToSI(carbonQuery.queryExecution.executedPlan)) {
+    if (isFilterPushedDownToSI(carbonQuery.queryExecution.executedPlan)) {
       assert(true)
     } else {
       assert(false)

--- a/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/TestCreateIndexTable.scala
+++ b/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/TestCreateIndexTable.scala
@@ -445,12 +445,6 @@ class TestCreateIndexTable extends QueryTest with BeforeAndAfterAll {
     }
   }
 
-  test("test blocking secondary Index on Partition table") {
-    intercept[RuntimeException] {
-      sql("""create index part_index on table part_si(c3) AS 'carbondata'""").show()
-    }
-  }
-
   object CarbonMetastore {
     import org.apache.carbondata.core.reader.ThriftReader
 

--- a/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/TestIndexModelForORFilterPushDown.scala
+++ b/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/TestIndexModelForORFilterPushDown.scala
@@ -17,9 +17,9 @@
 package org.apache.carbondata.spark.testsuite.secondaryindex
 
 import org.apache.carbondata.core.util.CarbonProperties
+import org.apache.carbondata.spark.testsuite.secondaryindex.TestSecondaryIndexUtils
+.isFilterPushedDownToSI;
 import org.apache.spark.sql.Row
-import org.apache.spark.sql.execution.SparkPlan
-import org.apache.spark.sql.secondaryindex.joins.BroadCastSIFilterPushJoin
 import org.apache.spark.sql.test.util.QueryTest
 import org.scalatest.BeforeAndAfterAll
 
@@ -234,21 +234,4 @@ class TestIndexModelForORFilterPushDown extends QueryTest with BeforeAndAfterAll
   override def afterAll: Unit = {
     dropTables
   }
-
-  /**
-   * Method to check whether the filter is push down to SI table or not
-   *
-   * @param sparkPlan
-   * @return
-   */
-  def isFilterPushedDownToSI(sparkPlan: SparkPlan): Boolean = {
-    var isValidPlan = false
-    sparkPlan.transform {
-      case broadCastSIFilterPushDown: BroadCastSIFilterPushJoin =>
-        isValidPlan = true
-        broadCastSIFilterPushDown
-    }
-    isValidPlan
-  }
-
 }

--- a/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/TestSIWithPartition.scala
+++ b/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/TestSIWithPartition.scala
@@ -1,0 +1,86 @@
+package org.apache.carbondata.spark.testsuite.secondaryindex
+
+import org.apache.spark.sql.test.util.QueryTest
+import org.scalatest.{BeforeAndAfterAll, Ignore}
+
+@Ignore
+class TestSIWithPartition extends QueryTest with BeforeAndAfterAll {
+
+  override protected def beforeAll(): Unit = {
+    sql("drop table if exists uniqdata1")
+    sql(
+      "CREATE TABLE uniqdata1 (CUST_ID INT,CUST_NAME STRING,DOB timestamp,DOJ timestamp," +
+      "BIGINT_COLUMN1 bigint,BIGINT_COLUMN2 bigint,DECIMAL_COLUMN1 DECIMAL(30, 10)," +
+      "DECIMAL_COLUMN2 DECIMAL(36, 10),Double_COLUMN1 double, Double_COLUMN2 double," +
+      "INTEGER_COLUMN1 int) PARTITIONED BY(ACTIVE_EMUI_VERSION string) STORED AS carbondata " +
+      "TBLPROPERTIES('TABLE_BLOCKSIZE'='256 MB')")
+    sql(s"LOAD DATA LOCAL INPATH '$resourcesPath/restructure/data_2000.csv' INTO " +
+        "TABLE uniqdata1 partition(ACTIVE_EMUI_VERSION='abc') OPTIONS('DELIMITER'=',', " +
+        "'BAD_RECORDS_LOGGER_ENABLE'='FALSE', 'BAD_RECORDS_ACTION'='FORCE','FILEHEADER'='CUST_ID," +
+        "CUST_NAME,ACTIVE_EMUI_VERSION,DOB,DOJ,BIGINT_COLUMN1,BIGINT_COLUMN2,DECIMAL_COLUMN1," +
+        "DECIMAL_COLUMN2,Double_COLUMN1,Double_COLUMN2,INTEGER_COLUMN1')")
+    sql(s"LOAD DATA LOCAL INPATH '$resourcesPath/restructure/data_2000.csv' INTO " +
+        "TABLE uniqdata1 partition(ACTIVE_EMUI_VERSION='abc') OPTIONS('DELIMITER'=',', " +
+        "'BAD_RECORDS_LOGGER_ENABLE'='FALSE', 'BAD_RECORDS_ACTION'='FORCE','FILEHEADER'='CUST_ID," +
+        "CUST_NAME,ACTIVE_EMUI_VERSION,DOB,DOJ,BIGINT_COLUMN1,BIGINT_COLUMN2,DECIMAL_COLUMN1," +
+        "DECIMAL_COLUMN2,Double_COLUMN1,Double_COLUMN2,INTEGER_COLUMN1')")
+    sql(s"LOAD DATA LOCAL INPATH '$resourcesPath/restructure/data_2000.csv' INTO " +
+        "TABLE uniqdata1 partition(ACTIVE_EMUI_VERSION='abc') OPTIONS('DELIMITER'=',', " +
+        "'BAD_RECORDS_LOGGER_ENABLE'='FALSE', 'BAD_RECORDS_ACTION'='FORCE','FILEHEADER'='CUST_ID," +
+        "CUST_NAME,ACTIVE_EMUI_VERSION,DOB,DOJ,BIGINT_COLUMN1,BIGINT_COLUMN2,DECIMAL_COLUMN1," +
+        "DECIMAL_COLUMN2,Double_COLUMN1,Double_COLUMN2,INTEGER_COLUMN1')")
+    sql(s"LOAD DATA LOCAL INPATH '$resourcesPath/restructure/data_2000.csv' INTO " +
+        "TABLE uniqdata1 partition(ACTIVE_EMUI_VERSION='abc') OPTIONS('DELIMITER'=',', " +
+        "'BAD_RECORDS_LOGGER_ENABLE'='FALSE', 'BAD_RECORDS_ACTION'='FORCE','FILEHEADER'='CUST_ID," +
+        "CUST_NAME,ACTIVE_EMUI_VERSION,DOB,DOJ,BIGINT_COLUMN1,BIGINT_COLUMN2,DECIMAL_COLUMN1," +
+        "DECIMAL_COLUMN2,Double_COLUMN1,Double_COLUMN2,INTEGER_COLUMN1')")
+  }
+
+  test("TESTING SI on partition column") {
+    intercept[UnsupportedOperationException] {
+      sql("create index indextable1 on table uniqdata1 (ACTIVE_EMUI_VERSION) AS 'carbondata'")
+    }
+  }
+
+  test("TESTING SI on normal column") {
+    sql("drop index if exists indextable1 on uniqdata1")
+    sql("create index indextable1 on table uniqdata1 (DOB, CUST_NAME) AS 'carbondata'")
+    sql("select * from uniqdata1 where ni(CUST_NAME='CUST_NAME_00108')").show()
+  }
+
+  test("TESTING SI on normal  + partition column") {
+    sql("drop index if exists indextable1 on uniqdata1")
+    sql("create index indextable1 on table uniqdata1 (DOB, CUST_NAME) AS 'carbondata'")
+    sql("select * from uniqdata1 where CUST_NAME='CUST_NAME_00108' and ACTIVE_EMUI_VERSION = 'abc'")
+      .show()
+  }
+
+
+  test("TESTING SI on MAJOR compaction") {
+    sql("drop index if exists indextable1 on uniqdata1")
+    sql("create index indextable1 on table uniqdata1 (DOB, CUST_NAME) AS 'carbondata'")
+    sql("alter table uniqdata1 compact 'minor'")
+    sql("select * from uniqdata1 where ACTIVE_EMUI_VERSION = 'abc' and " +
+        "CUST_NAME='CUST_NAME_00108'").show()
+    sql("drop index if exists indextable1 on uniqdata1")
+  }
+
+  test("TESTING SI on MINOR compaction") {
+    sql("drop index if exists indextable1 on uniqdata1")
+    sql("create index indextable1 on table uniqdata1 (DOB, CUST_NAME) AS 'carbondata'")
+    sql(s"LOAD DATA LOCAL INPATH '$resourcesPath/restructure/data_2000.csv' INTO " +
+        "TABLE uniqdata1 partition(ACTIVE_EMUI_VERSION='abc') OPTIONS('DELIMITER'=',', " +
+        "'BAD_RECORDS_LOGGER_ENABLE'='FALSE', 'BAD_RECORDS_ACTION'='FORCE','FILEHEADER'='CUST_ID," +
+        "CUST_NAME,ACTIVE_EMUI_VERSION,DOB,DOJ,BIGINT_COLUMN1,BIGINT_COLUMN2,DECIMAL_COLUMN1," +
+        "DECIMAL_COLUMN2,Double_COLUMN1,Double_COLUMN2,INTEGER_COLUMN1')")
+    sql("alter table uniqdata1 compact 'minor'")
+    sql("select * from uniqdata1 where CUST_NAME='CUST_NAME_00108'").show()
+
+    sql("drop index if exists indextable1 on uniqdata1")
+    sql("drop table if exists uniqdata1")
+  }
+
+  override protected def afterAll(): Unit = {
+
+  }
+}

--- a/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/TestSIWithPartition.scala
+++ b/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/TestSIWithPartition.scala
@@ -16,9 +16,9 @@
  */
 package org.apache.carbondata.spark.testsuite.secondaryindex
 
+import org.apache.carbondata.spark.testsuite.secondaryindex.TestSecondaryIndexUtils
+.isFilterPushedDownToSI;
 import org.apache.spark.sql.Row
-import org.apache.spark.sql.execution.SparkPlan
-import org.apache.spark.sql.secondaryindex.joins.BroadCastSIFilterPushJoin
 import org.apache.spark.sql.test.util.QueryTest
 import org.scalatest.{BeforeAndAfterAll, Ignore}
 
@@ -359,21 +359,5 @@ class TestSIWithPartition extends QueryTest with BeforeAndAfterAll {
   override protected def afterAll(): Unit = {
     sql("drop index if exists indextable1 on uniqdata1")
     sql("drop table if exists uniqdata1")
-  }
-
-  /**
-   * Method to check whether the filter is push down to SI table or not
-   *
-   * @param sparkPlan
-   * @return
-   */
-  private def isFilterPushedDownToSI(sparkPlan: SparkPlan): Boolean = {
-    var isValidPlan = false
-    sparkPlan.transform {
-      case broadCastSIFilterPushDown: BroadCastSIFilterPushJoin =>
-        isValidPlan = true
-        broadCastSIFilterPushDown
-    }
-    isValidPlan
   }
 }

--- a/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/TestSIWithPartition.scala
+++ b/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/TestSIWithPartition.scala
@@ -1,9 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.carbondata.spark.testsuite.secondaryindex
 
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.secondaryindex.joins.BroadCastSIFilterPushJoin
 import org.apache.spark.sql.test.util.QueryTest
 import org.scalatest.{BeforeAndAfterAll, Ignore}
 
-@Ignore
 class TestSIWithPartition extends QueryTest with BeforeAndAfterAll {
 
   override protected def beforeAll(): Unit = {
@@ -36,51 +54,326 @@ class TestSIWithPartition extends QueryTest with BeforeAndAfterAll {
         "DECIMAL_COLUMN2,Double_COLUMN1,Double_COLUMN2,INTEGER_COLUMN1')")
   }
 
-  test("TESTING SI on partition column") {
+  test("Testing SI on partition column") {
+    sql("drop index if exists indextable1 on uniqdata1")
     intercept[UnsupportedOperationException] {
       sql("create index indextable1 on table uniqdata1 (ACTIVE_EMUI_VERSION) AS 'carbondata'")
     }
   }
 
-  test("TESTING SI on normal column") {
+  test("Testing SI without partition column") {
     sql("drop index if exists indextable1 on uniqdata1")
     sql("create index indextable1 on table uniqdata1 (DOB, CUST_NAME) AS 'carbondata'")
-    sql("select * from uniqdata1 where ni(CUST_NAME='CUST_NAME_00108')").show()
+    val withoutIndex =
+      sql("select * from uniqdata1 where ni(CUST_NAME='CUST_NAME_00108')")
+        .collect().toSeq
+
+    checkAnswer(sql("select * from uniqdata1 where CUST_NAME='CUST_NAME_00108'"),
+      withoutIndex)
+
+    val df = sql("select * from uniqdata1 where CUST_NAME='CUST_NAME_00108'")
+      .queryExecution
+      .sparkPlan
+    if (!isFilterPushedDownToSI(df)) {
+      assert(false)
+    } else {
+      assert(true)
+    }
   }
 
-  test("TESTING SI on normal  + partition column") {
+  test("Testing SI with partition column[where clause]") {
     sql("drop index if exists indextable1 on uniqdata1")
     sql("create index indextable1 on table uniqdata1 (DOB, CUST_NAME) AS 'carbondata'")
-    sql("select * from uniqdata1 where CUST_NAME='CUST_NAME_00108' and ACTIVE_EMUI_VERSION = 'abc'")
-      .show()
+    val withoutIndex =
+      sql(
+        "select * from uniqdata1 where ni(CUST_NAME='CUST_NAME_00108' and ACTIVE_EMUI_VERSION = " +
+        "'abc')")
+        .collect().toSeq
+
+    checkAnswer(sql(
+      "select * from uniqdata1 where CUST_NAME='CUST_NAME_00108' and ACTIVE_EMUI_VERSION = 'abc'"),
+      withoutIndex)
+
+    val df = sql(
+      "select * from uniqdata1 where CUST_NAME='CUST_NAME_00108' and ACTIVE_EMUI_VERSION = 'abc'")
+      .queryExecution
+      .sparkPlan
+    if (!isFilterPushedDownToSI(df)) {
+      assert(false)
+    } else {
+      assert(true)
+    }
   }
 
-
-  test("TESTING SI on MAJOR compaction") {
+  test("Testing SI on partition table with OR condition") {
     sql("drop index if exists indextable1 on uniqdata1")
     sql("create index indextable1 on table uniqdata1 (DOB, CUST_NAME) AS 'carbondata'")
+    val withoutIndex =
+      sql(
+        "select * from uniqdata1 where ni(CUST_NAME='CUST_NAME_00108' OR ACTIVE_EMUI_VERSION = " +
+        "'abc')")
+        .collect().toSeq
+
+    checkAnswer(sql(
+      "select * from uniqdata1 where CUST_NAME='CUST_NAME_00108' OR ACTIVE_EMUI_VERSION = 'abc'"),
+      withoutIndex)
+
+    val df = sql(
+      "select * from uniqdata1 where CUST_NAME='CUST_NAME_00108' OR ACTIVE_EMUI_VERSION = 'abc'")
+      .queryExecution
+      .sparkPlan
+    if (!isFilterPushedDownToSI(df)) {
+      assert(true)
+    } else {
+      assert(false)
+    }
+  }
+
+  test("Testing SI on partition table with combination of OR OR") {
+    sql("drop index if exists indextable1 on uniqdata1")
+    sql("create index indextable1 on table uniqdata1 (DOB, CUST_NAME) AS 'carbondata'")
+    val withoutIndex =
+      sql(
+        "select * from uniqdata1 where ni(CUST_NAME='CUST_NAME_00108' OR CUST_ID='9000' OR " +
+        "ACTIVE_EMUI_VERSION = " +
+        "'abc')")
+        .collect().toSeq
+
+    checkAnswer(sql(
+      "select * from uniqdata1 where CUST_NAME='CUST_NAME_00108' OR CUST_ID='9000' OR " +
+      "ACTIVE_EMUI_VERSION = 'abc'"),
+      withoutIndex)
+
+    val df = sql(
+      "select * from uniqdata1 where CUST_NAME='CUST_NAME_00108' OR CUST_ID='9000' OR " +
+      "ACTIVE_EMUI_VERSION = 'abc'")
+      .queryExecution
+      .sparkPlan
+    if (!isFilterPushedDownToSI(df)) {
+      assert(true)
+    } else {
+      assert(false)
+    }
+  }
+
+  test("Testing SI on partition table with combination of OR AND") {
+    sql("drop index if exists indextable1 on uniqdata1")
+    sql("create index indextable1 on table uniqdata1 (DOB, CUST_NAME) AS 'carbondata'")
+    val withoutIndex =
+      sql(
+        "select * from uniqdata1 where ni(CUST_NAME='CUST_NAME_00108' OR CUST_ID='9000' AND " +
+        "ACTIVE_EMUI_VERSION = " +
+        "'abc')")
+        .collect().toSeq
+
+    checkAnswer(sql(
+      "select * from uniqdata1 where CUST_NAME='CUST_NAME_00108' OR CUST_ID='9000' AND " +
+      "ACTIVE_EMUI_VERSION = 'abc'"),
+      withoutIndex)
+
+    val df = sql(
+      "select * from uniqdata1 where CUST_NAME='CUST_NAME_00108' OR CUST_ID='9000' AND " +
+      "ACTIVE_EMUI_VERSION = 'abc'")
+      .queryExecution
+      .sparkPlan
+    if (!isFilterPushedDownToSI(df)) {
+      assert(true)
+    } else {
+      assert(false)
+    }
+  }
+
+  test("Testing SI on partition table with combination of AND OR") {
+    sql("drop index if exists indextable1 on uniqdata1")
+    sql("create index indextable1 on table uniqdata1 (DOB, CUST_NAME) AS 'carbondata'")
+    val withoutIndex =
+      sql(
+        "select * from uniqdata1 where ni(CUST_NAME='CUST_NAME_00108' AND CUST_ID='9000' OR " +
+        "ACTIVE_EMUI_VERSION = " +
+        "'abc')")
+        .collect().toSeq
+
+    checkAnswer(sql(
+      "select * from uniqdata1 where CUST_NAME='CUST_NAME_00108' AND CUST_ID='9000' OR " +
+      "ACTIVE_EMUI_VERSION = 'abc'"),
+      withoutIndex)
+
+    val df = sql(
+      "select * from uniqdata1 where CUST_NAME='CUST_NAME_00108' AND CUST_ID='9000' OR " +
+      "ACTIVE_EMUI_VERSION = 'abc'")
+      .queryExecution
+      .sparkPlan
+    if (!isFilterPushedDownToSI(df)) {
+      assert(true)
+    } else {
+      assert(false)
+    }
+  }
+
+  test("Testing SI on partition table with combination of AND AND") {
+    sql("drop index if exists indextable1 on uniqdata1")
+    sql("create index indextable1 on table uniqdata1 (DOB, CUST_NAME) AS 'carbondata'")
+    val withoutIndex =
+      sql(
+        "select * from uniqdata1 where ni(CUST_NAME='CUST_NAME_00108' AND CUST_ID='9000' AND " +
+        "ACTIVE_EMUI_VERSION = " +
+        "'abc')")
+        .collect().toSeq
+
+    checkAnswer(sql(
+      "select * from uniqdata1 where CUST_NAME='CUST_NAME_00108' AND CUST_ID='9000' AND " +
+      "ACTIVE_EMUI_VERSION = 'abc'"),
+      withoutIndex)
+
+    val df = sql(
+      "select * from uniqdata1 where CUST_NAME='CUST_NAME_00108' AND CUST_ID='9000' AND " +
+      "ACTIVE_EMUI_VERSION = 'abc'")
+      .queryExecution
+      .sparkPlan
+    if (!isFilterPushedDownToSI(df)) {
+      assert(false)
+    } else {
+      assert(true)
+    }
+  }
+
+  test("Testing SI on partition table with major compaction") {
+    sql("drop index if exists indextable1 on uniqdata1")
+    sql("create index indextable1 on table uniqdata1 (DOB, CUST_NAME) AS 'carbondata'")
+    val withoutIndex =
+      sql(
+        "select * from uniqdata1 where CUST_NAME='CUST_NAME_00108' and ACTIVE_EMUI_VERSION = " +
+        "'abc'")
+        .collect().toSeq
+
+    sql("alter table uniqdata1 compact 'major'")
+
+    checkAnswer(sql(
+      "select * from uniqdata1 where CUST_NAME='CUST_NAME_00108' and ACTIVE_EMUI_VERSION = 'abc'"),
+      withoutIndex)
+
+    val df = sql(
+      "select * from uniqdata1 where CUST_NAME='CUST_NAME_00108' and ACTIVE_EMUI_VERSION = 'abc'")
+      .queryExecution
+      .sparkPlan
+    if (!isFilterPushedDownToSI(df)) {
+      assert(false)
+    } else {
+      assert(true)
+    }
+  }
+
+  test("Testing SI on partition table with minor compaction") {
+    sql("drop index if exists indextable1 on uniqdata1")
+    sql("create index indextable1 on table uniqdata1 (DOB, CUST_NAME) AS 'carbondata'")
+
+    val withoutIndex =
+      sql(
+        "select * from uniqdata1 where CUST_NAME='CUST_NAME_00108' and ACTIVE_EMUI_VERSION = " +
+        "'abc'")
+        .collect().toSeq
+
     sql("alter table uniqdata1 compact 'minor'")
-    sql("select * from uniqdata1 where ACTIVE_EMUI_VERSION = 'abc' and " +
-        "CUST_NAME='CUST_NAME_00108'").show()
-    sql("drop index if exists indextable1 on uniqdata1")
+
+    checkAnswer(sql(
+      "select * from uniqdata1 where CUST_NAME='CUST_NAME_00108' and ACTIVE_EMUI_VERSION = 'abc'"),
+      withoutIndex)
+
+    val df = sql(
+      "select * from uniqdata1 where CUST_NAME='CUST_NAME_00108' and ACTIVE_EMUI_VERSION = 'abc'")
+      .queryExecution
+      .sparkPlan
+    if (!isFilterPushedDownToSI(df)) {
+      assert(false)
+    } else {
+      assert(true)
+    }
   }
 
-  test("TESTING SI on MINOR compaction") {
+  test("Testing SI on partition table with delete") {
     sql("drop index if exists indextable1 on uniqdata1")
     sql("create index indextable1 on table uniqdata1 (DOB, CUST_NAME) AS 'carbondata'")
-    sql(s"LOAD DATA LOCAL INPATH '$resourcesPath/restructure/data_2000.csv' INTO " +
-        "TABLE uniqdata1 partition(ACTIVE_EMUI_VERSION='abc') OPTIONS('DELIMITER'=',', " +
-        "'BAD_RECORDS_LOGGER_ENABLE'='FALSE', 'BAD_RECORDS_ACTION'='FORCE','FILEHEADER'='CUST_ID," +
-        "CUST_NAME,ACTIVE_EMUI_VERSION,DOB,DOJ,BIGINT_COLUMN1,BIGINT_COLUMN2,DECIMAL_COLUMN1," +
-        "DECIMAL_COLUMN2,Double_COLUMN1,Double_COLUMN2,INTEGER_COLUMN1')")
-    sql("alter table uniqdata1 compact 'minor'")
-    sql("select * from uniqdata1 where CUST_NAME='CUST_NAME_00108'").show()
 
+    checkAnswer(sql(
+      "select count(*) from uniqdata1 where CUST_NAME='CUST_NAME_00108' and ACTIVE_EMUI_VERSION =" +
+      " 'abc'"),
+      Seq(Row(4)))
+
+    sql("delete from uniqdata1 where CUST_NAME='CUST_NAME_00108'").show()
+
+    checkAnswer(sql(
+      "select count(*) from uniqdata1 where CUST_NAME='CUST_NAME_00108' and ACTIVE_EMUI_VERSION =" +
+      " 'abc'"),
+      Seq(Row(0)))
+
+    val df = sql(
+      "select * from uniqdata1 where CUST_NAME='CUST_NAME_00108' and ACTIVE_EMUI_VERSION = 'abc'")
+      .queryExecution
+      .sparkPlan
+    if (!isFilterPushedDownToSI(df)) {
+      assert(false)
+    } else {
+      assert(true)
+    }
+  }
+
+  test("Testing SI on partition table with update") {
+    sql("drop index if exists indextable1 on uniqdata1")
+    sql("create index indextable1 on table uniqdata1 (DOB, CUST_NAME) AS 'carbondata'")
+
+    checkAnswer(sql(
+      "select count(*) from uniqdata1 where CUST_ID='9000' and ACTIVE_EMUI_VERSION = 'abc'"),
+      Seq(Row(4)))
+    intercept[RuntimeException] {
+      sql("update uniqdata1 d set (d.CUST_ID) = ('8000')  where d.CUST_ID = '9000'").show()
+    }
+  }
+
+  test("Testing SI on partition table with rename") {
+    sql("drop index if exists indextable1 on uniqdata1")
+    sql("create index indextable1 on table uniqdata1 (DOB, CUST_NAME) AS 'carbondata'")
+
+    val withoutIndex =
+      sql(
+        "select * from uniqdata1 where CUST_NAME='CUST_NAME_00108' and ACTIVE_EMUI_VERSION = " +
+        "'abc'")
+        .collect().toSeq
+
+    sql("alter table uniqdata1 change CUST_NAME test string")
+
+    checkAnswer(sql(
+      "select * from uniqdata1 where test='CUST_NAME_00108' and ACTIVE_EMUI_VERSION = 'abc'"),
+      withoutIndex)
+
+    val df = sql(
+      "select * from uniqdata1 where test='CUST_NAME_00108' and ACTIVE_EMUI_VERSION = 'abc'")
+      .queryExecution
+      .sparkPlan
+    if (!isFilterPushedDownToSI(df)) {
+      assert(false)
+    } else {
+      assert(true)
+    }
+  }
+
+  override protected def afterAll(): Unit = {
     sql("drop index if exists indextable1 on uniqdata1")
     sql("drop table if exists uniqdata1")
   }
 
-  override protected def afterAll(): Unit = {
-
+  /**
+   * Method to check whether the filter is push down to SI table or not
+   *
+   * @param sparkPlan
+   * @return
+   */
+  private def isFilterPushedDownToSI(sparkPlan: SparkPlan): Boolean = {
+    var isValidPlan = false
+    sparkPlan.transform {
+      case broadCastSIFilterPushDown: BroadCastSIFilterPushJoin =>
+        isValidPlan = true
+        broadCastSIFilterPushDown
+    }
+    isValidPlan
   }
 }

--- a/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/TestSIWithSecondryIndex.scala
+++ b/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/TestSIWithSecondryIndex.scala
@@ -19,6 +19,8 @@ package org.apache.carbondata.spark.testsuite.secondaryindex
 import scala.collection.JavaConverters._
 
 import org.apache.carbondata.common.exceptions.sql.MalformedCarbonCommandException
+import org.apache.carbondata.spark.testsuite.secondaryindex.TestSecondaryIndexUtils
+.isFilterPushedDownToSI;
 import org.apache.spark.sql.{CarbonEnv, Row}
 import org.scalatest.BeforeAndAfterAll
 
@@ -26,8 +28,6 @@ import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.statusmanager.{LoadMetadataDetails, SegmentStatus, SegmentStatusManager}
 import org.apache.carbondata.core.util.CarbonProperties
 import org.apache.carbondata.core.util.path.CarbonTablePath
-import org.apache.spark.sql.execution.SparkPlan
-import org.apache.spark.sql.secondaryindex.joins.BroadCastSIFilterPushJoin
 import org.apache.spark.sql.test.util.QueryTest
 
 class TestSIWithSecondryIndex extends QueryTest with BeforeAndAfterAll {
@@ -230,21 +230,4 @@ class TestSIWithSecondryIndex extends QueryTest with BeforeAndAfterAll {
     sql("drop table if exists uniqdata")
     sql("drop table if exists uniqdataTable")
   }
-
-  /**
-    * Method to check whether the filter is push down to SI table or not
-    *
-    * @param sparkPlan
-    * @return
-    */
-  private def isFilterPushedDownToSI(sparkPlan: SparkPlan): Boolean = {
-    var isValidPlan = false
-    sparkPlan.transform {
-      case broadCastSIFilterPushDown: BroadCastSIFilterPushJoin =>
-        isValidPlan = true
-        broadCastSIFilterPushDown
-    }
-    isValidPlan
-  }
-
 }

--- a/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/TestSecondaryIndexUtils.scala
+++ b/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/TestSecondaryIndexUtils.scala
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.spark.testsuite.secondaryindex
+
+import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.secondaryindex.joins.BroadCastSIFilterPushJoin
+
+object TestSecondaryIndexUtils {
+  /**
+   * Method to check whether the filter is push down to SI table or not
+   *
+   * @param sparkPlan
+   * @return
+   */
+  def isFilterPushedDownToSI(sparkPlan: SparkPlan): Boolean = {
+    var isValidPlan = false
+    sparkPlan.transform {
+      case broadCastSIFilterPushDown: BroadCastSIFilterPushJoin =>
+        isValidPlan = true
+        broadCastSIFilterPushDown
+    }
+    isValidPlan
+  }
+}

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDeltaRowScanRDD.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDeltaRowScanRDD.scala
@@ -74,7 +74,9 @@ class CarbonDeltaRowScanRDD[T: ClassTag](
       val partition = p.asInstanceOf[CarbonSparkPartition]
       val splits = partition.multiBlockSplit.getAllSplits.asScala.filter { s =>
         updateStatusManager.getDetailsForABlock(
-          CarbonUpdateUtil.getSegmentBlockNameKey(s.getSegmentId, s.getBlockPath)) != null
+          CarbonUpdateUtil.getSegmentBlockNameKey(s.getSegmentId,
+            s.getBlockPath,
+            table.isHivePartitionTable)) != null
       }.asJava
       new CarbonSparkPartition(partition.rddId, partition.index,
         new CarbonMultiBlockSplit(splits, partition.multiBlockSplit.getLocations))

--- a/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/events/AlterTableCompactionPostEventListener.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/events/AlterTableCompactionPostEventListener.scala
@@ -109,8 +109,12 @@ class AlterTableCompactionPostEventListener extends OperationEventListener with 
           val loadName = mergedLoadName
             .substring(mergedLoadName.indexOf(CarbonCommonConstants.LOAD_FOLDER) +
                        CarbonCommonConstants.LOAD_FOLDER.length)
-          val mergeLoadStartTime = CarbonUpdateUtil.readCurrentTime()
-
+          val factTimestamp = carbonLoadModel.getFactTimeStamp
+          val mergeLoadStartTime = if (factTimestamp == 0) {
+            CarbonUpdateUtil.readCurrentTime()
+          } else {
+            factTimestamp
+          }
           val segmentIdToLoadStartTimeMapping: scala.collection.mutable.Map[String, java.lang
           .Long] = scala.collection.mutable.Map((loadName, mergeLoadStartTime))
           Compactor.createSecondaryIndexAfterCompaction(sQLContext,

--- a/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/rdd/CarbonSecondaryIndexRDD.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/rdd/CarbonSecondaryIndexRDD.scala
@@ -200,12 +200,7 @@ class CarbonSecondaryIndexRDD[K, V](
         .set("current.segmentfile", segmentId + "_" + carbonLoadModel.getFactTimeStamp)
     }
     val format =
-//      if (carbonLoadModel.getCarbonDataLoadSchema.getCarbonTable.isHivePartitionTable &&
-//          isCompactionCall) {
-//        CarbonInputFormatUtil.createCarbonFileInputFormat(absoluteTableIdentifier, job);
-//      } else {
-        CarbonInputFormatUtil.createCarbonInputFormat(absoluteTableIdentifier, job)
-//      }
+      CarbonInputFormatUtil.createCarbonInputFormat(absoluteTableIdentifier, job)
     // initialise query_id for job
     job.getConfiguration.set("query.id", queryId)
     var defaultParallelism = sparkContext.defaultParallelism

--- a/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/rdd/CarbonSecondaryIndexRDD.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/rdd/CarbonSecondaryIndexRDD.scala
@@ -196,8 +196,10 @@ class CarbonSecondaryIndexRDD[K, V](
     val job: Job = new Job(jobConf)
 
     if (carbonLoadModel.getCarbonDataLoadSchema.getCarbonTable.isHivePartitionTable) {
-      job.getConfiguration
-        .set("current.segmentfile", segmentId + "_" + carbonLoadModel.getFactTimeStamp)
+      // set the configuration for current segment file("current.segment") as
+      // same as carbon output committer
+      job.getConfiguration.set(CarbonCommonConstants.CURRENT_SEGMENTFILE,
+        segmentId + CarbonCommonConstants.UNDERSCORE + carbonLoadModel.getFactTimeStamp)
     }
     val format =
       CarbonInputFormatUtil.createCarbonInputFormat(absoluteTableIdentifier, job)

--- a/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/rdd/SecondaryIndexCreator.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/rdd/SecondaryIndexCreator.scala
@@ -164,13 +164,12 @@ object SecondaryIndexCreator {
               new SecondaryIndexCreationResultImpl,
               carbonLoadModel,
               secondaryIndexModel.secondaryIndex,
-              segId, execInstance, indexCarbonTable, forceAccessSegment).collect()
-            val segmentFileName =
+              segId, execInstance, indexCarbonTable, forceAccessSegment, isCompactionCall).collect()
               SegmentFileStore
                 .writeSegmentFile(indexCarbonTable,
                   segId,
                   String.valueOf(carbonLoadModel.getFactTimeStamp))
-            segmentToLoadStartTimeMap.put(segId, String.valueOf(carbonLoadModel.getFactTimeStamp))
+            segmentToLoadStartTimeMap.put(segId, carbonLoadModel.getFactTimeStamp.toString)
             if (secondaryIndexCreationStatus.length > 0) {
               eachSegmentSecondaryIndexCreationStatus = secondaryIndexCreationStatus
             }
@@ -360,6 +359,7 @@ object SecondaryIndexCreator {
     copyObj.setColumnCompressor(
       CarbonInternalScalaUtil.getCompressorForIndexTable(
         indexTable, carbonLoadModel.getCarbonDataLoadSchema.getCarbonTable))
+    copyObj.setFactTimeStamp(carbonLoadModel.getFactTimeStamp)
     copyObj
   }
 


### PR DESCRIPTION
 ### Why is this PR needed?
Currently Secondary index is not supported for partition table.
Secondary index should support on non partition columns instead of blocking full partition table.
 
### What changes were proposed in this PR?

 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes.
Below test cases added as part of testing secondary index on partition table
1. Plan validation
2. Filter(Non-Partition + partiton)
3. Compaction  + Filter
4. delete
5. Filter combinations(and, or)
6. rename non-partition columns and filter on partition + renamed column

    
