### PR TITLE
[CARBONDATA-3761] Remove redundant conversion for complex type insert

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/util/DataTypeUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/DataTypeUtil.java
@@ -476,6 +476,15 @@ public final class DataTypeUtil {
       return ByteUtil.toXorBytes((Integer) dimensionValue);
     } else if (actualDataType == DataTypes.LONG) {
       return ByteUtil.toXorBytes((Long) dimensionValue);
+    } else if (actualDataType == DataTypes.DOUBLE) {
+      return ByteUtil.toXorBytes((double) dimensionValue);
+    } else if (actualDataType == DataTypes.FLOAT) {
+      return ByteUtil.toXorBytes((float) dimensionValue);
+    } else if (DataTypes.isDecimal(actualDataType)) {
+      // Need to make BigDecimal object, else ByteUtil.toBytes will have precision loss
+      return bigDecimalToByte(new BigDecimal(dimensionValue.toString()));
+    } else if (actualDataType == DataTypes.BYTE) {
+      return ByteUtil.toXorBytes((byte) dimensionValue);
     } else if (actualDataType == DataTypes.TIMESTAMP) {
       return ByteUtil.toXorBytes((Long) dimensionValue);
     } else if (actualDataType == DataTypes.BINARY) {

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/util/CommonUtil.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/util/CommonUtil.scala
@@ -932,7 +932,8 @@ object CommonUtil {
             dataFieldsWithComplexDataType(fields(i).name).asInstanceOf[ArrayDataType]
               .writeByteArray(result.asInstanceOf[ArrayObject],
                 dataOutputStream,
-                badRecordLogHolder)
+                badRecordLogHolder,
+                true)
             dataOutputStream.close()
             data(i) = byteArray.toByteArray.asInstanceOf[AnyRef]
           case structType : StructType =>
@@ -943,7 +944,8 @@ object CommonUtil {
             dataFieldsWithComplexDataType(fields(i).name).asInstanceOf[StructDataType]
               .writeByteArray(result.asInstanceOf[StructObject],
                 dataOutputStream,
-                badRecordLogHolder)
+                badRecordLogHolder,
+                true)
             dataOutputStream.close()
             data(i) = byteArray.toByteArray.asInstanceOf[AnyRef]
           case mapType : MapType =>
@@ -954,7 +956,8 @@ object CommonUtil {
             dataFieldsWithComplexDataType(fields(i).name).asInstanceOf[ArrayDataType]
               .writeByteArray(result.asInstanceOf[ArrayObject],
                 dataOutputStream,
-                badRecordLogHolder)
+                badRecordLogHolder,
+                true)
             dataOutputStream.close()
             data(i) = byteArray.toByteArray.asInstanceOf[AnyRef]
           case other =>

--- a/processing/src/main/java/org/apache/carbondata/processing/datatypes/ArrayDataType.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/datatypes/ArrayDataType.java
@@ -172,15 +172,15 @@ public class ArrayDataType implements GenericDataType<ArrayObject> {
 
   @Override
   public void writeByteArray(ArrayObject input, DataOutputStream dataOutputStream,
-      BadRecordLogHolder logHolder) throws IOException {
+      BadRecordLogHolder logHolder, Boolean isWithoutConverter) throws IOException {
     if (input == null) {
       dataOutputStream.writeInt(1);
-      children.writeByteArray(null, dataOutputStream, logHolder);
+      children.writeByteArray(null, dataOutputStream, logHolder, isWithoutConverter);
     } else {
       Object[] data = input.getData();
       dataOutputStream.writeInt(data.length);
       for (Object eachInput : data) {
-        children.writeByteArray(eachInput, dataOutputStream, logHolder);
+        children.writeByteArray(eachInput, dataOutputStream, logHolder, isWithoutConverter);
       }
     }
   }

--- a/processing/src/main/java/org/apache/carbondata/processing/datatypes/GenericDataType.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/datatypes/GenericDataType.java
@@ -57,9 +57,11 @@ public interface GenericDataType<T> extends Serializable {
   /**
    * writes to byte stream
    * @param dataOutputStream
+   * @param isWithoutConverter
    * @throws IOException
    */
-  void writeByteArray(T input, DataOutputStream dataOutputStream, BadRecordLogHolder logHolder)
+  void writeByteArray(T input, DataOutputStream dataOutputStream, BadRecordLogHolder logHolder,
+      Boolean isWithoutConverter)
       throws IOException;
 
   /**

--- a/processing/src/main/java/org/apache/carbondata/processing/datatypes/StructDataType.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/datatypes/StructDataType.java
@@ -174,21 +174,21 @@ public class StructDataType implements GenericDataType<StructObject> {
 
   @Override
   public void writeByteArray(StructObject input, DataOutputStream dataOutputStream,
-      BadRecordLogHolder logHolder) throws IOException {
+      BadRecordLogHolder logHolder, Boolean isWithoutConverter) throws IOException {
     dataOutputStream.writeShort(children.size());
     if (input == null) {
       for (int i = 0; i < children.size(); i++) {
-        children.get(i).writeByteArray(null, dataOutputStream, logHolder);
+        children.get(i).writeByteArray(null, dataOutputStream, logHolder, isWithoutConverter);
       }
     } else {
       Object[] data = input.getData();
       for (int i = 0; i < data.length && i < children.size(); i++) {
-        children.get(i).writeByteArray(data[i], dataOutputStream, logHolder);
+        children.get(i).writeByteArray(data[i], dataOutputStream, logHolder, isWithoutConverter);
       }
 
       // For other children elements which don't have data, write empty
       for (int i = data.length; i < children.size(); i++) {
-        children.get(i).writeByteArray(null, dataOutputStream, logHolder);
+        children.get(i).writeByteArray(null, dataOutputStream, logHolder, isWithoutConverter);
       }
     }
   }

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/converter/impl/ComplexFieldConverterImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/converter/impl/ComplexFieldConverterImpl.java
@@ -53,7 +53,7 @@ public class ComplexFieldConverterImpl implements FieldConverter {
     ByteArrayOutputStream byteArray = new ByteArrayOutputStream();
     DataOutputStream dataOutputStream = new DataOutputStream(byteArray);
     try {
-      genericDataType.writeByteArray(value, dataOutputStream, logHolder);
+      genericDataType.writeByteArray(value, dataOutputStream, logHolder, false);
       dataOutputStream.close();
       return byteArray.toByteArray();
     } catch (Exception e) {

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/steps/InputProcessorStepWithNoConverterImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/steps/InputProcessorStepWithNoConverterImpl.java
@@ -383,7 +383,7 @@ public class InputProcessorStepWithNoConverterImpl extends AbstractDataLoadProce
           if (dataTypes[i].isComplexType() && isHivePartitionTable) {
             newData[i] = data[orderOfData[i]];
           } else if (dataTypes[i].isComplexType()) {
-            getComplexTypeByteArray(newData, i, data, dataFields[i], orderOfData[i]);
+            getComplexTypeByteArray(newData, i, data, dataFields[i], orderOfData[i], false);
           } else {
             DataType dataType = dataFields[i].getColumn().getDataType();
             if (dataType == DataTypes.DATE && data[orderOfData[i]] instanceof Long) {
@@ -419,7 +419,7 @@ public class InputProcessorStepWithNoConverterImpl extends AbstractDataLoadProce
           // keep the no dictionary measure column as original data
           newData[i] = data[i];
         } else if (dataTypes[i].isComplexType()) {
-          getComplexTypeByteArray(newData, i, data, dataFields[i], i);
+          getComplexTypeByteArray(newData, i, data, dataFields[i], i, true);
         } else if (dataTypes[i] == DataTypes.DATE && data[i] instanceof Long) {
           if (dateDictionaryGenerator == null) {
             dateDictionaryGenerator = DirectDictionaryKeyGeneratorFactory
@@ -435,13 +435,14 @@ public class InputProcessorStepWithNoConverterImpl extends AbstractDataLoadProce
     }
 
     private void getComplexTypeByteArray(Object[] newData, int index, Object[] data,
-        DataField dataField, int orderedIndex) {
+        DataField dataField, int orderedIndex, boolean isWithoutConverter) {
       ByteArrayOutputStream byteArray = new ByteArrayOutputStream();
       DataOutputStream dataOutputStream = new DataOutputStream(byteArray);
       try {
         GenericDataType complextType =
             dataFieldsWithComplexDataType.get(dataField.getColumn().getOrdinal());
-        complextType.writeByteArray(data[orderedIndex], dataOutputStream, logHolder);
+        complextType
+            .writeByteArray(data[orderedIndex], dataOutputStream, logHolder, isWithoutConverter);
         dataOutputStream.close();
         newData[index] = byteArray.toByteArray();
       } catch (BadRecordFoundException e) {


### PR DESCRIPTION
 ### Why is this PR needed?
 1)  In `PrimitiveDataType#writeByteArray`
`DataTypeUtil.parseValue(**input.toString()**, carbonDimension)`
Here we convert every complex child element to string and then parse as an object to handle bad records. Which leads to heavy GC

2) `DatatypeUtil#getBytesDataDataTypeForNoDictionaryColumn` -> double,float, byte, decimal case is missing. so we convert them to string and then convert to bytes. which create more redundant objects
 
 ### What changes were proposed in this PR?
1) For new Insert into flow, no need to handle bad records for complex types as it is already validated in source table. So, use object directly. This can decrease the memory foot print for complex type insert
2)  Add a case for double,float, byte, decimal data type.

 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No    
