### PR TITLE
[CARBONDATA-3788] Fix insert failure during global sort with huge data in new insert flow

### DIFF
--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -378,7 +378,7 @@ object CarbonDataRDDFactory {
             val convertedRdd = CommonLoadUtils.getConvertedInternalRow(
               colSchema,
               scanResultRdd.get,
-              isInsertFromStageCommand = false)
+              isGlobalSortPartition = false)
             if (isSortTable && sortScope.equals(SortScopeOptions.SortScope.GLOBAL_SORT)) {
               DataLoadProcessBuilderOnSpark.insertDataUsingGlobalSortWithInternalRow(sqlContext
                 .sparkSession,

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonInsertFromStageCommand.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonInsertFromStageCommand.scala
@@ -44,7 +44,6 @@ import org.apache.carbondata.core.statusmanager.{SegmentStatus, SegmentStatusMan
 import org.apache.carbondata.core.util.path.CarbonTablePath
 import org.apache.carbondata.hadoop.CarbonInputSplit
 import org.apache.carbondata.processing.loading.FailureCauses
-import org.apache.carbondata.processing.loading.constants.DataLoadProcessorConstants
 import org.apache.carbondata.processing.loading.model.CarbonLoadModel
 import org.apache.carbondata.processing.util.CarbonLoaderUtil
 import org.apache.carbondata.spark.load.DataLoadProcessBuilderOnSpark
@@ -353,10 +352,8 @@ case class CarbonInsertFromStageCommand(
         CarbonInsertIntoCommand(
           databaseNameOp = Option(table.getDatabaseName),
           tableName = table.getTableName,
-          options = scala.collection.immutable.Map(
-            "fileheader" -> header,
-            "binary_decoder" -> "base64",
-            DataLoadProcessorConstants.IS_INSERT_STAGE_COMMAND -> "true"),
+          options = scala.collection.immutable.Map("fileheader" -> header,
+            "binary_decoder" -> "base64"),
           isOverwriteTable = false,
           logicalPlan = selectedDataFrame.queryExecution.analyzed,
           tableInfo = table.getTableInfo,

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/constants/DataLoadProcessorConstants.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/constants/DataLoadProcessorConstants.java
@@ -40,7 +40,4 @@ public final class DataLoadProcessorConstants {
 
   // to indicate that it is optimized insert flow without rearrange of each data rows
   public static final String NO_REARRANGE_OF_ROWS = "NO_REARRANGE_OF_ROWS";
-
-  // to indicate CarbonInsertFromStageCommand flow
-  public static final String IS_INSERT_STAGE_COMMAND = "IS_INSERT_STAGE_COMMAND";
 }


### PR DESCRIPTION
 ### Why is this PR needed?
 Spark is resuing the internalRow in global sort partition flow with huge data.
As RDD of Internal row is persisted for global sort.
 
 ### What changes were proposed in this PR?
Need to have a copy and work on the internalRow before the last transform for global sort partition flow.
Already this was doing for insert stage command (which uses global sort partition)
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No

   