### PR TITLE
[CARBONDATA-3878] Get last modified time from 'tablestatus' file entry instead of segment file to reduce file operation 'getLastModifiedTime'

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/index/IndexStoreManager.java
+++ b/core/src/main/java/org/apache/carbondata/core/index/IndexStoreManager.java
@@ -515,11 +515,16 @@ public final class IndexStoreManager {
         UpdateVO updateVO =
             SegmentUpdateStatusManager.getInvalidTimestampRange(segment.getLoadMetadataDetails());
         SegmentRefreshInfo segmentRefreshInfo;
-        if (updateVO != null && updateVO.getLatestUpdateTimestamp() != null
+        if ((updateVO != null && updateVO.getLatestUpdateTimestamp() != null)
             || segment.getSegmentFileName() != null) {
-          long segmentFileTimeStamp = FileFactory.getCarbonFile(CarbonTablePath
-              .getSegmentFilePath(table.getTablePath(), segment.getSegmentFileName()))
-              .getLastModifiedTime();
+          long segmentFileTimeStamp;
+          if (null != segment.getLoadMetadataDetails()) {
+            segmentFileTimeStamp = segment.getLoadMetadataDetails().getLastModifiedTime();
+          } else {
+            segmentFileTimeStamp = FileFactory.getCarbonFile(CarbonTablePath
+                .getSegmentFilePath(table.getTablePath(), segment.getSegmentFileName()))
+                .getLastModifiedTime();
+          }
           segmentRefreshInfo =
               new SegmentRefreshInfo(updateVO.getLatestUpdateTimestamp(), 0, segmentFileTimeStamp);
         } else {

--- a/core/src/main/java/org/apache/carbondata/core/readcommitter/TableStatusReadCommittedScope.java
+++ b/core/src/main/java/org/apache/carbondata/core/readcommitter/TableStatusReadCommittedScope.java
@@ -95,7 +95,9 @@ public class TableStatusReadCommittedScope implements ReadCommittedScope {
   public SegmentRefreshInfo getCommittedSegmentRefreshInfo(Segment segment, UpdateVO updateVo) {
     SegmentRefreshInfo segmentRefreshInfo;
     long segmentFileTimeStamp = 0L;
-    if (null != segment.getSegmentFileName()) {
+    if (null != segment.getLoadMetadataDetails()) {
+      segmentFileTimeStamp = segment.getLoadMetadataDetails().getLastModifiedTime();
+    } else if (null != segment.getSegmentFileName()) {
       segmentFileTimeStamp = FileFactory.getCarbonFile(CarbonTablePath
           .getSegmentFilePath(identifier.getTablePath(), segment.getSegmentFileName()))
           .getLastModifiedTime();

--- a/core/src/main/java/org/apache/carbondata/core/statusmanager/LoadMetadataDetails.java
+++ b/core/src/main/java/org/apache/carbondata/core/statusmanager/LoadMetadataDetails.java
@@ -487,4 +487,11 @@ public class LoadMetadataDetails implements Serializable {
       fileFormat = null;
     }
   }
+
+  public long getLastModifiedTime() {
+    if (updateDeltaEndTimestamp != null) {
+      return convertTimeStampToLong(updateDeltaEndTimestamp);
+    }
+    return convertTimeStampToLong(timestamp);
+  }
 }


### PR DESCRIPTION
 ### Why is this PR needed?
 After the table has too many segments,  file operation 'getLastModifiedTime' on all segment files will take a long time.
 
 ### What changes were proposed in this PR?
 Get last modified time from 'tablestatus' file entry instead of segment file to reduce file operation 'getLastModifiedTime'
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No

    
