### PR TITLE
[CARBONDATA-3680]Add NI as a function not as udf

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonHiveIndexMetadataUtil.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonHiveIndexMetadataUtil.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.hive
 import org.apache.hadoop.hive.ql.exec.UDF
 import org.apache.spark.sql.{CarbonEnv, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
-import org.apache.spark.sql.catalyst.expressions.{Expression, ScalaUDF}
+import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.index.CarbonIndexUtil
 import org.apache.spark.sql.secondaryindex.util.FileInternalUtil
 
@@ -133,19 +133,15 @@ object CarbonHiveIndexMetadataUtil {
   }
 
   def transformToRemoveNI(expression: Expression): Expression = {
-    val newExpWithoutNI = expression.transform {
+    expression.transform {
       case hiveUDF: HiveSimpleUDF if hiveUDF.function.isInstanceOf[NonIndexUDFExpression] =>
         hiveUDF.asInstanceOf[HiveSimpleUDF].children.head
-      case scalaUDF: ScalaUDF if "NI".equalsIgnoreCase(scalaUDF.udfName.get) =>
-        scalaUDF.children.head
     }
-    newExpWithoutNI
   }
 
   def checkNIUDF(condition: Expression): Boolean = {
     condition match {
       case hiveUDF: HiveSimpleUDF if hiveUDF.function.isInstanceOf[NonIndexUDFExpression] => true
-      case scalaUDF: ScalaUDF if "NI".equalsIgnoreCase(scalaUDF.udfName.get) => true
       case _ => false
     }
   }


### PR DESCRIPTION
 ### Why is this PR needed?
 NI is registered as udf, so it is handled for both case of scalaUDF and HiveSimpleUDF
 
 ### What changes were proposed in this PR?
Register NI as a functionand remove unwanted case for ScalaUDF for NI functionality.
    
 ### Does this PR introduce any user interface change?
 - No
 - Yes. (please explain the change and update document)

 ### Is any new testcase added?
 - No(existing text cases will take care)

    
