### PR TITLE
[CARBONDATA-3925] flink write carbon file to hdfs when file size is less than 1M,can't write

### DIFF
--- a/integration/flink/src/main/java/org/apache/carbon/core/metadata/StageManager.java
+++ b/integration/flink/src/main/java/org/apache/carbon/core/metadata/StageManager.java
@@ -81,7 +81,7 @@ public final class StageManager {
   private static void writeSuccessFile(final String successFilePath) throws IOException {
     final DataOutputStream segmentStatusSuccessOutputStream =
         FileFactory.getDataOutputStream(successFilePath,
-            CarbonCommonConstants.BYTEBUFFER_SIZE, 1024);
+            CarbonCommonConstants.BYTEBUFFER_SIZE, 1024 * 1024 * 2);
     try {
       IOUtils.copyBytes(
           new ByteArrayInputStream(new byte[0]),

--- a/integration/flink/src/main/java/org/apache/carbon/flink/CarbonWriter.java
+++ b/integration/flink/src/main/java/org/apache/carbon/flink/CarbonWriter.java
@@ -41,7 +41,7 @@ import org.apache.log4j.Logger;
 public abstract class CarbonWriter extends ProxyFileWriter<Object[]> {
 
   private static final Logger LOGGER =
-      LogServiceFactory.getLogService(CarbonS3Writer.class.getName());
+      LogServiceFactory.getLogService(CarbonWriter.class.getName());
 
   public CarbonWriter(final CarbonWriterFactory factory,
       final String identifier, final CarbonTable table) {
@@ -87,7 +87,7 @@ public abstract class CarbonWriter extends ProxyFileWriter<Object[]> {
               "Upload file[" + file.getAbsolutePath() + "] to [" + remotePath + "] start.");
         }
         try {
-          CarbonUtil.copyCarbonDataFileToCarbonStorePath(file.getAbsolutePath(), remotePath, 1024);
+          CarbonUtil.copyCarbonDataFileToCarbonStorePath(file.getAbsolutePath(), remotePath, 1024 * 1024 * 2);
         } catch (CarbonDataWriterException exception) {
           LOGGER.error(exception.getMessage(), exception);
           throw exception;
@@ -131,7 +131,7 @@ public abstract class CarbonWriter extends ProxyFileWriter<Object[]> {
         LOGGER.debug("Upload file[" + file.getAbsolutePath() + "] to [" + remotePath + "] start.");
       }
       try {
-        CarbonUtil.copyCarbonDataFileToCarbonStorePath(file.getAbsolutePath(), remotePath, 1024);
+        CarbonUtil.copyCarbonDataFileToCarbonStorePath(file.getAbsolutePath(), remotePath, 1024 * 1024 * 2);
       } catch (CarbonDataWriterException exception) {
         LOGGER.error(exception.getMessage(), exception);
         throw exception;

--- a/integration/flink/src/main/java/org/apache/carbon/flink/CarbonWriter.java
+++ b/integration/flink/src/main/java/org/apache/carbon/flink/CarbonWriter.java
@@ -87,8 +87,8 @@ public abstract class CarbonWriter extends ProxyFileWriter<Object[]> {
               "Upload file[" + file.getAbsolutePath() + "] to [" + remotePath + "] start.");
         }
         try {
-          CarbonUtil.copyCarbonDataFileToCarbonStorePath(file.getAbsolutePath(), 
-                                                         remotePath, 1024 * 1024 * 2);
+          CarbonUtil.copyCarbonDataFileToCarbonStorePath(file.getAbsolutePath(), remotePath,
+                1024 * 1024 * 2);
         } catch (CarbonDataWriterException exception) {
           LOGGER.error(exception.getMessage(), exception);
           throw exception;
@@ -132,8 +132,8 @@ public abstract class CarbonWriter extends ProxyFileWriter<Object[]> {
         LOGGER.debug("Upload file[" + file.getAbsolutePath() + "] to [" + remotePath + "] start.");
       }
       try {
-        CarbonUtil.copyCarbonDataFileToCarbonStorePath(file.getAbsolutePath(),
-                                                       remotePath, 1024 * 1024 * 2);
+        CarbonUtil.copyCarbonDataFileToCarbonStorePath(file.getAbsolutePath(), remotePath,
+                1024 * 1024 * 2);
       } catch (CarbonDataWriterException exception) {
         LOGGER.error(exception.getMessage(), exception);
         throw exception;

--- a/integration/flink/src/main/java/org/apache/carbon/flink/CarbonWriter.java
+++ b/integration/flink/src/main/java/org/apache/carbon/flink/CarbonWriter.java
@@ -88,7 +88,7 @@ public abstract class CarbonWriter extends ProxyFileWriter<Object[]> {
         }
         try {
           CarbonUtil.copyCarbonDataFileToCarbonStorePath(file.getAbsolutePath(), remotePath,
-                1024 * 1024 * 2);
+                  1024 * 1024 * 2);
         } catch (CarbonDataWriterException exception) {
           LOGGER.error(exception.getMessage(), exception);
           throw exception;
@@ -133,7 +133,7 @@ public abstract class CarbonWriter extends ProxyFileWriter<Object[]> {
       }
       try {
         CarbonUtil.copyCarbonDataFileToCarbonStorePath(file.getAbsolutePath(), remotePath,
-                1024 * 1024 * 2);
+                  1024 * 1024 * 2);
       } catch (CarbonDataWriterException exception) {
         LOGGER.error(exception.getMessage(), exception);
         throw exception;

--- a/integration/flink/src/main/java/org/apache/carbon/flink/CarbonWriter.java
+++ b/integration/flink/src/main/java/org/apache/carbon/flink/CarbonWriter.java
@@ -87,7 +87,8 @@ public abstract class CarbonWriter extends ProxyFileWriter<Object[]> {
               "Upload file[" + file.getAbsolutePath() + "] to [" + remotePath + "] start.");
         }
         try {
-          CarbonUtil.copyCarbonDataFileToCarbonStorePath(file.getAbsolutePath(), remotePath, 1024 * 1024 * 2);
+          CarbonUtil.copyCarbonDataFileToCarbonStorePath(file.getAbsolutePath(), 
+                                                         remotePath, 1024 * 1024 * 2);
         } catch (CarbonDataWriterException exception) {
           LOGGER.error(exception.getMessage(), exception);
           throw exception;
@@ -131,7 +132,8 @@ public abstract class CarbonWriter extends ProxyFileWriter<Object[]> {
         LOGGER.debug("Upload file[" + file.getAbsolutePath() + "] to [" + remotePath + "] start.");
       }
       try {
-        CarbonUtil.copyCarbonDataFileToCarbonStorePath(file.getAbsolutePath(), remotePath, 1024 * 1024 * 2);
+        CarbonUtil.copyCarbonDataFileToCarbonStorePath(file.getAbsolutePath(),
+                                                       remotePath, 1024 * 1024 * 2);
       } catch (CarbonDataWriterException exception) {
         LOGGER.error(exception.getMessage(), exception);
         throw exception;


### PR DESCRIPTION
 ### write carbon file less than 1M , less than configured minimum value (dfs.namenode.fs-limits.min-block-size) 1M ;can't write hdfs file
 


 
 ### the default block size is set  1024 byte and compare with  file size;when file size big than 1KB but less than 1M ,can not write file to hdfs ;so set default block size to 2M  

    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No


    
