### PR TITLE
[CARBONDATA-3832]Added block and blocket pruning for the polygon expression processing

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/scan/expression/UnknownExpression.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/expression/UnknownExpression.java
@@ -19,8 +19,16 @@ package org.apache.carbondata.core.scan.expression;
 
 import java.util.List;
 
+import org.apache.carbondata.core.datastore.block.SegmentProperties;
+import org.apache.carbondata.core.scan.filter.executer.FilterExecuter;
+import org.apache.carbondata.core.scan.filter.resolver.FilterResolverIntf;
+
 public abstract class UnknownExpression extends Expression {
 
   public abstract List<ColumnExpression> getAllColumnList();
 
+  public FilterExecuter getFilterExecuter(FilterResolverIntf filterResolverIntf,
+      SegmentProperties segmentProperties) {
+    return null;
+  }
 }

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/FilterUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/FilterUtil.java
@@ -49,6 +49,7 @@ import org.apache.carbondata.core.metadata.schema.table.column.CarbonMeasure;
 import org.apache.carbondata.core.scan.expression.ColumnExpression;
 import org.apache.carbondata.core.scan.expression.Expression;
 import org.apache.carbondata.core.scan.expression.LiteralExpression;
+import org.apache.carbondata.core.scan.expression.UnknownExpression;
 import org.apache.carbondata.core.scan.expression.conditional.*;
 import org.apache.carbondata.core.scan.expression.exception.FilterIllegalMemberException;
 import org.apache.carbondata.core.scan.expression.exception.FilterUnsupportedException;
