### PR TITLE
[CARBONDATA-3889] Cleanup code for carbondata-common module

### DIFF
--- a/common/src/main/java/org/apache/carbondata/common/Maps.java
+++ b/common/src/main/java/org/apache/carbondata/common/Maps.java
@@ -25,7 +25,7 @@ import org.apache.carbondata.common.annotations.InterfaceAudience;
 public class Maps {
 
   /**
-   * Return value if key is contained in the map, else return defauleValue.
+   * Return value if key is contained in the map, else return defaultValue.
    * This is added to avoid JDK 8 dependency
    */
   public static <K, V> V getOrDefault(Map<K, V> map, K key, V defaultValue) {

--- a/common/src/main/java/org/apache/carbondata/common/constants/LoggerAction.java
+++ b/common/src/main/java/org/apache/carbondata/common/constants/LoggerAction.java
@@ -26,7 +26,7 @@ public enum LoggerAction {
   REDIRECT("REDIRECT"), // no null conversion moved to bad record and written to raw csv
   IGNORE("IGNORE"), // no null conversion moved to bad record and not written to raw csv
   FAIL("FAIL");  //data loading will fail if a bad record is found
-  private String name;
+  private final String name;
 
   LoggerAction(String name) {
     this.name = name;

--- a/common/src/main/java/org/apache/carbondata/common/exceptions/sql/MalformedCarbonCommandException.java
+++ b/common/src/main/java/org/apache/carbondata/common/exceptions/sql/MalformedCarbonCommandException.java
@@ -36,7 +36,7 @@ public class MalformedCarbonCommandException extends Exception {
   /**
    * The Error message.
    */
-  private String msg = "";
+  private final String msg;
 
   /**
    * Constructor

--- a/common/src/main/java/org/apache/carbondata/common/logging/LogService.java
+++ b/common/src/main/java/org/apache/carbondata/common/logging/LogService.java
@@ -35,7 +35,7 @@ public class LogService extends Logger {
   private static String hostName;
   private static String username;
 
-  {
+  static {
     try {
       hostName = InetAddress.getLocalHost().getHostName();
     } catch (UnknownHostException e) {
@@ -77,9 +77,9 @@ public class LogService extends Logger {
   }
 
   public void audit(String message) {
-    String threadid = Thread.currentThread().getId() + "";
+    String threadId = Thread.currentThread().getId() + "";
     super.log(AuditLevel.AUDIT,
-        "[" + hostName + "]" + "[" + username + "]" + "[Thread-" + threadid + "]" + message);
+        "[" + hostName + "]" + "[" + username + "]" + "[Thread-" + threadId + "]" + message);
   }
 
   /**
@@ -91,15 +91,8 @@ public class LogService extends Logger {
     super.log(StatisticLevel.STATISTIC, message);
   }
 
-  public boolean isDebugEnabled() {
-    return super.isDebugEnabled();
-  }
-
   public boolean isWarnEnabled() {
     return super.isEnabledFor(org.apache.log4j.Level.WARN);
   }
 
-  public boolean isInfoEnabled() {
-    return super.isInfoEnabled();
-  }
 }

--- a/common/src/main/java/org/apache/carbondata/common/logging/impl/ExtendedRollingFileAppender.java
+++ b/common/src/main/java/org/apache/carbondata/common/logging/impl/ExtendedRollingFileAppender.java
@@ -194,16 +194,19 @@ public class ExtendedRollingFileAppender extends RollingFileAppender {
   private void cleanUpLogs(final String startName, final String folderPath) {
     if (maxBackupIndex > 0) {
       // Clean the logs files
-      Runnable r = () -> {
-        synchronized (ExtendedRollingFileAppender.class) {
-          cleanupInProgress = true;
-          try {
-            cleanLogs(startName, folderPath, maxBackupIndex);
-          } catch (Throwable e) {
-            // ignore any error
-            LogLog.error("Cleaning logs failed", e);
-          } finally {
-            cleanupInProgress = false;
+      Runnable r = new Runnable() {
+
+        public void run() {
+          synchronized (ExtendedRollingFileAppender.class) {
+            cleanupInProgress = true;
+            try {
+              cleanLogs(startName, folderPath, maxBackupIndex);
+            } catch (Throwable e) {
+              // ignore any error
+              LogLog.error("Cleaning logs failed", e);
+            } finally {
+              cleanupInProgress = false;
+            }
           }
         }
       };

--- a/common/src/main/java/org/apache/carbondata/common/logging/impl/ExtendedRollingFileAppender.java
+++ b/common/src/main/java/org/apache/carbondata/common/logging/impl/ExtendedRollingFileAppender.java
@@ -18,7 +18,6 @@
 package org.apache.carbondata.common.logging.impl;
 
 import java.io.File;
-import java.io.FileFilter;
 import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.text.DateFormat;
@@ -63,16 +62,8 @@ public class ExtendedRollingFileAppender extends RollingFileAppender {
     File file = new File(folderPath);
 
     if (file.exists()) {
-      File[] files = file.listFiles(new FileFilter() {
-
-        public boolean accept(File file) {
-          if (!file.isDirectory() && file.getName().toLowerCase(Locale.US)
-              .startsWith(fileStartName)) {
-            return true;
-          }
-          return false;
-        }
-      });
+      File[] files = file.listFiles(f ->
+          !f.isDirectory() && f.getName().toLowerCase(Locale.US).startsWith(fileStartName));
 
       if (null == files) {
         return;
@@ -85,7 +76,7 @@ public class ExtendedRollingFileAppender extends RollingFileAppender {
       }
 
       // Sort the file based on its name.
-      TreeMap<String, File> sortedMap = new TreeMap<String, File>();
+      TreeMap<String, File> sortedMap = new TreeMap<>();
       for (File file1 : files) {
         sortedMap.put(file1.getName(), file1);
       }
@@ -95,7 +86,7 @@ public class ExtendedRollingFileAppender extends RollingFileAppender {
       sortedMap.remove(sortedMap.firstKey());
 
       Iterator<Entry<String, File>> it = sortedMap.entrySet().iterator();
-      Entry<String, File> temp = null;
+      Entry<String, File> temp;
 
       // After clean up the files should be maxBackupIndex -1 number of
       // files. Because one more backup file
@@ -151,7 +142,7 @@ public class ExtendedRollingFileAppender extends RollingFileAppender {
       String extension = "";
       if (fileName.contains(".")) {
         extension = fileName.substring(fileName.lastIndexOf("."));
-        buffer.append(fileName.substring(0, fileName.lastIndexOf(".")));
+        buffer.append(fileName, 0, fileName.lastIndexOf("."));
       } else {
         buffer.append(fileName);
       }
@@ -203,19 +194,16 @@ public class ExtendedRollingFileAppender extends RollingFileAppender {
   private void cleanUpLogs(final String startName, final String folderPath) {
     if (maxBackupIndex > 0) {
       // Clean the logs files
-      Runnable r = new Runnable() {
-
-        public void run() {
-          synchronized (ExtendedRollingFileAppender.class) {
-            cleanupInProgress = true;
-            try {
-              cleanLogs(startName, folderPath, maxBackupIndex);
-            } catch (Throwable e) {
-              // ignore any error
-              LogLog.error("Cleaning logs failed", e);
-            } finally {
-              cleanupInProgress = false;
-            }
+      Runnable r = () -> {
+        synchronized (ExtendedRollingFileAppender.class) {
+          cleanupInProgress = true;
+          try {
+            cleanLogs(startName, folderPath, maxBackupIndex);
+          } catch (Throwable e) {
+            // ignore any error
+            LogLog.error("Cleaning logs failed", e);
+          } finally {
+            cleanupInProgress = false;
           }
         }
       };

--- a/common/src/test/java/org/apache/carbondata/common/StringsSuite.java
+++ b/common/src/test/java/org/apache/carbondata/common/StringsSuite.java
@@ -36,7 +36,7 @@ public class StringsSuite {
   public void testMkString() {
     String[] strings = new String[]{};
     String output = Strings.mkString(strings, ",");
-    Assert.assertTrue(output.length() == 0);
+    Assert.assertEquals(0, output.length());
 
     strings = new String[]{"abc"};
     output = Strings.mkString(strings, ",");

--- a/common/src/test/java/org/apache/carbondata/common/logging/LogServiceFactoryTest_UT.java
+++ b/common/src/test/java/org/apache/carbondata/common/logging/LogServiceFactoryTest_UT.java
@@ -19,21 +19,13 @@ package org.apache.carbondata.common.logging;
 
 import junit.framework.TestCase;
 import org.apache.log4j.Logger;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 public class LogServiceFactoryTest_UT extends TestCase {
 
-  @Before public void setUp() throws Exception {
-  }
-
-  @After public void tearDown() throws Exception {
-  }
-
   @Test public void testGetLogService() {
     Logger logger = LogServiceFactory.getLogService(this.getClass().getName());
-    assertTrue(logger instanceof Logger);
+    assertNotNull(logger);
   }
 
 }

--- a/common/src/test/java/org/apache/carbondata/common/logging/impl/AuditExtendedRollingFileAppenderTest_UT.java
+++ b/common/src/test/java/org/apache/carbondata/common/logging/impl/AuditExtendedRollingFileAppenderTest_UT.java
@@ -21,7 +21,6 @@ import org.junit.Assert;
 import mockit.Deencapsulation;
 import org.apache.log4j.Logger;
 import org.apache.log4j.spi.LoggingEvent;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -29,15 +28,11 @@ public class AuditExtendedRollingFileAppenderTest_UT {
 
   private AuditExtendedRollingFileAppender rAppender = null;
 
-  @Before public void setUp() throws Exception {
+  @Before public void setUp() {
     rAppender = new AuditExtendedRollingFileAppender();
     Deencapsulation.setField(rAppender, "fileName", "audit.log");
     Deencapsulation.setField(rAppender, "maxBackupIndex", 1);
     Deencapsulation.setField(rAppender, "maxFileSize", 1000L);
-
-  }
-
-  @After public void tearDown() throws Exception {
 
   }
 

--- a/common/src/test/java/org/apache/carbondata/common/logging/impl/AuditLevelTest_UT.java
+++ b/common/src/test/java/org/apache/carbondata/common/logging/impl/AuditLevelTest_UT.java
@@ -19,17 +19,9 @@ package org.apache.carbondata.common.logging.impl;
 
 import junit.framework.TestCase;
 import org.apache.log4j.Level;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 public class AuditLevelTest_UT extends TestCase {
-
-  @Before public void setUp() throws Exception {
-  }
-
-  @After public void tearDown() throws Exception {
-  }
 
   @Test public void testAuditLevel() {
     assertEquals(AuditLevel.AUDIT.toInt(), 55000);

--- a/common/src/test/java/org/apache/carbondata/common/logging/impl/ExtendedRollingFileAppenderTest_UT.java
+++ b/common/src/test/java/org/apache/carbondata/common/logging/impl/ExtendedRollingFileAppenderTest_UT.java
@@ -21,7 +21,6 @@ import org.junit.Assert;
 import mockit.Deencapsulation;
 import org.apache.log4j.Logger;
 import org.apache.log4j.spi.LoggingEvent;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -29,14 +28,11 @@ public class ExtendedRollingFileAppenderTest_UT {
 
   private ExtendedRollingFileAppender rAppender = null;
 
-  @Before public void setUp() throws Exception {
+  @Before public void setUp() {
     rAppender = new ExtendedRollingFileAppender();
     Deencapsulation.setField(rAppender, "fileName", "dummy.log");
     Deencapsulation.setField(rAppender, "maxBackupIndex", 1);
     Deencapsulation.setField(rAppender, "maxFileSize", 1000L);
-  }
-
-  @After public void tearDown() throws Exception {
   }
 
   @Test public void testRollOver() {


### PR DESCRIPTION
 ### Why is this PR needed?
1. Field can be 'final'
2. Redundant 'if' statement
3. Empty method
4. Redundant 'throws' clause
5. Anonymous type can be replaced with lambda
6. Typo
7. Redundant String operation

 ### What changes were proposed in this PR?
1. change field to be 'final'
2. change redundant 'if' statement
3. remove Empty method
4. remove redundant 'throws' clause
5. change anonymous type  to lambda
6. fix typo
7. remove redundant String operation
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No

    
