### PR TITLE
[CARBONDATA-3941] Support binary data type reading from presto

### DIFF
--- a/integration/presto/src/main/java/org/apache/carbondata/presto/CarbonVectorBatch.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/CarbonVectorBatch.java
@@ -94,7 +94,8 @@ public class CarbonVectorBatch {
       return new FloatStreamReader(batchSize, field.getDataType());
     } else if (dataType == DataTypes.BYTE) {
       return new ByteStreamReader(batchSize, field.getDataType());
-    } else if (dataType == DataTypes.STRING || dataType == DataTypes.VARCHAR) {
+    } else if (dataType == DataTypes.STRING || dataType == DataTypes.VARCHAR
+        || dataType == DataTypes.BINARY) {
       return new SliceStreamReader(batchSize, field.getDataType());
     } else if (DataTypes.isDecimal(dataType)) {
       if (dataType instanceof DecimalType) {


### PR DESCRIPTION
 ### Why is this PR needed?
 when binary store is queried from presto, presto currently give 0 rows.
 
 ### What changes were proposed in this PR?
Presto can support binary (varBinary) data type reading by using the SliceStreamReader
and it can put binary byte[] using putByteArray() method of SliceStreamReader
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
