### PR TITLE
[CARBONDATA-3888] Move .flattened-pom.xml to target folder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -551,6 +551,7 @@
             <artifactId>flatten-maven-plugin</artifactId>
             <version>1.2.2</version>
             <configuration>
+              <outputDirectory>${project.build.directory}</outputDirectory>
             </configuration>
             <executions>
               <!-- enable flattening -->


### PR DESCRIPTION
 ### Why is this PR needed?
 after .flattened-pom.xml is generated in the project folder, it will impact the project import of Intellij idea
 
 ### What changes were proposed in this PR?
 set outputDirectory of  flatten-maven-plugin to  project.build.directory 
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No

    
