### PR TITLE
[CARBONDATA-3756] Fix stage query bug it only read the first blocklet of each carbondata file

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
@@ -927,14 +927,22 @@ public final class CarbonUtil {
     AbstractDataFileFooterConverter footerConverter =
         DataFileFooterConverterFactory.getInstance().getDataFileFooterConverter(version);
     List<DataFileFooter> footers = footerConverter.getIndexInfo(indexFilePath, null, true);
-
+    DataFileFooter blockFooter = null;
     // find the footer of the input data file (tableBlockInfo)
-    for (DataFileFooter footer : footers) {
-      if (footer.getBlockInfo().getFilePath().equals(dataFilePath)) {
-        return footer;
+    for (DataFileFooter blockletFooter : footers) {
+      if (blockletFooter.getBlockInfo().getFilePath().equals(dataFilePath)) {
+        if (blockFooter == null) {
+          blockFooter = blockletFooter;
+        } else {
+          blockFooter.getBlockletList().addAll(blockletFooter.getBlockletList());
+        }
       }
     }
-    throw new RuntimeException("Footer not found in index file");
+    if (blockFooter == null) {
+      throw new RuntimeException("Footer not found in index file");
+    } else {
+      return blockFooter;
+    }
   }
 
   /**


### PR DESCRIPTION
 ### Why is this PR needed?
The query of stage files only read the first blocklet of each carbondata file.
So when the file contains multiple blocklets, the query result will be wrong.
 
 ### What changes were proposed in this PR?
The query of stage files should read the all blocklets of all carbondata files.

 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No, who tell me how to add a test case.

    
