### PR TITLE
[HOTFIX] Fix wrong License header

### DIFF
--- a/python/pycarbon/tests/mnist/dataset_with_normal_schema/__init__.py
+++ b/python/pycarbon/tests/mnist/dataset_with_normal_schema/__init__.py
@@ -1,10 +1,11 @@
-#  Copyright (c) 2017-2018 Uber Technologies, Inc.
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
+#    http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/python/pycarbon/tests/mnist/dataset_with_unischema/__init__.py
+++ b/python/pycarbon/tests/mnist/dataset_with_unischema/__init__.py
@@ -1,10 +1,11 @@
-#  Copyright (c) 2017-2018 Uber Technologies, Inc.
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
+#    http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
 ### Why is this PR needed?
Two test files in pycarbon module has wrong license header.
As pycarbon depends on open source Apache license uber's petastrom project. 
These two testcase files were imported from that project has this error. 
 
 ### What changes were proposed in this PR?
Fix the license header same as other files.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No

    
