### PR TITLE
[CARBONDATA-3871][FOLLOW-UP] Fix memory issue when get data from row page

### DIFF
--- a/processing/src/main/java/org/apache/carbondata/processing/loading/sort/unsafe/merger/UnsafeInMemoryIntermediateDataMerger.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/sort/unsafe/merger/UnsafeInMemoryIntermediateDataMerger.java
@@ -147,7 +147,10 @@ public class UnsafeInMemoryIntermediateDataMerger implements Callable<Void> {
 
     // check if there no entry present
     if (!poll.hasNext()) {
-      poll.close();
+      // do not close the poll to free the memory of rowPage here
+      // because data in memory will be used in final merge sort
+      // and close in `UnsafeFinalMergePageHolder` in case of `spillDisk`
+      // is false. Please refer method `writeDataToMemory` in this class
       this.recordHolderHeap.poll();
       // change the file counter
       --this.holderCounter;


### PR DESCRIPTION
 ### Why is this PR needed?
PR  #3804 free the row page after running in-memory intermeidate merge, but the data will still be used in final sort because that merge only acquire the memory address and row page index instead of moving the rows from here to there. 
 
 ### What changes were proposed in this PR?
Remove code for freeing the row page in case of in-memory intermeidate merge.
As a special case, add comment for explanation.
    
 ### Does this PR introduce any user interface change?
 - No
 - Yes. (please explain the change and update document)

 ### Is any new testcase added?
 - No
 - Yes

    
