### PR TITLE
[CARBONDATA-3734] Fix insert failure on partition table when parition column is in sort column

### DIFF
--- a/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/TestPartitionWithMV.scala
+++ b/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/TestPartitionWithMV.scala
@@ -637,7 +637,10 @@ class TestPartitionWithMV extends QueryTest with BeforeAndAfterAll {
     sql("insert into updatetime_8 select 21,21,'fbv','gbv','wvsw','vwr',25")
     sql("alter table updatetime_8 compact 'minor'")
     sql("alter table updatetime_8 compact 'minor'")
+    val df = sql("select sum(hs_len) from updatetime_8 group by imex")
+    assert(TestUtil.verifyMVDataMap(df.queryExecution.optimizedPlan, "ag"))
     checkAnswer(sql("select sum(hs_len) from updatetime_8 group by imex"),Seq(Row(40),Row(42),Row(83)))
+    sql("drop table updatetime_8").show(200, false)
   }
 
   test("check partitioning for child tables with various combinations") {

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/DataLoadProcessBuilder.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/DataLoadProcessBuilder.java
@@ -252,9 +252,9 @@ public final class DataLoadProcessBuilder {
           partitionColumns, dataFields);
     } else {
       getDataFields(loadModel, dimensions, measures, complexDataFields, dataFields);
+      dataFields = updateDataFieldsBasedOnSortColumns(dataFields);
     }
-    configuration.setDataFields(
-        updateDataFieldsBasedOnSortColumns(dataFields).toArray(new DataField[dataFields.size()]));
+    configuration.setDataFields(dataFields.toArray(new DataField[0]));
     configuration.setBucketingInfo(carbonTable.getBucketingInfo());
     configuration.setBucketHashMethod(carbonTable.getBucketHashMethod());
     configuration.setPreFetch(loadModel.isPreFetch());
@@ -326,6 +326,10 @@ public final class DataLoadProcessBuilder {
     } else {
       partitionColumnSchemaList = new ArrayList<>();
     }
+    // 1.1 compatibility, dimensions will not have sort columns in the beginning in 1.1.
+    // Need to keep at the beginning now
+    List<DataField> sortDataFields = new ArrayList<>();
+    List<DataField> noSortDataFields = new ArrayList<>();
     for (CarbonColumn column : dimensions) {
       DataField dataField = new DataField(column);
       if (column.isComplex()) {
@@ -356,11 +360,23 @@ public final class DataLoadProcessBuilder {
             .contains(column.getColumnSchema())) {
           partitionColumns.add(dataField);
         } else {
-          dataFields.add(dataField);
+          if (dataField.getColumn().getColumnSchema().isSortColumn()) {
+            sortDataFields.add(dataField);
+          } else {
+            noSortDataFields.add(dataField);
+          }
         }
       }
     }
-    dataFields.addAll(complexDataFields);
+    if (sortDataFields.size() != 0) {
+      dataFields.addAll(sortDataFields);
+    }
+    if (noSortDataFields.size() != 0) {
+      dataFields.addAll(noSortDataFields);
+    }
+    if (complexDataFields.size() != 0) {
+      dataFields.addAll(complexDataFields);
+    }
     for (CarbonColumn column : measures) {
       if (partitionColumnSchemaList.size() != 0 && partitionColumnSchemaList
           .contains(column.getColumnSchema())) {


### PR DESCRIPTION
 ### Why is this PR needed?
 When partition column is a sort column.

a) currently sort columns won't be the head of attributes, so need to add logic as per that, as partition columns will be in the end for global sort.

b) While rearranging the data fields at executor, need to keep partition column in the end even though it is in sort column. 
 
 ### What changes were proposed in this PR?
prepare sort columns for global sort based on the table sort columns.
Keep partition in the end, even though it is in sort columns for data field attributes

 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No (already this scenario present in mv test case)
     
