### PR TITLE
[CARBONDATA-3820] Fix CDC failure when sort columns present in source dataframe

### DIFF
--- a/examples/spark/src/main/scala/org/apache/carbondata/examples/CDCExample.scala
+++ b/examples/spark/src/main/scala/org/apache/carbondata/examples/CDCExample.scala
@@ -141,6 +141,8 @@ object CDCExample {
         .write
         .format("carbondata")
         .option("tableName", "target")
+        .option("sort_scope", "global_sort")
+        .option("sort_column", "id")
         .mode(SaveMode.Overwrite)
         .save()
     }

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/mutation/merge/CarbonMergeDataSetCommand.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/mutation/merge/CarbonMergeDataSetCommand.scala
@@ -186,7 +186,7 @@ case class CarbonMergeDataSetCommand(
     CarbonInsertIntoWithDf(
       databaseNameOp = Some(carbonTable.getDatabaseName),
       tableName = carbonTable.getTableName,
-      options = Map(("fileheader" -> header)),
+      options = Map("fileheader" -> header, "sort_scope" -> "nosort"),
       isOverwriteTable = false,
       dataFrame = loadDF.select(tableCols.map(col): _*),
       updateModel = updateTableModel,
@@ -267,7 +267,7 @@ case class CarbonMergeDataSetCommand(
         StructField(status_on_mergeds, IntegerType)))
     val factory =
       new SparkCarbonFileFormat().prepareWrite(sparkSession, job,
-        carbonTable.getTableInfo.getFactTable.getTableProperties.asScala.toMap, schema)
+        Map(), schema)
     val config = SparkSQLUtil.broadCastHadoopConf(sparkSession.sparkContext, job.getConfiguration)
     (frame.rdd.coalesce(DistributionUtil.getConfiguredExecutors(sparkSession.sparkContext)).
       mapPartitionsWithIndex { case (index, iter) =>


### PR DESCRIPTION
 ### Why is this PR needed?
While merging into table with sortcolumns in the CDC Flow. The following exception will be throwed:
"column: id specified in sort columns does not exist in schema".
Root cause is that we use TBLProperteis with sortcolumns to create the TUPLEID_statusOnMerge carbonwriter, in which the sortcolumn、sortscope are all useless.

 ### What changes were proposed in this PR?
remove the sortcolumn property when creating TUPLEID_statusOnMerge carbonwriter.

 ### Does this PR introduce any user interface change?
No

 ### Is any new testcase added?
Yes

    
