### PR TITLE
[CARBONDATA-3957] Added property to enable disable the repair logic and provide a limit to number of segments in SILoadEventListenerForFailedSegments

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -2273,6 +2273,26 @@ public final class CarbonCommonConstants {
       500;
 
   /**
+   * Configured property to enable/disable load failed segments in SI table during
+   * load/insert command.
+   */
+  @CarbonProperty(dynamicConfigurable = true)
+  public static final String CARBON_LOAD_SI_REPAIR =  "carbon.load.si.repair";
+
+  /**
+   * Default value for load failed segments in SI table during
+   * load/insert command.
+   */
+  public static final String CARBON_LOAD_SI_REPAIR_DEFAULT = "true";
+
+  /**
+   * Property to give a limit to the number of segments that are reloaded in the
+   * SI table in the FailedSegments listener.
+   */
+  @CarbonProperty(dynamicConfigurable = true)
+  public static final String CARBON_SI_REPAIR_LIMIT =  "carbon.si.repair.limit";
+
+  /**
    * Set it to true to enable audit
    */
   public static final String CARBON_ENABLE_AUDIT = "carbon.audit.enabled";

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
@@ -2083,4 +2083,36 @@ public final class CarbonProperties {
             CarbonCommonConstants.CARBON_LOAD_DATEFORMAT_SETLENIENT_ENABLE_DEFAULT);
     return Boolean.parseBoolean(configuredValue);
   }
+
+  public boolean isSIRepairEnabled(String dbName, String tableName) {
+    // Check if user has enabled/disabled the use of property for the current db and table using
+    // the set command
+    String configuredValue = getSessionPropertyValue(
+            CarbonCommonConstants.CARBON_LOAD_SI_REPAIR + "." + dbName + "." + tableName);
+    if (configuredValue == null) {
+      // if not set in session properties then check carbon.properties for the same.
+      configuredValue = getProperty(CarbonCommonConstants.CARBON_LOAD_SI_REPAIR,
+            CarbonCommonConstants.CARBON_LOAD_SI_REPAIR_DEFAULT);
+    }
+    boolean propertyEnabled =  Boolean.parseBoolean(configuredValue);
+    if (propertyEnabled) {
+      LOGGER.info("SI Repair is enabled for " + dbName + "." + tableName);
+    }
+    return propertyEnabled;
+  }
+
+  public int getMaxSIRepairLimit(String dbName, String tableName) {
+    // Check if user has enabled/disabled the use of property for the current db and table using
+    // the set command
+    String thresholdValue = getSessionPropertyValue(
+            CarbonCommonConstants.CARBON_LOAD_SI_REPAIR + "." + dbName + "." + tableName);
+    if (thresholdValue == null) {
+      // if not set in session properties then check carbon.properties for the same.
+      thresholdValue = getProperty(CarbonCommonConstants.CARBON_SI_REPAIR_LIMIT);
+    }
+    if (thresholdValue == null) {
+      return Integer.MAX_VALUE;
+    }
+    return Math.abs(Integer.parseInt(thresholdValue));
+  }
 }

--- a/core/src/main/java/org/apache/carbondata/core/util/SessionParams.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/SessionParams.java
@@ -29,22 +29,7 @@ import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.constants.CarbonLoadOptionConstants;
 import org.apache.carbondata.core.exception.InvalidConfigurationException;
 
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_CUSTOM_BLOCK_DISTRIBUTION;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_ENABLE_INDEX_SERVER;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_ENABLE_MV;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_LOAD_DATEFORMAT_SETLENIENT_ENABLE;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_MAJOR_COMPACTION_SIZE;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_PUSH_ROW_FILTERS_FOR_VECTOR;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.CARBON_QUERY_STAGE_INPUT;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.COMPACTION_SEGMENT_LEVEL_THRESHOLD;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.ENABLE_AUTO_LOAD_MERGE;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.ENABLE_OFFHEAP_SORT;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.ENABLE_SI_LOOKUP_PARTIALSTRING;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.ENABLE_UNSAFE_IN_QUERY_EXECUTION;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.ENABLE_UNSAFE_SORT;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.ENABLE_VECTOR_READER;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.NUM_CORES_COMPACTING;
-import static org.apache.carbondata.core.constants.CarbonCommonConstants.NUM_CORES_LOADING;
+import static org.apache.carbondata.core.constants.CarbonCommonConstants.*;
 import static org.apache.carbondata.core.constants.CarbonLoadOptionConstants.CARBON_OPTIONS_BAD_RECORDS_ACTION;
 import static org.apache.carbondata.core.constants.CarbonLoadOptionConstants.CARBON_OPTIONS_BAD_RECORDS_LOGGER_ENABLE;
 import static org.apache.carbondata.core.constants.CarbonLoadOptionConstants.CARBON_OPTIONS_BAD_RECORD_PATH;
