### PR TITLE
[CARBONDATA-3875] Support show segments with stage

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/statusmanager/StageInput.java
+++ b/core/src/main/java/org/apache/carbondata/core/statusmanager/StageInput.java
@@ -45,6 +45,16 @@ public class StageInput {
    */
   private List<PartitionLocation> locations;
 
+  /**
+   * current stage create at this time.
+   */
+  private transient long createTime;
+
+  /**
+   * status of stage, unloaded or loading.
+   */
+  private StageStatus status;
+
   public StageInput() {
 
   }
@@ -83,6 +93,14 @@ public class StageInput {
     this.locations = locations;
   }
 
+  public StageStatus getStatus() {
+    return status;
+  }
+
+  public void setStatus(StageStatus status) {
+    this.status = status;
+  }
+
   public List<InputSplit> createSplits() {
     return
         files.entrySet().stream().filter(
@@ -92,6 +110,14 @@ public class StageInput {
                 base + CarbonCommonConstants.FILE_SEPARATOR + entry.getKey(),
                 0, entry.getValue(), ColumnarFormatVersion.V3, null)
         ).collect(Collectors.toList());
+  }
+
+  public long getCreateTime() {
+    return createTime;
+  }
+
+  public void setCreateTime(long createTime) {
+    this.createTime = createTime;
   }
 
   public static final class PartitionLocation {
@@ -131,6 +157,10 @@ public class StageInput {
       this.files = files;
     }
 
+  }
+
+  public enum StageStatus {
+    Unload, Loading
   }
 
 }

--- a/docs/segment-management-on-carbondata.md
+++ b/docs/segment-management-on-carbondata.md
@@ -32,7 +32,7 @@ concept which helps to maintain consistency of data and easy transaction managem
 
   ```
   SHOW [HISTORY] SEGMENTS
-  [FOR TABLE | ON] [db_name.]table_name [LIMIT number_of_segments]
+  [FOR TABLE | ON] [db_name.]table_name [INCLUDE STAGE] [LIMIT number_of_segments]
   [AS (select query from table_name_segments)]
   ```
 
@@ -63,6 +63,12 @@ concept which helps to maintain consistency of data and easy transaction managem
   Show all segments, include invisible segments
   ```
   SHOW HISTORY SEGMENTS ON CarbonDatabase.CarbonTable
+  ```
+
+  Show all segments, include stages
+  Stage status is 'Unload' or 'Loading', and stage ID, stage load time taken is null.
+  ```
+  SHOW SEGMENTS ON CarbonDatabase.CarbonTable INCLUDE STAGE
   ```
 
 
@@ -99,6 +105,9 @@ concept which helps to maintain consistency of data and easy transaction managem
   
   SHOW SEGMENTS ON CarbonTable AS
   SELECT avg(timeTakenMs) FROM CarbonTable_segments  
+  
+  SHOW SEGMENTS ON CarbonTable INCLUDE STAGE AS
+  SELECT avg(timeTakenMs) FROM CarbonTable_segments
   ```
 
 

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonInsertFromStageCommand.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonInsertFromStageCommand.scala
@@ -680,6 +680,8 @@ case class CarbonInsertFromStageCommand(
       val stageFiles = allFiles.filter { file =>
         !file.getName.endsWith(CarbonTablePath.SUCCESS_FILE_SUBFIX)
       }.filter { file =>
+        !file.getName.endsWith(CarbonTablePath.LOADING_FILE_SUBFIX)
+      }.filter { file =>
         successFiles.contains(file.getName)
       }.filterNot { file =>
         loadingFiles.contains(file.getName)

--- a/integration/spark/src/main/scala/org/apache/spark/sql/parser/CarbonSpark2SqlParser.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/parser/CarbonSpark2SqlParser.scala
@@ -541,21 +541,23 @@ class CarbonSpark2SqlParser extends CarbonDDLSqlParser {
    */
   protected lazy val showSegments: Parser[LogicalPlan] =
     (SHOW ~> opt(HISTORY) <~ SEGMENTS <~ ((FOR <~ TABLE) | ON)) ~ (ident <~ ".").? ~ ident ~
-    (LIMIT ~> numericLit).? ~ (AS  ~> restInput).? <~ opt(";") ^^ {
-      case showHistory ~ databaseName ~ tableName ~ limit ~ queryOp =>
+      opt(WITH <~ STAGE) ~ (LIMIT ~> numericLit).? ~ (AS  ~> restInput).? <~ opt(";") ^^ {
+      case showHistory ~ databaseName ~ tableName ~ withStage ~ limit ~ queryOp =>
         if (queryOp.isEmpty) {
           CarbonShowSegmentsCommand(
             CarbonParserUtil.convertDbNameToLowerCase(databaseName),
             tableName.toLowerCase(),
-            limit,
-            showHistory.isDefined)
+            if (limit.isDefined) Some(Integer.valueOf(limit.get)) else None,
+            showHistory.isDefined,
+            withStage.isDefined)
         } else {
           CarbonShowSegmentsAsSelectCommand(
             CarbonParserUtil.convertDbNameToLowerCase(databaseName),
             tableName.toLowerCase(),
             queryOp.get,
-            limit,
-            showHistory.isDefined)
+            if (limit.isDefined) Some(Integer.valueOf(limit.get)) else None,
+            showHistory.isDefined,
+            withStage.isDefined)
         }
     }
 


### PR DESCRIPTION
 ### Why is this PR needed?
 Currently, there is a lack of monitoring of the stages information, 'Show segments with stage' command shall be supported, which can provide monitoring information, such as createTime, partitioninfo, etc.
 
 ### What changes were proposed in this PR?
added 'With stage semantics'  in the show segments flow, which will collect stageinfo by read stage files.
    
 ### Does this PR introduce any user interface change?
 - Yes. 

 ### Is any new testcase added?
 - Yes

    
