### PR TITLE
[CARBONDATA-3881] Fix concurrent main table compaction and SI load issue

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/index/CarbonIndexUtil.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/index/CarbonIndexUtil.scala
@@ -274,19 +274,21 @@ object CarbonIndexUtil {
     if (isLoadToFailedSISegments && null != failedLoadMetaDataDetils) {
       val metadata = CarbonInternalLoaderUtil
         .getListOfValidSlices(SegmentStatusManager.readLoadMetadata(indexTable.getMetadataPath))
+      segmentIdToLoadStartTimeMapping = CarbonInternalLoaderUtil
+        .getSegmentToLoadStartTimeMapping(carbonLoadModel.getLoadMetadataDetails.asScala.toArray)
+        .asScala
       failedLoadMetaDataDetils.asScala.foreach(loadMetaDetail => {
         // check whether this segment is valid or invalid, if it is present in the valid list
-        // then don't consider it for reloading
-        if (!metadata.contains(loadMetaDetail.getLoadName)) {
+        // then don't consider it for reloading.
+        // Also main table should have this as a valid segment for reloading.
+        if (!metadata.contains(loadMetaDetail.getLoadName) &&
+            segmentIdToLoadStartTimeMapping.contains(loadMetaDetail.getLoadName)) {
           segmentsToReload.append(loadMetaDetail.getLoadName)
         }
       })
       LOGGER.info(
         s"SI segments to be reloaded for index table: ${
           indexTable.getTableUniqueName} are: ${segmentsToReload}")
-      segmentIdToLoadStartTimeMapping = CarbonInternalLoaderUtil
-        .getSegmentToLoadStartTimeMapping(carbonLoadModel.getLoadMetadataDetails.asScala.toArray)
-        .asScala
     } else {
       segmentIdToLoadStartTimeMapping = scala.collection.mutable
         .Map((carbonLoadModel.getSegmentId, carbonLoadModel.getFactTimeStamp))


### PR DESCRIPTION
 ### Why is this PR needed?
 Consider a scenario, where segmentX has loaded to main table but failed to load to SI table. So, while loading another segmentY, we reload failed SI segmentX. this time if the segmentX is compacted in main table and clean files executed on it. SI load will fail and segment id will not be found in segmentMap of SI and it throws exception.

 ### What changes were proposed in this PR?
just before reloading the failed SI segment. check if it is valid segment in main table.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No [concurrent scenario, hard to reproduce by UT]


    
