### PR TITLE
[CARBONDATA-3784] Added spark binary version to related modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,5 @@ python/.idea/
 */*/.cache-tests
 */*/*/.cache-main
 */*/*/.cache-tests
+*.flattened-pom.xml
 python/pycarbon/.pylintrc

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -58,12 +58,12 @@
     </dependency>
     <dependency>
       <groupId>org.apache.carbondata</groupId>
-      <artifactId>carbondata-spark</artifactId>
+      <artifactId>carbondata-spark_${spark.binary.version}</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.carbondata</groupId>
-      <artifactId>carbondata-mv-plan</artifactId>
+      <artifactId>carbondata-mv-plan_${spark.binary.version}</artifactId>
       <version>${project.version}</version>
     </dependency>
   </dependencies>

--- a/examples/flink/pom.xml
+++ b/examples/flink/pom.xml
@@ -63,7 +63,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.carbondata</groupId>
-      <artifactId>carbondata-spark</artifactId>
+      <artifactId>carbondata-spark_${spark.binary.version}</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/examples/spark/pom.xml
+++ b/examples/spark/pom.xml
@@ -36,7 +36,7 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.carbondata</groupId>
-      <artifactId>carbondata-spark</artifactId>
+      <artifactId>carbondata-spark_${spark.binary.version}</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
@@ -200,6 +200,21 @@
       <id>sdvtest</id>
       <properties>
         <maven.test.skip>true</maven.test.skip>
+      </properties>
+    </profile>
+    <profile>
+      <id>spark-2.3</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <properties>
+        <spark.binary.version>2.3</spark.binary.version>
+      </properties>
+    </profile>
+    <profile>
+      <id>spark-2.4</id>
+      <properties>
+        <spark.binary.version>2.4</spark.binary.version>
       </properties>
     </profile>
   </profiles>

--- a/index/examples/pom.xml
+++ b/index/examples/pom.xml
@@ -38,7 +38,7 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.carbondata</groupId>
-      <artifactId>carbondata-spark</artifactId>
+      <artifactId>carbondata-spark_${spark.binary.version}</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
@@ -79,5 +79,23 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>spark-2.3</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <properties>
+        <spark.binary.version>2.3</spark.binary.version>
+      </properties>
+    </profile>
+    <profile>
+      <id>spark-2.4</id>
+      <properties>
+        <spark.binary.version>2.4</spark.binary.version>
+      </properties>
+    </profile>
+  </profiles>
 
 </project>

--- a/index/secondary-index/pom.xml
+++ b/index/secondary-index/pom.xml
@@ -37,7 +37,7 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.carbondata</groupId>
-      <artifactId>carbondata-spark</artifactId>
+      <artifactId>carbondata-spark_${spark.binary.version}</artifactId>
       <version>${project.version}</version>
       <exclusions>
         <exclusion>
@@ -203,6 +203,21 @@
       <id>sdvtest</id>
       <properties>
         <maven.test.skip>true</maven.test.skip>
+      </properties>
+    </profile>
+    <profile>
+      <id>spark-2.3</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <properties>
+        <spark.binary.version>2.3</spark.binary.version>
+      </properties>
+    </profile>
+    <profile>
+      <id>spark-2.4</id>
+      <properties>
+        <spark.binary.version>2.4</spark.binary.version>
       </properties>
     </profile>
   </profiles>

--- a/integration/flink/pom.xml
+++ b/integration/flink/pom.xml
@@ -198,10 +198,13 @@
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
+            <properties>
+                <spark.binary.version>2.3</spark.binary.version>
+            </properties>
             <dependencies>
                 <dependency>
                     <groupId>org.apache.carbondata</groupId>
-                    <artifactId>carbondata-spark</artifactId>
+                    <artifactId>carbondata-spark_${spark.binary.version}</artifactId>
                     <version>${project.version}</version>
                     <scope>test</scope>
                     <exclusions>
@@ -215,10 +218,13 @@
         </profile>
         <profile>
             <id>spark-2.4</id>
+            <properties>
+                <spark.binary.version>2.4</spark.binary.version>
+            </properties>
             <dependencies>
                 <dependency>
                     <groupId>org.apache.carbondata</groupId>
-                    <artifactId>carbondata-spark</artifactId>
+                    <artifactId>carbondata-spark_${spark.binary.version}</artifactId>
                     <version>${project.version}</version>
                     <scope>test</scope>
                     <exclusions>

--- a/integration/spark/pom.xml
+++ b/integration/spark/pom.xml
@@ -26,7 +26,7 @@
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
-  <artifactId>carbondata-spark</artifactId>
+  <artifactId>carbondata-spark_${spark.binary.version}</artifactId>
   <name>Apache CarbonData :: Spark</name>
 
   <properties>
@@ -39,8 +39,6 @@
     <build.directory.projectHadoop>../../hadoop/target</build.directory.projectHadoop>
     <build.directory.projectFormat>../../format/target</build.directory.projectFormat>
     <build.directory.projectSpark>../../integration/spark/target</build.directory.projectSpark>
-    <!--<build.directory.projectHive>../../integration/hive/target</build.directory.projectHive>-->
-    <!--<build.directory.projectPresto>../../integration/presto/target</build.directory.projectPresto>-->
     <build.directory.projectStoreSdk>../../sdk/sdk/target</build.directory.projectStoreSdk>
     <build.directory.projectStreaming>../../streaming/target</build.directory.projectStreaming>
     <build.directory.projectBloom>../../index/bloom/target</build.directory.projectBloom>
@@ -52,8 +50,6 @@
     <classes.directory.projectHadoop>../../hadoop/target/classes</classes.directory.projectHadoop>
     <classes.directory.projectFormat>../../format/target/classes</classes.directory.projectFormat>
     <classes.directory.projectSpark>../../integration/spark/target/classes</classes.directory.projectSpark>
-    <!--<classes.directory.projectHive>../../integration/hive/target/classes</classes.directory.projectHive>-->
-    <!--<classes.directory.projectPresto>../../integration/presto/target/classes</classes.directory.projectPresto>-->
     <classes.directory.projectStoreSdk>../../sdk/sdk/target/classes</classes.directory.projectStoreSdk>
     <classes.directory.projectStreaming>../../streaming/target/classes</classes.directory.projectStreaming>
     <classes.directory.projectBloom>../../index/bloom/target/classes</classes.directory.projectBloom>
@@ -66,10 +62,6 @@
     <sources.directory.projectFormat>../../format/src/main/thrift</sources.directory.projectFormat>
     <sources.directory.projectSpark>../../integration/spark/src/main/scala</sources.directory.projectSpark>
     <sources.directory.projectSpark>../../integration/spark/src/main/java</sources.directory.projectSpark>
-    <!--<sources.directory.projectHive>../../integration/hive/src/main/java</sources.directory.projectHive>-->
-    <!--<sources.directory.projectHive>../../integration/hive/src/main/scala</sources.directory.projectHive>-->
-    <!--<sources.directory.projectPresto>../../integration/presto/src/main/java</sources.directory.projectPresto>-->
-    <!--<sources.directory.projectPresto>../../integration/presto/src/main/scala</sources.directory.projectPresto>-->
     <sources.directory.projectStoreSdk>../../sdk/sdk/src/main/java</sources.directory.projectStoreSdk>
     <sources.directory.projectStreaming>../../streaming/src/main/java</sources.directory.projectStreaming>
     <sources.directory.projectStreaming>../../streaming/src/main/scala</sources.directory.projectStreaming>
@@ -82,8 +74,6 @@
     <generated-sources.directory.projectHadoop>../../hadoop/target/generated-sources/annotations</generated-sources.directory.projectHadoop>
     <generated-sources.directory.projectFormat>../../format/target/generated-sources/annotations</generated-sources.directory.projectFormat>
     <generated-sources.directory.projectSpark>../../integration/spark/target/generated-sources/annotations</generated-sources.directory.projectSpark>
-    <!--<generated-sources.directory.projectHive>../../integration/hive/target/generated-sources/annotations</generated-sources.directory.projectHive>-->
-    <!--<generated-sources.directory.projectPresto>../../integration/presto/target/generated-sources/annotations</generated-sources.directory.projectPresto>-->
     <generated-sources.directory.projectStoreSdk>../../sdk/sdk/target/generated-sources/annotations</generated-sources.directory.projectStoreSdk>
     <generated-sources.directory.projectStreaming>../../streaming/target/generated-sources/annotations</generated-sources.directory.projectStreaming>
     <generated-sources.directory.projectBloom>../../index/bloom/target/generated-sources/annotations</generated-sources.directory.projectBloom>
@@ -139,7 +129,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.carbondata</groupId>
-      <artifactId>carbondata-mv-plan</artifactId>
+      <artifactId>carbondata-mv-plan_${spark.binary.version}</artifactId>
       <version>${project.version}</version>
     </dependency>
     <!-- spark -->
@@ -495,6 +485,9 @@
       <activation>
         <activeByDefault>true</activeByDefault>
       </activation>
+      <properties>
+        <spark.binary.version>2.3</spark.binary.version>
+      </properties>
       <build>
         <plugins>
           <plugin>
@@ -530,6 +523,9 @@
     </profile>
     <profile>
       <id>spark-2.4</id>
+      <properties>
+        <spark.binary.version>2.4</spark.binary.version>
+      </properties>
       <build>
         <plugins>
           <plugin>

--- a/mv/plan/pom.xml
+++ b/mv/plan/pom.xml
@@ -26,7 +26,7 @@
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
-  <artifactId>carbondata-mv-plan</artifactId>
+  <artifactId>carbondata-mv-plan_${spark.binary.version}</artifactId>
   <name>Apache CarbonData :: Materialized View Plan</name>
 
   <properties>
@@ -157,6 +157,9 @@
       <activation>
         <activeByDefault>true</activeByDefault>
       </activation>
+      <properties>
+        <spark.binary.version>2.3</spark.binary.version>
+      </properties>
       <build>
         <plugins>
           <plugin>
@@ -192,6 +195,9 @@
     </profile>
     <profile>
       <id>spark-2.4</id>
+      <properties>
+        <spark.binary.version>2.4</spark.binary.version>
+      </properties>
       <build>
         <plugins>
           <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -538,12 +538,38 @@
         <activeByDefault>true</activeByDefault>
       </activation>
       <properties>
+        <spark.binary.version>2.3</spark.binary.version>
         <spark.version>2.3.4</spark.version>
         <scala.binary.version>2.11</scala.binary.version>
         <scala.version>2.11.8</scala.version>
       </properties>
       <build>
         <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>flatten-maven-plugin</artifactId>
+            <!--<version>1.2.2</version>-->
+            <configuration>
+            </configuration>
+            <executions>
+              <!-- enable flattening -->
+              <execution>
+                <id>flatten</id>
+                <phase>process-resources</phase>
+                <goals>
+                  <goal>flatten</goal>
+                </goals>
+              </execution>
+              <!-- ensure proper cleanup -->
+              <execution>
+                <id>flatten.clean</id>
+                <phase>clean</phase>
+                <goals>
+                  <goal>clean</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
           <plugin>
             <groupId>org.eluder.coveralls</groupId>
             <artifactId>coveralls-maven-plugin</artifactId>
@@ -583,12 +609,38 @@
     <profile>
       <id>spark-2.4</id>
       <properties>
+        <spark.binary.version>2.4</spark.binary.version>
         <spark.version>2.4.5</spark.version>
         <scala.binary.version>2.11</scala.binary.version>
         <scala.version>2.11.12</scala.version>
       </properties>
       <build>
         <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>flatten-maven-plugin</artifactId>
+            <!--<version>1.2.2</version>-->
+            <configuration>
+            </configuration>
+            <executions>
+              <!-- enable flattening -->
+              <execution>
+                <id>flatten</id>
+                <phase>process-resources</phase>
+                <goals>
+                  <goal>flatten</goal>
+                </goals>
+              </execution>
+              <!-- ensure proper cleanup -->
+              <execution>
+                <id>flatten.clean</id>
+                <phase>clean</phase>
+                <goals>
+                  <goal>clean</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
           <plugin>
             <groupId>org.eluder.coveralls</groupId>
             <artifactId>coveralls-maven-plugin</artifactId>


### PR DESCRIPTION
 ### Why is this PR needed?
 For deploying multiple carbon jars version with different spark versions, the jar/module names should be different
 
 ### What changes were proposed in this PR?
Add spark binary version to the related modules to distinguish the jars based on spark version
    
 ### Does this PR introduce any user interface change?
 - No
 - Yes. (please explain the change and update document)

 ### Is any new testcase added?
 - No
 - Yes

    
