### PR TITLE
[CARBONDATA-3918]Fix extra data in count(*) after multiple updates with index server running

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/index/Segment.java
+++ b/core/src/main/java/org/apache/carbondata/core/index/Segment.java
@@ -309,6 +309,10 @@ public class Segment implements Serializable, Writable {
     return loadMetadataDetails;
   }
 
+  public void setLoadMetadataDetails(LoadMetadataDetails loadMetadataDetails) {
+    this.loadMetadataDetails = loadMetadataDetails;
+  }
+
   public long getIndexSize() {
     return indexSize;
   }

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableInputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableInputFormat.java
@@ -369,6 +369,7 @@ public class CarbonTableInputFormat<T> extends CarbonInputFormat<T> {
         getDataBlocksOfSegment(job, carbonTable, expression, validSegments,
             invalidSegments, segmentsToBeRefreshed);
     numBlocks = dataBlocksOfSegment.size();
+    updateLoadMetaDataDetailsToSegments(validSegments, dataBlocksOfSegment);
     for (org.apache.carbondata.hadoop.CarbonInputSplit inputSplit : dataBlocksOfSegment) {
 
       // Get the UpdateVO for those tables on which IUD operations being performed.
@@ -397,6 +398,21 @@ public class CarbonTableInputFormat<T> extends CarbonInputFormat<T> {
       result.add(inputSplit);
     }
     return result;
+  }
+
+  public void updateLoadMetaDataDetailsToSegments(List<Segment> validSegments,
+      List<org.apache.carbondata.hadoop.CarbonInputSplit> prunedSplits) {
+    for (CarbonInputSplit split : prunedSplits) {
+      Segment segment = split.getSegment();
+      if (segment.getLoadMetadataDetails() == null || segment.getReadCommittedScope() == null) {
+        if (validSegments.contains(segment)) {
+          segment.setLoadMetadataDetails(
+              validSegments.get(validSegments.indexOf(segment)).getLoadMetadataDetails());
+          segment.setReadCommittedScope(
+              validSegments.get(validSegments.indexOf(segment)).getReadCommittedScope());
+        }
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
 ### Why is this PR needed?
Select count * gives extra data after multiple updates with the index server running. This is because, once the horizontal compaction happens, it stores the index fils to cache and create new index and data files, so if the table is updated or deleted table, we will exclude those splits after getting all splits. Since once the splits come from index server since loadmetadatadetails are transient in Segment object, we will have null value for it as the slits are serialized from index server. Because of which it won't be able to filter out the IUD old segments. So it leads to extra data in count *.
 
 ### What changes were proposed in this PR?
Once we get the splits from the index server, then from the validSegments, get the loadmetadataDetails and readCommittedScope and set into the splits which solve this problem.
    
 ### Does this PR introduce any user interface change?
 - No


 ### Is any new testcase added?
 - No(tested in a cluster with index server running)

    
