### PR TITLE
[CARBONDATA-3914] Fixed exception on reading data from carbon-hive empty table.

### DIFF
--- a/integration/hive/src/main/java/org/apache/carbondata/hive/MapredCarbonInputFormat.java
+++ b/integration/hive/src/main/java/org/apache/carbondata/hive/MapredCarbonInputFormat.java
@@ -154,8 +154,16 @@ public class MapredCarbonInputFormat extends CarbonTableInputFormat<ArrayWritabl
     } else {
       carbonInputFormat = new CarbonFileInputFormat<>();
     }
-    List<org.apache.hadoop.mapreduce.InputSplit> splitList =
-        carbonInputFormat.getSplits(jobContext);
+    List<org.apache.hadoop.mapreduce.InputSplit> splitList;
+    try {
+      splitList = carbonInputFormat.getSplits(jobContext);
+    } catch (IOException ex) {
+      if (ex.getMessage().contains("No Index files are present in the table location :")) {
+        splitList = new ArrayList<>();
+      } else {
+        throw ex;
+      }
+    }
     InputSplit[] splits = new InputSplit[splitList.size()];
     CarbonInputSplit split;
     for (int i = 0; i < splitList.size(); i++) {

--- a/integration/hive/src/test/java/org/apache/carbondata/hive/HiveCarbonTest.java
+++ b/integration/hive/src/test/java/org/apache/carbondata/hive/HiveCarbonTest.java
@@ -86,6 +86,19 @@ public class HiveCarbonTest extends HiveTestUtils {
   }
 
   @Test
+  public void verifyEmptyTableSelectQuery() throws Exception {
+    statement.execute("drop table if exists hive_carbon_table1");
+    statement.execute("CREATE TABLE hive_carbon_table1(id INT, name STRING, scale DECIMAL, country STRING, salary DOUBLE) stored by 'org.apache.carbondata.hive.CarbonStorageHandler'");
+    statement.execute("drop table if exists hive_carbon_table2");
+    statement.execute("CREATE TABLE hive_carbon_table2(id INT, name STRING, scale DECIMAL, country STRING, salary DOUBLE) stored by 'org.apache.carbondata.hive.CarbonStorageHandler'");
+    statement.execute("INSERT into hive_carbon_table2 SELECT * FROM hive_carbon_table1");
+    checkAnswer(statement.executeQuery("SELECT * FROM hive_carbon_table2"),
+        connection.createStatement().executeQuery("select * from hive_carbon_table1"));
+    statement.execute("drop table if exists hive_carbon_table1");
+    statement.execute("drop table if exists hive_carbon_table2");
+  }
+
+  @Test
   public void verifyDataAfterLoadUsingSortColumns() throws Exception {
     statement.execute("drop table if exists hive_carbon_table5");
     statement.execute(

--- a/integration/hive/src/test/java/org/apache/carbondata/hive/HiveTestUtils.java
+++ b/integration/hive/src/test/java/org/apache/carbondata/hive/HiveTestUtils.java
@@ -66,11 +66,9 @@ public abstract class HiveTestUtils {
 
   public boolean checkAnswer(ResultSet actual, ResultSet expected) throws SQLException {
     Assert.assertEquals("Row Count Mismatch: ", expected.getFetchSize(), actual.getFetchSize());
-    int rowCountExpected = 0;
     List<String> expectedValuesList = new ArrayList<>();
     List<String> actualValuesList = new ArrayList<>();
     while (expected.next()) {
-      rowCountExpected ++;
       if (!actual.next()) {
         return false;
       }
@@ -88,7 +86,6 @@ public abstract class HiveTestUtils {
     }
     Collections.sort(expectedValuesList);Collections.sort(actualValuesList);
     Assert.assertArrayEquals(expectedValuesList.toArray(), actualValuesList.toArray());
-    Assert.assertTrue(rowCountExpected > 0);
     return true;
   }
 


### PR DESCRIPTION
 ### Why is this PR needed?
Reading data from empty carbontable through hive beeline was giving 'Unable read Carbon Schema' exception when no data is present in the carbon table. In case of empty table, some additional fields are present in the columns. And also schema is comma-separated which we are expecting to be colon-separated.
 
 ### What changes were proposed in this PR?
Return the empty data if no data is present. Validated the columns and column types and removed, if any extra field was added. Also parsed the schema in such a way that it can consider comma-separated values also.

    
 ### Does this PR introduce any user interface change?
 - No
 - Yes. (please explain the change and update document)

 ### Is any new testcase added?
 - Yes

    
