### PR TITLE
[CARBONDATA-3348]  Fix the case insensitive validation for duplicate sort column.

### DIFF
--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/util/CommonUtil.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/util/CommonUtil.scala
@@ -760,11 +760,13 @@ object CommonUtil {
       fields: Seq[(String, String)],
       varcharCols: Seq[String]
   ): Unit = {
-    if (sortKey.diff(sortKey.distinct).length > 0 ||
-        (sortKey.length > 1 && sortKey.contains(""))) {
+    val sortKeyLowerCase = sortKey.map(_.toLowerCase())
+    if ((sortKeyLowerCase).diff(sortKeyLowerCase.distinct).length > 0 ||
+      (sortKeyLowerCase.length > 1 && sortKeyLowerCase.contains(""))) {
       throw new MalformedCarbonCommandException(
-        "SORT_COLUMNS Either having duplicate columns : " +
-        sortKey.diff(sortKey.distinct).mkString(",") + " or it contains illegal argumnet.")
+        "SORT_COLUMNS Either contains duplicate columns : " +
+          sortKeyLowerCase.diff(sortKeyLowerCase.distinct).mkString(",") +
+          " or it contains an illegal argument.")
     }
 
     sortKey.foreach { column =>

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/alterTable/TestAlterTableSortColumnsProperty.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/alterTable/TestAlterTableSortColumnsProperty.scala
@@ -282,12 +282,17 @@ class TestAlterTableSortColumnsProperty extends QueryTest with BeforeAndAfterAll
     ex = intercept[RuntimeException] {
       sql("alter table alter_sc_validate set tblproperties('sort_columns'=' stringField1 , intField, stringField1')")
     }
-    assert(ex.getMessage.contains("SORT_COLUMNS Either having duplicate columns : stringField1 or it contains illegal argumnet"))
+    assert(ex.getMessage.contains("SORT_COLUMNS Either contains duplicate columns : stringfield1 or it contains an illegal argument"))
 
     ex = intercept[RuntimeException] {
       sql("alter table alter_sc_validate set tblproperties('sort_columns'=' stringField , intField, stringField')")
     }
-    assert(ex.getMessage.contains("SORT_COLUMNS Either having duplicate columns : stringField or it contains illegal argumnet"))
+    assert(ex.getMessage.contains("SORT_COLUMNS Either contains duplicate columns : stringfield or it contains an illegal argument"))
+
+    ex = intercept[RuntimeException] {
+      sql("alter table alter_sc_validate set tblproperties('sort_columns'=' stringField , intField, stringFIELD')")
+    }
+    assert(ex.getMessage.contains("SORT_COLUMNS Either contains duplicate columns : stringfield or it contains an illegal argument"))
 
     // not supported data type
 //    ex = intercept[RuntimeException] {

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/sortcolumns/TestSortColumns.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/sortcolumns/TestSortColumns.scala
@@ -297,7 +297,7 @@ class TestSortColumns extends QueryTest with BeforeAndAfterAll {
     val exceptionCaught = intercept[MalformedCarbonCommandException]{
       sql("CREATE TABLE sorttable1 (empno int, empname String, designation String, doj Timestamp, workgroupcategory int, workgroupcategoryname String, deptno int, deptname String, projectcode int, projectjoindate Timestamp, projectenddate Timestamp,attendance int,utilization int,salary int) STORED AS carbondata tblproperties('sort_columns'='empno,empname,empno')")
     }
-    assert(exceptionCaught.getMessage.equals("SORT_COLUMNS Either having duplicate columns : empno or it contains illegal argumnet."))
+    assert(exceptionCaught.getMessage.equals("SORT_COLUMNS Either contains duplicate columns : empno or it contains an illegal argument."))
   }
 
   test("Test tableTwo data") {


### PR DESCRIPTION
**Why is this PR needed?**
Currently the column name with different case(upper and lower)
is getting considered as different columns for sort properties.

 **What changes were proposed in this PR?**
    Added the case insensitive validation for duplicate sort column.

 **Does this PR introduce any user interface change?**
    No

**Is any new testcase added?**
    yes

   
