### PR TITLE
[WIP][HOTFIX] Fix module problems of mv and spark with spark binary version

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -58,12 +58,12 @@
     </dependency>
     <dependency>
       <groupId>org.apache.carbondata</groupId>
-      <artifactId>carbondata-spark_${spark.binary.version}</artifactId>
+      <artifactId>carbondata-spark</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.carbondata</groupId>
-      <artifactId>carbondata-mv-plan_${spark.binary.version}</artifactId>
+      <artifactId>carbondata-mv-plan</artifactId>
       <version>${project.version}</version>
     </dependency>
   </dependencies>

--- a/examples/flink/pom.xml
+++ b/examples/flink/pom.xml
@@ -63,7 +63,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.carbondata</groupId>
-      <artifactId>carbondata-spark_${spark.binary.version}</artifactId>
+      <artifactId>carbondata-spark</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/examples/spark/pom.xml
+++ b/examples/spark/pom.xml
@@ -36,7 +36,7 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.carbondata</groupId>
-      <artifactId>carbondata-spark_${spark.binary.version}</artifactId>
+      <artifactId>carbondata-spark</artifactId>
       <version>${project.version}</version>
       <exclusions>
         <exclusion>

--- a/index/examples/pom.xml
+++ b/index/examples/pom.xml
@@ -36,7 +36,7 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.carbondata</groupId>
-      <artifactId>carbondata-spark_${spark.binary.version}</artifactId>
+      <artifactId>carbondata-spark</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/index/secondary-index/pom.xml
+++ b/index/secondary-index/pom.xml
@@ -37,7 +37,7 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.carbondata</groupId>
-      <artifactId>carbondata-spark_${spark.binary.version}</artifactId>
+      <artifactId>carbondata-spark</artifactId>
       <version>${project.version}</version>
       <exclusions>
         <exclusion>

--- a/integration/flink/pom.xml
+++ b/integration/flink/pom.xml
@@ -202,7 +202,7 @@
             <dependencies>
                 <dependency>
                     <groupId>org.apache.carbondata</groupId>
-                    <artifactId>carbondata-spark_${spark.binary.version}</artifactId>
+                    <artifactId>carbondata-spark</artifactId>
                     <version>${project.version}</version>
                     <scope>test</scope>
                     <exclusions>
@@ -222,7 +222,7 @@
             <dependencies>
                 <dependency>
                     <groupId>org.apache.carbondata</groupId>
-                    <artifactId>carbondata-spark_${spark.binary.version}</artifactId>
+                    <artifactId>carbondata-spark</artifactId>
                     <version>${project.version}</version>
                     <scope>test</scope>
                     <exclusions>

--- a/integration/spark-common-cluster-test/pom.xml
+++ b/integration/spark-common-cluster-test/pom.xml
@@ -37,7 +37,7 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.carbondata</groupId>
-      <artifactId>carbondata-spark_${spark.binary.version}</artifactId>
+      <artifactId>carbondata-spark</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>

--- a/integration/spark/pom.xml
+++ b/integration/spark/pom.xml
@@ -26,8 +26,10 @@
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
-  <artifactId>carbondata-spark_${spark.binary.version}</artifactId>
+  <artifactId>carbondata-spark</artifactId>
   <name>Apache CarbonData :: Spark</name>
+
+  <packaging>jar</packaging>
 
   <properties>
     <dev.path>${basedir}/../../dev</dev.path>
@@ -159,7 +161,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.carbondata</groupId>
-      <artifactId>carbondata-mv-plan_${spark.binary.version}</artifactId>
+      <artifactId>carbondata-mv-plan</artifactId>
       <version>${project.version}</version>
       <exclusions>
         <exclusion>
@@ -267,6 +269,7 @@
   </dependencies>
 
   <build>
+    <finalName>carbondata-spark_${spark.binary.version}-${project.version}</finalName>
     <resources>
       <resource>
         <directory>src/resources</directory>

--- a/mv/plan/pom.xml
+++ b/mv/plan/pom.xml
@@ -26,8 +26,10 @@
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
-  <artifactId>carbondata-mv-plan_${spark.binary.version}</artifactId>
+  <artifactId>carbondata-mv-plan</artifactId>
   <name>Apache CarbonData :: Materialized View Plan</name>
+
+  <packaging>jar</packaging>
 
   <properties>
     <dev.path>${basedir}/../../dev</dev.path>
@@ -46,6 +48,7 @@
   </dependencies>
 
   <build>
+    <finalName>carbondata-mv-plan_${spark.binary.version}-${project.version}</finalName>
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
 ### Why is this PR needed?
 After #3700 , spark binary version addition. 
a) Module name always taking deafult profile spark binary version.
b)   IDE test cases are running with spark 2.3 even for spark2.4 because of above problem
 
 ### What changes were proposed in this PR?
a)  keep a simple module name without binary version
b) Use the package option with jar file name to have binary version in the final jar. 
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No

    
