### PR TITLE
[CARBONDATA-3830]Presto array columns read support

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/FillVector.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/FillVector.java
@@ -1,0 +1,347 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.core.datastore.page.encoding;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.BitSet;
+
+import org.apache.carbondata.core.metadata.datatype.DataType;
+import org.apache.carbondata.core.metadata.datatype.DataTypes;
+import org.apache.carbondata.core.metadata.datatype.DecimalConverterFactory;
+import org.apache.carbondata.core.scan.result.vector.CarbonColumnVector;
+import org.apache.carbondata.core.scan.result.vector.ColumnVectorInfo;
+import org.apache.carbondata.core.scan.result.vector.impl.CarbonColumnVectorImpl;
+import org.apache.carbondata.core.util.ByteUtil;
+
+public class FillVector {
+  private byte[] pageData;
+  private float floatFactor = 0;
+  private double factor = 0;
+  private ColumnVectorInfo vectorInfo;
+  private BitSet nullBits;
+
+  public FillVector(byte[] pageData, ColumnVectorInfo vectorInfo, BitSet nullBits) {
+    this.pageData = pageData;
+    this.vectorInfo = vectorInfo;
+    this.nullBits = nullBits;
+  }
+
+  public void setFactor(double factor) {
+    this.factor = factor;
+  }
+
+  public void setFloatFactor(float floatFactor) {
+    this.floatFactor = floatFactor;
+  }
+
+  public void basedOnType(CarbonColumnVector vector, DataType vectorDataType, int pageSize,
+      DataType pageDataType) {
+    if (vectorInfo.vector.getColumnVector() != null && ((CarbonColumnVectorImpl) vectorInfo.vector
+        .getColumnVector()).isComplex()) {
+      fillComplexType(vector.getColumnVector(), pageDataType);
+    } else {
+      fillPrimitiveType(vector, vectorDataType, pageSize, pageDataType);
+      vector.setIndex(0);
+    }
+  }
+
+  private void fillComplexType(CarbonColumnVector vector, DataType pageDataType) {
+    CarbonColumnVectorImpl vectorImpl = (CarbonColumnVectorImpl) vector;
+    if (vector != null && vector.getChildrenVector() != null) {
+      ArrayList<Integer> childElements = ((CarbonColumnVectorImpl) vector).getChildrenElements();
+      for (int i = 0; i < childElements.size(); i++) {
+        int count = childElements.get(i);
+        typeComplexObject(vectorImpl.getChildrenVector().get(0), count, pageDataType);
+        vector.putArrayObject();
+      }
+      vectorImpl.getChildrenVector().get(0).setIndex(0);
+    }
+  }
+
+  private void fillPrimitiveType(CarbonColumnVector vector, DataType vectorDataType, int pageSize,
+      DataType pageDataType) {
+    // offset which denotes the start index for pageData
+    int pageIndex = vector.getIndex();
+    int rowId = 0;
+
+    // Filling into vector is done based on page data type
+
+    if (vectorDataType == DataTypes.FLOAT && floatFactor != 0.0) {
+      if (pageDataType == DataTypes.BOOLEAN || pageDataType == DataTypes.BYTE) {
+        for (int i = 0; i < pageSize; i++) {
+          vector.putFloat(i, (pageData[pageIndex++] / floatFactor));
+        }
+      } else if (pageDataType == DataTypes.SHORT) {
+        int size = pageSize * DataTypes.SHORT.getSizeInBytes();
+        for (int i = 0; i < size; i += DataTypes.SHORT.getSizeInBytes()) {
+          vector.putFloat(rowId++,
+              (ByteUtil.toShortLittleEndian(pageData, pageIndex + i) / floatFactor));
+        }
+        pageIndex += size;
+      } else if (pageDataType == DataTypes.SHORT_INT) {
+        int size = pageSize * DataTypes.SHORT_INT.getSizeInBytes();
+        for (int i = 0; i < size; i += DataTypes.SHORT_INT.getSizeInBytes()) {
+          vector.putFloat(rowId++, (ByteUtil.valueOf3Bytes(pageData, pageIndex + i) / floatFactor));
+        }
+        pageIndex += size;
+      } else if (pageDataType == DataTypes.INT) {
+        int size = pageSize * DataTypes.INT.getSizeInBytes();
+        for (int i = 0; i < size; i += DataTypes.INT.getSizeInBytes()) {
+          vector.putFloat(rowId++,
+              (ByteUtil.toIntLittleEndian(pageData, pageIndex + i) / floatFactor));
+        }
+        pageIndex += size;
+      } else if (pageDataType == DataTypes.LONG) {
+        int size = pageSize * DataTypes.LONG.getSizeInBytes();
+        for (int i = 0; i < size; i += DataTypes.LONG.getSizeInBytes()) {
+          vector.putFloat(rowId++,
+              (float) (ByteUtil.toLongLittleEndian(pageData, pageIndex + i) / factor));
+        }
+        pageIndex += size;
+      } else {
+        throw new RuntimeException("internal error: " + this.toString());
+      }
+    } else if (vectorDataType == DataTypes.DOUBLE && factor != 0.0) {
+      if (pageDataType == DataTypes.BOOLEAN || pageDataType == DataTypes.BYTE) {
+        for (int i = 0; i < pageSize; i++) {
+          vector.putDouble(i, (pageData[pageIndex++] / factor));
+        }
+      } else if (pageDataType == DataTypes.SHORT) {
+        int size = pageSize * DataTypes.SHORT.getSizeInBytes();
+        for (int i = 0; i < size; i += DataTypes.SHORT.getSizeInBytes()) {
+          vector
+              .putDouble(rowId++, (ByteUtil.toShortLittleEndian(pageData, pageIndex + i) / factor));
+        }
+        pageIndex += size;
+      } else if (pageDataType == DataTypes.SHORT_INT) {
+        int size = pageSize * DataTypes.SHORT_INT.getSizeInBytes();
+        for (int i = 0; i < size; i += DataTypes.SHORT_INT.getSizeInBytes()) {
+          vector.putDouble(rowId++, (ByteUtil.valueOf3Bytes(pageData, pageIndex + i) / factor));
+        }
+        pageIndex += size;
+      } else if (pageDataType == DataTypes.INT) {
+        int size = pageSize * DataTypes.INT.getSizeInBytes();
+        for (int i = 0; i < size; i += DataTypes.INT.getSizeInBytes()) {
+          vector.putDouble(rowId++, (ByteUtil.toIntLittleEndian(pageData, pageIndex + i) / factor));
+        }
+        pageIndex += size;
+      } else if (pageDataType == DataTypes.LONG) {
+        int size = pageSize * DataTypes.LONG.getSizeInBytes();
+        for (int i = 0; i < size; i += DataTypes.LONG.getSizeInBytes()) {
+          vector
+              .putDouble(rowId++, (ByteUtil.toLongLittleEndian(pageData, pageIndex + i) / factor));
+        }
+        pageIndex += size;
+      } else {
+        throw new RuntimeException("Unsupported datatype : " + pageDataType);
+      }
+    } else if (pageDataType == DataTypes.BYTE_ARRAY) {
+      if (vectorDataType == DataTypes.STRING) {
+        int offset = pageIndex;
+        for (int j = 0; j < pageSize; j++) {
+          byte[] stringLen = new byte[4];
+          for (int k = 0; k < stringLen.length; k++) {
+            stringLen[k] = this.pageData[k + offset];
+          }
+          ByteBuffer wrapped = ByteBuffer.wrap(stringLen, 0, 4);
+          int len = wrapped.getInt();
+          offset += 4;
+          byte[] row = new byte[len];
+          System.arraycopy(this.pageData, offset, row, 0, len);
+          vector.putObject(0, row);
+          offset += len;
+        }
+        pageIndex = offset;
+      }
+    } else if (pageDataType == DataTypes.BOOLEAN || pageDataType == DataTypes.BYTE) {
+      if (vectorDataType == DataTypes.SHORT) {
+        for (int i = 0; i < pageSize; i++) {
+          vector.putShort(i, (short) pageData[pageIndex++]);
+        }
+      } else if (vectorDataType == DataTypes.INT) {
+        for (int i = 0; i < pageSize; i++) {
+          vector.putInt(i, (int) pageData[pageIndex++]);
+        }
+      } else if (vectorDataType == DataTypes.LONG) {
+        for (int i = 0; i < pageSize; i++) {
+          vector.putLong(i, pageData[pageIndex++]);
+        }
+      } else if (vectorDataType == DataTypes.TIMESTAMP) {
+        for (int i = 0; i < pageSize; i++) {
+          vector.putLong(i, (long) pageData[pageIndex++] * 1000);
+        }
+      } else if (vectorDataType == DataTypes.BOOLEAN || vectorDataType == DataTypes.BYTE) {
+        vector.putBytes(0, pageSize, pageData, pageIndex);
+        pageIndex += pageSize;
+      } else if (DataTypes.isDecimal(vectorDataType)) {
+        DecimalConverterFactory.DecimalConverter decimalConverter = vectorInfo.decimalConverter;
+        decimalConverter.fillVector(pageData, pageSize, vectorInfo, nullBits, pageDataType);
+      } else if (vectorDataType == DataTypes.FLOAT) {
+        for (int i = 0; i < pageSize; i++) {
+          vector.putFloat(i, pageData[pageIndex++]);
+        }
+      } else {
+        for (int i = 0; i < pageSize; i++) {
+          vector.putDouble(i, pageData[pageIndex++]);
+        }
+      }
+    } else if (pageDataType == DataTypes.SHORT) {
+      int size = pageSize * DataTypes.SHORT.getSizeInBytes();
+      if (vectorDataType == DataTypes.SHORT) {
+        for (int i = 0; i < size; i += DataTypes.SHORT.getSizeInBytes()) {
+          vector.putShort(rowId++, (ByteUtil.toShortLittleEndian(pageData, pageIndex + i)));
+        }
+      } else if (vectorDataType == DataTypes.INT) {
+        for (int i = 0; i < size; i += DataTypes.SHORT.getSizeInBytes()) {
+          vector.putInt(rowId++, (ByteUtil.toShortLittleEndian(pageData, pageIndex + i)));
+        }
+      } else if (vectorDataType == DataTypes.LONG) {
+        for (int i = 0; i < size; i += DataTypes.SHORT.getSizeInBytes()) {
+          vector.putLong(rowId++, (ByteUtil.toShortLittleEndian(pageData, pageIndex + i)));
+        }
+      } else if (vectorDataType == DataTypes.TIMESTAMP) {
+        for (int i = 0; i < size; i += DataTypes.SHORT.getSizeInBytes()) {
+          vector.putLong(rowId++,
+              ((long) ByteUtil.toShortLittleEndian(pageData, pageIndex + i)) * 1000);
+        }
+      } else if (DataTypes.isDecimal(vectorDataType)) {
+        DecimalConverterFactory.DecimalConverter decimalConverter = vectorInfo.decimalConverter;
+        decimalConverter.fillVector(pageData, pageSize, vectorInfo, nullBits, pageDataType);
+      } else if (vectorDataType == DataTypes.FLOAT) {
+        for (int i = 0; i < size; i += DataTypes.SHORT.getSizeInBytes()) {
+          vector.putFloat(rowId++, (float) (ByteUtil.toShortLittleEndian(pageData, pageIndex + i)));
+        }
+      } else {
+        for (int i = 0; i < size; i += DataTypes.SHORT.getSizeInBytes()) {
+          vector.putDouble(rowId++, (ByteUtil.toShortLittleEndian(pageData, pageIndex + i)));
+        }
+      }
+      pageIndex += size;
+    } else if (pageDataType == DataTypes.SHORT_INT) {
+      if (vectorDataType == DataTypes.INT) {
+        for (int i = 0; i < pageSize; i++) {
+          int shortInt = ByteUtil.valueOf3Bytes(pageData, (pageIndex + i) * 3);
+          vector.putInt(i, shortInt);
+        }
+      } else if (vectorDataType == DataTypes.LONG) {
+        for (int i = 0; i < pageSize; i++) {
+          int shortInt = ByteUtil.valueOf3Bytes(pageData, (pageIndex + i) * 3);
+          vector.putLong(i, shortInt);
+        }
+      } else if (vectorDataType == DataTypes.TIMESTAMP) {
+        for (int i = 0; i < pageSize; i++) {
+          int shortInt = ByteUtil.valueOf3Bytes(pageData, (pageIndex + i) * 3);
+          vector.putLong(i, (long) shortInt * 1000);
+        }
+      } else if (DataTypes.isDecimal(vectorDataType)) {
+        DecimalConverterFactory.DecimalConverter decimalConverter = vectorInfo.decimalConverter;
+        decimalConverter.fillVector(pageData, pageSize, vectorInfo, nullBits, DataTypes.SHORT_INT);
+      } else if (vectorDataType == DataTypes.FLOAT) {
+        for (int i = 0; i < pageSize; i++) {
+          int shortInt = ByteUtil.valueOf3Bytes(pageData, (pageIndex + i) * 3);
+          vector.putFloat(i, shortInt);
+        }
+      } else {
+        for (int i = 0; i < pageSize; i++) {
+          int shortInt = ByteUtil.valueOf3Bytes(pageData, (pageIndex + i) * 3);
+          vector.putDouble(i, shortInt);
+        }
+      }
+      pageIndex += pageSize;
+    } else if (pageDataType == DataTypes.INT) {
+      int size = pageSize * DataTypes.INT.getSizeInBytes();
+      if (vectorDataType == DataTypes.INT) {
+        for (int i = 0; i < size; i += DataTypes.INT.getSizeInBytes()) {
+          vector.putInt(rowId++, ByteUtil.toIntLittleEndian(pageData, pageIndex + i));
+        }
+      } else if (vectorDataType == DataTypes.LONG) {
+        for (int i = 0; i < size; i += DataTypes.INT.getSizeInBytes()) {
+          vector.putLong(rowId++, ByteUtil.toIntLittleEndian(pageData, pageIndex + i));
+        }
+      } else if (vectorDataType == DataTypes.TIMESTAMP) {
+        for (int i = 0; i < size; i += DataTypes.INT.getSizeInBytes()) {
+          vector
+              .putLong(rowId++, (long) ByteUtil.toIntLittleEndian(pageData, pageIndex + i) * 1000);
+        }
+      } else if (DataTypes.isDecimal(vectorDataType)) {
+        DecimalConverterFactory.DecimalConverter decimalConverter = vectorInfo.decimalConverter;
+        decimalConverter.fillVector(pageData, pageSize, vectorInfo, nullBits, pageDataType);
+      } else {
+        for (int i = 0; i < size; i += DataTypes.INT.getSizeInBytes()) {
+          vector.putDouble(rowId++, (ByteUtil.toIntLittleEndian(pageData, pageIndex + i)));
+        }
+      }
+      pageIndex += size;
+    } else if (pageDataType == DataTypes.LONG) {
+      int size = pageSize * DataTypes.LONG.getSizeInBytes();
+      if (vectorDataType == DataTypes.LONG) {
+        for (int i = 0; i < size; i += DataTypes.LONG.getSizeInBytes()) {
+          vector.putLong(rowId++, ByteUtil.toLongLittleEndian(pageData, pageIndex + i));
+        }
+      } else if (vectorDataType == DataTypes.TIMESTAMP) {
+        for (int i = 0; i < size; i += DataTypes.LONG.getSizeInBytes()) {
+          vector.putLong(rowId++, ByteUtil.toLongLittleEndian(pageData, pageIndex + i) * 1000);
+        }
+      } else if (DataTypes.isDecimal(vectorDataType)) {
+        DecimalConverterFactory.DecimalConverter decimalConverter = vectorInfo.decimalConverter;
+        decimalConverter.fillVector(pageData, pageSize, vectorInfo, nullBits, pageDataType);
+      }
+      pageIndex += size;
+    } else if (vectorDataType == DataTypes.FLOAT) {
+      int size = pageSize * DataTypes.FLOAT.getSizeInBytes();
+      for (int i = 0; i < size; i += DataTypes.FLOAT.getSizeInBytes()) {
+        vector.putFloat(rowId++, (ByteUtil.toFloatLittleEndian(this.pageData, pageIndex + i)));
+      }
+      pageIndex += size;
+    } else {
+      int size = pageSize * DataTypes.DOUBLE.getSizeInBytes();
+      for (int i = 0; i < size; i += DataTypes.DOUBLE.getSizeInBytes()) {
+        vector.putDouble(rowId++, (ByteUtil.toDoubleLittleEndian(pageData, pageIndex + i)));
+      }
+      pageIndex += size;
+    }
+    vector.setIndex(pageIndex);
+  }
+
+  private void typeArray(CarbonColumnVectorImpl vector, int len, DataType pageDataType) {
+    ArrayList<Integer> childElements = vector.getChildrenElements();
+    int childIndex = vector.getIndex();
+
+    for (int i = 0; i < len; i++) {
+      typeComplexObject(vector.getChildrenVector().get(0), childElements.get(childIndex),
+          pageDataType);
+      vector.putArrayObject();
+      childIndex++;
+    }
+    vector.setIndex(childIndex);
+
+  }
+
+  // Filling of respective complex types - array/map/struct
+  private void typeComplexObject(CarbonColumnVectorImpl vector, int len, DataType pageDataType) {
+    if (vector.isComplex()) {
+      if (vector.getDataTypeName().equals("ARRAY")) {
+        typeArray(vector, len, pageDataType);
+      }
+      // TODO: Similarly should handle cases for Map and Struct too
+    } else {
+      fillPrimitiveType(vector, vector.getType(), len, pageDataType);
+    }
+  }
+}

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/compress/DirectCompressCodec.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/compress/DirectCompressCodec.java
@@ -19,10 +19,7 @@ package org.apache.carbondata.core.datastore.page.encoding.compress;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.BitSet;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import org.apache.carbondata.core.datastore.ReusableDataBuffer;
 import org.apache.carbondata.core.datastore.TableSpec;
