### PR TITLE
[CARBONDATA-3783]Alter table drop column on main table is not dropping the eligible secondary index tables

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/index/DropIndexCommand.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/index/DropIndexCommand.scala
@@ -42,7 +42,8 @@ private[sql] case class DropIndexCommand(
     ifExistsSet: Boolean,
     dbNameOp: Option[String],
     parentTableName: String = null,
-    indexName: String)
+    indexName: String,
+    needLock: Boolean = true)
   extends RunnableCommand {
 
   def run(sparkSession: SparkSession): Seq[Row] = {
@@ -74,7 +75,11 @@ private[sql] case class DropIndexCommand(
     val LOGGER = LogServiceFactory.getLogService(this.getClass.getCanonicalName)
     val dbName = CarbonEnv.getDatabaseName(dbNameOp)(sparkSession)
     var tableIdentifierForAcquiringLock: AbsoluteTableIdentifier = null
-    val locksToBeAcquired = List(LockUsage.METADATA_LOCK, LockUsage.DROP_TABLE_LOCK)
+    val locksToBeAcquired = if (needLock) {
+      List(LockUsage.METADATA_LOCK, LockUsage.DROP_TABLE_LOCK)
+    } else {
+      List.empty
+    }
     val catalog = CarbonEnv.getInstance(sparkSession).carbonMetaStore
     // flag to check if folders and files can be successfully deleted
     var isValidDeletion = false

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/strategy/DDLStrategy.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/strategy/DDLStrategy.scala
@@ -33,7 +33,6 @@ import org.apache.spark.sql.hive.execution.CreateHiveTableAsSelectCommand
 import org.apache.spark.sql.hive.execution.command.{CarbonDropDatabaseCommand, CarbonResetCommand, CarbonSetCommand, MatchResetCommand}
 import org.apache.spark.sql.secondaryindex.command.CarbonCreateSecondaryIndexCommand
 
-import org.apache.carbondata.common.exceptions.sql.MalformedCarbonCommandException
 import org.apache.carbondata.common.logging.LogServiceFactory
 
 /**
@@ -230,7 +229,7 @@ class DDLStrategy(sparkSession: SparkSession) extends SparkStrategy {
           case c: Exception =>
             sys.error("Operation not allowed on non-carbon table")
         }
-      case dropIndex@DropIndexCommand(ifExistsSet, databaseNameOp, parentTableName, tableName) =>
+      case dropIndex@DropIndexCommand(ifExistsSet, databaseNameOp, parentTableName, tableName, _) =>
         val tableIdentifier = TableIdentifier(parentTableName, databaseNameOp)
         val isParentTableExists = sparkSession.sessionState.catalog.tableExists(tableIdentifier)
         if (!isParentTableExists) {

--- a/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/command/SICreationCommand.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/command/SICreationCommand.scala
@@ -351,6 +351,14 @@ private[sql] case class CarbonCreateSecondaryIndexCommand(
                 'false', 'parentTablePath' = '${carbonTable.getTablePath}',
                 'parentTableId' = '${carbonTable.getCarbonTableIdentifier.getTableId}')""")
           .collect()
+
+        // Refresh the index table
+        CarbonEnv
+          .getInstance(sparkSession)
+          .carbonMetaStore
+          .lookupRelation(indexModel.dbName, indexTableName)(sparkSession)
+          .asInstanceOf[CarbonRelation]
+          .carbonTable
       }
 
       CarbonIndexUtil.addIndexTableInfo(IndexType.SI.getIndexProviderName,


### PR DESCRIPTION

### Why is this PR needed?
Alter table drop column on main table when droping columns match to a secondary index table columns is actually not dropping secondary index table.
 
 ### What changes were proposed in this PR?
1. Have corrected the `dropApplicableSITables` to check if the drop columns are matching the index table columns. If all columns of a index table match to drop columns, then drop the index table itself.
2. Index table refresh was missed in `CarbonCreateSecondaryIndexCommand`. It was missed in secondary index feature PR.

 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
