### PR TITLE
[WIP] Read the index file to get row count when predicate only have partition columns

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/util/AbstractDataFileFooterConverter.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/AbstractDataFileFooterConverter.java
@@ -138,7 +138,8 @@ public abstract class AbstractDataFileFooterConverter {
     CarbonIndexFileReader indexReader = new CarbonIndexFileReader(configuration);
     List<DataFileFooter> dataFileFooters = new ArrayList<DataFileFooter>();
     String formattedPath = filePath.replace("\\", "/");
-    String parentPath = formattedPath.substring(0, formattedPath.lastIndexOf("/"));
+    int index = formattedPath.lastIndexOf("/");
+    String parentPath = index > 0 ? formattedPath.substring(0, index) : formattedPath;
     try {
       // open the reader
       if (fileData != null) {

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
@@ -946,6 +946,18 @@ public final class CarbonUtil {
   }
 
   /**
+   * Read index file and get row count.
+   */
+  public static int getRowCountFromIndexFile(String indexFilePath)
+          throws IOException {
+    return new SegmentIndexFileStore().readIdxFileGetRowCount(indexFilePath);
+  }
+
+  public static int getRowCountFromMergeIndexFile(String mergeIndexFilePath) throws IOException {
+    return new SegmentIndexFileStore().readMergeIdxFileGetRowCount(mergeIndexFilePath);
+  }
+
+  /**
    * Below method will be used to get the number of dimension column
    * in carbon column schema
    *

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/strategy/CarbonLateDecodeStrategy.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/strategy/CarbonLateDecodeStrategy.scala
@@ -103,7 +103,8 @@ private[sql] class CarbonLateDecodeStrategy extends SparkStrategy {
       case CountStarPlan(colAttr, PhysicalOperation(projectList, predicates, l: LogicalRelation))
         if l.relation.isInstanceOf[CarbonDatasourceHadoopRelation] && driverSideCountStar(l) =>
         val relation = l.relation.asInstanceOf[CarbonDatasourceHadoopRelation]
-        CarbonCountStar(colAttr, relation.carbonTable, SparkSession.getActiveSession.get) :: Nil
+        CarbonCountStar(colAttr, relation.carbonTable,
+          SparkSession.getActiveSession.get, predicates) :: Nil
       case ExtractEquiJoinKeys(Inner, leftKeys, rightKeys, condition,
       left, right)
         if isCarbonPlan(left) && CarbonInternalScalaUtil.checkIsIndexTable(right) =>


### PR DESCRIPTION
 ### Why is this PR needed?
 
 Read the index file direcctly when query count(*) for 1 partition without other filters, currentlly, it comes into scan prune logic, we can optimize it.
 ### What changes were proposed in this PR?
Read the index file to get row count when query count(*) for 1 partition without other filters
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No

    
