### PR TITLE
[CARBONDATA-3879] Filtering Segmets Optimazation

### DIFF
--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableInputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableInputFormat.java
@@ -389,14 +389,16 @@ public class CarbonTableInputFormat<T> extends CarbonInputFormat<T> {
 
   public void updateLoadMetaDataDetailsToSegments(List<Segment> validSegments,
       List<org.apache.carbondata.hadoop.CarbonInputSplit> prunedSplits) {
+    Map<String, Segment> validSegmentsMap = validSegments.stream()
+        .collect(Collectors.toMap(Segment::getSegmentNo, segment -> segment, (e1, e2) -> e1));
     for (CarbonInputSplit split : prunedSplits) {
       Segment segment = split.getSegment();
       if (segment.getLoadMetadataDetails() == null || segment.getReadCommittedScope() == null) {
-        if (validSegments.contains(segment)) {
+        if (validSegmentsMap.containsKey(segment.getSegmentNo())) {
           segment.setLoadMetadataDetails(
-              validSegments.get(validSegments.indexOf(segment)).getLoadMetadataDetails());
+              validSegmentsMap.get(segment.getSegmentNo()).getLoadMetadataDetails());
           segment.setReadCommittedScope(
-              validSegments.get(validSegments.indexOf(segment)).getReadCommittedScope());
+              validSegmentsMap.get(segment.getSegmentNo()).getReadCommittedScope());
         }
       }
     }


### PR DESCRIPTION
 ### Why is this PR needed?
During filter segments flow, there are a lot of LIST.CONTAINS, which has heavy time overhead when there are tens of thousands segments.

For example, if there are 50000 segments. it will trigger LIST.CONTAINS  for each segment, the LIST also has about 50000 elements. so the time complexity will be O（50000 * 50000 ）
 
 ### What changes were proposed in this PR?
Change List.CONTAINS to MAP.containsKEY
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No

    
