### PR TITLE
[CARBONDATA-3983] SI compatability issue

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -1878,6 +1878,11 @@ public final class CarbonCommonConstants {
   public static final String UNDERSCORE = "_";
 
   /**
+   * EQUALS
+   */
+  public static final String EQUALS = "=";
+
+  /**
    * POINT
    */
   public static final String POINT = ".";


### PR DESCRIPTION
 ### Why is this PR needed?
Read from maintable having SI returns empty resultset when SI is stored with old tuple id storage format. 
 
 ### What changes were proposed in this PR?
Checked if blockletPath contains old tuple id format, and convert it to compatible format.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No, tested in cluster

    
