### PR TITLE
[CARBONDATA-3966]Fix NullPointerException issue in case of reliability testing of load and compaction

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/readcommitter/TableStatusReadCommittedScope.java
+++ b/core/src/main/java/org/apache/carbondata/core/readcommitter/TableStatusReadCommittedScope.java
@@ -22,6 +22,7 @@ import java.util.Map;
 
 import org.apache.carbondata.common.annotations.InterfaceAudience;
 import org.apache.carbondata.common.annotations.InterfaceStability;
+import org.apache.carbondata.core.datastore.filesystem.CarbonFile;
 import org.apache.carbondata.core.datastore.impl.FileFactory;
 import org.apache.carbondata.core.index.Segment;
 import org.apache.carbondata.core.indexstore.blockletindex.SegmentIndexFileStore;
@@ -100,9 +101,11 @@ public class TableStatusReadCommittedScope implements ReadCommittedScope {
     if (null != segment.getLoadMetadataDetails()) {
       segmentFileTimeStamp = segment.getLoadMetadataDetails().getLastModifiedTime();
     } else if (null != segment.getSegmentFileName()) {
-      segmentFileTimeStamp = FileFactory.getCarbonFile(CarbonTablePath
-          .getSegmentFilePath(identifier.getTablePath(), segment.getSegmentFileName()))
-          .getLastModifiedTime();
+      CarbonFile segmentFile = FileFactory.getCarbonFile(CarbonTablePath
+          .getSegmentFilePath(identifier.getTablePath(), segment.getSegmentFileName()));
+      if (segmentFile.exists()) {
+        segmentFileTimeStamp = segmentFile.getLastModifiedTime();
+      }
     }
     if (updateVo != null) {
       segmentRefreshInfo =


### PR DESCRIPTION
 ### Why is this PR needed?
During the carbondata reliability and concurrency test of load, compaction and query, Some times nullPointerException is thrown. This is because, in `TableSegmentRefresher ` we get the last modified timestamp of the segment file, to decide to refresh the cache, in case of concurrency, it can happen that the segment file get deleted or during update, file may not be there, that time getLastModified time throws null pointer.
 
 ### What changes were proposed in this PR?
Before get the last modified time, always check for the file exists, as it can be deleted during that time due to concurrency, if not present, initialize to zero.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No(verified with concurrency of 1000s of segments.

    
