### PR TITLE
[CARBONDATA-3842] Fix incorrect results on mv with limit (Missed code during mv refcatory)

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/MVMatcher.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/MVMatcher.scala
@@ -726,7 +726,11 @@ private object SelectSelectNoChildDelta extends MVMatchPattern with PredicateHel
 
           if (r2eJoinsMatch) {
             if (isPredicateEmR && isOutputEmR && isOutputRmE && rejoin.isEmpty && isLOEmLOR) {
-              Seq(sel_1a)
+              if (sel_1q.flagSpec.isEmpty) {
+                Seq(sel_1a)
+              } else {
+                Seq(sel_1a.copy(flags = sel_1q.flags, flagSpec = sel_1q.flagSpec))
+              }
             } else {
               // no compensation needed
               val tChildren = new collection.mutable.ArrayBuffer[ModularPlan]()

--- a/integration/spark/src/test/scala/org/apache/carbondata/view/rewrite/TestAllOperationsOnMV.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/view/rewrite/TestAllOperationsOnMV.scala
@@ -610,10 +610,10 @@ class TestAllOperationsOnMV extends QueryTest with BeforeAndAfterEach {
     sql("drop materialized view if exists mv1")
     sql("create materialized view mv1  as select a.name,a.price from maintable a")
     var dataFrame = sql("select a.name,a.price from maintable a limit 1")
-    assert(dataFrame.count() == 1)
+    assert(dataFrame.collect().length == 1)
     TestUtil.verifyMVHit(dataFrame.queryExecution.optimizedPlan, "mv1")
     dataFrame = sql("select a.name,a.price from maintable a order by a.name limit 1")
-    assert(dataFrame.count() == 1)
+    assert(dataFrame.collect().length == 1)
     TestUtil.verifyMVHit(dataFrame.queryExecution.optimizedPlan, "mv1")
     sql("drop table if exists maintable")
   }


### PR DESCRIPTION
 ### Why is this PR needed?
 Already issue fixed in [PR-3652](https://github.com/apache/carbondata/pull/3651). Missed code during mv code refactory
 
 ### What changes were proposed in this PR?
Copy subsume Flag and FlagSpec to subsumerPlan while rewriting with summarydatasets.
Update the flagSpec as per the mv attributes and copy to relation.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No

    
