### PR TITLE
[CARBONDATA-3920]Fix compaction failure issue for SI table and metadata mismatch in concurrency

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/index/Segment.java
+++ b/core/src/main/java/org/apache/carbondata/core/index/Segment.java
@@ -275,6 +275,11 @@ public class Segment implements Serializable, Writable {
     return null;
   }
 
+  public static Segment getSegment(String segmentNo, String segmentFileName,
+      ReadCommittedScope readCommittedScope) {
+    return new Segment(segmentNo, segmentFileName, readCommittedScope);
+  }
+
   public Configuration getConfiguration() {
     return readCommittedScope.getConfiguration();
   }

--- a/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/events/CleanFilesPostEventListener.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/events/CleanFilesPostEventListener.scala
@@ -24,11 +24,18 @@ import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.index.CarbonIndexUtil
 import org.apache.spark.sql.optimizer.CarbonFilters
+import org.apache.spark.sql.secondaryindex.load.CarbonInternalLoaderUtil
 
 import org.apache.carbondata.common.logging.LogServiceFactory
+import org.apache.carbondata.core.constants.CarbonCommonConstants
+import org.apache.carbondata.core.datastore.impl.FileFactory
 import org.apache.carbondata.core.indexstore.PartitionSpec
+import org.apache.carbondata.core.locks.{CarbonLockFactory, ICarbonLock, LockUsage}
+import org.apache.carbondata.core.metadata.schema.table.CarbonTable
 import org.apache.carbondata.core.mutate.CarbonUpdateUtil
-import org.apache.carbondata.core.statusmanager.SegmentStatusManager
+import org.apache.carbondata.core.statusmanager.{LoadMetadataDetails, SegmentStatus, SegmentStatusManager}
+import org.apache.carbondata.core.util.CarbonUtil
+import org.apache.carbondata.core.util.path.CarbonTablePath
 import org.apache.carbondata.events.{CleanFilesPostEvent, Event, OperationContext, OperationEventListener}
 
 class CleanFilesPostEventListener extends OperationEventListener with Logging {
@@ -54,7 +61,66 @@ class CleanFilesPostEventListener extends OperationEventListener with Logging {
           SegmentStatusManager.deleteLoadsAndUpdateMetadata(
             indexTable, true, partitions.map(_.asJava).orNull)
           CarbonUpdateUtil.cleanUpDeltaFiles(indexTable, true)
+          cleanUpUnwantedSegmentsOfSIAndUpdateMetadata(indexTable, carbonTable)
         }
+    }
+  }
+
+  /**
+   * This method added to clean the segments which are success in SI and may be compacted or marked
+   * for delete in main table, which can happen in case of concurrent scenarios.
+   */
+  def cleanUpUnwantedSegmentsOfSIAndUpdateMetadata(indexTable: CarbonTable,
+      mainTable: CarbonTable): Unit = {
+    val mainTableStatusLock: ICarbonLock = CarbonLockFactory
+      .getCarbonLockObj(mainTable.getAbsoluteTableIdentifier, LockUsage.TABLE_STATUS_LOCK)
+    val indexTableStatusLock: ICarbonLock = CarbonLockFactory
+      .getCarbonLockObj(indexTable.getAbsoluteTableIdentifier, LockUsage.TABLE_STATUS_LOCK)
+    var mainTableLocked = false
+    var indexTableLocked = false
+    try {
+      mainTableLocked = mainTableStatusLock.lockWithRetries()
+      indexTableLocked = indexTableStatusLock.lockWithRetries()
+      if (mainTableLocked && indexTableLocked) {
+        val mainTableMetadataDetails =
+          SegmentStatusManager.readLoadMetadata(mainTable.getMetadataPath).toSet ++
+          SegmentStatusManager.readLoadHistoryMetadata(mainTable.getMetadataPath).toSet
+        val indexTableMetadataDetails =
+          SegmentStatusManager.readLoadMetadata(indexTable.getMetadataPath).toSet
+        val segToStatusMap = mainTableMetadataDetails
+          .map(detail => detail.getLoadName -> detail.getSegmentStatus).toMap
+
+        val unnecessarySegmentsOfSI = indexTableMetadataDetails.filter { indexDetail =>
+          indexDetail.getSegmentStatus.equals(SegmentStatus.SUCCESS) &&
+          segToStatusMap.contains(indexDetail.getLoadName) &&
+          (segToStatusMap(indexDetail.getLoadName).equals(SegmentStatus.COMPACTED) ||
+           segToStatusMap(indexDetail.getLoadName).equals(SegmentStatus.MARKED_FOR_DELETE))
+        }
+        LOGGER.info(s"Unwanted SI segments are: $unnecessarySegmentsOfSI")
+        unnecessarySegmentsOfSI.foreach { detail =>
+          val carbonFile = FileFactory
+            .getCarbonFile(CarbonTablePath
+              .getSegmentPath(indexTable.getTablePath, detail.getLoadName))
+          CarbonUtil.deleteFoldersAndFiles(carbonFile)
+        }
+        unnecessarySegmentsOfSI.foreach { detail =>
+          detail.setSegmentStatus(segToStatusMap(detail.getLoadName))
+          detail.setVisibility("false")
+        }
+
+        SegmentStatusManager.writeLoadDetailsIntoFile(
+          indexTable.getMetadataPath + CarbonTablePath.TABLE_STATUS_FILE,
+          unnecessarySegmentsOfSI.toArray)
+      } else {
+        LOGGER.error("Unable to get the lock file for main/Index table. Please try again later")
+      }
+    } catch {
+      case ex: Exception =>
+        LOGGER.error("clean up of unwanted SI segments failed", ex)
+      // ignore the exception
+    } finally {
+      indexTableStatusLock.unlock()
+      mainTableStatusLock.unlock()
     }
   }
 }

