### PR TITLE
[CARBONDATA-3993] Remove auto data deletion in IUD processs

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/mutate/CarbonUpdateUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/mutate/CarbonUpdateUtil.java
@@ -614,7 +614,7 @@ public class CarbonUpdateUtil {
         }
         // handle cleanup of merge index files and data files after small files merge happened for
         // SI table
-        cleanUpDataFilesAfterSmallFilesMergeForSI(table, segment);
+        cleanUpDataFilesAfterSmallFilesMergeForSI(table, segment, forceDelete);
       }
     }
     String UUID = String.valueOf(System.currentTimeMillis());
@@ -694,7 +694,7 @@ public class CarbonUpdateUtil {
    * refer {@link org.apache.spark.sql.secondaryindex.rdd.CarbonSIRebuildRDD}
    */
   private static void cleanUpDataFilesAfterSmallFilesMergeForSI(CarbonTable table,
-      LoadMetadataDetails segment) throws IOException {
+      LoadMetadataDetails segment, boolean forceDelete) throws IOException {
     if (table.isIndexTable()) {
       String segmentPath = CarbonTablePath
           .getSegmentPath(table.getAbsoluteTableIdentifier().getTablePath(),
@@ -719,7 +719,7 @@ public class CarbonUpdateUtil {
             && Long.parseLong(fileTimestamp) < startTimeStampFinal) {
           deleteFile = true;
         }
-        if (deleteFile) {
+        if (deleteFile && forceDelete) {
           // delete the files and folders.
           try {
             LOGGER.info("Deleting the invalid file : " + file.getName());
@@ -821,7 +821,7 @@ public class CarbonUpdateUtil {
       if (tableUpdateStatusFilename.endsWith(".write")) {
         long tableUpdateStatusFileTimeStamp = Long.parseLong(
             CarbonTablePath.DataFileUtil.getTimeStampFromFileName(tableUpdateStatusFilename));
-        if (isMaxQueryTimeoutExceeded(tableUpdateStatusFileTimeStamp)) {
+        if (isMaxQueryTimeoutExceeded(tableUpdateStatusFileTimeStamp) && forceDelete) {
           isDeleted = deleteInvalidFiles(invalidFile);
         }
       }

--- a/core/src/main/java/org/apache/carbondata/core/statusmanager/SegmentStatusManager.java
+++ b/core/src/main/java/org/apache/carbondata/core/statusmanager/SegmentStatusManager.java
@@ -960,9 +960,7 @@ public class SegmentStatusManager {
     if (details != null && details.length > 0) {
       for (LoadMetadataDetails oneRow : details) {
         if ((SegmentStatus.MARKED_FOR_DELETE == oneRow.getSegmentStatus()
-            || SegmentStatus.COMPACTED == oneRow.getSegmentStatus()
-            || SegmentStatus.INSERT_IN_PROGRESS == oneRow.getSegmentStatus()
-            || SegmentStatus.INSERT_OVERWRITE_IN_PROGRESS == oneRow.getSegmentStatus())
+            || SegmentStatus.COMPACTED == oneRow.getSegmentStatus())
             && oneRow.getVisibility().equalsIgnoreCase("true")) {
           return true;
         }

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -57,7 +57,6 @@ import org.apache.carbondata.core.segmentmeta.SegmentMetaDataInfo
 import org.apache.carbondata.core.statusmanager.{LoadMetadataDetails, SegmentStatus, SegmentStatusManager, SegmentUpdateStatusManager}
 import org.apache.carbondata.core.util.{CarbonProperties, CarbonSessionInfo, CarbonUtil, SessionParams, ThreadLocalSessionInfo}
 import org.apache.carbondata.core.util.path.CarbonTablePath
-import org.apache.carbondata.core.view.{MVSchema, MVStatus}
 import org.apache.carbondata.events.{OperationContext, OperationListenerBus}
 import org.apache.carbondata.indexserver.{DistributedRDDUtils, IndexServer}
 import org.apache.carbondata.processing.loading.FailureCauses
@@ -267,9 +266,8 @@ object CarbonDataRDDFactory {
             throw new Exception("Exception in compaction " + exception.getMessage)
           }
         } finally {
-          executor.shutdownNow()
           try {
-            compactor.deletePartialLoadsInCompaction()
+            executor.shutdownNow()
           } catch {
             // no need to throw this as compaction is over
             case ex: Exception =>

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonTableCompactor.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonTableCompactor.scala
@@ -92,7 +92,6 @@ class CarbonTableCompactor(carbonLoadModel: CarbonLoadModel,
            (CompactionType.IUD_UPDDEL_DELTA == compactionModel.compactionType &&
             loadsToMerge.size() > 0)) {
       val lastSegment = sortedSegments.get(sortedSegments.size() - 1)
-      deletePartialLoadsInCompaction()
       val compactedLoad = CarbonDataMergerUtil.getMergedLoadName(loadsToMerge)
       var segmentLocks: ListBuffer[ICarbonLock] = ListBuffer.empty
       loadsToMerge.asScala.foreach { segmentId =>

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonInsertIntoCommand.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonInsertIntoCommand.scala
@@ -45,7 +45,6 @@ import org.apache.carbondata.core.util.{CarbonProperties, DataTypeUtil, ThreadLo
 import org.apache.carbondata.core.util.path.CarbonTablePath
 import org.apache.carbondata.events.OperationContext
 import org.apache.carbondata.events.exception.PreEventException
-import org.apache.carbondata.processing.loading.TableProcessingOperations
 import org.apache.carbondata.processing.loading.exception.NoRetryException
 import org.apache.carbondata.processing.loading.model.CarbonLoadModel
 import org.apache.carbondata.processing.util.CarbonLoaderUtil
@@ -184,10 +183,6 @@ case class CarbonInsertIntoCommand(databaseNameOp: Option[String],
           getReArrangedSchemaLogicalRelation(reArrangedIndex, logicalPartitionRelation)
       }
     }
-    // Delete stale segment folders that are not in table status but are physically present in
-    // the Fact folder
-    LOGGER.info(s"Deleting stale folders if present for table $dbName.$tableName")
-    TableProcessingOperations.deletePartialLoadDataIfExist(table, false)
     var isUpdateTableStatusRequired = false
     val uuid = ""
     try {

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonInsertIntoWithDf.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonInsertIntoWithDf.scala
@@ -33,7 +33,6 @@ import org.apache.carbondata.core.util.{CarbonProperties, ThreadLocalSessionInfo
 import org.apache.carbondata.core.util.path.CarbonTablePath
 import org.apache.carbondata.events.OperationContext
 import org.apache.carbondata.events.exception.PreEventException
-import org.apache.carbondata.processing.loading.TableProcessingOperations
 import org.apache.carbondata.processing.loading.exception.NoRetryException
 import org.apache.carbondata.processing.loading.model.CarbonLoadModel
 import org.apache.carbondata.processing.util.CarbonLoaderUtil
@@ -87,10 +86,6 @@ case class CarbonInsertIntoWithDf(databaseNameOp: Option[String],
       options = options)
     val (timeStampFormat, dateFormat) = CommonLoadUtils.getTimeAndDateFormatFromLoadModel(
       carbonLoadModel)
-    // Delete stale segment folders that are not in table status but are physically present in
-    // the Fact folder
-    LOGGER.info(s"Deleting stale folders if present for table $dbName.$tableName")
-    TableProcessingOperations.deletePartialLoadDataIfExist(table, false)
     var isUpdateTableStatusRequired = false
     val uuid = ""
     try {

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonLoadDataCommand.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonLoadDataCommand.scala
@@ -40,7 +40,6 @@ import org.apache.carbondata.core.util._
 import org.apache.carbondata.core.util.path.CarbonTablePath
 import org.apache.carbondata.events.OperationContext
 import org.apache.carbondata.events.exception.PreEventException
-import org.apache.carbondata.processing.loading.TableProcessingOperations
 import org.apache.carbondata.processing.loading.exception.NoRetryException
 import org.apache.carbondata.processing.loading.model.CarbonLoadModel
 import org.apache.carbondata.processing.util.{CarbonDataProcessorUtil, CarbonLoaderUtil}
@@ -105,10 +104,6 @@ case class CarbonLoadDataCommand(databaseNameOp: Option[String],
     val (tf, df) = CommonLoadUtils.getTimeAndDateFormatFromLoadModel(carbonLoadModel)
     timeStampFormat = tf
     dateFormat = df
-    // Delete stale segment folders that are not in table status but are physically present in
-    // the Fact folder
-    LOGGER.info(s"Deleting stale folders if present for table $dbName.$tableName")
-    TableProcessingOperations.deletePartialLoadDataIfExist(table, false)
     var isUpdateTableStatusRequired = false
     val uuid = ""
     try {

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/mutation/DeleteExecution.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/mutation/DeleteExecution.scala
@@ -374,8 +374,6 @@ object DeleteExecution {
               blockMappingVO.getSegmentNumberOfBlockMapping)
           }
         } else {
-          // In case of failure , clean all related delete delta files
-          CarbonUpdateUtil.cleanStaleDeltaFiles(carbonTable, timestamp)
           val errorMsg =
             "Delete data operation is failed due to failure in creating delete delta file for " +
             "segment : " + resultOfBlock._2._1.getSegmentName + " block : " +
@@ -410,8 +408,6 @@ object DeleteExecution {
       LOGGER.info(s"Delete data operation is successful for " +
                   s"${ carbonTable.getDatabaseName }.${ carbonTable.getTableName }")
     } else {
-      // In case of failure , clean all related delete delta files
-      CarbonUpdateUtil.cleanStaleDeltaFiles(carbonTable, timestamp)
       val errorMessage = "Delete data operation is failed due to failure " +
                          "in table status update."
       LOGGER.error("Delete data operation is failed due to failure in table status update.")
@@ -440,8 +436,6 @@ object DeleteExecution {
               blockMappingVO.getSegmentNumberOfBlockMapping)
           }
         } else {
-          // In case of failure , clean all related delete delta files
-          CarbonUpdateUtil.cleanStaleDeltaFiles(carbonTable, timestamp)
           val errorMsg =
             "Delete data operation is failed due to failure in creating delete delta file for " +
             "segment : " + resultOfBlock._2._1.getSegmentName + " block : " +

--- a/processing/src/main/java/org/apache/carbondata/processing/util/CarbonLoaderUtil.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/util/CarbonLoaderUtil.java
@@ -40,7 +40,6 @@ import org.apache.carbondata.core.datastore.impl.FileFactory;
 import org.apache.carbondata.core.index.Segment;
 import org.apache.carbondata.core.locks.CarbonLockUtil;
 import org.apache.carbondata.core.locks.ICarbonLock;
-import org.apache.carbondata.core.locks.LockUsage;
 import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
 import org.apache.carbondata.core.metadata.SegmentFileStore;
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
@@ -253,7 +252,6 @@ public final class CarbonLoaderUtil {
         .getLockProperty(CarbonCommonConstants.MAX_TIMEOUT_FOR_CONCURRENT_LOCK,
             CarbonCommonConstants.MAX_TIMEOUT_FOR_CONCURRENT_LOCK_DEFAULT);
     // TODO only for overwrite scene
-    final List<LoadMetadataDetails> staleLoadMetadataDetails = new ArrayList<>();
     try {
       if (carbonLock.lockWithRetries(retryCount, maxTimeout)) {
         LOGGER.info(
@@ -264,7 +262,6 @@ public final class CarbonLoaderUtil {
                 CarbonTablePath.getMetadataPath(identifier.getTablePath()));
         List<LoadMetadataDetails> listOfLoadFolderDetails =
             new ArrayList<>(CarbonCommonConstants.DEFAULT_COLLECTION_SIZE);
-        List<CarbonFile> staleFolders = new ArrayList<>();
         Collections.addAll(listOfLoadFolderDetails, listOfLoadFolderDetailsArray);
         // create a new segment Id if load has just begun else add the already generated Id
         if (loadStartEntry) {
@@ -323,10 +320,6 @@ public final class CarbonLoaderUtil {
             for (LoadMetadataDetails entry : listOfLoadFolderDetails) {
               if (entry.getSegmentStatus() != SegmentStatus.INSERT_OVERWRITE_IN_PROGRESS) {
                 entry.setSegmentStatus(SegmentStatus.MARKED_FOR_DELETE);
-                // For insert overwrite, we will delete the old segment folder immediately
-                // So collect the old segments here
-                addToStaleFolders(identifier, staleFolders, entry);
-                staleLoadMetadataDetails.add(entry);
               }
             }
           }
@@ -336,11 +329,6 @@ public final class CarbonLoaderUtil {
             throw new IOException("Entry not found to update in the table status file");
           }
           listOfLoadFolderDetails.set(indexToOverwriteNewMetaEntry, newMetaEntry);
-        }
-        // when no records are inserted then newSegmentEntry will be SegmentStatus.MARKED_FOR_DELETE
-        // so empty segment folder should be deleted
-        if (newMetaEntry.getSegmentStatus() == SegmentStatus.MARKED_FOR_DELETE) {
-          addToStaleFolders(identifier, staleFolders, newMetaEntry);
         }
 
         for (LoadMetadataDetails detail: listOfLoadFolderDetails) {
@@ -358,43 +346,6 @@ public final class CarbonLoaderUtil {
         SegmentStatusManager.writeLoadDetailsIntoFile(tableStatusPath, listOfLoadFolderDetails
             .toArray(new LoadMetadataDetails[0]));
 
-        // Delete all old stale segment folders
-        for (CarbonFile staleFolder : staleFolders) {
-          // try block is inside for loop because even if there is failure in deletion of 1 stale
-          // folder still remaining stale folders should be deleted
-          try {
-            CarbonUtil.deleteFoldersAndFiles(staleFolder);
-          } catch (IOException | InterruptedException e) {
-            LOGGER.error("Failed to delete stale folder: " + e.getMessage(), e);
-          }
-        }
-        if (!staleLoadMetadataDetails.isEmpty()) {
-          final String segmentFileLocation =
-              CarbonTablePath.getSegmentFilesLocation(identifier.getTablePath())
-                  + CarbonCommonConstants.FILE_SEPARATOR;
-          final String segmentLockFileLocation =
-              CarbonTablePath.getLockFilesDirPath(identifier.getTablePath())
-                  + CarbonCommonConstants.FILE_SEPARATOR;
-          for (LoadMetadataDetails staleLoadMetadataDetail : staleLoadMetadataDetails) {
-            try {
-              CarbonUtil.deleteFoldersAndFiles(
-                  FileFactory.getCarbonFile(segmentFileLocation
-                      + staleLoadMetadataDetail.getSegmentFile())
-              );
-            } catch (IOException | InterruptedException e) {
-              LOGGER.error("Failed to delete segment file: " + e.getMessage(), e);
-            }
-            try {
-              CarbonUtil.deleteFoldersAndFiles(
-                  FileFactory.getCarbonFile(segmentLockFileLocation
-                      + CarbonTablePath.addSegmentPrefix(staleLoadMetadataDetail.getLoadName())
-                      + LockUsage.LOCK)
-              );
-            } catch (IOException | InterruptedException e) {
-              LOGGER.error("Failed to delete segment lock file: " + e.getMessage(), e);
-            }
-          }
-        }
         status = true;
       } else {
         LOGGER.error("Not able to acquire the lock for Table status updation for table " + loadModel
@@ -412,17 +363,6 @@ public final class CarbonLoaderUtil {
       }
     }
     return status;
-  }
-
-  private static void addToStaleFolders(AbsoluteTableIdentifier identifier,
-      List<CarbonFile> staleFolders, LoadMetadataDetails entry) throws IOException {
-    String path = CarbonTablePath.getSegmentPath(
-        identifier.getTablePath(), entry.getLoadName());
-    // add to the deletion list only if file exist else HDFS file system will throw
-    // exception while deleting the file if file path does not exist
-    if (FileFactory.isFileExist(path)) {
-      staleFolders.add(FileFactory.getCarbonFile(path));
-    }
   }
 
   /**


### PR DESCRIPTION
 ### Why is this PR needed?
Currently, in data management scenarios(Data Loading, Segments Compaction.etc), there exist some data deletion actions. And these actions are dangerous because they are written in different places and some corner cases will cause data deletion accidentally.
 
 ### What changes were proposed in this PR?
This PR remove auto data deletion during IUD( Insert, Update, Delete) process;
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No


    
