### PR TITLE
[CARBONDATA-3860] Fix IndexServer keeps loading some segments index repeatly

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletIndexFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletIndexFactory.java
@@ -72,6 +72,7 @@ import org.apache.carbondata.core.util.CarbonProperties;
 import org.apache.carbondata.core.util.path.CarbonTablePath;
 import org.apache.carbondata.events.Event;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.hadoop.fs.Path;
 
 /**
@@ -352,9 +353,13 @@ public class BlockletIndexFactory extends CoarseGrainIndexFactory
       throws IOException {
     SegmentBlockIndexInfo segmentBlockIndexInfo = segmentMap.get(segment.getSegmentNo());
     Set<TableBlockIndexUniqueIdentifier> tableBlockIndexUniqueIdentifiers = null;
-    if (null != segmentBlockIndexInfo && null != segmentBlockIndexInfo.getSegmentMetaDataInfo()) {
-      segment.setSegmentMetaDataInfo(
-          segmentMap.get(segment.getSegmentNo()).getSegmentMetaDataInfo());
+    if (null != segmentBlockIndexInfo &&
+            CollectionUtils.isNotEmpty(
+                    segmentBlockIndexInfo.getTableBlockIndexUniqueIdentifiers())) {
+      if (null != segmentBlockIndexInfo.getSegmentMetaDataInfo()) {
+        segment.setSegmentMetaDataInfo(
+                segmentMap.get(segment.getSegmentNo()).getSegmentMetaDataInfo());
+      }
       return segmentBlockIndexInfo.getTableBlockIndexUniqueIdentifiers();
     } else {
       tableBlockIndexUniqueIdentifiers =


### PR DESCRIPTION
  ### Why is this PR needed?
 In current getTableBlockIndexUniqueIdentifiers function. if the segmentBlockIndexInfo.getSegmentMetaDataInfo() is null, the IndexServer will keeps loading the index of this segment repeatly. We shall avoid to let it affect query performance, considering MetaDataInfo doesn't matter with the query processing.
 
 ### What changes were proposed in this PR?
Return the cached index directly if segmentBlockIndexInfo.getTableBlockIndexUniqueIdentifiers() is not empty 
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No

    
