### PR TITLE
[CARBONDATA-3976]CarbonData Update operation enhancement

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/mutate/CarbonUpdateUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/mutate/CarbonUpdateUtil.java
@@ -523,30 +523,11 @@ public class CarbonUpdateUtil {
           }
 
           // get Invalid update  delta files.
-          CarbonFile[] invalidUpdateDeltaFiles = updateStatusManager
-              .getUpdateDeltaFilesList(segment, false,
-                  CarbonCommonConstants.UPDATE_DELTA_FILE_EXT, true, allSegmentFiles,
-                  isInvalidFile);
-
-          // now for each invalid delta file need to check the query execution time out
-          // and then delete.
-          for (CarbonFile invalidFile : invalidUpdateDeltaFiles) {
-            compareTimestampsAndDelete(invalidFile, forceDelete, false);
+          if(deleteInvalidUpdateDeltaFiles(segment, allSegmentFiles, updateStatusManager, forceDelete)){
+            updateSegmentFile = true;
           }
-          // do the same for the index files.
-          CarbonFile[] invalidIndexFiles = updateStatusManager
-              .getUpdateDeltaFilesList(segment, false,
-                  CarbonCommonConstants.UPDATE_INDEX_FILE_EXT, true, allSegmentFiles,
-                  isInvalidFile);
 
-          // now for each invalid index file need to check the query execution time out
-          // and then delete.
 
-          for (CarbonFile invalidFile : invalidIndexFiles) {
-            if (compareTimestampsAndDelete(invalidFile, forceDelete, false)) {
-              updateSegmentFile = true;
-            }
-          }
           // now handle all the delete delta files which needs to be deleted.
           // there are 2 cases here .
           // 1. if the block is marked as compacted then the corresponding delta files
@@ -568,26 +549,16 @@ public class CarbonUpdateUtil {
                 .getDeleteDeltaInvalidFilesList(block, false,
                     allSegmentFiles, isAbortedFile);
             for (CarbonFile invalidFile : invalidDeleteDeltaFiles) {
-              boolean doForceDelete = true;
-              compareTimestampsAndDelete(invalidFile, doForceDelete, false);
+              compareTimestampsAndDelete(invalidFile, true, false);
             }
 
             // case 1
-            if (CarbonUpdateUtil.isBlockInvalid(block.getSegmentStatus())) {
-              completeListOfDeleteDeltaFiles = updateStatusManager
-                  .getDeleteDeltaInvalidFilesList(block, true,
-                      allSegmentFiles, isInvalidFile);
-              for (CarbonFile invalidFile : completeListOfDeleteDeltaFiles) {
-                compareTimestampsAndDelete(invalidFile, forceDelete, false);
-              }
-
-            } else {
-              invalidDeleteDeltaFiles = updateStatusManager
-                  .getDeleteDeltaInvalidFilesList(block, false,
-                      allSegmentFiles, isInvalidFile);
-              for (CarbonFile invalidFile : invalidDeleteDeltaFiles) {
-                compareTimestampsAndDelete(invalidFile, forceDelete, false);
-              }
+            completeListOfDeleteDeltaFiles = updateStatusManager
+                    .getDeleteDeltaInvalidFilesList(block,
+                            CarbonUpdateUtil.isBlockInvalid(block.getSegmentStatus()),
+                            allSegmentFiles, isInvalidFile);
+            for(CarbonFile invalidFile : completeListOfDeleteDeltaFiles){
+              compareTimestampsAndDelete(invalidFile, forceDelete, false);
             }
           }
           if (updateSegmentFile) {
@@ -721,27 +692,46 @@ public class CarbonUpdateUtil {
    * @param allSegmentFiles
    * @param updateStatusManager
    */
-  private static boolean deleteStaleCarbonDataFiles(LoadMetadataDetails segment,
-      CarbonFile[] allSegmentFiles, SegmentUpdateStatusManager updateStatusManager) {
-    CarbonFile[] invalidUpdateDeltaFiles = updateStatusManager
-        .getUpdateDeltaFilesList(segment, false,
-            CarbonCommonConstants.UPDATE_DELTA_FILE_EXT, true, allSegmentFiles,
-            true);
-    // now for each invalid delta file need to check the query execution time out
-    // and then delete.
-    for (CarbonFile invalidFile : invalidUpdateDeltaFiles) {
-      compareTimestampsAndDelete(invalidFile, true, false);
-    }
-    // do the same for the index files.
-    CarbonFile[] invalidIndexFiles = updateStatusManager
-        .getUpdateDeltaFilesList(segment, false,
-            CarbonCommonConstants.UPDATE_INDEX_FILE_EXT, true, allSegmentFiles,
-            true);
-    // now for each invalid index file need to check the query execution time out
-    // and then delete.
+  public static boolean deleteStaleCarbonDataFiles(LoadMetadataDetails segment,
+       CarbonFile[] allSegmentFiles, SegmentUpdateStatusManager updateStatusManager){
+    List<String> fileExtensions = new ArrayList<>();
+    fileExtensions.add(CarbonCommonConstants.UPDATE_INDEX_FILE_EXT);
+    fileExtensions.add(CarbonCommonConstants.UPDATE_DELTA_FILE_EXT);
     boolean updateSegmentFile = false;
-    for (CarbonFile invalidFile : invalidIndexFiles) {
-      if (compareTimestampsAndDelete(invalidFile, true, false)) {
+    CarbonFile[] invalidFiles = updateStatusManager.
+            getUpdateDeltaFilesList(segment,false,
+                    fileExtensions, true, allSegmentFiles,  true);
+    for(CarbonFile invalidFile : invalidFiles) {
+      if (compareTimestampsAndDelete(invalidFile, true, false) &&
+              invalidFile.getName().endsWith(CarbonCommonConstants.UPDATE_INDEX_FILE_EXT)) {
+        updateSegmentFile = true;
+      }
+    }
+    return updateSegmentFile;
+  }
+
+  /**
+   * This function for each invalid delta file and index file to check the query execution time out
+   * and then delete.
+   * @param segment
+   * @param allSegmentFiles
+   * @param updateStatusManager
+   * @param forceDelete
+   * @return
+   */
+
+  public static boolean deleteInvalidUpdateDeltaFiles(LoadMetadataDetails segment,
+       CarbonFile[] allSegmentFiles, SegmentUpdateStatusManager updateStatusManager, boolean forceDelete){
+    List<String> fileExtensions = new ArrayList<>();
+    fileExtensions.add(CarbonCommonConstants.UPDATE_INDEX_FILE_EXT);
+    fileExtensions.add(CarbonCommonConstants.UPDATE_DELTA_FILE_EXT);
+    boolean updateSegmentFile = false;
+    CarbonFile[] invalidFiles = updateStatusManager.
+            getUpdateDeltaFilesList(segment,false,
+                    fileExtensions, true, allSegmentFiles,  false);
+    for(CarbonFile invalidFile : invalidFiles) {
+      if (compareTimestampsAndDelete(invalidFile, forceDelete, false) &&
+              invalidFile.getName().endsWith(CarbonCommonConstants.UPDATE_INDEX_FILE_EXT)){
         updateSegmentFile = true;
       }
     }

--- a/core/src/main/java/org/apache/carbondata/core/statusmanager/SegmentUpdateStatusManager.java
+++ b/core/src/main/java/org/apache/carbondata/core/statusmanager/SegmentUpdateStatusManager.java
@@ -526,6 +526,79 @@ public class SegmentUpdateStatusManager {
 
   /**
    * Returns all update delta files of specified Segment.
+   * @param loadMetadataDetail
+   * @param validUpdateFiles
+   * @param filExtensions
+   * @param excludeOriginalFact
+   * @param allFilesOfSegment
+   * @param isAbortedFile
+   * @return
+   */
+
+  public CarbonFile[] getUpdateDeltaFilesList(LoadMetadataDetails loadMetadataDetail,
+       final boolean validUpdateFiles, final List<String> filExtensions, final boolean excludeOriginalFact,
+       CarbonFile[] allFilesOfSegment, boolean isAbortedFile){
+    String endTimeStamp = "";
+    String startTimeStamp = "";
+    long factTimeStamp = 0;
+
+    // if the segment is found then take the start and end time stamp.
+    startTimeStamp = loadMetadataDetail.getUpdateDeltaStartTimestamp();
+    endTimeStamp = loadMetadataDetail.getUpdateDeltaEndTimestamp();
+    factTimeStamp = loadMetadataDetail.getLoadStartTime();
+
+    // if start timestamp is empty then no update delta is found. so return empty list.
+    if (startTimeStamp.isEmpty()) {
+      return new CarbonFile[0];
+    }
+
+    final Long endTimeStampFinal = CarbonUpdateUtil.getTimeStampAsLong(endTimeStamp);
+    final Long startTimeStampFinal = CarbonUpdateUtil.getTimeStampAsLong(startTimeStamp);
+    final long factTimeStampFinal = factTimeStamp;
+
+    List<CarbonFile> listOfCarbonFiles =
+            new ArrayList<>(CarbonCommonConstants.DEFAULT_COLLECTION_SIZE);
+
+    // else scan the segment for the delta files with the respective timestamp.
+
+    for (CarbonFile eachFile : allFilesOfSegment) {
+
+      String fileName = eachFile.getName();
+      if (filExtensions.contains(fileName.substring(fileName.lastIndexOf(".")))) {
+        long timestamp =
+                Long.parseLong(CarbonTablePath.DataFileUtil.getTimeStampFromFileName(fileName));
+
+        if (excludeOriginalFact) {
+          if (factTimeStampFinal == timestamp) {
+            continue;
+          }
+        }
+
+        if (validUpdateFiles) {
+          if (timestamp <= endTimeStampFinal
+                  && timestamp >= startTimeStampFinal) {
+            listOfCarbonFiles.add(eachFile);
+          }
+        } else {
+          // invalid cases.
+          if (isAbortedFile) {
+            if (timestamp > endTimeStampFinal) {
+              listOfCarbonFiles.add(eachFile);
+            }
+          } else if (timestamp < startTimeStampFinal
+                  || timestamp > endTimeStampFinal) {
+            listOfCarbonFiles.add(eachFile);
+          }
+        }
+      }
+    }
+
+    return listOfCarbonFiles.toArray(new CarbonFile[listOfCarbonFiles.size()]);
+
+  }
+
+  /**
+   * Returns all update delta files of specified Segment.
    *
    * @param segmentId
    * @param validUpdateFiles


### PR DESCRIPTION
 ### Why is this PR needed?
 Update operation will clean up delta files before update( see
cleanUpDeltaFiles(carbonTable, false)), It's loop traversal metadata path
and segment path many times. When there are too many files, the overhead
will increase and update time will be longer.
 
 ### What changes were proposed in this PR?

In cleanUpDeltaFiles have some same points in get files method, like
updateStatusManager.getUpdateDeltaFilesList(segment,
false,CarbonCommonConstants.UPDATE_DELTA_FILE_EXT, true,
allSegmentFiles,true) and
updateStatusManager.getUpdateDeltaFilesList(segment,
false,CarbonCommonConstants.UPDATE_INDEX_FILE_EXT, true,
allSegmentFiles,true), They are just different file types，but loop traversal
segment path twice. we can merge it.
    
 ### Does this PR introduce any user interface change?
 - No
 - Yes. (please explain the change and update document)

 ### Is any new testcase added?
 - No
 - Yes

    
