### PR TITLE
[CARBONDATA-3786] presto carbon reader should use tablePath from hive catalog

### DIFF
--- a/integration/presto/src/main/prestodb/org/apache/carbondata/presto/CarbondataSplitManager.java
+++ b/integration/presto/src/main/prestodb/org/apache/carbondata/presto/CarbondataSplitManager.java
@@ -66,6 +66,7 @@ import com.facebook.presto.spi.TableNotFoundException;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.spi.predicate.TupleDomain;
 import com.google.common.collect.ImmutableList;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 
@@ -109,8 +110,12 @@ public class CarbondataSplitManager extends HiveSplitManager {
     if (!table.getStorage().getStorageFormat().getInputFormat().contains("carbon")) {
       return super.getSplits(transactionHandle, session, layoutHandle, splitSchedulingStrategy);
     }
-    String location = table.getStorage().getLocation();
-
+    // for hive metastore, get table location from catalog table's tablePath
+    String location = table.getStorage().getSerdeParameters().get("tablePath");
+    if (StringUtils.isEmpty(location))  {
+      // file metastore case tablePath can be null, so get from location
+      location = table.getStorage().getLocation();
+    }
     String queryId = System.nanoTime() + "";
     QueryStatistic statistic = new QueryStatistic();
     QueryStatisticsRecorder statisticRecorder = CarbonTimeStatisticsFactory.createDriverRecorder();

--- a/integration/presto/src/main/prestosql/org/apache/carbondata/presto/CarbondataSplitManager.java
+++ b/integration/presto/src/main/prestosql/org/apache/carbondata/presto/CarbondataSplitManager.java
@@ -68,6 +68,7 @@ import io.prestosql.spi.connector.FixedSplitSource;
 import io.prestosql.spi.connector.SchemaTableName;
 import io.prestosql.spi.connector.TableNotFoundException;
 import io.prestosql.spi.predicate.TupleDomain;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 
@@ -118,8 +119,12 @@ public class CarbondataSplitManager extends HiveSplitManager {
     if (!table.getStorage().getStorageFormat().getInputFormat().contains("carbon")) {
       return super.getSplits(transactionHandle, session, tableHandle, splitSchedulingStrategy);
     }
-    String location = table.getStorage().getLocation();
-
+    // for hive metastore, get table location from catalog table's tablePath
+    String location = table.getStorage().getSerdeParameters().get("tablePath");
+    if (StringUtils.isEmpty(location))  {
+      // file metastore case tablePath can be null, so get from location
+      location = table.getStorage().getLocation();
+    }
     String queryId = System.nanoTime() + "";
     QueryStatistic statistic = new QueryStatistic();
     QueryStatisticsRecorder statisticRecorder = CarbonTimeStatisticsFactory.createDriverRecorder();


### PR DESCRIPTION
 ### Why is this PR needed?
 In upgrade scenarios of 1.6 to 2.0, when sparl.sql.warehouse is not configured.
Hive storage location is not proper. so, presto carbon integration should use tablePath from hive storage instead of location.
 
 ### What changes were proposed in this PR?
use tablePath instead of location from hive metatstroe table.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No
    
