### PR TITLE
[CARBONDATA-3921] SI load fails with 'unable to get filestatus error' in concurrent scenario

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/rdd/SecondaryIndexCreator.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/rdd/SecondaryIndexCreator.scala
@@ -305,6 +305,7 @@ object SecondaryIndexCreator {
       indexCarbonTable
     } catch {
       case ex: Exception =>
+        LOGGER.error("load to SI failed", ex)
         FileInternalUtil
           .updateTableStatus(validSegmentList,
             secondaryIndexModel.carbonLoadModel.getDatabaseName,
@@ -316,7 +317,6 @@ object SecondaryIndexCreator {
               String](),
             indexCarbonTable,
             sc.sparkSession)
-        LOGGER.error(ex)
         throw ex
     } finally {
       // release the segment locks
@@ -339,7 +339,6 @@ object SecondaryIndexCreator {
         if (!isCompactionCall) {
           SegmentStatusManager
             .deleteLoadsAndUpdateMetadata(indexCarbonTable, false, null)
-          TableProcessingOperations.deletePartialLoadDataIfExist(indexCarbonTable, false)
         }
       } catch {
         case e: Exception =>


### PR DESCRIPTION
 ### Why is this PR needed?
 
 The clean up mechanism in SI finally block causes to delete the ongoing load files which caused the issue.

 ### What changes were proposed in this PR?

Remove calling of the API TableProcessingOperations.deletePartialLoadDataIfExist, as it's not required for the scenario and clean up happens with clean files and deleteLoadsAndUpdateMetadata API.
    
 ### Does this PR introduce any user interface change?
 - No
 - Yes. (please explain the change and update document)

 ### Is any new testcase added?
 - No
 - Yes

    
