### PR TITLE
[CARBONDATA-3834]Segment directory and the segment file in metadata are not created for partitioned table when 'carbon.merge.index.in.segment' property is set to false

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/preagg/TimeSeriesUDF.java
+++ b/core/src/main/java/org/apache/carbondata/core/preagg/TimeSeriesUDF.java
@@ -176,9 +176,9 @@ public class TimeSeriesUDF {
     } catch (IllegalArgumentException ex) {
       LOGGER.warn("Invalid value set for first of the week. Considering the default value as: "
           + CarbonCommonConstants.CARBON_TIMESERIES_FIRST_DAY_OF_WEEK_DEFAULT);
-      firstDayOfWeek = DaysOfWeekEnum.valueOf(CarbonProperties.getInstance()
-          .getProperty(CarbonCommonConstants.CARBON_TIMESERIES_FIRST_DAY_OF_WEEK_DEFAULT)
-          .toUpperCase()).getOrdinal();
+      firstDayOfWeek =
+          DaysOfWeekEnum.valueOf(CarbonCommonConstants.CARBON_TIMESERIES_FIRST_DAY_OF_WEEK_DEFAULT)
+              .getOrdinal();
     }
     calanderThreadLocal.get().setFirstDayOfWeek(firstDayOfWeek);
   }


### PR DESCRIPTION
 ### Why is this PR needed?
 Segment directory and the segment file in metadata are not created for partitioned table when 'carbon.merge.index.in.segment' property is set to false. And actual index files which were present in respective partition's '.tmp' directory are also deleted without moving them out to respective partition directory where its '.carbondata' file exist.
All the queries fail due to this problem as there is no segment and index files.

This issue was introduced from the resolution of an older optimization PR #3535
 
 ### What changes were proposed in this PR?
1. If 'carbon.merge.index.in.segment' property is false, we can create the segment directory and segment file, and move the index file from respective partition's temp directory to partition directory where the .carbondata file exists.
2. when carbon.timeseries.first.day.of.week property is configured with invalid value, null pointer exception is thrown instead of using default value.

 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes
