### PR TITLE
[CARBONDATA-3803] Mark CarbonSession as deprecated since 2.0

### DIFF
--- a/docs/quick-start-guide.md
+++ b/docs/quick-start-guide.md
@@ -123,7 +123,7 @@ Apache Spark Shell provides a simple way to learn the API, as well as a powerful
 
 #### Basics
 
-###### Option 1: Using CarbonSession
+###### Option 1: Using CarbonSession (deprecated since 2.0)
 Start Spark shell by running the following command in the Spark directory:
 
 ```

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonExtensions.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonExtensions.scala
@@ -24,6 +24,10 @@ import org.apache.spark.sql.execution.strategy.{CarbonLateDecodeStrategy, DDLStr
 import org.apache.spark.sql.hive.{CarbonIUDAnalysisRule, CarbonPreInsertionCasts}
 import org.apache.spark.sql.parser.CarbonExtensionSqlParser
 
+/**
+ * use SparkSessionExtensions to inject Carbon's extensions.
+ * @since 2.0
+ */
 class CarbonExtensions extends (SparkSessionExtensions => Unit) {
 
   override def apply(extensions: SparkSessionExtensions): Unit = {

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSession.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSession.scala
@@ -40,7 +40,11 @@ import org.apache.carbondata.streaming.CarbonStreamingQueryListener
  * Session implementation for {org.apache.spark.sql.SparkSession}
  * Implemented this class only to use our own SQL DDL commands.
  * User needs to use {CarbonSession.getOrCreateCarbon} to create Carbon session.
+ *
+ * @deprecated Since 2.0, only use for backward compatibility,
+ *             please switch to use {@link CarbonExtensions}.
  */
+@Deprecated
 class CarbonSession(@transient val sc: SparkContext,
     @transient private val existingSharedState: Option[SharedState],
     @transient private val useHiveMetaStore: Boolean = true

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSession.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSession.scala
@@ -50,6 +50,8 @@ class CarbonSession(@transient val sc: SparkContext,
     @transient private val useHiveMetaStore: Boolean = true
 ) extends SparkSession(sc) { self =>
 
+  logWarning("CarbonSession is deprecated since 2.0, please switch to CarbonExtensions")
+
   def this(sc: SparkContext) {
     this(sc, None)
   }


### PR DESCRIPTION
 ### Why is this PR needed?
 Better to use CarbonExtensions instead of CarbonSession in version 2.0.
 
 ### What changes were proposed in this PR?
mark CarbonSession as deprecated since version 2.0.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No, no need

    
