### PR TITLE
[CARBONDATA-3974] Improve partition purning performance in presto carbon integration

### DIFF
--- a/integration/presto/src/main/prestodb/org/apache/carbondata/presto/CarbondataModule.java
+++ b/integration/presto/src/main/prestodb/org/apache/carbondata/presto/CarbondataModule.java
@@ -21,6 +21,8 @@ import java.util.function.Supplier;
 
 import static java.util.Objects.requireNonNull;
 
+import org.apache.carbondata.core.constants.CarbonCommonConstants;
+import org.apache.carbondata.core.util.CarbonProperties;
 import org.apache.carbondata.presto.impl.CarbonTableReader;
 
 import com.facebook.presto.hive.CoercionPolicy;

--- a/integration/presto/src/main/prestodb/org/apache/carbondata/presto/impl/CarbonTableReader.java
+++ b/integration/presto/src/main/prestodb/org/apache/carbondata/presto/impl/CarbonTableReader.java
@@ -247,7 +247,7 @@ public class CarbonTableReader {
    *
    * @param tableCacheModel cached table
    * @param filters carbonData filters
-   * @param constraints presto filters
+   * @param filteredPartitions matched partitionSpec for the filter
    * @param config hadoop conf
    * @return list of multiblock split
    * @throws IOException
@@ -255,7 +255,7 @@ public class CarbonTableReader {
   public List<CarbonLocalMultiBlockSplit> getInputSplits(
       CarbonTableCacheModel tableCacheModel,
       Expression filters,
-      TupleDomain<HiveColumnHandle> constraints,
+      List<PartitionSpec> filteredPartitions,
       Configuration config) throws IOException {
     List<CarbonLocalInputSplit> result = new ArrayList<>();
     List<CarbonLocalMultiBlockSplit> multiBlockSplitList = new ArrayList<>();
@@ -272,15 +272,6 @@ public class CarbonTableReader {
     CarbonInputFormat.setTableInfo(config, carbonTable.getTableInfo());
 
     JobConf jobConf = new JobConf(config);
-    List<PartitionSpec> filteredPartitions = new ArrayList<>();
-
-    PartitionInfo partitionInfo = carbonTable.getPartitionInfo();
-    LoadMetadataDetails[] loadMetadataDetails = null;
-    if (partitionInfo != null && partitionInfo.getPartitionType() == PartitionType.NATIVE_HIVE) {
-      loadMetadataDetails = SegmentStatusManager.readTableStatusFile(
-          CarbonTablePath.getTableStatusFilePath(carbonTable.getTablePath()));
-      filteredPartitions = findRequiredPartitions(constraints, carbonTable, loadMetadataDetails);
-    }
     try {
       CarbonTableInputFormat.setTableInfo(config, tableInfo);
       CarbonTableInputFormat<Object> carbonTableInputFormat =

--- a/integration/presto/src/main/prestodb/org/apache/carbondata/presto/readers/ComplexTypeStreamReader.java
+++ b/integration/presto/src/main/prestodb/org/apache/carbondata/presto/readers/ComplexTypeStreamReader.java
@@ -1,0 +1,196 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.presto.readers;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import com.facebook.presto.spi.block.ArrayBlock;
+import com.facebook.presto.spi.block.RowBlock;
+import com.facebook.presto.spi.type.*;
+
+import org.apache.carbondata.core.metadata.datatype.DataType;
+import org.apache.carbondata.core.metadata.datatype.DataTypes;
+import org.apache.carbondata.core.metadata.datatype.StructField;
+import org.apache.carbondata.core.scan.result.vector.CarbonColumnVector;
+import org.apache.carbondata.core.scan.result.vector.impl.CarbonColumnVectorImpl;
+
+import com.facebook.presto.spi.block.Block;
+import com.facebook.presto.spi.block.BlockBuilder;
+
+import org.apache.carbondata.presto.CarbonVectorBatch;
+import org.apache.carbondata.presto.ColumnarVectorWrapperDirect;
+
+/**
+ * Class to read the complex type Stream [array/struct/map]
+ */
+
+public class ComplexTypeStreamReader extends CarbonColumnVectorImpl
+    implements PrestoVectorBlockBuilder {
+
+  protected int batchSize;
+
+  protected Type type;
+  protected BlockBuilder builder;
+
+  public ComplexTypeStreamReader(int batchSize, StructField field) {
+    super(batchSize, field.getDataType());
+    this.batchSize = batchSize;
+    this.type = getType(field);
+    List<CarbonColumnVector> childrenList = new ArrayList<>();
+    for (StructField child : field.getChildren()) {
+      childrenList.add(new ColumnarVectorWrapperDirect(Objects.requireNonNull(
+          CarbonVectorBatch.createDirectStreamReader(this.batchSize, child.getDataType(), child))));
+    }
+    setChildrenVector(childrenList);
+    this.builder = type.createBlockBuilder(null, batchSize);
+  }
+
+  Type getType(StructField field) {
+    DataType dataType = field.getDataType();
+    if (dataType == DataTypes.STRING || dataType == DataTypes.VARCHAR) {
+      return VarcharType.VARCHAR;
+    } else if (dataType == DataTypes.SHORT) {
+      return SmallintType.SMALLINT;
+    } else if (dataType == DataTypes.INT) {
+      return IntegerType.INTEGER;
+    } else if (dataType == DataTypes.LONG) {
+      return BigintType.BIGINT;
+    } else if (dataType == DataTypes.DOUBLE) {
+      return DoubleType.DOUBLE;
+    } else if (dataType == DataTypes.FLOAT) {
+      return RealType.REAL;
+    } else if (dataType == DataTypes.BOOLEAN) {
+      return BooleanType.BOOLEAN;
+    } else if (dataType == DataTypes.BINARY) {
+      return VarbinaryType.VARBINARY;
+    } else if (dataType == DataTypes.DATE) {
+      return DateType.DATE;
+    } else if (dataType == DataTypes.TIMESTAMP) {
+      return TimestampType.TIMESTAMP;
+    } else if (dataType == DataTypes.BYTE) {
+      return TinyintType.TINYINT;
+    } else if (DataTypes.isDecimal(dataType)) {
+      org.apache.carbondata.core.metadata.datatype.DecimalType decimal =
+          (org.apache.carbondata.core.metadata.datatype.DecimalType) dataType;
+      return DecimalType.createDecimalType(decimal.getPrecision(), decimal.getScale());
+    } else if (DataTypes.isArrayType(dataType)) {
+      return new ArrayType(getType(field.getChildren().get(0)));
+    } else if (DataTypes.isStructType(dataType)) {
+      List<RowType.Field> children = new ArrayList<>();
+      for (StructField child : field.getChildren()) {
+        children.add(new RowType.Field(Optional.of(child.getFieldName()), getType(child)));
+      }
+      return RowType.from(children);
+    } else {
+      throw new UnsupportedOperationException("Unsupported type: " + dataType);
+    }
+  }
+
+  @Override public Block buildBlock() {
+    return builder.build();
+  }
+
+  @Override public void setBatchSize(int batchSize) {
+    this.batchSize = batchSize;
+  }
+
+  public void putComplexObject(List<Integer> offsetVector) {
+    if (type instanceof ArrayType) {
+      // build child block
+      Block childBlock = buildChildBlock(getChildrenVector().get(0));
+      // prepare an offset vector with 0 as initial offset
+      int[] offsetVectorArray = new int[offsetVector.size() + 1];
+      for (int i = 1; i <= offsetVector.size(); i++) {
+        offsetVectorArray[i] = offsetVectorArray[i - 1] + offsetVector.get(i - 1);
+      }
+      // prepare Array block
+      Block arrayBlock = ArrayBlock
+          .fromElementBlock(offsetVector.size(), Optional.empty(), offsetVectorArray,
+              childBlock);
+      for (int position = 0; position < offsetVector.size(); position++) {
+        type.writeObject(builder, arrayBlock.getObject(position, Block.class));
+      }
+      getChildrenVector().get(0).getColumnVector().reset();
+    } else {
+      // build child blocks
+      List<Block> childBlocks = new ArrayList<>(getChildrenVector().size());
+      for (CarbonColumnVector child : getChildrenVector()) {
+        childBlocks.add(buildChildBlock(child));
+      }
+      // prepare ROW block
+      Block rowBlock = RowBlock
+          .fromFieldBlocks(childBlocks.get(0).getPositionCount(), Optional.empty(),
+              childBlocks.toArray(new Block[0]));
+      for (int position = 0; position < childBlocks.get(0).getPositionCount(); position++) {
+        type.writeObject(builder, rowBlock.getObject(position, Block.class));
+      }
+      for (CarbonColumnVector child : getChildrenVector()) {
+        child.getColumnVector().reset();
+      }
+    }
+  }
+
+  private Block buildChildBlock(CarbonColumnVector carbonColumnVector) {
+    DataType dataType = carbonColumnVector.getType();
+    carbonColumnVector = carbonColumnVector.getColumnVector();
+    if (dataType == DataTypes.STRING || dataType == DataTypes.BINARY
+        || dataType == DataTypes.VARCHAR) {
+      return ((SliceStreamReader) carbonColumnVector).buildBlock();
+    } else if (dataType == DataTypes.SHORT) {
+      return ((ShortStreamReader) carbonColumnVector).buildBlock();
+    } else if (dataType == DataTypes.INT || dataType == DataTypes.DATE) {
+      return ((IntegerStreamReader) carbonColumnVector).buildBlock();
+    } else if (dataType == DataTypes.LONG) {
+      return ((LongStreamReader) carbonColumnVector).buildBlock();
+    } else if (dataType == DataTypes.DOUBLE) {
+      return ((DoubleStreamReader) carbonColumnVector).buildBlock();
+    } else if (dataType == DataTypes.FLOAT) {
+      return ((FloatStreamReader) carbonColumnVector).buildBlock();
+    } else if (dataType == DataTypes.TIMESTAMP) {
+      return ((TimestampStreamReader) carbonColumnVector).buildBlock();
+    } else if (dataType == DataTypes.BOOLEAN) {
+      return ((BooleanStreamReader) carbonColumnVector).buildBlock();
+    } else if (DataTypes.isDecimal(dataType)) {
+      return ((DecimalSliceStreamReader) carbonColumnVector).buildBlock();
+    } else if (dataType == DataTypes.BYTE) {
+      return ((ByteStreamReader) carbonColumnVector).buildBlock();
+    } else if (DataTypes.isArrayType(dataType) || (DataTypes.isStructType(dataType))) {
+      return ((ComplexTypeStreamReader) carbonColumnVector).buildBlock();
+    } else {
+      throw new UnsupportedOperationException("unsupported for type :" + dataType);
+    }
+  }
+
+  @Override public void putNull(int rowId) {
+    builder.appendNull();
+  }
+
+  @Override public void reset() {
+    builder = type.createBlockBuilder(null, batchSize);
+  }
+
+  @Override public void putNulls(int rowId, int count) {
+    for (int i = 0; i < count; i++) {
+      builder.appendNull();
+    }
+  }
+}
+

--- a/integration/presto/src/main/prestodb/org/apache/carbondata/presto/readers/SliceStreamReader.java
+++ b/integration/presto/src/main/prestodb/org/apache/carbondata/presto/readers/SliceStreamReader.java
@@ -151,7 +151,7 @@ public class SliceStreamReader extends CarbonColumnVectorImpl implements PrestoV
       putNull(rowId);
     } else {
       if (dictionaryBlock == null) {
-        putByteArray(rowId, ByteUtil.toBytes((String) value));
+        putByteArray(rowId, (byte []) value);
       } else {
         putInt(rowId, (int) value);
       }

--- a/integration/presto/src/main/prestosql/org/apache/carbondata/presto/impl/CarbonTableReader.java
+++ b/integration/presto/src/main/prestosql/org/apache/carbondata/presto/impl/CarbonTableReader.java
@@ -247,9 +247,11 @@ public class CarbonTableReader {
    * @return list of multiblock split
    * @throws IOException
    */
-  public List<CarbonLocalMultiBlockSplit> getInputSplits(CarbonTableCacheModel tableCacheModel,
-      Expression filters, List<PartitionSpec> filteredPartitions, Configuration config)
-      throws IOException {
+  public List<CarbonLocalMultiBlockSplit> getInputSplits(
+      CarbonTableCacheModel tableCacheModel,
+      Expression filters,
+      List<PartitionSpec> filteredPartitions,
+      Configuration config) throws IOException {
     List<CarbonLocalInputSplit> result = new ArrayList<>();
     List<CarbonLocalMultiBlockSplit> multiBlockSplitList = new ArrayList<>();
     CarbonTable carbonTable = tableCacheModel.getCarbonTable();

--- a/integration/presto/src/test/prestodb/org/apache/carbondata/presto/server/PrestoTestUtil.scala
+++ b/integration/presto/src/test/prestodb/org/apache/carbondata/presto/server/PrestoTestUtil.scala
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.presto.server
+
+import com.facebook.presto.jdbc.PrestoArray
+
+
+object PrestoTestUtil {
+
+  // this method depends on prestodb jdbc PrestoArray class
+  def validateArrayOfPrimitiveTypeData(actualResult: List[Map[String, Any]],
+      longChar: String): Unit = {
+    for (row <- 0 to 1) {
+      val column1 = actualResult(row)("stringfield")
+      if (column1 == "row1") {
+        val column2 = actualResult(row)("arraybyte")
+          .asInstanceOf[PrestoArray]
+          .getArray()
+          .asInstanceOf[Array[Object]]
+        val column3 = actualResult(row)("arrayshort")
+          .asInstanceOf[PrestoArray]
+          .getArray()
+          .asInstanceOf[Array[Object]]
+        val column4 = actualResult(row)("arrayint")
+          .asInstanceOf[PrestoArray]
+          .getArray()
+          .asInstanceOf[Array[Object]]
+        assert(column2(0) == null)
+        assert(column3(0) == null)
+        assert(column4(0) == null)
+      } else if (column1 == "row2") {
+        val column2 = actualResult(row)("arrayint")
+          .asInstanceOf[PrestoArray]
+          .getArray()
+          .asInstanceOf[Array[Object]]
+        if (column2.sameElements(Array(4))) {
+          val column3 = actualResult(row)("arraybyte")
+            .asInstanceOf[PrestoArray]
+            .getArray()
+            .asInstanceOf[Array[Object]]
+          val column4 = actualResult(row)("arrayshort")
+            .asInstanceOf[PrestoArray]
+            .getArray()
+            .asInstanceOf[Array[Object]]
+          val column5 = actualResult(row)("arraylong")
+            .asInstanceOf[PrestoArray]
+            .getArray()
+            .asInstanceOf[Array[Object]]
+          val column6 = actualResult(row)("arrayfloat")
+            .asInstanceOf[PrestoArray]
+            .getArray()
+            .asInstanceOf[Array[Object]]
+          val column7 = actualResult(row)("arraydouble")
+            .asInstanceOf[PrestoArray]
+            .getArray()
+            .asInstanceOf[Array[Object]]
+          val column8 = actualResult(row)("arraybinary")
+            .asInstanceOf[PrestoArray]
+            .getArray()
+            .asInstanceOf[Array[Object]]
+          val column9 = actualResult(row)("arraydate")
+            .asInstanceOf[PrestoArray]
+            .getArray()
+            .asInstanceOf[Array[Object]]
+          val column10 = actualResult(row)("arraytimestamp")
+            .asInstanceOf[PrestoArray]
+            .getArray()
+            .asInstanceOf[Array[Object]]
+          val column11 = actualResult(row)("arrayboolean")
+            .asInstanceOf[PrestoArray]
+            .getArray()
+            .asInstanceOf[Array[Object]]
+          val column12 = actualResult(row)("arrayvarchar")
+            .asInstanceOf[PrestoArray]
+            .getArray()
+            .asInstanceOf[Array[Object]]
+          val column13 = actualResult(row)("arraydecimal")
+            .asInstanceOf[PrestoArray]
+            .getArray()
+            .asInstanceOf[Array[Object]]
+          val column14 = actualResult(row)("arraystring")
+            .asInstanceOf[PrestoArray]
+            .getArray()
+            .asInstanceOf[Array[Object]]
+
+          assert(column3.sameElements(Array(3, 5, 4)))
+          assert(column4.sameElements(Array(4, 5, 6)))
+          assert(column5.sameElements(Array(2L, 59999999L, 99999999999L)))
+          assert(column6.sameElements(Array(5.4646f, 5.55f, 0.055f)))
+          assert(column7.sameElements(Array(5.46464646464, 5.55, 0.055)))
+          assert(column8(0).asInstanceOf[Array[Byte]].length == 118198)
+          assert(column9.sameElements(Array("2019-03-02", "2020-03-02", "2021-04-02")))
+          assert(column10.sameElements(Array("2019-02-12 03:03:34.000",
+            "2020-02-12 03:03:34.000",
+            "2021-03-12 03:03:34.000")))
+          assert(column11.sameElements(Array(true, false)))
+          assert(column12.sameElements(Array(longChar)))
+          assert(column13.sameElements(Array("999.23", "0.12")))
+          assert(column14.sameElements(Array("japan", "china", "iceland")))
+        }
+      }
+    }
+  }
+}

--- a/integration/presto/src/test/prestodb/org/apache/carbondata/presto/server/PrestoTestUtil.scala
+++ b/integration/presto/src/test/prestodb/org/apache/carbondata/presto/server/PrestoTestUtil.scala
@@ -18,7 +18,6 @@ package org.apache.carbondata.presto.server
 
 import com.facebook.presto.jdbc.PrestoArray
 
-
 object PrestoTestUtil {
 
   // this method depends on prestodb jdbc PrestoArray class

--- a/integration/presto/src/test/prestosql/org/apache/carbondata/presto/server/PrestoTestUtil.scala
+++ b/integration/presto/src/test/prestosql/org/apache/carbondata/presto/server/PrestoTestUtil.scala
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.presto.server
+
+import io.prestosql.jdbc.PrestoArray
+
+
+object PrestoTestUtil {
+
+  // this method depends on prestosql jdbc PrestoArray class
+  def validateArrayOfPrimitiveTypeData(actualResult: List[Map[String, Any]],
+      longChar: String): Unit = {
+    for (row <- 0 to 1) {
+      val column1 = actualResult(row)("stringfield")
+      if (column1 == "row1") {
+        val column2 = actualResult(row)("arraybyte")
+          .asInstanceOf[PrestoArray]
+          .getArray()
+          .asInstanceOf[Array[Object]]
+        val column3 = actualResult(row)("arrayshort")
+          .asInstanceOf[PrestoArray]
+          .getArray()
+          .asInstanceOf[Array[Object]]
+        val column4 = actualResult(row)("arrayint")
+          .asInstanceOf[PrestoArray]
+          .getArray()
+          .asInstanceOf[Array[Object]]
+        assert(column2(0) == null)
+        assert(column3(0) == null)
+        assert(column4(0) == null)
+      } else if (column1 == "row2") {
+        val column2 = actualResult(row)("arrayint")
+          .asInstanceOf[PrestoArray]
+          .getArray()
+          .asInstanceOf[Array[Object]]
+        if (column2.sameElements(Array(4))) {
+          val column3 = actualResult(row)("arraybyte")
+            .asInstanceOf[PrestoArray]
+            .getArray()
+            .asInstanceOf[Array[Object]]
+          val column4 = actualResult(row)("arrayshort")
+            .asInstanceOf[PrestoArray]
+            .getArray()
+            .asInstanceOf[Array[Object]]
+          val column5 = actualResult(row)("arraylong")
+            .asInstanceOf[PrestoArray]
+            .getArray()
+            .asInstanceOf[Array[Object]]
+          val column6 = actualResult(row)("arrayfloat")
+            .asInstanceOf[PrestoArray]
+            .getArray()
+            .asInstanceOf[Array[Object]]
+          val column7 = actualResult(row)("arraydouble")
+            .asInstanceOf[PrestoArray]
+            .getArray()
+            .asInstanceOf[Array[Object]]
+          val column8 = actualResult(row)("arraybinary")
+            .asInstanceOf[PrestoArray]
+            .getArray()
+            .asInstanceOf[Array[Object]]
+          val column9 = actualResult(row)("arraydate")
+            .asInstanceOf[PrestoArray]
+            .getArray()
+            .asInstanceOf[Array[Object]]
+          val column10 = actualResult(row)("arraytimestamp")
+            .asInstanceOf[PrestoArray]
+            .getArray()
+            .asInstanceOf[Array[Object]]
+          val column11 = actualResult(row)("arrayboolean")
+            .asInstanceOf[PrestoArray]
+            .getArray()
+            .asInstanceOf[Array[Object]]
+          val column12 = actualResult(row)("arrayvarchar")
+            .asInstanceOf[PrestoArray]
+            .getArray()
+            .asInstanceOf[Array[Object]]
+          val column13 = actualResult(row)("arraydecimal")
+            .asInstanceOf[PrestoArray]
+            .getArray()
+            .asInstanceOf[Array[Object]]
+          val column14 = actualResult(row)("arraystring")
+            .asInstanceOf[PrestoArray]
+            .getArray()
+            .asInstanceOf[Array[Object]]
+
+          assert(column3.sameElements(Array(3, 5, 4)))
+          assert(column4.sameElements(Array(4, 5, 6)))
+          assert(column5.sameElements(Array(2L, 59999999L, 99999999999L)))
+          assert(column6.sameElements(Array(5.4646f, 5.55f, 0.055f)))
+          assert(column7.sameElements(Array(5.46464646464, 5.55, 0.055)))
+          assert(column8(0).asInstanceOf[Array[Byte]].length == 118198)
+          assert(column9.sameElements(Array("2019-03-02", "2020-03-02", "2021-04-02")))
+          assert(column10.sameElements(Array("2019-02-12 03:03:34.000",
+            "2020-02-12 03:03:34.000",
+            "2021-03-12 03:03:34.000")))
+          assert(column11.sameElements(Array(true, false)))
+          assert(column12.sameElements(Array(longChar)))
+          assert(column13.sameElements(Array("999.23", "0.12")))
+          assert(column14.sameElements(Array("japan", "china", "iceland")))
+        }
+      }
+    }
+  }
+}

--- a/integration/presto/src/test/prestosql/org/apache/carbondata/presto/server/PrestoTestUtil.scala
+++ b/integration/presto/src/test/prestosql/org/apache/carbondata/presto/server/PrestoTestUtil.scala
@@ -18,7 +18,6 @@ package org.apache.carbondata.presto.server
 
 import io.prestosql.jdbc.PrestoArray
 
-
 object PrestoTestUtil {
 
   // this method depends on prestosql jdbc PrestoArray class

--- a/integration/presto/src/test/scala/org/apache/carbondata/presto/integrationtest/PrestoTestNonTransactionalTableFiles.scala
+++ b/integration/presto/src/test/scala/org/apache/carbondata/presto/integrationtest/PrestoTestNonTransactionalTableFiles.scala
@@ -32,10 +32,9 @@ import org.apache.carbondata.core.datastore.filesystem.CarbonFile
 import org.apache.carbondata.core.datastore.impl.FileFactory
 import org.apache.carbondata.core.metadata.datatype.{DataTypes, Field, StructField}
 import org.apache.carbondata.core.util.{CarbonProperties, CarbonUtil}
-import org.apache.carbondata.presto.server.PrestoServer
+import org.apache.carbondata.presto.server.{PrestoServer, PrestoTestUtil}
 import org.apache.carbondata.sdk.file.{CarbonWriter, Schema}
 
-import io.prestosql.jdbc.PrestoArray
 
 class PrestoTestNonTransactionalTableFiles extends FunSuiteLike with BeforeAndAfterAll with BeforeAndAfterEach {
 
@@ -617,46 +616,7 @@ class PrestoTestNonTransactionalTableFiles extends FunSuiteLike with BeforeAndAf
       .executeQuery("select * from files5 ")
 
     assert(actualResult.size == 2)
-    for( row <- 0 to 1) {
-      var column1 = actualResult(row)("stringfield")
-      if(column1 == "row1") {
-        var column2 =  actualResult(row)("arraybyte").asInstanceOf[PrestoArray].getArray().asInstanceOf[Array[Object]]
-        var column3 =  actualResult(row)("arrayshort").asInstanceOf[PrestoArray].getArray().asInstanceOf[Array[Object]]
-        var column4 =  actualResult(row)("arrayint").asInstanceOf[PrestoArray].getArray().asInstanceOf[Array[Object]]
-        assert(column2(0) == null)
-        assert(column3(0) == null)
-        assert(column4(0) == null)
-      } else if(column1 == "row2") {
-        var column2 =  actualResult(row)("arrayint").asInstanceOf[PrestoArray].getArray().asInstanceOf[Array[Object]]
-        if (column2.sameElements(Array(4))) {
-          var column3 =  actualResult(row)("arraybyte").asInstanceOf[PrestoArray].getArray().asInstanceOf[Array[Object]]
-          var column4 =  actualResult(row)("arrayshort").asInstanceOf[PrestoArray].getArray().asInstanceOf[Array[Object]]
-          var column5 =  actualResult(row)("arraylong").asInstanceOf[PrestoArray].getArray().asInstanceOf[Array[Object]]
-          var column6 =  actualResult(row)("arrayfloat").asInstanceOf[PrestoArray].getArray().asInstanceOf[Array[Object]]
-          var column7 =  actualResult(row)("arraydouble").asInstanceOf[PrestoArray].getArray().asInstanceOf[Array[Object]]
-          var column8 =  actualResult(row)("arraybinary").asInstanceOf[PrestoArray].getArray().asInstanceOf[Array[Object]]
-          var column9 =  actualResult(row)("arraydate").asInstanceOf[PrestoArray].getArray().asInstanceOf[Array[Object]]
-          var column10 =  actualResult(row)("arraytimestamp").asInstanceOf[PrestoArray].getArray().asInstanceOf[Array[Object]]
-          var column11 =  actualResult(row)("arrayboolean").asInstanceOf[PrestoArray].getArray().asInstanceOf[Array[Object]]
-          var column12 =  actualResult(row)("arrayvarchar").asInstanceOf[PrestoArray].getArray().asInstanceOf[Array[Object]]
-          var column13 =  actualResult(row)("arraydecimal").asInstanceOf[PrestoArray].getArray().asInstanceOf[Array[Object]]
-          var column14 =  actualResult(row)("arraystring").asInstanceOf[PrestoArray].getArray().asInstanceOf[Array[Object]]
-
-          assert(column3.sameElements(Array(3,5,4)))
-          assert(column4.sameElements(Array(4,5,6)))
-          assert(column5.sameElements(Array(2L,59999999L, 99999999999L)))
-          assert(column6.sameElements(Array(5.4646f,5.55f,0.055f)))
-          assert(column7.sameElements(Array(5.46464646464,5.55,0.055)))
-          assert(column8(0).asInstanceOf[Array[Byte]].size == 118198)
-          assert(column9.sameElements(Array("2019-03-02","2020-03-02","2021-04-02")))
-          assert(column10.sameElements(Array("2019-02-12 03:03:34.000","2020-02-12 03:03:34.000","2021-03-12 03:03:34.000")))
-          assert(column11.sameElements(Array(true,false)))
-          assert(column12.sameElements(Array(longChar)))
-          assert(column13.sameElements(Array("999.23","0.12")))
-          assert(column14.sameElements(Array("japan","china","iceland")))
-        }
-      }
-    }
+    PrestoTestUtil.validateArrayOfPrimitiveTypeData(actualResult, longChar)
     FileUtils.deleteDirectory(new File(writerPathComplex))
   }
 


### PR DESCRIPTION
 ### Why is this PR needed?
a) For 200K segments table in cloud, presto partition query was taking more than 5 hours. the reason is it was reading all segment files for partition pruning. Now it is less than a minute !
b) If the query filter is < or > or more than one value. Partition pruning is not working in presto. 
c) prestodb profile compilation is broken from previous PR

 ### What changes were proposed in this PR?
a)  HiveTableHandle already have partition spec, matching for the filters (it has queried metastore to get all partitions and pruned it). So, create partitionSpec based on that. Also handled for both prestodb and prestosql  
b)  #3885 , broke prestodb compilation, only prestosql is compiled. 
c)  #3887, also didn't handled prestodb

    
 ### Does this PR introduce any user interface change?
 - No


 ### Is any new testcase added?
 - No [Need to add spark support and create better UT for presto, TODO]
verified manually


    