--- a/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/util/SecondaryIndexUtil.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/util/SecondaryIndexUtil.scala
@@ -199,9 +199,11 @@ object SecondaryIndexUtil {
       }
       if (finalMergeStatus) {
         if (null != mergeStatus && mergeStatus.length != 0) {
+          val validSegmentsToUse = validSegments.asScala
+            .filter(segment => mergeStatus.map(_._2).toSet.contains(segment.getSegmentNo))
           deleteOldIndexOrMergeIndexFiles(
             carbonLoadModel.getFactTimeStamp,
-            validSegments,
+            validSegmentsToUse.toList.asJava,
             indexCarbonTable)
           mergedSegments.asScala.map { seg =>
             val file = SegmentFileStore.writeSegmentFile(

--- a/processing/src/main/java/org/apache/carbondata/processing/merger/CarbonDataMergerUtil.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/merger/CarbonDataMergerUtil.java
@@ -933,10 +933,10 @@ public final class CarbonDataMergerUtil {
     for (LoadMetadataDetails segment : loadMetadataDetails) {
       //check if this load is an already merged load.
       if (null != segment.getMergedLoadName()) {
-
-        segments.add(Segment.toSegment(segment.getMergedLoadName(), null));
+        segments
+            .add(Segment.getSegment(segment.getMergedLoadName(), segment.getSegmentFile(), null));
       } else {
-        segments.add(Segment.toSegment(segment.getLoadName(), null));
+        segments.add(Segment.getSegment(segment.getLoadName(), segment.getSegmentFile(), null));
       }
     }
     return segments;


### PR DESCRIPTION

 ### Why is this PR needed?
 1. When load and compaction are happening concurrently, in reliability test segment data will be deleted from SI table, which leads to exception/failures
2. pre-priming was happening for SI table segment in case of compaction before making SI segment as a success.
 
 ### What changes were proposed in this PR?
1. remove unnecessary cleaning API call from SI flow and before compaction success segment locks were getting released for SI, handle that
2. do the code refactoring in case of SI load after main table compaction to handle proper pre-priming after segments were made success.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No(tested in cluster with 10 concurrency and around 1000 loads)

    
