### PR TITLE
[CARBONDATA-3991] Fix the set modified time function on S3 and Alluxio file system

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/AbstractDFSCarbonFile.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/AbstractDFSCarbonFile.java
@@ -420,6 +420,20 @@ public abstract class AbstractDFSCarbonFile implements CarbonFile {
   }
 
   @Override
+  public boolean createNewFile(boolean overwrite) throws IOException {
+    if (!overwrite && fileSystem.exists(path)) {
+      return false;
+    } else {
+      // Pass the permissions during file creation itself
+      fileSystem
+          .create(path, false, fileSystem.getConf().getInt("io.file.buffer.size", 4096),
+              fileSystem.getDefaultReplication(path), fileSystem.getDefaultBlockSize(path), null)
+          .close();
+      return true;
+    }
+  }
+
+  @Override
   public boolean deleteFile() throws IOException {
     return fileSystem.delete(path, true);
   }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/CarbonFile.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/CarbonFile.java
@@ -131,6 +131,8 @@ public interface CarbonFile {
 
   boolean createNewFile(final FsPermission permission) throws IOException;
 
+  boolean createNewFile(final boolean overwrite) throws IOException;
+
   boolean deleteFile() throws IOException;
 
   boolean mkdirs() throws IOException;

--- a/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/LocalCarbonFile.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/LocalCarbonFile.java
@@ -422,6 +422,11 @@ public class LocalCarbonFile implements CarbonFile {
   }
 
   @Override
+  public boolean createNewFile(boolean overwrite) throws IOException {
+    return file.createNewFile();
+  }
+
+  @Override
   public boolean deleteFile() {
     return FileFactory.deleteAllFilesOfDir(file);
   }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/impl/FileFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/impl/FileFactory.java
@@ -297,6 +297,26 @@ public final class FileFactory {
     return getCarbonFile(filePath).deleteFile();
   }
 
+  public static long setLastModifiedTimeToCurrentTime(String filePath) throws IOException {
+    switch (getFileType(filePath)) {
+      case ALLUXIO:
+      case S3:
+        if (getCarbonFile(filePath).getSize() > 0) {
+          throw new IOException("Unsupported setLastModifiedTime operation on NonEmpty File");
+        }
+        getCarbonFile(filePath).createNewFile(true);
+        return getCarbonFile(filePath).getLastModifiedTime();
+      case LOCAL:
+      case HDFS:
+      case VIEWFS:
+      case CUSTOM:
+      default:
+        long currentTime = System.currentTimeMillis();
+        getCarbonFile(filePath).setLastModifiedTime(currentTime);
+        return currentTime;
+    }
+  }
+
   public static boolean deleteAllFilesOfDir(File path) {
     if (!path.exists()) {
       return true;

--- a/core/src/main/java/org/apache/carbondata/core/statusmanager/LoadMetadataDetails.java
+++ b/core/src/main/java/org/apache/carbondata/core/statusmanager/LoadMetadataDetails.java
@@ -150,6 +150,10 @@ public class LoadMetadataDetails implements Serializable {
     this.timestamp = Long.toString(timestamp);
   }
 
+  public void setLoadEndTime(String timestampStr) {
+    this.timestamp = timestampStr;
+  }
+
   public SegmentStatus getSegmentStatus() {
     return loadStatus;
   }
@@ -492,6 +496,10 @@ public class LoadMetadataDetails implements Serializable {
     if (!StringUtils.isEmpty(updateDeltaEndTimestamp)) {
       return convertTimeStampToLong(updateDeltaEndTimestamp);
     }
-    return convertTimeStampToLong(timestamp);
+    if (!StringUtils.isEmpty(timestamp)) {
+      return convertTimeStampToLong(timestamp);
+    }
+    return convertTimeStampToLong(
+            String.valueOf(CarbonCommonConstants.SEGMENT_LOAD_TIME_DEFAULT));
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/view/MVProvider.java
+++ b/core/src/main/java/org/apache/carbondata/core/view/MVProvider.java
@@ -550,9 +550,8 @@ public class MVProvider {
             this.schemaIndexFilePath,
             new FsPermission(FsAction.ALL, FsAction.ALL, FsAction.ALL));
       }
-      long lastModifiedTime = System.currentTimeMillis();
-      FileFactory.getCarbonFile(this.schemaIndexFilePath).setLastModifiedTime(lastModifiedTime);
-      this.lastModifiedTime = lastModifiedTime;
+      this.lastModifiedTime =
+          FileFactory.setLastModifiedTimeToCurrentTime(this.schemaIndexFilePath);
     }
 
   }

--- a/core/src/test/java/org/apache/carbondata/core/carbon/datastorage/filesystem/store/impl/FileFactoryImplUnitTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/carbon/datastorage/filesystem/store/impl/FileFactoryImplUnitTest.java
@@ -21,6 +21,8 @@ import java.io.DataOutputStream;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.datastore.filesystem.CarbonFile;
@@ -168,6 +170,16 @@ public class FileFactoryImplUnitTest {
   @Test public void testGetCarbonFile() throws IOException {
     FileFactory.getDataOutputStream(filePath);
     assertNotNull(FileFactory.getCarbonFile(filePath));
+  }
+
+  @Test public void testSetLastModifiedTimeToCurrentTime()
+      throws IOException, ParseException, InterruptedException {
+    FileFactory.createNewFile(filePath);
+    long lastModifiedTimeBeforeUpdate = FileFactory.getCarbonFile(filePath).getLastModifiedTime();
+    Thread.sleep(100);
+    FileFactory.setLastModifiedTimeToCurrentTime(filePath);
+    long lastModifiedTimeAfterUpdate = FileFactory.getCarbonFile(filePath).getLastModifiedTime();
+    assert(lastModifiedTimeAfterUpdate > lastModifiedTimeBeforeUpdate);
   }
 
   @Test public void testTruncateFile() {

--- a/core/src/test/java/org/apache/carbondata/core/datastore/filesystem/AlluxioCarbonFileTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/datastore/filesystem/AlluxioCarbonFileTest.java
@@ -85,6 +85,44 @@ public class AlluxioCarbonFileTest {
         file.delete();
     }
 
+    @Test(expected = IOException.class)
+    public void testCreateNewTable() throws IOException {
+        new MockUp<Path>() {
+            @Mock
+            public FileSystem getFileSystem(Configuration conf) throws IOException {
+                return new DistributedFileSystem();
+            }
+
+        };
+        new MockUp<DistributedFileSystem>() {
+            @Mock
+            public boolean exists(Path f) throws IOException {
+                return true;
+            }
+        };
+        alluxioCarbonFile = new AlluxioCarbonFile(fileStatus);
+        assertFalse(alluxioCarbonFile.createNewFile(false));
+        new MockUp<DistributedFileSystem>() {
+            @Mock
+            public FSDataOutputStream create(Path f, boolean overwrite, int bufferSize, short replication, long blockSize, Progressable progress) throws  IOException{
+                throw new IOException();
+            }
+            @Mock
+            public Configuration getConf() {
+                return new Configuration();
+            }
+            @Mock
+            public short getDefaultReplication(Path path) {
+                return 1;
+            }
+            @Mock
+            public long getDefaultBlockSize(Path f) {
+                return 1;
+            }
+        };
+        alluxioCarbonFile.createNewFile(true);
+    }
+
     @Test
     public void testRenameForceForException() throws IOException {
 
@@ -398,7 +436,7 @@ public class AlluxioCarbonFileTest {
         }
 
         @Override
-        public FileStatus[] listStatus(Path path) throws FileNotFoundException, IOException {
+        public FileStatus[] listStatus(Path path) throws IOException {
             return new FileStatus[0];
         }
 

--- a/core/src/test/java/org/apache/carbondata/core/load/LoadMetadataDetailsUnitTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/load/LoadMetadataDetailsUnitTest.java
@@ -116,6 +116,8 @@ public class LoadMetadataDetailsUnitTest {
     loadMetadataDetails.setUpdateDeltaEndTimestamp("01-01-2016 00:00:00");
     assertEquals(loadMetadataDetails.getLastModifiedTime(), timeStamp);;
     loadMetadataDetails.setUpdateDeltaEndTimestamp(null);
+    loadMetadataDetails.setLoadEndTime(null);
+    assertEquals(loadMetadataDetails.getLastModifiedTime(), -1);
     loadMetadataDetails.setLoadEndTime(timeStamp);
     assertEquals(loadMetadataDetails.getLastModifiedTime(), timeStamp);
     loadMetadataDetails.setUpdateDeltaEndTimestamp("");

--- a/integration/hive/src/main/java/org/apache/carbondata/hive/util/HiveCarbonUtil.java
+++ b/integration/hive/src/main/java/org/apache/carbondata/hive/util/HiveCarbonUtil.java
@@ -237,7 +237,6 @@ public class HiveCarbonUtil {
         .fromWrapperToExternalTableInfo(tableInfo, tableInfo.getDatabaseName(),
             tableInfo.getFactTable().getTableName()));
     thriftWriter.close();
-    FileFactory.getCarbonFile(schemaFilePath).setLastModifiedTime(System.currentTimeMillis());
   }
 
   public static HiveMetaHook getMetaHook() {

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonInsertFromStageCommand.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonInsertFromStageCommand.scala
@@ -507,9 +507,10 @@ case class CarbonInsertFromStageCommand(
         override def call(): (CarbonFile, CarbonFile, Boolean) = {
           try {
             // Get the loading files path
+            val stageLoadingFilePath = stagePath +
+              File.separator + files._1.getName + CarbonTablePath.LOADING_FILE_SUFFIX;
             val stageLoadingFile =
-              FileFactory.getCarbonFile(stagePath +
-                File.separator + files._1.getName + CarbonTablePath.LOADING_FILE_SUFFIX);
+              FileFactory.getCarbonFile(stageLoadingFilePath);
             // Try to create loading files
             // make isFailed to be true if createNewFile return false.
             // the reason can be file exists or exceptions.
@@ -517,7 +518,9 @@ case class CarbonInsertFromStageCommand(
             // if file exists, modify the lastmodifiedtime of the file.
             if (isFailed) {
               // make isFailed to be true if setLastModifiedTime return false.
-              isFailed = !stageLoadingFile.setLastModifiedTime(System.currentTimeMillis());
+              val modifiedTime = System.currentTimeMillis();
+              isFailed = (modifiedTime >
+                FileFactory.setLastModifiedTimeToCurrentTime(stageLoadingFilePath))
             }
             (files._1, files._2, isFailed)
           } catch {

--- a/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonFileMetastore.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonFileMetastore.scala
@@ -430,8 +430,7 @@ class CarbonFileMetastore extends CarbonMetaStore {
     thriftWriter.open(FileWriteOperation.OVERWRITE)
     thriftWriter.write(thriftTableInfo)
     thriftWriter.close()
-    val modifiedTime = System.currentTimeMillis()
-    FileFactory.getCarbonFile(schemaFilePath).setLastModifiedTime(modifiedTime)
+    val modifiedTime = FileFactory.getCarbonFile(schemaFilePath).getLastModifiedTime()
     updateSchemasUpdatedTime(identifier.getCarbonTableIdentifier.getTableId, modifiedTime)
     identifier.getTablePath
   }


### PR DESCRIPTION
##Why is this PR needed?
If there are some update or create mv in S3 and Alluxio files ,those operations do not take effect. And the other tenant can't find the changes in this operation and cause a data consistency problem.

##What changes were proposed in this PR?
In this PR, we set two function to fix this problem.
1. Create a new file for S3 and Alluxio to set a tag to update.
2. Set a switch case like function to select different scenario in update or create.

##Does this PR introduce any user interface change?
No

##Is any new testcase added?
Yes
    
