### PR TITLE
[CARBONDATA-3893] [IUD] Fix getting block name in compacted segment with dot for horizontal compaction delta files

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/statusmanager/SegmentUpdateStatusManager.java
+++ b/core/src/main/java/org/apache/carbondata/core/statusmanager/SegmentUpdateStatusManager.java
@@ -448,10 +448,9 @@ public class SegmentUpdateStatusManager {
           @Override
           public boolean accept(CarbonFile pathName) {
             String fileName = pathName.getName();
-            if (fileName.endsWith(CarbonCommonConstants.DELETE_DELTA_FILE_EXT)
-                && pathName.getSize() > 0) {
-              String firstPart = fileName.substring(0, fileName.indexOf('.'));
-              String blkName = firstPart.substring(0, firstPart.lastIndexOf("-"));
+            if (pathName.getSize() > 0
+                && fileName.endsWith(CarbonCommonConstants.DELETE_DELTA_FILE_EXT)) {
+              String blkName = fileName.substring(0, fileName.lastIndexOf("-"));
               long timestamp =
                   Long.parseLong(CarbonTablePath.DataFileUtil.getTimeStampFromFileName(fileName));
               if (blockName.equals(blkName) && (Long.compare(timestamp, deltaEndTimeStamp) <= 0)


### PR DESCRIPTION
 ### Why is this PR needed?
 Currentlly, during horizontal compaction, driver will list delta files in segment to merge them, during this comparasion it will use block name, current code only consider the blocks in normal segment, but not consider the compacted segement, for example, in XXXX-12.2-time.deletedelta the block name should be XXXX-12.2 not XXXX, if use XXX it will not list the delta files and horizontal compaction will not merge delta files.
 
 ### What changes were proposed in this PR?
Correct the parse of block name 
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No

    
