### PR TITLE
[CARBONDATA-3793]Data load with partition columns fail with InvalidLoadOptionException when load option 'header' is set to 'true'

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/datasources/SparkCarbonTableFormat.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/datasources/SparkCarbonTableFormat.scala
@@ -126,9 +126,9 @@ with Serializable {
     optionsFinal.put(
       "fileheader",
       dataSchema.fields.map(_.name.toLowerCase).mkString(",") + "," + partitionStr)
+    optionsFinal.put("header", "false")
     val optionsLocal = new mutable.HashMap[String, String]()
     optionsLocal ++= options
-    optionsLocal += (("header", "false"))
     new CarbonLoadModelBuilder(table).build(
       optionsLocal.toMap.asJava,
       optionsFinal,


### PR DESCRIPTION
 ### Why is this PR needed?
 Data load with partition columns fail with `InvalidLoadOptionException` when load option `header` is set to `true`.
 
 ### What changes were proposed in this PR?
In `SparkCarbonTableFormat.prepareWrite()` method after adding the `fileheader` option with header columns to `optionsFinal`, need to set `header` option to `false`.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No
    
