### PR TITLE
[CARBONDATA-3680]Fix add segment issue with SI table

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/scan/executor/impl/AbstractQueryExecutor.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/executor/impl/AbstractQueryExecutor.java
@@ -487,8 +487,12 @@ public abstract class AbstractQueryExecutor<E> implements QueryExecutor<E> {
             queryProperties.complexFilterDimension));
     if (null != queryModel.getDataMapFilter()) {
       FilterResolverIntf filterResolverIntf;
-      // loading the filter executor tree for filter evaluation
-      filterResolverIntf = queryModel.getDataMapFilter().getResolver();
+      if (!filePath.startsWith(queryModel.getTable().getTablePath())) {
+        filterResolverIntf = queryModel.getDataMapFilter().getExternalSegmentResolver();
+      } else {
+        // loading the filter executor tree for filter evaluation
+        filterResolverIntf = queryModel.getDataMapFilter().getResolver();
+      }
       blockExecutionInfo.setFilterExecuterTree(
           FilterUtil.getFilterExecuterTree(filterResolverIntf, segmentProperties,
               blockExecutionInfo.getComlexDimensionInfoMap(), false));

--- a/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/TestSIWithAddSegment.scala
+++ b/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/TestSIWithAddSegment.scala
@@ -26,7 +26,6 @@ import org.apache.carbondata.core.metadata.datatype.Field
 import org.apache.carbondata.core.util.path.CarbonTablePath
 import org.apache.carbondata.sdk.file.{CarbonSchemaReader, CarbonWriterBuilder, Schema}
 
-@Ignore
 class TestSIWithAddSegment extends QueryTest with BeforeAndAfterAll {
 
   val newSegmentPath: String = warehouse + "/newsegment/"
@@ -64,14 +63,14 @@ class TestSIWithAddSegment extends QueryTest with BeforeAndAfterAll {
     assert(d.queryExecution.executedPlan.isInstanceOf[BroadCastSIFilterPushJoin])
   }
 
-  ignore("compare results of SI and NI after adding segments") {
+  test("compare results of SI and NI after adding segments") {
     val siResult = sql("select * from maintable where c = 'm'")
     val niResult = sql("select * from maintable where ni(c = 'm')")
     assert(!niResult.queryExecution.executedPlan.isInstanceOf[BroadCastSIFilterPushJoin])
     checkAnswer(siResult, niResult)
   }
 
-  ignore("test SI creation after adding segments") {
+  test("test SI creation after adding segments") {
     sql("create table maintable1(a string, b int, c string) stored as carbondata")
     sql("insert into maintable1 select 'k',1,'k'")
     sql("insert into maintable1 select 'l',2,'l'")
@@ -93,7 +92,7 @@ class TestSIWithAddSegment extends QueryTest with BeforeAndAfterAll {
     checkAnswer(siResult, niResult)
   }
 
-  ignore("test query on SI with all external segments") {
+  test("test query on SI with all external segments") {
     sql("drop table if exists maintable1")
     sql("create table maintable1(a string, b int, c string) stored as carbondata")
     sql("CREATE INDEX maintable1_si  on table maintable1 (c) as 'carbondata'")

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonAddLoadCommand.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonAddLoadCommand.scala
@@ -278,6 +278,10 @@ case class CarbonAddLoadCommand(
       operationContext.setProperty(
         carbonTable.getTableUniqueName + "_Segment",
         model.getSegmentId)
+      // when this event is triggered, SI load listener will be called for all the SI tables under
+      // this main table, no need to load the SI tables for add load command, so add this property
+      // to check in SI loadevent listener to avoid loading to SI.
+      operationContext.setProperty("isAddLoad", "true")
       val loadTablePreStatusUpdateEvent: LoadTablePreStatusUpdateEvent =
         new LoadTablePreStatusUpdateEvent(
           carbonTable.getCarbonTableIdentifier,

--- a/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/events/SILoadEventListener.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/events/SILoadEventListener.scala
@@ -42,6 +42,10 @@ class SILoadEventListener extends OperationEventListener with Logging {
   override def onEvent(event: Event, operationContext: OperationContext): Unit = {
     event match {
       case _: LoadTablePreStatusUpdateEvent =>
+        if (operationContext.getProperty("isAddLoad") != null &&
+            operationContext.getProperty("isAddLoad").toString.toBoolean) {
+          return
+        }
         LOGGER.info("Load pre status update event-listener called")
         val loadTablePreStatusUpdateEvent = event.asInstanceOf[LoadTablePreStatusUpdateEvent]
         val carbonLoadModel = loadTablePreStatusUpdateEvent.getCarbonLoadModel

--- a/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/load/CarbonInternalLoaderUtil.java
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/load/CarbonInternalLoaderUtil.java
@@ -308,17 +308,17 @@ public class CarbonInternalLoaderUtil {
    */
   public static boolean checkMainTableSegEqualToSISeg(String carbonTablePath,
       String indexTablePath) {
-    List<String> mainList =
-        getListOfValidSlices(SegmentStatusManager.readLoadMetadata(carbonTablePath));
+    List<String> mainTableSegmentsList =
+        getListOfValidSlices(SegmentStatusManager.readCarbonMetaData(carbonTablePath));
     List<String> indexList =
         getListOfValidSlices(SegmentStatusManager.readLoadMetadata(indexTablePath));
-    Collections.sort(mainList);
+    Collections.sort(mainTableSegmentsList);
     Collections.sort(indexList);
-    if (indexList.size() != mainList.size()) {
+    if (indexList.size() != mainTableSegmentsList.size()) {
       return false;
     }
     for (int i = 0; i < indexList.size(); i++) {
-      if (!indexList.get(i).equalsIgnoreCase(mainList.get(i))) {
+      if (!indexList.get(i).equalsIgnoreCase(mainTableSegmentsList.get(i))) {
         return false;
       }
     }


### PR DESCRIPTION
 ### Why is this PR needed?
 When add segment is done on main table which has SI also on it. Then filter query is fired on SI column, only segments which are loaded can be considered for SI pruning and external segment should be queried from main table.
 
 ### What changes were proposed in this PR?
Handle while pruning for external segment. if external segment, get the filter from extersegment filter tree.
    
 ### Does this PR introduce any user interface change?
 - No
 - Yes. (please explain the change and update document)

 ### Is any new testcase added?
  - Yes, enabled ignored test cases.

    
