### PR TITLE
[CARBONDATA-3751]:  Segments are not Marked for delete if everything is deleted in a segment with index server enabled

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/indexstore/ExtendedBlocklet.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/ExtendedBlocklet.java
@@ -169,6 +169,9 @@ public class ExtendedBlocklet extends Blocklet {
       throws IOException {
     super.write(out);
     if (isCountJob) {
+      // In CarbonInputSplit, getDetailInfo() is a lazy call. we want to avoid this during
+      // countStar query. As rowCount is filled inside getDetailInfo(). In countStar case we may
+      // not have proper row count. So, always take row count from indexRow.
       out.writeLong(inputSplit.getIndexRow().getInt(BlockletIndexRowIndexes.ROW_COUNT_INDEX));
       out.writeUTF(inputSplit.getSegmentId());
     } else {

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/ExtendedBlocklet.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/ExtendedBlocklet.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.carbondata.core.datamap.Segment;
+import org.apache.carbondata.core.indexstore.blockletindex.BlockletIndexRowIndexes;
 import org.apache.carbondata.core.indexstore.row.IndexRow;
 import org.apache.carbondata.core.metadata.ColumnarFormatVersion;
 import org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema;
@@ -168,7 +169,7 @@ public class ExtendedBlocklet extends Blocklet {
       throws IOException {
     super.write(out);
     if (isCountJob) {
-      out.writeLong(inputSplit.getRowCount());
+      out.writeLong(inputSplit.getIndexRow().getInt(BlockletIndexRowIndexes.ROW_COUNT_INDEX));
       out.writeUTF(inputSplit.getSegmentId());
     } else {
       if (dataMapUniqueId == null) {

--- a/core/src/main/java/org/apache/carbondata/hadoop/CarbonInputSplit.java
+++ b/core/src/main/java/org/apache/carbondata/hadoop/CarbonInputSplit.java
@@ -735,6 +735,10 @@ public class CarbonInputSplit extends FileSplit
     return path;
   }
 
+  public IndexRow getIndexRow() {
+    return indexRow;
+  }
+
   public String getFilePath() {
     return this.filePath;
   }


### PR DESCRIPTION
 ### Why is this PR needed?
 When all the rows are deleted from a segment with index server enabled, the segment is not Marked for delete.
 
 ### What changes were proposed in this PR?
Rowcount was always being sent as 0 from the index server DistributedPruneRDD. Getting that value from DataMapRow now
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No 


    
