### PR TITLE
[CARBONDATA-3988] Allow SI creation on first dimension column

### DIFF
--- a/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/TestCreateIndexTable.scala
+++ b/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/TestCreateIndexTable.scala
@@ -126,21 +126,6 @@ class TestCreateIndexTable extends QueryTest with BeforeAndAfterAll {
 
   }
 
-  test("test create index table cols order same as start order of parent table") {
-    try {
-      sql("drop index if exists index_on_measure on carbon")
-      sql("create index index_on_measure on table carbon (empno,empname,designation,doj,"+
-          "workgroupcategory) AS 'carbondata'")
-      assert(false)
-    } catch {
-      case ex: Exception =>
-        assert(ex.getMessage.equalsIgnoreCase(
-          "Index table column indexing order is same as Parent table column start order"))
-    } finally{
-      sql("drop index if exists index_on_measure on carbon")
-     }
-  }
-
   test("test create index table on more than one column") {
     try {
       sql("drop index if exists index_more_columns on carbon")

--- a/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/command/SICreationCommand.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/command/SICreationCommand.scala
@@ -244,18 +244,6 @@ private[sql] case class CarbonCreateSecondaryIndexCommand(
                                "number of key columns in Source table")
       }
 
-      var isColsIndexedAsPerTable = true
-      for (i <- indexModel.columnNames.indices) {
-        val mainTableDims = dims.sortBy(_.getOrdinal)
-        if (!mainTableDims(i).getColName.equalsIgnoreCase(indexModel.columnNames(i))) {
-          isColsIndexedAsPerTable = false
-        }
-      }
-
-      if (isColsIndexedAsPerTable) {
-        throw new ErrorMessage(
-          s"Index table column indexing order is same as Parent table column start order")
-      }
       // Should not allow to create index on an index table
       val isIndexTable = carbonTable.isIndexTable
       if (isIndexTable) {


### PR DESCRIPTION
 ### Why is this PR needed?
 In some scenarios like, A table having 100 columns. with sort columns as (A,B,C). Currently we don't allow SI creation on column 'A'.  Due to this If the filter is B=x, A=y.  There will be huge task to scan main table as SI is not supported for column 'A'. Instead if we allow SI for A,B. There will be less task to scan main table and over all query execution will be faster.
**Let user decide he need to create SI for first column or not, instead of we blocking always.**
 
 ### What changes were proposed in this PR?
Allow first dimension column also as SI column. 

 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No 

    
