### PR TITLE
[CARBONDATA-3914] Fixed issue on reading data from carbon table through hive beeline when no data is present in table.

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
@@ -24,6 +24,7 @@ import java.io.Closeable;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -2137,7 +2138,7 @@ public final class CarbonUtil {
     if (fistFilePath == null) {
       // Check if we can infer the schema from the hive metastore.
       LOGGER.error("CarbonData file is not present in the table location");
-      throw new IOException("CarbonData file is not present in the table location");
+      throw new FileNotFoundException("CarbonData file is not present in the table location");
     }
     CarbonHeaderReader carbonHeaderReader = new CarbonHeaderReader(fistFilePath, configuration);
     List<ColumnSchema> columnSchemaList = carbonHeaderReader.readSchema();

--- a/integration/hive/src/main/java/org/apache/carbondata/hive/MapredCarbonInputFormat.java
+++ b/integration/hive/src/main/java/org/apache/carbondata/hive/MapredCarbonInputFormat.java
@@ -17,6 +17,7 @@
 
 package org.apache.carbondata.hive;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -116,6 +117,8 @@ public class MapredCarbonInputFormat extends CarbonTableInputFormat<ArrayWritabl
     try {
       carbonTable = getCarbonTable(jobContext.getConfiguration(),
           jobContext.getConfiguration().get(hive_metastoreConstants.META_TABLE_LOCATION));
+    } catch (FileNotFoundException e) {
+      return new InputSplit[0];
     } catch (Exception e) {
       throw new IOException("Unable read Carbon Schema: ", e);
     }


### PR DESCRIPTION
**Why is this PR needed?**
Reading data from empty carbontable through hive beeline was giving "Unable read Carbon 	    Schema" exception, when no data is present in the carbon table. 
    
**What changes were proposed in this PR?**
This PR will help to fix above scenario by returning the empty result when no data is inserted in table.
    
**Does this PR introduce any user interface change?**
No
    
**Is any new testcase added?**
No
    
