### PR TITLE
[CARBONDATA-3771] Fixed date filter issue and use hive constants instead of hard-coded values

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
@@ -855,7 +855,13 @@ public final class CarbonProperties {
    * Return the store path
    */
   public static String getStorePath() {
-    return getInstance().getProperty(CarbonCommonConstants.STORE_LOCATION);
+    String storePath = getInstance().getProperty(CarbonCommonConstants.STORE_LOCATION);
+    if (storePath == null) {
+      // Internally spark sets the value of spark.warehouse.dir to hive.metastore.warehouse.dir.
+      // So no need to check for spark property.
+      storePath = FileFactory.getConfiguration().get("hive.metastore.warehouse.dir");
+    }
+    return storePath;
   }
 
   /**

--- a/core/src/main/java/org/apache/carbondata/core/writer/CarbonIndexFileMergeWriter.java
+++ b/core/src/main/java/org/apache/carbondata/core/writer/CarbonIndexFileMergeWriter.java
@@ -202,7 +202,7 @@ public class CarbonIndexFileMergeWriter {
     return null;
   }
 
-  private String writeMergeIndexFileBasedOnSegmentFile(String segmentId,
+  public String writeMergeIndexFileBasedOnSegmentFile(String segmentId,
       List<String> indexFileNamesTobeAdded, SegmentFileStore segmentFileStore,
       CarbonFile[] indexFiles, String uuid, String partitionPath) throws IOException {
     SegmentIndexFileStore fileStore = new SegmentIndexFileStore();

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableInputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableInputFormat.java
@@ -89,7 +89,7 @@ public class CarbonTableInputFormat<T> extends CarbonInputFormat<T> {
   public static final String INPUT_FILES = "mapreduce.input.carboninputformat.files";
   private static final Logger LOG =
       LogServiceFactory.getLogService(CarbonTableInputFormat.class.getName());
-  public static final String CARBON_TRANSACTIONAL_TABLE =
+  protected static final String CARBON_TRANSACTIONAL_TABLE =
       "mapreduce.input.carboninputformat.transactional";
   public static final String DATABASE_NAME = "mapreduce.input.carboninputformat.databaseName";
   public static final String TABLE_NAME = "mapreduce.input.carboninputformat.tableName";
@@ -354,7 +354,6 @@ public class CarbonTableInputFormat<T> extends CarbonInputFormat<T> {
   private List<InputSplit> getSplits(JobContext job, IndexFilter expression,
       List<Segment> validSegments, SegmentUpdateStatusManager updateStatusManager,
       List<Segment> invalidSegments) throws IOException {
-
     List<String> segmentsToBeRefreshed = new ArrayList<>();
     if (!CarbonProperties.getInstance()
         .isDistributedPruningEnabled(carbonTable.getDatabaseName(), carbonTable.getTableName())) {

--- a/integration/hive/src/main/java/org/apache/carbondata/hive/Hive2CarbonExpression.java
+++ b/integration/hive/src/main/java/org/apache/carbondata/hive/Hive2CarbonExpression.java
@@ -39,6 +39,7 @@ import org.apache.carbondata.core.scan.expression.logical.OrExpression;
 import org.apache.carbondata.hadoop.api.CarbonInputFormat;
 import org.apache.carbondata.hive.util.DataTypeUtil;
 
+import org.apache.hadoop.hive.ql.plan.ExprNodeConstantDesc;
 import org.apache.hadoop.hive.ql.plan.ExprNodeDesc;
 import org.apache.hadoop.hive.ql.plan.ExprNodeFieldDesc;
 import org.apache.hadoop.hive.ql.plan.ExprNodeGenericFuncDesc;
@@ -65,6 +66,14 @@ public class Hive2CarbonExpression {
   private static final Logger LOG =
       LogServiceFactory.getLogService(CarbonInputFormat.class.getName());
 
+  private static String getExpressionValue(ExprNodeDesc exprNodeDesc) {
+    if (exprNodeDesc instanceof ExprNodeConstantDesc) {
+      return ((ExprNodeConstantDesc) exprNodeDesc).getValue().toString();
+    } else {
+      return exprNodeDesc.getExprString().replace("'", "");
+    }
+  }
+
   public static Expression convertExprHive2Carbon(ExprNodeDesc exprNodeDesc) {
     if (exprNodeDesc instanceof ExprNodeGenericFuncDesc) {
       ExprNodeGenericFuncDesc exprNodeGenericFuncDesc = (ExprNodeGenericFuncDesc) exprNodeDesc;
@@ -75,7 +84,7 @@ public class Hive2CarbonExpression {
             getDateType(l1.get(left).getTypeString()));
         List<Expression> listExpr = new ArrayList<>();
         for (int i = right; i < l1.size(); i++) {
-          LiteralExpression literalExpression = new LiteralExpression(l1.get(i).getExprString(),
+          LiteralExpression literalExpression = new LiteralExpression(getExpressionValue(l1.get(i)),
               getDateType(l1.get(left).getTypeString()));
           listExpr.add(literalExpression);
         }
@@ -93,7 +102,6 @@ public class Hive2CarbonExpression {
         Expression rightExpression =
             convertExprHive2Carbon(exprNodeGenericFuncDesc.getChildren().get(right));
         return new AndExpression(leftExpression, rightExpression);
-
       } else if (udf instanceof GenericUDFOPEqual) {
         ColumnExpression columnExpression = null;
         if (l1.get(left) instanceof ExprNodeFieldDesc) {
@@ -103,38 +111,43 @@ public class Hive2CarbonExpression {
               getDateType(l1.get(left).getTypeString()));
         }
         LiteralExpression literalExpression =
-            new LiteralExpression(l1.get(right).getExprString().replace("'", ""),
+            new LiteralExpression(getExpressionValue(l1.get(right)),
                 getDateType(l1.get(right).getTypeString()));
         return new EqualToExpression(columnExpression, literalExpression);
       } else if (udf instanceof GenericUDFOPEqualOrGreaterThan) {
         ColumnExpression columnExpression = new ColumnExpression(l1.get(left).getCols().get(left),
             getDateType(l1.get(left).getTypeString()));
-        LiteralExpression literalExpression = new LiteralExpression(l1.get(right).getExprString(),
-            getDateType(l1.get(left).getTypeString()));
+        LiteralExpression literalExpression =
+            new LiteralExpression(getExpressionValue(l1.get(right)),
+                getDateType(l1.get(left).getTypeString()));
         return new GreaterThanEqualToExpression(columnExpression, literalExpression);
       } else if (udf instanceof GenericUDFOPGreaterThan) {
         ColumnExpression columnExpression = new ColumnExpression(l1.get(left).getCols().get(left),
             getDateType(l1.get(left).getTypeString()));
-        LiteralExpression literalExpression = new LiteralExpression(l1.get(right).getExprString(),
-            getDateType(l1.get(left).getTypeString()));
+        LiteralExpression literalExpression =
+            new LiteralExpression(getExpressionValue(l1.get(right)),
+                getDateType(l1.get(left).getTypeString()));
         return new GreaterThanExpression(columnExpression, literalExpression);
       } else if (udf instanceof GenericUDFOPNotEqual) {
         ColumnExpression columnExpression = new ColumnExpression(l1.get(left).getCols().get(left),
             getDateType(l1.get(left).getTypeString()));
-        LiteralExpression literalExpression = new LiteralExpression(l1.get(right).getExprString(),
-            getDateType(l1.get(left).getTypeString()));
+        LiteralExpression literalExpression =
+            new LiteralExpression(getExpressionValue(l1.get(right)),
+                getDateType(l1.get(left).getTypeString()));
         return new NotEqualsExpression(columnExpression, literalExpression);
       } else if (udf instanceof GenericUDFOPEqualOrLessThan) {
         ColumnExpression columnExpression = new ColumnExpression(l1.get(left).getCols().get(left),
             getDateType(l1.get(left).getTypeString()));
-        LiteralExpression literalExpression = new LiteralExpression(l1.get(right).getExprString(),
-            getDateType(l1.get(left).getTypeString()));
+        LiteralExpression literalExpression =
+            new LiteralExpression(getExpressionValue(l1.get(right)),
+                getDateType(l1.get(left).getTypeString()));
         return new LessThanEqualToExpression(columnExpression, literalExpression);
       } else if (udf instanceof GenericUDFOPLessThan) {
         ColumnExpression columnExpression = new ColumnExpression(l1.get(left).getCols().get(left),
             getDateType(l1.get(left).getTypeString()));
-        LiteralExpression literalExpression = new LiteralExpression(l1.get(right).getExprString(),
-            getDateType(l1.get(left).getTypeString()));
+        LiteralExpression literalExpression =
+            new LiteralExpression(getExpressionValue(l1.get(right)),
+                getDateType(l1.get(left).getTypeString()));
         return new LessThanExpression(columnExpression, literalExpression);
       } else if (udf instanceof GenericUDFOPNull) {
         ColumnExpression columnExpression = new ColumnExpression(l1.get(left).getCols().get(left),

--- a/integration/hive/src/main/java/org/apache/carbondata/hive/MapredCarbonOutputCommitter.java
+++ b/integration/hive/src/main/java/org/apache/carbondata/hive/MapredCarbonOutputCommitter.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.hive;
+
+import java.io.IOException;
+import java.util.Random;
+import java.util.UUID;
+
+import org.apache.carbondata.common.logging.LogServiceFactory;
+import org.apache.carbondata.core.metadata.SegmentFileStore;
+import org.apache.carbondata.core.util.ThreadLocalSessionInfo;
+import org.apache.carbondata.hadoop.api.CarbonOutputCommitter;
+import org.apache.carbondata.hadoop.api.CarbonTableOutputFormat;
+import org.apache.carbondata.hive.util.HiveCarbonUtil;
+import org.apache.carbondata.processing.loading.model.CarbonLoadModel;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.JobContext;
+import org.apache.hadoop.mapred.OutputCommitter;
+import org.apache.hadoop.mapred.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.JobID;
+import org.apache.hadoop.mapreduce.JobStatus;
+import org.apache.hadoop.mapreduce.TaskAttemptID;
+import org.apache.hadoop.mapreduce.TaskID;
+import org.apache.hadoop.mapreduce.TaskType;
+import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl;
+import org.apache.log4j.Logger;
+
+public class MapredCarbonOutputCommitter extends OutputCommitter {
+
+  private CarbonOutputCommitter carbonOutputCommitter;
+
+  private final Logger LOGGER =
+      LogServiceFactory.getLogService(this.getClass().getName());
+
+  @Override
+  public void setupJob(JobContext jobContext) throws IOException {
+    ThreadLocalSessionInfo.setConfigurationToCurrentThread(jobContext.getConfiguration());
+    String a = jobContext.getJobConf().get(JobConf.MAPRED_MAP_TASK_ENV);
+    Random random = new Random();
+    JobID jobId = new JobID(UUID.randomUUID().toString(), 0);
+    TaskID task = new TaskID(jobId, TaskType.MAP, random.nextInt());
+    TaskAttemptID attemptID = new TaskAttemptID(task, random.nextInt());
+    org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl context =
+        new TaskAttemptContextImpl(jobContext.getJobConf(), attemptID);
+    CarbonLoadModel carbonLoadModel =
+        HiveCarbonUtil.getCarbonLoadModel(jobContext.getConfiguration());
+    CarbonTableOutputFormat.setLoadModel(jobContext.getConfiguration(), carbonLoadModel);
+    carbonOutputCommitter =
+        new CarbonOutputCommitter(new Path(carbonLoadModel.getTablePath()), context);
+    carbonOutputCommitter.setupJob(jobContext);
+    String loadModelStr = jobContext.getConfiguration().get("mapreduce.carbontable.load.model");
+    jobContext.getJobConf().set(JobConf.MAPRED_MAP_TASK_ENV,
+        a + ",carbon=" + loadModelStr);
+    jobContext.getJobConf().set(JobConf.MAPRED_REDUCE_TASK_ENV,
+        a + ",carbon=" + loadModelStr);
+  }
+
+  @Override
+  public void setupTask(TaskAttemptContext taskAttemptContext) throws IOException {
+
+  }
+
+  @Override
+  public boolean needsTaskCommit(TaskAttemptContext taskAttemptContext) throws IOException {
+    return false;
+  }
+
+  @Override
+  public void commitTask(TaskAttemptContext taskAttemptContext) throws IOException {
+
+  }
+
+  @Override
+  public void abortTask(TaskAttemptContext taskAttemptContext) throws IOException {
+
+  }
+
+  @Override
+  public void abortJob(JobContext jobContext, int status) throws IOException {
+    if (carbonOutputCommitter != null) {
+      carbonOutputCommitter.abortJob(jobContext, JobStatus.State.FAILED);
+      throw new RuntimeException("Failed to commit Job");
+    }
+  }
+
+  @Override
+  public void commitJob(JobContext jobContext) throws IOException {
+    try {
+      Configuration configuration = jobContext.getConfiguration();
+      CarbonLoadModel carbonLoadModel = MapredCarbonOutputFormat.getLoadModel(configuration);
+      ThreadLocalSessionInfo.unsetAll();
+      SegmentFileStore.writeSegmentFile(carbonLoadModel.getCarbonDataLoadSchema().getCarbonTable(),
+          carbonLoadModel.getSegmentId(), String.valueOf(carbonLoadModel.getFactTimeStamp()));
+      SegmentFileStore
+          .mergeIndexAndWriteSegmentFile(carbonLoadModel.getCarbonDataLoadSchema().getCarbonTable(),
+              carbonLoadModel.getSegmentId(), String.valueOf(carbonLoadModel.getFactTimeStamp()));
+      CarbonTableOutputFormat.setLoadModel(configuration, carbonLoadModel);
+      carbonOutputCommitter.commitJob(jobContext);
+    } catch (Exception e) {
+      LOGGER.error(e);
+      throw e;
+    }
+  }
+}

--- a/integration/hive/src/test/java/org/apache/carbondata/hive/Hive2CarbonExpressionTest.java
+++ b/integration/hive/src/test/java/org/apache/carbondata/hive/Hive2CarbonExpressionTest.java
@@ -24,6 +24,8 @@ import java.util.List;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.datamap.IndexFilter;
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
+import org.apache.carbondata.core.scan.expression.Expression;
+import org.apache.carbondata.core.scan.expression.LiteralExpression;
 import org.apache.carbondata.core.util.CarbonProperties;
 import org.apache.carbondata.hadoop.api.CarbonFileInputFormat;
 import org.apache.carbondata.hadoop.api.CarbonInputFormat;
@@ -77,6 +79,7 @@ public class Hive2CarbonExpressionTest {
       Assert.fail("create table failed: " + e.getMessage());
     }
   }
+
   @Test
   public void testEqualHiveFilter() throws IOException {
     ExprNodeDesc column = new ExprNodeColumnDesc(TypeInfoFactory.intTypeInfo, "id", null, false);
@@ -350,5 +353,21 @@ public class Hive2CarbonExpressionTest {
     List<InputSplit> list= format.getSplits(job);
     Assert.assertEquals(0, list.size());
 
+  }
+
+  @Test
+  public void testFilterOnDate() throws IOException {
+    ExprNodeDesc column =
+        new ExprNodeColumnDesc(TypeInfoFactory.dateTypeInfo, "datee", null, false);
+    ExprNodeDesc constant = new ExprNodeConstantDesc(TypeInfoFactory.dateTypeInfo, "2020-01-01");
+    List<ExprNodeDesc> children = Lists.newArrayList();
+    children.add(column);
+    children.add(constant);
+    ExprNodeGenericFuncDesc node =
+        new ExprNodeGenericFuncDesc(TypeInfoFactory.dateTypeInfo, new GenericUDFOPEqual(),
+            children);
+    Expression expression = Hive2CarbonExpression.convertExprHive2Carbon(node);
+    assert (((LiteralExpression) expression.getChildren().get(1)).getLiteralExpValue().toString()
+        .equalsIgnoreCase("2020-01-01"));
   }
 }

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/DataLoadExecutor.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/DataLoadExecutor.java
@@ -19,7 +19,6 @@ package org.apache.carbondata.processing.loading;
 
 import org.apache.carbondata.common.CarbonIterator;
 import org.apache.carbondata.common.logging.LogServiceFactory;
-import org.apache.carbondata.core.metadata.CarbonTableIdentifier;
 import org.apache.carbondata.processing.loading.exception.BadRecordFoundException;
 import org.apache.carbondata.processing.loading.exception.CarbonDataLoadingException;
 import org.apache.carbondata.processing.loading.exception.NoRetryException;
@@ -65,21 +64,6 @@ public class DataLoadExecutor {
       throw new CarbonDataLoadingException(
           "Data Loading failed for table " + loadModel.getTableName(), e);
     }
-  }
-
-  /**
-   * This method will remove any bad record key from the map entry
-   *
-   * @param carbonTableIdentifier
-   * @return
-   */
-  private boolean badRecordFound(CarbonTableIdentifier carbonTableIdentifier) {
-    String badRecordLoggerKey = carbonTableIdentifier.getBadRecordLoggerKey();
-    boolean badRecordKeyFound = false;
-    if (null != BadRecordsLogger.hasBadRecord(badRecordLoggerKey)) {
-      badRecordKeyFound = true;
-    }
-    return badRecordKeyFound;
   }
 
   /**


### PR DESCRIPTION
 ### Why is this PR needed?
Filter on date column is giving wrong results due to incorrect carbon expression. 
 
 ### What changes were proposed in this PR?
For date column getExprString is giving the filter value as 'DATE2020-01-01' which causes the filter to fail.
Changed to `((ExprNodeConstantDesc)` `exprNodeDesc).getValue().toString()` for ConstantDesc for better handling
    
 ### Does this PR introduce any user interface change?
 - No
 - Yes. (please explain the change and update document)

 ### Is any new testcase added?
 - No
 - Yes

    
