### PR TITLE
[CARBONDATA-3886] Use qualified table name for global sort compaction

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/util/SparkSQLUtil.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/util/SparkSQLUtil.scala
@@ -165,9 +165,9 @@ object SparkSQLUtil {
      * datatype of column data and corresponding datatype in schema provided to create dataframe.
      * Since carbonScanRDD gives Long data for timestamp column and corresponding column datatype in
      * schema is Timestamp, this validation fails if we use createDataFrame API which takes rdd as
-     * input. Hence, using below API which creates dataframe from tablename.
+     * input. Hence, using below API which creates dataframe from qualified tablename.
      */
-    sparkSession.sqlContext.table(carbonTable.getTableName)
+    sparkSession.sqlContext.table(carbonTable.getDatabaseName + "." + carbonTable.getTableName)
   }
 
   def setOutputMetrics(outputMetrics: OutputMetrics, dataLoadMetrics: DataLoadMetrics): Unit = {


### PR DESCRIPTION
 ### Why is this PR needed?
 Global sort compaction is not using database name while making dataframe. 
some times it uses default database when spark cannot match this table name belong to which database.
 
 ### What changes were proposed in this PR?
Use qualified table name (dbname + table name) while creating a datafame.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No

    
