### PR TITLE
[HOTFIX] Aviod cleaning segments after reading tablestatus failed

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/util/path/CarbonTablePath.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/path/CarbonTablePath.java
@@ -41,7 +41,7 @@ public class CarbonTablePath {
   private static final String DICTIONARY_EXT = ".dict";
   public static final String SCHEMA_FILE = "schema";
   private static final String FACT_DIR = "Fact";
-  private static final String SEGMENT_PREFIX = "Segment_";
+  public static final String SEGMENT_PREFIX = "Segment_";
   private static final String PARTITION_PREFIX = "Part";
   private static final String DATA_PART_PREFIX = "part-";
   public static final String BATCH_PREFIX = "_batchno";

--- a/integration/spark/src/test/scala/org/apache/carbondata/integration/spark/testsuite/dataload/TestLoadDataGeneral.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/integration/spark/testsuite/dataload/TestLoadDataGeneral.scala
@@ -19,25 +19,25 @@ package org.apache.carbondata.integration.spark.testsuite.dataload
 
 import java.math.BigDecimal
 
+import org.apache.commons.io.FileUtils
+import org.apache.commons.lang3.RandomStringUtils
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.test.util.QueryTest
 import org.scalatest.BeforeAndAfterEach
 
-import org.apache.carbondata.core.util.path.CarbonTablePath
-import org.apache.carbondata.core.datastore.impl.FileFactory
-import org.apache.carbondata.core.metadata.CarbonMetadata
 import org.apache.carbondata.core.constants.{CarbonCommonConstants, CarbonLoadOptionConstants}
+import org.apache.carbondata.core.datastore.impl.FileFactory
 import org.apache.carbondata.core.index.Segment
+import org.apache.carbondata.core.metadata.CarbonMetadata
 import org.apache.carbondata.core.util.CarbonProperties
+import org.apache.carbondata.core.util.path.CarbonTablePath
 import org.apache.carbondata.spark.util.BadRecordUtil
-import org.apache.commons.io.FileUtils
-import org.apache.commons.lang3.RandomStringUtils
 
 class TestLoadDataGeneral extends QueryTest with BeforeAndAfterEach {
 
   val badRecordAction = CarbonProperties.getInstance()
     .getProperty(CarbonCommonConstants.CARBON_BAD_RECORDS_ACTION);
-  val testdata =s"$resourcesPath/MoreThan32KChar.csv"
+  val testdata = s"$resourcesPath/MoreThan32KChar.csv"
   val longChar: String = RandomStringUtils.randomAlphabetic(33000)
 
   override def beforeEach {
@@ -310,7 +310,8 @@ class TestLoadDataGeneral extends QueryTest with BeforeAndAfterEach {
     val tableStatusFile = CarbonTablePath.getTableStatusFilePath(carbonTable.getTablePath)
     FileFactory.getCarbonFile(tableStatusFile).delete()
     sql("insert into stale values('k')")
-    checkAnswer(sql("select * from stale"), Row("k"))
+    // if table lose tablestatus file, the system should keep all data.
+    checkAnswer(sql("select * from stale"), Seq(Row("k"), Row("k")))
   }
 
   test("test data loading with directly writing fact data to hdfs") {


### PR DESCRIPTION
 ### Why is this PR needed?
 1. After reading tablestatus file failed,  method TableProcessingOperations. deletePartialLoadDataIfExist will delete all related segments.

 2. If the tablestatus file was removed, the system will delete all original segment before loading. 

 ### What changes were proposed in this PR?
1. check the result of reading tablestatus file, if it is empty, no need to process.
2. if the table status was removed, the system shouldn't delete any segment.
3. re-factory code to avoid invoking getAbsolutePath method too many times.

    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No

    
