### PR TITLE
[CARBONDATA-3753] optimize double/float stats collector

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/statistics/PrimitivePageStatsCollector.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/statistics/PrimitivePageStatsCollector.java
@@ -233,20 +233,18 @@ public class PrimitivePageStatsCollector implements ColumnPageStatsCollector, Si
 
   /**
    * Return number of digit after decimal point
-   * TODO: it operation is costly, optimize for performance
    */
   private int getDecimalCount(double value) {
     int decimalPlaces = 0;
     try {
-      String strValue = BigDecimal.valueOf(Math.abs(value)).toPlainString();
-      int integerPlaces = strValue.indexOf('.');
-      if (-1 != integerPlaces) {
-        decimalPlaces = strValue.length() - integerPlaces - 1;
+      BigDecimal decimalValue = BigDecimal.valueOf(value);
+      decimalPlaces = decimalValue.scale();
+      if (decimalPlaces == 1) {
         // If decimal places are one and it is just zero then treat the decimal count a zero.
-        if (decimalPlaces == 1) {
-          if (strValue.substring(integerPlaces + 1, strValue.length()).equals(ZERO_STRING)) {
-            decimalPlaces = 0;
-          }
+        // note: here toString() uses stringCache of BigDecimal
+        String str = decimalValue.toString();
+        if (str.charAt(str.length() - 1) == '0') {
+          decimalPlaces = 0;
         }
       }
     } catch (NumberFormatException e) {
@@ -273,7 +271,7 @@ public class PrimitivePageStatsCollector implements ColumnPageStatsCollector, Si
       int decimalCount = getDecimalCount(value);
       decimalCountForComplexPrimitive = decimalCount;
       if (decimalCount > 5) {
-        // If deciaml count is too big, we do not do adaptive encoding.
+        // If decimal count is too big, we do not do adaptive encoding.
         // So set decimal to negative value
         decimal = -1;
       } else if (decimalCount > decimal) {
@@ -294,7 +292,7 @@ public class PrimitivePageStatsCollector implements ColumnPageStatsCollector, Si
       int decimalCount = getDecimalCount(value);
       decimalCountForComplexPrimitive = decimalCount;
       if (decimalCount > 5) {
-        // If deciaml count is too big, we do not do adaptive encoding.
+        // If decimal count is too big, we do not do adaptive encoding.
         // So set decimal to negative value
         decimal = -1;
       } else if (decimalCount > decimal) {


### PR DESCRIPTION
 ### Why is this PR needed?
For every double/float column's value. we call 
`PrimitivePageStatsCollector.getDecimalCount(double value)`
problem is, here we create new bigdecimal object and plain string object every time.
Which leads in huge memory usage during insert.

 ### What changes were proposed in this PR?
Create only Bigdecimal object and use scale from that. 
    
 ### Does this PR introduce any user interface change?
 - No
 
 ### Is any new testcase added?
 - No
 
Before the change:
![Screenshot from 2020-03-26 16-45-12](https://user-images.githubusercontent.com/5889404/77640947-380c0e80-6f81-11ea-97ff-f1b8942d99c6.png)


After the change:
![Screenshot from 2020-03-26 16-51-31](https://user-images.githubusercontent.com/5889404/77641533-34c55280-6f82-11ea-8a60-bfb6c8d8f52a.png)

There is about 5% improvement in insert for the TPCH lineitem table with10GB data without any change in store size.

  