@@ -155,6 +140,7 @@ public class SessionParams implements Serializable, Cloneable {
       case ENABLE_AUTO_LOAD_MERGE:
       case CARBON_PUSH_ROW_FILTERS_FOR_VECTOR:
       case CARBON_LOAD_DATEFORMAT_SETLENIENT_ENABLE:
+      case CARBON_LOAD_SI_REPAIR:
       case CARBON_ENABLE_INDEX_SERVER:
       case CARBON_QUERY_STAGE_INPUT:
       case CARBON_ENABLE_MV:
@@ -181,6 +167,7 @@ public class SessionParams implements Serializable, Cloneable {
         break;
       case CARBON_OPTIONS_GLOBAL_SORT_PARTITIONS:
       case NUM_CORES_LOADING:
+      case CARBON_SI_REPAIR_LIMIT:
       case NUM_CORES_COMPACTING:
       case BLOCKLET_SIZE_IN_MB:
       case CARBON_MAJOR_COMPACTION_SIZE:
@@ -214,6 +201,13 @@ public class SessionParams implements Serializable, Cloneable {
         break;
       default:
         if (key.startsWith(CARBON_ENABLE_INDEX_SERVER) && key.split("\\.").length == 6) {
+          isValid = true;
+        } else if (key.startsWith(CARBON_SI_REPAIR_LIMIT)) {
+          isValid = CarbonUtil.validateValidIntType(value);
+          if (!isValid) {
+            throw new InvalidConfigurationException("Invalid CARBON_SI_REPAIR_LIMIT");
+          }
+        } else if (key.startsWith(CARBON_LOAD_SI_REPAIR) && key.split("\\.").length == 6) {
           isValid = true;
         } else if (key.startsWith(CarbonCommonConstants.CARBON_INPUT_SEGMENTS)) {
           isValid = CarbonUtil.validateRangeOfSegmentList(value);

--- a/docs/configuration-parameters.md
+++ b/docs/configuration-parameters.md
@@ -94,6 +94,8 @@ This section provides the details of all the configurations required for the Car
 | carbon.binary.decoder | None | Support configurable decode for loading. Two decoders supported: base64 and hex |
 | carbon.local.dictionary.size.threshold.inmb | 4 | size based threshold for local dictionary in MB, maximum allowed size is 16 MB. |
 | carbon.enable.bad.record.handling.for.insert | false | by default, disable the bad record and converter step during "insert into" |
+| carbon.load.si.repair | true | by default, enable loading for failed segments in SI during load/insert command |
+| carbon.si.repair.limit | (none) | Number of failed segments to be loaded in SI when repairing missing segments in SI, by default load all the missing segments. Supports value from 0 to 2147483646 |
 
 ## Compaction Configuration
 

--- a/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/TestSIWithSecondryIndex.scala
+++ b/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/TestSIWithSecondryIndex.scala
@@ -175,6 +175,7 @@ class TestSIWithSecondryIndex extends QueryTest with BeforeAndAfterAll {
     val carbontable = CarbonEnv.getCarbonTable(Some("default"), "uniqdata")(sqlContext.sparkSession)
     val details = SegmentStatusManager.readLoadMetadata(indexTable.getMetadataPath)
     val failSegments = List("3","4")
+    sql(s"""set carbon.si.repair.limit = 2""")
     var loadMetadataDetailsList = Array[LoadMetadataDetails]()
     details.foreach{detail =>
       if(failSegments.contains(detail.getLoadName)){
@@ -201,6 +202,7 @@ class TestSIWithSecondryIndex extends QueryTest with BeforeAndAfterAll {
            |SERDEPROPERTIES ('isSITableEnabled' = 'false')""".stripMargin)
     val count2 = sql("select * from uniqdata where workgroupcategoryname = 'developer'").count()
     val df2 = sql("select * from uniqdata where workgroupcategoryname = 'developer'").queryExecution.sparkPlan
+    sql(s"""set carbon.si.repair.limit = 1""")
     assert(count1 == count2)
     assert(isFilterPushedDownToSI(df1))
     assert(!isFilterPushedDownToSI(df2))

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/index/IndexRepairCommand.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/index/IndexRepairCommand.scala
@@ -112,7 +112,8 @@ extends DataCommand {
           indexTables.foreach {
             indexTableName =>
               CarbonIndexUtil.processSIRepair(indexTableName, mainCarbonTable, carbonLoadModel,
-                indexMetadata, mainTableDetails, secondaryIndexProvider)(sparkSession)
+                indexMetadata, mainTableDetails, secondaryIndexProvider,
+                Integer.MAX_VALUE)(sparkSession)
           }
         } else {
           val indexTablesToRepair = indexTables.filter(indexTable => indexTable
@@ -120,7 +121,8 @@ extends DataCommand {
           indexTablesToRepair.foreach {
             indexTableName =>
               CarbonIndexUtil.processSIRepair(indexTableName, mainCarbonTable, carbonLoadModel,
-                indexMetadata, mainTableDetails, secondaryIndexProvider)(sparkSession)
+                indexMetadata, mainTableDetails, secondaryIndexProvider,
+                Integer.MAX_VALUE)(sparkSession)
           }
           if (indexTablesToRepair.isEmpty) {
             throw new Exception("Unable to find index table" + indexTableToRepair.get)


### PR DESCRIPTION
 ### Why is this PR needed?
In the main table with SI tables after every load/insert command , SILoadEventListenerForFailedSegments.scala checks for missing segments or segments mismatch in SI table and loads the missing/deleted segments to the SI table. In case when there are very large number of missing segments in the SI table(10000's), the repair logic will run for multiple days and will thus block the next load.  
 
 ### What changes were proposed in this PR?
The above mentioned issue is solved using 2 carbon properties.
1. carbon.load.si.repair- This property lets the user enable/disable the repair SI logic in SILoadEventListenerForFailedSegments. The default value of this property is true.
2. carbon.si.repair.limit - This property decides the number of failed segments that are being loaded again in the SI table in SILoadEventListenerForFailedSegments. By default repairing all the segments. Instead of repairing all the segments in one load the user can now set a limit thus not blocking the next load for the in case of large number of missing SI segments. 
    
 ### Does this PR introduce any user interface change?
 - No
 - Yes. (please explain the change and update document)

 ### Is any new testcase added?
 - No
 - Yes

    
