### PR TITLE
[CARBONDATA-3986] Fix multiple issues during compaction and concurrent scenarios

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/index/TableIndex.java
+++ b/core/src/main/java/org/apache/carbondata/core/index/TableIndex.java
@@ -607,7 +607,7 @@ public final class TableIndex extends OperationEventListener {
     for (Segment segment : segments) {
       List<CoarseGrainIndex> indexes = defaultIndex.getIndexFactory().getIndexes(segment);
       for (CoarseGrainIndex index : indexes) {
-        if (null != partitions) {
+        if (null != partitions && !partitions.isEmpty()) {
           // if it has partitioned index but there is no partitioned information stored, it means
           // partitions are dropped so return empty list.
           if (index.validatePartitionInfo(partitions)) {

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockIndex.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockIndex.java
@@ -613,7 +613,7 @@ public class BlockIndex extends CoarseGrainIndex
       Map<String, Long> blockletToRowCountMap = new HashMap<>();
       // if it has partitioned index but there is no partitioned information stored, it means
       // partitions are dropped so return empty list.
-      if (partitions != null) {
+      if (partitions != null && !partitions.isEmpty()) {
         if (validatePartitionInfo(partitions)) {
           return totalRowCount;
         }

--- a/core/src/main/java/org/apache/carbondata/core/statusmanager/SegmentStatusManager.java
+++ b/core/src/main/java/org/apache/carbondata/core/statusmanager/SegmentStatusManager.java
@@ -291,7 +291,7 @@ public class SegmentStatusManager {
    * @return file content, null is file does not exist
    * @throws IOException if IO errors
    */
-  private static String readFileAsString(String tableStatusPath) throws IOException {
+  public static String readFileAsString(String tableStatusPath) throws IOException {
     DataInputStream dataInputStream = null;
     BufferedReader buffReader = null;
     InputStreamReader inStream = null;
@@ -632,7 +632,7 @@ public class SegmentStatusManager {
    * @param content content to write
    * @throws IOException if IO errors
    */
-  private static void writeStringIntoFile(String filePath, String content) throws IOException {
+  public static void writeStringIntoFile(String filePath, String content) throws IOException {
     AtomicFileOperations fileWrite = AtomicFileOperationFactory.getAtomicFileOperations(filePath);
     BufferedWriter brWriter = null;
     DataOutputStream dataOutputStream = null;
@@ -1065,8 +1065,14 @@ public class SegmentStatusManager {
             CarbonLockFactory.getCarbonLockObj(identifier, LockUsage.TABLE_STATUS_LOCK);
         boolean locked = false;
         try {
+          int retryCount = CarbonLockUtil
+              .getLockProperty(CarbonCommonConstants.NUMBER_OF_TRIES_FOR_CONCURRENT_LOCK,
+                  CarbonCommonConstants.NUMBER_OF_TRIES_FOR_CONCURRENT_LOCK_DEFAULT);
+          int maxTimeout = CarbonLockUtil
+              .getLockProperty(CarbonCommonConstants.MAX_TIMEOUT_FOR_CONCURRENT_LOCK,
+                  CarbonCommonConstants.MAX_TIMEOUT_FOR_CONCURRENT_LOCK_DEFAULT);
           // Update load metadata file after cleaning deleted nodes
-          locked = carbonTableStatusLock.lockWithRetries();
+          locked = carbonTableStatusLock.lockWithRetries(retryCount, maxTimeout);
           if (locked) {
             LOG.info("Table status lock has been successfully acquired.");
             // Again read status and check to verify update required or not.

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -268,9 +268,15 @@ object CarbonDataRDDFactory {
           }
         } finally {
           executor.shutdownNow()
-          compactor.deletePartialLoadsInCompaction()
-          if (compactionModel.compactionType != CompactionType.IUD_UPDDEL_DELTA) {
-            compactionLock.unlock()
+          try {
+            compactor.deletePartialLoadsInCompaction()
+          } catch {
+            // no need to throw this as compaction is over
+            case ex: Exception =>
+          } finally {
+            if (compactionModel.compactionType != CompactionType.IUD_UPDDEL_DELTA) {
+              compactionLock.unlock()
+            }
           }
         }
       }

--- a/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/util/SecondaryIndexUtil.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/util/SecondaryIndexUtil.scala
@@ -37,6 +37,7 @@ import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.datastore.block.{TableBlockInfo, TaskBlockInfo}
 import org.apache.carbondata.core.datastore.impl.FileFactory
 import org.apache.carbondata.core.index.{IndexStoreManager, Segment}
+import org.apache.carbondata.core.locks.CarbonLockUtil
 import org.apache.carbondata.core.metadata.SegmentFileStore
 import org.apache.carbondata.core.metadata.blocklet.DataFileFooter
 import org.apache.carbondata.core.metadata.datatype.DataType
@@ -225,7 +226,13 @@ object SecondaryIndexUtil {
           val statusLock =
             new SegmentStatusManager(indexCarbonTable.getAbsoluteTableIdentifier).getTableStatusLock
           try {
-            if (statusLock.lockWithRetries()) {
+            val retryCount = CarbonLockUtil.getLockProperty(CarbonCommonConstants
+              .NUMBER_OF_TRIES_FOR_CONCURRENT_LOCK,
+              CarbonCommonConstants.NUMBER_OF_TRIES_FOR_CONCURRENT_LOCK_DEFAULT)
+            val maxTimeout = CarbonLockUtil.getLockProperty(CarbonCommonConstants
+              .MAX_TIMEOUT_FOR_CONCURRENT_LOCK,
+              CarbonCommonConstants.MAX_TIMEOUT_FOR_CONCURRENT_LOCK_DEFAULT)
+            if (statusLock.lockWithRetries(retryCount, maxTimeout)) {
               val endTime = System.currentTimeMillis()
               val loadMetadataDetails = SegmentStatusManager
                 .readLoadMetadata(indexCarbonTable.getMetadataPath)
@@ -242,6 +249,10 @@ object SecondaryIndexUtil {
               SegmentStatusManager
                 .writeLoadDetailsIntoFile(CarbonTablePath.getTableStatusFilePath(tablePath),
                   loadMetadataDetails)
+            } else {
+              throw new RuntimeException(
+                "Not able to acquire the lock for table status updation for table " + databaseName +
+                "." + indexCarbonTable.getTableName)
             }
           } finally {
             if (statusLock != null) {

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/TableProcessingOperations.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/TableProcessingOperations.java
@@ -31,6 +31,10 @@ import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.datastore.filesystem.CarbonFile;
 import org.apache.carbondata.core.datastore.impl.FileFactory;
+import org.apache.carbondata.core.locks.CarbonLockFactory;
+import org.apache.carbondata.core.locks.CarbonLockUtil;
+import org.apache.carbondata.core.locks.ICarbonLock;
+import org.apache.carbondata.core.locks.LockUsage;
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
 import org.apache.carbondata.core.statusmanager.LoadMetadataDetails;
 import org.apache.carbondata.core.statusmanager.SegmentStatusManager;
@@ -64,45 +68,86 @@ public class TableProcessingOperations {
       if (allSegments == null || allSegments.length == 0) {
         return;
       }
-      LoadMetadataDetails[] details = SegmentStatusManager.readLoadMetadata(metaDataLocation);
-      // there is no segment or failed to read tablestatus file.
-      // so it should stop immediately.
-      if (details == null || details.length == 0) {
-        return;
-      }
-      Set<String> metadataSet = new HashSet<>(details.length);
-      for (LoadMetadataDetails detail : details) {
-        metadataSet.add(detail.getLoadName());
-      }
-      List<CarbonFile> staleSegments = new ArrayList<>(allSegments.length);
-      for (CarbonFile segment : allSegments) {
-        String segmentName = segment.getName();
-        // check segment folder pattern
-        if (segmentName.startsWith(CarbonTablePath.SEGMENT_PREFIX)) {
-          String[] parts = segmentName.split(CarbonCommonConstants.UNDERSCORE);
-          if (parts.length == 2) {
-            boolean isOriginal = !parts[1].contains(".");
-            if (isCompactionFlow) {
-              // in compaction flow, it should be big segment and segment metadata is not exists
-              if (!isOriginal && !metadataSet.contains(parts[1])) {
-                staleSegments.add(segment);
-              }
-            } else {
-              // in loading flow, it should be original segment and segment metadata is not exists
-              if (isOriginal && !metadataSet.contains(parts[1])) {
-                staleSegments.add(segment);
+      int retryCount = CarbonLockUtil
+          .getLockProperty(CarbonCommonConstants.NUMBER_OF_TRIES_FOR_CONCURRENT_LOCK,
+              CarbonCommonConstants.NUMBER_OF_TRIES_FOR_CONCURRENT_LOCK_DEFAULT);
+      int maxTimeout = CarbonLockUtil
+          .getLockProperty(CarbonCommonConstants.MAX_TIMEOUT_FOR_CONCURRENT_LOCK,
+              CarbonCommonConstants.MAX_TIMEOUT_FOR_CONCURRENT_LOCK_DEFAULT);
+      ICarbonLock carbonTableStatusLock = CarbonLockFactory
+          .getCarbonLockObj(carbonTable.getAbsoluteTableIdentifier(), LockUsage.TABLE_STATUS_LOCK);
+      try {
+        if (carbonTableStatusLock.lockWithRetries(retryCount, maxTimeout)) {
+          LoadMetadataDetails[] details = SegmentStatusManager.readLoadMetadata(metaDataLocation);
+          // there is no segment or failed to read tablestatus file.
+          // so it should stop immediately.
+          if (details == null || details.length == 0) {
+            return;
+          }
+          Set<String> metadataSet = new HashSet<>(details.length);
+          for (LoadMetadataDetails detail : details) {
+            metadataSet.add(detail.getLoadName());
+          }
+          List<CarbonFile> staleSegments = new ArrayList<>(allSegments.length);
+          Set<String> staleSegmentsId = new HashSet<>(allSegments.length);
+          for (CarbonFile segment : allSegments) {
+            String segmentName = segment.getName();
+            // check segment folder pattern
+            if (segmentName.startsWith(CarbonTablePath.SEGMENT_PREFIX)) {
+              String[] parts = segmentName.split(CarbonCommonConstants.UNDERSCORE);
+              if (parts.length == 2) {
+                boolean isOriginal = !parts[1].contains(".");
+                if (isCompactionFlow) {
+                  // in compaction flow,
+                  // it should be merged segment and segment metadata doesn't exists
+                  if (!isOriginal && !metadataSet.contains(parts[1])) {
+                    staleSegments.add(segment);
+                    staleSegmentsId.add(parts[1]);
+                  }
+                } else {
+                  // in loading flow,
+                  // it should be original segment and segment metadata doesn't exists
+                  if (isOriginal && !metadataSet.contains(parts[1])) {
+                    staleSegments.add(segment);
+                    staleSegmentsId.add(parts[1]);
+                  }
+                }
               }
             }
           }
+          // delete segment folders one by one
+          for (CarbonFile staleSegment : staleSegments) {
+            try {
+              CarbonUtil.deleteFoldersAndFiles(staleSegment);
+            } catch (IOException | InterruptedException e) {
+              LOGGER.error("Unable to delete the given path :: " + e.getMessage(), e);
+            }
+          }
+          if (staleSegments.size() > 0) {
+            // get the segment metadata path
+            String segmentFilesLocation =
+                CarbonTablePath.getSegmentFilesLocation(carbonTable.getTablePath());
+            // delete the segment metadata files also
+            CarbonFile[] staleSegmentMetadataFiles = FileFactory.getCarbonFile(segmentFilesLocation)
+                .listFiles(file -> (staleSegmentsId
+                    .contains(file.getName().split(CarbonCommonConstants.UNDERSCORE)[0])));
+            for (CarbonFile staleSegmentMetadataFile : staleSegmentMetadataFiles) {
+              staleSegmentMetadataFile.delete();
+            }
+          }
+        } else {
+          String errorMessage =
+              "Not able to acquire the Table status lock for partial load deletion for table "
+                  + carbonTable.getDatabaseName() + "." + carbonTable.getTableName();
+          if (isCompactionFlow) {
+            LOGGER.error(errorMessage + ", retry compaction");
+            throw new RuntimeException(errorMessage + ", retry compaction");
+          } else {
+            LOGGER.error(errorMessage);
+          }
         }
-      }
-      // delete segment one by one
-      for (CarbonFile staleSegment : staleSegments) {
-        try {
-          CarbonUtil.deleteFoldersAndFiles(staleSegment);
-        } catch (IOException | InterruptedException e) {
-          LOGGER.error("Unable to delete the given path :: " + e.getMessage(), e);
-        }
+      } finally {
+        carbonTableStatusLock.unlock();
       }
     }
   }


### PR DESCRIPTION
 ### Why is this PR needed?
Fix multiple issues during compaction and concurrent scenarios
a)  Auto compaction/multiple times minor compaction is called, it was considering compacted segments and coming compaction again ad overwriting the files and segments
b) Minor/ auto compaction should skip >=2 level segments, now only skipping =2 level segments
c) when compaction failed, no need to call merge index
d) At executor, When segment file or table status file failed to write during merge index event, need to remove the stale files.
e) during partial load cleanup segment folders are removed but segment metadata files were not removed
f) Some table status retry issues
g) BlockIndex was not checking for empty partition

 ### What changes were proposed in this PR?
a) Auto compaction/minor compaction consider only SUCCESS or PARTIAL_SUCCESS Segments
b) Minor/ auto compaction should skip >=2 level segments
c) when compaction failed, no need to call merge index
d) At executor, When segment file or table status file failed to write during merge index event, Remove the stale files.
e) During partial load cleanup segment metadata files also need to be removed
f)  add retry to table status 
g) BlockIndex need to check for empty partition     
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No [as mostly concurrent scenarios]


    
