### PR TITLE
[CARBONDATA-3782] changes to reflect default behaviour in case of invalid configuration…

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
@@ -1850,17 +1850,24 @@ public final class CarbonProperties {
    * This method validates the numOfThreadsForPruning
    */
   public static int getNumOfThreadsForPruning() {
-    int numOfThreadsForPruning = Integer.parseInt(CarbonProperties.getInstance()
-        .getProperty(CarbonCommonConstants.CARBON_MAX_DRIVER_THREADS_FOR_BLOCK_PRUNING,
-            CarbonCommonConstants.CARBON_MAX_DRIVER_THREADS_FOR_BLOCK_PRUNING_DEFAULT));
-    if (numOfThreadsForPruning > Integer
-        .parseInt(CarbonCommonConstants.CARBON_MAX_DRIVER_THREADS_FOR_BLOCK_PRUNING_DEFAULT)
-        || numOfThreadsForPruning < 1) {
-      LOGGER.info("Invalid value for carbon.max.driver.threads.for.block.pruning, value :"
-          + numOfThreadsForPruning + " .using the default threads : "
-          + CarbonCommonConstants.CARBON_MAX_DRIVER_THREADS_FOR_BLOCK_PRUNING_DEFAULT);
-      numOfThreadsForPruning = Integer
-          .parseInt(CarbonCommonConstants.CARBON_MAX_DRIVER_THREADS_FOR_BLOCK_PRUNING_DEFAULT);
+    int numOfThreadsForPruning;
+    String maxDriverThreadsForBockPruning =
+        CarbonCommonConstants.CARBON_MAX_DRIVER_THREADS_FOR_BLOCK_PRUNING;
+    int defaultNumberOfThreads =
+        Integer.parseInt(CarbonCommonConstants.CARBON_MAX_DRIVER_THREADS_FOR_BLOCK_PRUNING_DEFAULT);
+    String logMessage = " is not a valid input for " + maxDriverThreadsForBockPruning
+        + ". Using the default number of threads : " + defaultNumberOfThreads;
+    try {
+      numOfThreadsForPruning = Integer.parseInt(CarbonProperties.getInstance()
+          .getProperty(maxDriverThreadsForBockPruning, String.valueOf(defaultNumberOfThreads)));
+      if (numOfThreadsForPruning > defaultNumberOfThreads || numOfThreadsForPruning < 1) {
+        LOGGER.info(numOfThreadsForPruning + logMessage);
+        numOfThreadsForPruning = defaultNumberOfThreads;
+      }
+    } catch (NumberFormatException e) {
+      LOGGER.info(
+          CarbonProperties.getInstance().getProperty(maxDriverThreadsForBockPruning + logMessage));
+      numOfThreadsForPruning = defaultNumberOfThreads;
     }
     return numOfThreadsForPruning;
   }

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/NewCarbonDataLoadRDD.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/NewCarbonDataLoadRDD.scala
@@ -22,6 +22,7 @@ import java.text.SimpleDateFormat
 import java.util.{Date, UUID}
 
 import scala.collection.mutable
+import scala.util.Try
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.mapreduce.{TaskAttemptID, TaskType}
@@ -135,7 +136,8 @@ class NewCarbonDataLoadRDD[K, V](
 
         val preFetch = CarbonProperties.getInstance().getProperty(CarbonCommonConstants
           .USE_PREFETCH_WHILE_LOADING, CarbonCommonConstants.USE_PREFETCH_WHILE_LOADING_DEFAULT)
-        carbonLoadModel.setPreFetch(preFetch.toBoolean)
+        carbonLoadModel.setPreFetch(Try(preFetch.toBoolean).getOrElse(CarbonCommonConstants
+          .USE_PREFETCH_WHILE_LOADING_DEFAULT.toBoolean))
         val recordReaders = getInputIterators
         val loader = new SparkPartitionLoader(model,
           theSplit.index,


### PR DESCRIPTION


 ### Why is this PR needed?
 Invalid configuration values in carbon.properties causes operation failure instead of reflecting default configuration value behaviour.
 
 ### What changes were proposed in this PR?

    
 ### Does this PR introduce any user interface change?
 - No
 - Yes. (please explain the change and update document)

 ### Is any new testcase added?
 - No
 - Yes

    
