### PR TITLE
[Carbondata-3883] Added filtering for the deleted rows for local dictionary fields

### DIFF
--- a/integration/presto/src/main/java/org/apache/carbondata/presto/CarbonColumnVectorWrapper.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/CarbonColumnVectorWrapper.java
@@ -28,6 +28,7 @@ import org.apache.carbondata.core.scan.scanner.LazyPageLoader;
 public class CarbonColumnVectorWrapper implements CarbonColumnVector {
 
   private CarbonColumnVectorImpl columnVector;
+  private CarbonColumnVectorWrapper dictionaryVectorWrapper;
 
   private boolean[] filteredRows;
 
@@ -40,6 +41,11 @@ public class CarbonColumnVectorWrapper implements CarbonColumnVector {
   public CarbonColumnVectorWrapper(CarbonColumnVectorImpl columnVector, boolean[] filteredRows) {
     this.columnVector = columnVector;
     this.filteredRows = filteredRows;
+
+    if (columnVector.getDictionaryVector() != null) {
+      dictionaryVectorWrapper = new CarbonColumnVectorWrapper(
+              (CarbonColumnVectorImpl)columnVector.getDictionaryVector(), filteredRows);
+    }
   }
 
   @Override
@@ -273,7 +279,7 @@ public class CarbonColumnVectorWrapper implements CarbonColumnVector {
 
   @Override
   public CarbonColumnVector getDictionaryVector() {
-    return this.columnVector.getDictionaryVector();
+    return this.dictionaryVectorWrapper;
   }
 
   @Override


### PR DESCRIPTION

 ### Why is this PR needed?
 In Presto integration when reading records for table with string fields and local dictionary enabled gives improper result.
 
 ### What changes were proposed in this PR?
Added a CarbondataColumnVectorWrapper for the dictionary vector for column for which internally create dictionary vector.
Wrapper is used to filter the deleted records.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No

    
