### PR TITLE
[CARBONDATA-3830] Support Array and Struct of all primitive type reading from presto

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/reader/dimension/v3/DimensionChunkReaderV3.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/reader/dimension/v3/DimensionChunkReaderV3.java
@@ -257,6 +257,11 @@ public class DimensionChunkReaderV3 extends AbstractDimensionChunkReader {
           .decodeAndFillVector(pageData.array(), offset, pageMetadata.data_page_length, vectorInfo,
               nullBitSet, isLocalDictEncodedPage, pageMetadata.numberOfRowsInpage,
               reusableDataBuffer);
+      if (vectorInfo.vector.getType().isComplexType() && !vectorInfo.vectorStack.isEmpty()) {
+        // For complex type, always top of the vector stack is processed in decodeAndFillVector.
+        // so, pop() the top vector as its processing is finished.
+        vectorInfo.vectorStack.pop();
+      }
       return null;
     } else {
       return decoder

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/LocalDictDimensionDataChunkStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/LocalDictDimensionDataChunkStore.java
@@ -70,11 +70,11 @@ public class LocalDictDimensionDataChunkStore implements DimensionDataChunkStore
     }
     BitSet nullBitset = new BitSet();
     CarbonColumnVector dictionaryVector = ColumnarVectorWrapperDirectFactory
-        .getDirectVectorWrapperFactory(vector.getDictionaryVector(), invertedIndex, nullBitset,
-            vectorInfo.deletedRows, false, true);
+        .getDirectVectorWrapperFactory(vectorInfo, vector.getDictionaryVector(), invertedIndex,
+            nullBitset, vectorInfo.deletedRows, false, true);
     vector = ColumnarVectorWrapperDirectFactory
