### PR TITLE
[CARBONDATA-3856] Support the LIMIT operator for show segments command

### DIFF
--- a/docs/segment-management-on-carbondata.md
+++ b/docs/segment-management-on-carbondata.md
@@ -32,7 +32,7 @@ concept which helps to maintain consistency of data and easy transaction managem
 
   ```
   SHOW [HISTORY] SEGMENTS
-  [FOR TABLE | ON] [db_name.]table_name
+  [FOR TABLE | ON] [db_name.]table_name [LIMIT number_of_segments]
   [AS (select query from table_name_segments)]
   ```
 
@@ -52,6 +52,12 @@ concept which helps to maintain consistency of data and easy transaction managem
 
   ```
   SHOW SEGMENTS ON CarbonDatabase.CarbonTable
+  ```
+
+  Show 10 visible segments with the largest segmentid
+
+  ```
+  SHOW SEGMENTS ON CarbonDatabase.CarbonTable LIMIT 10
   ```
 
   Show all segments, include invisible segments
@@ -81,6 +87,9 @@ concept which helps to maintain consistency of data and easy transaction managem
 
   ```
   SHOW SEGMENTS ON CarbonTable AS 
+  SELECT * FROM CarbonTable_segments
+  
+  SHOW SEGMENTS ON CarbonTable LIMIT 10 AS 
   SELECT * FROM CarbonTable_segments
   
   SHOW SEGMENTS ON CarbonTable AS

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonShowSegmentsAsSelectCommand.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonShowSegmentsAsSelectCommand.scala
@@ -35,6 +35,7 @@ case class CarbonShowSegmentsAsSelectCommand(
     databaseNameOp: Option[String],
     tableName: String,
     query: String,
+    limit: Option[String],
     showHistory: Boolean = false)
   extends DataCommand {
 
@@ -71,7 +72,7 @@ case class CarbonShowSegmentsAsSelectCommand(
 
   private def createDataFrame: DataFrame = {
     val tablePath = carbonTable.getTablePath
-    val segments = CarbonStore.readSegments(tablePath, showHistory)
+    val segments = CarbonStore.readSegments(tablePath, showHistory, limit)
     val tempViewName = makeTempViewName(carbonTable)
     registerSegmentRowView(sparkSession, tempViewName, carbonTable, segments)
     try {

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonShowSegmentsCommand.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonShowSegmentsCommand.scala
@@ -30,6 +30,7 @@ import org.apache.carbondata.core.statusmanager.LoadMetadataDetails
 case class CarbonShowSegmentsCommand(
     databaseNameOp: Option[String],
     tableName: String,
+    limit: Option[String],
     showHistory: Boolean = false)
   extends DataCommand {
 
@@ -54,7 +55,7 @@ case class CarbonShowSegmentsCommand(
       throw new MalformedCarbonCommandException("Unsupported operation on non transactional table")
     }
     val tablePath = carbonTable.getTablePath
-    val segments = readSegments(tablePath, showHistory)
+    val segments = readSegments(tablePath, showHistory, limit)
     if (segments.nonEmpty) {
       showBasic(segments, tablePath)
     } else {
@@ -65,13 +66,8 @@ case class CarbonShowSegmentsCommand(
   override protected def opName: String = "SHOW SEGMENTS"
 
   private def showBasic(
-      allSegments: Array[LoadMetadataDetails],
+      segments: Array[LoadMetadataDetails],
       tablePath: String): Seq[Row] = {
-    val segments = allSegments.sortWith { (l1, l2) =>
-      java.lang.Double.parseDouble(l1.getLoadName) >
-      java.lang.Double.parseDouble(l2.getLoadName)
-    }
-
     segments
       .map { segment =>
         val startTime = getLoadStartTime(segment)

--- a/integration/spark/src/main/scala/org/apache/spark/sql/parser/CarbonSpark2SqlParser.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/parser/CarbonSpark2SqlParser.scala
@@ -541,18 +541,20 @@ class CarbonSpark2SqlParser extends CarbonDDLSqlParser {
    */
   protected lazy val showSegments: Parser[LogicalPlan] =
     (SHOW ~> opt(HISTORY) <~ SEGMENTS <~ ((FOR <~ TABLE) | ON)) ~ (ident <~ ".").? ~ ident ~
-    (AS  ~> restInput).? <~ opt(";") ^^ {
-      case showHistory ~ databaseName ~ tableName ~ queryOp =>
+    (LIMIT ~> numericLit).? ~ (AS  ~> restInput).? <~ opt(";") ^^ {
+      case showHistory ~ databaseName ~ tableName ~ limit ~ queryOp =>
         if (queryOp.isEmpty) {
           CarbonShowSegmentsCommand(
             CarbonParserUtil.convertDbNameToLowerCase(databaseName),
             tableName.toLowerCase(),
+            limit,
             showHistory.isDefined)
         } else {
           CarbonShowSegmentsAsSelectCommand(
             CarbonParserUtil.convertDbNameToLowerCase(databaseName),
             tableName.toLowerCase(),
             queryOp.get,
+            limit,
             showHistory.isDefined)
         }
     }

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/segmentreading/TestSegmentReading.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/segmentreading/TestSegmentReading.scala
@@ -254,10 +254,12 @@ class TestSegmentReading extends QueryTest with BeforeAndAfterAll {
       val col = df.collect().map{
         row => Row(row.getString(0),row.getString(1),row.getString(7))
       }.toSeq
-      assert(col.equals(Seq(Row("0","Compacted","0.1"),
+      assert(col.equals(Seq(
+        Row("2","Success","NA"),
         Row("1","Compacted","0.1"),
         Row("0.1","Success","NA"),
-        Row("2","Success","NA"))))
+        Row("0","Compacted","0.1")
+       )))
     }
     finally {
       sql("SET carbon.input.segments.default.carbon_table=*")


### PR DESCRIPTION
 ### Why is this PR needed?
 When the number segments is large, "SHOW SEGMENTS" time overhead is too high. The LIMIT operator shall be supported in the SHOW SEGMENTS command.
 
 ### What changes were proposed in this PR?
Add LIMIT operator in the grammar parsing and read segments function.
    
 ### Does this PR introduce any user interface change?
Yes

 ### Is any new testcase added?
Yes
    
