### PR TITLE
[CARBONDATA-3961] reorder filter expression based on storage ordinal

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -2557,4 +2557,10 @@ public final class CarbonCommonConstants {
   public static final String COMPLEX_DELIMITER_LEVEL_3_DEFAULT = "@";
 
   public static final String FILE_HEADER = "fileHeader";
+
+  @CarbonProperty(dynamicConfigurable = true)
+  public static final String CARBON_REORDER_FILTER = "carbon.reorder.filter";
+
+  public static final String CARBON_REORDER_FILTER_DEFAULT = "true";
+
 }

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
@@ -2105,7 +2105,7 @@ public final class CarbonProperties {
     // Check if user has enabled/disabled the use of property for the current db and table using
     // the set command
     String thresholdValue = getSessionPropertyValue(
-            CarbonCommonConstants.CARBON_LOAD_SI_REPAIR + "." + dbName + "." + tableName);
+        CarbonCommonConstants.CARBON_LOAD_SI_REPAIR + "." + dbName + "." + tableName);
     if (thresholdValue == null) {
       // if not set in session properties then check carbon.properties for the same.
       thresholdValue = getProperty(CarbonCommonConstants.CARBON_SI_REPAIR_LIMIT);
@@ -2114,5 +2114,12 @@ public final class CarbonProperties {
       return Integer.MAX_VALUE;
     }
     return Math.abs(Integer.parseInt(thresholdValue));
+  }
+
+  public static boolean isFilterReorderingEnabled() {
+    return Boolean.parseBoolean(
+        getInstance().getProperty(CarbonCommonConstants.CARBON_REORDER_FILTER,
+        CarbonCommonConstants.CARBON_REORDER_FILTER_DEFAULT)
+    );
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/util/SessionParams.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/SessionParams.java
@@ -227,6 +227,8 @@ public class SessionParams implements Serializable, Cloneable {
             throw new InvalidConfigurationException("The sort scope " + key
                 + " can have only either NO_SORT, LOCAL_SORT or GLOBAL_SORT.");
           }
+        } else if (key.equalsIgnoreCase(CARBON_REORDER_FILTER)) {
+          isValid = true;
         } else {
           throw new InvalidConfigurationException(
               "The key " + key + " not supported for dynamic configuration.");

--- a/docs/configuration-parameters.md
+++ b/docs/configuration-parameters.md
@@ -230,7 +230,7 @@ RESET
 | carbon.index.visible.<db_name>.<table_name>.<index_name> | To specify query on ***db_name.table_name*** to not use the index ***index_name***. |
 | carbon.load.indexes.parallel.<db_name>.<table_name> | To enable parallel index loading for a table. when db_name.table_name are not specified, i.e., when ***carbon.load.indexes.parallel.*** is set, it applies for all the tables of the session. |
 | carbon.enable.index.server                | To use index server for caching and pruning. This property can be used for a session or for a particular table with ***carbon.enable.index.server.<db_name>.<table_name>***. |
-
+| carbon.reorder.filter                     | This property can be used to enabled/disable filter reordering. Should be disabled only when the user has optimized the filter condition.
 **Examples:**
 
 * Add or Update:

--- a/integration/spark/src/main/scala/org/apache/carbondata/geo/InPolygonUDF.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/geo/InPolygonUDF.scala
@@ -30,6 +30,6 @@ class InPolygonUDF extends (String => Boolean) with Serializable {
 
 @InterfaceAudience.Internal
 case class InPolygon(queryString: String) extends Filter {
-  override def references: Array[String] = null
+  override def references: Array[String] = Array()
 }
 

--- a/integration/spark/src/main/scala/org/apache/carbondata/index/TextMatchUDF.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/index/TextMatchUDF.scala
@@ -37,10 +37,10 @@ class TextMatchMaxDocUDF extends ((String, Int) => Boolean) with Serializable {
 
 @InterfaceAudience.Internal
 case class TextMatch(queryString: String) extends Filter {
-  override def references: Array[String] = null
+  override def references: Array[String] = Array()
 }
 
 @InterfaceAudience.Internal
 case class TextMatchLimit(queryString: String, maxDoc: String) extends Filter {
-  override def references: Array[String] = null
+  override def references: Array[String] = Array()
 }

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonBoundReference.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonBoundReference.scala
@@ -20,18 +20,24 @@ package org.apache.spark.sql
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.sources.Filter
 
+object ExtractReferences {
+  def apply(expr: Expression): Array[String] = {
+    expr.references.map(_.name).toArray
+  }
+}
+
 case class CastExpr(expr: Expression) extends Filter {
-  override def references: Array[String] = null
+  override def references: Array[String] = ExtractReferences(expr)
 }
 
 case class FalseExpr() extends Filter {
-  override def references: Array[String] = null
+  override def references: Array[String] = Array.empty
 }
 
 case class CarbonEndsWith(expr: Expression) extends Filter {
-  override def references: Array[String] = null
+  override def references: Array[String] = ExtractReferences(expr)
 }
 
 case class CarbonContainsWith(expr: Expression) extends Filter {
-  override def references: Array[String] = null
+  override def references: Array[String] = ExtractReferences(expr)
 }

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonDatasourceHadoopRelation.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonDatasourceHadoopRelation.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.execution.command.management.CarbonInsertIntoCommand
 import org.apache.spark.sql.execution.strategy.PushDownHelper
 import org.apache.spark.sql.hive.CarbonRelation
 import org.apache.spark.sql.optimizer.CarbonFilters
-import org.apache.spark.sql.sources.{BaseRelation, Filter, InsertableRelation}
+import org.apache.spark.sql.sources.{And, BaseRelation, Filter, InsertableRelation, Or}
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CarbonException
 
@@ -72,7 +72,9 @@ case class CarbonDatasourceHadoopRelation(
       projects: Seq[NamedExpression],
       filters: Array[Filter],
       partitions: Seq[PartitionSpec]): RDD[InternalRow] = {
-    val filterExpression: Option[Expression] = filters.flatMap { filter =>
+    val reorderedFilter = filters.map(CarbonFilters.reorderFilter(_, carbonTable)).sortBy(_._2)
+    val filterExpression: Option[Expression] = reorderedFilter.flatMap { tuple =>
+      val filter = tuple._1
       CarbonFilters.createCarbonFilter(schema, filter,
         carbonTable.getTableInfo.getFactTable.getTableProperties.asScala)
     }.reduceOption(new AndExpression(_, _))

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonDatasourceHadoopRelation.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonDatasourceHadoopRelation.scala
@@ -72,9 +72,8 @@ case class CarbonDatasourceHadoopRelation(
       projects: Seq[NamedExpression],
       filters: Array[Filter],
       partitions: Seq[PartitionSpec]): RDD[InternalRow] = {
-    val reorderedFilter = filters.map(CarbonFilters.reorderFilter(_, carbonTable)).sortBy(_._2)
-    val filterExpression: Option[Expression] = reorderedFilter.flatMap { tuple =>
-      val filter = tuple._1
+    val reorderedFilter = CarbonFilters.reorderFilter(filters, carbonTable)
+    val filterExpression: Option[Expression] = reorderedFilter.flatMap { filter =>
       CarbonFilters.createCarbonFilter(schema, filter,
         carbonTable.getTableInfo.getFactTable.getTableProperties.asScala)
     }.reduceOption(new AndExpression(_, _))

--- a/integration/spark/src/main/scala/org/apache/spark/sql/hive/execution/command/CarbonHiveCommands.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/hive/execution/command/CarbonHiveCommands.scala
@@ -99,8 +99,7 @@ object CarbonSetCommand {
     if (key.startsWith(CarbonCommonConstants.CARBON_INPUT_SEGMENTS)) {
       if (key.split("\\.").length == 5) {
         sessionParams.addProperty(key.toLowerCase(), value)
-      }
-      else {
+      } else {
         throw new MalformedCarbonCommandException(
           "property should be in \" carbon.input.segments.<database_name>" +
           ".<table_name>=<seg_id list> \" format.")
@@ -121,8 +120,7 @@ object CarbonSetCommand {
     } else if (key.startsWith(CarbonLoadOptionConstants.CARBON_TABLE_LOAD_SORT_SCOPE)) {
       if (key.split("\\.").length == 7) {
         sessionParams.addProperty(key.toLowerCase(), value)
-      }
-      else {
+      } else {
         throw new MalformedCarbonCommandException(
           "property should be in \" carbon.table.load.sort.scope.<database_name>" +
           ".<table_name>=<sort_scope> \" format.")
@@ -132,8 +130,9 @@ object CarbonSetCommand {
       if (keySplits.length == 6 || keySplits.length == 4) {
         sessionParams.addProperty(key.toString, value)
       }
-    }
-    else if (isCarbonProperty) {
+    } else if (key.equalsIgnoreCase(CarbonCommonConstants.CARBON_REORDER_FILTER)) {
+      sessionParams.addProperty(key, value)
+    } else if (isCarbonProperty) {
       sessionParams.addProperty(key, value)
     }
   }

--- a/integration/spark/src/test/scala/org/apache/spark/carbondata/query/TestFilterReordering.scala
+++ b/integration/spark/src/test/scala/org/apache/spark/carbondata/query/TestFilterReordering.scala
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.carbondata.query
+
+import org.apache.spark.sql.CarbonEnv
+import org.apache.spark.sql.optimizer.CarbonFilters
+import org.apache.spark.sql.sources.{And, EqualTo, Filter, Or}
+import org.apache.spark.sql.test.util.QueryTest
+import org.scalatest.BeforeAndAfterAll
+
+class TestFilterReordering extends QueryTest with BeforeAndAfterAll{
+
+  override protected def beforeAll(): Unit = {
+    sql("drop table if exists filter_reorder")
+    sql("create table filter_reorder(one string, two string, three string, four int, " +
+        "five int) stored as carbondata")
+  }
+
+  test("Test filter reorder with various conditions") {
+    val filter1 = Or(And(EqualTo("four", 11), EqualTo("two", 11)), EqualTo("one", 11))
+    val table = CarbonEnv.getCarbonTable(None, "filter_reorder")(sqlContext.sparkSession)
+    var d: (Filter, Int) = CarbonFilters.reorderFilter(filter1, table)
+    assert(d._1.references.sameElements(Array("one", "two", "four")))
+
+    val filter2 = Or(Or(EqualTo("four", 11), EqualTo("two", 11)),
+      Or(EqualTo("one", 11), Or(EqualTo("five", 11), EqualTo("three", 11))))
+    d = CarbonFilters.reorderFilter(filter2, table)
+    assert(d._1.references.sameElements(Array("one", "two", "three", "four", "five")))
+
+    val filter3 = Or(Or(EqualTo("four", 11), EqualTo("two", 11)),
+      Or(EqualTo("one", 11), Or(EqualTo("five", 11),
+        And(EqualTo("three", 11), EqualTo("three", 11)))))
+    d = CarbonFilters.reorderFilter(filter3, table)
+    assert(d._1.references.sameElements(Array("one", "three", "three", "five", "two", "four")))
+  }
+
+  override protected def afterAll(): Unit = {
+    sql("drop table if exists filter_reorder")
+  }
+}


### PR DESCRIPTION
 ### Why is this PR needed?
 Currently the filter is being executed in the user specified order, which may be different than the storage order. This can cause a lot of backward seek in cloud storage solutions resulting in slower performance.
 
 ### What changes were proposed in this PR?
Reorder the filter according to the column storage ordinal.
    
 ### Does this PR introduce any user interface change?
 - No
 - Yes. (please explain the change and update document)

 ### Is any new testcase added?
 - No
 - Yes

    
