### PR TITLE
[CARBONDATA-3981] Presto filter check on binary, byte and float datatypes

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/util/DataTypeUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/DataTypeUtil.java
@@ -327,6 +327,11 @@ public final class DataTypeUtil {
           return null;
         }
         return Float.parseFloat(data);
+      } else if (actualDataType == DataTypes.BYTE) {
+        if (data.isEmpty()) {
+          return null;
+        }
+        return Byte.parseByte(data);
       } else if (actualDataType == DataTypes.DOUBLE) {
         if (data.isEmpty()) {
           return null;

--- a/integration/presto/src/main/prestodb/org/apache/carbondata/presto/PrestoFilterUtil.java
+++ b/integration/presto/src/main/prestodb/org/apache/carbondata/presto/PrestoFilterUtil.java
@@ -78,16 +78,22 @@ public class PrestoFilterUtil {
     HiveType colType = columnHandle.getHiveType();
     if (colType.equals(HiveType.HIVE_BOOLEAN)) {
       return DataTypes.BOOLEAN;
+    } else if (colType.equals(HiveType.HIVE_BINARY)) {
+      return DataTypes.BINARY;
     } else if (colType.equals(HiveType.HIVE_SHORT)) {
       return DataTypes.SHORT;
     } else if (colType.equals(HiveType.HIVE_INT)) {
       return DataTypes.INT;
+    } else if (colType.equals(HiveType.HIVE_FLOAT)) {
+      return DataTypes.FLOAT;
     } else if (colType.equals(HiveType.HIVE_LONG)) {
       return DataTypes.LONG;
     } else if (colType.equals(HiveType.HIVE_DOUBLE)) {
       return DataTypes.DOUBLE;
     } else if (colType.equals(HiveType.HIVE_STRING)) {
       return DataTypes.STRING;
+    } else if (colType.equals(HiveType.HIVE_BYTE)) {
+      return DataTypes.BYTE;
     } else if (colType.equals(HiveType.HIVE_DATE)) {
       return DataTypes.DATE;
     } else if (colType.equals(HiveType.HIVE_TIMESTAMP)) {
@@ -282,9 +288,11 @@ public class PrestoFilterUtil {
   private static Object convertDataByType(Object rawData, HiveType type) {
     if (type.equals(HiveType.HIVE_INT) || type.equals(HiveType.HIVE_SHORT)) {
       return Integer.valueOf(rawData.toString());
+    } else if (type.equals(HiveType.HIVE_FLOAT)) {
+      return Float.intBitsToFloat((int) ((Long) rawData).longValue());
     } else if (type.equals(HiveType.HIVE_LONG)) {
       return rawData;
-    } else if (type.equals(HiveType.HIVE_STRING)) {
+    } else if (type.equals(HiveType.HIVE_STRING) || type.equals(HiveType.HIVE_BINARY)) {
       if (rawData instanceof Slice) {
         return ((Slice) rawData).toStringUtf8();
       } else {

--- a/integration/presto/src/main/prestosql/org/apache/carbondata/presto/PrestoFilterUtil.java
+++ b/integration/presto/src/main/prestosql/org/apache/carbondata/presto/PrestoFilterUtil.java
@@ -78,16 +78,22 @@ public class PrestoFilterUtil {
     HiveType colType = columnHandle.getHiveType();
     if (colType.equals(HiveType.HIVE_BOOLEAN)) {
       return DataTypes.BOOLEAN;
+    } else if (colType.equals(HiveType.HIVE_BINARY)) {
+      return DataTypes.BINARY;
     } else if (colType.equals(HiveType.HIVE_SHORT)) {
       return DataTypes.SHORT;
     } else if (colType.equals(HiveType.HIVE_INT)) {
       return DataTypes.INT;
+    } else if (colType.equals(HiveType.HIVE_FLOAT)) {
+      return DataTypes.FLOAT;
     } else if (colType.equals(HiveType.HIVE_LONG)) {
       return DataTypes.LONG;
     } else if (colType.equals(HiveType.HIVE_DOUBLE)) {
       return DataTypes.DOUBLE;
     } else if (colType.equals(HiveType.HIVE_STRING)) {
       return DataTypes.STRING;
+    } else if (colType.equals(HiveType.HIVE_BYTE)) {
+      return DataTypes.BYTE;
     } else if (colType.equals(HiveType.HIVE_DATE)) {
       return DataTypes.DATE;
     } else if (colType.equals(HiveType.HIVE_TIMESTAMP)) {
@@ -282,9 +288,11 @@ public class PrestoFilterUtil {
   private static Object convertDataByType(Object rawData, HiveType type) {
     if (type.equals(HiveType.HIVE_INT) || type.equals(HiveType.HIVE_SHORT)) {
       return Integer.valueOf(rawData.toString());
+    } else if (type.equals(HiveType.HIVE_FLOAT)) {
+      return Float.intBitsToFloat((int) ((Long) rawData).longValue());
     } else if (type.equals(HiveType.HIVE_LONG)) {
       return rawData;
-    } else if (type.equals(HiveType.HIVE_STRING)) {
+    } else if (type.equals(HiveType.HIVE_STRING) || type.equals(HiveType.HIVE_BINARY)) {
       if (rawData instanceof Slice) {
         return ((Slice) rawData).toStringUtf8();
       } else {


### PR DESCRIPTION
 ### Why is this PR needed?
 Due to the absence of binary, byte and float datatypes check, there were either empty results or a problem during object serialisation in presto filter queries.
 
 ### What changes were proposed in this PR?
 Above datatype conversions and checks has been added in prestoFIlterUtil.java
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