-        .getDirectVectorWrapperFactory(vector, invertedIndex, nullBitset, vectorInfo.deletedRows,
-            false, false);
+        .getDirectVectorWrapperFactory(vectorInfo, vector, invertedIndex, nullBitset,
+            vectorInfo.deletedRows, false, false);
     for (int i = 0; i < rowsNum; i++) {
       int surrogate = CarbonUtil.getSurrogateInternal(data, i * columnValueSize, columnValueSize);
       if (surrogate == CarbonCommonConstants.MEMBER_DEFAULT_VAL_SURROGATE_KEY) {

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/safe/SafeFixedLengthDimensionDataChunkStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/safe/SafeFixedLengthDimensionDataChunkStore.java
@@ -56,7 +56,8 @@ public class SafeFixedLengthDimensionDataChunkStore extends SafeAbstractDimensio
     BitSet deletedRows = vectorInfo.deletedRows;
     BitSet nullBits = new BitSet(numOfRows);
     vector = ColumnarVectorWrapperDirectFactory
-        .getDirectVectorWrapperFactory(vector, invertedIndex, nullBits, deletedRows, false, false);
+        .getDirectVectorWrapperFactory(vectorInfo, vector, invertedIndex, nullBits, deletedRows,
+            false, false);
     fillVector(data, vectorInfo, vector);
     if (vector instanceof ConvertibleVector) {
       ((ConvertibleVector) vector).convert();

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/safe/SafeVariableLengthDimensionDataChunkStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/safe/SafeVariableLengthDimensionDataChunkStore.java
@@ -109,8 +109,8 @@ public abstract class SafeVariableLengthDimensionDataChunkStore
     AbstractNonDictionaryVectorFiller vectorFiller = NonDictionaryVectorFillerFactory
         .getVectorFiller(getLengthSize(), dt, numberOfRows, dataLength);
     vector = ColumnarVectorWrapperDirectFactory
-        .getDirectVectorWrapperFactory(vector, invertedIndex, new BitSet(), vectorInfo.deletedRows,
-            false, false);
+        .getDirectVectorWrapperFactory(vectorInfo, vector, invertedIndex, new BitSet(),
+            vectorInfo.deletedRows, false, false);
     vectorFiller.fillVector(data, vector);
     if (vector instanceof ConvertibleVector) {
       ((ConvertibleVector) vector).convert();

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/adaptive/AdaptiveDeltaFloatingCodec.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/adaptive/AdaptiveDeltaFloatingCodec.java
@@ -260,6 +260,10 @@ public class AdaptiveDeltaFloatingCodec extends AdaptiveCodec {
               false);
       DataType vectorDataType = vector.getType();
       int rowId = 0;
+      int shortSizeInBytes = DataTypes.SHORT.getSizeInBytes();
+      int shortIntSizeInBytes = DataTypes.SHORT_INT.getSizeInBytes();
+      int intSizeInBytes = DataTypes.INT.getSizeInBytes();
+      int longSizeInBytes = DataTypes.LONG.getSizeInBytes();
       if (vectorDataType == DataTypes.FLOAT) {
         float floatFactor = factor.floatValue();
         if (pageDataType == DataTypes.BOOLEAN || pageDataType == DataTypes.BYTE) {
@@ -267,27 +271,27 @@ public class AdaptiveDeltaFloatingCodec extends AdaptiveCodec {
             vector.putFloat(i, (max - pageData[i]) / floatFactor);
           }
         } else if (pageDataType == DataTypes.SHORT) {
-          int size = pageSize * DataTypes.SHORT.getSizeInBytes();
-          for (int i = 0; i < size; i += DataTypes.SHORT.getSizeInBytes()) {
+          int size = pageSize * shortSizeInBytes;
+          for (int i = 0; i < size; i += shortSizeInBytes) {
             vector
                 .putFloat(rowId++, (max - ByteUtil.toShortLittleEndian(pageData, i)) / floatFactor);
           }
 
         } else if (pageDataType == DataTypes.SHORT_INT) {
-          int size = pageSize * DataTypes.SHORT_INT.getSizeInBytes();
-          for (int i = 0; i < size; i += DataTypes.SHORT_INT.getSizeInBytes()) {
+          int size = pageSize * shortIntSizeInBytes;
+          for (int i = 0; i < size; i += shortIntSizeInBytes) {
             int shortInt = ByteUtil.valueOf3Bytes(pageData, i);
             vector.putFloat(rowId++, (max - shortInt) / floatFactor);
           }
         } else if (pageDataType == DataTypes.INT) {
-          int size = pageSize * DataTypes.INT.getSizeInBytes();
-          for (int i = 0; i < size; i += DataTypes.INT.getSizeInBytes()) {
+          int size = pageSize * intSizeInBytes;
+          for (int i = 0; i < size; i += intSizeInBytes) {
             vector.putFloat(rowId++, (max - ByteUtil.toIntLittleEndian(pageData, i)) / floatFactor);
           }
         } else if (pageDataType == DataTypes.LONG) {
           // complex primitive float type can enter here.
-          int size = pageSize * DataTypes.LONG.getSizeInBytes();
-          for (int i = 0; i < size; i += DataTypes.LONG.getSizeInBytes()) {
+          int size = pageSize * longSizeInBytes;
+          for (int i = 0; i < size; i += longSizeInBytes) {
             vector.putFloat(rowId++,
                 (float) ((max - ByteUtil.toLongLittleEndian(pageData, i)) / factor));
           }
@@ -300,25 +304,25 @@ public class AdaptiveDeltaFloatingCodec extends AdaptiveCodec {
             vector.putDouble(rowId++, (max - pageData[i]) / factor);
           }
         } else if (pageDataType == DataTypes.SHORT) {
-          int size = pageSize * DataTypes.SHORT.getSizeInBytes();
-          for (int i = 0; i < size; i += DataTypes.SHORT.getSizeInBytes()) {
+          int size = pageSize * shortSizeInBytes;
+          for (int i = 0; i < size; i += shortSizeInBytes) {
             vector.putDouble(rowId++, (max - ByteUtil.toShortLittleEndian(pageData, i)) / factor);
           }
 
         } else if (pageDataType == DataTypes.SHORT_INT) {
-          int size = pageSize * DataTypes.SHORT_INT.getSizeInBytes();
-          for (int i = 0; i < size; i += DataTypes.SHORT_INT.getSizeInBytes()) {
+          int size = pageSize * shortIntSizeInBytes;
+          for (int i = 0; i < size; i += shortIntSizeInBytes) {
             int shortInt = ByteUtil.valueOf3Bytes(pageData, i);
             vector.putDouble(rowId++, (max - shortInt) / factor);
           }
         } else if (pageDataType == DataTypes.INT) {
-          int size = pageSize * DataTypes.INT.getSizeInBytes();
-          for (int i = 0; i < size; i += DataTypes.INT.getSizeInBytes()) {
+          int size = pageSize * intSizeInBytes;
+          for (int i = 0; i < size; i += intSizeInBytes) {
             vector.putDouble(rowId++, (max - ByteUtil.toIntLittleEndian(pageData, i)) / factor);
           }
         } else if (pageDataType == DataTypes.LONG) {
-          int size = pageSize * DataTypes.LONG.getSizeInBytes();
-          for (int i = 0; i < size; i += DataTypes.LONG.getSizeInBytes()) {
+          int size = pageSize * longSizeInBytes;
+          for (int i = 0; i < size; i += longSizeInBytes) {
             vector.putDouble(rowId++, (max - ByteUtil.toLongLittleEndian(pageData, i)) / factor);
           }
         } else {

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/adaptive/AdaptiveDeltaIntegralCodec.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/adaptive/AdaptiveDeltaIntegralCodec.java
@@ -311,12 +311,8 @@ public class AdaptiveDeltaIntegralCodec extends AdaptiveCodec {
     public void decodeAndFillVector(byte[] pageData, ColumnVectorInfo vectorInfo, BitSet nullBits,
         DataType pageDataType, int pageSize) {
       CarbonColumnVector vector = vectorInfo.vector;
-      DataType vectorDataType = vector.getType();
       BitSet deletedRows = vectorInfo.deletedRows;
-      vector = ColumnarVectorWrapperDirectFactory
-          .getDirectVectorWrapperFactory(vector, vectorInfo.invertedIndex, nullBits, deletedRows,
-              true, false);
-      fillVector(pageData, vector, vectorDataType, pageDataType, pageSize, vectorInfo);
+      fillVector(pageData, vector, pageDataType, pageSize, vectorInfo, nullBits);
       if ((deletedRows == null || deletedRows.isEmpty())
           && !(vectorInfo.vector instanceof SequentialFill)) {
         for (int i = nullBits.nextSetBit(0); i >= 0; i = nullBits.nextSetBit(i + 1)) {
@@ -328,8 +324,14 @@ public class AdaptiveDeltaIntegralCodec extends AdaptiveCodec {
       }
     }
 
-    private void fillVector(byte[] pageData, CarbonColumnVector vector,
-        DataType vectorDataType, DataType pageDataType, int pageSize, ColumnVectorInfo vectorInfo) {
+    private void fillVector(byte[] pageData, CarbonColumnVector vector, DataType pageDataType,
+        int pageSize, ColumnVectorInfo vectorInfo, BitSet nullBits) {
+      // get the updated values if it is decode of child vector
+      pageSize = ColumnVectorInfo.getUpdatedPageSizeForChildVector(vectorInfo, pageSize);
+      vector = ColumnarVectorWrapperDirectFactory
+          .getDirectVectorWrapperFactory(vectorInfo, vector, null, nullBits, vectorInfo.deletedRows,
+              true, false);
+      DataType vectorDataType = vector.getType();
       int newScale = 0;
       if (vectorInfo.measure != null) {
         newScale = vectorInfo.measure.getMeasure().getScale();
@@ -352,7 +354,7 @@ public class AdaptiveDeltaIntegralCodec extends AdaptiveCodec {
           for (int i = 0; i < pageSize; i++) {
             vector.putLong(i, (max - (long) pageData[i]) * 1000);
           }
-        } else if (vectorDataType == DataTypes.BOOLEAN) {
+        } else if (vectorDataType == DataTypes.BOOLEAN || vectorDataType == DataTypes.BYTE) {
           for (int i = 0; i < pageSize; i++) {
             vector.putByte(i, (byte) (max - pageData[i]));
           }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/adaptive/AdaptiveDeltaIntegralCodec.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/adaptive/AdaptiveDeltaIntegralCodec.java
@@ -378,28 +378,29 @@ public class AdaptiveDeltaIntegralCodec extends AdaptiveCodec {
           }
         }
       } else if (pageDataType == DataTypes.SHORT) {
-        int size = pageSize * DataTypes.SHORT.getSizeInBytes();
+        int shortSizeInBytes = DataTypes.SHORT.getSizeInBytes();
+        int size = pageSize * shortSizeInBytes;
         if (vectorDataType == DataTypes.SHORT) {
-          for (int i = 0; i < size; i += DataTypes.SHORT.getSizeInBytes()) {
+          for (int i = 0; i < size; i += shortSizeInBytes) {
             vector.putShort(rowId++, (short) (max - ByteUtil.toShortLittleEndian(pageData, i)));
           }
         } else if (vectorDataType == DataTypes.INT) {
-          for (int i = 0; i < size; i += DataTypes.SHORT.getSizeInBytes()) {
+          for (int i = 0; i < size; i += shortSizeInBytes) {
             vector.putInt(rowId++, (int) (max - ByteUtil.toShortLittleEndian(pageData, i)));
           }
         } else if (vectorDataType == DataTypes.LONG) {
-          for (int i = 0; i < size; i += DataTypes.SHORT.getSizeInBytes()) {
+          for (int i = 0; i < size; i += shortSizeInBytes) {
             vector.putLong(rowId++, (max - ByteUtil.toShortLittleEndian(pageData, i)));
           }
         } else if (vectorDataType == DataTypes.TIMESTAMP) {
-          for (int i = 0; i < size; i += DataTypes.SHORT.getSizeInBytes()) {
+          for (int i = 0; i < size; i += shortSizeInBytes) {
             vector
                 .putLong(rowId++, (max - (long) ByteUtil.toShortLittleEndian(pageData, i)) * 1000);
           }
         } else if (DataTypes.isDecimal(vectorDataType)) {
           DecimalConverterFactory.DecimalConverter decimalConverter = vectorInfo.decimalConverter;
           int precision = vectorInfo.measure.getMeasure().getPrecision();
-          for (int i = 0; i < size; i += DataTypes.SHORT.getSizeInBytes()) {
+          for (int i = 0; i < size; i += shortSizeInBytes) {
             BigDecimal decimal =
                 decimalConverter.getDecimal(max - ByteUtil.toShortLittleEndian(pageData, i));
             if (decimal.scale() < newScale) {
@@ -408,28 +409,29 @@ public class AdaptiveDeltaIntegralCodec extends AdaptiveCodec {
             vector.putDecimal(rowId++, decimal, precision);
           }
         } else if (vectorDataType == DataTypes.FLOAT) {
-          for (int i = 0; i < size; i += DataTypes.SHORT.getSizeInBytes()) {
+          for (int i = 0; i < size; i += shortSizeInBytes) {
             vector.putFloat(rowId++, (int) (max - ByteUtil.toShortLittleEndian(pageData, i)));
           }
         } else {
-          for (int i = 0; i < size; i += DataTypes.SHORT.getSizeInBytes()) {
+          for (int i = 0; i < size; i += shortSizeInBytes) {
             vector.putDouble(rowId++, (max - ByteUtil.toShortLittleEndian(pageData, i)));
           }
         }
       } else if (pageDataType == DataTypes.SHORT_INT) {
-        int size = pageSize * DataTypes.SHORT_INT.getSizeInBytes();
+        int shortIntSizeInBytes = DataTypes.SHORT_INT.getSizeInBytes();
+        int size = pageSize * shortIntSizeInBytes;
         if (vectorDataType == DataTypes.INT) {
-          for (int i = 0; i < size; i += DataTypes.SHORT_INT.getSizeInBytes()) {
+          for (int i = 0; i < size; i += shortIntSizeInBytes) {
             int shortInt = ByteUtil.valueOf3Bytes(pageData, i);
             vector.putInt(rowId++, (int) (max - shortInt));
           }
         } else if (vectorDataType == DataTypes.LONG) {
-          for (int i = 0; i < size; i += DataTypes.SHORT_INT.getSizeInBytes()) {
+          for (int i = 0; i < size; i += shortIntSizeInBytes) {
             int shortInt = ByteUtil.valueOf3Bytes(pageData, i);
             vector.putLong(rowId++, (max - shortInt));
           }
         } else if (vectorDataType == DataTypes.TIMESTAMP) {
-          for (int i = 0; i < size; i += DataTypes.SHORT_INT.getSizeInBytes()) {
+          for (int i = 0; i < size; i += shortIntSizeInBytes) {
             vector.putLong(rowId++, (max - (long) ByteUtil.valueOf3Bytes(pageData, i)) * 1000);
           }
         } else if (DataTypes.isDecimal(vectorDataType)) {
@@ -444,34 +446,35 @@ public class AdaptiveDeltaIntegralCodec extends AdaptiveCodec {
             vector.putDecimal(i, decimal, precision);
           }
         } else if (vectorDataType == DataTypes.FLOAT) {
-          for (int i = 0; i < size; i += DataTypes.SHORT_INT.getSizeInBytes()) {
+          for (int i = 0; i < size; i += shortIntSizeInBytes) {
             int shortInt = ByteUtil.valueOf3Bytes(pageData, i);
             vector.putFloat(rowId++, (int) (max - shortInt));
           }
         } else {
-          for (int i = 0; i < size; i += DataTypes.SHORT_INT.getSizeInBytes()) {
+          for (int i = 0; i < size; i += shortIntSizeInBytes) {
             int shortInt = ByteUtil.valueOf3Bytes(pageData, i);
             vector.putDouble(rowId++, (max - shortInt));
           }
         }
       } else if (pageDataType == DataTypes.INT) {
-        int size = pageSize * DataTypes.INT.getSizeInBytes();
+        int intSizeInBytes = DataTypes.INT.getSizeInBytes();
+        int size = pageSize * intSizeInBytes;
         if (vectorDataType == DataTypes.INT) {
-          for (int i = 0; i < size; i += DataTypes.INT.getSizeInBytes()) {
+          for (int i = 0; i < size; i += intSizeInBytes) {
             vector.putInt(rowId++, (int) (max - ByteUtil.toIntLittleEndian(pageData, i)));
           }
         } else if (vectorDataType == DataTypes.LONG) {
-          for (int i = 0; i < size; i += DataTypes.INT.getSizeInBytes()) {
+          for (int i = 0; i < size; i += intSizeInBytes) {
             vector.putLong(rowId++, (max - ByteUtil.toIntLittleEndian(pageData, i)));
           }
         } else if (vectorDataType == DataTypes.TIMESTAMP) {
-          for (int i = 0; i < size; i += DataTypes.INT.getSizeInBytes()) {
+          for (int i = 0; i < size; i += intSizeInBytes) {
             vector.putLong(rowId++, (max - (long) ByteUtil.toIntLittleEndian(pageData, i)) * 1000);
           }
         } else if (DataTypes.isDecimal(vectorDataType)) {
           DecimalConverterFactory.DecimalConverter decimalConverter = vectorInfo.decimalConverter;
           int precision = vectorInfo.measure.getMeasure().getPrecision();
-          for (int i = 0; i < size; i += DataTypes.INT.getSizeInBytes()) {
+          for (int i = 0; i < size; i += intSizeInBytes) {
             BigDecimal decimal =
                 decimalConverter.getDecimal(max - ByteUtil.toIntLittleEndian(pageData, i));
             if (decimal.scale() < newScale) {
@@ -480,24 +483,25 @@ public class AdaptiveDeltaIntegralCodec extends AdaptiveCodec {
             vector.putDecimal(rowId++, decimal, precision);
           }
         } else {
-          for (int i = 0; i < size; i += DataTypes.INT.getSizeInBytes()) {
+          for (int i = 0; i < size; i += intSizeInBytes) {
             vector.putDouble(rowId++, (max - ByteUtil.toIntLittleEndian(pageData, i)));
           }
         }
       } else if (pageDataType == DataTypes.LONG) {
-        int size = pageSize * DataTypes.LONG.getSizeInBytes();
+        int longSizeInBytes = DataTypes.LONG.getSizeInBytes();
+        int size = pageSize * longSizeInBytes;
         if (vectorDataType == DataTypes.LONG) {
-          for (int i = 0; i < size; i += DataTypes.LONG.getSizeInBytes()) {
+          for (int i = 0; i < size; i += longSizeInBytes) {
             vector.putLong(rowId++, (max - ByteUtil.toLongLittleEndian(pageData, i)));
           }
         } else if (vectorDataType == DataTypes.TIMESTAMP) {
-          for (int i = 0; i < size; i += DataTypes.LONG.getSizeInBytes()) {
+          for (int i = 0; i < size; i += longSizeInBytes) {
             vector.putLong(rowId++, (max - ByteUtil.toLongLittleEndian(pageData, i)) * 1000);
           }
         } else if (DataTypes.isDecimal(vectorDataType)) {
           DecimalConverterFactory.DecimalConverter decimalConverter = vectorInfo.decimalConverter;
           int precision = vectorInfo.measure.getMeasure().getPrecision();
-          for (int i = 0; i < size; i += DataTypes.LONG.getSizeInBytes()) {
+          for (int i = 0; i < size; i += longSizeInBytes) {
             BigDecimal decimal =
                 decimalConverter.getDecimal(max - ByteUtil.toLongLittleEndian(pageData, i));
             if (decimal.scale() < newScale) {

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/adaptive/AdaptiveFloatingCodec.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/adaptive/AdaptiveFloatingCodec.java
@@ -251,31 +251,35 @@ public class AdaptiveFloatingCodec extends AdaptiveCodec {
           .getDirectVectorWrapperFactory(vectorInfo, vector, null, nullBits, vectorInfo.deletedRows,
               true, false);
       DataType vectorDataType = vector.getType();
+      int shortSizeInBytes = DataTypes.SHORT.getSizeInBytes();
+      int shortIntSizeInBytes = DataTypes.SHORT_INT.getSizeInBytes();
+      int intSizeInBytes = DataTypes.INT.getSizeInBytes();
+      int longSizeInBytes = DataTypes.LONG.getSizeInBytes();
       if (vectorDataType == DataTypes.FLOAT) {
         if (pageDataType == DataTypes.BOOLEAN || pageDataType == DataTypes.BYTE) {
           for (int i = 0; i < pageSize; i++) {
             vector.putFloat(i, (pageData[i] / floatFactor));
           }
         } else if (pageDataType == DataTypes.SHORT) {
-          int size = pageSize * DataTypes.SHORT.getSizeInBytes();
-          for (int i = 0; i < size; i += DataTypes.SHORT.getSizeInBytes()) {
+          int size = pageSize * shortSizeInBytes;
+          for (int i = 0; i < size; i += shortSizeInBytes) {
             vector.putFloat(rowId++, (ByteUtil.toShortLittleEndian(pageData, i) / floatFactor));
           }
 
         } else if (pageDataType == DataTypes.SHORT_INT) {
-          int size = pageSize * DataTypes.SHORT_INT.getSizeInBytes();
-          for (int i = 0; i < size; i += DataTypes.SHORT_INT.getSizeInBytes()) {
+          int size = pageSize * shortIntSizeInBytes;
+          for (int i = 0; i < size; i += shortIntSizeInBytes) {
             vector.putFloat(rowId++, (ByteUtil.valueOf3Bytes(pageData, i) / floatFactor));
           }
         } else if (pageDataType == DataTypes.INT) {
-          int size = pageSize * DataTypes.INT.getSizeInBytes();
-          for (int i = 0; i < size; i += DataTypes.INT.getSizeInBytes()) {
+          int size = pageSize * intSizeInBytes;
+          for (int i = 0; i < size; i += intSizeInBytes) {
             vector.putFloat(rowId++, (ByteUtil.toIntLittleEndian(pageData, i) / floatFactor));
           }
         } else if (pageDataType == DataTypes.LONG) {
           // complex primitive float type can enter here.
-          int size = pageSize * DataTypes.LONG.getSizeInBytes();
-          for (int i = 0; i < size; i += DataTypes.LONG.getSizeInBytes()) {
+          int size = pageSize * longSizeInBytes;
+          for (int i = 0; i < size; i += longSizeInBytes) {
             vector.putFloat(rowId++, (float) (ByteUtil.toLongLittleEndian(pageData, i) / factor));
           }
         } else {
@@ -287,24 +291,24 @@ public class AdaptiveFloatingCodec extends AdaptiveCodec {
             vector.putDouble(i, (pageData[i] / factor));
           }
         } else if (pageDataType == DataTypes.SHORT) {
-          int size = pageSize * DataTypes.SHORT.getSizeInBytes();
-          for (int i = 0; i < size; i += DataTypes.SHORT.getSizeInBytes()) {
+          int size = pageSize * shortSizeInBytes;
+          for (int i = 0; i < size; i += shortSizeInBytes) {
             vector.putDouble(rowId++, (ByteUtil.toShortLittleEndian(pageData, i) / factor));
           }
         } else if (pageDataType == DataTypes.SHORT_INT) {
-          int size = pageSize * DataTypes.SHORT_INT.getSizeInBytes();
-          for (int i = 0; i < size; i += DataTypes.SHORT_INT.getSizeInBytes()) {
+          int size = pageSize * shortIntSizeInBytes;
+          for (int i = 0; i < size; i += shortIntSizeInBytes) {
             vector.putDouble(rowId++, (ByteUtil.valueOf3Bytes(pageData, i) / factor));
           }
 
         } else if (pageDataType == DataTypes.INT) {
-          int size = pageSize * DataTypes.INT.getSizeInBytes();
-          for (int i = 0; i < size; i += DataTypes.INT.getSizeInBytes()) {
+          int size = pageSize * intSizeInBytes;
+          for (int i = 0; i < size; i += intSizeInBytes) {
             vector.putDouble(rowId++, (ByteUtil.toIntLittleEndian(pageData, i) / factor));
           }
         } else if (pageDataType == DataTypes.LONG) {
-          int size = pageSize * DataTypes.LONG.getSizeInBytes();
-          for (int i = 0; i < size; i += DataTypes.LONG.getSizeInBytes()) {
+          int size = pageSize * longSizeInBytes;
+          for (int i = 0; i < size; i += longSizeInBytes) {
             vector.putDouble(rowId++, (ByteUtil.toLongLittleEndian(pageData, i) / factor));
           }
         } else {

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/adaptive/AdaptiveIntegralCodec.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/adaptive/AdaptiveIntegralCodec.java
@@ -340,32 +340,33 @@ public class AdaptiveIntegralCodec extends AdaptiveCodec {
           }
         }
       } else if (pageDataType == DataTypes.SHORT) {
-        int size = pageSize * DataTypes.SHORT.getSizeInBytes();
+        int shortSizeInBytes = DataTypes.SHORT.getSizeInBytes();
+        int size = pageSize * shortSizeInBytes;
         if (vectorDataType == DataTypes.SHORT) {
-          for (int i = 0; i < size; i += DataTypes.SHORT.getSizeInBytes()) {
+          for (int i = 0; i < size; i += shortSizeInBytes) {
             vector.putShort(rowId++, (ByteUtil.toShortLittleEndian(pageData, i)));
           }
         } else if (vectorDataType == DataTypes.INT) {
-          for (int i = 0; i < size; i += DataTypes.SHORT.getSizeInBytes()) {
+          for (int i = 0; i < size; i += shortSizeInBytes) {
             vector.putInt(rowId++, (ByteUtil.toShortLittleEndian(pageData, i)));
           }
         } else if (vectorDataType == DataTypes.LONG) {
-          for (int i = 0; i < size; i += DataTypes.SHORT.getSizeInBytes()) {
+          for (int i = 0; i < size; i += shortSizeInBytes) {
             vector.putLong(rowId++, (ByteUtil.toShortLittleEndian(pageData, i)));
           }
         } else if (vectorDataType == DataTypes.TIMESTAMP) {
-          for (int i = 0; i < size; i += DataTypes.SHORT.getSizeInBytes()) {
+          for (int i = 0; i < size; i += shortSizeInBytes) {
             vector.putLong(rowId++, ((long) ByteUtil.toShortLittleEndian(pageData, i)) * 1000);
           }
         } else if (DataTypes.isDecimal(vectorDataType)) {
           DecimalConverterFactory.DecimalConverter decimalConverter = vectorInfo.decimalConverter;
           decimalConverter.fillVector(pageData, pageSize, vectorInfo, nullBits, pageDataType);
         } else if (vectorDataType == DataTypes.FLOAT) {
-          for (int i = 0; i < size; i += DataTypes.SHORT.getSizeInBytes()) {
+          for (int i = 0; i < size; i += shortSizeInBytes) {
             vector.putFloat(rowId++, (ByteUtil.toShortLittleEndian(pageData, i)));
           }
         } else {
-          for (int i = 0; i < size; i += DataTypes.SHORT.getSizeInBytes()) {
+          for (int i = 0; i < size; i += shortSizeInBytes) {
             vector.putDouble(rowId++, ByteUtil.toShortLittleEndian(pageData, i));
           }
         }
@@ -402,35 +403,37 @@ public class AdaptiveIntegralCodec extends AdaptiveCodec {
           }
         }
       } else if (pageDataType == DataTypes.INT) {
-        int size = pageSize * DataTypes.INT.getSizeInBytes();
+        int intSizeInBytes = DataTypes.INT.getSizeInBytes();
+        int size = pageSize * intSizeInBytes;
         if (vectorDataType == DataTypes.INT) {
-          for (int i = 0; i < size; i += DataTypes.INT.getSizeInBytes()) {
+          for (int i = 0; i < size; i += intSizeInBytes) {
             vector.putInt(rowId++, ByteUtil.toIntLittleEndian(pageData, i));
           }
         } else if (vectorDataType == DataTypes.LONG) {
-          for (int i = 0; i < size; i += DataTypes.INT.getSizeInBytes()) {
+          for (int i = 0; i < size; i += intSizeInBytes) {
             vector.putLong(rowId++, ByteUtil.toIntLittleEndian(pageData, i));
           }
         } else if (vectorDataType == DataTypes.TIMESTAMP) {
-          for (int i = 0; i < size; i += DataTypes.INT.getSizeInBytes()) {
+          for (int i = 0; i < size; i += intSizeInBytes) {
             vector.putLong(rowId++, (long) ByteUtil.toIntLittleEndian(pageData, i) * 1000);
           }
         } else if (DataTypes.isDecimal(vectorDataType)) {
           DecimalConverterFactory.DecimalConverter decimalConverter = vectorInfo.decimalConverter;
           decimalConverter.fillVector(pageData, pageSize, vectorInfo, nullBits, pageDataType);
         } else {
-          for (int i = 0; i < size; i += DataTypes.INT.getSizeInBytes()) {
+          for (int i = 0; i < size; i += intSizeInBytes) {
             vector.putDouble(rowId++, ByteUtil.toIntLittleEndian(pageData, i));
           }
         }
       } else if (pageDataType == DataTypes.LONG) {
-        int size = pageSize * DataTypes.LONG.getSizeInBytes();
+        int longSizeInBytes = DataTypes.LONG.getSizeInBytes();
+        int size = pageSize * longSizeInBytes;
         if (vectorDataType == DataTypes.LONG) {
-          for (int i = 0; i < size; i += DataTypes.LONG.getSizeInBytes()) {
+          for (int i = 0; i < size; i += longSizeInBytes) {
             vector.putLong(rowId++, ByteUtil.toLongLittleEndian(pageData, i));
           }
         } else if (vectorDataType == DataTypes.TIMESTAMP) {
-          for (int i = 0; i < size; i += DataTypes.LONG.getSizeInBytes()) {
+          for (int i = 0; i < size; i += longSizeInBytes) {
             vector.putLong(rowId++, ByteUtil.toLongLittleEndian(pageData, i) * 1000);
           }
         } else if (DataTypes.isDecimal(vectorDataType)) {
@@ -438,8 +441,9 @@ public class AdaptiveIntegralCodec extends AdaptiveCodec {
           decimalConverter.fillVector(pageData, pageSize, vectorInfo, nullBits, pageDataType);
         }
       } else {
-        int size = pageSize * DataTypes.DOUBLE.getSizeInBytes();
-        for (int i = 0; i < size; i += DataTypes.DOUBLE.getSizeInBytes()) {
+        int doubleSizeInBytes = DataTypes.DOUBLE.getSizeInBytes();
+        int size = pageSize * doubleSizeInBytes;
+        for (int i = 0; i < size; i += doubleSizeInBytes) {
           vector.putDouble(rowId++, ByteUtil.toDoubleLittleEndian(pageData, i));
         }
       }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/adaptive/AdaptiveIntegralCodec.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/adaptive/AdaptiveIntegralCodec.java
@@ -285,12 +285,8 @@ public class AdaptiveIntegralCodec extends AdaptiveCodec {
     public void decodeAndFillVector(byte[] pageData, ColumnVectorInfo vectorInfo, BitSet nullBits,
         DataType pageDataType, int pageSize) {
       CarbonColumnVector vector = vectorInfo.vector;
-      DataType vectorDataType = vector.getType();
       BitSet deletedRows = vectorInfo.deletedRows;
-      vector = ColumnarVectorWrapperDirectFactory
-          .getDirectVectorWrapperFactory(vector, vectorInfo.invertedIndex, nullBits, deletedRows,
-              true, false);
-      fillVector(pageData, vector, vectorDataType, pageDataType, pageSize, vectorInfo, nullBits);
+      fillVector(pageData, vector, pageDataType, pageSize, vectorInfo, nullBits);
       if ((deletedRows == null || deletedRows.isEmpty())
           && !(vectorInfo.vector instanceof SequentialFill)) {
         for (int i = nullBits.nextSetBit(0); i >= 0; i = nullBits.nextSetBit(i + 1)) {
@@ -303,8 +299,14 @@ public class AdaptiveIntegralCodec extends AdaptiveCodec {
 
     }
 
-    private void fillVector(byte[] pageData, CarbonColumnVector vector, DataType vectorDataType,
-        DataType pageDataType, int pageSize, ColumnVectorInfo vectorInfo, BitSet nullBits) {
+    private void fillVector(byte[] pageData, CarbonColumnVector vector, DataType pageDataType,
+        int pageSize, ColumnVectorInfo vectorInfo, BitSet nullBits) {
+      // get the updated values if it is decode of child vector
+      pageSize = ColumnVectorInfo.getUpdatedPageSizeForChildVector(vectorInfo, pageSize);
+      vector = ColumnarVectorWrapperDirectFactory
+          .getDirectVectorWrapperFactory(vectorInfo, vector, null, nullBits, vectorInfo.deletedRows,
+              true, false);
+      DataType vectorDataType = vector.getType();
       int rowId = 0;
       if (pageDataType == DataTypes.BOOLEAN || pageDataType == DataTypes.BYTE) {
         if (vectorDataType == DataTypes.SHORT) {
@@ -323,7 +325,7 @@ public class AdaptiveIntegralCodec extends AdaptiveCodec {
           for (int i = 0; i < pageSize; i++) {
             vector.putLong(i, (long) pageData[i] * 1000);
           }
-        } else if (vectorDataType == DataTypes.BOOLEAN) {
+        } else if (vectorDataType == DataTypes.BOOLEAN || vectorDataType == DataTypes.BYTE) {
           vector.putBytes(0, pageSize, pageData, 0);
         } else if (DataTypes.isDecimal(vectorDataType)) {
           DecimalConverterFactory.DecimalConverter decimalConverter = vectorInfo.decimalConverter;

--- a/core/src/main/java/org/apache/carbondata/core/scan/collector/impl/DictionaryBasedVectorResultCollector.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/collector/impl/DictionaryBasedVectorResultCollector.java
@@ -98,6 +98,14 @@ public class DictionaryBasedVectorResultCollector extends AbstractScannedResultC
         columnVectorInfo.dimension = queryDimensions[i];
         columnVectorInfo.ordinal = queryDimensions[i].getDimension().getOrdinal();
         allColumnInfo[queryDimensions[i].getOrdinal()] = columnVectorInfo;
+      } else if (queryDimensions[i].getDimension().isComplex()) {
+        ColumnVectorInfo columnVectorInfo = new ColumnVectorInfo();
+        complexList.add(columnVectorInfo);
+        columnVectorInfo.dimension = queryDimensions[i];
+        columnVectorInfo.ordinal = queryDimensions[i].getDimension().getOrdinal();
+        columnVectorInfo.genericQueryType =
+            executionInfo.getComplexDimensionInfoMap().get(columnVectorInfo.ordinal);
+        allColumnInfo[queryDimensions[i].getOrdinal()] = columnVectorInfo;
       } else if (queryDimensions[i].getDimension().getDataType() != DataTypes.DATE) {
         ColumnVectorInfo columnVectorInfo = new ColumnVectorInfo();
         noDictInfoList.add(columnVectorInfo);
@@ -111,14 +119,6 @@ public class DictionaryBasedVectorResultCollector extends AbstractScannedResultC
         columnVectorInfo.directDictionaryGenerator = DirectDictionaryKeyGeneratorFactory
             .getDirectDictionaryGenerator(queryDimensions[i].getDimension().getDataType());
         columnVectorInfo.ordinal = queryDimensions[i].getDimension().getOrdinal();
-        allColumnInfo[queryDimensions[i].getOrdinal()] = columnVectorInfo;
-      } else if (queryDimensions[i].getDimension().isComplex()) {
-        ColumnVectorInfo columnVectorInfo = new ColumnVectorInfo();
-        complexList.add(columnVectorInfo);
-        columnVectorInfo.dimension = queryDimensions[i];
-        columnVectorInfo.ordinal = queryDimensions[i].getDimension().getOrdinal();
-        columnVectorInfo.genericQueryType =
-            executionInfo.getComplexDimensionInfoMap().get(columnVectorInfo.ordinal);
         allColumnInfo[queryDimensions[i].getOrdinal()] = columnVectorInfo;
       } else {
         ColumnVectorInfo columnVectorInfo = new ColumnVectorInfo();
@@ -251,7 +251,7 @@ public class DictionaryBasedVectorResultCollector extends AbstractScannedResultC
 
   private void fillResultToColumnarBatch(BlockletScannedResult scannedResult) {
     scannedResult.fillDataChunks(dictionaryInfo, noDictionaryInfo, measureColumnInfo,
-        measureInfo.getMeasureOrdinals());
+        measureInfo.getMeasureOrdinals(), complexInfo);
 
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/vector/CarbonColumnVector.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/vector/CarbonColumnVector.java
@@ -18,6 +18,8 @@
 package org.apache.carbondata.core.scan.result.vector;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.apache.carbondata.core.metadata.datatype.DataType;
 import org.apache.carbondata.core.scan.scanner.LazyPageLoader;
@@ -114,4 +116,20 @@ public interface CarbonColumnVector {
 
   void setLazyPage(LazyPageLoader lazyPage);
 
+  // Added default implementation for interface,
+  // to avoid implementing presto required functions for spark or core module.
+  default List<CarbonColumnVector> getChildrenVector() {
+    return new ArrayList<>(0);
+  }
+
+  // Added default implementation for interface,
+  // to avoid implementing presto required functions for spark or core module.
+  default void putComplexObject(List<Integer> offsetVector) {
+  }
+
+  // Added default implementation for interface,
+  // to avoid implementing presto required functions for spark or core module.
+  default CarbonColumnVector getColumnVector() {
+    return null;
+  }
 }

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/vector/impl/CarbonColumnVectorImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/vector/impl/CarbonColumnVectorImpl.java
@@ -114,7 +114,7 @@ public class CarbonColumnVectorImpl implements CarbonColumnVector {
     return childrenVector;
   }
 
-  public void setChildrenVector(ArrayList<CarbonColumnVector> childrenVector) {
+  public void setChildrenVector(List<CarbonColumnVector> childrenVector) {
     this.childrenVector = childrenVector;
   }
 
@@ -122,14 +122,14 @@ public class CarbonColumnVectorImpl implements CarbonColumnVector {
     return childElementsForEachRow;
   }
 
-  public void setNumberOfChildElementsInEachRow(ArrayList<Integer> childrenElements) {
+  public void setNumberOfChildElementsInEachRow(List<Integer> childrenElements) {
     this.childElementsForEachRow = childrenElements;
   }
 
   public void setNumberOfChildElementsForArray(byte[] parentPageData, int pageSize) {
     // for complex array type, go through parent page to get the child information
     ByteBuffer childInfoBuffer = ByteBuffer.wrap(parentPageData);
-    ArrayList<Integer> childElementsForEachRow = new ArrayList<>();
+    List<Integer> childElementsForEachRow = new ArrayList<>();
     // Parent page array data looks like
     // number of children in each row [4 byte], Offset [4 byte],
     // number of children in each row [4 byte], Offset [4 byte]...
@@ -145,7 +145,7 @@ public class CarbonColumnVectorImpl implements CarbonColumnVector {
   public void setNumberOfChildElementsForStruct(byte[] parentPageData, int pageSize) {
     // for complex struct type, go through parent page to get the child information
     ByteBuffer childInfoBuffer = ByteBuffer.wrap(parentPageData);
-    ArrayList<Integer> childElementsForEachRow = new ArrayList<>();
+    List<Integer> childElementsForEachRow = new ArrayList<>();
     // Parent page struct data looks like
     // number of children in each row [2 byte], number of children in each row [2 byte],
     // number of children in each row [2 byte], number of children in each row [2 byte]...

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/vector/impl/CarbonColumnVectorImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/vector/impl/CarbonColumnVectorImpl.java
@@ -18,8 +18,11 @@
 package org.apache.carbondata.core.scan.result.vector.impl;
 
 import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;
+import java.util.List;
 
 import org.apache.carbondata.core.metadata.datatype.DataType;
 import org.apache.carbondata.core.metadata.datatype.DataTypes;
@@ -70,9 +73,13 @@ public class CarbonColumnVectorImpl implements CarbonColumnVector {
 
   private CarbonColumnVector dictionaryVector;
 
+  private List<CarbonColumnVector> childrenVector;
+
   private LazyPageLoader lazyPage;
 
   private boolean loaded;
+
+  private List<Integer> childElementsForEachRow;
 
   public CarbonColumnVectorImpl(int batchSize, DataType dataType) {
     this.batchSize = batchSize;
@@ -100,6 +107,53 @@ public class CarbonColumnVectorImpl implements CarbonColumnVector {
       data = new Object[batchSize];
     }
 
+  }
+
+  @Override
+  public List<CarbonColumnVector> getChildrenVector() {
+    return childrenVector;
+  }
+
+  public void setChildrenVector(ArrayList<CarbonColumnVector> childrenVector) {
+    this.childrenVector = childrenVector;
+  }
+
+  public List<Integer> getNumberOfChildrenElementsInEachRow() {
+    return childElementsForEachRow;
+  }
+
+  public void setNumberOfChildElementsInEachRow(ArrayList<Integer> childrenElements) {
+    this.childElementsForEachRow = childrenElements;
+  }
+
+  public void setNumberOfChildElementsForArray(byte[] parentPageData, int pageSize) {
+    // for complex array type, go through parent page to get the child information
+    ByteBuffer childInfoBuffer = ByteBuffer.wrap(parentPageData);
+    ArrayList<Integer> childElementsForEachRow = new ArrayList<>();
+    // Parent page array data looks like
+    // number of children in each row [4 byte], Offset [4 byte],
+    // number of children in each row [4 byte], Offset [4 byte]...
+    while (pageSize != childElementsForEachRow.size()) {
+      // get the number of children in current row
+      childElementsForEachRow.add(childInfoBuffer.getInt());
+      // skip offset
+      childInfoBuffer.getInt();
+    }
+    setNumberOfChildElementsInEachRow(childElementsForEachRow);
+  }
+
+  public void setNumberOfChildElementsForStruct(byte[] parentPageData, int pageSize) {
+    // for complex struct type, go through parent page to get the child information
+    ByteBuffer childInfoBuffer = ByteBuffer.wrap(parentPageData);
+    ArrayList<Integer> childElementsForEachRow = new ArrayList<>();
+    // Parent page struct data looks like
+    // number of children in each row [2 byte], number of children in each row [2 byte],
+    // number of children in each row [2 byte], number of children in each row [2 byte]...
+    while (pageSize != childElementsForEachRow.size()) {
+      int elements = childInfoBuffer.getShort();
+      childElementsForEachRow.add(elements);
+    }
+    setNumberOfChildElementsInEachRow(childElementsForEachRow);
   }
 
   @Override

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/vector/impl/directread/ColumnarVectorWrapperDirectFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/vector/impl/directread/ColumnarVectorWrapperDirectFactory.java
@@ -20,6 +20,7 @@ package org.apache.carbondata.core.scan.result.vector.impl.directread;
 import java.util.BitSet;
 
 import org.apache.carbondata.core.scan.result.vector.CarbonColumnVector;
+import org.apache.carbondata.core.scan.result.vector.ColumnVectorInfo;
 
 /**
  * Factory to create ColumnarVectors for inverted index and delete delta queries.
@@ -30,6 +31,7 @@ public final class ColumnarVectorWrapperDirectFactory {
    * Gets carbon vector wrapper to fill the underlying vector based on inverted index and delete
    * delta.
    *
+   * @param vectorInfo       vectorInfo used to get the complex child vector
    * @param columnVector     Actual vector to be filled.
    * @param invertedIndex    Inverted index of column page
    * @param nullBitset       row locations of nulls in bitset
@@ -38,11 +40,15 @@ public final class ColumnarVectorWrapperDirectFactory {
    *                         there is no null bitset.
    * @return wrapped CarbonColumnVector
    */
-  public static CarbonColumnVector getDirectVectorWrapperFactory(CarbonColumnVector columnVector,
-      int[] invertedIndex, BitSet nullBitset, BitSet deletedRows, boolean isnullBitsExists,
-      boolean isDictVector) {
+  public static CarbonColumnVector getDirectVectorWrapperFactory(ColumnVectorInfo vectorInfo,
+      CarbonColumnVector columnVector, int[] invertedIndex, BitSet nullBitset, BitSet deletedRows,
+      boolean isnullBitsExists, boolean isDictVector) {
     // If it is sequential data filler then add the null bitset.
     if (columnVector instanceof SequentialFill) {
+      if (columnVector.getType().isComplexType() && !vectorInfo.vectorStack.isEmpty()) {
+        // update to child vector, as it is child vector filling flow
+        columnVector = vectorInfo.vectorStack.peek();
+      }
       // If it has inverted index then create a dummy delete rows bitset so that it goes to
       // ColumnarVectorWrapperDirectWithDeleteDeltaAndInvertedIndex, here it does the sequential
       // filling using another vector.

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/vector/impl/directread/ColumnarVectorWrapperDirectWithDeleteDelta.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/vector/impl/directread/ColumnarVectorWrapperDirectWithDeleteDelta.java
@@ -20,6 +20,7 @@ package org.apache.carbondata.core.scan.result.vector.impl.directread;
 import java.math.BigDecimal;
 import java.util.BitSet;
 
+import org.apache.carbondata.core.metadata.datatype.DataType;
 import org.apache.carbondata.core.scan.result.vector.CarbonColumnVector;
 
 /**
@@ -39,6 +40,11 @@ class ColumnarVectorWrapperDirectWithDeleteDelta extends AbstractCarbonColumnarV
     super(vectorWrapper);
     this.deletedRows = deletedRows;
     this.nullBits = nullBits;
+  }
+
+  @Override
+  public DataType getType() {
+    return columnVector.getType();
   }
 
   @Override

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/CarbonColumnVectorWrapper.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/CarbonColumnVectorWrapper.java
@@ -48,6 +48,10 @@ public class CarbonColumnVectorWrapper implements CarbonColumnVector {
     }
   }
 
+  public CarbonColumnVector getColumnVector() {
+    return columnVector;
+  }
+
   @Override
   public void putBoolean(int rowId, boolean value) {
     if (!filteredRows[rowId]) {

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/CarbonVectorBatch.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/CarbonVectorBatch.java
@@ -22,22 +22,9 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.apache.carbondata.core.constants.CarbonV3DataFormatConstants;
-import org.apache.carbondata.core.metadata.datatype.DataType;
-import org.apache.carbondata.core.metadata.datatype.DataTypes;
-import org.apache.carbondata.core.metadata.datatype.DecimalType;
-import org.apache.carbondata.core.metadata.datatype.StructField;
+import org.apache.carbondata.core.metadata.datatype.*;
 import org.apache.carbondata.core.scan.result.vector.impl.CarbonColumnVectorImpl;
-import org.apache.carbondata.presto.readers.BooleanStreamReader;
-import org.apache.carbondata.presto.readers.ByteStreamReader;
-import org.apache.carbondata.presto.readers.DecimalSliceStreamReader;
-import org.apache.carbondata.presto.readers.DoubleStreamReader;
-import org.apache.carbondata.presto.readers.FloatStreamReader;
-import org.apache.carbondata.presto.readers.IntegerStreamReader;
-import org.apache.carbondata.presto.readers.LongStreamReader;
-import org.apache.carbondata.presto.readers.ObjectStreamReader;
-import org.apache.carbondata.presto.readers.ShortStreamReader;
-import org.apache.carbondata.presto.readers.SliceStreamReader;
-import org.apache.carbondata.presto.readers.TimestampStreamReader;
+import org.apache.carbondata.presto.readers.*;
 
 public class CarbonVectorBatch {
 
@@ -103,6 +90,8 @@ public class CarbonVectorBatch {
       } else {
         return null;
       }
+    } else if (field.getDataType().isComplexType()) {
+      return new ComplexTypeStreamReader(batchSize, field);
     } else {
       return new ObjectStreamReader(batchSize, field.getDataType());
     }

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/ColumnarVectorWrapperDirect.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/ColumnarVectorWrapperDirect.java
@@ -19,6 +19,7 @@ package org.apache.carbondata.presto;
 
 import java.math.BigDecimal;
 import java.util.BitSet;
+import java.util.List;
 
 import org.apache.carbondata.core.metadata.datatype.DataType;
 import org.apache.carbondata.core.scan.result.vector.CarbonColumnVector;
@@ -30,7 +31,7 @@ import org.apache.carbondata.core.scan.scanner.LazyPageLoader;
 /**
  * Fills the vector directly with out considering any deleted rows.
  */
-class ColumnarVectorWrapperDirect implements CarbonColumnVector, SequentialFill {
+public class ColumnarVectorWrapperDirect implements CarbonColumnVector, SequentialFill {
   /**
    * It is adapter class of complete ColumnarBatch.
    */
@@ -45,7 +46,7 @@ class ColumnarVectorWrapperDirect implements CarbonColumnVector, SequentialFill 
 
   private BitSet nullBitSet;
 
-  ColumnarVectorWrapperDirect(CarbonColumnVectorImpl columnVector) {
+  public ColumnarVectorWrapperDirect(CarbonColumnVectorImpl columnVector) {
     this.columnVector = columnVector;
     this.dictionaryVector = columnVector.getDictionaryVector();
     this.nullBitSet = new BitSet();
@@ -203,8 +204,19 @@ class ColumnarVectorWrapperDirect implements CarbonColumnVector, SequentialFill 
 
   @Override
   public void putObject(int rowId, Object obj) {
-    throw new UnsupportedOperationException(
-        "Not supported this opeartion from " + this.getClass().getName());
+    columnVector.putObject(rowId, obj);
+  }
+
+  public CarbonColumnVectorImpl getColumnVector() {
+    return this.columnVector;
+  }
+
+  public List<CarbonColumnVector> getChildrenVector() {
+    return columnVector.getChildrenVector();
+  }
+
+  public void putComplexObject(List<Integer> offsetVector) {
+    columnVector.putComplexObject(offsetVector);
   }
 
   @Override

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/PrestoCarbonVectorizedRecordReader.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/PrestoCarbonVectorizedRecordReader.java
@@ -26,6 +26,7 @@ import org.apache.carbondata.core.keygenerator.directdictionary.DirectDictionary
 import org.apache.carbondata.core.keygenerator.directdictionary.DirectDictionaryKeyGeneratorFactory;
 import org.apache.carbondata.core.metadata.datatype.DataTypes;
 import org.apache.carbondata.core.metadata.datatype.StructField;
+import org.apache.carbondata.core.metadata.schema.table.column.CarbonDimension;
 import org.apache.carbondata.core.scan.executor.QueryExecutor;
 import org.apache.carbondata.core.scan.executor.QueryExecutorFactory;
 import org.apache.carbondata.core.scan.executor.exception.QueryExecutionException;
@@ -163,6 +164,19 @@ class PrestoCarbonVectorizedRecordReader extends AbstractRecordReader<Object> {
     return 0;
   }
 
+  public StructField fillChildFields(CarbonDimension dimension) {
+    List<CarbonDimension> listOfChildDimensions =
+            dimension.getListOfChildDimensions();
+    ArrayList<StructField> childFields = null;
+    if (listOfChildDimensions != null) {
+      childFields = new ArrayList<>();
+      for (CarbonDimension childDimension : listOfChildDimensions) {
+        childFields.add(fillChildFields(childDimension));
+      }
+    }
+    return new StructField(dimension.getColName(), dimension.getDataType(), childFields);
+  }
+
   /**
    * Returns the ColumnarBatch object that will be used for all rows returned by this reader.
    * This object is reused. Calling this enables the vectorized reader. This should be called
@@ -173,11 +187,15 @@ class PrestoCarbonVectorizedRecordReader extends AbstractRecordReader<Object> {
     List<ProjectionDimension> queryDimension = queryModel.getProjectionDimensions();
     List<ProjectionMeasure> queryMeasures = queryModel.getProjectionMeasures();
     StructField[] fields = new StructField[queryDimension.size() + queryMeasures.size()];
-    for (int i = 0; i < queryDimension.size(); i++) {
-      ProjectionDimension dim = queryDimension.get(i);
+    for (ProjectionDimension dim : queryDimension) {
       if (dim.getDimension().isComplex()) {
+        List<CarbonDimension> childDimensions = dim.getDimension().getListOfChildDimensions();
+        ArrayList<StructField> childFields = new ArrayList<StructField>();
+        for (CarbonDimension childDimension : childDimensions) {
+          childFields.add(fillChildFields(childDimension));
+        }
         fields[dim.getOrdinal()] =
-            new StructField(dim.getColumnName(), dim.getDimension().getDataType());
+            new StructField(dim.getColumnName(), dim.getDimension().getDataType(), childFields);
       } else if (dim.getDimension().getDataType() == DataTypes.DATE) {
         DirectDictionaryGenerator generator = DirectDictionaryKeyGeneratorFactory
             .getDirectDictionaryGenerator(dim.getDimension().getDataType());

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/PrestoCarbonVectorizedRecordReader.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/PrestoCarbonVectorizedRecordReader.java
@@ -167,7 +167,7 @@ class PrestoCarbonVectorizedRecordReader extends AbstractRecordReader<Object> {
   public StructField fillChildFields(CarbonDimension dimension) {
     List<CarbonDimension> listOfChildDimensions =
             dimension.getListOfChildDimensions();
-    ArrayList<StructField> childFields = null;
+    List<StructField> childFields = null;
     if (listOfChildDimensions != null) {
       childFields = new ArrayList<>();
       for (CarbonDimension childDimension : listOfChildDimensions) {
@@ -190,7 +190,7 @@ class PrestoCarbonVectorizedRecordReader extends AbstractRecordReader<Object> {
     for (ProjectionDimension dim : queryDimension) {
       if (dim.getDimension().isComplex()) {
         List<CarbonDimension> childDimensions = dim.getDimension().getListOfChildDimensions();
-        ArrayList<StructField> childFields = new ArrayList<StructField>();
+        List<StructField> childFields = new ArrayList<StructField>();
         for (CarbonDimension childDimension : childDimensions) {
           childFields.add(fillChildFields(childDimension));
         }

--- a/integration/presto/src/main/prestosql/org/apache/carbondata/presto/readers/ComplexTypeStreamReader.java
+++ b/integration/presto/src/main/prestosql/org/apache/carbondata/presto/readers/ComplexTypeStreamReader.java
@@ -54,7 +54,7 @@ public class ComplexTypeStreamReader extends CarbonColumnVectorImpl
     super(batchSize, field.getDataType());
     this.batchSize = batchSize;
     this.type = getType(field);
-    ArrayList<CarbonColumnVector> childrenList = new ArrayList<>();
+    List<CarbonColumnVector> childrenList = new ArrayList<>();
     for (StructField child : field.getChildren()) {
       childrenList.add(new ColumnarVectorWrapperDirect(Objects.requireNonNull(
           CarbonVectorBatch.createDirectStreamReader(this.batchSize, child.getDataType(), child))));

--- a/integration/presto/src/main/prestosql/org/apache/carbondata/presto/readers/ComplexTypeStreamReader.java
+++ b/integration/presto/src/main/prestosql/org/apache/carbondata/presto/readers/ComplexTypeStreamReader.java
@@ -1,0 +1,196 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.presto.readers;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import io.prestosql.spi.block.ArrayBlock;
+import io.prestosql.spi.block.RowBlock;
+import io.prestosql.spi.type.*;
+
+import org.apache.carbondata.core.metadata.datatype.DataType;
+import org.apache.carbondata.core.metadata.datatype.DataTypes;
+import org.apache.carbondata.core.metadata.datatype.StructField;
+import org.apache.carbondata.core.scan.result.vector.CarbonColumnVector;
+import org.apache.carbondata.core.scan.result.vector.impl.CarbonColumnVectorImpl;
+
+import io.prestosql.spi.block.Block;
+import io.prestosql.spi.block.BlockBuilder;
+
+import org.apache.carbondata.presto.CarbonVectorBatch;
+import org.apache.carbondata.presto.ColumnarVectorWrapperDirect;
+
+/**
+ * Class to read the complex type Stream [array/struct/map]
+ */
+
+public class ComplexTypeStreamReader extends CarbonColumnVectorImpl
+    implements PrestoVectorBlockBuilder {
+
+  protected int batchSize;
+
+  protected Type type;
+  protected BlockBuilder builder;
+
+  public ComplexTypeStreamReader(int batchSize, StructField field) {
+    super(batchSize, field.getDataType());
+    this.batchSize = batchSize;
+    this.type = getType(field);
+    ArrayList<CarbonColumnVector> childrenList = new ArrayList<>();
+    for (StructField child : field.getChildren()) {
+      childrenList.add(new ColumnarVectorWrapperDirect(Objects.requireNonNull(
+          CarbonVectorBatch.createDirectStreamReader(this.batchSize, child.getDataType(), child))));
+    }
+    setChildrenVector(childrenList);
+    this.builder = type.createBlockBuilder(null, batchSize);
+  }
+
+  Type getType(StructField field) {
+    DataType dataType = field.getDataType();
+    if (dataType == DataTypes.STRING || dataType == DataTypes.VARCHAR) {
+      return VarcharType.VARCHAR;
+    } else if (dataType == DataTypes.SHORT) {
+      return SmallintType.SMALLINT;
+    } else if (dataType == DataTypes.INT) {
+      return IntegerType.INTEGER;
+    } else if (dataType == DataTypes.LONG) {
+      return BigintType.BIGINT;
+    } else if (dataType == DataTypes.DOUBLE) {
+      return DoubleType.DOUBLE;
+    } else if (dataType == DataTypes.FLOAT) {
+      return RealType.REAL;
+    } else if (dataType == DataTypes.BOOLEAN) {
+      return BooleanType.BOOLEAN;
+    } else if (dataType == DataTypes.BINARY) {
+      return VarbinaryType.VARBINARY;
+    } else if (dataType == DataTypes.DATE) {
+      return DateType.DATE;
+    } else if (dataType == DataTypes.TIMESTAMP) {
+      return TimestampType.TIMESTAMP;
+    } else if (dataType == DataTypes.BYTE) {
+      return TinyintType.TINYINT;
+    } else if (DataTypes.isDecimal(dataType)) {
+      org.apache.carbondata.core.metadata.datatype.DecimalType decimal =
+          (org.apache.carbondata.core.metadata.datatype.DecimalType) dataType;
+      return DecimalType.createDecimalType(decimal.getPrecision(), decimal.getScale());
+    } else if (DataTypes.isArrayType(dataType)) {
+      return new ArrayType(getType(field.getChildren().get(0)));
+    } else if (DataTypes.isStructType(dataType)) {
+      List<RowType.Field> children = new ArrayList<>();
+      for (StructField child : field.getChildren()) {
+        children.add(new RowType.Field(Optional.of(child.getFieldName()), getType(child)));
+      }
+      return RowType.from(children);
+    } else {
+      throw new UnsupportedOperationException("Unsupported type: " + dataType);
+    }
+  }
+
+  @Override public Block buildBlock() {
+    return builder.build();
+  }
+
+  @Override public void setBatchSize(int batchSize) {
+    this.batchSize = batchSize;
+  }
+
+  public void putComplexObject(List<Integer> offsetVector) {
+    if (type instanceof ArrayType) {
+      // build child block
+      Block childBlock = buildChildBlock(getChildrenVector().get(0));
+      // prepare an offset vector with 0 as initial offset
+      int[] offsetVectorArray = new int[offsetVector.size() + 1];
+      for (int i = 1; i <= offsetVector.size(); i++) {
+        offsetVectorArray[i] = offsetVectorArray[i - 1] + offsetVector.get(i - 1);
+      }
+      // prepare Array block
+      Block arrayBlock = ArrayBlock
+          .fromElementBlock(offsetVector.size(), Optional.empty(), offsetVectorArray,
+              childBlock);
+      for (int position = 0; position < offsetVector.size(); position++) {
+        type.writeObject(builder, arrayBlock.getObject(position, Block.class));
+      }
+      getChildrenVector().get(0).getColumnVector().reset();
+    } else {
+      // build child blocks
+      List<Block> childBlocks = new ArrayList<>(getChildrenVector().size());
+      for (CarbonColumnVector child : getChildrenVector()) {
+        childBlocks.add(buildChildBlock(child));
+      }
+      // prepare ROW block
+      Block rowBlock = RowBlock
+          .fromFieldBlocks(childBlocks.get(0).getPositionCount(), Optional.empty(),
+              childBlocks.toArray(new Block[0]));
+      for (int position = 0; position < childBlocks.get(0).getPositionCount(); position++) {
+        type.writeObject(builder, rowBlock.getObject(position, Block.class));
+      }
+      for (CarbonColumnVector child : getChildrenVector()) {
+        child.getColumnVector().reset();
+      }
+    }
+  }
+
+  private Block buildChildBlock(CarbonColumnVector carbonColumnVector) {
+    DataType dataType = carbonColumnVector.getType();
+    carbonColumnVector = carbonColumnVector.getColumnVector();
+    if (dataType == DataTypes.STRING || dataType == DataTypes.BINARY
+        || dataType == DataTypes.VARCHAR) {
+      return ((SliceStreamReader) carbonColumnVector).buildBlock();
+    } else if (dataType == DataTypes.SHORT) {
+      return ((ShortStreamReader) carbonColumnVector).buildBlock();
+    } else if (dataType == DataTypes.INT || dataType == DataTypes.DATE) {
+      return ((IntegerStreamReader) carbonColumnVector).buildBlock();
+    } else if (dataType == DataTypes.LONG) {
+      return ((LongStreamReader) carbonColumnVector).buildBlock();
+    } else if (dataType == DataTypes.DOUBLE) {
+      return ((DoubleStreamReader) carbonColumnVector).buildBlock();
+    } else if (dataType == DataTypes.FLOAT) {
+      return ((FloatStreamReader) carbonColumnVector).buildBlock();
+    } else if (dataType == DataTypes.TIMESTAMP) {
+      return ((TimestampStreamReader) carbonColumnVector).buildBlock();
+    } else if (dataType == DataTypes.BOOLEAN) {
+      return ((BooleanStreamReader) carbonColumnVector).buildBlock();
+    } else if (DataTypes.isDecimal(dataType)) {
+      return ((DecimalSliceStreamReader) carbonColumnVector).buildBlock();
+    } else if (dataType == DataTypes.BYTE) {
+      return ((ByteStreamReader) carbonColumnVector).buildBlock();
+    } else if (DataTypes.isArrayType(dataType) || (DataTypes.isStructType(dataType))) {
+      return ((ComplexTypeStreamReader) carbonColumnVector).buildBlock();
+    } else {
+      throw new UnsupportedOperationException("unsupported for type :" + dataType);
+    }
+  }
+
+  @Override public void putNull(int rowId) {
+    builder.appendNull();
+  }
+
+  @Override public void reset() {
+    builder = type.createBlockBuilder(null, batchSize);
+  }
+
+  @Override public void putNulls(int rowId, int count) {
+    for (int i = 0; i < count; i++) {
+      builder.appendNull();
+    }
+  }
+}
+

--- a/integration/presto/src/main/prestosql/org/apache/carbondata/presto/readers/SliceStreamReader.java
+++ b/integration/presto/src/main/prestosql/org/apache/carbondata/presto/readers/SliceStreamReader.java
@@ -151,7 +151,7 @@ public class SliceStreamReader extends CarbonColumnVectorImpl implements PrestoV
       putNull(rowId);
     } else {
       if (dictionaryBlock == null) {
-        putByteArray(rowId, ByteUtil.toBytes((String) value));
+        putByteArray(rowId, (byte []) value);
       } else {
         putInt(rowId, (int) value);
       }

--- a/processing/src/main/java/org/apache/carbondata/processing/datatypes/PrimitiveDataType.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/datatypes/PrimitiveDataType.java
@@ -240,16 +240,17 @@ public class PrimitiveDataType implements GenericDataType<Object> {
       BadRecordLogHolder logHolder, Boolean isWithoutConverter) throws IOException {
     String parsedValue = null;
     // write null value
-    if (null == input ||
-        (this.carbonDimension.getDataType() == DataTypes.STRING && input.equals(nullFormat))) {
+    if (null == input || ((this.carbonDimension.getDataType() == DataTypes.STRING
+        || this.carbonDimension.getDataType() == DataTypes.VARCHAR) && input.equals(nullFormat))) {
       updateNullValue(dataOutputStream, logHolder);
       return;
     }
     // write null value after converter
     if (!isWithoutConverter) {
       parsedValue = DataTypeUtil.parseValue(input.toString(), carbonDimension);
-      if (null == parsedValue || (this.carbonDimension.getDataType() == DataTypes.STRING
-          && parsedValue.equals(nullFormat))) {
+      if (null == parsedValue || ((this.carbonDimension.getDataType() == DataTypes.STRING
+          || this.carbonDimension.getDataType() == DataTypes.VARCHAR) && parsedValue
+          .equals(nullFormat))) {
         updateNullValue(dataOutputStream, logHolder);
         return;
       }
@@ -413,7 +414,8 @@ public class PrimitiveDataType implements GenericDataType<Object> {
 
   private void updateNullValue(DataOutputStream dataOutputStream, BadRecordLogHolder logHolder)
       throws IOException {
-    if (this.carbonDimension.getDataType() == DataTypes.STRING) {
+    if (this.carbonDimension.getDataType() == DataTypes.STRING
+        || this.carbonDimension.getDataType() == DataTypes.VARCHAR) {
       if (DataTypeUtil.isByteArrayComplexChildColumn(dataType)) {
         dataOutputStream.writeInt(CarbonCommonConstants.MEMBER_DEFAULT_VAL_ARRAY.length);
       } else {


### PR DESCRIPTION
 ### Why is this PR needed?
Currently, presto cannot read complex data type stores. Sometimes it gives empty results and some times exception. 
 
 ### What changes were proposed in this PR?
- Supported all the 13 complex primitive types (including binary, refer the testcase added) with non-nested array and struct data type 

- Supported complex type in Direct vector filling flow :
Currently, spark integration carbondata will use row level filling for complex type instead of vector filling. But presto supports only vector reading. so need to support complex type in vector filling.

- Supported complex primitive vector handling in DIRECT_COMPESS, ADAPTIVE_CODEC flows
Encoding of all the complex primitive type is either DIRECT_COMPESS or ADAPTIVE_CODEC, it will never use a legacy encoding. so, because of this string, varchar (with/without local dictionary), binary, date vector filling need to handle in DIRECT_COMPESS. Parent column also comes as DIRECT_COMPESS. Extracted data from parent column page here.

- Supported vector stack in complex column vectorInfo to store all the children vectors.

- Keep a list of children vector inside CarbonColumnVectorImpl.java 

- Support ComplexStreamReader to fill presto ROW (struct) block and ARRAY block.

- Handle null value filling by wrapping children vector with ColumnarVectorWrapperDirect

**Limitations / next work:**
Some pending TODO 's are,
- Local dictionary need to handle for string / varchar columns as DIRECT_COMPRESS flow don't have that handling
- Can support map of all primitive types 
- Can support multilevel nested arrays and struct 

    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes [Added test case for all 13 primitive type with array and struct, null values and more than one page data]

    
Co-authored-by: akkio-97 <akshay.nuthala@gmail.com>