### PR TITLE
[CARBONDATA-3909] Fix Global sort data load failure issue with Decimal value as NULL

### DIFF
--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/util/CommonUtil.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/util/CommonUtil.scala
@@ -931,7 +931,12 @@ object CommonUtil {
               DataTypes.STRING)
           }
         case d: DecimalType =>
-          data(i) = row.getDecimal(i, d.precision, d.scale).toJavaBigDecimal
+          val decimalValue = row.getDecimal(i, d.precision, d.scale)
+          if (null == decimalValue) {
+            data(i) = null
+          } else {
+            data(i) = decimalValue.toJavaBigDecimal
+          }
         case arrayType: ArrayType =>
           val result = convertSparkComplexTypeToCarbonObject(row.get(i, arrayType), arrayType)
           // convert carbon complex object to byte array


### PR DESCRIPTION
 ### Why is this PR needed?
 Global sort Data load having decimal value as NULL fails with NPE
 
 ### What changes were proposed in this PR?
Added null check, if actual data is null for decimal types and assigned data to NULL value
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
