### PR TITLE
[HOTFIX] Exclude netty-all in lower version which could conflict with higher version

### DIFF
--- a/examples/flink/pom.xml
+++ b/examples/flink/pom.xml
@@ -44,6 +44,17 @@
       <groupId>org.apache.flink</groupId>
       <artifactId>flink-clients_${scala.binary.version}</artifactId>
       <version>${flink.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-all</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-all</artifactId>
+      <version>4.1.17.Final</version>
     </dependency>
     <dependency>
       <groupId>org.apache.carbondata</groupId>

--- a/examples/spark/pom.xml
+++ b/examples/spark/pom.xml
@@ -53,6 +53,17 @@
       <groupId>org.alluxio</groupId>
       <artifactId>alluxio-core-client-hdfs</artifactId>
       <version>1.8.1</version>
+      <exclusions>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-all</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-all</artifactId>
+      <version>4.1.17.Final</version>
     </dependency>
     <dependency>
       <groupId>org.alluxio</groupId>


### PR DESCRIPTION


 ### Why is this PR needed?
 
 exclude netty-all in lower version which could conflict with higher version
 ### What changes were proposed in this PR?
pom
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No

    
