### PR TITLE
[CARBONDATA-3844]Fix scan the relevant database instead of scanning all

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/view/MVCatalog.java
+++ b/core/src/main/java/org/apache/carbondata/core/view/MVCatalog.java
@@ -17,6 +17,8 @@
 
 package org.apache.carbondata.core.view;
 
+import java.util.List;
+
 import org.apache.carbondata.core.metadata.schema.table.RelationIdentifier;
 
 /**
@@ -27,9 +29,9 @@ import org.apache.carbondata.core.metadata.schema.table.RelationIdentifier;
 public interface MVCatalog<T> {
 
   /**
-   * List all registered valid schema catalogs
+   * List list databases valid schema catalogs
    */
-  T[] getValidSchemas();
+  T[] getValidSchemas(List<String> databases);
 
   /**
    * Register schema to the catalog.

--- a/core/src/main/java/org/apache/carbondata/core/view/MVManager.java
+++ b/core/src/main/java/org/apache/carbondata/core/view/MVManager.java
@@ -234,6 +234,23 @@ public abstract class MVManager {
     }
     return statusDetails;
   }
+  /**
+   * Get databases list mv status details
+   */
+  public List<MVStatusDetail> getEnabledStatusDetails(List<String> databases)
+          throws IOException {
+    List<MVStatusDetail> enabledStatusDetails = new ArrayList<>();
+    for (String databaseName :databases) {
+      List<MVStatusDetail> statusDetails =
+              schemaProvider.getStatusDetails(this, databaseName);
+      for (MVStatusDetail statusDetail : statusDetails) {
+        if (statusDetail.getStatus() == MVStatus.ENABLED) {
+          enabledStatusDetails.add(statusDetail);
+        }
+      }
+    }
+    return enabledStatusDetails;
+  }
 
   /**
    * Get enabled mv status details

--- a/integration/spark/src/main/scala/org/apache/carbondata/view/MVCatalogInSpark.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/view/MVCatalogInSpark.scala
@@ -17,6 +17,7 @@
 
 package org.apache.carbondata.view
 
+import java.util
 import java.util.concurrent.locks.ReentrantReadWriteLock
 
 import scala.collection.JavaConverters._
@@ -67,8 +68,8 @@ case class MVCatalogInSpark(session: SparkSession)
     }
   }
 
-  override def getValidSchemas: Array[MVSchemaWrapper] = {
-    val enabledStatusDetails = viewManager.getEnabledStatusDetails.asScala
+  override def getValidSchemas(databases: util.List[String]): Array[MVSchemaWrapper] = {
+    val enabledStatusDetails = viewManager.getEnabledStatusDetails(databases).asScala
     // Only select the enabled mvs for the query.
     val enabledSchemas = viewSchemas.filter {
       enabledSchema =>

--- a/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/MVRewriteRule.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/MVRewriteRule.scala
@@ -16,6 +16,8 @@
  */
 package org.apache.spark.sql.optimizer
 
+import java.util
+
 import scala.collection.JavaConverters._
 
 import org.apache.spark.sql.SparkSession
@@ -187,7 +189,11 @@ class MVRewriteRule(session: SparkSession) extends Rule[LogicalPlan] {
         case relation: LogicalRelation if relation.catalogTable.isDefined => relation.catalogTable
         case relation: HiveTableRelation => Option(relation.tableMeta)
       }
-      val validSchemas = catalog.getValidSchemas()
+      val databasesList = new util.ArrayList[String]()
+      catalogs.foreach (carbonTable => {
+        databasesList.add(carbonTable.get.database)
+      })
+      val validSchemas = catalog.getValidSchemas(databasesList)
       catalogs.nonEmpty &&
       !isRewritten(validSchemas, catalogs) &&
       !isRelatedTableSegmentsSetAsInput(catalogs) &&


### PR DESCRIPTION
 ### Why is this PR needed?
 When a query is executed, all databases of metadata are scanned, and if the number of databases is very large, the execution time increases for a long time each time, reducing query performance
 
 ### What changes were proposed in this PR?
scan the relevant database instead of scanning all
    
 ### Does this PR introduce any user interface change?
 - No
 - Yes. (please explain the change and update document)

 ### Is any new testcase added?
 - No
 - Yes

    
