### PR TITLE
[CARBONDATA-3773] Skip Validate partition info in Indexserver count star flow

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/index/TableIndex.java
+++ b/core/src/main/java/org/apache/carbondata/core/index/TableIndex.java
@@ -623,7 +623,7 @@ public final class TableIndex extends OperationEventListener {
 
   /**
    * Get the mapping of blocklet path and row count for all blocks. This method skips the
-   * validation of partition info for countStar job.
+   * validation of partition info for countStar job with indexserver enabled.
    */
   public Map<String, Long> getBlockRowCount(TableIndex defaultIndex, List<Segment> allsegments,
       final List<PartitionSpec> partitions) throws IOException {

--- a/core/src/main/java/org/apache/carbondata/core/index/TableIndex.java
+++ b/core/src/main/java/org/apache/carbondata/core/index/TableIndex.java
@@ -601,14 +601,14 @@ public final class TableIndex extends OperationEventListener {
    * @throws IOException
    */
   public Map<String, Long> getBlockRowCount(List<Segment> allsegments,
-      final List<PartitionSpec> partitions, TableIndex defaultIndex)
+      final List<PartitionSpec> partitions, TableIndex defaultIndex, boolean isIUDFlow)
       throws IOException {
     List<Segment> segments = getCarbonSegments(allsegments);
     Map<String, Long> blockletToRowCountMap = new HashMap<>();
     for (Segment segment : segments) {
       List<CoarseGrainIndex> indexes = defaultIndex.getIndexFactory().getIndexes(segment);
       for (CoarseGrainIndex index : indexes) {
-        index.getRowCountForEachBlock(segment, partitions, blockletToRowCountMap);
+        index.getRowCountForEachBlock(segment, partitions, blockletToRowCountMap, isIUDFlow);
       }
     }
     return blockletToRowCountMap;

--- a/core/src/main/java/org/apache/carbondata/core/index/dev/Index.java
+++ b/core/src/main/java/org/apache/carbondata/core/index/dev/Index.java
@@ -67,7 +67,7 @@ public interface Index<T extends Blocklet> {
    * blockletpath and the row count
    */
   Map<String, Long> getRowCountForEachBlock(Segment segment, List<PartitionSpec> partitions,
-      Map<String, Long> blockletToRowCountMap);
+      Map<String, Long> blockletToRowCountMap, boolean isIUDFlow);
 
   // TODO Move this method to Abstract class
   /**

--- a/core/src/main/java/org/apache/carbondata/core/index/dev/Index.java
+++ b/core/src/main/java/org/apache/carbondata/core/index/dev/Index.java
@@ -67,13 +67,18 @@ public interface Index<T extends Blocklet> {
    * blockletpath and the row count
    */
   Map<String, Long> getRowCountForEachBlock(Segment segment, List<PartitionSpec> partitions,
-      Map<String, Long> blockletToRowCountMap, boolean isIUDFlow);
+      Map<String, Long> blockletToRowCountMap);
 
   // TODO Move this method to Abstract class
   /**
    * Validate whether the current segment needs to be fetching the required data
    */
   boolean isScanRequired(FilterResolverIntf filterExp);
+
+  /**
+   * Validate Partition info, to check if any partitions is dropped
+   */
+  boolean validatePartitionInfo(List<PartitionSpec> partitions);
 
   /**
    * Clear complete index table and release memory.

--- a/core/src/main/java/org/apache/carbondata/core/index/dev/cgindex/CoarseGrainIndex.java
+++ b/core/src/main/java/org/apache/carbondata/core/index/dev/cgindex/CoarseGrainIndex.java
@@ -51,7 +51,7 @@ public abstract class CoarseGrainIndex implements Index<Blocklet> {
 
   @Override
   public Map<String, Long> getRowCountForEachBlock(Segment segment, List<PartitionSpec> partitions,
-      Map<String, Long> blockletToRowCountMap) {
+      Map<String, Long> blockletToRowCountMap, boolean isIUDFlow) {
     throw new UnsupportedOperationException("Operation not supported");
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/index/dev/cgindex/CoarseGrainIndex.java
+++ b/core/src/main/java/org/apache/carbondata/core/index/dev/cgindex/CoarseGrainIndex.java
@@ -51,7 +51,12 @@ public abstract class CoarseGrainIndex implements Index<Blocklet> {
 
   @Override
   public Map<String, Long> getRowCountForEachBlock(Segment segment, List<PartitionSpec> partitions,
-      Map<String, Long> blockletToRowCountMap, boolean isIUDFlow) {
+      Map<String, Long> blockletToRowCountMap) {
+    throw new UnsupportedOperationException("Operation not supported");
+  }
+
+  @Override
+  public boolean validatePartitionInfo(List<PartitionSpec> partitions) {
     throw new UnsupportedOperationException("Operation not supported");
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/index/dev/fgindex/FineGrainIndex.java
+++ b/core/src/main/java/org/apache/carbondata/core/index/dev/fgindex/FineGrainIndex.java
@@ -50,7 +50,7 @@ public abstract class FineGrainIndex implements Index<FineGrainBlocklet> {
 
   @Override
   public Map<String, Long> getRowCountForEachBlock(Segment segment, List<PartitionSpec> partitions,
-      Map<String, Long> blockletToRowCountMap) {
+      Map<String, Long> blockletToRowCountMap, boolean isIUDFlow) {
     throw new UnsupportedOperationException("Operation not supported");
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/index/dev/fgindex/FineGrainIndex.java
+++ b/core/src/main/java/org/apache/carbondata/core/index/dev/fgindex/FineGrainIndex.java
@@ -50,7 +50,12 @@ public abstract class FineGrainIndex implements Index<FineGrainBlocklet> {
 
   @Override
   public Map<String, Long> getRowCountForEachBlock(Segment segment, List<PartitionSpec> partitions,
-      Map<String, Long> blockletToRowCountMap, boolean isIUDFlow) {
+      Map<String, Long> blockletToRowCountMap) {
+    throw new UnsupportedOperationException("Operation not supported");
+  }
+
+  @Override
+  public boolean validatePartitionInfo(List<PartitionSpec> partitions) {
     throw new UnsupportedOperationException("Operation not supported");
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockIndex.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockIndex.java
@@ -613,7 +613,7 @@ public class BlockIndex extends CoarseGrainIndex
         taskSummaryDMStore.getIndexRow(getTaskSummarySchema(), 0).getLong(TASK_ROW_COUNT);
     if (totalRowCount == 0) {
       Map<String, Long> blockletToRowCountMap = new HashMap<>();
-      getRowCountForEachBlock(segment, partitions, blockletToRowCountMap);
+      getRowCountForEachBlock(segment, partitions, blockletToRowCountMap, false);
       for (long blockletRowCount : blockletToRowCountMap.values()) {
         totalRowCount += blockletRowCount;
       }
@@ -626,13 +626,13 @@ public class BlockIndex extends CoarseGrainIndex
   }
 
   public Map<String, Long> getRowCountForEachBlock(Segment segment, List<PartitionSpec> partitions,
-      Map<String, Long> blockletToRowCountMap) {
+      Map<String, Long> blockletToRowCountMap, boolean isIUDFlow) {
     if (memoryDMStore.getRowCount() == 0) {
       return new HashMap<>();
     }
     // if it has partitioned index but there is no partitioned information stored, it means
     // partitions are dropped so return empty list.
-    if (partitions != null) {
+    if (partitions != null && isIUDFlow) {
       if (!validatePartitionInfo(partitions)) {
         return new HashMap<>();
       }

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableInputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableInputFormat.java
@@ -500,13 +500,13 @@ public class CarbonTableInputFormat<T> extends CarbonInputFormat<T> {
             throw e;
           }
           TableIndex defaultIndex = IndexStoreManager.getInstance().getDefaultIndex(table);
-          blockletToRowCountMap
-              .putAll(defaultIndex.getBlockRowCount(filteredSegment, partitions, defaultIndex));
+          blockletToRowCountMap.putAll(
+              defaultIndex.getBlockRowCount(filteredSegment, partitions, defaultIndex, true));
         }
       } else {
         TableIndex defaultIndex = IndexStoreManager.getInstance().getDefaultIndex(table);
         blockletToRowCountMap
-            .putAll(defaultIndex.getBlockRowCount(filteredSegment, partitions, defaultIndex));
+            .putAll(defaultIndex.getBlockRowCount(filteredSegment, partitions, defaultIndex, true));
       }
       // key is the (segmentId","+blockletPath) and key is the row count of that blocklet
       for (Map.Entry<String, Long> eachBlocklet : blockletToRowCountMap.entrySet()) {

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableInputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableInputFormat.java
@@ -500,13 +500,13 @@ public class CarbonTableInputFormat<T> extends CarbonInputFormat<T> {
             throw e;
           }
           TableIndex defaultIndex = IndexStoreManager.getInstance().getDefaultIndex(table);
-          blockletToRowCountMap.putAll(
-              defaultIndex.getBlockRowCount(filteredSegment, partitions, defaultIndex, true));
+          blockletToRowCountMap
+              .putAll(defaultIndex.getBlockRowCount(filteredSegment, partitions, defaultIndex));
         }
       } else {
         TableIndex defaultIndex = IndexStoreManager.getInstance().getDefaultIndex(table);
         blockletToRowCountMap
-            .putAll(defaultIndex.getBlockRowCount(filteredSegment, partitions, defaultIndex, true));
+            .putAll(defaultIndex.getBlockRowCount(filteredSegment, partitions, defaultIndex));
       }
       // key is the (segmentId","+blockletPath) and key is the row count of that blocklet
       for (Map.Entry<String, Long> eachBlocklet : blockletToRowCountMap.entrySet()) {

--- a/integration/spark/src/main/scala/org/apache/carbondata/indexserver/DistributedCountRDD.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/indexserver/DistributedCountRDD.scala
@@ -108,8 +108,8 @@ class DistributedCountRDD(@transient ss: SparkSession, indexInputFormat: IndexIn
       val defaultIndex = IndexStoreManager.getInstance
         .getIndex(indexInputFormat.getCarbonTable, split.head
           .asInstanceOf[IndexInputSplitWrapper].getDistributable.getIndexSchema)
-      defaultIndex.getBlockRowCount(segments.toList.asJava, indexInputFormat
-        .getPartitions, defaultIndex, false).asScala
+      defaultIndex.getBlockRowCount(defaultIndex, segments.toList.asJava, indexInputFormat
+        .getPartitions).asScala
     }
   }
 

--- a/integration/spark/src/main/scala/org/apache/carbondata/indexserver/DistributedCountRDD.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/indexserver/DistributedCountRDD.scala
@@ -109,7 +109,7 @@ class DistributedCountRDD(@transient ss: SparkSession, indexInputFormat: IndexIn
         .getIndex(indexInputFormat.getCarbonTable, split.head
           .asInstanceOf[IndexInputSplitWrapper].getDistributable.getIndexSchema)
       defaultIndex.getBlockRowCount(segments.toList.asJava, indexInputFormat
-        .getPartitions, defaultIndex).asScala
+        .getPartitions, defaultIndex, false).asScala
     }
   }
 


### PR DESCRIPTION
 ### Why is this PR needed?
 BlockIndex.ValidatePartitionInfo check was added for IUD scenario as part of countStar query performance improvement in [PR-3148](https://github.com/apache/carbondata/pull/3148). For count(*) flow with indexserver, validatePartitionInfo is called multiple times (No. of Blocks * No. of Partitions), which is not required.
 
 ### What changes were proposed in this PR?
Skip ValidatePartition check in case of Count(*) query with indexserver
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
