### PR TITLE
[CARBONDATA-3947]Fixed Hive read/write operation for Insert into Select operation.

### DIFF
--- a/integration/hive/src/test/java/org/apache/carbondata/hive/HiveCarbonTest.java
+++ b/integration/hive/src/test/java/org/apache/carbondata/hive/HiveCarbonTest.java
@@ -71,6 +71,21 @@ public class HiveCarbonTest extends HiveTestUtils {
   }
 
   @Test
+  public void verifyInsertIntoSelectOperation() throws Exception {
+    statement.execute("drop table if exists hive_carbon_table1");
+    statement.execute("CREATE TABLE hive_carbon_table1(id INT, name STRING, scale DECIMAL, country STRING, salary DOUBLE) stored by 'org.apache.carbondata.hive.CarbonStorageHandler'");
+    statement.execute("INSERT into hive_carbon_table1 SELECT 1, 'RAM', '2.3', 'INDIA', 3500");
+    statement.execute("INSERT into hive_carbon_table1 SELECT 2, 'RAJU', '2.4', 'RUSSIA', 3600");
+    statement.execute("drop table if exists hive_carbon_table2");
+    statement.execute("CREATE TABLE hive_carbon_table2(id INT, name STRING, scale DECIMAL, country STRING, salary DOUBLE) stored by 'org.apache.carbondata.hive.CarbonStorageHandler'");
+    statement.execute("INSERT into hive_carbon_table2 SELECT * FROM hive_carbon_table1");
+    checkAnswer(statement.executeQuery("SELECT * FROM hive_carbon_table2"),
+        connection.createStatement().executeQuery("select * from hive_carbon_table1"));
+    statement.execute("drop table if exists hive_carbon_table1");
+    statement.execute("drop table if exists hive_carbon_table2");
+  }
+
+  @Test
   public void verifyDataAfterLoadUsingSortColumns() throws Exception {
     statement.execute("drop table if exists hive_carbon_table5");
     statement.execute(


### PR DESCRIPTION
 ### Why is this PR needed?
 FileNotFound Exception is thrown for Hive read/write operation.
 
 ### What changes were proposed in this PR?
When carbon schema file is not present at given location then build the table from the configuration at place of throwing exception.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
