### PR TITLE
[CARBONDATA-3900] [CARBONDATA-3882] [CARBONDATA-3881] Fix multiple concurrent issues in table status lock and segment lock for SI and maintable

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/index/CarbonIndexUtil.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/index/CarbonIndexUtil.scala
@@ -274,19 +274,21 @@ object CarbonIndexUtil {
     if (isLoadToFailedSISegments && null != failedLoadMetaDataDetils) {
       val metadata = CarbonInternalLoaderUtil
         .getListOfValidSlices(SegmentStatusManager.readLoadMetadata(indexTable.getMetadataPath))
+      segmentIdToLoadStartTimeMapping = CarbonInternalLoaderUtil
+        .getSegmentToLoadStartTimeMapping(carbonLoadModel.getLoadMetadataDetails.asScala.toArray)
+        .asScala
       failedLoadMetaDataDetils.asScala.foreach(loadMetaDetail => {
         // check whether this segment is valid or invalid, if it is present in the valid list
-        // then don't consider it for reloading
-        if (!metadata.contains(loadMetaDetail.getLoadName)) {
+        // then don't consider it for reloading.
+        // Also main table should have this as a valid segment for reloading.
+        if (!metadata.contains(loadMetaDetail.getLoadName) &&
+            segmentIdToLoadStartTimeMapping.contains(loadMetaDetail.getLoadName)) {
           segmentsToReload.append(loadMetaDetail.getLoadName)
         }
       })
       LOGGER.info(
         s"SI segments to be reloaded for index table: ${
           indexTable.getTableUniqueName} are: ${segmentsToReload}")
-      segmentIdToLoadStartTimeMapping = CarbonInternalLoaderUtil
-        .getSegmentToLoadStartTimeMapping(carbonLoadModel.getLoadMetadataDetails.asScala.toArray)
-        .asScala
     } else {
       segmentIdToLoadStartTimeMapping = scala.collection.mutable
         .Map((carbonLoadModel.getSegmentId, carbonLoadModel.getFactTimeStamp))

--- a/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/load/CarbonInternalLoaderUtil.java
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/load/CarbonInternalLoaderUtil.java
@@ -235,22 +235,20 @@ public class CarbonInternalLoaderUtil {
    *
    */
   public static boolean updateLoadMetadataWithMergeStatus(CarbonTable indexCarbonTable,
-      String[] loadsToMerge, String mergedLoadNumber, CarbonLoadModel carbonLoadModel,
-      Map<String, String> segmentToLoadStartTimeMap, long mergeLoadStartTime,
-      SegmentStatus segmentStatus, long newLoadStartTime, List<String> rebuiltSegments)
-      throws IOException {
+      String[] loadsToMerge, String mergedLoadNumber, Map<String, String> segmentToLoadStartTimeMap,
+      long mergeLoadStartTime, SegmentStatus segmentStatus, long newLoadStartTime,
+      List<String> rebuiltSegments) throws IOException {
     boolean tableStatusUpdationStatus = false;
     List<String> loadMergeList = new ArrayList<>(Arrays.asList(loadsToMerge));
-    AbsoluteTableIdentifier absoluteTableIdentifier =
-        carbonLoadModel.getCarbonDataLoadSchema().getCarbonTable().getAbsoluteTableIdentifier();
-    SegmentStatusManager segmentStatusManager = new SegmentStatusManager(absoluteTableIdentifier);
+    SegmentStatusManager segmentStatusManager =
+        new SegmentStatusManager(indexCarbonTable.getAbsoluteTableIdentifier());
 
     ICarbonLock carbonLock = segmentStatusManager.getTableStatusLock();
 
     try {
       if (carbonLock.lockWithRetries()) {
-        LOGGER.info("Acquired lock for the table " + carbonLoadModel.getDatabaseName() + "."
-            + carbonLoadModel.getTableName() + " for table status updation ");
+        LOGGER.info("Acquired lock for the table " + indexCarbonTable.getDatabaseName() + "."
+            + indexCarbonTable.getTableName() + " for table status updation ");
         LoadMetadataDetails[] loadDetails =
             SegmentStatusManager.readLoadMetadata(indexCarbonTable.getMetadataPath());
 
@@ -305,17 +303,17 @@ public class CarbonInternalLoaderUtil {
         tableStatusUpdationStatus = true;
       } else {
         LOGGER.error(
-            "Could not able to obtain lock for table" + carbonLoadModel.getDatabaseName() + "."
-                + carbonLoadModel.getTableName() + "for table status updation");
+            "Could not able to obtain lock for table" + indexCarbonTable.getDatabaseName() + "."
+                + indexCarbonTable.getTableName() + "for table status updation");
       }
     } finally {
       if (carbonLock.unlock()) {
-        LOGGER.info("Table unlocked successfully after table status updation" + carbonLoadModel
-            .getDatabaseName() + "." + carbonLoadModel.getTableName());
+        LOGGER.info("Table unlocked successfully after table status updation" + indexCarbonTable
+            .getDatabaseName() + "." + indexCarbonTable.getTableName());
       } else {
         LOGGER.error(
-            "Unable to unlock Table lock for table" + carbonLoadModel.getDatabaseName() + "."
-                + carbonLoadModel.getTableName() + " during table status updation");
+            "Unable to unlock Table lock for table" + indexCarbonTable.getDatabaseName() + "."
+                + indexCarbonTable.getTableName() + " during table status updation");
       }
     }
     return tableStatusUpdationStatus;

--- a/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/load/Compactor.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/load/Compactor.scala
@@ -85,7 +85,6 @@ object Compactor {
           indexCarbonTable,
           loadsToMerge,
           validSegments.head,
-          carbonLoadModel,
           segmentToSegmentTimestampMap,
           segmentIdToLoadStartTimeMapping(validSegments.head),
           SegmentStatus.INSERT_IN_PROGRESS, 0L, List.empty.asJava)
@@ -119,7 +118,6 @@ object Compactor {
           indexCarbonTable,
           loadsToMerge,
           validSegments.head,
-          carbonLoadModel,
           segmentToSegmentTimestampMap,
           segmentIdToLoadStartTimeMapping(validSegments.head),
           SegmentStatus.SUCCESS,

--- a/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/util/SecondaryIndexUtil.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/util/SecondaryIndexUtil.scala
@@ -223,20 +223,20 @@ object SecondaryIndexUtil {
           val statusLock =
             new SegmentStatusManager(indexCarbonTable.getAbsoluteTableIdentifier).getTableStatusLock
           try {
-            val endTime = System.currentTimeMillis()
-            val loadMetadataDetails = SegmentStatusManager
-              .readLoadMetadata(indexCarbonTable.getMetadataPath)
-            loadMetadataDetails.foreach(loadMetadataDetail => {
-              if (rebuiltSegments.contains(loadMetadataDetail.getLoadName)) {
-                loadMetadataDetail.setLoadStartTime(carbonLoadModel.getFactTimeStamp)
-                loadMetadataDetail.setLoadEndTime(endTime)
-                CarbonLoaderUtil
-                  .addDataIndexSizeIntoMetaEntry(loadMetadataDetail,
-                    loadMetadataDetail.getLoadName,
-                    indexCarbonTable)
-              }
-            })
             if (statusLock.lockWithRetries()) {
+              val endTime = System.currentTimeMillis()
+              val loadMetadataDetails = SegmentStatusManager
+                .readLoadMetadata(indexCarbonTable.getMetadataPath)
+              loadMetadataDetails.foreach(loadMetadataDetail => {
+                if (rebuiltSegments.contains(loadMetadataDetail.getLoadName)) {
+                  loadMetadataDetail.setLoadStartTime(carbonLoadModel.getFactTimeStamp)
+                  loadMetadataDetail.setLoadEndTime(endTime)
+                  CarbonLoaderUtil
+                    .addDataIndexSizeIntoMetaEntry(loadMetadataDetail,
+                      loadMetadataDetail.getLoadName,
+                      indexCarbonTable)
+                }
+              })
               SegmentStatusManager
                 .writeLoadDetailsIntoFile(CarbonTablePath.getTableStatusFilePath(tablePath),
                   loadMetadataDetails)
@@ -443,32 +443,32 @@ object SecondaryIndexUtil {
     val loadFolderDetailsArrayMainTable =
       SegmentStatusManager.readLoadMetadata(parentCarbonTable.getMetadataPath)
     indexTables.asScala.foreach { indexTable =>
-      val tableStatusFilePath = CarbonTablePath.getTableStatusFilePath(indexTable.getTablePath)
-      if (CarbonUtil.isFileExists(tableStatusFilePath)) {
-        val loadFolderDetailsArray = SegmentStatusManager.readLoadMetadata(indexTable
-          .getMetadataPath);
-        if (null != loadFolderDetailsArray && loadFolderDetailsArray.nonEmpty) {
-          val statusLock =
-            new SegmentStatusManager(indexTable.getAbsoluteTableIdentifier).getTableStatusLock
-          try {
-            if (statusLock.lockWithRetries()) {
+      val statusLock =
+        new SegmentStatusManager(indexTable.getAbsoluteTableIdentifier).getTableStatusLock
+      try {
+        if (statusLock.lockWithRetries()) {
+          val tableStatusFilePath = CarbonTablePath.getTableStatusFilePath(indexTable.getTablePath)
+          if (CarbonUtil.isFileExists(tableStatusFilePath)) {
+            val loadFolderDetailsArray = SegmentStatusManager.readLoadMetadata(indexTable
+              .getMetadataPath);
+            if (null != loadFolderDetailsArray && loadFolderDetailsArray.nonEmpty) {
               SegmentStatusManager.writeLoadDetailsIntoFile(
                 CarbonTablePath.getTableStatusFilePath(indexTable.getTablePath),
                 updateTimeStampForIndexTable(loadFolderDetailsArrayMainTable,
                   loadFolderDetailsArray))
             }
-          } catch {
-            case ex: Exception =>
-              LOGGER.error(ex.getMessage);
-          } finally {
-            if (statusLock != null) {
-              statusLock.unlock()
-            }
+          } else {
+            LOGGER.info(
+              "Table status file does not exist for index table: " + indexTable.getTableUniqueName)
           }
         }
-      } else {
-        LOGGER.info(
-          "Table status file does not exist for index table: " + indexTable.getTableUniqueName)
+      } catch {
+        case ex: Exception =>
+          LOGGER.error(ex.getMessage);
+      } finally {
+        if (statusLock != null) {
+          statusLock.unlock()
+        }
       }
     }
   }


### PR DESCRIPTION
 ### Why is this PR needed?
**[CARBONDATA-3900]** Fix maintable load failure in concurrent load and compaction scenario
Main table load flow segment lock is released before updating the table status success.
So, concurrent operation was considering this segment as stale segment (as segment lock is not present) and cleaning it. Leading to unable to get file status exception. 

**[CARBONDATA-3882]** Fix wrong lock and missing Table status lock in some SI flows
 1) In updateLoadMetadataWithMergeStatus, we want update SI table status, but lock is acquired on main table
2) triggerCompaction, updateTableStatusForIndexTables -> table status write is happening without lock
 
**[CARBONDATA-3881]**  Fix concurrent main table compaction and SI load issue
Consider a scenario, where segmentX has loaded to main table but failed to load to SI table. So, while loading another segmentY, we reload failed SI segmentX. this time if the segmentX is compacted in main table and clean files executed on it. SI load will fail and segment id will not be found in segmentMap of SI and it throws exception.

 ### What changes were proposed in this PR?
**for [CARBONDATA-3900]**
release segment lock after main table is updated.

**for [CARBONDATA-3882]**
1) In updateLoadMetadataWithMergeStatus, take a lock on SI table
2) triggerCompaction, updateTableStatusForIndexTables -> add a lock for table status write

**for [CARBONDATA-3881]**
just before reloading the failed SI segment. check if it is valid segment in main table.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No [issue comes in concurrent scenarios]


    
