### PR TITLE
[CARBONDATA-3984] Fix compaction and longStringColumn validation issue.

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/scan/expression/conditional/EqualToExpression.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/expression/conditional/EqualToExpression.java
@@ -70,7 +70,7 @@ public class EqualToExpression extends BinaryConditionalExpression {
     DataType dataType = val1.getDataType();
     if (dataType == DataTypes.BOOLEAN) {
       result = val1.getBoolean().equals(val2.getBoolean());
-    } else if (dataType == DataTypes.STRING) {
+    } else if (dataType == DataTypes.STRING || dataType == DataTypes.VARCHAR) {
       result = val1.getString().equals(val2.getString());
     } else if (dataType == DataTypes.SHORT) {
       result = val1.getShort().equals(val2.getShort());

--- a/core/src/main/java/org/apache/carbondata/core/scan/expression/conditional/GreaterThanEqualToExpression.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/expression/conditional/GreaterThanEqualToExpression.java
@@ -52,7 +52,7 @@ public class GreaterThanEqualToExpression extends BinaryConditionalExpression {
     DataType dataType = exprResVal1.getDataType();
     if (dataType == DataTypes.BOOLEAN) {
       result = elRes.getBoolean().compareTo(erRes.getBoolean()) >= 0;
-    } else if (dataType == DataTypes.STRING) {
+    } else if (dataType == DataTypes.STRING || dataType == DataTypes.VARCHAR) {
       result = elRes.getString().compareTo(erRes.getString()) >= 0;
     } else if (dataType == DataTypes.SHORT) {
       result = elRes.getShort() >= (erRes.getShort());

--- a/core/src/main/java/org/apache/carbondata/core/scan/expression/conditional/GreaterThanExpression.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/expression/conditional/GreaterThanExpression.java
@@ -54,7 +54,7 @@ public class GreaterThanExpression extends BinaryConditionalExpression {
     DataType dataType = val1.getDataType();
     if (dataType == DataTypes.BOOLEAN) {
       result = exprLeftRes.getBoolean().compareTo(exprRightRes.getBoolean()) > 0;
-    } else if (dataType == DataTypes.STRING) {
+    } else if (dataType == DataTypes.STRING || dataType == DataTypes.VARCHAR) {
       result = exprLeftRes.getString().compareTo(exprRightRes.getString()) > 0;
     } else if (dataType == DataTypes.DOUBLE) {
       result = exprLeftRes.getDouble() > (exprRightRes.getDouble());

--- a/core/src/main/java/org/apache/carbondata/core/scan/expression/conditional/InExpression.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/expression/conditional/InExpression.java
@@ -57,7 +57,7 @@ public class InExpression extends BinaryConditionalExpression {
         DataType dataType = val.getDataType();
         if (dataType == DataTypes.BOOLEAN) {
           val = new ExpressionResult(val.getDataType(), expressionResVal.getBoolean());
-        } else if (dataType == DataTypes.STRING) {
+        } else if (dataType == DataTypes.STRING || dataType == DataTypes.VARCHAR) {
           val = new ExpressionResult(val.getDataType(), expressionResVal.getString());
         } else if (dataType == DataTypes.SHORT) {
           val = new ExpressionResult(val.getDataType(), expressionResVal.getShort());

--- a/core/src/main/java/org/apache/carbondata/core/scan/expression/conditional/LessThanEqualToExpression.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/expression/conditional/LessThanEqualToExpression.java
@@ -52,7 +52,7 @@ public class LessThanEqualToExpression extends BinaryConditionalExpression {
     DataType dataType = exprResValue1.getDataType();
     if (dataType == DataTypes.BOOLEAN) {
       result = elRes.getBoolean().compareTo(erRes.getBoolean()) <= 0;
-    } else if (dataType == DataTypes.STRING) {
+    } else if (dataType == DataTypes.STRING || dataType == DataTypes.VARCHAR) {
       result = elRes.getString().compareTo(erRes.getString()) <= 0;
     } else if (dataType == DataTypes.SHORT) {
       result = elRes.getShort() <= (erRes.getShort());

--- a/core/src/main/java/org/apache/carbondata/core/scan/expression/conditional/LessThanExpression.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/expression/conditional/LessThanExpression.java
@@ -56,7 +56,7 @@ public class LessThanExpression extends BinaryConditionalExpression {
     DataType dataType = val1.getDataType();
     if (dataType == DataTypes.BOOLEAN) {
       result = elRes.getBoolean().compareTo(erRes.getBoolean()) < 0;
-    } else if (dataType == DataTypes.STRING) {
+    } else if (dataType == DataTypes.STRING || dataType == DataTypes.VARCHAR) {
       result = elRes.getString().compareTo(erRes.getString()) < 0;
     } else if (dataType == DataTypes.SHORT) {
       result = elRes.getShort() < (erRes.getShort());

--- a/core/src/main/java/org/apache/carbondata/core/scan/expression/conditional/NotEqualsExpression.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/expression/conditional/NotEqualsExpression.java
@@ -66,7 +66,7 @@ public class NotEqualsExpression extends BinaryConditionalExpression {
     DataType dataType = val1.getDataType();
     if (dataType == DataTypes.BOOLEAN) {
       result = !val1.getBoolean().equals(val2.getBoolean());
-    } else if (dataType == DataTypes.STRING) {
+    } else if (dataType == DataTypes.STRING || dataType == DataTypes.VARCHAR) {
       result = !val1.getString().equals(val2.getString());
     } else if (dataType == DataTypes.SHORT) {
       result = val1.getShort().shortValue() != val2.getShort().shortValue();

--- a/core/src/main/java/org/apache/carbondata/core/scan/expression/conditional/NotInExpression.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/expression/conditional/NotInExpression.java
@@ -80,7 +80,7 @@ public class NotInExpression extends BinaryConditionalExpression {
           val = new ExpressionResult(val.getDataType(), exprResVal.getBoolean());
         } else if (dataType == DataTypes.STRING) {
           val = new ExpressionResult(val.getDataType(), exprResVal.getString());
-        } else if (dataType == DataTypes.SHORT) {
+        } else if (dataType == DataTypes.SHORT || dataType == DataTypes.VARCHAR) {
           val = new ExpressionResult(val.getDataType(), exprResVal.getShort());
         } else if (dataType == DataTypes.INT) {
           val = new ExpressionResult(val.getDataType(), exprResVal.getInt());

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
@@ -3344,6 +3344,8 @@ public final class CarbonUtil {
     // for setting long string columns
     if (!longStringColumnsString.isEmpty()) {
       String[] inputColumns = longStringColumnsString.split(",");
+      inputColumns = Arrays.stream(inputColumns).map(String::trim)
+              .map(String::toLowerCase).toArray(String[]::new);
       Set<String> longStringSet = new HashSet<>(Arrays.asList(inputColumns));
       List<org.apache.carbondata.format.ColumnSchema> varCharColumns = new ArrayList<>();
       // change data type to varchar and extract the varchar columns

--- a/integration/spark/src/main/scala/org/apache/spark/util/AlterTableUtil.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/util/AlterTableUtil.scala
@@ -886,7 +886,7 @@ object AlterTableUtil {
   def validateLongStringColumns(longStringColumns: String,
       carbonTable: CarbonTable): Unit = {
     // don't allow duplicate column names
-    val longStringCols = longStringColumns.split(",")
+    val longStringCols = longStringColumns.split(",").map(column => column.trim.toLowerCase)
     if (longStringCols.distinct.lengthCompare(longStringCols.size) != 0) {
       val duplicateColumns = longStringCols
         .diff(longStringCols.distinct).distinct
@@ -898,14 +898,14 @@ object AlterTableUtil {
     // check if the column specified exists in table schema and must be of string data type
     val colSchemas = carbonTable.getTableInfo.getFactTable.getListOfColumns.asScala
     longStringCols.foreach { col =>
-      if (!colSchemas.exists(x => x.getColumnName.equalsIgnoreCase(col.trim))) {
-        val errorMsg = "LONG_STRING_COLUMNS column: " + col.trim +
+      if (!colSchemas.exists(x => x.getColumnName.equalsIgnoreCase(col))) {
+        val errorMsg = "LONG_STRING_COLUMNS column: " + col +
                        " does not exist in table. Please check the DDL."
         throw new MalformedCarbonCommandException(errorMsg)
-      } else if (colSchemas.exists(x => x.getColumnName.equalsIgnoreCase(col.trim) &&
+      } else if (colSchemas.exists(x => x.getColumnName.equalsIgnoreCase(col) &&
                                           !x.getDataType.toString
                                             .equalsIgnoreCase("STRING"))) {
-        val errMsg = "LONG_STRING_COLUMNS column: " + col.trim +
+        val errMsg = "LONG_STRING_COLUMNS column: " + col +
                      " is not a string datatype column"
         throw new MalformedCarbonCommandException(errMsg)
       }


### PR DESCRIPTION
 ### Why is this PR needed?
Fix multiple issues occurred after altering the column dataType to long_string_column.
a) When dataType of a String column which is also provided as range column in table properties is altered to long_string_column. It throws following error while performing compaction on the table.
**VARCHAR not supported for the filter expression;** 
b) When longStringColumn name is present in UpperCase then Validation check for SortColumns fails. As names of SortColumns are present in LowerCase.

 ### What changes were proposed in this PR?
a) Added condition for VARCHAR datatype in all conditional expressions.
b) Changed the long_string_columns name to lowerCase before doing validation.
   
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes
    
