### PR TITLE
[CARBONDATA-3768] Fix query not hitting mv without alias, with mv having Alias

### DIFF
--- a/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/MVCreateTestCase.scala
+++ b/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/MVCreateTestCase.scala
@@ -1242,6 +1242,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     val df2 = sql(
       " select cast(floor((m_month +1000) / 900) * 900 - 2000 AS INT),c_code as abc  from maintable")
     assert(TestUtil.verifyMVDataMap(df1.queryExecution.optimizedPlan, "da_cast"))
+    assert(TestUtil.verifyMVDataMap(df2.queryExecution.optimizedPlan, "da_cast"))
   }
 
   test("test cast of expression with mv") {
@@ -1270,6 +1271,8 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
       "create materialized view da_cast as select cast(m_month + 1000 AS INT) as a, c_code as abc from maintable")
     checkAnswer(sql("select cast(m_month + 1000 AS INT) as a, c_code as abc from maintable"), Seq(Row(1010, "xxx")))
     var df1 = sql("select cast(m_month + 1000 AS INT) as a, c_code as abc from maintable")
+    assert(TestUtil.verifyMVDataMap(df1.queryExecution.optimizedPlan, "da_cast"))
+    df1 = sql("select cast(m_month + 1000 AS INT), c_code from maintable")
     assert(TestUtil.verifyMVDataMap(df1.queryExecution.optimizedPlan, "da_cast"))
     sql("drop materialized view if exists da_cast")
     sql(

--- a/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/TestAllOperationsOnMV.scala
+++ b/mv/core/src/test/scala/org/apache/carbondata/mv/rewrite/TestAllOperationsOnMV.scala
@@ -564,11 +564,17 @@ class TestAllOperationsOnMV extends QueryTest with BeforeAndAfterEach {
     sql("create table maintable(name string, age int, add string) STORED AS carbondata")
     sql("insert into maintable values('abc',1,'a'),('def',2,'b'),('ghi',3,'c')")
     val res = sql("select sum(age) from maintable")
+    val res1 = sql("select age,sum(age) from maintable group by age")
     sql("drop materialized view if exists mv3")
     sql("create materialized view mv3 as select age,sum(age) from maintable group by age")
     val df = sql("select sum(age) from maintable")
     TestUtil.verifyMVDataMap(df.queryExecution.optimizedPlan, "mv3")
     checkAnswer(res, df)
+    sql("drop materialized view if exists mv3")
+    sql("create materialized view mv3 as select age as a,sum(age) as b from maintable group by age")
+    val df1 = sql("select age,sum(age) from maintable group by age")
+    TestUtil.verifyMVDataMap(df1.queryExecution.optimizedPlan, "mv3")
+    checkAnswer(res1, df1)
     sql("drop table if exists maintable")
   }
 

--- a/mv/core/src/test/scala/org/apache/carbondata/mv/timeseries/TestMVTimeSeriesLoadAndQuery.scala
+++ b/mv/core/src/test/scala/org/apache/carbondata/mv/timeseries/TestMVTimeSeriesLoadAndQuery.scala
@@ -240,6 +240,7 @@ class TestMVTimeSeriesLoadAndQuery extends QueryTest with BeforeAndAfterAll {
   }
 
   test("test mvtimeseries with alias") {
+    val result = sql("select timeseries(projectjoindate,'month'),projectcode from maintable group by timeseries(projectjoindate,'month'),projectcode")
     dropDataMap("datamap1")
     sql(
       "create materialized view datamap1 as " +
@@ -247,9 +248,11 @@ class TestMVTimeSeriesLoadAndQuery extends QueryTest with BeforeAndAfterAll {
     loadData("maintable")
     val df1 = sql("select timeseries(projectjoindate,'month') as t,projectcode as y from maintable group by timeseries(projectjoindate,'month'),projectcode")
     checkPlan("datamap1", df1)
-    // TODO: fix the base issue of alias with group by
-    //   val df2 = sql("select timeseries(projectjoindate,'month'),projectcode from maintable group by timeseries(projectjoindate,'month'),projectcode")
-    //   checkPlan("datamap1", df2)
+    val df2 = sql("select timeseries(projectjoindate,'month'),projectcode from maintable group by timeseries(projectjoindate,'month'),projectcode")
+    checkPlan("datamap1", df2)
+    checkAnswer(result, df2)
+    val df4 = sql("select timeseries(projectjoindate,'month'),projectcode as y from maintable group by timeseries(projectjoindate,'month'),projectcode")
+    checkPlan("datamap1", df4)
     dropDataMap("datamap1")
     sql(
       "create materialized view datamap1 as " +


### PR DESCRIPTION
 ### Why is this PR needed?
create MV with select query having alias. Query without alias is not hitting mv.
 
 ### What changes were proposed in this PR?
While query matching, check if outputlist with alias contains all user outputlist.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
