### PR TITLE
[CARBONDATA-3799] Fix inverted index cannot work with adaptive encoding

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/adaptive/AdaptiveCodec.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/adaptive/AdaptiveCodec.java
@@ -162,7 +162,14 @@ public abstract class AdaptiveCodec implements ColumnPageCodec {
     ByteArrayOutputStream stream = new ByteArrayOutputStream();
     DataOutputStream out = new DataOutputStream(stream);
     if (null != indexStorage) {
-      out.write(result.array(), 0, result.position());
+      if (result.isDirect()) {
+        // cannot apply result.array() on direct buffers
+        for (int i = result.position(); i < result.limit(); i++) {
+          out.writeByte(result.get(i));
+        }
+      } else {
+        out.write(result.array(), result.position(), result.limit());
+      }
       if (indexStorage.getRowIdPageLengthInBytes() > 0) {
         out.writeInt(indexStorage.getRowIdPageLengthInBytes());
         short[] rowIdPage = (short[]) indexStorage.getRowIdPage();

--- a/integration/spark/src/test/scala/org/apache/carbondata/integration/spark/testsuite/primitiveTypes/TestAdaptiveEncodingForPrimitiveTypes.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/integration/spark/testsuite/primitiveTypes/TestAdaptiveEncodingForPrimitiveTypes.scala
@@ -392,6 +392,18 @@ class TestAdaptiveEncodingForPrimitiveTypes extends QueryTest with BeforeAndAfte
     sql("drop table if exists negativeTable")
   }
 
+  test("test inverted index issue ") {
+    sql("DROP TABLE IF EXISTS source")
+    sql("CREATE TABLE source(intField int) stored as carbondata TBLPROPERTIES('sort_columns'='intField','inverted_index'='intField')")
+    // this is stored as short data after adaptive encoding
+    sql("insert into source select 32000 union all select 0");
+    checkAnswer(sql("SELECT * from source"), Seq(Row(0), Row(32000)))
+    // this is stored as BYTE data after adaptive encoding
+    sql("insert into source select 32000 ");
+    checkAnswer(sql("SELECT * from source"), Seq(Row(0), Row(32000), Row(32000)))
+    sql("DROP TABLE IF EXISTS source")
+  }
+
   override def afterAll: Unit = {
     CarbonProperties.getInstance()
       .addProperty(CarbonCommonConstants.ENABLE_UNSAFE_SORT, CarbonCommonConstants.ENABLE_UNSAFE_SORT_DEFAULT)


### PR DESCRIPTION
 ### Why is this PR needed?
After PR #3638, Inverted index cannot work with adaptive encoding.
two issues are present
a) For Byte adaptive type (Not DirectByteBuffer), Encoded column page has wrong result, as position() is used instead of limit()
b) For short adaptive type (DirectByteBuffer), result.array() will fail as it is unsupported for direct byte buffer.
 
 ### What changes were proposed in this PR?
For problem
a) use limit() instead of position()
b) write byte by byte instead of .array()

 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes
