### PR TITLE
[CARBONDATA-3887] Fixed insert failure for global sort null data

### DIFF
--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/util/CommonUtil.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/util/CommonUtil.scala
@@ -921,52 +921,55 @@ object CommonUtil {
     var i = 0
     val fieldTypesLen = fields.length
     while (i < fieldTypesLen) {
-      if (!row.isNullAt(i)) {
-        fields(i).dataType match {
-          case StringType =>
-            data(i) = DataTypeUtil.getBytesDataDataTypeForNoDictionaryColumn(row.getString(i),
+      fields(i).dataType match {
+        case StringType =>
+          data(i) = if (row.isNullAt(i)) {
+            DataTypeUtil.getBytesDataDataTypeForNoDictionaryColumn(null,
               DataTypes.STRING)
-          case d: DecimalType =>
-            data(i) = row.getDecimal(i, d.precision, d.scale).toJavaBigDecimal
-          case arrayType : ArrayType =>
-            val result = convertSparkComplexTypeToCarbonObject(row.get(i, arrayType), arrayType)
-            // convert carbon complex object to byte array
-            val byteArray: ByteArrayOutputStream = new ByteArrayOutputStream()
-            val dataOutputStream: DataOutputStream = new DataOutputStream(byteArray)
-            dataFieldsWithComplexDataType(fields(i).name).asInstanceOf[ArrayDataType]
-              .writeByteArray(result.asInstanceOf[ArrayObject],
-                dataOutputStream,
-                badRecordLogHolder,
-                true)
-            dataOutputStream.close()
-            data(i) = byteArray.toByteArray.asInstanceOf[AnyRef]
-          case structType : StructType =>
-            val result = convertSparkComplexTypeToCarbonObject(row.get(i, structType), structType)
-            // convert carbon complex object to byte array
-            val byteArray: ByteArrayOutputStream = new ByteArrayOutputStream()
-            val dataOutputStream: DataOutputStream = new DataOutputStream(byteArray)
-            dataFieldsWithComplexDataType(fields(i).name).asInstanceOf[StructDataType]
-              .writeByteArray(result.asInstanceOf[StructObject],
-                dataOutputStream,
-                badRecordLogHolder,
-                true)
-            dataOutputStream.close()
-            data(i) = byteArray.toByteArray.asInstanceOf[AnyRef]
-          case mapType : MapType =>
-            val result = convertSparkComplexTypeToCarbonObject(row.get(i, mapType), mapType)
-            // convert carbon complex object to byte array
-            val byteArray: ByteArrayOutputStream = new ByteArrayOutputStream()
-            val dataOutputStream: DataOutputStream = new DataOutputStream(byteArray)
-            dataFieldsWithComplexDataType(fields(i).name).asInstanceOf[ArrayDataType]
-              .writeByteArray(result.asInstanceOf[ArrayObject],
-                dataOutputStream,
-                badRecordLogHolder,
-                true)
-            dataOutputStream.close()
-            data(i) = byteArray.toByteArray.asInstanceOf[AnyRef]
-          case other =>
-            data(i) = row.get(i, other)
-        }
+          } else {
+            DataTypeUtil.getBytesDataDataTypeForNoDictionaryColumn(row.getString(i),
+              DataTypes.STRING)
+          }
+        case d: DecimalType =>
+          data(i) = row.getDecimal(i, d.precision, d.scale).toJavaBigDecimal
+        case arrayType: ArrayType =>
+          val result = convertSparkComplexTypeToCarbonObject(row.get(i, arrayType), arrayType)
+          // convert carbon complex object to byte array
+          val byteArray: ByteArrayOutputStream = new ByteArrayOutputStream()
+          val dataOutputStream: DataOutputStream = new DataOutputStream(byteArray)
+          dataFieldsWithComplexDataType(fields(i).name).asInstanceOf[ArrayDataType]
+            .writeByteArray(result.asInstanceOf[ArrayObject],
+              dataOutputStream,
+              badRecordLogHolder,
+              true)
+          dataOutputStream.close()
+          data(i) = byteArray.toByteArray.asInstanceOf[AnyRef]
+        case structType: StructType =>
+          val result = convertSparkComplexTypeToCarbonObject(row.get(i, structType), structType)
+          // convert carbon complex object to byte array
+          val byteArray: ByteArrayOutputStream = new ByteArrayOutputStream()
+          val dataOutputStream: DataOutputStream = new DataOutputStream(byteArray)
+          dataFieldsWithComplexDataType(fields(i).name).asInstanceOf[StructDataType]
+            .writeByteArray(result.asInstanceOf[StructObject],
+              dataOutputStream,
+              badRecordLogHolder,
+              true)
+          dataOutputStream.close()
+          data(i) = byteArray.toByteArray.asInstanceOf[AnyRef]
+        case mapType: MapType =>
+          val result = convertSparkComplexTypeToCarbonObject(row.get(i, mapType), mapType)
+          // convert carbon complex object to byte array
+          val byteArray: ByteArrayOutputStream = new ByteArrayOutputStream()
+          val dataOutputStream: DataOutputStream = new DataOutputStream(byteArray)
+          dataFieldsWithComplexDataType(fields(i).name).asInstanceOf[ArrayDataType]
+            .writeByteArray(result.asInstanceOf[ArrayObject],
+              dataOutputStream,
+              badRecordLogHolder,
+              true)
+          dataOutputStream.close()
+          data(i) = byteArray.toByteArray.asInstanceOf[AnyRef]
+        case other =>
+          data(i) = row.get(i, other)
       }
       i += 1
     }


### PR DESCRIPTION
 ### Why is this PR needed?
 Load data is failing with "Unsupported dataType: String" exception when null data is loaded into a string column in global_sort table as there is No handling for null data for string column
 
 ### What changes were proposed in this PR?
 Added a check for null data and handle for the same in global sort flow.

 ### Does this PR introduce any user interface change?
 - No
 - Yes. (please explain the change and update document)

 ### Is any new testcase added?
 - No
 - Yes

    
