### PR TITLE
[CARBONDATA-3727] Fix NPE of sort merger

### DIFF
--- a/processing/src/main/java/org/apache/carbondata/processing/sort/sortdata/SingleThreadFinalSortFilesMerger.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/sort/sortdata/SingleThreadFinalSortFilesMerger.java
@@ -306,7 +306,7 @@ public class SingleThreadFinalSortFilesMerger extends CarbonIterator<Object[]> {
    * @return more element is present
    */
   public boolean hasNext() {
-    return this.recordHolderHeapLocal.size() > 0;
+    return this.recordHolderHeapLocal != null && this.recordHolderHeapLocal.size() > 0;
   }
 
   public void close() {


### PR DESCRIPTION
 ### Why is this PR needed?
 Fix NPE of sort merger in range sort cases.
in ParallelReadMergeSorterWithColumnRangeImpl, finalMerger.startFinalMerge will check whether
filesToMerge.size() == 0, if true it wil return without createRecordHolderQueue and as a result it is null, and finally the code will call finalMerger.hasNext() to check whether the iterator has next, but the recordHolderHeapLocal is null, it will throw NPE.
 ### What changes were proposed in this PR?
Add null check if recordHolderHeapLocal is null, it means not created and need merged files == 0, so it also means no next value.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No

    
