### PR TITLE
[CARBONDATA-3899] Drop materialized view when executed concurrently from 4 concurrent client fails in all 4 clients.

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/view/MVManager.java
+++ b/core/src/main/java/org/apache/carbondata/core/view/MVManager.java
@@ -143,7 +143,7 @@ public abstract class MVManager {
   /**
    * Drops the mv schema from storage
    *
-   * @param viewName index name
+   * @param viewName mv name
    */
   public void deleteSchema(String databaseName, String viewName) throws IOException {
     schemaProvider.dropSchema(this, databaseName, viewName);

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/view/CarbonDropMVCommand.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/view/CarbonDropMVCommand.scala
@@ -23,6 +23,7 @@ import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.execution.command.AtomicRunnableCommand
 import org.apache.spark.sql.execution.command.table.CarbonDropTableCommand
 
+import org.apache.carbondata.common.exceptions.sql.MalformedMVCommandException
 import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.core.datastore.impl.FileFactory
 import org.apache.carbondata.core.util.CarbonProperties
@@ -90,6 +91,13 @@ case class CarbonDropMVCommand(
         }
 
         this.dropTableCommand = dropTableCommand
+      } else {
+        if (!ifExistsSet) {
+          throw new MalformedMVCommandException(
+            s"Materialized view with name ${ databaseName }.${ name } does not exists")
+        } else {
+          return Seq.empty
+        }
       }
     } catch {
       case exception: Exception =>

--- a/integration/spark/src/test/scala/org/apache/carbondata/view/MVTest.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/view/MVTest.scala
@@ -24,6 +24,8 @@ import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.datasources.LogicalRelation
 import org.apache.spark.sql.test.util.QueryTest
 import org.scalatest.BeforeAndAfterAll
+
+import org.apache.carbondata.common.exceptions.sql.MalformedMVCommandException
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.util.{CarbonProperties, ThreadLocalSessionInfo}
 import org.apache.carbondata.spark.exception.ProcessMetaDataException
@@ -176,6 +178,13 @@ class MVTest extends QueryTest with BeforeAndAfterAll {
     } finally {
       sql("drop table source")
     }
+  }
+
+  test("test drop mv must fail if not exists") {
+    val ex = intercept[MalformedMVCommandException] {
+      sql("drop materialized view MV_notPresent")
+    }
+    assert(ex.getMessage.contains("Materialized view with name default.MV_notPresent does not exists"))
   }
 
   test("test refresh mv on manual") {

--- a/integration/spark/src/test/scala/org/apache/carbondata/view/rewrite/MVCreateTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/view/rewrite/MVCreateTestCase.scala
@@ -955,9 +955,9 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     sql(" insert into mvtable1 select 'n4',12,12")
     sql("update mvtable1 set(name) = ('updatedName')").show()
     checkAnswer(sql("select count(*) from mvtable1 where name = 'updatedName'"),Seq(Row(4)))
+    sql(s"drop materialized view MV11")
     sql("drop table if exists mvtable1")
     sql("drop table if exists mvtable2")
-    sql(s"drop materialized view MV11")
   }
 
   test("test create materialized view with streaming table")  {
@@ -1166,8 +1166,8 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     val frame = sql("select count(*) from mvtable1")
     assert(!TestUtil.verifyMVHit(frame.queryExecution.optimizedPlan, "MV11"))
     checkAnswer(frame,Seq(Row(1)))
-    sql("drop table if exists mvtable1")
     sql(s"drop materialized view MV11")
+    sql("drop table if exists mvtable1")
   }
 
   test("test mv with duplicate columns in query and constant column") {


### PR DESCRIPTION
 ### Why is this PR needed?
1) drop materialized view when executed concurrently from 4 concurrent client fails in all 4 clients.
   Also, materialized view when created in one session and queried on another open session will not hit MV.
2) drop mv if not exists must fail.
 
 ### What changes were proposed in this PR?
1) made view manager as a single instance for all sessions, so that changes executed from one session gets reflected in others.
2) added check for drop mv command to throw an exception if the materialized view is not present.

 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