@@ -32,26 +29,22 @@ import org.apache.carbondata.core.datastore.page.ColumnPage;
 import org.apache.carbondata.core.datastore.page.ColumnPageValueConverter;
 import org.apache.carbondata.core.datastore.page.LazyColumnPage;
 import org.apache.carbondata.core.datastore.page.VarLengthColumnPageBase;
-import org.apache.carbondata.core.datastore.page.encoding.ColumnPageCodec;
-import org.apache.carbondata.core.datastore.page.encoding.ColumnPageDecoder;
-import org.apache.carbondata.core.datastore.page.encoding.ColumnPageEncoder;
-import org.apache.carbondata.core.datastore.page.encoding.ColumnPageEncoderMeta;
+import org.apache.carbondata.core.datastore.page.encoding.*;
 import org.apache.carbondata.core.metadata.datatype.DataType;
 import org.apache.carbondata.core.metadata.datatype.DataTypes;
 import org.apache.carbondata.core.metadata.datatype.DecimalConverterFactory;
 import org.apache.carbondata.core.scan.result.vector.CarbonColumnVector;
 import org.apache.carbondata.core.scan.result.vector.ColumnVectorInfo;
+import org.apache.carbondata.core.scan.result.vector.impl.CarbonColumnVectorImpl;
 import org.apache.carbondata.core.scan.result.vector.impl.directread.ColumnarVectorWrapperDirectFactory;
 import org.apache.carbondata.core.scan.result.vector.impl.directread.ConvertibleVector;
 import org.apache.carbondata.core.scan.result.vector.impl.directread.SequentialFill;
