### PR TITLE
[CARBONDATA-3931]Fix Secondary index with index column as DateType giving wrong results

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/scan/wrappers/ByteArrayWrapper.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/wrappers/ByteArrayWrapper.java
@@ -19,6 +19,7 @@ package org.apache.carbondata.core.scan.wrappers;
 
 import java.io.Serializable;
 
+import org.apache.carbondata.core.util.ByteUtil;
 import org.apache.carbondata.core.util.ByteUtil.UnsafeComparer;
 
 /**
@@ -102,6 +103,15 @@ public class ByteArrayWrapper implements Comparable<ByteArrayWrapper>, Serializa
    */
   public byte[][] getComplexTypesKeys() {
     return this.complexTypesKeys;
+  }
+
+  /**
+   * to get the dictionary column data
+   * @param index
+   * @return
+   */
+  public int getDictionaryKeyByIndex(int index) {
+    return ByteUtil.convertBytesToInt(this.getDictionaryKey(), index * 4);
   }
 
   /**

--- a/core/src/main/java/org/apache/carbondata/core/util/ByteUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/ByteUtil.java
@@ -781,14 +781,6 @@ public final class ByteUtil {
     return 4;
   }
 
-  public static int[] convertBytesToIntArray(byte[] input) {
-    int[] output = new int[input.length / 4];
-    for (int i = 0; i < output.length; i++) {
-      output[i] = convertBytesToInt(input, i * 4);
-    }
-    return output;
-  }
-
   public static long[] convertBytesToLongArray(byte[] input) {
     long[] output = new long[input.length / 4];
     for (int i = 0; i < output.length; i++) {

--- a/integration/spark/src/main/java/org/apache/spark/sql/secondaryindex/query/SecondaryIndexQueryResultProcessor.java
+++ b/integration/spark/src/main/java/org/apache/spark/sql/secondaryindex/query/SecondaryIndexQueryResultProcessor.java
@@ -34,7 +34,6 @@ import org.apache.carbondata.core.metadata.schema.table.column.CarbonDimension;
 import org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema;
 import org.apache.carbondata.core.scan.result.RowBatch;
 import org.apache.carbondata.core.scan.wrappers.ByteArrayWrapper;
-import org.apache.carbondata.core.util.ByteUtil;
 import org.apache.carbondata.core.util.CarbonProperties;
 import org.apache.carbondata.core.util.CarbonUtil;
 import org.apache.carbondata.core.util.DataTypeUtil;
@@ -247,12 +246,9 @@ public class SecondaryIndexQueryResultProcessor {
   private Object[] prepareRowObjectForSorting(Object[] row) {
     ByteArrayWrapper wrapper = (ByteArrayWrapper) row[0];
     // ByteBuffer[] noDictionaryBuffer = new ByteBuffer[noDictionaryCount];
+
     List<CarbonDimension> dimensions = segmentProperties.getDimensions();
     Object[] preparedRow = new Object[dimensions.size() + measureCount];
-
-    // get dictionary values for date type
-    byte[] dictionaryKey = wrapper.getDictionaryKey();
-    int[] dictionaryValues = ByteUtil.convertBytesToIntArray(dictionaryKey);
 
     int noDictionaryIndex = 0;
     int dictionaryIndex = 0;
@@ -262,7 +258,7 @@ public class SecondaryIndexQueryResultProcessor {
       CarbonDimension dims = dimensions.get(i);
       if (dims.hasEncoding(Encoding.DICTIONARY)) {
         // dictionary
-        preparedRow[i] = dictionaryValues[dictionaryIndex++];
+        preparedRow[i] = wrapper.getDictionaryKeyByIndex(dictionaryIndex++);
       } else {
         // no dictionary dims
         byte[] noDictionaryKeyByIndex = wrapper.getNoDictionaryKeyByIndex(noDictionaryIndex++);

--- a/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/rdd/CarbonSecondaryIndexRDD.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/rdd/CarbonSecondaryIndexRDD.scala
@@ -85,9 +85,6 @@ class CarbonSecondaryIndexRDD[K, V](
   val factToIndexColumnMapping: Array[Int] = SecondaryIndexUtil
     .prepareColumnMappingOfFactToIndexTable(carbonLoadModel.getCarbonDataLoadSchema.getCarbonTable,
       indexTable, isDictColsAlone = false)
-  val factToIndexDictColumnMapping: Array[Int] = SecondaryIndexUtil
-    .prepareColumnMappingOfFactToIndexTable(carbonLoadModel.getCarbonDataLoadSchema.getCarbonTable,
-      indexTable, isDictColsAlone = true)
 
   override def internalCompute(theSplit: Partition, context: TaskContext): Iterator[(K, V)] = {
     val LOGGER = LogServiceFactory.getLogService(this.getClass.getName)
@@ -147,8 +144,7 @@ class CarbonSecondaryIndexRDD[K, V](
               columnCardinality,
               segmentId,
               indexCarbonTable,
-              factToIndexColumnMapping,
-              factToIndexDictColumnMapping)
+              factToIndexColumnMapping)
         context.addTaskCompletionListener { context =>
           if (null != secondaryIndexQueryResultProcessor) {
             secondaryIndexQueryResultProcessor.close()

--- a/processing/src/main/java/org/apache/carbondata/processing/merger/CompactionResultSortProcessor.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/merger/CompactionResultSortProcessor.java
@@ -36,7 +36,6 @@ import org.apache.carbondata.core.metadata.schema.table.column.CarbonColumn;
 import org.apache.carbondata.core.metadata.schema.table.column.CarbonDimension;
 import org.apache.carbondata.core.scan.result.iterator.RawResultIterator;
 import org.apache.carbondata.core.scan.wrappers.ByteArrayWrapper;
-import org.apache.carbondata.core.util.ByteUtil;
 import org.apache.carbondata.core.util.CarbonProperties;
 import org.apache.carbondata.core.util.CarbonUtil;
 import org.apache.carbondata.core.util.DataTypeUtil;
@@ -311,12 +310,6 @@ public class CompactionResultSortProcessor extends AbstractResultProcessor {
   private Object[] prepareRowObjectForSorting(Object[] row) {
     ByteArrayWrapper wrapper = (ByteArrayWrapper) row[0];
     Object[] preparedRow = new Object[dimensions.size() + measureCount];
-    byte[] dictionaryKey = wrapper.getDictionaryKey();
-    int[] keyArray = ByteUtil.convertBytesToIntArray(dictionaryKey);
-    Object[] dictionaryValues = new Object[dimensionColumnCount + measureCount];
-    for (int i = 0; i < keyArray.length; i++) {
-      dictionaryValues[i] = keyArray[i];
-    }
     int noDictionaryIndex = 0;
     int dictionaryIndex = 0;
     int complexIndex = 0;
@@ -325,7 +318,7 @@ public class CompactionResultSortProcessor extends AbstractResultProcessor {
       CarbonDimension dims = dimensions.get(i);
       if (dims.getDataType() == DataTypes.DATE && !dims.isComplex()) {
         // dictionary
-        preparedRow[i] = dictionaryValues[dictionaryIndex++];
+        preparedRow[i] = wrapper.getDictionaryKeyByIndex(dictionaryIndex++);
       } else if (!dims.isComplex()) {
         // no dictionary dims
         byte[] noDictionaryKeyByIndex = wrapper.getNoDictionaryKeyByIndex(noDictionaryIndex++);


### PR DESCRIPTION
 ### Why is this PR needed?
 On data load to SI with date type, dictionary values is loaded from `factToIndexDictColumnMapping` instead of getting from main table query results. `factToIndexDictColumnMapping` will have value as 0, hence only first row data will be loaded
 
 ### What changes were proposed in this PR?
Get dictionary Keys from wrapper and convert it to Int and load to SI. Removed factToIndexDictColumnMapping.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
