### PR TITLE
[CARBONDATA-3780]Old store read compatibility issue for Index handler column

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/metadata/converter/ThriftWrapperSchemaConverterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/converter/ThriftWrapperSchemaConverterImpl.java
@@ -605,6 +605,14 @@ public class ThriftWrapperSchemaConverterImpl implements SchemaConverter {
           .setLocalDictColumnsToWrapperSchema(listOfColumns, externalTableSchema.tableProperties,
               externalTableSchema.tableProperties
                   .get(CarbonCommonConstants.LOCAL_DICTIONARY_ENABLE));
+      String handler = externalTableSchema.tableProperties.get(CarbonCommonConstants.INDEX_HANDLER);
+      if (handler != null) {
+        for (ColumnSchema columnSchema : listOfColumns) {
+          if (handler.equalsIgnoreCase(columnSchema.getColumnName())) {
+            columnSchema.setIndexColumn(true);
+          }
+        }
+      }
     }
     wrapperTableSchema.setListOfColumns(listOfColumns);
     wrapperTableSchema.setSchemaEvolution(


### PR DESCRIPTION

 ### Why is this PR needed?
 Table created in older version do not have indexColumn property in columnSchema. Newer versions have indexColumn property in columnSchema with default value as false. Due to this, when Old store is read, index handler column which is hidden to user is also treated as normal schema column and can perform operations like alter table on the index column.
 
 ### What changes were proposed in this PR?
During schema read, if the index_handler property is present, check if column name matches to index handler name and set indexColumn property value to true.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No