-import org.apache.carbondata.core.util.ByteUtil;
 import org.apache.carbondata.format.Encoding;
 
 /**
  * This codec directly apply compression on the input data
  */
 public class DirectCompressCodec implements ColumnPageCodec {
-
   private DataType dataType;
 
   public DirectCompressCodec(DataType dataType) {
@@ -246,7 +239,37 @@ public class DirectCompressCodec implements ColumnPageCodec {
       vector = ColumnarVectorWrapperDirectFactory
           .getDirectVectorWrapperFactory(vector, vectorInfo.invertedIndex, nullBits, deletedRows,
               true, false);
-      fillVector(pageData, vector, vectorDataType, pageDataType, pageSize, vectorInfo, nullBits);
+      Stack<CarbonColumnVectorImpl> vectorStack = vectorInfo.getVectorStack();
+      // Only if vectorStack is null, it is initialized with the parent vector
+      if (vectorStack == null && vectorInfo.vector.getColumnVector() != null) {
+        vectorStack = new Stack<>();
+        // pushing the parent vector
+        vectorStack.push((CarbonColumnVectorImpl) vectorInfo.vector.getColumnVector());
+        vectorInfo.setVectorStack(vectorStack);
+      }
+      /*
+       * if top of vector stack is a complex vector then
+       * add their children into the stack and load them too.
+       * TODO: If there are multiple children push them into stack and load them iteratively
+       */
+      CarbonColumnVectorImpl parentVector = null;
+      if (vectorStack != null && vectorStack.peek().isComplex()) {
+        if (vectorStack.size() > 1) {
+          parentVector = vectorStack.get(vectorStack.size() - 2);
+        }
+        vectorStack.peek().setChildrenElements(pageData, parentVector, pageSize);
+
+        vectorStack.push(vectorStack.peek().getChildrenVector().get(0));
+        vectorStack.peek().loadPage();
+        return;
+      }
+
+      FillVector fill = new FillVector(pageData, vectorInfo, nullBits);
+      fill.basedOnType(vector, vectorDataType, pageSize, pageDataType);
+      if (vectorStack != null && vectorStack.size() > 0) {
+        vectorStack.pop();
+      }
+
       if ((deletedRows == null || deletedRows.isEmpty())
           && !(vectorInfo.vector instanceof SequentialFill)) {
         for (int i = nullBits.nextSetBit(0); i >= 0; i = nullBits.nextSetBit(i + 1)) {
@@ -255,137 +278,6 @@ public class DirectCompressCodec implements ColumnPageCodec {
       }
       if (vector instanceof ConvertibleVector) {
         ((ConvertibleVector) vector).convert();
-      }
-    }
-
-    private void fillVector(byte[] pageData, CarbonColumnVector vector, DataType vectorDataType,
-        DataType pageDataType, int pageSize, ColumnVectorInfo vectorInfo, BitSet nullBits) {
-      int rowId = 0;
-      if (pageDataType == DataTypes.BOOLEAN || pageDataType == DataTypes.BYTE) {
-        if (vectorDataType == DataTypes.SHORT) {
-          for (int i = 0; i < pageSize; i++) {
-            vector.putShort(i, pageData[i]);
-          }
-        } else if (vectorDataType == DataTypes.INT) {
-          for (int i = 0; i < pageSize; i++) {
-            vector.putInt(i, pageData[i]);
-          }
-        } else if (vectorDataType == DataTypes.LONG) {
-          for (int i = 0; i < pageSize; i++) {
-            vector.putLong(i, pageData[i]);
-          }
-        } else if (vectorDataType == DataTypes.TIMESTAMP) {
-          for (int i = 0; i < pageSize; i++) {
-            vector.putLong(i, (long) pageData[i] * 1000);
-          }
-        } else if (vectorDataType == DataTypes.BOOLEAN || vectorDataType == DataTypes.BYTE) {
-          vector.putBytes(0, pageSize, pageData, 0);
-        } else if (DataTypes.isDecimal(vectorDataType)) {
-          DecimalConverterFactory.DecimalConverter decimalConverter = vectorInfo.decimalConverter;
-          decimalConverter.fillVector(pageData, pageSize, vectorInfo, nullBits, pageDataType);
-        } else {
-          for (int i = 0; i < pageSize; i++) {
-            vector.putDouble(i, pageData[i]);
-          }
-        }
-      } else if (pageDataType == DataTypes.SHORT) {
-        int size = pageSize * DataTypes.SHORT.getSizeInBytes();
-        if (vectorDataType == DataTypes.SHORT) {
-          for (int i = 0; i < size; i += DataTypes.SHORT.getSizeInBytes()) {
-            vector.putShort(rowId++, (ByteUtil.toShortLittleEndian(pageData, i)));
-          }
-        } else if (vectorDataType == DataTypes.INT) {
-          for (int i = 0; i < size; i += DataTypes.SHORT.getSizeInBytes()) {
-            vector.putInt(rowId++, ByteUtil.toShortLittleEndian(pageData, i));
-          }
-        } else if (vectorDataType == DataTypes.LONG) {
-          for (int i = 0; i < size; i += DataTypes.SHORT.getSizeInBytes()) {
-            vector.putLong(rowId++, ByteUtil.toShortLittleEndian(pageData, i));
-          }
-        } else if (vectorDataType == DataTypes.TIMESTAMP) {
-          for (int i = 0; i < size; i += DataTypes.SHORT.getSizeInBytes()) {
-            vector.putLong(rowId++, (long) ByteUtil.toShortLittleEndian(pageData, i) * 1000);
-          }
-        } else if (DataTypes.isDecimal(vectorDataType)) {
-          DecimalConverterFactory.DecimalConverter decimalConverter = vectorInfo.decimalConverter;
-          decimalConverter.fillVector(pageData, pageSize, vectorInfo, nullBits, pageDataType);
-        } else {
-          for (int i = 0; i < size; i += DataTypes.SHORT.getSizeInBytes()) {
-            vector.putDouble(rowId++, ByteUtil.toShortLittleEndian(pageData, i));
-          }
-        }
-
-      } else if (pageDataType == DataTypes.SHORT_INT) {
-        if (vectorDataType == DataTypes.INT) {
-          for (int i = 0; i < pageSize; i++) {
-            int shortInt = ByteUtil.valueOf3Bytes(pageData, i * 3);
-            vector.putInt(i, shortInt);
-          }
-        } else if (vectorDataType == DataTypes.LONG) {
-          for (int i = 0; i < pageSize; i++) {
-            int shortInt = ByteUtil.valueOf3Bytes(pageData, i * 3);
-            vector.putLong(i, shortInt);
-          }
-        } else if (vectorDataType == DataTypes.TIMESTAMP) {
-          for (int i = 0; i < pageSize; i++) {
-            int shortInt = ByteUtil.valueOf3Bytes(pageData, i * 3);
-            vector.putLong(i, (long) shortInt * 1000);
-          }
-        } else if (DataTypes.isDecimal(vectorDataType)) {
-          DecimalConverterFactory.DecimalConverter decimalConverter = vectorInfo.decimalConverter;
-          decimalConverter.fillVector(pageData, pageSize, vectorInfo, nullBits, pageDataType);
-        } else {
-          for (int i = 0; i < pageSize; i++) {
-            int shortInt = ByteUtil.valueOf3Bytes(pageData, i * 3);
-            vector.putDouble(i, shortInt);
-          }
-        }
-      } else if (pageDataType == DataTypes.INT) {
-        int size = pageSize * DataTypes.INT.getSizeInBytes();
-        if (vectorDataType == DataTypes.INT) {
-          for (int i = 0; i < size; i += DataTypes.INT.getSizeInBytes()) {
-            vector.putInt(rowId++, ByteUtil.toIntLittleEndian(pageData, i));
-          }
-        } else if (vectorDataType == DataTypes.LONG) {
-          for (int i = 0; i < size; i += DataTypes.INT.getSizeInBytes()) {
-            vector.putLong(rowId++, ByteUtil.toIntLittleEndian(pageData, i));
-          }
-        } else if (vectorDataType == DataTypes.TIMESTAMP) {
-          for (int i = 0; i < size; i += DataTypes.INT.getSizeInBytes()) {
-            vector.putLong(rowId++, (long) ByteUtil.toIntLittleEndian(pageData, i) * 1000);
-          }
-        } else if (DataTypes.isDecimal(vectorDataType)) {
-          DecimalConverterFactory.DecimalConverter decimalConverter = vectorInfo.decimalConverter;
-          decimalConverter.fillVector(pageData, pageSize, vectorInfo, nullBits, pageDataType);
-        } else {
-          for (int i = 0; i < size; i += DataTypes.INT.getSizeInBytes()) {
-            vector.putDouble(rowId++, ByteUtil.toIntLittleEndian(pageData, i));
-          }
-        }
-      } else if (pageDataType == DataTypes.LONG) {
-        int size = pageSize * DataTypes.LONG.getSizeInBytes();
-        if (vectorDataType == DataTypes.LONG) {
-          for (int i = 0; i < size; i += DataTypes.LONG.getSizeInBytes()) {
-            vector.putLong(rowId++, ByteUtil.toLongLittleEndian(pageData, i));
-          }
-        } else if (vectorDataType == DataTypes.TIMESTAMP) {
-          for (int i = 0; i < size; i += DataTypes.LONG.getSizeInBytes()) {
-            vector.putLong(rowId++, ByteUtil.toLongLittleEndian(pageData, i) * 1000);
-          }
-        } else if (DataTypes.isDecimal(vectorDataType)) {
-          DecimalConverterFactory.DecimalConverter decimalConverter = vectorInfo.decimalConverter;
-          decimalConverter.fillVector(pageData, pageSize, vectorInfo, nullBits, pageDataType);
-        }
-      } else if (vectorDataType == DataTypes.FLOAT) {
-        int size = pageSize * DataTypes.FLOAT.getSizeInBytes();
-        for (int i = 0; i < size; i += DataTypes.FLOAT.getSizeInBytes()) {
-          vector.putFloat(rowId++, ByteUtil.toFloatLittleEndian(pageData, i));
-        }
-      } else {
-        int size = pageSize * DataTypes.DOUBLE.getSizeInBytes();
-        for (int i = 0; i < size; i += DataTypes.DOUBLE.getSizeInBytes()) {
-          vector.putDouble(rowId++, ByteUtil.toDoubleLittleEndian(pageData, i));
-        }
       }
     }
   };

--- a/core/src/main/java/org/apache/carbondata/core/scan/collector/impl/DictionaryBasedVectorResultCollector.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/collector/impl/DictionaryBasedVectorResultCollector.java
@@ -98,6 +98,14 @@ public class DictionaryBasedVectorResultCollector extends AbstractScannedResultC
         columnVectorInfo.dimension = queryDimensions[i];
         columnVectorInfo.ordinal = queryDimensions[i].getDimension().getOrdinal();
         allColumnInfo[queryDimensions[i].getOrdinal()] = columnVectorInfo;
+      } else if (queryDimensions[i].getDimension().isComplex()) {
+        ColumnVectorInfo columnVectorInfo = new ColumnVectorInfo();
+        complexList.add(columnVectorInfo);
+        columnVectorInfo.dimension = queryDimensions[i];
+        columnVectorInfo.ordinal = queryDimensions[i].getDimension().getOrdinal();
+        columnVectorInfo.genericQueryType =
+            executionInfo.getComplexDimensionInfoMap().get(columnVectorInfo.ordinal);
+        allColumnInfo[queryDimensions[i].getOrdinal()] = columnVectorInfo;
       } else if (queryDimensions[i].getDimension().getDataType() != DataTypes.DATE) {
         ColumnVectorInfo columnVectorInfo = new ColumnVectorInfo();
         noDictInfoList.add(columnVectorInfo);
@@ -111,14 +119,6 @@ public class DictionaryBasedVectorResultCollector extends AbstractScannedResultC
         columnVectorInfo.directDictionaryGenerator = DirectDictionaryKeyGeneratorFactory
             .getDirectDictionaryGenerator(queryDimensions[i].getDimension().getDataType());
         columnVectorInfo.ordinal = queryDimensions[i].getDimension().getOrdinal();
-        allColumnInfo[queryDimensions[i].getOrdinal()] = columnVectorInfo;
-      } else if (queryDimensions[i].getDimension().isComplex()) {
-        ColumnVectorInfo columnVectorInfo = new ColumnVectorInfo();
-        complexList.add(columnVectorInfo);
-        columnVectorInfo.dimension = queryDimensions[i];
-        columnVectorInfo.ordinal = queryDimensions[i].getDimension().getOrdinal();
-        columnVectorInfo.genericQueryType =
-            executionInfo.getComplexDimensionInfoMap().get(columnVectorInfo.ordinal);
         allColumnInfo[queryDimensions[i].getOrdinal()] = columnVectorInfo;
       } else {
         ColumnVectorInfo columnVectorInfo = new ColumnVectorInfo();
@@ -251,7 +251,7 @@ public class DictionaryBasedVectorResultCollector extends AbstractScannedResultC
 
   private void fillResultToColumnarBatch(BlockletScannedResult scannedResult) {
     scannedResult.fillDataChunks(dictionaryInfo, noDictionaryInfo, measureColumnInfo,
-        measureInfo.getMeasureOrdinals());
+        measureInfo.getMeasureOrdinals(), complexInfo);
 
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/vector/CarbonColumnVector.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/vector/CarbonColumnVector.java
@@ -18,8 +18,10 @@
 package org.apache.carbondata.core.scan.result.vector;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 import org.apache.carbondata.core.metadata.datatype.DataType;
+import org.apache.carbondata.core.scan.result.vector.impl.CarbonColumnVectorImpl;
 import org.apache.carbondata.core.scan.scanner.LazyPageLoader;
 
 public interface CarbonColumnVector {
@@ -113,5 +115,18 @@ public interface CarbonColumnVector {
   CarbonColumnVector getDictionaryVector();
 
   void setLazyPage(LazyPageLoader lazyPage);
+
+  // to get the original vector from wrapper
+  CarbonColumnVector getColumnVector();
+
+  List<CarbonColumnVectorImpl> getChildrenVector();
+
+  void putArrayObject();
+
+  // returns the start index in order to read the pageData
+  int getIndex();
+
+  // updates the last read index after reading the pageData
+  void setIndex(int index);
 
 }

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/vector/ColumnVectorInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/vector/ColumnVectorInfo.java
@@ -18,12 +18,14 @@
 package org.apache.carbondata.core.scan.result.vector;
 
 import java.util.BitSet;
+import java.util.Stack;
 
 import org.apache.carbondata.core.keygenerator.directdictionary.DirectDictionaryGenerator;
 import org.apache.carbondata.core.metadata.datatype.DecimalConverterFactory;
 import org.apache.carbondata.core.scan.filter.GenericQueryType;
 import org.apache.carbondata.core.scan.model.ProjectionDimension;
 import org.apache.carbondata.core.scan.model.ProjectionMeasure;
+import org.apache.carbondata.core.scan.result.vector.impl.CarbonColumnVectorImpl;
 
 public class ColumnVectorInfo implements Comparable<ColumnVectorInfo> {
   public int offset;
@@ -39,6 +41,15 @@ public class ColumnVectorInfo implements Comparable<ColumnVectorInfo> {
   public int[] invertedIndex;
   public BitSet deletedRows;
   public DecimalConverterFactory.DecimalConverter decimalConverter;
+  public Stack<CarbonColumnVectorImpl> vectorStack = null;
+
+  public Stack<CarbonColumnVectorImpl> getVectorStack() {
+    return vectorStack;
+  }
+
+  public void setVectorStack(Stack<CarbonColumnVectorImpl> vectorStack) {
+    this.vectorStack = vectorStack;
+  }
 
   @Override
   public int compareTo(ColumnVectorInfo o) {

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/vector/impl/directread/ColumnarVectorWrapperDirectWithDeleteDelta.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/vector/impl/directread/ColumnarVectorWrapperDirectWithDeleteDelta.java
@@ -19,8 +19,10 @@ package org.apache.carbondata.core.scan.result.vector.impl.directread;
 
 import java.math.BigDecimal;
 import java.util.BitSet;
+import java.util.List;
 
 import org.apache.carbondata.core.scan.result.vector.CarbonColumnVector;
+import org.apache.carbondata.core.scan.result.vector.impl.CarbonColumnVectorImpl;
 
 /**
  * Column vector for column pages which has delete delta, so it uses delta bitset to filter out
@@ -39,6 +41,31 @@ class ColumnarVectorWrapperDirectWithDeleteDelta extends AbstractCarbonColumnarV
     super(vectorWrapper);
     this.deletedRows = deletedRows;
     this.nullBits = nullBits;
+  }
+
+  @Override
+  public CarbonColumnVector getColumnVector() {
+    throw new UnsupportedOperationException("Operation not allowed");
+  }
+
+  @Override
+  public List<CarbonColumnVectorImpl> getChildrenVector() {
+    throw new UnsupportedOperationException("Operation not allowed");
+  }
+
+  @Override
+  public void putArrayObject() {
+    throw new UnsupportedOperationException("Operation not allowed");
+  }
+
+  @Override
+  public int getIndex() {
+    return 0;
+  }
+
+  @Override
+  public void setIndex(int index) {
+
   }
 
   @Override

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/vector/impl/directread/ColumnarVectorWrapperDirectWithInvertedIndex.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/vector/impl/directread/ColumnarVectorWrapperDirectWithInvertedIndex.java
@@ -18,9 +18,11 @@
 package org.apache.carbondata.core.scan.result.vector.impl.directread;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 import org.apache.carbondata.core.metadata.datatype.DataType;
 import org.apache.carbondata.core.scan.result.vector.CarbonColumnVector;
+import org.apache.carbondata.core.scan.result.vector.impl.CarbonColumnVectorImpl;
 
 /**
  * Column vector for column pages which has inverted index, so it uses inverted index
@@ -38,6 +40,31 @@ public class ColumnarVectorWrapperDirectWithInvertedIndex extends AbstractCarbon
     super(columnVector);
     this.invertedIndex = invertedIndex;
     this.isnullBitsExists = isnullBitsExists;
+  }
+
+  @Override
+  public CarbonColumnVector getColumnVector() {
+    throw new UnsupportedOperationException("Operation not allowed");
+  }
+
+  @Override
+  public List<CarbonColumnVectorImpl> getChildrenVector() {
+    throw new UnsupportedOperationException("Operation not allowed");
+  }
+
+  @Override
+  public void putArrayObject() {
+    throw new UnsupportedOperationException("Operation not allowed");
+  }
+
+  @Override
+  public int getIndex() {
+    return 0;
+  }
+
+  @Override
+  public void setIndex(int index) {
+
   }
 
   @Override

--- a/integration/presto/pom.xml
+++ b/integration/presto/pom.xml
@@ -37,7 +37,16 @@
   </properties>
 
   <dependencies>
-
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.avro</groupId>
+      <artifactId>avro</artifactId>
+      <version>1.8.1</version>
+    </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/CarbonColumnVectorWrapper.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/CarbonColumnVectorWrapper.java
@@ -18,6 +18,7 @@
 package org.apache.carbondata.presto;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 import org.apache.carbondata.core.metadata.datatype.DataType;
 import org.apache.carbondata.core.scan.result.vector.CarbonColumnVector;
@@ -46,6 +47,26 @@ public class CarbonColumnVectorWrapper implements CarbonColumnVector {
       dictionaryVectorWrapper = new CarbonColumnVectorWrapper(
               (CarbonColumnVectorImpl)columnVector.getDictionaryVector(), filteredRows);
     }
+  }
+
+  public CarbonColumnVector getColumnVector() {
+    throw new UnsupportedOperationException("Operation not allowed");
+  }
+
+  public List<CarbonColumnVectorImpl> getChildrenVector() {
+    throw new UnsupportedOperationException("Operation not allowed");
+  }
+
+  public void putArrayObject() {
+    throw new UnsupportedOperationException("Operation not allowed");
+  }
+
+  public int getIndex() {
+    throw new UnsupportedOperationException("Operation not allowed");
+  }
+
+  public void setIndex(int index) {
+    throw new UnsupportedOperationException("Operation not allowed");
   }
 
   @Override

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/CarbonVectorBatch.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/CarbonVectorBatch.java
@@ -22,22 +22,9 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.apache.carbondata.core.constants.CarbonV3DataFormatConstants;
-import org.apache.carbondata.core.metadata.datatype.DataType;
-import org.apache.carbondata.core.metadata.datatype.DataTypes;
-import org.apache.carbondata.core.metadata.datatype.DecimalType;
-import org.apache.carbondata.core.metadata.datatype.StructField;
+import org.apache.carbondata.core.metadata.datatype.*;
 import org.apache.carbondata.core.scan.result.vector.impl.CarbonColumnVectorImpl;
-import org.apache.carbondata.presto.readers.BooleanStreamReader;
-import org.apache.carbondata.presto.readers.ByteStreamReader;
-import org.apache.carbondata.presto.readers.DecimalSliceStreamReader;
-import org.apache.carbondata.presto.readers.DoubleStreamReader;
-import org.apache.carbondata.presto.readers.FloatStreamReader;
-import org.apache.carbondata.presto.readers.IntegerStreamReader;
-import org.apache.carbondata.presto.readers.LongStreamReader;
-import org.apache.carbondata.presto.readers.ObjectStreamReader;
-import org.apache.carbondata.presto.readers.ShortStreamReader;
-import org.apache.carbondata.presto.readers.SliceStreamReader;
-import org.apache.carbondata.presto.readers.TimestampStreamReader;
+import org.apache.carbondata.presto.readers.*;
 
 public class CarbonVectorBatch {
 
@@ -103,6 +90,10 @@ public class CarbonVectorBatch {
       } else {
         return null;
       }
+    } else if (DataTypes.isArrayType(field.getDataType())) {
+
+      StructField childField = field.getChildren().get(0);
+      return new ArrayStreamReader(batchSize, childField.getDataType(), field.getChildren().get(0));
     } else {
       return new ObjectStreamReader(batchSize, field.getDataType());
     }

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/ColumnarVectorWrapperDirect.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/ColumnarVectorWrapperDirect.java
@@ -19,6 +19,7 @@ package org.apache.carbondata.presto;
 
 import java.math.BigDecimal;
 import java.util.BitSet;
+import java.util.List;
 
 import org.apache.carbondata.core.metadata.datatype.DataType;
 import org.apache.carbondata.core.scan.result.vector.CarbonColumnVector;
@@ -203,8 +204,29 @@ class ColumnarVectorWrapperDirect implements CarbonColumnVector, SequentialFill 
 
   @Override
   public void putObject(int rowId, Object obj) {
-    throw new UnsupportedOperationException(
-        "Not supported this opeartion from " + this.getClass().getName());
+    columnVector.putObject(rowId, obj);
+  }
+
+  public CarbonColumnVectorImpl getColumnVector() {
+    return this.columnVector;
+  }
+
+  public List<CarbonColumnVectorImpl> getChildrenVector() {
+    return null;
+  }
+
+  public void putArrayObject() {
+    columnVector.putArrayObject();
+  }
+
+  @Override
+  public int getIndex() {
+    return 0;
+  }
+
+  @Override
+  public void setIndex(int index) {
+
   }
 
   @Override

--- a/integration/presto/src/main/prestosql/org/apache/carbondata/presto/readers/ArrayStreamReader.java
+++ b/integration/presto/src/main/prestosql/org/apache/carbondata/presto/readers/ArrayStreamReader.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.presto.readers;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.prestosql.spi.type.*;
+
+import org.apache.carbondata.core.metadata.datatype.DataType;
+import org.apache.carbondata.core.metadata.datatype.DataTypes;
+import org.apache.carbondata.core.metadata.datatype.StructField;
+import org.apache.carbondata.core.scan.result.vector.impl.CarbonColumnVectorImpl;
+
+import io.prestosql.spi.block.Block;
+import io.prestosql.spi.block.BlockBuilder;
+
+import org.apache.carbondata.presto.CarbonVectorBatch;
+
+/**
+ * Class to read the Array Stream
+ */
+
+public class ArrayStreamReader extends CarbonColumnVectorImpl implements PrestoVectorBlockBuilder {
+
+  protected int batchSize;
+
+  protected Type type;
+  protected BlockBuilder builder;
+  Block childBlock = null;
+  private int index = 0;
+
+  public ArrayStreamReader(int batchSize, DataType dataType, StructField field) {
+    super(batchSize, dataType);
+    this.batchSize = batchSize;
+    this.type = getArrayOfType(field, dataType);
+    ArrayList<CarbonColumnVectorImpl> childrenList= new ArrayList<>();
+    childrenList.add(CarbonVectorBatch.createDirectStreamReader(this.batchSize, field.getDataType(), field));
+    setChildrenVector(childrenList);
+    this.builder = type.createBlockBuilder(null, batchSize);
+  }
+
+  public int getIndex() {
+    return index;
+  }
+
+  public void setIndex(int index) {
+    this.index = index;
+  }
+
+  public String getDataTypeName() {
+    return "ARRAY";
+  }
+
+  Type getArrayOfType(StructField field, DataType dataType) {
+    if (dataType == DataTypes.STRING) {
+      return new ArrayType(VarcharType.VARCHAR);
+    } else if (dataType == DataTypes.BYTE) {
+      return new ArrayType(TinyintType.TINYINT);
+    } else if (dataType == DataTypes.SHORT) {
+      return new ArrayType(SmallintType.SMALLINT);
+    } else if (dataType == DataTypes.INT) {
+      return new ArrayType(IntegerType.INTEGER);
+    } else if (dataType == DataTypes.LONG) {
+      return new ArrayType(BigintType.BIGINT);
+    } else if (dataType == DataTypes.DOUBLE) {
+      return new ArrayType(DoubleType.DOUBLE);
+    } else if (dataType == DataTypes.FLOAT) {
+      return new ArrayType(RealType.REAL);
+    } else if (dataType == DataTypes.BOOLEAN) {
+      return new ArrayType(BooleanType.BOOLEAN);
+    } else if (dataType == DataTypes.TIMESTAMP) {
+      return new ArrayType(TimestampType.TIMESTAMP);
+    } else if (DataTypes.isArrayType(dataType)) {
+      StructField childField = field.getChildren().get(0);
+      return new ArrayType(getArrayOfType(childField, childField.getDataType()));
+    } else {
+      throw new UnsupportedOperationException("Unsupported type: " + dataType);
+    }
+  }
+
+  @Override
+  public Block buildBlock() {
+    return builder.build();
+  }
+
+  public boolean isComplex() {
+    return true;
+  }
+
+  @Override
+  public void setBatchSize(int batchSize) {
+    this.batchSize = batchSize;
+  }
+
+  @Override
+  public void putObject(int rowId, Object value) {
+    if (value == null) {
+      putNull(rowId);
+    } else {
+      getChildrenVector().get(0).putObject(rowId, value);
+    }
+  }
+
+  public void putArrayObject() {
+    if (DataTypes.isArrayType(this.getType())) {
+      childBlock = ((ArrayStreamReader) getChildrenVector().get(0)).buildBlock();
+    } else if (this.getType() == DataTypes.STRING) {
+      childBlock = ((SliceStreamReader) getChildrenVector().get(0)).buildBlock();
+    } else if (this.getType() == DataTypes.INT) {
+      childBlock = ((IntegerStreamReader) getChildrenVector().get(0)).buildBlock();
+    } else if (this.getType() == DataTypes.LONG) {
+      childBlock = ((LongStreamReader) getChildrenVector().get(0)).buildBlock();
+    } else if (this.getType() == DataTypes.DOUBLE) {
+      childBlock = ((DoubleStreamReader) getChildrenVector().get(0)).buildBlock();
+    } else if (this.getType() == DataTypes.FLOAT) {
+      childBlock = ((FloatStreamReader) getChildrenVector().get(0)).buildBlock();
+    } else if (this.getType() == DataTypes.BOOLEAN) {
+      childBlock = ((BooleanStreamReader) getChildrenVector().get(0)).buildBlock();
+    } else if (this.getType() == DataTypes.BYTE) {
+      childBlock = ((ByteStreamReader) getChildrenVector().get(0)).buildBlock();
+    } else if (this.getType() == DataTypes.TIMESTAMP) {
+      childBlock = ((TimestampStreamReader) getChildrenVector().get(0)).buildBlock();
+    } else if (this.getType() == DataTypes.SHORT) {
+      childBlock = ((ShortStreamReader) getChildrenVector().get(0)).buildBlock();
+    }
+    type.writeObject(builder, childBlock);
+    getChildrenVector().get(0).reset();
+  }
+
+  @Override
+  public void putNull(int rowId) {
+    builder.appendNull();
+  }
+
+  @Override
+  public void reset() {
+    builder = type.createBlockBuilder(null, batchSize);
+  }
+
+  @Override
+  public void putNulls(int rowId, int count) {
+    for (int i = 0; i < count; i++) {
+      builder.appendNull();
+    }
+  }
+}
+

--- a/integration/presto/src/main/prestosql/org/apache/carbondata/presto/readers/IntegerStreamReader.java
+++ b/integration/presto/src/main/prestosql/org/apache/carbondata/presto/readers/IntegerStreamReader.java
@@ -34,6 +34,16 @@ public class IntegerStreamReader extends CarbonColumnVectorImpl
 
   protected BlockBuilder builder;
 
+  private int index = 0;
+
+  public int getIndex() {
+    return index;
+  }
+
+  public void setIndex(int index) {
+    this.index = index;
+  }
+
   public IntegerStreamReader(int batchSize, DataType dataType) {
     super(batchSize, dataType);
     this.batchSize = batchSize;

--- a/integration/presto/src/main/prestosql/org/apache/carbondata/presto/readers/SliceStreamReader.java
+++ b/integration/presto/src/main/prestosql/org/apache/carbondata/presto/readers/SliceStreamReader.java
@@ -151,7 +151,7 @@ public class SliceStreamReader extends CarbonColumnVectorImpl implements PrestoV
       putNull(rowId);
     } else {
       if (dictionaryBlock == null) {
-        putByteArray(rowId, ByteUtil.toBytes((String) value));
+        putByteArray(rowId, (byte []) value);
       } else {
         putInt(rowId, (int) value);
       }

--- a/integration/presto/src/test/scala/org/apache/carbondata/presto/integrationtest/GenerateFiles.scala
+++ b/integration/presto/src/test/scala/org/apache/carbondata/presto/integrationtest/GenerateFiles.scala
@@ -1,0 +1,545 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.presto.integrationtest
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, DataInputStream, File, InputStream}
+import java.util
+
+import scala.collection.JavaConverters._
+
+import org.apache.avro
+import org.apache.avro.file.DataFileWriter
+import org.apache.avro.generic.{GenericDatumReader, GenericDatumWriter, GenericRecord}
+import org.apache.avro.io.{DecoderFactory, Encoder}
+import org.junit.Assert
+
+import org.apache.carbondata.sdk.file.CarbonWriter
+
+class GenerateFiles {
+
+  def singleLevelArrayFile() = {
+    val json1: String =
+      """ {"stringCol": "bob","intCol": 14,"doubleCol": 10.5,"realCol": 12.7,
+        |"boolCol": true,"arrayStringCol1":["Street1"],"arrayStringCol2": ["India", "Egypt"],
+        |"arrayIntCol": [1,2,3],"arrayBigIntCol":[70000,600000000],"arrayRealCol":[1.111,2.2],
+        |"arrayDoubleCol":[1.1,2.2,3.3], "arrayBooleanCol": [true, false, true]} """.stripMargin
+    val json2: String =
+      """ {"stringCol": "Alex","intCol": 15,"doubleCol": 11.5,"realCol": 13.7,
+        |"boolCol": true, "arrayStringCol1": ["Street1", "Street2"],"arrayStringCol2": ["Japan",
+        |"China", "India"],"arrayIntCol": [1,2,3,4],"arrayBigIntCol":[70000,600000000,8000],
+        |"arrayRealCol":[1.1,2.2,3.3],"arrayDoubleCol":[1.1,2.2,4.45,3.3],
+        |"arrayBooleanCol": [true, true, true]} """.stripMargin
+    val json3: String =
+      """ {"stringCol": "Rio","intCol": 16,"doubleCol": 12.5,"realCol": 14.7,
+        |"boolCol": true, "arrayStringCol1": ["Street1", "Street2","Street3"],
+        |"arrayStringCol2": ["China", "Brazil", "Paris", "France"],"arrayIntCol": [1,2,3,4,5],
+        |"arrayBigIntCol":[70000,600000000,8000,9111111111],"arrayRealCol":[1.1,2.2,3.3,4.45],
+        |"arrayDoubleCol":[1.1,2.2,4.45,5.5,3.3], "arrayBooleanCol": [true, false, true]} """
+        .stripMargin
+    val json4: String =
+      """ {"stringCol": "bob","intCol": 14,"doubleCol": 10.5,"realCol": 12.7,
+        |"boolCol": true, "arrayStringCol1":["Street1"],"arrayStringCol2": ["India", "Egypt"],
+        |"arrayIntCol": [1,2,3],"arrayBigIntCol":[70000,600000000],"arrayRealCol":[1.1,2.2],
+        |"arrayDoubleCol":[1.1,2.2,3.3], "arrayBooleanCol": [true, false, true]} """.stripMargin
+    val json5: String =
+      """ {"stringCol": "Alex","intCol": 15,"doubleCol": 11.5,"realCol": 13.7,
+        |"boolCol": true, "arrayStringCol1": ["Street1", "Street2"],"arrayStringCol2": ["Japan",
+        |"China", "India"],"arrayIntCol": [1,2,3,4],"arrayBigIntCol":[70000,600000000,8000],
+        |"arrayRealCol":[1.1,2.2,3.3],"arrayDoubleCol":[4,1,21.222,15.231],
+        |"arrayBooleanCol": [false, false, false]} """.stripMargin
+
+
+    val mySchema =
+      """ {
+        |      "name": "address",
+        |      "type": "record",
+        |      "fields": [
+        |      {
+        |      "name": "stringCol",
+        |      "type": "string"
+        |      },
+        |      {
+        |      "name": "intCol",
+        |      "type": "int"
+        |      },
+        |      {
+        |      "name": "doubleCol",
+        |      "type": "double"
+        |      },
+        |      {
+        |      "name": "realCol",
+        |      "type": "float"
+        |      },
+        |      {
+        |      "name": "boolCol",
+        |      "type": "boolean"
+        |      },
+        |      {
+        |      "name": "arrayStringCol1",
+        |      "type": {
+        |      "type": "array",
+        |      "items": {
+        |      "name": "street",
+        |      "type": "string"
+        |      }
+        |      }
+        |      },
+        |      {
+        |      "name": "arrayStringCol2",
+        |      "type": {
+        |      "type": "array",
+        |      "items": {
+        |      "name": "street",
+        |      "type": "string"
+        |      }
+        |      }
+        |      },
+        |      {
+        |      "name": "arrayIntCol",
+        |      "type": {
+        |      "type": "array",
+        |      "items": {
+        |      "name": "street",
+        |      "type": "int"
+        |      }
+        |      }
+        |      },
+        |      {
+        |      "name": "arrayBigIntCol",
+        |      "type": {
+        |      "type": "array",
+        |      "items": {
+        |      "name": "street",
+        |      "type": "long"
+        |      }
+        |      }
+        |      },
+        |      {
+        |      "name": "arrayRealCol",
+        |      "type": {
+        |      "type": "array",
+        |      "items": {
+        |      "name": "street",
+        |      "type": "float"
+        |      }
+        |      }
+        |      },
+        |      {
+        |      "name": "arrayDoubleCol",
+        |      "type": {
+        |      "type": "array",
+        |      "items": {
+        |      "name": "street",
+        |      "type": "double"
+        |      }
+        |      }
+        |      },
+        |      {
+        |      "name": "arrayBooleanCol",
+        |      "type": {
+        |      "type": "array",
+        |      "items": {
+        |      "name": "street",
+        |      "type": "boolean"
+        |      }
+        |      }
+        |      }
+        |      ]
+        |  }
+                   """.stripMargin
+
+    val nn = new avro.Schema.Parser().parse(mySchema)
+    val record1 = jsonToAvro(json1, mySchema)
+    val record2 = jsonToAvro(json2, mySchema)
+    val record3 = jsonToAvro(json3, mySchema)
+    val record4 = jsonToAvro(json4, mySchema)
+    val record5 = jsonToAvro(json5, mySchema)
+    var writerPath = new File(this.getClass.getResource("/").getPath
+                              + "../../target/store/sdk_output/files")
+      .getCanonicalPath
+    //getCanonicalPath gives path with \, but the code expects /.
+    writerPath = writerPath.replace("\\", "/")
+    try {
+      val writer = CarbonWriter.builder
+        .outputPath(writerPath)
+        .enableLocalDictionary(false)
+        .uniqueIdentifier(System.currentTimeMillis())
+        .withAvroInput(nn)
+        .writtenBy("GenerateFiles")
+        .build()
+      writer.write(record1)
+      writer.write(record2)
+      writer.write(record3)
+      writer.write(record4)
+      writer.write(record5)
+      writer.close()
+    } catch {
+      case e: Exception =>
+        Assert.fail(e.getMessage)
+    }
+  }
+
+  def twoLevelArrayFile() = {
+    val json1 =
+      """   {
+        |         "arrayArrayInt": [[1,2,3], [4,5]],
+        |         "arrayArrayBigInt":[[90000,600000000],[8000],[911111111]],
+        |         "arrayArrayReal":[[1.111,2.2], [9.139,2.98]],
+        |         "arrayArrayDouble":[[1.111,2.2], [9.139,2.98989898]],
+        |         "arrayArrayString":[["Japan", "China"], ["India"]],
+        |         "arrayArrayBoolean":[[false, false], [false]]
+        |        }   """.stripMargin
+    val json2 =
+      """   {
+        |         "arrayArrayInt": [[1,2,3], [0,5], [1,2,3,4,5], [4,5]],
+        |         "arrayArrayBigInt":[[40000, 600000000, 8000],[9111111111]],
+        |         "arrayArrayReal":[[1.111, 2.2], [9.139, 2.98], [9.99]],
+        |         "arrayArrayDouble":[[1.111, 2.2],[9.139777, 2.98],[9.99888]],
+        |         "arrayArrayString":[["China", "Brazil"], ["Paris", "France"]],
+        |         "arrayArrayBoolean":[[false], [true, false]]
+        |        }   """.stripMargin
+    val json3 =
+      """   {
+        |         "arrayArrayInt": [[1], [0], [3], [4,5]],
+        |         "arrayArrayBigInt":[[5000],[600000000],[8000,9111111111],[20000],[600000000,
+        |         8000,9111111111]],
+        |         "arrayArrayReal":[[9.198]],
+        |         "arrayArrayDouble":[[0.1987979]],
+        |         "arrayArrayString":[["Japan", "China", "India"]],
+        |         "arrayArrayBoolean":[[false, true, false]]
+        |        }   """.stripMargin
+    val json4 =
+      """   {
+        |         "arrayArrayInt": [[0,9,0,1,3,2,3,4,7]],
+        |         "arrayArrayBigInt":[[5000, 600087000, 8000, 9111111111, 20000, 600000000, 8000,
+        |          977777]],
+        |         "arrayArrayReal":[[1.111, 2.2], [9.139, 2.98, 4.67], [2.91, 2.2], [9.139, 2.98]],
+        |         "arrayArrayDouble":[[1.111, 2.0, 4.67, 2.91, 2.2, 9.139, 2.98]],
+        |         "arrayArrayString":[["Japan"], ["China"], ["India"]],
+        |         "arrayArrayBoolean":[[false], [true], [false]]
+        |        }   """.stripMargin
+
+    val mySchema =
+      """ {
+        |	"name": "address",
+        |	"type": "record",
+        |	"fields": [
+        |  {
+        |			"name": "arrayArrayInt",
+        |			"type": {
+        |				"type": "array",
+        |				"items": {
+        |					"name": "FloorNum",
+        |					"type": "array",
+        |					"items": {
+        |							"name": "EachdoorNums",
+        |							"type": "int"
+        |						}
+        |				}
+        |			}
+        |		},
+        |  {
+        |			"name": "arrayArrayBigInt",
+        |			"type": {
+        |				"type": "array",
+        |				"items": {
+        |					"name": "FloorNum",
+        |					"type": "array",
+        |					"items": {
+        |							"name": "EachdoorNums",
+        |							"type": "long"
+        |						}
+        |				}
+        |			}
+        |		},
+        |  {
+        |			"name": "arrayArrayReal",
+        |			"type": {
+        |				"type": "array",
+        |				"items": {
+        |					"name": "FloorNum",
+        |					"type": "array",
+        |					"items": {
+        |							"name": "EachdoorNums",
+        |							"type": "float"
+        |						}
+        |				}
+        |			}
+        |		},
+        |  {
+        |			"name": "arrayArrayDouble",
+        |			"type": {
+        |				"type": "array",
+        |				"items": {
+        |					"name": "FloorNum",
+        |					"type": "array",
+        |					"items": {
+        |							"name": "EachdoorNums",
+        |							"type": "double"
+        |						}
+        |				}
+        |			}
+        |		},
+        |  {
+        |			"name": "arrayArrayString",
+        |			"type": {
+        |				"type": "array",
+        |				"items": {
+        |					"name": "FloorNum",
+        |					"type": "array",
+        |					"items": {
+        |							"name": "EachdoorNums",
+        |							"type": "string"
+        |						}
+        |				}
+        |			}
+        |		},
+        |  {
+        |			"name": "arrayArrayBoolean",
+        |			"type": {
+        |				"type": "array",
+        |				"items": {
+        |					"name": "FloorNum",
+        |					"type": "array",
+        |					"items": {
+        |							"name": "EachdoorNums",
+        |							"type": "boolean"
+        |						}
+        |				}
+        |			}
+        |		}
+        |	]
+        |} """.stripMargin
+
+    val nn = new avro.Schema.Parser().parse(mySchema)
+    val record1 = jsonToAvro(json1, mySchema)
+    val record2 = jsonToAvro(json2, mySchema)
+    val record3 = jsonToAvro(json3, mySchema)
+    val record4 = jsonToAvro(json4, mySchema)
+    var writerPath = new File(this.getClass.getResource("/").getPath
+                              + "../../target/store/sdk_output/files2")
+      .getCanonicalPath
+    //getCanonicalPath gives path with \, but the code expects /.
+    writerPath = writerPath.replace("\\", "/")
+    try {
+      val writer = CarbonWriter.builder
+        .outputPath(writerPath)
+        .enableLocalDictionary(false)
+        .uniqueIdentifier(System.currentTimeMillis())
+        .withAvroInput(nn)
+        .writtenBy("GenerateFiles")
+        .build()
+      writer.write(record1)
+      writer.write(record2)
+      writer.write(record3)
+      writer.write(record4)
+      writer.close()
+    } catch {
+      case e: Exception =>
+        Assert.fail(e.getMessage)
+    }
+  }
+
+  def threeLevelArrayFile() = {
+    val json1 =
+      """ {
+        | "array3_Int": [[[1,2,3], [4,5]], [[6,7,8], [9]], [[1,2], [4,5]]],
+        | "array3_BigInt":[[[90000,600000000],[8000]],[[911111111]]],
+        | "array3_Real":[[[1.111,2.2], [9.139,2.98]]],
+        | "array3_Double":[[[1.111,2.2]], [[9.139,2.98989898]]],
+        | "array3_String":[[["Japan", "China"], ["Brazil", "Paris"]], [["India"]]],
+        | "array3_Boolean":[[[false, false], [false]], [[true]]]
+        | } """.stripMargin
+    val json2 =
+      """ {
+        | "array3_Int": [[[1,2,3], [0,5], [1,2,3,4,5], [4,5]]],
+        | "array3_BigInt":[[[40000,600000000,8000],[9111111111]]],
+        | "array3_Real":[[[1.111,2.2], [9.139,2.98]], [[9.99]]],
+        | "array3_Double":[[[1.111,2.2], [9.139777,2.98]], [[9.99888]]],
+        | "array3_String":[[["China", "Brazil"], ["Paris", "France"]]],
+        | "array3_Boolean":[[[false], [true, false]]]
+        | } """.stripMargin
+    val json3 =
+      """ {
+        | "array3_Int": [[[1],[0],[3]],[[4,5]]],
+        | "array3_BigInt":[[[5000],[600000000],[8000,9111111111],[20000],[600000000,8000,
+        | 9111111111]]],
+        | "array3_Real":[[[9.198]]],
+        | "array3_Double":[[[0.1987979]]],
+        | "array3_String":[[["Japan", "China", "India"]]],
+        | "array3_Boolean":[[[false, true, false]]]
+        | } """.stripMargin
+    val json4 =
+      """ {
+        | "array3_Int": [[[0,9,0,1,3,2,3,4,7]]],
+        | "array3_BigInt":[[[5000,600087000,8000,9111111111,20000,600000000,8000,977777]]],
+        | "array3_Real":[[[1.111,2.2], [9.139,2.98,4.67]], [[2.91,2.2], [9.139,2.98]]],
+        | "array3_Double":[[[1.111,2,4.67, 2.91,2.2, 9.139,2.98]]],
+        | "array3_String":[[["Japan"], ["China"], ["India"]]],
+        | "array3_Boolean":[[[false], [true], [false]]]
+        | } """.stripMargin
+
+    val mySchema =
+      """ {
+        |	"name": "address",
+        |	"type": "record",
+        |	"fields": [
+        |  {
+        |			"name": "array3_Int",
+        |			"type": {
+        |				"type": "array",
+        |				"items": {
+        |					"type": "array",
+        |					"items": {
+        |     					"type": "array",
+        |          		"items": {
+        |							"type": "int"
+        |              }
+        |						}
+        |				}
+        |			}
+        |		},
+        |  {
+        |			"name": "array3_BigInt",
+        |			"type": {
+        |				"type": "array",
+        |				"items": {
+        |					"type": "array",
+        |					"items": {
+        |     					"type": "array",
+        |          		"items": {
+        |							"type": "long"
+        |              }
+        |						}
+        |				}
+        |			}
+        |		},
+        |  {
+        |			"name": "array3_Real",
+        |			"type": {
+        |				"type": "array",
+        |				"items": {
+        |					"type": "array",
+        |					"items": {
+        |     					"type": "array",
+        |          		"items": {
+        |							"type": "float"
+        |              }
+        |						}
+        |				}
+        |			}
+        |		},
+        |  {
+        |			"name": "array3_Double",
+        |			"type": {
+        |				"type": "array",
+        |				"items": {
+        |					"type": "array",
+        |					"items": {
+        |     					"type": "array",
+        |          		"items": {
+        |							"type": "double"
+        |              }
+        |						}
+        |				}
+        |			}
+        |		},
+        |  {
+        |			"name": "array3_String",
+        |			"type": {
+        |				"type": "array",
+        |				"items": {
+        |					"type": "array",
+        |					"items": {
+        |     					"type": "array",
+        |          		"items": {
+        |							"type": "string"
+        |              }
+        |						}
+        |				}
+        |			}
+        |		},
+        |  {
+        |			"name": "array3_Boolean",
+        |			"type": {
+        |				"type": "array",
+        |				"items": {
+        |					"type": "array",
+        |					"items": {
+        |     					"type": "array",
+        |          		"items": {
+        |							"type": "boolean"
+        |              }
+        |						}
+        |				}
+        |			}
+        |		}
+        |	]
+        |} """.stripMargin
+
+    val nn = new avro.Schema.Parser().parse(mySchema)
+    val record1 = jsonToAvro(json1, mySchema)
+    val record2 = jsonToAvro(json2, mySchema)
+    val record3 = jsonToAvro(json3, mySchema)
+    val record4 = jsonToAvro(json4, mySchema)
+    var writerPath = new File(this.getClass.getResource("/").getPath
+                              + "../../target/store/sdk_output/files3")
+      .getCanonicalPath
+    //getCanonicalPath gives path with \, but the code expects /.
+    writerPath = writerPath.replace("\\", "/")
+    try {
+      val writer = CarbonWriter.builder
+        .outputPath(writerPath)
+        .enableLocalDictionary(false)
+        .uniqueIdentifier(System.currentTimeMillis())
+        .withAvroInput(nn)
+        .writtenBy("GenerateFiles")
+        .build()
+      writer.write(record1)
+      writer.write(record2)
+      writer.write(record3)
+      writer.write(record4)
+      writer.close()
+    } catch {
+      case e: Exception =>
+        Assert.fail(e.getMessage)
+    }
+  }
+
+  def jsonToAvro(json: String, avroSchema: String): GenericRecord = {
+    var input: InputStream = null
+    var writer: DataFileWriter[GenericRecord] = null
+    var encoder: Encoder = null
+    var output: ByteArrayOutputStream = null
+    try {
+      val schema = new org.apache.avro.Schema.Parser().parse(avroSchema)
+      val reader = new GenericDatumReader[GenericRecord](schema)
+      input = new ByteArrayInputStream(json.getBytes())
+      output = new ByteArrayOutputStream()
+      val din = new DataInputStream(input)
+      writer = new DataFileWriter[GenericRecord](new GenericDatumWriter[GenericRecord]())
+      writer.create(schema, output)
+      val decoder = DecoderFactory.get().jsonDecoder(schema, din)
+      var datum: GenericRecord = reader.read(null, decoder)
+      return datum
+    } finally {
+      input.close()
+      writer.close()
+    }
+  }
+}

--- a/integration/presto/src/test/scala/org/apache/carbondata/presto/integrationtest/PrestoReadTableFilesTest.scala
+++ b/integration/presto/src/test/scala/org/apache/carbondata/presto/integrationtest/PrestoReadTableFilesTest.scala
@@ -1,0 +1,410 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.presto.integrationtest
+
+import java.io.File
+import java.util
+import java.util.Arrays.asList
+
+import io.prestosql.jdbc.PrestoArray
+import org.apache.carbondata.core.constants.CarbonCommonConstants
+import org.apache.carbondata.core.datastore.impl.FileFactory
+import org.apache.carbondata.core.util.{CarbonProperties, CarbonUtil}
+import org.apache.carbondata.presto.server.PrestoServer
+import org.apache.commons.io.FileUtils
+import org.scalatest.{BeforeAndAfterAll, FunSuiteLike, BeforeAndAfterEach}
+
+class PrestoReadTableFilesTest extends FunSuiteLike with BeforeAndAfterAll with BeforeAndAfterEach{
+
+  private val rootPath = new File(this.getClass.getResource("/").getPath
+    + "../../../..").getCanonicalPath
+  private val storePath = s"$rootPath/integration/presto/target/store"
+  private val prestoServer = new PrestoServer
+
+  override def beforeAll: Unit = {
+    CarbonProperties.getInstance().addProperty(CarbonCommonConstants.CARBON_WRITTEN_BY_APPNAME,
+      "Presto")
+    CarbonProperties.getInstance().addProperty(CarbonCommonConstants.CARBON_WRITTEN_BY_APPNAME,
+      "Presto")
+    val map = new util.HashMap[String, String]()
+    map.put("hive.metastore", "file")
+    map.put("hive.metastore.catalog.dir", s"file://$storePath")
+
+    prestoServer.startServer("sdk_output", map)
+  }
+
+  override def afterAll(): Unit = {
+    prestoServer.stopServer()
+    CarbonUtil.deleteFoldersAndFiles(FileFactory.getCarbonFile(storePath))
+  }
+
+  private def createComplexTableForSingleLevelArray = {
+    prestoServer.execute("drop table if exists sdk_output.files")
+    prestoServer.execute("drop schema if exists sdk_output")
+    prestoServer.execute("create schema sdk_output")
+    prestoServer
+      .execute(
+        "create table sdk_output.files(stringCol varchar, intCol int, doubleCol double, realCol real, boolCol boolean, arrayStringCol1 array(varchar), arrayStringcol2 array(varchar), arrayIntCol array(int), arrayBigIntCol array(bigint), arrayRealCol array(real), arrayDoubleCol array(double), arrayBooleanCol array(boolean)) with(format='CARBON') ")
+  }
+
+  private def createComplexTableFor2LevelArray = {
+    prestoServer.execute("drop table if exists sdk_output.files2")
+    prestoServer.execute("drop schema if exists sdk_output")
+    prestoServer.execute("create schema sdk_output")
+        prestoServer
+      .execute(
+        "create table sdk_output.files2(arrayArrayInt array(array(int)), arrayArrayBigInt array(array(bigint)), arrayArrayReal array(array(real)), arrayArrayDouble array(array(double)), arrayArrayString array(array(varchar)), arrayArrayBoolean array(array(boolean))) with(format='CARBON') ")
+  }
+
+  private def createComplexTableFor3LevelArray = {
+    prestoServer.execute("drop table if exists sdk_output.files3")
+    prestoServer.execute("drop schema if exists sdk_output")
+    prestoServer.execute("create schema sdk_output")
+    prestoServer
+        .execute(
+          "create table sdk_output.files3(array3_Int array(array(array(int))), array3_BigInt array(array(array(bigint))), array3_Real array(array(array(real))), array3_Double array(array(array(double))), array3_String array(array(array(varchar))), array3_Boolean array(array(array(boolean))) ) with(format='CARBON') ")
+    }
+
+
+  def cleanTestData(path: String): Unit = {
+    FileUtils.deleteDirectory(new File(path))
+  }
+
+  test("test single-array complex columns") {
+    createComplexTableForSingleLevelArray
+    val gen = new GenerateFiles()
+    gen.singleLevelArrayFile();
+    val actualResult: List[Map[String, Any]] = prestoServer
+      .executeQuery("SELECT arrayStringCol2, arrayIntCol, arrayBigIntCol, arrayDoubleCol, arrayRealCol, arrayBooleanCol FROM files")
+
+    // check number of rows
+    assert(actualResult.size == 5)
+
+    // check number of columns in each row
+    assert(actualResult(0).size == 6)
+    assert(actualResult(1).size == 6)
+    assert(actualResult(2).size == 6)
+    assert(actualResult(3).size == 6)
+    assert(actualResult(4).size == 6)
+
+    for( row <- 0 to actualResult.size - 1){
+      var actual1 = (actualResult(row)("arrayStringCol2").asInstanceOf[PrestoArray].getArray()).asInstanceOf[Array[Object]]
+      var actual2 = (actualResult(row)("arrayIntCol").asInstanceOf[PrestoArray].getArray()).asInstanceOf[Array[Object]]
+      var actual3 = (actualResult(row)("arrayBigIntCol").asInstanceOf[PrestoArray].getArray()).asInstanceOf[Array[Object]]
+      var actual4 = (actualResult(row)("arrayDoubleCol").asInstanceOf[PrestoArray].getArray()).asInstanceOf[Array[Object]]
+      var actual5 = (actualResult(row)("arrayRealCol").asInstanceOf[PrestoArray].getArray()).asInstanceOf[Array[Object]]
+      var actual6 = (actualResult(row)("arrayBooleanCol").asInstanceOf[PrestoArray].getArray()).asInstanceOf[Array[Object]]
+
+      if(row == 0){
+        assert(actual1.sameElements(Array("India", "Egypt")))
+        assert(actual2.sameElements(Array(1,2,3)))
+        assert(actual3.sameElements(Array(70000L, 600000000L)))
+        assert(actual4.sameElements(Array(1.1,2.2,3.3)))
+        assert(actual5.sameElements(Array(1.111F,2.2F)))
+        assert(actual6.sameElements(Array(true, false, true)))
+      } else if(row == 1) {
+        assert(actual1.sameElements(Array("Japan", "China", "India")))
+        assert(actual2.sameElements(Array(1,2,3,4)))
+        assert(actual3.sameElements(Array(70000L, 600000000L,8000L)))
+        assert(actual4.sameElements(Array(1.1, 2.2, 4.45, 3.3)))
+        assert(actual5.sameElements(Array(1.1F,2.2F,3.3f)))
+        assert(actual6.sameElements(Array(true, true, true)))
+      } else if(row == 2) {
+        assert(actual1.sameElements(Array("China", "Brazil", "Paris", "France")))
+        assert(actual2.sameElements(Array(1,2,3,4,5)))
+        assert(actual3.sameElements(Array(70000L, 600000000L, 8000L, 9111111111L)))
+        assert(actual4.sameElements(Array(1.1, 2.2, 4.45, 5.5, 3.3)))
+        assert(actual5.sameElements(Array(1.1F, 2.2F, 3.3F, 4.45F)))
+        assert(actual6.sameElements(Array(true, false, true)))
+      } else if(row == 3) {
+        assert(actual1.sameElements(Array("India", "Egypt")))
+        assert(actual2.sameElements(Array(1,2,3)))
+        assert(actual3.sameElements(Array(70000L, 600000000L)))
+        assert(actual4.sameElements(Array(1.1, 2.2, 3.3)))
+        assert(actual5.sameElements(Array(1.1F,2.2F)))
+        assert(actual6.sameElements(Array(true, false, true)))
+      } else if(row == 4) {
+        assert(actual1.sameElements(Array("Japan", "China", "India")))
+        assert(actual2.sameElements(Array(1,2,3,4)))
+        assert(actual3.sameElements(Array(70000L, 600000000L,8000L)))
+        assert(actual4.sameElements(Array(4.0, 1.0, 21.222, 15.231)))
+        assert(actual5.sameElements(Array(1.1F,2.2F,3.3F)))
+        assert(actual6.sameElements(Array(false, false, false)))
+      }
+
+    }
+
+    cleanTestData(storePath + "/sdk_output/files")
+  }
+
+
+  /*
+  +--------------------------------------------+---------------------------------------------------------------------------------+---------------------------------------------------------------+--------------------------------------------+----------------------------------+--------------------------+
+  |arrayarrayint                               |arrayarraybigint                                                                 |arrayarrayreal                                                 |arrayarraydouble                            |arrayarraystring                  |arrayarrayboolean         |
+  +--------------------------------------------+---------------------------------------------------------------------------------+---------------------------------------------------------------+--------------------------------------------+----------------------------------+--------------------------+
+  |[[1, 2, 3], [4, 5]]                         |[[90000, 600000000], [8000], [911111111]]                                        |[[1.111, 2.2], [9.139, 2.98]]                                  |[[1.111, 2.2], [9.139, 2.98989898]]         |[[Japan, China], [India]]         |[[false, false], [false]] |
+  |[[1, 2, 3], [0, 5], [1, 2, 3, 4, 5], [4, 5]]|[[40000, 600000000, 8000], [9111111111]]                                         |[[1.111, 2.2], [9.139, 2.98], [9.99]]                          |[[1.111, 2.2], [9.139777, 2.98], [9.99888]] |[[China, Brazil], [Paris, France]]|[[false], [true, false]]  |
+  |[[1], [0], [3], [4, 5]]                     |[[5000], [600000000], [8000, 9111111111], [20000], [600000000, 8000, 9111111111]]|[[9.198]]                                                      |[[0.1987979]]                               |[[Japan, China, India]]           |[[false, true, false]]    |
+  |[[0, 9, 0, 1, 3, 2, 3, 4, 7]]               |[[5000, 600087000, 8000, 9111111111, 20000, 600000000, 8000, 977777]]            |[[1.111, 2.2], [9.139, 2.98, 4.67], [2.91, 2.2], [9.139, 2.98]]|[[1.111, 2.0, 4.67, 2.91, 2.2, 9.139, 2.98]]|[[Japan], [China], [India]]       |[[false], [true], [false]]|
+  +--------------------------------------------+---------------------------------------------------------------------------------+---------------------------------------------------------------+--------------------------------------------+----------------------------------+--------------------------+
+  */
+
+
+  test("test 2-level for array of int, bigInt") {
+    createComplexTableFor2LevelArray
+    val gen = new GenerateFiles()
+    gen.twoLevelArrayFile();
+    val actualResult: List[Map[String, Any]] = prestoServer
+      .executeQuery("SELECT arrayArrayint, arrayArrayBigInt FROM files2")
+
+    // check number of rows
+    assert(actualResult.size == 4)
+
+    //check number of columns in each row
+    assert(actualResult(0).size == 2)
+    assert(actualResult(1).size == 2)
+    assert(actualResult(2).size == 2)
+    assert(actualResult(3).size == 2)
+
+    var row_1 = (actualResult(0)("arrayArrayint").asInstanceOf[PrestoArray].getArray()).asInstanceOf[Array[Object]]
+    var row_2 = (actualResult(1)("arrayArrayint").asInstanceOf[PrestoArray].getArray()).asInstanceOf[Array[Object]]
+    var row_3 = (actualResult(2)("arrayArrayint").asInstanceOf[PrestoArray].getArray()).asInstanceOf[Array[Object]]
+    var row_4 = (actualResult(3)("arrayArrayint").asInstanceOf[PrestoArray].getArray()).asInstanceOf[Array[Object]]
+
+    // check number of child elements in each 2-level arrayArrayint
+    assert(row_1.length == 2);
+    assert(row_2.length == 4);
+    assert(row_3.length == 4);
+    assert(row_4.length == 1);
+
+    // check actual data in each single-level array
+    assert(asList(row_1(0), row_1(1)) == asList(asList(1,2,3), asList(4,5)))
+    assert(asList(row_2(0), row_2(1), row_2(2), row_2(3)) == asList(asList(1,2,3), asList(0,5), asList(1,2,3,4,5), asList(4,5)))
+    assert(asList(row_3(0), row_3(1), row_3(2), row_3(3)) == asList(asList(1), asList(0), asList(3), asList(4,5)))
+    assert(asList(row_4(0)) == asList(asList(0,9,0,1,3,2,3,4,7)))
+
+    row_1 = (actualResult(0)("arrayArrayBigInt").asInstanceOf[PrestoArray].getArray()).asInstanceOf[Array[Object]]
+    row_2 = (actualResult(1)("arrayArrayBigInt").asInstanceOf[PrestoArray].getArray()).asInstanceOf[Array[Object]]
+    row_3 = (actualResult(2)("arrayArrayBigInt").asInstanceOf[PrestoArray].getArray()).asInstanceOf[Array[Object]]
+    row_4 = (actualResult(3)("arrayArrayBigInt").asInstanceOf[PrestoArray].getArray()).asInstanceOf[Array[Object]]
+
+    // check number of child elements in each 2-level arrayArrayBigInt
+    assert(row_1.length == 3);
+    assert(row_2.length == 2);
+    assert(row_3.length == 5);
+    assert(row_4.length == 1);
+
+    // check actual data in each single-level array
+    assert(asList(row_1(0),row_1(1),row_1(2)) == (asList(asList(90000L, 600000000L), asList(8000L), asList(911111111L))))
+    assert(asList(row_2(0),row_2(1)) == asList(asList(40000L, 600000000L, 8000L), asList(9111111111L)))
+    assert(asList(row_3(0),row_3(1),row_3(2),row_3(3),row_3(4)) == asList(asList(5000L),asList(600000000L),asList(8000L,9111111111L),asList(20000L),asList(600000000L,8000L,9111111111L)))
+    assert(asList(row_4(0)) == asList(asList(5000L, 600087000L, 8000L, 9111111111L, 20000L, 600000000L, 8000L, 977777L)))
+
+    cleanTestData(storePath + "/sdk_output/files2")
+  }
+
+  test("test 2-level array for real and double") {
+    createComplexTableFor2LevelArray
+    val gen = new GenerateFiles()
+    gen.twoLevelArrayFile();
+    val actualResult: List[Map[String, Any]] = prestoServer
+      .executeQuery("SELECT arrayArrayReal, arrayArrayDouble FROM files2")
+
+    // check number of rows
+    assert(actualResult.size == 4)
+
+    //check number of columns in each row
+    assert(actualResult(0).size == 2)
+    assert(actualResult(1).size == 2)
+
+    var row_1 = (actualResult(0)("arrayArrayReal").asInstanceOf[PrestoArray].getArray()).asInstanceOf[Array[Object]]
+    var row_2 = (actualResult(1)("arrayArrayReal").asInstanceOf[PrestoArray].getArray()).asInstanceOf[Array[Object]]
+    var row_3 = (actualResult(2)("arrayArrayReal").asInstanceOf[PrestoArray].getArray()).asInstanceOf[Array[Object]]
+    var row_4 = (actualResult(3)("arrayArrayReal").asInstanceOf[PrestoArray].getArray()).asInstanceOf[Array[Object]]
+
+    // check number of child elements in each 2-level arrayArrayDouble
+    assert(row_1.length == 2);
+    assert(row_2.length == 3);
+    assert(row_3.length == 1);
+    assert(row_4.length == 4);
+
+    // check actual data in each single-level array
+    assert(asList(row_1(0),row_1(1)) == asList(asList(1.111F, 2.2F), asList(9.139F, 2.98F)))
+    assert(asList(row_2(0),row_2(1),row_2(2)) == asList(asList(1.111F, 2.2F), asList(9.139F, 2.98F), asList(9.99F)))
+    assert(asList(row_3(0)) == asList(asList(9.198F)))
+    assert(asList(row_4(0),row_4(1),row_4(2),row_4(3)) == asList(asList(1.111F, 2.2F), asList(9.139F, 2.98F, 4.67F), asList(2.91F, 2.2F), asList(9.139F, 2.98F)))
+
+    row_1 = (actualResult(0)("arrayArrayDouble").asInstanceOf[PrestoArray].getArray()).asInstanceOf[Array[Object]]
+    row_2 = (actualResult(1)("arrayArrayDouble").asInstanceOf[PrestoArray].getArray()).asInstanceOf[Array[Object]]
+    row_3 = (actualResult(2)("arrayArrayDouble").asInstanceOf[PrestoArray].getArray()).asInstanceOf[Array[Object]]
+    row_4 = (actualResult(3)("arrayArrayDouble").asInstanceOf[PrestoArray].getArray()).asInstanceOf[Array[Object]]
+
+    // check number of child elements in each 2-level arrayArrayDouble
+    assert(row_1.length == 2);
+    assert(row_2.length == 3);
+    assert(row_3.length == 1);
+    assert(row_4.length == 1);
+
+    // check actual data in each single-level array
+    assert(asList(row_1(0),row_1(1)) == asList(asList(1.111, 2.2),asList(9.139, 2.98989898)))
+    assert(asList(row_2(0),row_2(1),row_2(2)) == asList(asList(1.111, 2.2),asList(9.139777, 2.98),asList(9.99888)))
+    assert(asList(row_3(0)) == asList(asList(0.1987979)))
+    assert(asList(row_4(0)) == asList(asList(1.111, 2.0, 4.67, 2.91, 2.2, 9.139, 2.98)))
+
+    cleanTestData(storePath + "/sdk_output/files2")
+  }
+
+  test("test 2-level array for string and boolean") {
+    createComplexTableFor2LevelArray
+    val gen = new GenerateFiles()
+    gen.twoLevelArrayFile();
+    val actualResult: List[Map[String, Any]] = prestoServer
+      .executeQuery("SELECT arrayArrayString, arrayArrayBoolean FROM files2")
+
+    // check number of rows
+    assert(actualResult.size == 4)
+
+    //check number of columns in each row
+    assert(actualResult(0).size == 2)
+    assert(actualResult(1).size == 2)
+
+    var row_1 = (actualResult(0)("arrayArrayString").asInstanceOf[PrestoArray].getArray()).asInstanceOf[Array[Object]]
+    var row_2 = (actualResult(1)("arrayArrayString").asInstanceOf[PrestoArray].getArray()).asInstanceOf[Array[Object]]
+    var row_3 = (actualResult(2)("arrayArrayString").asInstanceOf[PrestoArray].getArray()).asInstanceOf[Array[Object]]
+    var row_4 = (actualResult(3)("arrayArrayString").asInstanceOf[PrestoArray].getArray()).asInstanceOf[Array[Object]]
+
+    // check number of child elements in each 2-level arrayArrayDouble
+    assert(row_1.length == 2);
+    assert(row_2.length == 2);
+    assert(row_3.length == 1);
+    assert(row_4.length == 3);
+
+    // check actual data in each single-level array
+    assert(asList(row_1(0),row_1(1)) == asList(asList("Japan", "China"), asList("India")))
+    assert(asList(row_2(0),row_2(1)) == asList(asList("China", "Brazil"), asList("Paris", "France")))
+    assert(asList(row_3(0)) == asList(asList("Japan", "China", "India")))
+    assert(asList(row_4(0),row_4(1),row_4(2)) == asList(asList("Japan"), asList("China"), asList("India")))
+
+    row_1 = (actualResult(0)("arrayArrayBoolean").asInstanceOf[PrestoArray].getArray()).asInstanceOf[Array[Object]]
+    row_2 = (actualResult(1)("arrayArrayBoolean").asInstanceOf[PrestoArray].getArray()).asInstanceOf[Array[Object]]
+    row_3 = (actualResult(2)("arrayArrayBoolean").asInstanceOf[PrestoArray].getArray()).asInstanceOf[Array[Object]]
+    row_4 = (actualResult(3)("arrayArrayBoolean").asInstanceOf[PrestoArray].getArray()).asInstanceOf[Array[Object]]
+
+    // check number of child elements in each 2-level arrayArrayDouble
+    assert(row_1.length == 2);
+    assert(row_2.length == 2);
+    assert(row_3.length == 1);
+    assert(row_4.length == 3);
+
+    // check actual data in each single-level array
+    assert(asList(row_1(0),row_1(1)) == asList(asList(false, false), asList(false)))
+    assert(asList(row_2(0),row_2(1)) == asList(asList(false), asList(true, false)))
+    assert(asList(row_3(0)) == asList(asList(false, true, false)))
+    assert(asList(row_4(0),row_4(1),row_4(2)) == asList(asList(false), asList(true), asList(false)))
+
+    cleanTestData(storePath + "/sdk_output/files2")
+  }
+
+  test("test 3-level array for int, BigInt, Real, Double, String and Boolean columns") {
+    createComplexTableFor3LevelArray
+    val gen = new GenerateFiles()
+    gen.threeLevelArrayFile();
+    val actualResult: List[Map[String, Any]] = prestoServer
+      .executeQuery("SELECT array3_Int, array3_BigInt, array3_Real, array3_Double, array3_String, array3_Boolean  FROM files3")
+
+    // check total number of 3-level array elements
+    assert(actualResult.size == 4)
+
+    // check number of columns in each row
+    assert(actualResult(0).size == 6)
+    assert(actualResult(1).size == 6)
+    assert(actualResult(2).size == 6)
+    assert(actualResult(3).size == 6)
+
+    var row_1 = (actualResult(0)("array3_Int").asInstanceOf[PrestoArray].getArray()).asInstanceOf[Array[Object]]
+    var row_2 = (actualResult(1)("array3_Int").asInstanceOf[PrestoArray].getArray()).asInstanceOf[Array[Object]]
+    var row_3 = (actualResult(2)("array3_Int").asInstanceOf[PrestoArray].getArray()).asInstanceOf[Array[Object]]
+    var row_4 = (actualResult(3)("array3_Int").asInstanceOf[PrestoArray].getArray()).asInstanceOf[Array[Object]]
+
+    // check number of child elements in each 3-level array
+    assert(row_1.length == 3);
+    assert(row_2.length == 1);
+    assert(row_3.length == 2);
+    assert(row_4.length == 1);
+
+    assert(asList(row_1(0), row_1(1), row_1(2)) == asList(asList(asList(1,2,3),asList(4,5)),asList(asList(6,7,8),asList(9)),asList(asList(1,2),asList(4,5))))
+    assert(asList(row_2(0)) == asList(asList(asList(1,2,3), asList(0,5),asList(1,2,3,4,5), asList(4,5))))
+    assert(asList(row_3(0), row_3(1)) == asList(asList(asList(1),asList(0),asList(3)),asList(asList(4,5))))
+    assert(asList(row_4(0)) == asList(asList(asList(0,9,0,1,3,2,3,4,7))))
+
+
+    row_1 = (actualResult(0)("array3_BigInt").asInstanceOf[PrestoArray].getArray()).asInstanceOf[Array[Object]]
+    row_2 = (actualResult(1)("array3_BigInt").asInstanceOf[PrestoArray].getArray()).asInstanceOf[Array[Object]]
+    row_3 = (actualResult(2)("array3_BigInt").asInstanceOf[PrestoArray].getArray()).asInstanceOf[Array[Object]]
+    row_4 = (actualResult(3)("array3_BigInt").asInstanceOf[PrestoArray].getArray()).asInstanceOf[Array[Object]]
+
+    assert(asList(row_1(0), row_1(1)) == asList(asList(asList(90000L,600000000L), asList(8000L)), asList(asList(911111111L))))
+    assert(asList(row_2(0)) == asList(asList(asList(40000L,600000000L,8000L), asList(9111111111L))))
+    assert(asList(row_3(0)) == asList(asList(asList(5000L),asList(600000000L),asList(8000L,9111111111L),asList(20000L),asList(600000000L,8000L,9111111111L))))
+    assert(asList(row_4(0)) == asList(asList(asList(5000L,600087000L,8000L,9111111111L,20000L,600000000L,8000L,977777L))))
+
+    row_1 = (actualResult(0)("array3_Real").asInstanceOf[PrestoArray].getArray()).asInstanceOf[Array[Object]]
+    row_2 = (actualResult(1)("array3_Real").asInstanceOf[PrestoArray].getArray()).asInstanceOf[Array[Object]]
+    row_3 = (actualResult(2)("array3_Real").asInstanceOf[PrestoArray].getArray()).asInstanceOf[Array[Object]]
+    row_4 = (actualResult(3)("array3_Real").asInstanceOf[PrestoArray].getArray()).asInstanceOf[Array[Object]]
+
+    assert(asList(row_1(0)) == asList(asList(asList(1.111F,2.2F), asList(9.139F,2.98F))))
+    assert(asList(row_2(0), row_2(1)) == asList(asList(asList(1.111F,2.2F), asList(9.139F,2.98F)),asList(asList(9.99F))))
+    assert(asList(row_3(0)) == asList(asList(asList(9.198F))))
+    assert(asList(row_4(0), row_4(1)) == asList(asList(asList(1.111F,2.2F), asList(9.139F,2.98F,4.67F)), asList(asList(2.91F,2.2F),asList(9.139F,2.98F))))
+
+    row_1 = (actualResult(0)("array3_Double").asInstanceOf[PrestoArray].getArray()).asInstanceOf[Array[Object]]
+    row_2 = (actualResult(1)("array3_Double").asInstanceOf[PrestoArray].getArray()).asInstanceOf[Array[Object]]
+    row_3 = (actualResult(2)("array3_Double").asInstanceOf[PrestoArray].getArray()).asInstanceOf[Array[Object]]
+    row_4 = (actualResult(3)("array3_Double").asInstanceOf[PrestoArray].getArray()).asInstanceOf[Array[Object]]
+
+    assert(asList(row_1(0),row_1(1)) == asList(asList(asList(1.111,2.2)), asList(asList(9.139,2.98989898))))
+    assert(asList(row_2(0), row_2(1)) == asList(asList(asList(1.111,2.2), asList(9.139777,2.98)),asList(asList(9.99888))))
+    assert(asList(row_3(0)) == asList(asList(asList(0.1987979))))
+    assert(asList(row_4(0)) == asList(asList(asList(1.111,2,4.67, 2.91,2.2, 9.139,2.98))))
+
+    row_1 = (actualResult(0)("array3_String").asInstanceOf[PrestoArray].getArray()).asInstanceOf[Array[Object]]
+    row_2 = (actualResult(1)("array3_String").asInstanceOf[PrestoArray].getArray()).asInstanceOf[Array[Object]]
+    row_3 = (actualResult(2)("array3_String").asInstanceOf[PrestoArray].getArray()).asInstanceOf[Array[Object]]
+    row_4 = (actualResult(3)("array3_String").asInstanceOf[PrestoArray].getArray()).asInstanceOf[Array[Object]]
+
+    assert(asList(row_1(0),row_1(1)) == asList(asList(asList("Japan", "China"), asList("Brazil", "Paris")),asList(asList("India"))))
+    assert(asList(row_2(0)) == asList(asList(asList("China", "Brazil"), asList("Paris", "France"))))
+    assert(asList(row_3(0)) == asList(asList(asList("Japan", "China", "India"))))
+    assert(asList(row_4(0)) == asList(asList(asList("Japan"), asList("China"), asList("India"))))
+
+
+    row_1 = (actualResult(0)("array3_Boolean").asInstanceOf[PrestoArray].getArray()).asInstanceOf[Array[Object]]
+    row_2 = (actualResult(1)("array3_Boolean").asInstanceOf[PrestoArray].getArray()).asInstanceOf[Array[Object]]
+    row_3 = (actualResult(2)("array3_Boolean").asInstanceOf[PrestoArray].getArray()).asInstanceOf[Array[Object]]
+    row_4 = (actualResult(3)("array3_Boolean").asInstanceOf[PrestoArray].getArray()).asInstanceOf[Array[Object]]
+
+    assert(asList(row_1(0),row_1(1)) == asList(asList(asList(false, false), asList(false)), asList(asList(true))))
+    assert(asList(row_2(0)) == asList(asList(asList(false), asList(true, false))))
+    assert(asList(row_3(0)) == asList(asList(asList(false, true, false))))
+    assert(asList(row_4(0)) == asList(asList(asList(false), asList(true), asList(false))))
+
+    cleanTestData(storePath + "/sdk_output/files3")
+
+  }
+}

--- a/integration/spark/src/main/java/org/apache/carbondata/spark/vectorreader/ColumnarVectorWrapper.java
+++ b/integration/spark/src/main/java/org/apache/carbondata/spark/vectorreader/ColumnarVectorWrapper.java
@@ -18,10 +18,12 @@
 package org.apache.carbondata.spark.vectorreader;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 import org.apache.carbondata.core.metadata.datatype.DataType;
 import org.apache.carbondata.core.scan.result.vector.CarbonColumnVector;
 import org.apache.carbondata.core.scan.result.vector.CarbonDictionary;
+import org.apache.carbondata.core.scan.result.vector.impl.CarbonColumnVectorImpl;
 import org.apache.carbondata.core.scan.scanner.LazyPageLoader;
 
 import org.apache.spark.sql.CarbonVectorProxy;
@@ -54,6 +56,26 @@ class ColumnarVectorWrapper implements CarbonColumnVector {
     this.filteredRows = filteredRows;
     this.carbonVectorProxy = writableColumnVector;
     this.ordinal = ordinal;
+  }
+
+  public CarbonColumnVector getColumnVector() {
+    throw new UnsupportedOperationException("Operation not allowed");
+  }
+
+  public List<CarbonColumnVectorImpl> getChildrenVector() {
+    throw new UnsupportedOperationException("Operation not allowed");
+  }
+
+  public void putArrayObject() {
+    throw new UnsupportedOperationException("Operation not allowed");
+  }
+
+  public int getIndex() {
+    throw new UnsupportedOperationException("Operation not allowed");
+  }
+
+  public void setIndex(int index) {
+    throw new UnsupportedOperationException("Operation not allowed");
   }
 
   @Override

--- a/integration/spark/src/main/java/org/apache/carbondata/spark/vectorreader/ColumnarVectorWrapperDirect.java
+++ b/integration/spark/src/main/java/org/apache/carbondata/spark/vectorreader/ColumnarVectorWrapperDirect.java
@@ -18,10 +18,12 @@
 package org.apache.carbondata.spark.vectorreader;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 import org.apache.carbondata.core.metadata.datatype.DataType;
 import org.apache.carbondata.core.scan.result.vector.CarbonColumnVector;
 import org.apache.carbondata.core.scan.result.vector.CarbonDictionary;
+import org.apache.carbondata.core.scan.result.vector.impl.CarbonColumnVectorImpl;
 import org.apache.carbondata.core.scan.scanner.LazyPageLoader;
 
 import org.apache.spark.sql.CarbonVectorProxy;
@@ -51,10 +53,34 @@ class ColumnarVectorWrapperDirect implements CarbonColumnVector {
 
   private CarbonColumnVector dictionaryVector;
 
+  private int index;
+
   ColumnarVectorWrapperDirect(CarbonVectorProxy writableColumnVector, int ordinal) {
     this.sparkColumnVectorProxy = writableColumnVector.getColumnVector(ordinal);
     this.carbonVectorProxy = writableColumnVector;
     this.ordinal = ordinal;
+  }
+
+  @Override
+  public CarbonColumnVector getColumnVector() {
+    return null;
+  }
+
+  public List<CarbonColumnVectorImpl> getChildrenVector() {
+    return null;
+  }
+
+  public void putArrayObject() {
+    return;
+  }
+
+  public int getIndex() {
+    return index;
+  }
+
+  @Override
+  public void setIndex(int index) {
+    this.index = index;
   }
 
   @Override


### PR DESCRIPTION
Array Stream Reader and test cases added

 ### Why is this PR needed?
 This PR will enable Presto to read array columns.
 
 ### What changes were proposed in this PR?
Enables reading of array of int, BigInt, Real, Double, varchar and Boolean columns.

Please go through the design document for better understanding-
https://issues.apache.org/jira/browse/CARBONDATA-3830

**Method **fillVector()** in each of the following files have been shifted to a new file **FillVector.java** :**
AdaptiveFloatingCodec.java (responsible for filling of float, double)
AdaptiveIntegralCodec.java (responsible for filling of int, long)
DirectCompressCodec.java (responsible for filling of string, boolean)


**Reason for shifting:**
1. Avoid redundant code in each **fillVector()** method implemented in the above mentioned different files.
2. Betterment of code flow, be it primitive or complex types.



    
 ### Does this PR introduce any user interface change?
 - No
 - Yes. (please explain the change and update document)

 ### Is any new testcase added?
 - Yes, test file - **PrestoReadTableFilesTest.scala**

    
