### PR TITLE
[CARBONDATA-3839]Fix rename file failed for FilterFileSystem DFS object

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/HDFSCarbonFile.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/HDFSCarbonFile.java
@@ -23,6 +23,7 @@ import org.apache.carbondata.common.logging.LogServiceFactory;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FilterFileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.log4j.Logger;
@@ -76,6 +77,11 @@ public class HDFSCarbonFile extends AbstractDFSCarbonFile {
       if (fileSystem instanceof DistributedFileSystem) {
         ((DistributedFileSystem) fileSystem).rename(path, new Path(changetoName),
             org.apache.hadoop.fs.Options.Rename.OVERWRITE);
+        return true;
+      } else if ((fileSystem instanceof FilterFileSystem) && (((FilterFileSystem) fileSystem)
+          .getRawFileSystem() instanceof DistributedFileSystem)) {
+        ((DistributedFileSystem) ((FilterFileSystem) fileSystem).getRawFileSystem())
+            .rename(path, new Path(changetoName), org.apache.hadoop.fs.Options.Rename.OVERWRITE);
         return true;
       } else {
         return fileSystem.rename(path, new Path(changetoName));


### PR DESCRIPTION
 ### Why is this PR needed?
 Rename file fails in HDFS when the FS object is of FilterFileSystem, (which basically can contain any filesystem to use as basic filesystem)
 
 ### What changes were proposed in this PR?
While rename force, have a check for this FS object
    
 ### Does this PR introduce any user interface change?
 - No


 ### Is any new testcase added?
 - No(Tested in cluster)

    
