### PR TITLE
[CARBONDATA-3907]Refactor to use CommonLoadUtils API's firePreLoadEvents and firePostLoadEvents to trigger Load pre and post events

### DIFF
--- a/processing/src/main/java/org/apache/carbondata/processing/loading/events/LoadEvents.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/events/LoadEvents.java
@@ -51,12 +51,6 @@ public class LoadEvents {
       this.isOverWriteTable = isOverWriteTable;
     }
 
-    public LoadTablePreExecutionEvent(CarbonTableIdentifier carbonTableIdentifier,
-        CarbonLoadModel carbonLoadModel) {
-      this.carbonTableIdentifier = carbonTableIdentifier;
-      this.carbonLoadModel = carbonLoadModel;
-    }
-
     public CarbonTableIdentifier getCarbonTableIdentifier() {
       return carbonTableIdentifier;
     }


### PR DESCRIPTION
 ### Why is this PR needed?
Currently we have 2 different ways of firing LoadTablePreExecutionEvent and LoadTablePostExecutionEvent. We can reuse firePreLoadEvents and firePostLoadEvents methods from CommonLoadUtils to trigger LoadTablePreExecutionEvent and LoadTablePostExecutionEvent respectively in alter table add segment flow as well.
 
 ### What changes were proposed in this PR?
Reuse firePreLoadEvents and firePostLoadEvents methods from CommonLoadUtils to trigger LoadTablePreExecutionEvent and LoadTablePostExecutionEvent respectively in alter table add segment flow.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No
