### PR TITLE
[CARBONDATA-3759]Refactor segmentRefreshInfo and fix cache issue in multiple application scenario

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/readcommitter/LatestFilesReadCommittedScope.java
+++ b/core/src/main/java/org/apache/carbondata/core/readcommitter/LatestFilesReadCommittedScope.java
@@ -220,7 +220,7 @@ public class LatestFilesReadCommittedScope implements ReadCommittedScope {
         if (indexFileStore.get(timestamp) == null) {
           indexList = new ArrayList<>(1);
           segmentRefreshInfo =
-              new SegmentRefreshInfo(carbonIndexFiles[i].getLastModifiedTime(), 0);
+              new SegmentRefreshInfo(carbonIndexFiles[i].getLastModifiedTime(), 0, 0L);
           segmentTimestampUpdaterMap.put(timestamp, segmentRefreshInfo);
         } else {
           // Entry is already present.

--- a/core/src/main/java/org/apache/carbondata/core/readcommitter/TableStatusReadCommittedScope.java
+++ b/core/src/main/java/org/apache/carbondata/core/readcommitter/TableStatusReadCommittedScope.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import org.apache.carbondata.common.annotations.InterfaceAudience;
 import org.apache.carbondata.common.annotations.InterfaceStability;
 import org.apache.carbondata.core.datamap.Segment;
+import org.apache.carbondata.core.datastore.impl.FileFactory;
 import org.apache.carbondata.core.indexstore.blockletindex.SegmentIndexFileStore;
 import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
 import org.apache.carbondata.core.metadata.SegmentFileStore;
@@ -93,10 +94,17 @@ public class TableStatusReadCommittedScope implements ReadCommittedScope {
 
   public SegmentRefreshInfo getCommittedSegmentRefreshInfo(Segment segment, UpdateVO updateVo) {
     SegmentRefreshInfo segmentRefreshInfo;
+    long segmentFileTimeStamp = 0L;
+    if (null != segment.getSegmentFileName()) {
+      segmentFileTimeStamp = FileFactory.getCarbonFile(CarbonTablePath
+          .getSegmentFilePath(identifier.getTablePath(), segment.getSegmentFileName()))
+          .getLastModifiedTime();
+    }
     if (updateVo != null) {
-      segmentRefreshInfo = new SegmentRefreshInfo(updateVo.getLatestUpdateTimestamp(), 0);
+      segmentRefreshInfo =
+          new SegmentRefreshInfo(updateVo.getLatestUpdateTimestamp(), 0, segmentFileTimeStamp);
     } else {
-      segmentRefreshInfo = new SegmentRefreshInfo(0L, 0);
+      segmentRefreshInfo = new SegmentRefreshInfo(0L, 0, segmentFileTimeStamp);
     }
     return segmentRefreshInfo;
   }

--- a/core/src/main/java/org/apache/carbondata/core/statusmanager/SegmentRefreshInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/statusmanager/SegmentRefreshInfo.java
@@ -21,12 +21,17 @@ import java.io.Serializable;
 
 public class SegmentRefreshInfo implements Serializable {
 
-  private Long segmentUpdatedTimestamp;
+  private Long segmentUpdatedTimestamp = 0L;
   private Integer countOfFileInSegment;
+  private Long segmentFileTimestamp = 0L;
 
-  public SegmentRefreshInfo(Long segmentUpdatedTimestamp, Integer countOfFileInSegment) {
-    this.segmentUpdatedTimestamp = segmentUpdatedTimestamp;
+  public SegmentRefreshInfo(Long segmentUpdatedTimestamp, Integer countOfFileInSegment,
+      Long segmentFileTimestamp) {
+    if (segmentUpdatedTimestamp != null) {
+      this.segmentUpdatedTimestamp = segmentUpdatedTimestamp;
+    }
     this.countOfFileInSegment = countOfFileInSegment;
+    this.segmentFileTimestamp = segmentFileTimestamp;
   }
 
   public Long getSegmentUpdatedTimestamp() {
@@ -37,24 +42,21 @@ public class SegmentRefreshInfo implements Serializable {
     this.segmentUpdatedTimestamp = segmentUpdatedTimestamp;
   }
 
-  public Integer getCountOfFileInSegment() {
-    return countOfFileInSegment;
-  }
-
   public void setCountOfFileInSegment(Integer countOfFileInSegment) {
     this.countOfFileInSegment = countOfFileInSegment;
+  }
+
+  public Long getSegmentFileTimestamp() {
+    return segmentFileTimestamp;
   }
 
   public boolean compare(Object o) {
     if (!(o instanceof SegmentRefreshInfo)) return false;
 
     SegmentRefreshInfo that = (SegmentRefreshInfo) o;
-
-    if (segmentUpdatedTimestamp > that.segmentUpdatedTimestamp || !countOfFileInSegment
-        .equals(that.countOfFileInSegment)) {
-      return true;
-    }
-    return false;
+    return segmentUpdatedTimestamp > that.segmentUpdatedTimestamp
+        || segmentFileTimestamp > that.segmentFileTimestamp || !countOfFileInSegment
+        .equals(that.countOfFileInSegment);
   }
 
   @Override

--- a/core/src/main/java/org/apache/carbondata/core/statusmanager/SegmentUpdateStatusManager.java
+++ b/core/src/main/java/org/apache/carbondata/core/statusmanager/SegmentUpdateStatusManager.java
@@ -783,23 +783,18 @@ public class SegmentUpdateStatusManager {
 
   /**
    * Returns the invalid timestamp range of a segment.
-   * @param segmentId
-   * @return
    */
-  public UpdateVO getInvalidTimestampRange(String segmentId) {
+  public static UpdateVO getInvalidTimestampRange(LoadMetadataDetails loadMetadataDetails) {
     UpdateVO range = new UpdateVO();
-    for (LoadMetadataDetails segment : segmentDetails) {
-      if (segment.getLoadName().equalsIgnoreCase(segmentId)) {
-        range.setSegmentId(segmentId);
-        range.setFactTimestamp(segment.getLoadStartTime());
-        if (!segment.getUpdateDeltaStartTimestamp().isEmpty() && !segment
-            .getUpdateDeltaEndTimestamp().isEmpty()) {
-          range.setUpdateDeltaStartTimestamp(
-              CarbonUpdateUtil.getTimeStampAsLong(segment.getUpdateDeltaStartTimestamp()));
-          range.setLatestUpdateTimestamp(
-              CarbonUpdateUtil.getTimeStampAsLong(segment.getUpdateDeltaEndTimestamp()));
-        }
-        return range;
+    if (loadMetadataDetails != null) {
+      range.setSegmentId(loadMetadataDetails.getLoadName());
+      range.setFactTimestamp(loadMetadataDetails.getLoadStartTime());
+      if (!loadMetadataDetails.getUpdateDeltaStartTimestamp().isEmpty() && !loadMetadataDetails
+          .getUpdateDeltaEndTimestamp().isEmpty()) {
+        range.setUpdateDeltaStartTimestamp(CarbonUpdateUtil
+            .getTimeStampAsLong(loadMetadataDetails.getUpdateDeltaStartTimestamp()));
+        range.setLatestUpdateTimestamp(
+            CarbonUpdateUtil.getTimeStampAsLong(loadMetadataDetails.getUpdateDeltaEndTimestamp()));
       }
     }
     return range;

--- a/integration/spark/src/main/scala/org/apache/carbondata/indexserver/DistributedRDDUtils.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/indexserver/DistributedRDDUtils.scala
@@ -381,7 +381,7 @@ object DistributedRDDUtils {
         // Adding valid segments to segments to be refreshed, so that the select query
         // goes in the same executor.
         DataMapStoreManager.getInstance
-          .getSegmentsToBeRefreshed(carbonTable, updateStatusManager, validSegments.toList.asJava)
+          .getSegmentsToBeRefreshed(carbonTable, validSegments.toList.asJava)
         val indexServerLoadEvent: IndexServerLoadEvent =
           IndexServerLoadEvent(
             sparkSession,

--- a/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/joins/BroadCastSIFilterPushJoin.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/joins/BroadCastSIFilterPushJoin.scala
@@ -337,7 +337,7 @@ object BroadCastSIFilterPushJoin {
       if (CarbonProperties.getInstance
         .isDistributedPruningEnabled(carbonTable.getDatabaseName, carbonTable.getTableName)) {
         val segmentsToBeRefreshed: util.List[String] = DataMapStoreManager.getInstance
-          .getSegmentsToBeRefreshed(carbonTable, updateStatusManager, validSegmentsToAccess)
+          .getSegmentsToBeRefreshed(carbonTable, validSegmentsToAccess)
         try {
           val dataMapFormat: DistributableDataMapFormat =
             new DistributableDataMapFormat(carbonTable,


### PR DESCRIPTION
 ### Why is this PR needed?
 1. currently the segmentRefreshInfo is helping to clear the cache only in update cases and it fails to refresh the cache if any segment files changes or get updates.
2. when two applications are running on same store. One application changes some segment files changes and removes old cache and may be delete files, which wont be reflected in other application, which may result in either wrong results or query failure.
 
 ### What changes were proposed in this PR?
refactor the segmentRefreshInfo to clear the cache and update when there are any updates on segments and if the segment files of respective segments changes.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No
 Tested in cluster and existing test cases will be enough.

    
