### PR TITLE
[CARBONDATA-3846]Data load issue for boolean column configured as BUCKET_COLUMNS

### DIFF
--- a/integration/spark/src/test/scala/org/apache/spark/carbondata/bucketing/TableBucketingTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/spark/carbondata/bucketing/TableBucketingTestCase.scala
@@ -1018,6 +1018,28 @@ class TableBucketingTestCase extends QueryTest with BeforeAndAfterAll {
     assert(shuffleExists2, "shuffle should exist when some bucket columns not exist in filter")
   }
 
+  test("test load data with boolean type as bucket column") {
+    sql("drop table if exists boolean_table")
+    sql(
+      s"""
+         | CREATE TABLE boolean_table(
+         | booleanField BOOLEAN,
+         | stringField STRING,
+         | intField INT
+         | )
+         | STORED AS carbondata
+         | TBLPROPERTIES('BUCKET_NUMBER'='1', 'BUCKET_COLUMNS'='booleanField')
+       """.stripMargin)
+
+    sql(
+      s"""
+         | LOAD DATA LOCAL INPATH '$resourcesPath/bool/supportBooleanWithFileHeader.csv'
+         | INTO TABLE boolean_table
+           """.stripMargin)
+
+    checkAnswer(sql("select count(*) from boolean_table"), Row(10))
+  }
+
   override def afterAll {
     CarbonProperties.getInstance()
       .addProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT,

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/partition/impl/SparkHashExpressionPartitionerImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/partition/impl/SparkHashExpressionPartitionerImpl.java
@@ -93,7 +93,7 @@ public class SparkHashExpressionPartitionerImpl implements Partitioner<CarbonRow
       }
       int intValue = 0;
       if (value[index] instanceof Boolean) {
-        boolean boolValue = (boolean) value[intValue];
+        boolean boolValue = (boolean) value[index];
         intValue = boolValue ? 1 : 0;
       } else if (value[index] instanceof Float) {
         intValue = Float.floatToIntBits((float) value[index]);


### PR DESCRIPTION
 ### Why is this PR needed?
During data load with bucket column, boolean values were retrieved using wrong index.
Issue occurs only when table has more than one column(including boolean type). Due to this wrong index, wrong column data was retrieved, instead of boolean, hence throwing ClassCastException and **data load failure**.
 
 ### What changes were proposed in this PR?
Boolean values are now retrieved using the correct index.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
