### PR TITLE
[CARBONDATA-3728] Fix insert failure on partition table with local sort

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/TableSpec.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/TableSpec.java
@@ -30,6 +30,7 @@ import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
 import org.apache.carbondata.core.metadata.schema.table.Writable;
 import org.apache.carbondata.core.metadata.schema.table.column.CarbonDimension;
 import org.apache.carbondata.core.metadata.schema.table.column.CarbonMeasure;
+import org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema;
 
 public class TableSpec {
 
@@ -56,22 +57,64 @@ public class TableSpec {
   private int[] dictDimActualPosition;
   private int[] noDictDimActualPosition;
 
-  public TableSpec(CarbonTable carbonTable) {
+  public TableSpec(CarbonTable carbonTable, boolean keepPartitionColumnsToEnd) {
     this.carbonTable = carbonTable;
     List<CarbonDimension> dimensions = carbonTable.getVisibleDimensions();
     List<CarbonMeasure> measures = carbonTable.getVisibleMeasures();
-    // first calculate total number of columnar field considering column group and complex column
-    numSimpleDimensions = 0;
-    for (CarbonDimension dimension : dimensions) {
-      if (!dimension.isComplex()) {
-        numSimpleDimensions++;
+    if (keepPartitionColumnsToEnd && carbonTable.getPartitionInfo() != null) {
+      // keep the partition columns in the end
+      List<CarbonDimension> reArrangedDimensions = new ArrayList<>();
+      List<CarbonMeasure> reArrangedMeasures = new ArrayList<>();
+      List<CarbonDimension> partitionDimensions = new ArrayList<>();
+      List<CarbonMeasure> partitionMeasures = new ArrayList<>();
+      List<ColumnSchema> columnSchemaList = carbonTable.getPartitionInfo().getColumnSchemaList();
+      for (CarbonDimension dim : dimensions) {
+        if (columnSchemaList.contains(dim.getColumnSchema())) {
+          partitionDimensions.add(dim);
+        } else {
+          reArrangedDimensions.add(dim);
+        }
       }
+      if (partitionDimensions.size() != 0) {
+        reArrangedDimensions.addAll(partitionDimensions);
+      }
+
+      for (CarbonMeasure measure : measures) {
+        if (columnSchemaList.contains(measure.getColumnSchema())) {
+          partitionMeasures.add(measure);
+        } else {
+          reArrangedMeasures.add(measure);
+        }
+      }
+      if (partitionMeasures.size() != 0) {
+        reArrangedMeasures.addAll(partitionMeasures);
+      }
+      // first calculate total number of columnar field considering column group and complex column
+      numSimpleDimensions = 0;
+      for (CarbonDimension dimension : reArrangedDimensions) {
+        if (!dimension.isComplex()) {
+          numSimpleDimensions++;
+        }
+      }
+      dimensionSpec = new DimensionSpec[dimensions.size()];
+      measureSpec = new MeasureSpec[measures.size()];
+      noDictionaryDimensionSpec = new ArrayList<>();
+      addDimensions(reArrangedDimensions);
+      addMeasures(reArrangedMeasures);
+    } else {
+      // first calculate total number of columnar field considering column group and complex column
+      numSimpleDimensions = 0;
+      for (CarbonDimension dimension : dimensions) {
+        if (!dimension.isComplex()) {
+          numSimpleDimensions++;
+        }
+      }
+      dimensionSpec = new DimensionSpec[dimensions.size()];
+      measureSpec = new MeasureSpec[measures.size()];
+      noDictionaryDimensionSpec = new ArrayList<>();
+      addDimensions(dimensions);
+      addMeasures(measures);
     }
-    dimensionSpec = new DimensionSpec[dimensions.size()];
-    measureSpec = new MeasureSpec[measures.size()];
-    noDictionaryDimensionSpec = new ArrayList<>();
-    addDimensions(dimensions);
-    addMeasures(measures);
   }
 
   private void addDimensions(List<CarbonDimension> dimensions) {

--- a/core/src/main/java/org/apache/carbondata/core/datastore/TableSpec.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/TableSpec.java
@@ -78,7 +78,6 @@ public class TableSpec {
       if (partitionDimensions.size() != 0) {
         reArrangedDimensions.addAll(partitionDimensions);
       }
-
       for (CarbonMeasure measure : measures) {
         if (columnSchemaList.contains(measure.getColumnSchema())) {
           partitionMeasures.add(measure);
@@ -89,32 +88,21 @@ public class TableSpec {
       if (partitionMeasures.size() != 0) {
         reArrangedMeasures.addAll(partitionMeasures);
       }
-      // first calculate total number of columnar field considering column group and complex column
-      numSimpleDimensions = 0;
-      for (CarbonDimension dimension : reArrangedDimensions) {
-        if (!dimension.isComplex()) {
-          numSimpleDimensions++;
-        }
-      }
-      dimensionSpec = new DimensionSpec[dimensions.size()];
-      measureSpec = new MeasureSpec[measures.size()];
-      noDictionaryDimensionSpec = new ArrayList<>();
-      addDimensions(reArrangedDimensions);
-      addMeasures(reArrangedMeasures);
-    } else {
-      // first calculate total number of columnar field considering column group and complex column
-      numSimpleDimensions = 0;
-      for (CarbonDimension dimension : dimensions) {
-        if (!dimension.isComplex()) {
-          numSimpleDimensions++;
-        }
-      }
-      dimensionSpec = new DimensionSpec[dimensions.size()];
-      measureSpec = new MeasureSpec[measures.size()];
-      noDictionaryDimensionSpec = new ArrayList<>();
-      addDimensions(dimensions);
-      addMeasures(measures);
+      dimensions = reArrangedDimensions;
+      measures = reArrangedMeasures;
     }
+    // first calculate total number of columnar field considering column group and complex column
+    numSimpleDimensions = 0;
+    for (CarbonDimension dimension : dimensions) {
+      if (!dimension.isComplex()) {
+        numSimpleDimensions++;
+      }
+    }
+    dimensionSpec = new DimensionSpec[dimensions.size()];
+    measureSpec = new MeasureSpec[measures.size()];
+    noDictionaryDimensionSpec = new ArrayList<>();
+    addDimensions(dimensions);
+    addMeasures(measures);
   }
 
   private void addDimensions(List<CarbonDimension> dimensions) {

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/management/CommonLoadUtils.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/management/CommonLoadUtils.scala
@@ -61,6 +61,7 @@ import org.apache.carbondata.core.util._
 import org.apache.carbondata.core.util.path.CarbonTablePath
 import org.apache.carbondata.events.{BuildDataMapPostExecutionEvent, BuildDataMapPreExecutionEvent, OperationContext, OperationListenerBus}
 import org.apache.carbondata.indexserver.DistributedRDDUtils
+import org.apache.carbondata.processing.loading.constants.DataLoadProcessorConstants
 import org.apache.carbondata.processing.loading.events.LoadEvents.{LoadTablePostExecutionEvent, LoadTablePreExecutionEvent}
 import org.apache.carbondata.processing.loading.model.{CarbonLoadModelBuilder, LoadOption}
 import org.apache.carbondata.processing.loading.model.CarbonLoadModel
@@ -610,7 +611,8 @@ object CommonLoadUtils {
       optionsOriginal: mutable.Map[String, String],
       currPartitions: util.List[PartitionSpec]): LogicalRelation = {
     val table = loadModel.getCarbonDataLoadSchema.getCarbonTable
-    val metastoreSchema = if (optionsOriginal.contains("no_rearrange_of_rows")) {
+    val metastoreSchema =
+      if (optionsOriginal.contains(DataLoadProcessorConstants.NO_REARRANGE_OF_ROWS)) {
       StructType(catalogTable.schema.fields.map{f =>
         val column = table.getColumnByName(f.name)
         val updatedDataType = if (column.getDataType ==
@@ -695,7 +697,7 @@ object CommonLoadUtils {
       fileFormat = new SparkCarbonTableFormat,
       options = options.toMap)(sparkSession = sparkSession)
 
-    if (options.contains("no_rearrange_of_rows")) {
+    if (options.contains(DataLoadProcessorConstants.NO_REARRANGE_OF_ROWS)) {
       CarbonReflectionUtils.getLogicalRelation(hdfsRelation,
         metastoreSchema.toAttributes,
         Some(catalogTable),
@@ -981,7 +983,7 @@ object CommonLoadUtils {
       }
       val opt = collection.mutable.Map() ++ loadParams.optionsOriginal
       if (loadParams.scanResultRDD.isDefined) {
-        opt += (("no_rearrange_of_rows", "true"))
+        opt += ((DataLoadProcessorConstants.NO_REARRANGE_OF_ROWS, "true"))
       }
       // Create and ddd the segment to the tablestatus.
       CarbonLoaderUtil.readAndUpdateLoadProgressInTableMeta(loadParams.carbonLoadModel,

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/datasources/SparkCarbonTableFormat.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/datasources/SparkCarbonTableFormat.scala
@@ -51,6 +51,7 @@ import org.apache.carbondata.core.util.path.CarbonTablePath
 import org.apache.carbondata.hadoop.api.{CarbonOutputCommitter, CarbonTableOutputFormat}
 import org.apache.carbondata.hadoop.api.CarbonTableOutputFormat.CarbonRecordWriter
 import org.apache.carbondata.hadoop.internal.ObjectArrayWritable
+import org.apache.carbondata.processing.loading.constants.DataLoadProcessorConstants
 import org.apache.carbondata.processing.loading.model.{CarbonLoadModel, CarbonLoadModelBuilder, LoadOption}
 import org.apache.carbondata.processing.util.CarbonBadRecordUtil
 import org.apache.carbondata.spark.util.{CarbonScalaUtil, CommonUtil}
@@ -134,7 +135,7 @@ with Serializable {
       model,
       conf)
     CarbonTableOutputFormat.setOverwrite(conf, options("overwrite").toBoolean)
-    if (options.contains("no_rearrange_of_rows")) {
+    if (options.contains(DataLoadProcessorConstants.NO_REARRANGE_OF_ROWS)) {
       model.setLoadWithoutConverterWithoutReArrangeStep(true)
     } else {
       model.setLoadWithoutConverterStep(true)

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/CarbonDataLoadConfiguration.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/CarbonDataLoadConfiguration.java
@@ -248,6 +248,23 @@ public class CarbonDataLoadConfiguration {
     return type;
   }
 
+  public DataType[] getMeasureDataTypeAsDataFieldOrder() {
+    // same as data fields order
+    List<Integer> measureIndexes = new ArrayList<>(dataFields.length);
+    int measureCount = 0;
+    for (int i = 0; i < dataFields.length; i++) {
+      if (!dataFields[i].getColumn().isDimension()) {
+        measureIndexes.add(i);
+        measureCount++;
+      }
+    }
+    DataType[] type = new DataType[measureCount];
+    for (int i = 0; i < type.length; i++) {
+      type[i] = dataFields[measureIndexes.get(i)].getColumn().getDataType();
+    }
+    return type;
+  }
+
   /**
    * Get the data types of the no dictionary and the complex dimensions of the table
    *

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/DataLoadProcessBuilder.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/DataLoadProcessBuilder.java
@@ -232,7 +232,7 @@ public final class DataLoadProcessBuilder {
     configuration.setDataLoadProperty(CarbonLoadOptionConstants.CARBON_OPTIONS_BINARY_DECODER,
         loadModel.getBinaryDecoder());
     if (loadModel.isLoadWithoutConverterWithoutReArrangeStep()) {
-      configuration.setDataLoadProperty("no_rearrange_of_rows",
+      configuration.setDataLoadProperty(DataLoadProcessorConstants.NO_REARRANGE_OF_ROWS,
           loadModel.isLoadWithoutConverterWithoutReArrangeStep());
     }
     List<CarbonDimension> dimensions = carbonTable.getVisibleDimensions();

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/DataLoadProcessBuilder.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/DataLoadProcessBuilder.java
@@ -260,7 +260,7 @@ public final class DataLoadProcessBuilder {
     if (carbonTable.isHivePartitionTable()) {
       configuration.setWritingCoresCount((short) 1);
     }
-    TableSpec tableSpec = new TableSpec(carbonTable);
+    TableSpec tableSpec = new TableSpec(carbonTable, false);
     configuration.setTableSpec(tableSpec);
     if (loadModel.getSdkWriterCores() > 0) {
       configuration.setWritingCoresCount(loadModel.getSdkWriterCores());

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/constants/DataLoadProcessorConstants.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/constants/DataLoadProcessorConstants.java
@@ -38,4 +38,6 @@ public final class DataLoadProcessorConstants {
 
   public static final String FACT_FILE_PATH = "FACT_FILE_PATH";
 
+  // to indicate that it is optimized insert flow without rearrange of each data rows
+  public static final String NO_REARRANGE_OF_ROWS = "NO_REARRANGE_OF_ROWS";
 }

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/steps/CarbonRowDataWriterProcessorStepImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/steps/CarbonRowDataWriterProcessorStepImpl.java
@@ -44,6 +44,7 @@ import org.apache.carbondata.processing.datamap.DataMapWriterListener;
 import org.apache.carbondata.processing.loading.AbstractDataLoadProcessorStep;
 import org.apache.carbondata.processing.loading.CarbonDataLoadConfiguration;
 import org.apache.carbondata.processing.loading.DataField;
+import org.apache.carbondata.processing.loading.constants.DataLoadProcessorConstants;
 import org.apache.carbondata.processing.loading.exception.BadRecordFoundException;
 import org.apache.carbondata.processing.loading.exception.CarbonDataLoadingException;
 import org.apache.carbondata.processing.loading.row.CarbonRowBatch;
@@ -137,7 +138,8 @@ public class CarbonRowDataWriterProcessorStepImpl extends AbstractDataLoadProces
       CarbonTimeStatisticsFactory.getLoadStatisticsInstance()
           .recordDictionaryValue2MdkAdd2FileTime(CarbonTablePath.DEPRECATED_PARTITION_ID,
               System.currentTimeMillis());
-      if (configuration.getDataLoadProperty("no_rearrange_of_rows") != null) {
+      if (configuration.getDataLoadProperty(
+          DataLoadProcessorConstants.NO_REARRANGE_OF_ROWS) != null) {
         initializeNoReArrangeIndexes();
       }
       if (iterators.length == 1) {
@@ -363,7 +365,8 @@ public class CarbonRowDataWriterProcessorStepImpl extends AbstractDataLoadProces
   private void processBatch(CarbonRowBatch batch, CarbonFactHandler dataHandler, int iteratorIndex)
       throws CarbonDataLoadingException {
     try {
-      if (configuration.getDataLoadProperty("no_rearrange_of_rows") != null) {
+      if (configuration.getDataLoadProperty(
+          DataLoadProcessorConstants.NO_REARRANGE_OF_ROWS) != null) {
         // convert without re-arrange
         while (batch.hasNext()) {
           CarbonRow row = batch.next();

--- a/processing/src/main/java/org/apache/carbondata/processing/sort/sortdata/SortParameters.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/sort/sortdata/SortParameters.java
@@ -30,6 +30,7 @@ import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
 import org.apache.carbondata.core.util.CarbonProperties;
 import org.apache.carbondata.core.util.path.CarbonTablePath;
 import org.apache.carbondata.processing.loading.CarbonDataLoadConfiguration;
+import org.apache.carbondata.processing.loading.constants.DataLoadProcessorConstants;
 import org.apache.carbondata.processing.util.CarbonDataProcessorUtil;
 
 import org.apache.commons.lang3.StringUtils;
@@ -489,7 +490,7 @@ public class SortParameters implements Serializable {
         CarbonCommonConstants.CARBON_PREFETCH_BUFFERSIZE,
         CarbonCommonConstants.CARBON_PREFETCH_BUFFERSIZE_DEFAULT)));
 
-    if (configuration.getDataLoadProperty("no_rearrange_of_rows") != null
+    if (configuration.getDataLoadProperty(DataLoadProcessorConstants.NO_REARRANGE_OF_ROWS) != null
         && configuration.getTableSpec().getCarbonTable().getPartitionInfo() != null) {
       // In case of partition, partition data will be present in the end for rearrange flow
       // So, prepare the indexes and mapping as per dataFields order.

--- a/processing/src/main/java/org/apache/carbondata/processing/sort/sortdata/SortParameters.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/sort/sortdata/SortParameters.java
@@ -158,6 +158,8 @@ public class SortParameters implements Serializable {
    */
   private int[] noDictSortColumnSchemaOrderMapping;
 
+  private boolean isInsertWithoutReArrangeFlow;
+
   public SortParameters getCopy() {
     SortParameters parameters = new SortParameters();
     parameters.tempFileLocation = tempFileLocation;
@@ -196,6 +198,7 @@ public class SortParameters implements Serializable {
     parameters.dictDimActualPosition = dictDimActualPosition;
     parameters.noDictActualPosition = noDictActualPosition;
     parameters.noDictSortColumnSchemaOrderMapping = noDictSortColumnSchemaOrderMapping;
+    parameters.isInsertWithoutReArrangeFlow = isInsertWithoutReArrangeFlow;
     return parameters;
   }
 
@@ -407,6 +410,14 @@ public class SortParameters implements Serializable {
     this.noDictSortColumnSchemaOrderMapping = noDictSortColumnSchemaOrderMapping;
   }
 
+  public boolean isInsertWithoutReArrangeFlow() {
+    return isInsertWithoutReArrangeFlow;
+  }
+
+  public void setInsertWithoutReArrangeFlow(boolean insertWithoutReArrangeFlow) {
+    isInsertWithoutReArrangeFlow = insertWithoutReArrangeFlow;
+  }
+
   public static SortParameters createSortParameters(CarbonDataLoadConfiguration configuration) {
     SortParameters parameters = new SortParameters();
     CarbonTableIdentifier tableIdentifier =
@@ -431,10 +442,6 @@ public class SortParameters implements Serializable {
         CarbonDataProcessorUtil.getIsVarcharColumnMapping(configuration.getDataFields()));
     parameters.setNumberOfSortColumns(configuration.getNumberOfSortColumns());
     parameters.setNumberOfNoDictSortColumns(configuration.getNumberOfNoDictSortColumns());
-    parameters.setNoDictionarySortColumn(CarbonDataProcessorUtil
-        .getNoDictSortColMapping(parameters.getCarbonTable()));
-    parameters.setNoDictSortColumnSchemaOrderMapping(CarbonDataProcessorUtil
-        .getColumnIdxBasedOnSchemaInRow(parameters.getCarbonTable()));
     parameters.setSortColumn(configuration.getSortColumnMapping());
     parameters.setObserver(new SortObserver());
     // get sort buffer size
@@ -482,18 +489,46 @@ public class SortParameters implements Serializable {
         CarbonCommonConstants.CARBON_PREFETCH_BUFFERSIZE,
         CarbonCommonConstants.CARBON_PREFETCH_BUFFERSIZE_DEFAULT)));
 
-    DataType[] measureDataType = configuration.getMeasureDataType();
-    parameters.setMeasureDataType(measureDataType);
-    parameters.setNoDictDataType(CarbonDataProcessorUtil
-        .getNoDictDataTypes(configuration.getTableSpec().getCarbonTable()));
-    Map<String, DataType[]> noDictSortAndNoSortDataTypes = CarbonDataProcessorUtil
-        .getNoDictSortAndNoSortDataTypes(configuration.getTableSpec().getCarbonTable());
-    parameters.setNoDictSortDataType(noDictSortAndNoSortDataTypes.get("noDictSortDataTypes"));
-    parameters.setNoDictNoSortDataType(noDictSortAndNoSortDataTypes.get("noDictNoSortDataTypes"));
-    parameters.setNoDictActualPosition(configuration.getTableSpec().getNoDictDimActualPosition());
-    parameters.setDictDimActualPosition(configuration.getTableSpec().getDictDimActualPosition());
-    parameters.setUpdateDictDims(configuration.getTableSpec().isUpdateDictDim());
-    parameters.setUpdateNonDictDims(configuration.getTableSpec().isUpdateNoDictDims());
+    if (configuration.getDataLoadProperty("no_rearrange_of_rows") != null
+        && configuration.getTableSpec().getCarbonTable().getPartitionInfo() != null) {
+      // In case of partition, partition data will be present in the end for rearrange flow
+      // So, prepare the indexes and mapping as per dataFields order.
+      parameters.setInsertWithoutReArrangeFlow(true);
+      parameters.setNoDictionarySortColumn(CarbonDataProcessorUtil
+          .getNoDictSortColMappingAsDataFieldOrder(configuration.getDataFields()));
+      parameters.setNoDictSortColumnSchemaOrderMapping(CarbonDataProcessorUtil
+          .getColumnIdxBasedOnSchemaInRowAsDataFieldOrder(configuration.getDataFields()));
+      parameters.setMeasureDataType(configuration.getMeasureDataTypeAsDataFieldOrder());
+      parameters.setNoDictDataType(CarbonDataProcessorUtil
+          .getNoDictDataTypesAsDataFieldOrder(configuration.getDataFields()));
+      Map<String, DataType[]> noDictSortAndNoSortDataTypes = CarbonDataProcessorUtil
+          .getNoDictSortAndNoSortDataTypesAsDataFieldOrder(configuration.getDataFields());
+      parameters.setNoDictSortDataType(noDictSortAndNoSortDataTypes.get("noDictSortDataTypes"));
+      parameters.setNoDictNoSortDataType(noDictSortAndNoSortDataTypes.get("noDictNoSortDataTypes"));
+      // keep partition columns in the end for table spec by getting rearranged tale spec
+      TableSpec tableSpec = new TableSpec(configuration.getTableSpec().getCarbonTable(), true);
+      parameters.setNoDictActualPosition(tableSpec.getNoDictDimActualPosition());
+      parameters.setDictDimActualPosition(tableSpec.getDictDimActualPosition());
+      parameters.setUpdateDictDims(tableSpec.isUpdateDictDim());
+      parameters.setUpdateNonDictDims(tableSpec.isUpdateNoDictDims());
+    } else {
+      parameters.setNoDictionarySortColumn(CarbonDataProcessorUtil
+          .getNoDictSortColMapping(parameters.getCarbonTable()));
+      parameters.setNoDictSortColumnSchemaOrderMapping(CarbonDataProcessorUtil
+          .getColumnIdxBasedOnSchemaInRow(parameters.getCarbonTable()));
+      parameters.setMeasureDataType(configuration.getMeasureDataType());
+      parameters.setNoDictDataType(CarbonDataProcessorUtil
+          .getNoDictDataTypes(configuration.getTableSpec().getCarbonTable()));
+      Map<String, DataType[]> noDictSortAndNoSortDataTypes = CarbonDataProcessorUtil
+          .getNoDictSortAndNoSortDataTypes(configuration.getTableSpec().getCarbonTable());
+      parameters.setNoDictSortDataType(noDictSortAndNoSortDataTypes.get("noDictSortDataTypes"));
+      parameters.setNoDictNoSortDataType(noDictSortAndNoSortDataTypes.get("noDictNoSortDataTypes"));
+      TableSpec tableSpec = configuration.getTableSpec();
+      parameters.setNoDictActualPosition(tableSpec.getNoDictDimActualPosition());
+      parameters.setDictDimActualPosition(tableSpec.getDictDimActualPosition());
+      parameters.setUpdateDictDims(tableSpec.isUpdateDictDim());
+      parameters.setUpdateNonDictDims(tableSpec.isUpdateNoDictDims());
+    }
     return parameters;
   }
 
@@ -579,7 +614,7 @@ public class SortParameters implements Serializable {
         .getNoDictSortColMapping(parameters.getCarbonTable()));
     parameters.setNoDictSortColumnSchemaOrderMapping(CarbonDataProcessorUtil
         .getColumnIdxBasedOnSchemaInRow(parameters.getCarbonTable()));
-    TableSpec tableSpec = new TableSpec(carbonTable);
+    TableSpec tableSpec = new TableSpec(carbonTable, false);
     parameters.setNoDictActualPosition(tableSpec.getNoDictDimActualPosition());
     parameters.setDictDimActualPosition(tableSpec.getDictDimActualPosition());
     parameters.setUpdateDictDims(tableSpec.isUpdateDictDim());

--- a/processing/src/main/java/org/apache/carbondata/processing/store/CarbonFactDataHandlerModel.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/CarbonFactDataHandlerModel.java
@@ -304,7 +304,7 @@ public class CarbonFactDataHandlerModel {
     carbonFactDataHandlerModel.setBlockSizeInMB(carbonTable.getBlockSizeInMB());
     carbonFactDataHandlerModel.setColumnCompressor(loadModel.getColumnCompressor());
 
-    carbonFactDataHandlerModel.tableSpec = new TableSpec(carbonTable);
+    carbonFactDataHandlerModel.tableSpec = new TableSpec(carbonTable, false);
     DataMapWriterListener listener = new DataMapWriterListener();
     listener.registerAllWriter(
         carbonTable,


### PR DESCRIPTION
 ### Why is this PR needed?
 In the new Insert flow, partition column data is maintained at the end till convert to 3 steps of the write step. 

But when local sort happens before the write step, The mapping is derived based on original internal order instead of partition internal order. Hence insert fails during sorting.
 
 ### What changes were proposed in this PR?
Use internal partition order instead of internal order. 

Support 1.1 compatibility 

avoid impact for sort step of load flow partition.
   
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
  - Yes

    
