### PR TITLE
[CARBONDATA-3877] Reduce read tablestatus overhead during inserting into partition table

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/metadata/SegmentFileStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/SegmentFileStore.java
@@ -1149,6 +1149,23 @@ public class SegmentFileStore {
    * @throws IOException
    */
   public static List<PartitionSpec> getPartitionSpecs(String segmentId, String tablePath,
+      String segmentFilePath, String loadStartTime) throws IOException {
+    SegmentFileStore fileStore = new SegmentFileStore(tablePath, segmentFilePath);
+    List<PartitionSpec> partitionSpecs = fileStore.getPartitionSpecs();
+    for (PartitionSpec spec : partitionSpecs) {
+      spec.setUuid(segmentId + "_" + loadStartTime);
+    }
+    return partitionSpecs;
+  }
+
+  /**
+   * Get the partition specs of the segment
+   * @param segmentId
+   * @param tablePath
+   * @return
+   * @throws IOException
+   */
+  public static List<PartitionSpec> getPartitionSpecs(String segmentId, String tablePath,
       LoadMetadataDetails[] details)
       throws IOException {
     LoadMetadataDetails segEntry = null;

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonOutputCommitter.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonOutputCommitter.java
@@ -232,10 +232,13 @@ public class CarbonOutputCommitter extends FileOutputCommitter {
     String segmentsToBeDeleted =
         context.getConfiguration().get(CarbonTableOutputFormat.SEGMENTS_TO_BE_DELETED, "");
     List<Segment> segmentDeleteList = Segment.toSegmentList(segmentsToBeDeleted.split(","), null);
-    Set<Segment> segmentSet = new HashSet<>(
-        new SegmentStatusManager(carbonTable.getAbsoluteTableIdentifier(),
-            context.getConfiguration()).getValidAndInvalidSegments(carbonTable.isMV())
-            .getValidSegments());
+    Set<Segment> segmentSet = new HashSet<>();
+    if (updateTime != null || uniqueId != null) {
+      segmentSet = new HashSet<>(
+          new SegmentStatusManager(carbonTable.getAbsoluteTableIdentifier(),
+              context.getConfiguration()).getValidAndInvalidSegments(carbonTable.isMV())
+                  .getValidSegments());
+    }
     if (updateTime != null) {
       CarbonUpdateUtil.updateTableMetadataStatus(segmentSet, carbonTable, updateTime, true,
           segmentDeleteList);

--- a/integration/spark/src/main/scala/org/apache/spark/rdd/CarbonMergeFilesRDD.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/rdd/CarbonMergeFilesRDD.scala
@@ -229,14 +229,15 @@ class CarbonMergeFilesRDD(
 
   override def internalGetPartitions: Array[Partition] = {
     if (isHivePartitionedTable) {
-      val metadataDetails = SegmentStatusManager
-        .readLoadMetadata(CarbonTablePath.getMetadataPath(carbonTable.getTablePath))
       // in case of partition table make rdd partitions per partition of the carbon table
       val partitionPaths: java.util.Map[String, java.util.List[String]] = new java.util.HashMap()
       if (partitionInfo == null || partitionInfo.isEmpty) {
         segments.foreach(segment => {
+          val loadStartTime = segmentFileNameToSegmentIdMap.get(segment)
+          val segmentFileName = SegmentFileStore.genSegmentFileName(
+            segment, loadStartTime) + CarbonTablePath.SEGMENT_EXT
           val partitionSpecs = SegmentFileStore
-            .getPartitionSpecs(segment, carbonTable.getTablePath, metadataDetails)
+            .getPartitionSpecs(segment, carbonTable.getTablePath, segmentFileName, loadStartTime)
             .asScala.map(_.getLocation.toString)
           partitionPaths.put(segment, partitionSpecs.asJava)
         })

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonInsertIntoCommand.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonInsertIntoCommand.scala
@@ -202,8 +202,6 @@ case class CarbonInsertIntoCommand(databaseNameOp: Option[String],
           updateModel = None,
           operationContext = operationContext)
 
-      // Clean up the old invalid segment data before creating a new entry for new load.
-      SegmentStatusManager.deleteLoadsAndUpdateMetadata(table, false, currPartitions)
       // add the start entry for the new load in the table status file
       if (!table.isHivePartitionTable) {
         CarbonLoaderUtil.readAndUpdateLoadProgressInTableMeta(

--- a/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/events/SILoadEventListenerForFailedSegments.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/events/SILoadEventListenerForFailedSegments.scala
@@ -64,7 +64,6 @@ class SILoadEventListenerForFailedSegments extends OperationEventListener with L
           .lookupRelation(Some(carbonLoadModel.getDatabaseName),
             carbonLoadModel.getTableName)(sparkSession).asInstanceOf[CarbonRelation].carbonTable
         val indexMetadata = carbonTable.getIndexMetadata
-        val mainTableDetails = SegmentStatusManager.readLoadMetadata(carbonTable.getMetadataPath)
         val secondaryIndexProvider = IndexType.SI.getIndexProviderName
         if (null != indexMetadata && null != indexMetadata.getIndexesMap &&
             null != indexMetadata.getIndexesMap.get(secondaryIndexProvider)) {
@@ -72,6 +71,8 @@ class SILoadEventListenerForFailedSegments extends OperationEventListener with L
             .get(secondaryIndexProvider).keySet().asScala
           // if there are no index tables for a given fact table do not perform any action
           if (indexTables.nonEmpty) {
+            val mainTableDetails =
+              SegmentStatusManager.readLoadMetadata(carbonTable.getMetadataPath)
             indexTables.foreach {
               indexTableName =>
                 val isLoadSIForFailedSegments = sparkSession.sessionState.catalog

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/TableProcessingOperations.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/TableProcessingOperations.java
@@ -54,11 +54,10 @@ public class TableProcessingOperations {
   public static void deletePartialLoadDataIfExist(CarbonTable carbonTable,
       final boolean isCompactionFlow) throws IOException {
     String metaDataLocation = carbonTable.getMetadataPath();
-    final LoadMetadataDetails[] details = SegmentStatusManager.readLoadMetadata(metaDataLocation);
-
     //delete folder which metadata no exist in tablestatus
     String partitionPath = CarbonTablePath.getPartitionDir(carbonTable.getTablePath());
     if (FileFactory.isFileExist(partitionPath)) {
+      final LoadMetadataDetails[] details = SegmentStatusManager.readLoadMetadata(metaDataLocation);
       CarbonFile carbonFile = FileFactory.getCarbonFile(partitionPath);
       CarbonFile[] listFiles = carbonFile.listFiles(new CarbonFileFilter() {
         @Override


### PR DESCRIPTION
 ### Why is this PR needed?
 Currently during inserting into a partition table, there are a lot of tablestauts read operations, but when storing table status file in object store, reading of table status file may fail (receive IOException or JsonSyntaxException) when table status file is being modifying, which leading to High failure rate when concurrent insert into a partition table.
 
 ### What changes were proposed in this PR?
(1) Three codes was removed：calcute sizeinbytes, clean segments, deleteLoadsAndUpdateMetadata
     'calcute sizeinbytes' is useless during inserting into flow. 'clean segments' and 'deleteLoadsAndUpdateMetadata' are supported by 'clean files' command, which can be removed from inserting into flow. 
(2) Reduce duplicate tablestatus operations and limit the conditions to get tablestatus.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No

    
