### PR TITLE
[CARBONDATA-3820] CDC update as new segment should use target table sort_scope

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/mutation/merge/CarbonMergeDataSetCommand.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/mutation/merge/CarbonMergeDataSetCommand.scala
@@ -219,7 +219,7 @@ case class CarbonMergeDataSetCommand(
     val dataFrame = loadDF.select(tableCols.map(col): _*)
     CarbonInsertIntoCommand(databaseNameOp = Some(carbonTable.getDatabaseName),
       tableName = carbonTable.getTableName,
-      options = Map("fileheader" -> header, "sort_scope" -> "no_sort"),
+      options = Map("fileheader" -> header),
       isOverwriteTable = false,
       dataFrame.queryExecution.logical,
       carbonTable.getTableInfo,


### PR DESCRIPTION
 ### Why is this PR needed?
Originally when CDC is developed, it was using target table sort_scope for new segment added but
 #3764 has added nosort (this is wrong code, but no functional impact as it was not changing new segment load to no_sort)
 #3856 has changed it to no_sort (creates a functional impact by changing target table new segment to use to no_sort)
 
 ### What changes were proposed in this PR?
CDC update as new segment should use target table sort_scope
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No (verified manually the flows)


    
