### PR TITLE
[WIP] Allow force refresh table If table already exist in hive

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
@@ -323,19 +323,25 @@ object CarbonEnv {
     var databaseLocation =
       sparkSession.sessionState.catalog.asInstanceOf[SessionCatalog].getDatabaseMetadata(dbName)
         .locationUri.toString
+    LOGGER.info("##### databaseLocation is" + databaseLocation)
     // for default database and db ends with .db
     // check whether the carbon store and hive store is same or different.
     if ((!EnvHelper.isLegacy(sparkSession)) &&
         (dbName.equals("default") || databaseLocation.endsWith(".db"))) {
       val carbonStorePath = CarbonProperties.getStorePath()
+      LOGGER.info("##### didn't enter " + carbonStorePath)
       val hiveStorePath = sparkSession.conf.get("spark.sql.warehouse.dir", carbonStorePath)
+      LOGGER.info("##### hiveStorePath " + hiveStorePath)
       // if carbon.store does not point to spark.sql.warehouse.dir then follow the old table path
       // format
       if (carbonStorePath != null && !hiveStorePath.equals(carbonStorePath)) {
         databaseLocation = CarbonProperties.getStorePath +
                            CarbonCommonConstants.FILE_SEPARATOR +
                            dbName
+        LOGGER.info("##### newwwww " + databaseLocation)
       }
+    } else {
+      LOGGER.info("##### didn't enter " )
     }
     databaseLocation
   }
@@ -356,12 +362,14 @@ object CarbonEnv {
     }
   }
 
-  private def newTablePath(
+  def newTablePath(
       databaseNameOp: Option[String],
       tableName: String
   )(sparkSession: SparkSession): String = {
     val dbName = getDatabaseName(databaseNameOp)(sparkSession)
+    LOGGER.info("##### dbName is" + dbName)
     val dbLocation = getDatabaseLocation(dbName, sparkSession)
+    LOGGER.info("##### dbLocation is" + dbLocation)
     dbLocation + CarbonCommonConstants.FILE_SEPARATOR + tableName
   }
 


### PR DESCRIPTION
 ### Why is this PR needed?
 Consider a scenario of upgrade from 1.6 carbon jars to 2.0, 
carbon.storelocation is s3a//, but spark.sql.warehouse.dir is not configured.
Once upgrade is done and refresh is performed. Latest 2.0 takes path from spark.sql.warehouse.dir for refresh table, so hive table will have default fs warehouse location not s3a//. Which is wrong location.

So, need to allow user to configure spark.sql.warehouse.dir properly and do refresh again.
But we are not allowing refresh again as table already present in hive,
 
 ### What changes were proposed in this PR?
Allow refresh again even if table exists in hive
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No


    
