### PR TITLE
[HOTFIX]Compilation error in assembly module as it could not resolve the mv-core dependency

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -66,11 +66,6 @@
       <artifactId>carbondata-mv-plan</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <dependency>
-      <groupId>org.apache.carbondata</groupId>
-      <artifactId>carbondata-mv-core</artifactId>
-      <version>${project.version}</version>
-    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
 ### Why is this PR needed?
Recent PR #3692 removes carbondata-mv-core module and part of the code is moved to carbondata-spark module. But assembly module still has dependency to mv-core in its pom.
Below is compilation error in assembly module as it could not resolve the mv-core dependency - 
`[ERROR] Failed to execute goal on project carbondata-assembly: Could not resolve dependencies for project org.apache.carbondata:carbondata-assembly:pom:2.0.0-SNAPSHOT: Failure to find org.apache.carbondata:carbondata-mv-core:jar:2.0.0-SNAPSHOT in https://repo1.maven.org/maven2 was cached in the local repository, resolution will not be reattempted until the update interval of central has elapsed or updates are forced -> [Help 1]`
 
 ### What changes were proposed in this PR?
Removed carbondata-mv-core dependency from assembly module.

 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No
    
