### PR TITLE
[CARBONDATA-3854] Quotechar support to more than one character

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/catalyst/CarbonParserUtil.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/catalyst/CarbonParserUtil.scala
@@ -946,14 +946,6 @@ object CarbonParserUtil {
       throw new MalformedCarbonCommandException(errorMessage)
     }
 
-    // Validate QUOTECHAR length
-    if (options.exists(_._1.equalsIgnoreCase("QUOTECHAR"))) {
-      val quoteChar: String = options.get("quotechar").get.head._2
-      if (quoteChar.length > 1 ) {
-        throw new MalformedCarbonCommandException("QUOTECHAR cannot be more than one character.")
-      }
-    }
-
     // Validate COMMENTCHAR length
     if (options.exists(_._1.equalsIgnoreCase("COMMENTCHAR"))) {
       val commentChar: String = options.get("commentchar").get.head._2

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestLoadOptions.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/dataload/TestLoadOptions.scala
@@ -35,14 +35,6 @@ class TestLoadOptions extends QueryTest with BeforeAndAfterAll {
     sql("drop table if exists TestLoadTableOptions")
   }
 
-  test("test load data with more than one char in quotechar option") {
-    val errorMessage = intercept[MalformedCarbonCommandException] {
-      sql(s"LOAD DATA LOCAL INPATH '$resourcesPath/dataretention1.csv' INTO TABLE " +
-          s"TestLoadTableOptions OPTIONS('QUOTECHAR'='\\\\')")
-    }.getMessage
-    assert(errorMessage.equals("QUOTECHAR cannot be more than one character."))
-  }
-
   test("test load data with more than one char in commentchar option") {
     val errorMessage = intercept[MalformedCarbonCommandException] {
       sql(s"LOAD DATA LOCAL INPATH '$resourcesPath/dataretention1.csv' INTO TABLE " +

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/model/CarbonLoadModelBuilder.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/model/CarbonLoadModelBuilder.java
@@ -181,7 +181,8 @@ public class CarbonLoadModelBuilder {
 
     validateGlobalSortPartitions(global_sort_partitions);
     carbonLoadModel.setEscapeChar(checkDefaultValue(optionsFinal.get("escapechar"), "\\"));
-    carbonLoadModel.setQuoteChar(checkDefaultValue(optionsFinal.get("quotechar"), "\""));
+    carbonLoadModel.setQuoteChar(
+        CarbonUtil.unescapeChar(checkDefaultValue(optionsFinal.get("quotechar"), "\"")));
     carbonLoadModel.setCommentChar(checkDefaultValue(optionsFinal.get("commentchar"), "#"));
     String lineSeparator = CarbonUtil.unescapeChar(options.get("line_separator"));
     if (lineSeparator != null) {


### PR DESCRIPTION
 ### Why is this PR needed?
Need to support more than one character the same as a like **delimiter**.
Quote char support to unprintable character like \u0009 \u0010
Currently, carbondata will not support setting quotechar to printable char like \u0009.
the current behaviour is quotechar will through exception if we give more than one character.

 
 ### What changes were proposed in this PR?

    
 ### Does this PR introduce any user interface change?
 - No
 - Yes. (please explain the change and update document)

 ### Is any new testcase added?
 - No
 - Yes

    
