### PR TITLE
[CARBONDATA-3853] Data load failure when loading with bucket column as DATE data type

### DIFF
--- a/processing/src/main/java/org/apache/carbondata/processing/loading/partition/impl/SparkHashExpressionPartitionerImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/partition/impl/SparkHashExpressionPartitionerImpl.java
@@ -48,8 +48,9 @@ public class SparkHashExpressionPartitionerImpl implements Partitioner<CarbonRow
       DataType dataType = columnSchemas.get(i).getDataType();
       if (dataType == DataTypes.LONG || dataType == DataTypes.DOUBLE) {
         hashes[i] = new LongHash(indexes.get(i));
-      } else if (dataType == DataTypes.SHORT || dataType == DataTypes.INT ||
-          dataType == DataTypes.FLOAT || dataType == DataTypes.BOOLEAN) {
+      } else if (dataType == DataTypes.SHORT || dataType == DataTypes.INT
+          || dataType == DataTypes.FLOAT || dataType == DataTypes.BOOLEAN
+          || dataType == DataTypes.DATE) {
         hashes[i] = new IntegralHash(indexes.get(i));
       } else if (DataTypes.isDecimal(dataType)) {
         hashes[i] = new DecimalHash(indexes.get(i));


### PR DESCRIPTION
[CARBONDATA-3853] Data load failure when loading with bucket column as DATE data type

 ### Why is this PR needed?
 While loading data into a table which has bucket column as DATE data type then receiving data load failure due to class-cast exception. The class-cast exception is due to DATE data type is not going as IntegralHash type for getting the hash because of there is no case for DATE datatype and it is going for StringHash type and typecast results class-cast Exception.
 
 ### What changes were proposed in this PR?
Added a OR (||) condition if data type is DATE then it will go IntegralHash getHash() method for getting the hash code.   
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
