### PR TITLE
[CARBONDATA-3923] support global sort for SI

### DIFF
--- a/docs/index/secondary-index-guide.md
+++ b/docs/index/secondary-index-guide.md
@@ -84,7 +84,8 @@ EXPLAIN SELECT a from maintable where c = 'cd';
   'carbondata'
   PROPERTIES('table_blocksize'='1')
   ```
- 
+  **NOTE**:
+  * supported properties are table_blocksize, column_meta_cache, cache_level, carbon.column.compressor, sort_scope and global_sort_partitions.
  
 #### How SI tables are selected
 

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/load/DataLoadProcessBuilderOnSpark.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/load/DataLoadProcessBuilderOnSpark.scala
@@ -288,19 +288,19 @@ object DataLoadProcessBuilderOnSpark {
   private def updateLoadStatus(model: CarbonLoadModel, partialSuccessAccum: LongAccumulator
   ): Array[(String, (LoadMetadataDetails, ExecutionErrors))] = {
     // Update status
+    val loadMetadataDetails = new LoadMetadataDetails()
+    loadMetadataDetails.setLoadName(model.getSegmentId)
     if (partialSuccessAccum.value != 0) {
       val uniqueLoadStatusId = model.getTableName + CarbonCommonConstants.UNDERSCORE +
         "Partial_Success"
-      val loadMetadataDetails = new LoadMetadataDetails()
       loadMetadataDetails.setSegmentStatus(SegmentStatus.LOAD_PARTIAL_SUCCESS)
-      val executionErrors = new ExecutionErrors(FailureCauses.NONE, "")
+      val executionErrors = ExecutionErrors(FailureCauses.NONE, "")
       executionErrors.failureCauses = FailureCauses.BAD_RECORDS
       Array((uniqueLoadStatusId, (loadMetadataDetails, executionErrors)))
     } else {
       val uniqueLoadStatusId = model.getTableName + CarbonCommonConstants.UNDERSCORE + "Success"
-      val loadMetadataDetails = new LoadMetadataDetails()
       loadMetadataDetails.setSegmentStatus(SegmentStatus.SUCCESS)
-      val executionErrors = new ExecutionErrors(FailureCauses.NONE, "")
+      val executionErrors = ExecutionErrors(FailureCauses.NONE, "")
       Array((uniqueLoadStatusId, (loadMetadataDetails, executionErrors)))
     }
   }

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/util/CommonUtil.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/util/CommonUtil.scala
@@ -25,6 +25,7 @@ import java.util.UUID
 import java.util.regex.{Matcher, Pattern}
 
 import scala.collection.JavaConverters._
+import scala.collection.mutable
 import scala.collection.mutable.Map
 import scala.math.BigDecimal.RoundingMode
 
@@ -797,6 +798,26 @@ object CommonUtil {
         throw new MalformedCarbonCommandException(
           s"Invalid SORT_SCOPE ${ sortScopeOption.get }, " +
           s"valid SORT_SCOPE are 'NO_SORT', 'LOCAL_SORT' and 'GLOBAL_SORT'")
+      }
+    }
+  }
+
+  def validateGlobalSortPartitions(propertiesMap: mutable.Map[String, String]): Unit = {
+    if (propertiesMap.contains("global_sort_partitions")) {
+      val globalSortPartitionsProp = propertiesMap("global_sort_partitions")
+      var pass = false
+      try {
+        val globalSortPartitions = Integer.parseInt(globalSortPartitionsProp)
+        if (globalSortPartitions > 0) {
+          pass = true
+        }
+      } catch {
+        case _ =>
+      }
+      if (!pass) {
+        throw new MalformedCarbonCommandException(
+          s"Table property global_sort_partitions : ${ globalSortPartitionsProp }" +
+          s" is invalid")
       }
     }
   }

--- a/integration/spark/src/main/scala/org/apache/spark/sql/parser/CarbonSpark2SqlParser.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/parser/CarbonSpark2SqlParser.scala
@@ -191,6 +191,10 @@ class CarbonSpark2SqlParser extends CarbonDDLSqlParser {
             table.database, indexName.toLowerCase, tableColumns, properties)
           CarbonSparkSqlParserUtil.validateColumnCompressorProperty(
             properties.getOrElse(CarbonCommonConstants.COMPRESSOR, null))
+          // validate sort scope
+          CommonUtil.validateSortScope(properties)
+          // validate global_sort_partitions
+          CommonUtil.validateGlobalSortPartitions(properties)
           CarbonCreateSecondaryIndexCommand(
             indexModel,
             properties,
@@ -640,7 +644,9 @@ class CarbonSpark2SqlParser extends CarbonDDLSqlParser {
     val supportedPropertiesForIndexTable = Seq("TABLE_BLOCKSIZE",
       "COLUMN_META_CACHE",
       "CACHE_LEVEL",
-      CarbonCommonConstants.COMPRESSOR.toUpperCase)
+      CarbonCommonConstants.COMPRESSOR.toUpperCase,
+      "SORT_SCOPE",
+      "GLOBAL_SORT_PARTITIONS")
     tableProperties.foreach { property =>
       if (!supportedPropertiesForIndexTable.contains(property._1.toUpperCase)) {
         val errorMessage = "Unsupported Table property in index creation: " + property._1.toString

--- a/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/load/Compactor.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/load/Compactor.scala
@@ -22,7 +22,7 @@ import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
 
 import org.apache.spark.rdd.CarbonMergeFilesRDD
-import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.{CarbonEnv, SQLContext}
 import org.apache.spark.sql.index.CarbonIndexUtil
 import org.apache.spark.sql.secondaryindex.command.{IndexModel, SecondaryIndexModel}
 import org.apache.spark.sql.secondaryindex.events.LoadTableSIPostExecutionEvent
@@ -74,6 +74,11 @@ object Compactor {
         carbonLoadModel.getTableName,
         indexColumns,
         index.getKey)
+      val indexCarbonTable = CarbonEnv.getCarbonTable(Some(carbonLoadModel.getDatabaseName),
+        index.getKey)(sqlContext.sparkSession)
+      val header = indexCarbonTable.getCreateOrderColumn.asScala
+        .map(_.getColName).toArray
+      CarbonIndexUtil.initializeSILoadModel(carbonLoadModel, header)
       val secondaryIndexModel = SecondaryIndexModel(sqlContext,
         carbonLoadModel,
         carbonLoadModel.getCarbonDataLoadSchema.getCarbonTable,

--- a/integration/spark/src/main/scala/org/apache/spark/util/AlterTableUtil.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/util/AlterTableUtil.scala
@@ -414,7 +414,7 @@ object AlterTableUtil {
       // validate the range column properties
       validateRangeColumnProperties(carbonTable, lowerCasePropertiesMap)
 
-      validateGlobalSortPartitions(carbonTable, lowerCasePropertiesMap)
+      CommonUtil.validateGlobalSortPartitions(lowerCasePropertiesMap)
 
       // validate the Sort Scope and Sort Columns
       validateSortScopeAndSortColumnsProperties(carbonTable,
@@ -625,27 +625,6 @@ object AlterTableUtil {
           s" is not exists in the table")
       } else {
         propertiesMap.put(CarbonCommonConstants.RANGE_COLUMN, rangeColumn.getColName)
-      }
-    }
-  }
-
-  def validateGlobalSortPartitions(carbonTable: CarbonTable,
-      propertiesMap: mutable.Map[String, String]): Unit = {
-    if (propertiesMap.get("global_sort_partitions").isDefined) {
-      val globalSortPartitionsProp = propertiesMap.get("global_sort_partitions").get
-      var pass = false
-      try {
-        val globalSortPartitions = Integer.parseInt(globalSortPartitionsProp)
-        if (globalSortPartitions > 0) {
-          pass = true
-        }
-      } catch {
-        case _ =>
-      }
-      if (!pass) {
-        throw new MalformedCarbonCommandException(
-          s"Table property global_sort_partitions : ${ globalSortPartitionsProp }" +
-          s" is invalid")
       }
     }
   }


### PR DESCRIPTION
 ### Why is this PR needed?
Secondary index is always created with local sort, should support global sort, it can improve SI lookup performance.
 
 ### What changes were proposed in this PR?
support `sort_scope` and `global_sort_partitions` in create index property.

  
 ### Does this PR introduce any user interface change?
 - No
 
 ### Is any new testcase added?
 - Yes

    
