### PR TITLE
[CARBONDATA-3843] Fix merge index issue in streaming table

### DIFF
--- a/docs/ddl-of-carbondata.md
+++ b/docs/ddl-of-carbondata.md
@@ -751,8 +751,9 @@ Users can specify which columns to include and exclude for local dictionary gene
      ```
 
      **NOTE:**
+     * Merge index is supported on streaming table from carbondata 2.0.1 version.
+     But streaming segments (ROW_V1) cannot create merge index.
 
-     * Merge index is not supported on streaming table.
 
    - #### SET and UNSET
    

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonAlterTableCompactionCommand.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonAlterTableCompactionCommand.scala
@@ -131,11 +131,6 @@ case class CarbonAlterTableCompactionCommand(
       }
       Seq.empty
     } else if (compactionType == CompactionType.SEGMENT_INDEX) {
-      if (table.isStreamingSink) {
-        throw new MalformedCarbonCommandException(
-          "Unsupported alter operation on carbon table: Merge index is not supported on streaming" +
-          " table")
-      }
       val version = CarbonUtil.getFormatVersion(table)
       val isOlderVersion = version == ColumnarFormatVersion.V1 ||
                            version == ColumnarFormatVersion.V2


### PR DESCRIPTION
 ### Why is this PR needed?
Merge index is not created for normal segment (created by load, insert, compaction or handoff) on streaming table. 
 
 ### What changes were proposed in this PR?
For a streaming table other than streaming segment (Row_V1), allow merge index creation for all kinds of segments.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes