### PR TITLE
[HOTFIX] Fix Repeated access to getSegmentProperties

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletIndexFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletIndexFactory.java
@@ -653,9 +653,13 @@ public class BlockletIndexFactory extends CoarseGrainIndexFactory
       throws IOException {
     List<Blocklet> blocklets = new ArrayList<>();
     List<CoarseGrainIndex> dataMaps = getIndexes(segment, partitions);
+    if (dataMaps.size() == 0) {
+      return blocklets;
+    }
+    SegmentProperties segmentProperties = getSegmentPropertiesFromDataMap(dataMaps.get(0));
     for (CoarseGrainIndex dataMap : dataMaps) {
       blocklets.addAll(dataMap
-          .prune((FilterResolverIntf) null, getSegmentProperties(segment, partitions), partitions,
+          .prune((FilterResolverIntf) null, segmentProperties, partitions,
               null, this.getCarbonTable()));
     }
     return blocklets;


### PR DESCRIPTION
 ### Why is this PR needed?
 getSegmentProperties is accessed repeated in query processing, which  leads to  heavy time overhead.
 
 ### What changes were proposed in this PR?
Reuse the segmentProperty.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No

    
