### PR TITLE
[CARBONDATA-3972] Date/timestamp compatability between hive and carbon

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/keygenerator/directdictionary/timestamp/DateDirectDictionaryGenerator.java
+++ b/core/src/main/java/org/apache/carbondata/core/keygenerator/directdictionary/timestamp/DateDirectDictionaryGenerator.java
@@ -54,14 +54,16 @@ public class DateDirectDictionaryGenerator extends AbstractDirectDictionaryGener
   static {
     SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd");
     df.setTimeZone(TimeZone.getTimeZone("GMT"));
+    df.setLenient(true);
     long minValue = 0;
     long maxValue = 0;
     try {
-      minValue = df.parse("0001-01-01").getTime();
+      minValue = df.parse("0000-01-01").getTime();
       maxValue = df.parse("9999-12-31").getTime();
     } catch (ParseException e) {
       // the Exception will not occur as constant value is being parsed
     }
+    df.setLenient(false);
     MIN_VALUE = minValue;
     MAX_VALUE = maxValue;
   }


### PR DESCRIPTION
 ### Why is this PR needed?
To ensure the date/timestamp that is supported by hive also to be supported by carbon.
Ex: 0000-01-01 is accepted by hive as a valid record and converted to 0001-01-01.
 
 ### What changes were proposed in this PR?
Changed the min value of date which is used for validation. When setlenient flag is set to true, carbon can convert and support
0000 year.
    
 ### Does this PR introduce any user interface change?
 - No
 - Yes. (please explain the change and update document)

 ### Is any new testcase added?
 - No
 - Yes

    
