### PR TITLE
[CARBONDATA-3873] Secondary index compaction with maintable clean files causing exception

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/AbstractDFSCarbonFile.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/AbstractDFSCarbonFile.java
@@ -455,7 +455,7 @@ public abstract class AbstractDFSCarbonFile implements CarbonFile {
     try {
       listStatus = fileSystem.listStatus(path);
     } catch (IOException e) {
-      LOGGER.error("Exception occured: " + e.getMessage(), e);
+      LOGGER.warn("Exception occured: " + e.getMessage(), e);
       return new CarbonFile[0];
     }
     return getFiles(listStatus);


### PR DESCRIPTION
[CARBONDATA-3873] Secondary index compaction with maintable clean files causing exception
 ### Why is this PR needed?
Compaction with secondary index and cleaning files of the main table after compaction fails then we are getting Exception.
If any compaction is failed for one of SI and if it is not disable then it will be considered for query execution. When query executed on SI table which is failed in compaction and it doesn't have correct data hence received Exception.
 
 ### What changes were proposed in this PR?
1) If any compaction is failed then disable all SI which are successful. They will be enabled after the next load.
2) Changing Error to the warning in table creation flow as it is a success case we should not give ERROR.

 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No

    
https://issues.apache.org/jira/browse/CARBONDATA-3873