### PR TITLE
[CARBONDATA-3871] Optimize performance when getting row from heap

### DIFF
--- a/processing/src/main/java/org/apache/carbondata/processing/loading/sort/CarbonPriorityQueue.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/sort/CarbonPriorityQueue.java
@@ -19,6 +19,7 @@ package org.apache.carbondata.processing.loading.sort;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.Comparator;
 import java.util.PriorityQueue;
 
 import org.apache.carbondata.processing.loading.exception.CarbonDataLoadingException;
@@ -35,7 +36,15 @@ public class CarbonPriorityQueue<E> extends PriorityQueue<E> {
 
   public CarbonPriorityQueue(int initialCapacity) {
     super(initialCapacity);
+    init();
+  }
 
+  public CarbonPriorityQueue(int initialCapacity, Comparator<? super E> comparator) {
+    super(initialCapacity, comparator);
+    init();
+  }
+
+  private void init() {
     try {
       queueField = PriorityQueue.class.getDeclaredField("queue");
       queueField.setAccessible(true);

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/sort/CarbonPriorityQueue.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/sort/CarbonPriorityQueue.java
@@ -29,7 +29,7 @@ import org.apache.carbondata.processing.loading.exception.CarbonDataLoadingExcep
  * by accessing member/method in PriorityQueue
  */
 public class CarbonPriorityQueue<E> extends PriorityQueue<E> {
-  private transient Object[] queue;
+  private transient Field queueField;
   private transient Method siftDownMethod;
   private static final long serialVersionUID = 1L;
 
@@ -37,9 +37,8 @@ public class CarbonPriorityQueue<E> extends PriorityQueue<E> {
     super(initialCapacity);
 
     try {
-      Field field = PriorityQueue.class.getDeclaredField("queue");
-      field.setAccessible(true);
-      queue = (Object[]) field.get(this);
+      queueField = PriorityQueue.class.getDeclaredField("queue");
+      queueField.setAccessible(true);
       siftDownMethod = PriorityQueue.class.getDeclaredMethod("siftDown", int.class, Object.class);
       siftDownMethod.setAccessible(true);
     } catch (ReflectiveOperationException e) {
@@ -49,7 +48,8 @@ public class CarbonPriorityQueue<E> extends PriorityQueue<E> {
 
   public void siftTopDown() {
     try {
-      siftDownMethod.invoke(this, 0, queue[0]);
+      Object topNode = ((Object[]) queueField.get(this))[0];
+      siftDownMethod.invoke(this, 0, topNode);
     } catch (ReflectiveOperationException e) {
       throw new CarbonDataLoadingException("Reflective operation failed", e);
     }

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/sort/CarbonPriorityQueue.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/sort/CarbonPriorityQueue.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.processing.loading.sort;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.PriorityQueue;
+
+import org.apache.carbondata.processing.loading.exception.CarbonDataLoadingException;
+
+/**
+ * This class is used to optimize sort step performance while getting row from heap,
+ * including intermediate merge and final sort merge in loading process,
+ * by accessing member/method in PriorityQueue
+ */
+public class CarbonPriorityQueue<E> extends PriorityQueue<E> {
+  private transient Object[] queue;
+  private transient Method siftDownMethod;
+  private static final long serialVersionUID = 1L;
+
+  public CarbonPriorityQueue(int initialCapacity) {
+    super(initialCapacity);
+
+    try {
+      Field field = PriorityQueue.class.getDeclaredField("queue");
+      field.setAccessible(true);
+      queue = (Object[]) field.get(this);
+      siftDownMethod = PriorityQueue.class.getDeclaredMethod("siftDown", int.class, Object.class);
+      siftDownMethod.setAccessible(true);
+    } catch (ReflectiveOperationException e) {
+      throw new CarbonDataLoadingException("Reflective operation failed", e);
+    }
+  }
+
+  public void siftTopDown() {
+    try {
+      siftDownMethod.invoke(this, 0, queue[0]);
+    } catch (ReflectiveOperationException e) {
+      throw new CarbonDataLoadingException("Reflective operation failed", e);
+    }
+  }
+}

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/sort/unsafe/merger/UnsafeInMemoryIntermediateDataMerger.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/sort/unsafe/merger/UnsafeInMemoryIntermediateDataMerger.java
@@ -147,6 +147,7 @@ public class UnsafeInMemoryIntermediateDataMerger implements Callable<Void> {
 
     // check if there no entry present
     if (!poll.hasNext()) {
+      poll.close();
       this.recordHolderHeap.poll();
       // change the file counter
       --this.holderCounter;

--- a/processing/src/main/java/org/apache/carbondata/processing/merger/RowResultMergerProcessor.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/merger/RowResultMergerProcessor.java
@@ -18,11 +18,9 @@
 package org.apache.carbondata.processing.merger;
 
 import java.io.IOException;
-import java.util.AbstractQueue;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-import java.util.PriorityQueue;
 
 import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
@@ -38,6 +36,7 @@ import org.apache.carbondata.core.scan.wrappers.ByteArrayWrapper;
 import org.apache.carbondata.core.util.ByteUtil;
 import org.apache.carbondata.processing.exception.SliceMergerException;
 import org.apache.carbondata.processing.loading.model.CarbonLoadModel;
+import org.apache.carbondata.processing.loading.sort.CarbonPriorityQueue;
 import org.apache.carbondata.processing.store.CarbonFactDataHandlerColumnar;
 import org.apache.carbondata.processing.store.CarbonFactDataHandlerModel;
 import org.apache.carbondata.processing.store.CarbonFactHandler;
@@ -59,7 +58,7 @@ public class RowResultMergerProcessor extends AbstractResultProcessor {
   /**
    * record holder heap
    */
-  private AbstractQueue<RawResultIterator> recordHolderHeap;
+  private CarbonPriorityQueue<RawResultIterator> recordHolderHeap;
 
   private static final Logger LOGGER =
       LogServiceFactory.getLogService(RowResultMergerProcessor.class.getName());
@@ -97,7 +96,7 @@ public class RowResultMergerProcessor extends AbstractResultProcessor {
 
   private void initRecordHolderHeap(List<RawResultIterator> rawResultIteratorList) {
     // create the List of RawResultIterator.
-    recordHolderHeap = new PriorityQueue<RawResultIterator>(rawResultIteratorList.size(),
+    recordHolderHeap = new CarbonPriorityQueue<>(rawResultIteratorList.size(),
         new RowResultMergerProcessor.CarbonMdkeyComparator());
   }
 
@@ -126,7 +125,7 @@ public class RowResultMergerProcessor extends AbstractResultProcessor {
       RawResultIterator iterator = null;
       while (index > 1) {
         // iterator the top record
-        iterator = this.recordHolderHeap.poll();
+        iterator = this.recordHolderHeap.peek();
         Object[] convertedRow = iterator.next();
         if (null == convertedRow) {
           index--;
@@ -144,10 +143,11 @@ public class RowResultMergerProcessor extends AbstractResultProcessor {
         if (!iterator.hasNext()) {
           index--;
           iterator.close();
+          this.recordHolderHeap.poll();
           continue;
         }
-        // add record to heap
-        this.recordHolderHeap.add(iterator);
+        // maintain heap
+        this.recordHolderHeap.siftTopDown();
       }
       // if record holder is not empty then iterator the slice holder from
       // heap

--- a/processing/src/main/java/org/apache/carbondata/processing/merger/RowResultMergerProcessor.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/merger/RowResultMergerProcessor.java
@@ -130,6 +130,7 @@ public class RowResultMergerProcessor extends AbstractResultProcessor {
         if (null == convertedRow) {
           index--;
           iterator.close();
+          this.recordHolderHeap.poll();
           continue;
         }
         if (!isDataPresent) {


### PR DESCRIPTION
 ### Why is this PR needed?
 Currently carbon uses priority queue to sort holders of sorted rows. 
 It first polls a holder from the heap, and adds it back if holder is not empty.
 This will cause two times heap maintainance. We can reduce half of that operation,
and test shows it can save one third of time to get rows . 
 
 ### What changes were proposed in this PR?
 What will be done when poll item from priority queue currently is:
1. remove first item.
2. move the last item to the position of first item, siftDown the new first item.

In this patch, we will peek(without removing from heap) the first item and get a row, 
and siftDown the holder to a proper position if the holder is not empty.

Since this will affect order of non-sorted columns, it depends on #3813 
    
 ### Does this PR introduce any user interface change?
 - No
 - Yes. (please explain the change and update document)

 ### Is any new testcase added?
 - No
 - Yes

    
