### PR TITLE
[CARBONDATA-3822] Fixed load time taken and added format back

### DIFF
--- a/integration/spark/src/main/scala/org/apache/carbondata/api/CarbonStore.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/api/CarbonStore.scala
@@ -115,9 +115,9 @@ object CarbonStore {
       "NA"
     } else {
       Duration.between(
-        Instant.ofEpochMilli(load.getLoadEndTime),
-        Instant.ofEpochMilli(load.getLoadStartTime)
-      ).toString
+        Instant.ofEpochMilli(load.getLoadStartTime),
+        Instant.ofEpochMilli(load.getLoadEndTime)
+      ).toString.replace("PT", "")
     }
   }
 

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonShowSegmentsCommand.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonShowSegmentsCommand.scala
@@ -42,7 +42,8 @@ case class CarbonShowSegmentsCommand(
       AttributeReference("Load Time Taken", StringType, nullable = true)(),
       AttributeReference("Partition", StringType, nullable = true)(),
       AttributeReference("Data Size", StringType, nullable = false)(),
-      AttributeReference("Index Size", StringType, nullable = false)())
+      AttributeReference("Index Size", StringType, nullable = false)(),
+      AttributeReference("File Format", StringType, nullable = false)())
   }
 
   override def processData(sparkSession: SparkSession): Seq[Row] = {
@@ -91,7 +92,8 @@ case class CarbonShowSegmentsCommand(
           timeTaken,
           partitionString,
           Strings.formatSize(dataSize.toFloat),
-          Strings.formatSize(indexSize.toFloat))
+          Strings.formatSize(indexSize.toFloat),
+          segment.getFileFormat.toString)
       }.toSeq
   }
 }

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/addsegment/AddSegmentTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/addsegment/AddSegmentTestCase.scala
@@ -228,10 +228,10 @@ class AddSegmentTestCase extends QueryTest with BeforeAndAfterAll {
     checkAnswer(sql("select empname from addsegment1 where empname='arvind'"), Seq(Row("arvind"),Row("arvind")))
     checkAnswer(sql("select count(empname) from addsegment1"), Seq(Row(20)))
     checkAnswer(sql("select count(*) from addsegment1"), Seq(Row(20)))
-    sql("show segments for table addsegment1").show(100, false)
     val showSeg = sql("show segments for table addsegment1").collectAsList()
     val descFormattedSize = sql("desc formatted addsegment1").collect().filter(_.get(0).toString.startsWith("Table Data Size")).head.get(1).toString
     val size = getDataSize(newPath)
+    assert(showSeg.get(0).getString(7).equalsIgnoreCase("parquet"))
     assert(descFormattedSize.split("KB")(0).toDouble > 0.0d)
     assert(showSeg.get(0).get(5).toString.equalsIgnoreCase(size))
     assert(showSeg.get(0).get(6).toString.equalsIgnoreCase("NA"))

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/segment/ShowSegmentTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/segment/ShowSegmentTestCase.scala
@@ -187,6 +187,16 @@ class ShowSegmentTestCase extends QueryTest with BeforeAndAfterAll {
     dropTable(tableName)
   }
 
+  test("test for load time and format name") {
+    sql("drop table if exists a")
+    sql("create table a(a string) stored as carbondata")
+    sql("insert into a select 'k'")
+    val rows = sql("show segments for table a").collect()
+    assert(rows(0).getString(3).replace("S", "").toDouble > 0)
+    assert(rows(0).getString(7).equalsIgnoreCase("columnar_v3"))
+    sql("drop table if exists a")
+  }
+
   private def insertTestDataIntoTable(tableName: String) = {
     sql(s"insert into ${ tableName } select 'abc1',1")
     sql(s"insert into ${ tableName } select 'abc2',2")


### PR DESCRIPTION
 ### Why is this PR needed?
1.  Load time taken is shown as  PT-1.0S which is wrong(negative time)
2. Show segment is missing format information.

 ### What changes were proposed in this PR?
1. Fix the time and remove PT to show the time as "1.0S" for better viewing.
2. Added format back
   
 ### Does this PR introduce any user interface change?
 - No
 - Yes. (please explain the change and update document)

 ### Is any new testcase added?
 - No
 - Yes

    
