### PR TITLE
[CARBONDATA-3884] During Concurrent loads in main table with SI table with isSITableEnabled  = false, one of the concurrent load fails

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/events/SILoadEventListenerForFailedSegments.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/events/SILoadEventListenerForFailedSegments.scala
@@ -190,14 +190,21 @@ class SILoadEventListenerForFailedSegments extends OperationEventListener with L
 
   def checkIfMainTableLoadIsValid(mainTableDetails: Array[LoadMetadataDetails],
     loadName: String): Boolean = {
+    // in concurrent scenarios there can be cases when loadName is not present in the
+    // mainTableDetails array. Added a check to see if the loadName is even present in the
+    // mainTableDetails.
     val mainTableLoadDetail = mainTableDetails
-      .filter(mainTableDetail => mainTableDetail.getLoadName.equals(loadName)).head
-    if (mainTableLoadDetail.getSegmentStatus ==
-        SegmentStatus.MARKED_FOR_DELETE ||
-        mainTableLoadDetail.getSegmentStatus == SegmentStatus.COMPACTED) {
+      .filter(mainTableDetail => mainTableDetail.getLoadName.equals(loadName))
+    if (mainTableLoadDetail.length == 0) {
       false
     } else {
-      true
+      if (mainTableLoadDetail.head.getSegmentStatus ==
+        SegmentStatus.MARKED_FOR_DELETE ||
+        mainTableLoadDetail.head.getSegmentStatus == SegmentStatus.COMPACTED) {
+        false
+      } else {
+        true
+      }
     }
   }
 }


### PR DESCRIPTION
 ### Why is this PR needed?
Concurrent load failure in main table with SI table with isSITableEnabled  = false
 
 ### What changes were proposed in this PR?
Check if the load name is present in the mainTableDetails array
Adding compaction case in SILoadEventListenerForFailedSegments
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No

    
