### PR TITLE
[CARBONDATA-3879] Filtering Segments Optimazation

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/index/TableIndex.java
+++ b/core/src/main/java/org/apache/carbondata/core/index/TableIndex.java
@@ -206,7 +206,8 @@ public final class TableIndex extends OperationEventListener {
       Set<Path> partitionLocations, List<ExtendedBlocklet> blocklets,
       Map<Segment, List<Index>> indexes) throws IOException {
     for (Segment segment : segments) {
-      if (indexes.get(segment).isEmpty() || indexes.get(segment) == null) {
+      if (segment == null ||
+          indexes.get(segment) == null || indexes.get(segment).isEmpty()) {
         continue;
       }
       boolean isExternalSegment = segment.getSegmentPath() != null;


### PR DESCRIPTION
 ### Why is this PR needed?
 During filter segments flow, there are a lot of LIST.CONTAINS, which has heavy time overhead when there are tens of thousands segments.
 For example, if there are 50000 segments. it will trigger LIST.CONTAINS  for each segment, the LIST also has about 50000 elements. so the time complexity will be O（50000 * 50000 ）
 
 ### What changes were proposed in this PR?
Change List.CONTAINS to MAP.containsKEY
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No

    
