### PR TITLE
[CARBONDATA-3817]Fix table creation with all columns as  partition columns

### DIFF
--- a/integration/hive/src/main/java/org/apache/carbondata/hive/CarbonHiveSerDe.java
+++ b/integration/hive/src/main/java/org/apache/carbondata/hive/CarbonHiveSerDe.java
@@ -32,6 +32,7 @@ import org.apache.carbondata.core.metadata.schema.SchemaReader;
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
 import org.apache.carbondata.core.metadata.schema.table.TableInfo;
 import org.apache.carbondata.core.metadata.schema.table.column.CarbonColumn;
+import org.apache.carbondata.core.util.CarbonUtil;
 import org.apache.carbondata.core.util.path.CarbonTablePath;
 
 import org.apache.hadoop.conf.Configuration;
@@ -115,7 +116,8 @@ public class CarbonHiveSerDe extends AbstractSerDe {
   private void inferSchema(Properties tbl, List<String> columnNames, List<TypeInfo> columnTypes) {
     if (columnNames.size() == 0 && columnTypes.size() == 0) {
       String external = tbl.getProperty("EXTERNAL");
-      String location = tbl.getProperty(hive_metastoreConstants.META_TABLE_LOCATION);
+      String location = CarbonUtil.checkAndAppendFileSystemURIScheme(
+          tbl.getProperty(hive_metastoreConstants.META_TABLE_LOCATION));
       if (external != null && "TRUE".equals(external) && location != null) {
         String[] names =
             tbl.getProperty(hive_metastoreConstants.META_TABLE_NAME).split("\\.");

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/standardpartition/StandardPartitionTableLoadingTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/standardpartition/StandardPartitionTableLoadingTestCase.scala
@@ -18,7 +18,7 @@ package org.apache.carbondata.spark.testsuite.standardpartition
 
 import java.io.{File, FileWriter, IOException}
 import java.util
-import java.util.concurrent.{Callable, Executors, ExecutorService}
+import java.util.concurrent.{Callable, ExecutorService, Executors}
 
 import org.apache.commons.io.FileUtils
 import org.apache.hadoop.conf.Configuration
@@ -26,7 +26,7 @@ import org.apache.spark.sql.catalyst.{InternalRow, TableIdentifier}
 import org.apache.spark.sql.execution.strategy.CarbonDataSourceScan
 import org.apache.spark.sql.optimizer.CarbonFilters
 import org.apache.spark.sql.test.util.QueryTest
-import org.apache.spark.sql.{CarbonEnv, Row}
+import org.apache.spark.sql.{AnalysisException, CarbonEnv, Row}
 import org.scalatest.BeforeAndAfterAll
 
 import org.apache.carbondata.common.Strings
@@ -551,6 +551,19 @@ class StandardPartitionTableLoadingTestCase extends QueryTest with BeforeAndAfte
     checkAnswer(sql("show partitions cs_load_p"), Seq(
       Row("empno=100/empname=indra/designation=yy"),
       Row("empno=99/empname=ravi/designation=xx")))
+  }
+
+  test("test create partition table with all the columns as partition columns") {
+    sql("drop table if exists partitionall_columns")
+    val ex = intercept[AnalysisException] {
+      sql(
+        """
+          | CREATE TABLE partitionall_columns
+          | PARTITIONED BY (empno int,empname String, designation String)
+          | STORED AS carbondata
+      """.stripMargin)
+    }
+    assert(ex.getMessage().equalsIgnoreCase("Cannot use all columns for partition columns;"))
   }
 
   def verifyInsertForPartitionTable(tableName: String, sort_scope: String): Unit = {


### PR DESCRIPTION
 ### Why is this PR needed?
1.  When all the columns are given as partition columns during create table, create table should fail as a minimum one column should be present as a non-partition column. This is because after #3574 , we improved the create data source table and we call CreateDataSourceTableCommand of spark.
Since we are creating as Hive table, if while creating hive compatible way, if it fails, then it will fall back to save its metadata in the Spark SQL specific way, so partition validation fails when we try to store in hive compatible way, so in retry, it will pass which is wrong behavior for hive compatible table.
 2. in Hive integration location do not have file system URI prepared for it

 ### What changes were proposed in this PR?
1. For partition table, if all the columns are present as partition columns, then validate with the same API which spark does.
2. append file system URI for location parameter while inferring schema.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new test case added?
  - Yes

    
