### PR TITLE
[CARBONDATA-3774]Fix hiding the actual exceptions during tableExists check

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonFileMetastore.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonFileMetastore.scala
@@ -251,8 +251,10 @@ class CarbonFileMetastore extends CarbonMetaStore {
     try {
       lookupRelation(tableIdentifier)(sparkSession)
     } catch {
-      case _: Exception =>
+      case _: NoSuchTableException =>
         return false
+      case ex: Exception =>
+        throw ex
     }
     true
   }


### PR DESCRIPTION
 ### Why is this PR needed?
 1. In table exists API, we catch all exceptions and say table does not exists which is wrong

 ### What changes were proposed in this PR?
1. Catch only NoSuchTableException fro spark and return false, for other exceptions, throw it to caller

    
 ### Does this PR introduce any user interface change?
 - No


 ### Is any new testcase added?
 - No(existing test will take care)

    
