### PR TITLE
[CARBONDATA-3948] Fix for Bloom Index create failure

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/index/CarbonCreateIndexCommand.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/index/CarbonCreateIndexCommand.scala
@@ -238,8 +238,18 @@ case class CarbonCreateIndexCommand(
               false)
             val enabledIndexInfo = IndexTableInfo.enableIndex(indexInfo, indexModel.indexName)
 
-            // set index information in parent table
-            val parentIndexMetadata = parentTable.getIndexMetadata
+            // set index information in parent table. Create it if it is null.
+            val parentIndexMetadata = if (
+              parentTable.getTableInfo.getFactTable.getTableProperties
+                .get(parentTable.getCarbonTableIdentifier.getTableId) != null) {
+              parentTable.getIndexMetadata
+            } else {
+              val tempIndexMetaData = new IndexMetadata(false)
+              tempIndexMetaData.addIndexTableInfo(indexProviderName,
+                indexModel.indexName,
+                indexSchema.getProperties)
+              tempIndexMetaData
+            }
             parentIndexMetadata.updateIndexStatus(indexProviderName,
               indexModel.indexName,
               IndexStatus.ENABLED.name())


### PR DESCRIPTION
 ### Why is this PR needed?
In the case when the whole flow goes to fallback mode in the index server, the parent table retrieved again in the processData function of carboncreateIndexCommand does not contain the serialized IndexMetaData. This issue is only seen in spark-sql because the same jvm is used between driver and executor 

 ### What changes were proposed in this PR?
Setting the index information in parent table after the table is retrieved again and creating it if it is null
    
 ### Does this PR introduce any user interface change?
 - No
 - Yes. (please explain the change and update document)

 ### Is any new testcase added?
 - No
 - Yes

    
