### PR TITLE
[WIP]Fix MV case sensitive issues with ImplicitCastInputTypes and Add Doc for Show MV

### DIFF
--- a/docs/mv-guide.md
+++ b/docs/mv-guide.md
@@ -23,6 +23,7 @@
 * [Querying Data](#querying-data)
 * [Compaction](#compacting)
 * [Data Management](#data-management)
+* [Show Materialized Views](#show-materialized-views)
 * [Time Series Support](#time-series-support)
 * [Time Series RollUp Support](#time-series-rollup-support)
 
@@ -221,6 +222,26 @@
    
  Basically, user can manually trigger the operation by re-building the materialized view.
 
+### Show Materialized Views
+
+ Command syntax:
+   ```
+     SHOW MATERIALIZED VIEWS [ON TABLE [db_name.]table_name]
+   ```
+
+SHOW MATERIALIZED VIEWS command will display the information about all the materialized 
+views created on the database or on the carbon table.
+The current information includes:
+
+ | Column Info            | Description                                                      |
+ |-----------------------------|----------------------------------------------------------------------------|
+ | Database               | Materialized view database name                               |
+ | Name                  | Materialized view name                                         | 
+ | Status                  | ENABLED / DISABLED                                          |
+ | Refresh Mode          | FULL / INCREMENTAL refresh to MV                          |
+ | Refresh Trigger Mode  | ON_COMMIT / ON_MANUAL refresh to MV provided by user |
+ | Properties              | Table properties of the materialized view                       |
+  
 ## Time Series Support
 
  Time series data are simply measurements or events that are tracked, monitored, down sampled, and 

--- a/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/MVMatcher.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/MVMatcher.scala
@@ -93,7 +93,10 @@ private abstract class MVMatchPattern extends Logging {
             case function: ScalaUDF if function.function.isInstanceOf[TimeSeriesFunction] =>
               getTransformedTimeSeriesFunction(function) -> alias.toAttribute
             case cast: Cast if cast.child.isInstanceOf[AttributeReference] =>
-              getTransformedCastExpression(cast) -> alias.toAttribute
+              getTransformedCastOrImplicitCastExpression(cast) -> alias.toAttribute
+            case implicitCastInputTypeExp: ImplicitCastInputTypes =>
+              getTransformedCastOrImplicitCastExpression(implicitCastInputTypeExp) ->
+              alias.toAttribute
             case _ =>
               alias.child -> alias.toAttribute
           }
@@ -120,7 +123,9 @@ private abstract class MVMatchPattern extends Logging {
                 case function: ScalaUDF if function.function.isInstanceOf[TimeSeriesFunction] =>
                   getTransformedTimeSeriesFunction(function)
                 case cast: Cast if cast.child.isInstanceOf[AttributeReference] =>
-                  getTransformedCastExpression(cast)
+                  getTransformedCastOrImplicitCastExpression(cast)
+                case implicitCastInputTypeExp: ImplicitCastInputTypes =>
+                  getTransformedCastOrImplicitCastExpression(implicitCastInputTypeExp)
               }
               attribute = aliasMapExp.get(newExp)
             }
@@ -247,10 +252,12 @@ private abstract class MVMatchPattern extends Logging {
   }
 
   /**
-   * transform cast expression to change it's child attribute reference name to lower case
+   * transform castOrImplicitCastExp expression to change it's child attribute reference name to
+   * lower case
    */
-  protected def getTransformedCastExpression(cast: Cast): Expression = {
-    cast.transform {
+  protected def getTransformedCastOrImplicitCastExpression(
+      castOrImplicitCastExp: Expression): Expression = {
+    castOrImplicitCastExp.transform {
       case reference: AttributeReference =>
         CarbonToSparkAdapter.createAttributeReference(
           reference.name.toLowerCase,


### PR DESCRIPTION


 ### Why is this PR needed?
 Issue 1:
Queries having implicitCastInputTypes expressions is not hitting mv when expression is provided in Upper case
Issue 2:
MV document does not have info for SHOW MATERIALIZED VIEWS command
 
 ### What changes were proposed in this PR?
Solution 1:
Transform castOrImplicitCastExp expression to change it's child attribute reference name to lower case while matching subsumer and subsume

Solution 2:
Added document for SHOW MATERIALIZED VIEWS command
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
