### PR TITLE
[CARBONDATA-3725]fix concurrent creation of Materialized Views issue

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datamap/DataMapCatalog.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/DataMapCatalog.java
@@ -48,4 +48,9 @@ public interface DataMapCatalog<T> {
    */
   void refresh();
 
+  /**
+   * This checks whether the datamapSchema is already registered
+   */
+  Boolean isSchemaAlreadyRegistered(String dataMapName);
+
 }

--- a/core/src/main/java/org/apache/carbondata/core/datamap/DataMapCatalog.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/DataMapCatalog.java
@@ -51,6 +51,6 @@ public interface DataMapCatalog<T> {
   /**
    * This checks whether the datamapSchema is already registered
    */
-  Boolean isSchemaAlreadyRegistered(String dataMapName);
+  Boolean isMVExists(String mvName);
 
 }

--- a/core/src/main/java/org/apache/carbondata/core/datamap/DataMapStoreManager.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/DataMapStoreManager.java
@@ -249,7 +249,7 @@ public final class DataMapStoreManager {
         dataMapCatalog.registerSchema(dataMapSchema);
       }
     } else {
-      if (!dataMapCatalog.isSchemaAlreadyRegistered(dataMapSchema.getDataMapName())) {
+      if (!dataMapCatalog.isMVExists(dataMapSchema.getDataMapName())) {
         dataMapCatalog.registerSchema(dataMapSchema);
       }
     }
@@ -275,8 +275,10 @@ public final class DataMapStoreManager {
    * @param providerName
    * @return
    */
-  public synchronized DataMapCatalog getDataMapCatalog(DataMapProvider dataMapProvider,
-      String providerName, boolean clearCatalogs) throws IOException {
+  public synchronized DataMapCatalog getDataMapCatalog(
+      DataMapProvider dataMapProvider,
+      String providerName,
+      boolean clearCatalogs) throws IOException {
     // This method removes the datamapCatalog for the corresponding provider if the session gets
     // refreshed or updated
     if (clearCatalogs) {

--- a/core/src/main/java/org/apache/carbondata/core/datamap/DataMapStoreManager.java
+++ b/core/src/main/java/org/apache/carbondata/core/datamap/DataMapStoreManager.java
@@ -228,22 +228,28 @@ public final class DataMapStoreManager {
    * @param dataMapProvider
    * @param dataMapSchema
    */
-  public void registerDataMapCatalog(DataMapProvider dataMapProvider,
-      DataMapSchema dataMapSchema) throws IOException {
-    synchronized (lockObject) {
-      initializeDataMapCatalogs(dataMapProvider);
-      String name = dataMapSchema.getProviderName().toLowerCase();
-      DataMapCatalog dataMapCatalog = dataMapCatalogs.get(name);
-      if (dataMapCatalog == null) {
-        dataMapCatalog = dataMapProvider.createDataMapCatalog();
-        // If MVDataMapProvider, then createDataMapCatalog will return summaryDatasetCatalog
-        // instance, which needs to be added to dataMapCatalogs.
-        // For other datamaps, createDataMapCatalog will return null, so no need to register
-        if (dataMapCatalog != null) {
-          dataMapCatalogs.put(name, dataMapCatalog);
-          dataMapCatalog.registerSchema(dataMapSchema);
-        }
-      } else {
+  public synchronized void registerDataMapCatalog(DataMapProvider dataMapProvider,
+      DataMapSchema dataMapSchema, boolean clearCatalogs) throws IOException {
+    // this check is added to check if when registering the datamapCatalog, if the catalog map has
+    // datasets with old session, then need to clear and reload the map, else error can be thrown
+    // if the databases are different in both the sessions
+    if (clearCatalogs) {
+      dataMapCatalogs = null;
+    }
+    initializeDataMapCatalogs(dataMapProvider);
+    String name = dataMapSchema.getProviderName().toLowerCase();
+    DataMapCatalog dataMapCatalog = dataMapCatalogs.get(name);
+    if (dataMapCatalog == null) {
+      dataMapCatalog = dataMapProvider.createDataMapCatalog();
+      // If MVDataMapProvider, then createDataMapCatalog will return summaryDatasetCatalog
+      // instance, which needs to be added to dataMapCatalogs.
+      // For other datamaps, createDataMapCatalog will return null, so no need to register
+      if (dataMapCatalog != null) {
+        dataMapCatalogs.put(name, dataMapCatalog);
+        dataMapCatalog.registerSchema(dataMapSchema);
+      }
+    } else {
+      if (!dataMapCatalog.isSchemaAlreadyRegistered(dataMapSchema.getDataMapName())) {
         dataMapCatalog.registerSchema(dataMapSchema);
       }
     }
@@ -269,26 +275,23 @@ public final class DataMapStoreManager {
    * @param providerName
    * @return
    */
-  public synchronized DataMapCatalog getDataMapCatalog(
-      DataMapProvider dataMapProvider,
-      String providerName) throws IOException {
+  public synchronized DataMapCatalog getDataMapCatalog(DataMapProvider dataMapProvider,
+      String providerName, boolean clearCatalogs) throws IOException {
+    // This method removes the datamapCatalog for the corresponding provider if the session gets
+    // refreshed or updated
+    if (clearCatalogs) {
+      dataMapCatalogs = null;
+    }
     initializeDataMapCatalogs(dataMapProvider);
     return dataMapCatalogs.get(providerName.toLowerCase());
-  }
-
-  /**
-   * This method removes the datamapCatalog for the corresponding provider if the session gets
-   * refreshed or updated
-   */
-  public void clearDataMapCatalog() {
-    dataMapCatalogs = null;
   }
 
   /**
    * Initialize by reading all datamaps from store and re register it
    * @param dataMapProvider
    */
-  private void initializeDataMapCatalogs(DataMapProvider dataMapProvider) throws IOException {
+  private synchronized void initializeDataMapCatalogs(DataMapProvider dataMapProvider)
+      throws IOException {
     if (dataMapCatalogs == null) {
       dataMapCatalogs = new ConcurrentHashMap<>();
       List<DataMapSchema> dataMapSchemas = getAllDataMapSchemas();

--- a/mv/core/src/main/scala/org/apache/carbondata/mv/extension/MVAnalyzerRule.scala
+++ b/mv/core/src/main/scala/org/apache/carbondata/mv/extension/MVAnalyzerRule.scala
@@ -85,14 +85,13 @@ class MVAnalyzerRule(sparkSession: SparkSession) extends Rule[LogicalPlan] {
     }
     if (needAnalysis) {
       var catalog = DataMapStoreManager.getInstance().getDataMapCatalog(dataMapProvider,
-        DataMapClassProvider.MV.getShortName).asInstanceOf[SummaryDatasetCatalog]
+        DataMapClassProvider.MV.getShortName, false).asInstanceOf[SummaryDatasetCatalog]
       // when first time DataMapCatalogs are initialized, it stores session info also,
       // but when carbon session is newly created, catalog map will not be cleared,
       // so if session info is different, remove the entry from map.
       if (catalog != null && !catalog.mvSession.sparkSession.equals(sparkSession)) {
-        DataMapStoreManager.getInstance().clearDataMapCatalog()
         catalog = DataMapStoreManager.getInstance().getDataMapCatalog(dataMapProvider,
-          DataMapClassProvider.MV.getShortName).asInstanceOf[SummaryDatasetCatalog]
+          DataMapClassProvider.MV.getShortName, true).asInstanceOf[SummaryDatasetCatalog]
       }
       if (catalog != null && isValidPlan(plan, catalog)) {
         val modularPlan = catalog.mvSession.sessionState.rewritePlan(plan).withMVTable

--- a/mv/core/src/main/scala/org/apache/carbondata/mv/extension/MVDataMapProvider.scala
+++ b/mv/core/src/main/scala/org/apache/carbondata/mv/extension/MVDataMapProvider.scala
@@ -34,7 +34,7 @@ import org.apache.carbondata.core.datamap.{DataMapCatalog, DataMapProvider, Data
 import org.apache.carbondata.core.datamap.dev.{DataMap, DataMapFactory}
 import org.apache.carbondata.core.datamap.status.DataMapStatusManager
 import org.apache.carbondata.core.indexstore.Blocklet
-import org.apache.carbondata.core.metadata.schema.datamap.DataMapProperty
+import org.apache.carbondata.core.metadata.schema.datamap.{DataMapClassProvider, DataMapProperty}
 import org.apache.carbondata.core.metadata.schema.table.{CarbonTable, DataMapSchema}
 import org.apache.carbondata.mv.rewrite.{SummaryDataset, SummaryDatasetCatalog}
 import org.apache.carbondata.processing.util.CarbonLoaderUtil
@@ -62,7 +62,13 @@ class MVDataMapProvider(
       ctasSqlStatement,
       true)
     try {
-      DataMapStoreManager.getInstance.registerDataMapCatalog(this, dataMapSchema)
+      val catalog = DataMapStoreManager.getInstance().getDataMapCatalog(this,
+        DataMapClassProvider.MV.getShortName, false).asInstanceOf[SummaryDatasetCatalog]
+      if (catalog != null && !catalog.mvSession.sparkSession.equals(sparkSession)) {
+        DataMapStoreManager.getInstance.registerDataMapCatalog(this, dataMapSchema, true)
+      } else {
+        DataMapStoreManager.getInstance.registerDataMapCatalog(this, dataMapSchema, false)
+      }
       if (dataMapSchema.isLazy) {
         DataMapStatusManager.disableDataMap(dataMapSchema.getDataMapName)
       }

--- a/mv/core/src/main/scala/org/apache/carbondata/mv/extension/MVHelper.scala
+++ b/mv/core/src/main/scala/org/apache/carbondata/mv/extension/MVHelper.scala
@@ -304,7 +304,7 @@ object MVHelper {
     val dataMapProvider = DataMapManager.get().getDataMapProvider(null,
       new DataMapSchema("", DataMapClassProvider.MV.getShortName), sparkSession)
     var catalog = DataMapStoreManager.getInstance().getDataMapCatalog(dataMapProvider,
-      DataMapClassProvider.MV.getShortName).asInstanceOf[SummaryDatasetCatalog]
+      DataMapClassProvider.MV.getShortName, false).asInstanceOf[SummaryDatasetCatalog]
     if (catalog == null) {
       catalog = new SummaryDatasetCatalog(sparkSession)
     }

--- a/mv/core/src/main/scala/org/apache/carbondata/mv/rewrite/SummaryDatasetCatalog.scala
+++ b/mv/core/src/main/scala/org/apache/carbondata/mv/rewrite/SummaryDatasetCatalog.scala
@@ -25,6 +25,7 @@ import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.datasources.FindDataSourceTable
 
+import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.core.datamap.DataMapCatalog
 import org.apache.carbondata.core.datamap.status.DataMapStatusManager
 import org.apache.carbondata.core.metadata.schema.table.DataMapSchema
@@ -52,6 +53,8 @@ case class MVPlanWrapper(plan: ModularPlan, dataMapSchema: DataMapSchema) extend
 
 private[mv] class SummaryDatasetCatalog(sparkSession: SparkSession)
   extends DataMapCatalog[SummaryDataset] {
+
+  private val LOGGER = LogServiceFactory.getLogService(this.getClass.getCanonicalName)
 
   @transient
   private val summaryDatasets = new scala.collection.mutable.ArrayBuffer[SummaryDataset]
@@ -107,12 +110,19 @@ private[mv] class SummaryDatasetCatalog(sparkSession: SparkSession)
       // catalog, if the datamap is in database other than sparkSession.currentDataBase(), then it
       // fails to register, so set the database present in the dataMapSchema Object
       setCurrentDataBase(dataMapSchema.getRelationIdentifier.getDatabaseName)
-      val mvPlan = MVParser.getMVPlan(dataMapSchema.getCtasQuery, sparkSession)
-      // here setting back to current database of current session, because if the actual query
-      // contains db name in query like, select db1.column1 from table and current database is
-      // default and if we drop the db1, still the session has current db as db1.
-      // So setting back to current database.
-      setCurrentDataBase(currentDatabase)
+      val mvPlan = try {
+        MVParser.getMVPlan(dataMapSchema.getCtasQuery, sparkSession)
+      } catch {
+        case ex: Exception =>
+          LOGGER.error("Error executing the updated query during register datamap schema", ex)
+          throw ex
+      } finally {
+        // here setting back to current database of current session, because if the actual query
+        // contains db name in query like, select db1.column1 from table and current database is
+        // default and if we drop the db1, still the session has current db as db1.
+        // So setting back to current database.
+        setCurrentDataBase(currentDatabase)
+      }
       val planToRegister = MVHelper.dropDummyFunc(mvPlan)
       val modularPlan =
         mvSession.sessionState.modularizer.modularize(
@@ -161,6 +171,14 @@ private[mv] class SummaryDatasetCatalog(sparkSession: SparkSession)
     }
   }
 
+  /**
+   * Checks if the schema is already registered
+   */
+  private[mv] def isSchemaAlreadyRegistered(dataMapName: String): java.lang.Boolean = {
+    val dataIndex = summaryDatasets
+      .indexWhere(sd => sd.dataMapSchema.getDataMapName.equals(dataMapName))
+    dataIndex > 0
+  }
 
   override def listAllValidSchema(): Array[SummaryDataset] = {
     val statusDetails = DataMapStatusManager.getEnabledDataMapStatusDetails

--- a/mv/core/src/main/scala/org/apache/carbondata/mv/rewrite/SummaryDatasetCatalog.scala
+++ b/mv/core/src/main/scala/org/apache/carbondata/mv/rewrite/SummaryDatasetCatalog.scala
@@ -114,7 +114,7 @@ private[mv] class SummaryDatasetCatalog(sparkSession: SparkSession)
         MVParser.getMVPlan(dataMapSchema.getCtasQuery, sparkSession)
       } catch {
         case ex: Exception =>
-          LOGGER.error("Error executing the updated query during register datamap schema", ex)
+          LOGGER.error("Error executing the updated query during register MV schema", ex)
           throw ex
       } finally {
         // here setting back to current database of current session, because if the actual query
@@ -174,9 +174,9 @@ private[mv] class SummaryDatasetCatalog(sparkSession: SparkSession)
   /**
    * Checks if the schema is already registered
    */
-  private[mv] def isSchemaAlreadyRegistered(dataMapName: String): java.lang.Boolean = {
+  private[mv] def isMVExists(mvName: String): java.lang.Boolean = {
     val dataIndex = summaryDatasets
-      .indexWhere(sd => sd.dataMapSchema.getDataMapName.equals(dataMapName))
+      .indexWhere(sd => sd.dataMapSchema.getDataMapName.equals(mvName))
     dataIndex > 0
   }
 


### PR DESCRIPTION
 ### Why is this PR needed?
When two create MVs are running concurrently in two different sessions with two different databases, then in any create fails in any session, other sessions's current database is changed and corresponding queries fails with table not found exception.
 
 ### What changes were proposed in this PR?
When the session is changed we need to clear the datamap catalog map which may lead to this problem. Initially it was handled only for query and other flows, it wasnt handled in create MV flow. Handled same, make proper synchronisations to avoid these problems. 
    
 ### Does this PR introduce any user interface change?
 - No
 - Yes. (added a isSchemaRegistered in DatamapCatalog Interface, which is required to avoid multiple registration of same datamap schemas)

 ### Is any new testcase added?
 - No, existing test cases will take care

    
