### PR TITLE
[CARBONDATA-3754]avoid listing index files during SI rebuild

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/metadata/SegmentFileStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/SegmentFileStore.java
@@ -1245,6 +1245,24 @@ public class SegmentFileStore {
   }
 
   /**
+   * This method returns the list of indx/merge index files for a segment in carbonTable.
+   */
+  public static Set<String> getIndexFilesListForSegment(Segment segment, String tablePath)
+      throws IOException {
+    Set<String> indexFiles;
+    if (segment.getSegmentFileName() == null) {
+      String segmentPath = CarbonTablePath.getSegmentPath(tablePath, segment.getSegmentNo());
+      indexFiles =
+          new SegmentIndexFileStore().getMergeOrIndexFilesFromSegment(segmentPath).keySet();
+    } else {
+      SegmentFileStore segmentFileStore =
+          new SegmentFileStore(tablePath, segment.getSegmentFileName());
+      indexFiles = segmentFileStore.getIndexOrMergeFiles().keySet();
+    }
+    return indexFiles;
+  }
+
+  /**
    * It contains the segment information like location, partitions and related index files
    */
   public static class SegmentFile implements Serializable {

--- a/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/rdd/CarbonSIRebuildRDD.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/rdd/CarbonSIRebuildRDD.scala
@@ -331,20 +331,6 @@ class CarbonSIRebuildRDD[K, V](
           val carbonFile = FileFactory.getCarbonFile(split.getFilePath)
           carbonFile.delete()
         }
-
-        // delete the indexfile/merge index carbonFile of old data files
-        val segmentPath = FileFactory.getCarbonFile(indexTable.getSegmentPath(segmentId))
-        val indexFiles = segmentPath.listFiles(new CarbonFileFilter {
-          override def accept(carbonFile: CarbonFile): Boolean = {
-            (carbonFile.getName.endsWith(CarbonTablePath.INDEX_FILE_EXT) ||
-             carbonFile.getName.endsWith(CarbonTablePath.MERGE_INDEX_FILE_EXT)) &&
-            DataFileUtil.getTimeStampFromFileName(carbonFile.getAbsolutePath).toLong <
-            carbonLoadModelCopy.getFactTimeStamp
-          }
-        })
-        indexFiles.foreach { indexFile =>
-          indexFile.delete()
-        }
       }
 
       private def deleteLocalDataFolders(): Unit = {


### PR DESCRIPTION
 ### Why is this PR needed?
 List files was done during rebuild of SI, which will be costly in case of S3 and OBS
 
 ### What changes were proposed in this PR?
avoided list files and delete files handled through segmentFileStore
    
 ### Does this PR introduce any user interface change?
 - No
 - Yes. (please explain the change and update document)

 ### Is any new testcase added?
 - No(existing tests will takecare)

    
