### PR TITLE
[HOTFIX] Avoid reading table status file again per query

### DIFF
--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableInputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableInputFormat.java
@@ -572,4 +572,8 @@ public class CarbonTableInputFormat<T> extends CarbonInputFormat<T> {
     }
     return readCommittedScope;
   }
+
+  public void setReadCommittedScope(ReadCommittedScope readCommittedScope) {
+    this.readCommittedScope = readCommittedScope;
+  }
 }

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
@@ -50,6 +50,7 @@ import org.apache.carbondata.core.datastore.impl.FileFactory
 import org.apache.carbondata.core.indexstore.PartitionSpec
 import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier
 import org.apache.carbondata.core.metadata.schema.table.{CarbonTable, TableInfo}
+import org.apache.carbondata.core.readcommitter.ReadCommittedScope
 import org.apache.carbondata.core.scan.expression.Expression
 import org.apache.carbondata.core.scan.expression.conditional.ImplicitExpression
 import org.apache.carbondata.core.scan.expression.logical.AndExpression
@@ -98,6 +99,8 @@ class CarbonScanRDD[T: ClassTag](
 
   private var segmentsToAccess: Array[Segment] = _
 
+  private var readCommittedScope: ReadCommittedScope = _
+
   @transient val LOGGER = LogServiceFactory.getLogService(this.getClass.getName)
 
   override def internalGetPartitions: Array[Partition] = {
@@ -133,6 +136,11 @@ class CarbonScanRDD[T: ClassTag](
       // get splits
       getSplitsStartTime = System.currentTimeMillis()
       if (null == splits) {
+        format match {
+          case inputFormat: CarbonTableInputFormat[Object] =>
+            inputFormat.setReadCommittedScope(readCommittedScope)
+          case _ =>
+        }
         splits = format.getSplits(job)
       }
       getSplitsEndTime = System.currentTimeMillis()
@@ -780,5 +788,9 @@ class CarbonScanRDD[T: ClassTag](
     if (null != dataMapFilter) {
       dataMapFilter.setExpression(new AndExpression(dataMapFilter.getExpression, expressionVal))
     }
+  }
+
+  def setReadCommittedScope(readCommittedScope: ReadCommittedScope): Unit = {
+    this.readCommittedScope = readCommittedScope
   }
 }


### PR DESCRIPTION
 ### Why is this PR needed?
 After add segment feature, we take snapshot twice (which leads in two times table status IO), we can refuse the original snapshot
a. First time snapshot in LateDecodeStrategy.pruneFilterProjectRaw()
b. second time in CarbonTableInputFormat.getSplits()
 
 ### What changes were proposed in this PR?
Take snapshot only once and reuse in the second place
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No


    