@@ -188,6 +189,14 @@ public final class FilterUtil {
           return new FalseFilterExecutor();
         case ROWLEVEL:
         default:
+          if (filterExpressionResolverTree.getFilterExpression() instanceof UnknownExpression) {
+            FilterExecuter filterExecuter =
+                ((UnknownExpression) filterExpressionResolverTree.getFilterExpression())
+                    .getFilterExecuter(filterExpressionResolverTree, segmentProperties);
+            if (filterExecuter != null) {
+              return filterExecuter;
+            }
+          }
           return new RowLevelFilterExecuterImpl(
               ((RowLevelFilterResolverImpl) filterExpressionResolverTree)
                   .getDimColEvaluatorInfoList(),

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RowLevelFilterExecuterImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RowLevelFilterExecuterImpl.java
@@ -70,7 +70,7 @@ public class RowLevelFilterExecuterImpl implements FilterExecuter {
   /**
    * it has index at which given dimension is stored in file
    */
-  int[] dimensionChunkIndex;
+  protected int[] dimensionChunkIndex;
 
   /**
    * it has index at which given measure is stored in file.

--- a/geo/src/main/java/org/apache/carbondata/geo/scan/filter/executor/PolygonFilterExecutorImpl.java
+++ b/geo/src/main/java/org/apache/carbondata/geo/scan/filter/executor/PolygonFilterExecutorImpl.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.geo.scan.filter.executor;
+
+import java.util.BitSet;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.carbondata.core.datastore.block.SegmentProperties;
+import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
+import org.apache.carbondata.core.metadata.datatype.DataTypes;
+import org.apache.carbondata.core.scan.expression.Expression;
+import org.apache.carbondata.core.scan.filter.GenericQueryType;
+import org.apache.carbondata.core.scan.filter.executer.RowLevelFilterExecuterImpl;
+import org.apache.carbondata.core.scan.filter.resolver.resolverinfo.DimColumnResolvedFilterInfo;
+import org.apache.carbondata.core.scan.filter.resolver.resolverinfo.MeasureColumnResolvedFilterInfo;
+import org.apache.carbondata.core.util.DataTypeUtil;
+import org.apache.carbondata.geo.scan.expression.PolygonExpression;
+
+/**
+ * Polygon filter executor. Prunes Blocks and Blocklets based on the selected ranges of polygon.
+ */
+public class PolygonFilterExecutorImpl extends RowLevelFilterExecuterImpl {
+  public PolygonFilterExecutorImpl(List<DimColumnResolvedFilterInfo> dimColEvaluatorInfoList,
+      List<MeasureColumnResolvedFilterInfo> msrColEvalutorInfoList, Expression exp,
+      AbsoluteTableIdentifier tableIdentifier, SegmentProperties segmentProperties,
+      Map<Integer, GenericQueryType> complexDimensionInfoMap) {
+    super(dimColEvaluatorInfoList, msrColEvalutorInfoList, exp, tableIdentifier, segmentProperties,
+        complexDimensionInfoMap);
+  }
+
+  private int getNearestRangeIndex(List<Long[]> ranges, long searchForNumber) {
+    Long[] range;
+    int low = 0, mid = 0, high = ranges.size() - 1;
+    while (low <= high) {
+      mid = low + ((high - low) / 2);
+      range = ranges.get(mid);
+      if (searchForNumber >= range[0]) {
+        if (searchForNumber <= range[1]) {
+          // Return the range index if the number is between min and max values of the range
+          return mid;
+        } else {
+          // Number is bigger than this range's min and max. Search on the right side of the range
+          low = mid + 1;
+        }
+      } else {
+        // Number is smaller than this range's min and max. Search on the left side of the range
+        high = mid - 1;
+      }
+    }
+    return mid;
+  }
+
+  /**
+   * Checks if the current block or blocklet needs to be scanned
+   * @param maxValue Max value in the current block or blocklet
+   * @param minValue Min value in te current block or blocklet
+   * @return True or False  True if current block or blocket needs to be scanned. Otherwise False.
+   */
+  private boolean isScanRequired(byte[] maxValue, byte[] minValue) {
+    PolygonExpression polygon = (PolygonExpression) exp;
+    List<Long[]> ranges = polygon.getRanges();
+    Long min =
+        (Long) DataTypeUtil.getDataBasedOnDataTypeForNoDictionaryColumn(minValue, DataTypes.LONG);
+    Long max =
+        (Long) DataTypeUtil.getDataBasedOnDataTypeForNoDictionaryColumn(maxValue, DataTypes.LONG);
+
+    // Find the nearest possible range index for both the min and max values. If a value do not
+    // exist in the any of the range, get the preceding range index where it fits best
+    int startIndex = getNearestRangeIndex(ranges, min);
+    int endIndex = getNearestRangeIndex(ranges, max);
+    if (endIndex > startIndex) {
+       // Multiple ranges fall between min and max. Need to scan this block or blocklet
+      return true;
+    }
+    // Got same index for both min and max values.
+    Long[] oneRange = ranges.subList(startIndex, endIndex + 1).get(0);
+    if ((min >= oneRange[0] && min <= oneRange[1]) || (max >= oneRange[0] && max <= oneRange[1])) {
+      // Either min or max is within the range
+      return true;
+    }
+    // No range between min and max values. Scan can be avoided for this block or blocklet
+    return false;
+  }
+
+  @Override
+  public BitSet isScanRequired(byte[][] blockMaxValue, byte[][] blockMinValue,
+      boolean[] isMinMaxSet) {
+    assert (exp instanceof PolygonExpression);
+    int dimIndex = dimensionChunkIndex[0];
+    BitSet bitSet = new BitSet(1);
+    if (isMinMaxSet[dimIndex] && isScanRequired(blockMaxValue[dimIndex], blockMinValue[dimIndex])) {
+      bitSet.set(0);
+    }
+    return bitSet;
+  }
+}


### PR DESCRIPTION
 ### Why is this PR needed?
 At present, carbon doesn't do block/blocklet pruning for polygon fileter queries. It does rowlevel filtering at carbon layer and returns result. With this approach, all the carbon files are scanned irrespective of the where there are any matching rows in the block. It also has spark overhead to launch many jobs and tasks to process them. Thus affects the overall performance of polygon query.
 
 ### What changes were proposed in this PR?
Leverage the existing block pruning mechanism in the carbon and avoided the unwanted blocks with block pruning. Thus reduce the number of splits. And at the executor side, used blocklet pruning and reduced the number of blocklets to be read and scanned.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
