### PR TITLE
[CARBONDATA-3818] Missed code to check "MV with same query already exists" during MV Refactory

### DIFF
--- a/integration/spark/src/main/scala/org/apache/carbondata/view/MVCatalogInSpark.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/view/MVCatalogInSpark.scala
@@ -163,10 +163,10 @@ case class MVCatalogInSpark(session: SparkSession)
   }
 
   /**
-   * Check if mv with same query already present in catalog
+   * Check and return mv having same query already present in the catalog
    */
-  def isMVWithSameQueryPresent(query: LogicalPlan): Boolean = {
-    lookupSchema(query).nonEmpty
+  def getMVWithSameQueryPresent(query: LogicalPlan): Option[MVSchemaWrapper] = {
+    lookupSchema(query)
   }
 
   /** Returns feasible registered mv schemas for processing the given ModularPlan. */

--- a/integration/spark/src/main/scala/org/apache/carbondata/view/MVCatalogInSpark.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/view/MVCatalogInSpark.scala
@@ -162,6 +162,13 @@ case class MVCatalogInSpark(session: SparkSession)
     }
   }
 
+  /**
+   * Check if mv with same query already present in catalog
+   */
+  def isMVWithSameQueryPresent(query: LogicalPlan): Boolean = {
+    lookupSchema(query).nonEmpty
+  }
+
   /** Returns feasible registered mv schemas for processing the given ModularPlan. */
   private def lookupSchema(plan: LogicalPlan): Option[MVSchemaWrapper] = {
     withReadLock {

--- a/integration/spark/src/main/scala/org/apache/carbondata/view/MVHelper.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/view/MVHelper.scala
@@ -289,8 +289,8 @@ object MVHelper {
             if (null != relation) {
               relatedFields += RelatedFieldWrapper(
                 relation.database,
-                reference.name,
-                relation.identifier.table)
+                relation.identifier.table,
+                reference.name)
             }
         }
         findDuplicateColumns(fieldColumnsMap, alias.sql, columns, true)

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/view/CarbonCreateMVCommand.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/view/CarbonCreateMVCommand.scala
@@ -162,8 +162,11 @@ case class CarbonCreateMVCommand(
     val logicalPlan = MVHelper.dropDummyFunction(
       MVQueryParser.getQueryPlan(queryString, session))
       // check if mv with same query already exists
-    if (viewCatalog.isMVWithSameQueryPresent(logicalPlan)) {
-      throw new MalformedMVCommandException("MV with same query already exists")
+    val mvSchemaWrapper = viewCatalog.getMVWithSameQueryPresent(logicalPlan)
+    if (mvSchemaWrapper.nonEmpty) {
+      val mvWithSameQuery = mvSchemaWrapper.get.viewSchema.getIdentifier.getTableName
+      throw new MalformedMVCommandException(
+        s"MV with the name `$mvWithSameQuery` has been already created with the same query")
     }
     val modularPlan = checkQuery(logicalPlan)
     val viewSchema = getOutputSchema(logicalPlan)

--- a/integration/spark/src/test/scala/org/apache/carbondata/view/timeseries/TestCreateMVWithTimeSeries.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/view/timeseries/TestCreateMVWithTimeSeries.scala
@@ -213,7 +213,7 @@ class TestCreateMVWithTimeSeries extends QueryTest with BeforeAndAfterAll {
     sql("drop materialized view if exists mv2")
     intercept[MalformedMVCommandException] {
       sql("create materialized view mv2 as select timeseries(projectjoindate,'Second'), sum(projectcode) from maintable group by timeseries(projectjoindate,'Second')")
-    }.getMessage.contains("MV with same query already exists")
+    }.getMessage.contains("MV with the name `mv1` has been already created with the same query")
     sql("drop materialized view if exists mv1")
   }
 

--- a/integration/spark/src/test/scala/org/apache/carbondata/view/timeseries/TestCreateMVWithTimeSeries.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/view/timeseries/TestCreateMVWithTimeSeries.scala
@@ -19,7 +19,7 @@ package org.apache.carbondata.view.timeseries
 
 import java.util.concurrent.{Callable, Executors, TimeUnit}
 
-import org.apache.carbondata.common.exceptions.sql.MalformedCarbonCommandException
+import org.apache.carbondata.common.exceptions.sql.{MalformedCarbonCommandException, MalformedMVCommandException}
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.util.CarbonProperties
 import org.apache.carbondata.view.rewrite.TestUtil
@@ -204,6 +204,16 @@ class TestCreateMVWithTimeSeries extends QueryTest with BeforeAndAfterAll {
     val df2 = sql("select timeseries(projectjoinDATE,'SECOnd'), sum(projectcode) from maintable where projectcode=8 group by timeseries(projectjoinDATE,'SECOnd')")
     TestUtil.verifyMVHit(df1.queryExecution.optimizedPlan, "mv1")
     TestUtil.verifyMVHit(df2.queryExecution.optimizedPlan, "mv1")
+    sql("drop materialized view if exists mv1")
+  }
+
+  test("check if mv with same query exists") {
+    sql("drop materialized view if exists mv1")
+    sql("create materialized view mv1 as select timeseries(projectjoindate,'Second'), sum(projectcode) from maintable group by timeseries(projectjoindate,'Second')")
+    sql("drop materialized view if exists mv2")
+    intercept[MalformedMVCommandException] {
+      sql("create materialized view mv2 as select timeseries(projectjoindate,'Second'), sum(projectcode) from maintable group by timeseries(projectjoindate,'Second')")
+    }.getMessage.contains("MV with same query already exists")
     sql("drop materialized view if exists mv1")
   }
 


### PR DESCRIPTION
 ### Why is this PR needed?
  Missed code to check "MV with same query already exists" during MV Refactory.
 
 ### What changes were proposed in this PR?
Add code to which if "MV with same query already exists" and add testcase
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
