### PR TITLE
[CARBONDATA-3929]Improve CDC performance

### DIFF
--- a/integration/spark/pom.xml
+++ b/integration/spark/pom.xml
@@ -154,6 +154,28 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>com.databricks</groupId>
+      <artifactId>spark-avro_${scala.binary.version}</artifactId>
+      <version>4.0.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.avro</groupId>
+          <artifactId>avro</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-avro_${scala.binary.version}</artifactId>
+      <version>2.4.5</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.avro</groupId>
+          <artifactId>avro</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-sql-kafka-0-10_${scala.binary.version}</artifactId>
       <exclusions>

--- a/integration/spark/src/main/spark2.3/com/databricks/spark/avro/AvroWriter.scala
+++ b/integration/spark/src/main/spark2.3/com/databricks/spark/avro/AvroWriter.scala
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.databricks.spark.avro
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.execution.datasources.OutputWriterFactory
+
+/**
+ * This class is to get the avro writer from databricks avro module, as its not present in spark2.3
+ * and spark-avro module is included in spark project from spark-2.4. So for spark-2.4, we use Avro
+ * writer from spark project.
+ */
+object AvroWriter {
+
+  def getWriter(spark: org.apache.spark.sql.SparkSession,
+      job: org.apache.hadoop.mapreduce.Job,
+      dataSchema: org.apache.spark.sql.types.StructType,
+      options: scala.Predef.Map[scala.Predef.String, scala.Predef.String] = Map.empty)
+  : OutputWriterFactory = {
+    new DefaultSource().prepareWrite(spark, job,
+      options, dataSchema)
+  }
+}
+
+/**
+ * This reads the avro files from the given path and return the RDD[Row]
+ */
+object AvroReader {
+
+  def readAvro(spark: org.apache.spark.sql.SparkSession, deltaPath: String): RDD[Row] = {
+    spark.sparkContext
+      .hadoopConfiguration
+      .set("avro.mapred.ignore.inputs.without.extension", "false")
+    spark.read.avro(deltaPath).rdd
+  }
+}

--- a/integration/spark/src/main/spark2.3/org/apache/spark/sql/avro/AvroFileFormatFactory.scala
+++ b/integration/spark/src/main/spark2.3/org/apache/spark/sql/avro/AvroFileFormatFactory.scala
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.avro
+
+import com.databricks.spark.avro.{AvroReader, AvroWriter}
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.execution.datasources.OutputWriterFactory
+
+object AvroFileFormatFactory {
+
+  /**
+   * return the avro writer to write the avro files
+   * @return avro writer
+   */
+  def getAvroWriter(spark: org.apache.spark.sql.SparkSession,
+      job: org.apache.hadoop.mapreduce.Job,
+      dataSchema: org.apache.spark.sql.types.StructType,
+      options: scala.Predef.Map[scala.Predef.String, scala.Predef.String] = Map.empty)
+  : OutputWriterFactory = {
+    AvroWriter.getWriter(spark, job, dataSchema, options)
+  }
+
+  /**
+   * Reads the avro files present at the given path
+   * @param deltaPath path to read the avro files from.
+   * @return RDD[Row]
+   */
+  def readAvro(spark: org.apache.spark.sql.SparkSession, deltaPath: String): RDD[Row] = {
+    spark.sparkContext
+      .hadoopConfiguration
+      .set("avro.mapred.ignore.inputs.without.extension", "false")
+    AvroReader.readAvro(spark, deltaPath)
+  }
+}

--- a/integration/spark/src/main/spark2.4/org/apache/spark/sql/avro/AvroFileFormatFactory.scala
+++ b/integration/spark/src/main/spark2.4/org/apache/spark/sql/avro/AvroFileFormatFactory.scala
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.avro
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.execution.datasources.OutputWriterFactory
+
+object AvroFileFormatFactory {
+
+  /**
+   * return the avro writer to write the avro files
+   * @return avro writer
+   */
+  def getAvroWriter(spark: org.apache.spark.sql.SparkSession,
+      job: org.apache.hadoop.mapreduce.Job,
+      dataSchema: org.apache.spark.sql.types.StructType,
+      options: scala.Predef.Map[scala.Predef.String, scala.Predef.String] = Map.empty)
+  : OutputWriterFactory = {
+    new AvroFileFormat().prepareWrite(spark, job, options, dataSchema)
+  }
+
+  /**
+   * Reads the avro files present at the given path
+   * @param deltaPath path to read the avro files from.
+   * @return RDD[Row]
+   */
+  def readAvro(spark: org.apache.spark.sql.SparkSession, deltaPath: String): RDD[Row] = {
+    spark.sparkContext
+      .hadoopConfiguration
+      .set("avro.mapred.ignore.inputs.without.extension", "false")
+    spark.read.format("avro").load(s"$deltaPath").rdd
+  }
+}


### PR DESCRIPTION
 ### Why is this PR needed?
This PR is to improve the CDC merge performance. CDC is currently very slow in the case of full outer joins and slow in normal cases. Identified pain points are as below:
1. currently we are writing the intermediate delete data to carbon format, which is the columnar format, and we do a full scan which is slow. Here since intermediate, we do full scan, compression, columnar format, its all-time taking.
2. Full outer join case is very slow.
3. when we insert new data into new segments, we follow the old insert flow with the converter step.
4. since we write the intermediate data carbon format, we use coalesce to limit the partition to number of active executors.
 
 ### What changes were proposed in this PR?
Some improvements points are identified as below
1. Write the intermediate data to a faster row format like Avro.
2. use bucketing on join column and do the repartition of the Dataframe before performing the join operation, which avoids the shuffle on one side as shuffle is major time consuming part in join.
3. make the insert flow to the new flow without the converter step.
4. remove coalesce and can use resource to write the intermediate Avro data in a faster way.
    
Performance results
| --- |
| DataSize -> 2GB target table data |
| 230MB source table data |
| InnerJoin case - around 17000+ deleted rows, 70400 odd updated rows |
| Full outer Join case - 2million target data, 0.2million src data, 70400 odd rows updated and some deleted |


|   | Old Time(sec) |   | New Time(sec) |   |
| :---: | :---: | :---: | :---: | :---: |
| **Join Type** | **1st time query** | **2nd time query** | **1st time query** | **2nd time query** |
| **Inner Join** | 20 | 9.6 | 14 | 4.6 |
| **Full Outer Join** | 43 | 17.8 | 26 | 7.7 |
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
