### PR TITLE
[CARBONDATA-3939]Exception added for index creation on long string columns

### DIFF
--- a/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/TestCreateIndexTable.scala
+++ b/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/TestCreateIndexTable.scala
@@ -370,6 +370,26 @@ class TestCreateIndexTable extends QueryTest with BeforeAndAfterAll {
     }
   }
 
+  test("index creation on long string columns") {
+    sql("drop table if exists si_table")
+    sql(
+      s"""
+         | CREATE TABLE si_table(
+         | name STRING,
+         | longstr STRING
+         | )
+         | STORED AS carbondata
+         | TBLPROPERTIES(
+         | 'LONG_STRING_COLUMNS'='longstr')
+         | """.stripMargin)
+
+    sql("drop index if exists temp_ind on si_table")
+    val thrown = intercept[Exception] {
+      sql("create index temp_ind on table si_table (longstr) AS 'carbondata'")
+    }
+    assert(thrown.getMessage.contains("one or more index columns specified contains long string column in table default.si_table. SI cannot be created on long string columns."))
+  }
+
   test("drop index on temp table") {
     sql(
       "CREATE temporary table dropindextemptable(id int,name string,city string,age int) using " +

--- a/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/command/SICreationCommand.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/command/SICreationCommand.scala
@@ -261,6 +261,16 @@ private[sql] case class CarbonCreateSecondaryIndexCommand(
         throw new ErrorMessage(
           s"Table [$tableName] under database [$databaseName] is already an index table")
       }
+      // creation of index on long string columns are not supported
+      if (dims.filter(dimension => indexModel.columnNames
+        .contains(dimension.getColName))
+        .map(_.getDataType)
+        .exists(dataType => dataType.equals(DataTypes.VARCHAR))) {
+        throw new ErrorMessage(
+          s"one or more index columns specified contains long string column" +
+          s" in table $databaseName.$tableName. SI cannot be created on long string columns.")
+      }
+
       // Check whether index table column order is same as another index table column order
       oldIndexInfo = carbonTable.getIndexInfo
       if (null == oldIndexInfo) {


### PR DESCRIPTION
 ### Why is this PR needed?
 Index creation for long string columns are not yet supported.
 
 ### What changes were proposed in this PR?
Exceptions are thrown if user tries to create the same.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
