### PR TITLE
[CARBONDATA-3811] Fix flat folder query returns 0 rows

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/metadata/SegmentFileStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/SegmentFileStore.java
@@ -833,7 +833,13 @@ public class SegmentFileStore {
       for (Map.Entry<String, FolderDetails> entry : getLocationMap().entrySet()) {
         String location = entry.getKey();
         if (entry.getValue().isRelative) {
-          location = tablePath + location;
+          if (location.equals("/")) {
+            // incase of flat folder, the relative segment location is '/',
+            // so don't append it as we again add file separator for file names.
+            location = tablePath;
+          } else {
+            location = tablePath + location;
+          }
         }
         if (entry.getValue().status.equals(SegmentStatus.SUCCESS.getMessage())) {
           String mergeFileName = entry.getValue().getMergeFileName();


### PR DESCRIPTION
 ### Why is this PR needed?
This issue doesn't happen for local or s3a file system (because below method don't lookup from the map for those file system). observed with HDFS file system.
In case of `'flat_folder'='true'` table property,
`BlockletIndexUtil#createBlockMetaInfo` method for HDFS looks up meta info from `fileNameToMetaInfoMapping` map.
key was having single /, but value stored with //. so unable to match the key. no segment is selected for query.  
Example:
**key to lookup**:
hdfs://localhost:54311/user/hive/warehouse/carbon.store/naruto/yy/part-0-0_batchno0-0-0-1589266774602.snappy.carbondata -> {BlockMetaInfo@21140} 
**Actual key:**
hdfs://localhost:54311/user/hive/warehouse/carbon.store/naruto/yy//part-0-0_batchno0-0-0-1589266774602.snappy.carbondata
 
 ### What changes were proposed in this PR?
Path should not have // in first place. This was a bug in case of flat folder.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No [happens only in HDFS cluster]

    
