### PR TITLE
[CARBONDATA-3732] Fix ClassCastException with rand() udf function

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/strategy/CarbonLateDecodeStrategy.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/strategy/CarbonLateDecodeStrategy.scala
@@ -201,6 +201,18 @@ private[sql] class CarbonLateDecodeStrategy extends SparkStrategy {
   }
 
   /**
+   * get deterministic expression for NamedExpression
+   */
+  private def makeDeterministicExp(exp: NamedExpression): Expression = {
+    exp match {
+      case alias: Alias if alias.child.isInstanceOf[CustomDeterministicExpression] =>
+        alias
+      case _ =>
+        CustomDeterministicExpression(exp)
+    }
+  }
+
+  /**
    * Convert all Expression to deterministic Expression
    */
   private def makeDeterministic(plan: LogicalPlan): LogicalPlan = {
@@ -220,7 +232,7 @@ private[sql] class CarbonLateDecodeStrategy extends SparkStrategy {
                 Some(a))
             case exp: NamedExpression
               if !exp.deterministic && !exp.isInstanceOf[CustomDeterministicExpression] =>
-              CustomDeterministicExpression(exp)
+              makeDeterministicExp(exp)
           }
         } else {
           p
@@ -239,7 +251,7 @@ private[sql] class CarbonLateDecodeStrategy extends SparkStrategy {
                 Some(a))
             case exp: NamedExpression
               if !exp.deterministic && !exp.isInstanceOf[CustomDeterministicExpression] =>
-              CustomDeterministicExpression(exp)
+              makeDeterministicExp(exp)
           }
         } else {
           f

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/detailquery/CastColumnTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/detailquery/CastColumnTestCase.scala
@@ -953,10 +953,16 @@ class CastColumnTestCase extends QueryTest with BeforeAndAfterAll {
     )
   }
 
-  // Direct Dictionary and Timestamp Column.
-
-
-
+  test("test cast with rand UDF") {
+    sql("drop table if exists cast_rand")
+    sql("create table cast_rand(name string,gender string,age int) stored as carbondata")
+    sql("insert into cast_rand values('xxx','male',10)")
+    sql("select * from (select name, rand() from cast_rand) where name='xxx'").collect()
+    sql("select * from (select name, cast(floor(rand() * 5) as int) as `yyy` from cast_rand) where yyy<1").collect()
+    sql("select * from (select name, cast((rand() * 5) as int) as `yyy` from cast_rand) where yyy<1").collect()
+    sql("select * from (select name, floor(rand() * 5) from cast_rand) where name='xxx'").collect()
+    sql("drop table if exists cast_rand")
+  }
 
   override def afterAll {
     CarbonProperties.getInstance()
@@ -966,5 +972,6 @@ class CastColumnTestCase extends QueryTest with BeforeAndAfterAll {
     sql("drop table if exists DICTIONARY_HIVE_1")
     sql("drop table if exists NO_DICTIONARY_CARBON_2")
     sql("drop table if exists NO_DICTIONARY_HIVE_2")
+    sql("drop table if exists cast_rand")
   }
 }


### PR DESCRIPTION
 ### Why is this PR needed?
 ClassCastException is thrown, while running queries with cast of rand() function. This is because, while making a deterministic expression, we are converting an alias of CustomDeterministic expression to CustomDeterministic expression again, which is not needed.
 
 ### What changes were proposed in this PR?
Do not convert an Alias of CustomDeterministic expression to CustomDeterministic expression again
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
