### PR TITLE
[CRBONDATA-3746] Support column chunk cache in reader

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -491,6 +491,12 @@ public final class CarbonCommonConstants {
   // default blocklet size value in MB
   public static final String TABLE_BLOCKLET_SIZE_DEFAULT = "64";
 
+  // table property to enable column chunk data cache in reader
+  public static final String COLUMN_CACHE_ENABLED = "column_cache_enable";
+
+  // default is disabled
+  public static final String COLUMN_CACHE_ENABLED_DEFAULT = "false";
+
   /**
    * set in column level to disable inverted index
    * @Deprecated :This property is deprecated, it is kept just for compatibility

--- a/core/src/main/java/org/apache/carbondata/core/datastore/block/TableBlockInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/block/TableBlockInfo.java
@@ -48,6 +48,11 @@ public class TableBlockInfo implements Distributable, Serializable {
   private static final long serialVersionUID = -6502868998599821172L;
 
   /**
+   * Table ID of this block belongs to
+   */
+  private String tableId;
+
+  /**
    * full qualified file path of the block
    */
   private String filePath;
@@ -105,6 +110,14 @@ public class TableBlockInfo implements Distributable, Serializable {
   public TableBlockInfo(String filePath, long blockOffset, String segmentId,
       String[] locations, long blockLength, ColumnarFormatVersion version,
       String[] deletedDeltaFilePath) {
+    this(null, filePath, blockOffset, segmentId,
+        locations, blockLength, version, deletedDeltaFilePath);
+  }
+
+  public TableBlockInfo(String tableId, String filePath, long blockOffset, String segmentId,
+      String[] locations, long blockLength, ColumnarFormatVersion version,
+      String[] deletedDeltaFilePath) {
+    this.tableId = tableId;
     this.filePath = FileFactory.getUpdatedFilePath(filePath);
     this.blockOffset = blockOffset;
     this.segment = Segment.toSegment(segmentId);
@@ -123,6 +136,7 @@ public class TableBlockInfo implements Distributable, Serializable {
    */
   public TableBlockInfo copy() {
     TableBlockInfo info = new TableBlockInfo();
+    info.tableId = tableId;
     info.filePath = filePath;
     info.blockOffset = blockOffset;
     info.blockLength = blockLength;
@@ -340,6 +354,10 @@ public class TableBlockInfo implements Distributable, Serializable {
 
   public void setDataFileFooter(DataFileFooter dataFileFooter) {
     this.dataFileFooter = dataFileFooter;
+  }
+
+  public String getTableId() {
+    return tableId;
   }
 
   @Override

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/AbstractRawColumnChunk.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/AbstractRawColumnChunk.java
@@ -26,6 +26,14 @@ import org.apache.carbondata.format.DataChunk3;
  */
 public abstract class AbstractRawColumnChunk {
 
+  /**
+   * Indicating weather this object is cached in
+   * {@link ColumnChunkCache}.
+   * If it is cached, memory will not be free when {@link #freeMemory()} is called.
+   * It will be free when it is evicted from the cache
+   */
+  protected boolean isCached;
+
   private byte[][] minValues;
 
   private byte[][] maxValues;
@@ -53,6 +61,15 @@ public abstract class AbstractRawColumnChunk {
     this.rawData = rawData;
     this.offSet = offSet;
     this.length = length;
+    this.isCached = false;
+  }
+
+  public boolean isCached() {
+    return isCached;
+  }
+
+  public void setCached(boolean cached) {
+    isCached = cached;
   }
 
   public byte[][] getMinValues() {
@@ -100,7 +117,9 @@ public abstract class AbstractRawColumnChunk {
   }
 
   public void freeMemory() {
-    rawData = null;
+    if (!isCached()) {
+      rawData = null;
+    }
   }
 
   public int getColumnIndex() {

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/impl/DimensionRawColumnChunk.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/impl/DimensionRawColumnChunk.java
@@ -143,16 +143,18 @@ public class DimensionRawColumnChunk extends AbstractRawColumnChunk {
 
   @Override
   public void freeMemory() {
-    super.freeMemory();
-    if (null != dataChunks) {
-      for (int i = 0; i < dataChunks.length; i++) {
-        if (dataChunks[i] != null) {
-          dataChunks[i].freeMemory();
-          dataChunks[i] = null;
+    if (!isCached()) {
+      super.freeMemory();
+      if (null != dataChunks) {
+        for (int i = 0; i < dataChunks.length; i++) {
+          if (dataChunks[i] != null) {
+            dataChunks[i].freeMemory();
+            dataChunks[i] = null;
+          }
         }
       }
+      rawData = null;
     }
-    rawData = null;
   }
 
   public void setFileReader(FileReader fileReader) {

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/impl/MeasureRawColumnChunk.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/impl/MeasureRawColumnChunk.java
@@ -127,16 +127,18 @@ public class MeasureRawColumnChunk extends AbstractRawColumnChunk {
 
   @Override
   public void freeMemory() {
-    super.freeMemory();
-    if (null != columnPages) {
-      for (int i = 0; i < columnPages.length; i++) {
-        if (columnPages[i] != null) {
-          columnPages[i].freeMemory();
-          columnPages[i] = null;
+    if (!isCached()) {
+      super.freeMemory();
+      if (null != columnPages) {
+        for (int i = 0; i < columnPages.length; i++) {
+          if (columnPages[i] != null) {
+            columnPages[i].freeMemory();
+            columnPages[i] = null;
+          }
         }
       }
+      rawData = null;
     }
-    rawData = null;
   }
 
   public void setFileReader(FileReader fileReader) {

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/impl/VariableLengthDimensionColumnPage.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/impl/VariableLengthDimensionColumnPage.java
@@ -116,6 +116,7 @@ public class VariableLengthDimensionColumnPage extends AbstractDimensionColumnPa
   public int fillVector(ColumnVectorInfo[] vectorInfo, int chunkIndex) {
     ColumnVectorInfo columnVectorInfo = vectorInfo[chunkIndex];
     CarbonColumnVector vector = columnVectorInfo.vector;
+    dataChunkStore.initVector(vector);
     int offset = columnVectorInfo.offset;
     int vectorOffset = columnVectorInfo.vectorOffset;
     int len = offset + columnVectorInfo.size;
@@ -140,6 +141,7 @@ public class VariableLengthDimensionColumnPage extends AbstractDimensionColumnPa
       int chunkIndex) {
     ColumnVectorInfo columnVectorInfo = vectorInfo[chunkIndex];
     CarbonColumnVector vector = columnVectorInfo.vector;
+    dataChunkStore.initVector(vector);
     int offset = columnVectorInfo.offset;
     int vectorOffset = columnVectorInfo.vectorOffset;
     int len = offset + columnVectorInfo.size;

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/DimensionDataChunkStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/DimensionDataChunkStore.java
@@ -27,6 +27,12 @@ import org.apache.carbondata.core.scan.result.vector.ColumnVectorInfo;
 public interface DimensionDataChunkStore {
 
   /**
+   * Initialize the vector, like setting the local dictionary in the vector
+   */
+  default void initVector(CarbonColumnVector vector) {
+  }
+
+  /**
    * Below method will be used to put the rows and its metadata in offheap
    *
    * @param invertedIndex        inverted index to be stored

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/LocalDictDimensionDataChunkStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/LocalDictDimensionDataChunkStore.java
@@ -47,6 +47,11 @@ public class LocalDictDimensionDataChunkStore implements DimensionDataChunkStore
     this.dataLength = dataLength;
   }
 
+  @Override
+  public void initVector(CarbonColumnVector vector) {
+    vector.setDictionary(dictionary);
+  }
+
   /**
    * Below method will be used to put the rows and its metadata in offheap
    *
@@ -64,10 +69,7 @@ public class LocalDictDimensionDataChunkStore implements DimensionDataChunkStore
     int columnValueSize = dimensionDataChunkStore.getColumnValueSize();
     int rowsNum = dataLength / columnValueSize;
     CarbonColumnVector vector = vectorInfo.vector;
-    if (!dictionary.isDictionaryUsed()) {
-      vector.setDictionary(dictionary);
-      dictionary.setDictionaryUsed();
-    }
+    vector.setDictionary(dictionary);
     BitSet nullBitset = new BitSet();
     CarbonColumnVector dictionaryVector = ColumnarVectorWrapperDirectFactory
         .getDirectVectorWrapperFactory(vector.getDictionaryVector(), invertedIndex, nullBitset,
@@ -99,10 +101,6 @@ public class LocalDictDimensionDataChunkStore implements DimensionDataChunkStore
 
   @Override
   public void fillRow(int rowId, CarbonColumnVector vector, int vectorRow) {
-    if (!dictionary.isDictionaryUsed()) {
-      vector.setDictionary(dictionary);
-      dictionary.setDictionaryUsed();
-    }
     int surrogate = dimensionDataChunkStore.getSurrogate(rowId);
     if (surrogate == CarbonCommonConstants.MEMBER_DEFAULT_VAL_SURROGATE_KEY) {
       vector.putNull(vectorRow);

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/columncache/ColumnChunkCache.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/columncache/ColumnChunkCache.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.core.indexstore.columncache;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.carbondata.common.logging.LogServiceFactory;
+import org.apache.carbondata.core.datastore.chunk.AbstractRawColumnChunk;
+import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.RemovalListener;
+import com.google.common.cache.RemovalNotification;
+import org.apache.log4j.Logger;
+
+/**
+ * Column Chunk level data cache for table which is enabled for this feature.
+ */
+public class ColumnChunkCache {
+
+  private static Logger LOG =
+      LogServiceFactory.getLogService(ColumnChunkCache.class.getCanonicalName());
+
+  // A global cache for all tables which is enabled for this feature.
+  // The cached object is raw column chunks including raw binary data, so we can
+  // leverage this cache to avoid IO read from underlying storage.
+  private static Map<String, Cache<CacheKey, AbstractRawColumnChunk>> cacheForEachTable =
+      new ConcurrentHashMap<>();
+
+  /**
+   * Enable or disable the column chunk cache for specified table, based on the whether the
+   * corresponding table property is set
+   */
+  public static void setCacheForTable(CarbonTable carbonTable) {
+    String tableId = carbonTable.getTableId();
+    boolean shouldEnable = carbonTable.isColumnCacheEnabled();
+    boolean alreadyEnabled = cacheForEachTable.containsKey(tableId);
+    if (alreadyEnabled && !shouldEnable) {
+      cacheForEachTable.get(tableId).invalidateAll();
+      cacheForEachTable.remove(tableId);
+    } else if (!alreadyEnabled && shouldEnable) {
+      Cache<CacheKey, AbstractRawColumnChunk> cache = createCacheForTable(tableId);
+      cacheForEachTable.put(tableId, cache);
+    }
+  }
+
+  private static Cache<CacheKey, AbstractRawColumnChunk> createCacheForTable(String tableId) {
+    return CacheBuilder.newBuilder()
+        // expire after 10 minutes after last accessed
+        .expireAfterAccess(10, TimeUnit.MINUTES)
+        // max number of entries
+        .maximumSize(1000)
+        .removalListener(new RemovalListener<CacheKey, AbstractRawColumnChunk>() {
+          @Override
+          public void onRemoval(RemovalNotification<CacheKey, AbstractRawColumnChunk> entry) {
+            AbstractRawColumnChunk chunk = entry.getValue();
+            if (chunk != null) {
+              chunk.setCached(false);
+              chunk.freeMemory();
+              if (LOG.isInfoEnabled()) {
+                CacheKey key = entry.getKey();
+                LOG.info(String.format("column cache removed: key %s", key.toString()));
+              }
+            }
+          }
+        }).build();
+  }
+
+  /**
+   * Return true if column chunk cache is enabled for specified table
+   */
+  public static boolean isEnabledForTable(String tableId) {
+    return tableId != null && cacheForEachTable.containsKey(tableId);
+  }
+
+  /**
+   * Put column chunk into the cache
+   */
+  public static void put(String tableId, CacheKey key, AbstractRawColumnChunk chunk) {
+    if (isEnabledForTable(tableId)) {
+      cacheForEachTable.get(tableId).put(key, chunk);
+      chunk.setCached(true);
+      if (LOG.isInfoEnabled()) {
+        LOG.info(String.format("column cache added: table %s, key %s", tableId, key.toString()));
+      }
+    }
+  }
+
+  /**
+   * Get column chunk from cache
+   */
+  public static Optional<AbstractRawColumnChunk> get(String tableId, CacheKey key) {
+    if (isEnabledForTable(tableId)) {
+      AbstractRawColumnChunk data = cacheForEachTable.get(tableId).getIfPresent(key);
+      if (data == null) {
+        if (LOG.isInfoEnabled()) {
+          LOG.info(String.format("column cache miss: table %s, key %s", tableId, key.toString()));
+        }
+        return Optional.empty();
+      } else {
+        if (LOG.isInfoEnabled()) {
+          LOG.info(String.format("column cache hit: table %s, key %s", tableId, key.toString()));
+        }
+        return Optional.of(data);
+      }
+    } else {
+      return Optional.empty();
+    }
+  }
+
+  /**
+   * Remove cached column chunks for specified table
+   */
+  public static void remove(String tableId) {
+    if (isEnabledForTable(tableId)) {
+      cacheForEachTable.get(tableId).invalidateAll();
+    }
+  }
+
+  public static class CacheKey {
+    private String dataFilePath;
+    private long columnChunkOffset;
+
+    public CacheKey(String dataFilePath, long columnChunkOffset) {
+      this.dataFilePath = dataFilePath;
+      this.columnChunkOffset = columnChunkOffset;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      CacheKey cacheKey = (CacheKey) o;
+      return columnChunkOffset == cacheKey.columnChunkOffset &&
+          dataFilePath.equals(cacheKey.dataFilePath);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(dataFilePath, columnChunkOffset);
+    }
+
+    @Override
+    public String toString() {
+      return "{" + "path='" + dataFilePath + '\'' + ", offset=" + columnChunkOffset + '}';
+    }
+  }
+}

--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/CarbonTable.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/CarbonTable.java
@@ -846,6 +846,15 @@ public class CarbonTable implements Serializable, Writable {
     return tableInfo;
   }
 
+  public String getTableProperty(String propertyName) {
+    return getTableInfo().getFactTable().getTableProperties().get(propertyName);
+  }
+
+  public boolean isColumnCacheEnabled() {
+    String value = getTableProperty(CarbonCommonConstants.COLUMN_CACHE_ENABLED);
+    return value != null && value.equalsIgnoreCase("true");
+  }
+
   /**
    * Return true if this is a streaming table (table with property "streaming"="true" or "sink")
    */

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/vector/CarbonDictionary.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/vector/CarbonDictionary.java
@@ -23,10 +23,6 @@ public interface CarbonDictionary  {
 
   int getDictionarySize();
 
-  boolean isDictionaryUsed();
-
-  void setDictionaryUsed();
-
   byte[] getDictionaryValue(int index);
 
   byte[][] getAllDictionaryValues();

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/vector/impl/CarbonDictionaryImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/vector/impl/CarbonDictionaryImpl.java
@@ -25,8 +25,6 @@ public class CarbonDictionaryImpl implements CarbonDictionary {
 
   private int actualSize;
 
-  private boolean isDictUsed;
-
   public CarbonDictionaryImpl(byte[][] dictionary, int actualSize) {
     this.dictionary = dictionary;
     this.actualSize = actualSize;
@@ -40,16 +38,6 @@ public class CarbonDictionaryImpl implements CarbonDictionary {
   @Override
   public int getDictionarySize() {
     return this.dictionary.length;
-  }
-
-  @Override
-  public boolean isDictionaryUsed() {
-    return this.isDictUsed;
-  }
-
-  @Override
-  public void setDictionaryUsed() {
-    this.isDictUsed = true;
   }
 
   @Override

--- a/core/src/main/java/org/apache/carbondata/hadoop/CarbonInputSplit.java
+++ b/core/src/main/java/org/apache/carbondata/hadoop/CarbonInputSplit.java
@@ -291,12 +291,13 @@ public class CarbonInputSplit extends FileSplit
         dataMapWritePath);
   }
 
-  public static List<TableBlockInfo> createBlocks(List<CarbonInputSplit> splitList) {
+  public static List<TableBlockInfo> createBlocks(
+      String tableId, List<CarbonInputSplit> splitList) {
     List<TableBlockInfo> tableBlockInfoList = new ArrayList<>();
     for (CarbonInputSplit split : splitList) {
       try {
         TableBlockInfo blockInfo =
-            new TableBlockInfo(split.getFilePath(), split.getStart(),
+            new TableBlockInfo(tableId, split.getFilePath(), split.getStart(),
                 split.getSegment().toString(), split.getLocations(), split.getLength(),
                 split.getVersion(), split.getDeleteDeltaFiles());
         blockInfo.setDetailInfo(split.getDetailInfo());
@@ -312,10 +313,10 @@ public class CarbonInputSplit extends FileSplit
     return tableBlockInfoList;
   }
 
-  public static TableBlockInfo getTableBlockInfo(CarbonInputSplit inputSplit) {
+  public static TableBlockInfo getTableBlockInfo(String tableId, CarbonInputSplit inputSplit) {
     try {
       TableBlockInfo blockInfo =
-          new TableBlockInfo(inputSplit.getFilePath(),
+          new TableBlockInfo(tableId, inputSplit.getFilePath(),
               inputSplit.getStart(), inputSplit.getSegment().toString(), inputSplit.getLocations(),
               inputSplit.getLength(), inputSplit.getVersion(),
               inputSplit.getDeleteDeltaFiles());

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/CarbonRecordReader.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/CarbonRecordReader.java
@@ -27,6 +27,7 @@ import org.apache.carbondata.core.datamap.DataMapStoreManager;
 import org.apache.carbondata.core.datastore.FileReader;
 import org.apache.carbondata.core.datastore.block.TableBlockInfo;
 import org.apache.carbondata.core.datastore.impl.FileFactory;
+import org.apache.carbondata.core.indexstore.columncache.ColumnChunkCache;
 import org.apache.carbondata.core.scan.executor.QueryExecutor;
 import org.apache.carbondata.core.scan.executor.QueryExecutorFactory;
 import org.apache.carbondata.core.scan.executor.exception.QueryExecutionException;
@@ -110,9 +111,11 @@ public class CarbonRecordReader<T> extends AbstractRecordReader<T> {
     // It should use the exists tableBlockInfos if tableBlockInfos of queryModel is not empty
     // otherwise the prune is no use before this method
     if (!queryModel.isFG()) {
-      List<TableBlockInfo> tableBlockInfoList = CarbonInputSplit.createBlocks(splitList);
+      List<TableBlockInfo> tableBlockInfoList = CarbonInputSplit.createBlocks(
+          queryModel.getTable().getTableId(), splitList);
       queryModel.setTableBlockInfos(tableBlockInfoList);
     }
+    ColumnChunkCache.setCacheForTable(queryModel.getTable());
     readSupport.initialize(queryModel.getProjectionColumns(), queryModel.getTable());
     carbonIterator = new ChunkRowIterator(queryExecutor.execute(queryModel));
   }

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/util/CarbonVectorizedRecordReader.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/util/CarbonVectorizedRecordReader.java
@@ -29,6 +29,7 @@ import org.apache.carbondata.core.constants.CarbonV3DataFormatConstants;
 import org.apache.carbondata.core.datastore.FileReader;
 import org.apache.carbondata.core.datastore.block.TableBlockInfo;
 import org.apache.carbondata.core.datastore.impl.FileFactory;
+import org.apache.carbondata.core.indexstore.columncache.ColumnChunkCache;
 import org.apache.carbondata.core.metadata.datatype.DataType;
 import org.apache.carbondata.core.metadata.datatype.DataTypes;
 import org.apache.carbondata.core.metadata.datatype.StructField;
@@ -107,7 +108,9 @@ public class CarbonVectorizedRecordReader extends AbstractRecordReader<Object> {
     } else {
       throw new RuntimeException("unsupported input split type: " + inputSplit);
     }
-    List<TableBlockInfo> tableBlockInfoList = CarbonInputSplit.createBlocks(splitList);
+    List<TableBlockInfo> tableBlockInfoList = CarbonInputSplit.createBlocks(
+        queryModel.getTable().getTableId(), splitList);
+    ColumnChunkCache.setCacheForTable(queryModel.getTable());
     queryModel.setTableBlockInfos(tableBlockInfoList);
     queryModel.setVectorReader(true);
     try {

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/PrestoCarbonVectorizedRecordReader.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/PrestoCarbonVectorizedRecordReader.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.carbondata.core.datastore.block.TableBlockInfo;
+import org.apache.carbondata.core.indexstore.columncache.ColumnChunkCache;
 import org.apache.carbondata.core.keygenerator.directdictionary.DirectDictionaryGenerator;
 import org.apache.carbondata.core.keygenerator.directdictionary.DirectDictionaryKeyGeneratorFactory;
 import org.apache.carbondata.core.metadata.datatype.DataTypes;
@@ -106,7 +107,9 @@ class PrestoCarbonVectorizedRecordReader extends AbstractRecordReader<Object> {
     } else {
       throw new RuntimeException("unsupported input split type: " + inputSplit);
     }
-    List<TableBlockInfo> tableBlockInfoList = CarbonInputSplit.createBlocks(splitList);
+    List<TableBlockInfo> tableBlockInfoList = CarbonInputSplit.createBlocks(
+        queryModel.getTable().getTableId(), splitList);
+    ColumnChunkCache.setCacheForTable(queryModel.getTable());
     queryModel.setTableBlockInfos(tableBlockInfoList);
     queryModel.setVectorReader(true);
     queryExecutor =

--- a/integration/presto/src/main/prestosql/org/apache/carbondata/presto/CarbondataPageSource.java
+++ b/integration/presto/src/main/prestosql/org/apache/carbondata/presto/CarbondataPageSource.java
@@ -28,6 +28,7 @@ import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.datamap.DataMapFilter;
 import org.apache.carbondata.core.datastore.block.TableBlockInfo;
 import org.apache.carbondata.core.datastore.impl.FileFactory;
+import org.apache.carbondata.core.indexstore.columncache.ColumnChunkCache;
 import org.apache.carbondata.core.keygenerator.directdictionary.DirectDictionaryGenerator;
 import org.apache.carbondata.core.keygenerator.directdictionary.DirectDictionaryKeyGeneratorFactory;
 import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
@@ -410,9 +411,10 @@ class CarbondataPageSource implements ConnectorPageSource {
       queryModel.setStatisticsRecorder(
           CarbonTimeStatisticsFactory.createExecutorRecorder(queryModel.getQueryId()));
 
-      List<TableBlockInfo> tableBlockInfoList =
-          CarbonInputSplit.createBlocks(carbonInputSplit.getAllSplits());
+      List<TableBlockInfo> tableBlockInfoList = CarbonInputSplit.createBlocks(
+          queryModel.getTable().getTableId(), carbonInputSplit.getAllSplits());
       queryModel.setTableBlockInfos(tableBlockInfoList);
+      ColumnChunkCache.setCacheForTable(queryModel.getTable());
       return queryModel;
     } catch (IOException e) {
       throw new RuntimeException("Unable to get the Query Model ", e);

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonMergerRDD.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonMergerRDD.scala
@@ -132,7 +132,7 @@ class CarbonMergerRDD[K, V](
         } else {
           broadCastSplits.value.getInputSplit
         }
-        val tableBlockInfoList = CarbonInputSplit.createBlocks(splitList)
+        val tableBlockInfoList = CarbonInputSplit.createBlocks(carbonTable.getTableId, splitList)
 
         Collections.sort(tableBlockInfoList)
 
@@ -453,7 +453,7 @@ class CarbonMergerRDD[K, V](
 
       try {
         dataFileFooter = CarbonUtil.readMetadataFile(
-          CarbonInputSplit.getTableBlockInfo(carbonInputSplit))
+          CarbonInputSplit.getTableBlockInfo(tableId, carbonInputSplit))
       } catch {
         case e: IOException =>
           logError("Exception in preparing the data file footer for compaction " + e.getMessage)
@@ -479,7 +479,7 @@ class CarbonMergerRDD[K, V](
         var dataFileFooter: DataFileFooter = null
         try {
           dataFileFooter = CarbonUtil.readMetadataFile(
-            CarbonInputSplit.getTableBlockInfo(split))
+            CarbonInputSplit.getTableBlockInfo(tableId, split))
         } catch {
           case e: IOException =>
             logError("Exception in preparing the data file footer for compaction " + e.getMessage)
@@ -514,7 +514,7 @@ class CarbonMergerRDD[K, V](
         // Check the cardinality of each columns and set the highest.
         try {
           dataFileFooter = CarbonUtil.readMetadataFile(
-            CarbonInputSplit.getTableBlockInfo(split))
+            CarbonInputSplit.getTableBlockInfo(tableId, split))
         } catch {
           case e: IOException =>
             logError("Exception in preparing the data file footer for compaction " + e.getMessage)
@@ -648,7 +648,7 @@ class CarbonMergerRDD[K, V](
         val multiBlockSplit = result.get(j).asInstanceOf[CarbonSparkPartition].split.value
         val splitList = multiBlockSplit.getAllSplits
         logInfo(s"Node: ${ multiBlockSplit.getLocations.mkString(",") }, No.Of Blocks: " +
-                s"${ CarbonInputSplit.createBlocks(splitList).size }")
+                s"${ CarbonInputSplit.createBlocks(carbonTable.getTableId, splitList).size }")
       }
     }
     result.toArray(new Array[Partition](result.size))

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/vectorreader/VectorizedCarbonRecordReader.java
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/vectorreader/VectorizedCarbonRecordReader.java
@@ -26,6 +26,7 @@ import org.apache.log4j.Logger;
 import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.constants.CarbonV3DataFormatConstants;
 import org.apache.carbondata.core.datastore.block.TableBlockInfo;
+import org.apache.carbondata.core.indexstore.columncache.ColumnChunkCache;
 import org.apache.carbondata.core.keygenerator.directdictionary.DirectDictionaryGenerator;
 import org.apache.carbondata.core.keygenerator.directdictionary.DirectDictionaryKeyGeneratorFactory;
 import org.apache.carbondata.core.metadata.datatype.DataType;
@@ -132,7 +133,9 @@ public class VectorizedCarbonRecordReader extends AbstractRecordReader<Object> {
     } else {
       throw new RuntimeException("unsupported input split type: " + inputSplit);
     }
-    List<TableBlockInfo> tableBlockInfoList = CarbonInputSplit.createBlocks(splitList);
+    List<TableBlockInfo> tableBlockInfoList = CarbonInputSplit.createBlocks(
+        queryModel.getTable().getTableId(), splitList);
+    ColumnChunkCache.setCacheForTable(queryModel.getTable());
     queryModel.setTableBlockInfos(tableBlockInfoList);
     queryModel.setVectorReader(true);
     try {

--- a/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/rdd/CarbonSIRebuildRDD.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/rdd/CarbonSIRebuildRDD.scala
@@ -188,7 +188,7 @@ class CarbonSIRebuildRDD[K, V](
       try {
         // sorting the table block info List.
         val splitList = carbonSparkPartition.split.value.getAllSplits
-        val tableBlockInfoList = CarbonInputSplit.createBlocks(splitList)
+        val tableBlockInfoList = CarbonInputSplit.createBlocks(indexTableId, splitList)
         segmentId = tableBlockInfoList.get(0).getSegmentId
 
         Collections.sort(tableBlockInfoList)

--- a/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/rdd/CarbonSecondaryIndexRDD.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/rdd/CarbonSecondaryIndexRDD.scala
@@ -119,7 +119,7 @@ class CarbonSecondaryIndexRDD[K, V](
         val carbonSparkPartition = theSplit.asInstanceOf[CarbonSparkPartition]
         // sorting the table block info List.
         val splitList = carbonSparkPartition.split.value.getAllSplits
-        val tableBlockInfoList = CarbonInputSplit.createBlocks(splitList)
+        val tableBlockInfoList = CarbonInputSplit.createBlocks(tableId, splitList)
         Collections.sort(tableBlockInfoList)
         val taskAndBlockMapping: TaskBlockInfo =
           SecondaryIndexUtil.createTaskAndBlockMapping(tableBlockInfoList)
@@ -301,7 +301,7 @@ class CarbonSecondaryIndexRDD[K, V](
       for (j <- 0 until result.size) {
         val multiBlockSplit = result.get(j).asInstanceOf[CarbonSparkPartition].split.value
         val splitList = multiBlockSplit.getAllSplits
-        val tableBlocks: util.List[TableBlockInfo] = CarbonInputSplit.createBlocks(splitList)
+        val tableBlocks = CarbonInputSplit.createBlocks(tableId, splitList)
         val tableBlocksSize: Int = tableBlocks.size
         if (tableBlocksSize > 0) {
           // read the footer and get column cardinality which will be same for all tasks in a
@@ -310,7 +310,7 @@ class CarbonSecondaryIndexRDD[K, V](
             .readFileFooter(tableBlocks.get(tableBlocks.size() - 1))
         }
         logInfo(s"Node: ${ multiBlockSplit.getLocations.mkString(",") }, No.Of Blocks: " +
-                s"${ CarbonInputSplit.createBlocks(splitList).size }")
+                s"${ CarbonInputSplit.createBlocks(tableId, splitList).size }")
       }
       result.toArray(new Array[Partition](result.size))
     } else {

--- a/integration/spark/src/main/scala/org/apache/spark/util/AlterTableUtil.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/util/AlterTableUtil.scala
@@ -570,7 +570,8 @@ object AlterTableUtil {
       "SORT_COLUMNS",
       "GLOBAL_SORT_PARTITIONS",
       "LONG_STRING_COLUMNS",
-      "INDEX_CACHE_EXPIRATION_SECONDS")
+      "INDEX_CACHE_EXPIRATION_SECONDS",
+      "COLUMN_CACHE_ENABLE")
     supportedOptions.contains(propKey.toUpperCase)
   }
 

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/allqueries/AllDataTypesTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/allqueries/AllDataTypesTestCase.scala
@@ -17,11 +17,13 @@
 
 package org.apache.carbondata.spark.testsuite.allqueries
 
+import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.test.util.QueryTest
-import org.apache.spark.sql.{Row, SaveMode}
+import org.apache.spark.sql.{CarbonEnv, Row, SaveMode}
 import org.scalatest.BeforeAndAfterAll
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants
+import org.apache.carbondata.core.indexstore.columncache.ColumnChunkCache
 import org.apache.carbondata.core.util.CarbonProperties
 
 /**
@@ -42,6 +44,7 @@ class AllDataTypesTestCase extends QueryTest with BeforeAndAfterAll {
     sql("create table if not exists Carbon_automation_test_hive (imei string,deviceInformationId int,MAC string,deviceColor string,device_backColor string,modelId string,marketName string,AMSize string,ROMSize string,CUPAudit string,CPIClocked string,series string,productionDate timestamp,bomCode string,internalModels string, deliveryTime string, channelsId string, channelsName string , deliveryAreaId string, deliveryCountry string, deliveryProvince string, deliveryCity string,deliveryDistrict string, deliveryStreet string, oxSingleNumber string,contractNumber int, ActiveCheckTime string, ActiveAreaId string, ActiveCountry string, ActiveProvince string, Activecity string, ActiveDistrict string, ActiveStreet string, ActiveOperatorId string, Active_releaseId string, Active_EMUIVersion string, Active_operaSysVersion string, Active_BacVerNumber string, Active_BacFlashVer string, Active_webUIVersion string, Active_webUITypeCarrVer string,Active_webTypeDataVerNumber string, Active_operatorsVersion string, Active_phonePADPartitionedVersions string, Latest_YEAR int, Latest_MONTH int, Latest_DAY int, Latest_HOUR string, Latest_areaId string, Latest_country string, Latest_province string, Latest_city string, Latest_district string, Latest_street string, Latest_releaseId string, Latest_EMUIVersion string, Latest_operaSysVersion string, Latest_BacVerNumber string, Latest_BacFlashVer string, Latest_webUIVersion string, Latest_webUITypeCarrVer string, Latest_webTypeDataVerNumber string, Latest_operatorsVersion string, Latest_phonePADPartitionedVersions string, Latest_operatorId string, gamePointId int,gamePointDescription string)row format delimited fields terminated by ','")
     sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/100_olap.csv' INTO table Carbon_automation_test_hive""")
 
+    sql("alter table Carbon_automation_test set tblproperties ('column_cache_enable'='true')")
   }
 
   def clean {
@@ -51,6 +54,7 @@ class AllDataTypesTestCase extends QueryTest with BeforeAndAfterAll {
   }
 
   override def afterAll {
+    sql("alter table Carbon_automation_test set tblproperties ('column_cache_enable'='false')")
     clean
   }
 
@@ -59,7 +63,6 @@ class AllDataTypesTestCase extends QueryTest with BeforeAndAfterAll {
     checkAnswer(
       sql("select channelsId, sum(Latest_DAY+ 10) as a from Carbon_automation_test group by  channelsId"),
       Seq(Row("1", 132), Row("2", 110), Row("3", 176), Row("4", 132), Row("5", 132), Row("6", 209), Row("7", 198)))
-
   }
 
   test("select channelsId, Latest_DAY from Carbon_automation_test where count(channelsId) = 1") {

--- a/processing/src/main/java/org/apache/carbondata/processing/merger/CarbonCompactionUtil.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/merger/CarbonCompactionUtil.java
@@ -468,7 +468,7 @@ public class CarbonCompactionUtil {
       for (CarbonInputSplit split : carbonInputSplits) {
         DataFileFooter dataFileFooter = null;
         dataFileFooter =
-            CarbonUtil.readMetadataFile(CarbonInputSplit.getTableBlockInfo(split), true);
+            CarbonUtil.readMetadataFile(CarbonInputSplit.getTableBlockInfo(null, split), true);
 
         if (-1 == idx) {
           List<ColumnSchema> allColumns = dataFileFooter.getColumnInTable();


### PR DESCRIPTION
 ### Why is this PR needed?
 In some environment where memory is more but IO is slow, cache is a good technology to accelerate the query performance.

There are many existing cache solution that carbon can leverage, like Alluxio, Redis. However, these solutions usually caches block level object which requires big memory and less efficient since they do not aware of the table schema. 

CarbonData is designed for analytic scenario and IO unit is in column chunk wise, so it is preferred to support column chunk level caching instead of whole file block. In this way, cache requires less memory thus we can cache more data in memory, so hopefully we can get higher cache hit rate. 
 
 ### What changes were proposed in this PR?
1. A global cache in reader is added, by using Guava cache
2. Support basic flow to leverage and update of the cache
3. The cache is per table, support enable and disable the cache by table ID.
    
 ### Does this PR introduce any user interface change?
 - No
 - Yes. (please explain the change and update document)

 ### Is any new testcase added?
 - No
 - Yes

    
