### PR TITLE
[CARBONDATA-3910]Fix load failure in cluster when csv present in local file system in case of global sort

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -1623,7 +1623,7 @@ public final class CarbonCommonConstants {
 
   public static final String HDFSURL_PREFIX = "hdfs://";
 
-  public static final String LOCAL_FILE_PREFIX = "file://";
+  public static final String LOCAL_FILE_PREFIX = "file:/";
 
   public static final String VIEWFSURL_PREFIX = "viewfs://";
 

--- a/core/src/main/java/org/apache/carbondata/core/metadata/AbsoluteTableIdentifier.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/AbsoluteTableIdentifier.java
@@ -82,7 +82,7 @@ public class AbsoluteTableIdentifier implements Serializable {
 
   public String appendWithLocalPrefix(String path) {
     if (tablePath.startsWith(CarbonCommonConstants.LOCAL_FILE_PREFIX)) {
-      return CarbonCommonConstants.LOCAL_FILE_PREFIX + path;
+      return CarbonCommonConstants.LOCAL_FILE_PREFIX + CarbonCommonConstants.FILE_SEPARATOR + path;
     } else {
       return path;
     }


### PR DESCRIPTION
 ### Why is this PR needed?
 when the csv file is present in local file system and we load the table in cluster, it fails with file not found. This is because when we try to update the file path, we remove one slash in schema which causes this issue.
 
 ### What changes were proposed in this PR?
Its better to check for "file:/" instead of "file:///" for local file, as getUpdatedfilePath API may remove one slash and cause this issue. 

    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No(tested in cluster)

    
