### PR TITLE
[HOTFIX] Fixed task distribution issue in SegmentPruneRDD

### DIFF
--- a/integration/spark/src/main/scala/org/apache/carbondata/indexserver/SegmentPruneRDD.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/indexserver/SegmentPruneRDD.scala
@@ -32,6 +32,15 @@ class SegmentPruneRDD(@transient private val ss: SparkSession,
     dataMapFormat: IndexInputFormat)
   extends CarbonRDD[(String, SegmentWrapper)](ss, Nil) {
 
+  override protected def getPreferredLocations(split: Partition): Seq[String] = {
+    val locations = split.asInstanceOf[IndexRDDPartition].getLocations
+    if (locations != null) {
+      locations.toSeq
+    } else {
+      Seq()
+    }
+  }
+
   override protected def internalGetPartitions: Array[Partition] = {
     new DistributedPruneRDD(ss, dataMapFormat).partitions
   }


### PR DESCRIPTION
 ### Why is this PR needed?
 SI queries are degraded because getPrefferedLocation is
not overridden in SegmentPruneRDD due to which tasks are fired randomly to any executors
 
 ### What changes were proposed in this PR?
override getPrefferedLocation so that tasks are fired to correct executors.
    
 ### Does this PR introduce any user interface change?
 - No
 - Yes. (please explain the change and update document)

 ### Is any new testcase added?
 - No
 - Yes

    
