### PR TITLE
[CARBONDATA-3815]Insert into table select from another table throws exception for spatial tables

### DIFF
--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonInputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonInputFormat.java
@@ -858,7 +858,7 @@ public abstract class CarbonInputFormat<T> extends FileInputFormat<Void, T> {
     List<String> projectColumns = new ArrayList<>();
     // complex type and add just the parent column name while skipping the child columns.
     for (ColumnSchema col : colList) {
-      if (!col.getColumnName().contains(".")) {
+      if (!col.isComplexColumn()) {
         projectColumns.add(col.getColumnName());
       }
     }

--- a/integration/spark/src/main/java/org/apache/carbondata/spark/util/Util.java
+++ b/integration/spark/src/main/java/org/apache/carbondata/spark/util/Util.java
@@ -111,7 +111,7 @@ public class Util {
     List<ColumnSchema> columns = table.getTableInfo().getFactTable().getListOfColumns();
     List<ColumnSchema> validColumnSchema = new ArrayList<>();
     for (ColumnSchema column : columns) {
-      if (!column.isInvisible() && !column.getColumnName().contains(".")) {
+      if (!column.isInvisible() && !column.isIndexColumn() && !column.isComplexColumn()) {
         validColumnSchema.add(column);
       }
     }

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -374,12 +374,14 @@ object CarbonDataRDDFactory {
               .getTableInfo
               .getFactTable
               .getListOfColumns
-              .asScala.filterNot(col => col.isInvisible || col.getColumnName.contains("."))
+              .asScala
+              .filterNot(col => col.isInvisible || col.isIndexColumn || col.isComplexColumn)
             val convertedRdd = CommonLoadUtils.getConvertedInternalRow(
               colSchema,
               scanResultRdd.get,
               isGlobalSortPartition = false)
-            if (isSortTable && sortScope.equals(SortScopeOptions.SortScope.GLOBAL_SORT)) {
+            if (isSortTable && sortScope.equals(SortScopeOptions.SortScope.GLOBAL_SORT) &&
+                !carbonLoadModel.isIndexColumnsPresent) {
               DataLoadProcessBuilderOnSpark.insertDataUsingGlobalSortWithInternalRow(sqlContext
                 .sparkSession,
                 convertedRdd,

--- a/integration/spark/src/main/scala/org/apache/spark/sql/carbondata/execution/datasources/SparkCarbonFileFormat.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/carbondata/execution/datasources/SparkCarbonFileFormat.scala
@@ -103,7 +103,7 @@ class SparkCarbonFileFormat extends FileFormat
     var schema = new StructType
     val fields = tableInfo.getFactTable.getListOfColumns.asScala.map { col =>
       // TODO find better way to know its a child
-      if (!col.getColumnName.contains(".")) {
+      if (!col.isComplexColumn) {
         Some((col.getSchemaOrdinal,
           StructField(col.getColumnName,
             SparkTypeConverter.convertCarbonToSparkDataType(col, table))))

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonInsertIntoCommand.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonInsertIntoCommand.scala
@@ -161,9 +161,9 @@ case class CarbonInsertIntoCommand(databaseNameOp: Option[String],
         null
       }
     val convertedStaticPartition = getConvertedStaticPartitionMap(partitionColumnSchema)
-    val (reArrangedIndex, selectedColumnSchema) = getReArrangedIndexAndSelectedSchema(
-      tableInfo,
-      partitionColumnSchema)
+    val (reArrangedIndex, selectedColumnSchema) = getReArrangedIndexAndSelectedSchema(tableInfo,
+      partitionColumnSchema,
+      carbonLoadModel)
     val newLogicalPlan = getReArrangedLogicalPlan(
       reArrangedIndex,
       selectedColumnSchema,
@@ -468,7 +468,8 @@ case class CarbonInsertIntoCommand(databaseNameOp: Option[String],
 
   def getReArrangedIndexAndSelectedSchema(
       tableInfo: TableInfo,
-      partitionColumnSchema: mutable.Buffer[ColumnSchema]): (Seq[Int], Seq[ColumnSchema]) = {
+      partitionColumnSchema: mutable.Buffer[ColumnSchema],
+      carbonLoadModel: CarbonLoadModel): (Seq[Int], Seq[ColumnSchema]) = {
     var reArrangedIndex: Seq[Int] = Seq()
     var selectedColumnSchema: Seq[ColumnSchema] = Seq()
     var partitionIndex: Seq[Int] = Seq()
@@ -495,16 +496,20 @@ case class CarbonInsertIntoCommand(databaseNameOp: Option[String],
     }
     columnSchema.foreach {
       col =>
-        var skipPartitionColumn = false
-        if (partitionColumnNames != null &&
-            partitionColumnNames.contains(col.getColumnName)) {
-          partitionIndex = partitionIndex :+ createOrderMap(col.getColumnName)
-          skipPartitionColumn = true
+        if (col.isIndexColumn) {
+          carbonLoadModel.setIndexColumnsPresent(true)
         } else {
-          reArrangedIndex = reArrangedIndex :+ createOrderMap(col.getColumnName)
-        }
-        if (!skipPartitionColumn) {
-          selectedColumnSchema = selectedColumnSchema :+ col
+          var skipPartitionColumn = false
+          if (partitionColumnNames != null &&
+              partitionColumnNames.contains(col.getColumnName)) {
+            partitionIndex = partitionIndex :+ createOrderMap(col.getColumnName)
+            skipPartitionColumn = true
+          } else {
+            reArrangedIndex = reArrangedIndex :+ createOrderMap(col.getColumnName)
+          }
+          if (!skipPartitionColumn) {
+            selectedColumnSchema = selectedColumnSchema :+ col
+          }
         }
     }
     if (partitionColumnSchema != null) {

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/management/CommonLoadUtils.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/management/CommonLoadUtils.scala
@@ -557,7 +557,7 @@ object CommonLoadUtils {
       .getListOfColumns
       .asScala
     if (table.getPartitionInfo != null) {
-      colSchema = colSchema.filterNot(x => x.isInvisible || x.getColumnName.contains(".") ||
+      colSchema = colSchema.filterNot(x => x.isInvisible || x.isComplexColumn ||
                                            x.getSchemaOrdinal == -1 ||
                                            table.getPartitionInfo.getColumnSchemaList.contains(x))
       colSchema = colSchema ++ table
@@ -567,7 +567,7 @@ object CommonLoadUtils {
         .getColumnSchemaList.size()))
         .asInstanceOf[Array[ColumnSchema]]
     } else {
-      colSchema = colSchema.filterNot(x => x.isInvisible || x.getColumnName.contains(".") ||
+      colSchema = colSchema.filterNot(x => x.isInvisible || x.isComplexColumn ||
                                            x.getSchemaOrdinal == -1)
     }
     val updatedRdd: RDD[InternalRow] = CommonLoadUtils.getConvertedInternalRow(

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/parser/impl/JsonRowParser.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/parser/impl/JsonRowParser.java
@@ -163,7 +163,7 @@ public class JsonRowParser implements RowParser {
 
   private static String extractChildColumnName(CarbonColumn column) {
     String columnName = column.getColName();
-    if (columnName.contains(".")) {
+    if (column.getColumnSchema().isComplexColumn()) {
       // complex type child column names can be like following
       // a) struct type --> parent.child
       // b) array type --> parent.val.val...child [If create table flow]

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/steps/InputProcessorStepWithNoConverterImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/steps/InputProcessorStepWithNoConverterImpl.java
@@ -409,27 +409,28 @@ public class InputProcessorStepWithNoConverterImpl extends AbstractDataLoadProce
 
     private Object[] convertToNoDictionaryToBytesWithoutReArrange(Object[] data,
         DataField[] dataFields) {
-      Object[] newData = new Object[data.length];
+      Object[] newData = new Object[dataFields.length];
       // now dictionary is removed, no need of no dictionary mapping
-      for (int i = 0; i < data.length; i++) {
+      for (int i = 0, index = 0; i < dataFields.length; i++) {
         if (dataFields[i].getColumn().isIndexColumn()) {
           continue;
         }
         if (DataTypeUtil.isPrimitiveColumn(dataTypes[i])) {
           // keep the no dictionary measure column as original data
-          newData[i] = data[i];
+          newData[i] = data[index];
         } else if (dataTypes[i].isComplexType()) {
-          getComplexTypeByteArray(newData, i, data, dataFields[i], i, true);
-        } else if (dataTypes[i] == DataTypes.DATE && data[i] instanceof Long) {
+          getComplexTypeByteArray(newData, i, data, dataFields[i], index, true);
+        } else if (dataTypes[i] == DataTypes.DATE && data[index] instanceof Long) {
           if (dateDictionaryGenerator == null) {
             dateDictionaryGenerator = DirectDictionaryKeyGeneratorFactory
                 .getDirectDictionaryGenerator(dataTypes[i], dataFields[i].getDateFormat());
           }
-          newData[i] = dateDictionaryGenerator.generateKey((long) data[i]);
+          newData[i] = dateDictionaryGenerator.generateKey((long) data[index]);
         } else {
           newData[i] =
-              DataTypeUtil.getBytesDataDataTypeForNoDictionaryColumn(data[i], dataTypes[i]);
+              DataTypeUtil.getBytesDataDataTypeForNoDictionaryColumn(data[index], dataTypes[i]);
         }
+        index++;
       }
       return newData;
     }

--- a/sdk/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonSchemaReader.java
+++ b/sdk/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonSchemaReader.java
@@ -259,7 +259,7 @@ public class CarbonSchemaReader {
     List<ColumnSchema> schemaList = reader.readSchema();
     for (int i = 0; i < schemaList.size(); i++) {
       ColumnSchema columnSchema = schemaList.get(i);
-      if (!(columnSchema.getColumnName().contains("."))) {
+      if (!(columnSchema.isComplexColumn())) {
         columnSchemaList.add(columnSchema);
       }
     }


### PR DESCRIPTION
 ### Why is this PR needed?
Insert into table select from another table throws exception for spatial tables. NoSuchElementException exception is thrown with 'mygeohash' column.

 ### What changes were proposed in this PR?

- Excluded spatial columns during getReArrangedIndexAndSelectedSchema. And have set the carbonLoadModel.setIndexColumnsPresent if spatial columns are present during rearranging.
- If the target spatial table has sort_scope configured as global-sort, have made the insert flow to go through `loadDataFrame()` instead of `insertDataUsingGlobalSortWithInternalRow()` in CarbonDataRDDFactory.loadCarbonData(). This ensures that it goes through existing load without Conversion Step and spatial column values are regenerated in the flow.
- Added testcases for 
        1. insert into table without sort_scope configuration.
        2. insert into table with sort_scope configuration.
        3. Load data to table with partition.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
