### PR TITLE
[CARBONDATA-3763] Fix wrong insert result during insert stage command

### DIFF
--- a/integration/flink/src/test/scala/org/apache/carbon/flink/TestCarbonPartitionWriter.scala
+++ b/integration/flink/src/test/scala/org/apache/carbon/flink/TestCarbonPartitionWriter.scala
@@ -194,6 +194,9 @@ class TestCarbonPartitionWriter extends QueryTest {
 
       checkAnswer(sql(s"SELECT count(1) FROM $tableName"), Seq(Row(1000)))
 
+      checkAnswer(sql(s"SELECT stringField FROM $tableName order by stringField limit 2"),
+        Seq(Row("test0"), Row("test1")))
+
       val rows = sql(s"SELECT * FROM $tableName limit 1").collect()
       assertResult(1)(rows.length)
       assertResult(Array[Byte](2, 3, 4))(rows(0).get(rows(0).fieldIndex("binaryfield")).asInstanceOf[GenericRowWithSchema](0))

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -375,7 +375,10 @@ object CarbonDataRDDFactory {
               .getFactTable
               .getListOfColumns
               .asScala.filterNot(col => col.isInvisible || col.getColumnName.contains("."))
-            val convertedRdd = CommonLoadUtils.getConvertedInternalRow(colSchema, scanResultRdd.get)
+            val convertedRdd = CommonLoadUtils.getConvertedInternalRow(
+              colSchema,
+              scanResultRdd.get,
+              isInsertFromStageCommand = false)
             if (isSortTable && sortScope.equals(SortScopeOptions.SortScope.GLOBAL_SORT)) {
               DataLoadProcessBuilderOnSpark.insertDataUsingGlobalSortWithInternalRow(sqlContext
                 .sparkSession,

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonInsertFromStageCommand.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonInsertFromStageCommand.scala
@@ -44,6 +44,7 @@ import org.apache.carbondata.core.statusmanager.{SegmentStatus, SegmentStatusMan
 import org.apache.carbondata.core.util.path.CarbonTablePath
 import org.apache.carbondata.hadoop.CarbonInputSplit
 import org.apache.carbondata.processing.loading.FailureCauses
+import org.apache.carbondata.processing.loading.constants.DataLoadProcessorConstants
 import org.apache.carbondata.processing.loading.model.CarbonLoadModel
 import org.apache.carbondata.processing.util.CarbonLoaderUtil
 import org.apache.carbondata.spark.load.DataLoadProcessBuilderOnSpark
@@ -352,8 +353,10 @@ case class CarbonInsertFromStageCommand(
         CarbonInsertIntoCommand(
           databaseNameOp = Option(table.getDatabaseName),
           tableName = table.getTableName,
-          options = scala.collection.immutable.Map("fileheader" -> header,
-            "binary_decoder" -> "base64"),
+          options = scala.collection.immutable.Map(
+            "fileheader" -> header,
+            "binary_decoder" -> "base64",
+            DataLoadProcessorConstants.IS_INSERT_STAGE_COMMAND -> "true"),
           isOverwriteTable = false,
           logicalPlan = selectedDataFrame.queryExecution.analyzed,
           tableInfo = table.getTableInfo,

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/constants/DataLoadProcessorConstants.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/constants/DataLoadProcessorConstants.java
@@ -40,4 +40,7 @@ public final class DataLoadProcessorConstants {
 
   // to indicate that it is optimized insert flow without rearrange of each data rows
   public static final String NO_REARRANGE_OF_ROWS = "NO_REARRANGE_OF_ROWS";
+
+  // to indicate CarbonInsertFromStageCommand flow
+  public static final String IS_INSERT_STAGE_COMMAND = "IS_INSERT_STAGE_COMMAND";
 }


### PR DESCRIPTION
 ### Why is this PR needed?
For insertStageCommand, spark is reusing the internalRow as two times we transform from RDD[InternalRow] -> dataframe -> logical Plan -> RDD[InternalRow]. So, same data is inserted on other rows
 
 ### What changes were proposed in this PR?
Copy the internalRow after the last transform.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes (added validation)

   