### PR TITLE
[CARBONDATA-3995] Support presto querying older complex type stores

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/reader/dimension/v3/DimensionChunkReaderV3.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/reader/dimension/v3/DimensionChunkReaderV3.java
@@ -253,6 +253,8 @@ public class DimensionChunkReaderV3 extends AbstractDimensionChunkReader {
     ColumnPageDecoder decoder = encodingFactory.createDecoder(encodings, encoderMetas,
         compressorName, vectorInfo != null);
     if (vectorInfo != null) {
+      // set encodings of current page in the vectorInfo, used for decoding the complex child page
+      vectorInfo.encodings = encodings;
       decoder
           .decodeAndFillVector(pageData.array(), offset, pageMetadata.data_page_length, vectorInfo,
               nullBitSet, isLocalDictEncodedPage, pageMetadata.numberOfRowsInpage,

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/vector/ColumnVectorInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/vector/ColumnVectorInfo.java
@@ -28,6 +28,7 @@ import org.apache.carbondata.core.scan.filter.GenericQueryType;
 import org.apache.carbondata.core.scan.model.ProjectionDimension;
 import org.apache.carbondata.core.scan.model.ProjectionMeasure;
 import org.apache.carbondata.core.scan.result.vector.impl.CarbonColumnVectorImpl;
+import org.apache.carbondata.format.Encoding;
 
 public class ColumnVectorInfo implements Comparable<ColumnVectorInfo> {
   public int offset;
@@ -45,6 +46,8 @@ public class ColumnVectorInfo implements Comparable<ColumnVectorInfo> {
   public DecimalConverterFactory.DecimalConverter decimalConverter;
   // Vector stack is used in complex column vectorInfo to store all the children vectors.
   public Stack<CarbonColumnVector> vectorStack = new Stack<>();
+  // store the encoding of the column, used while decoding the page for filling the vector
+  public List<Encoding> encodings;
 
   @Override
   public int compareTo(ColumnVectorInfo o) {


### PR DESCRIPTION
 ### Why is this PR needed?
 Before carbon 2.0, complex child length is stored as SHORT for string, varchar, binary, date, decimal types.
So, In 2.0 as it is stored as INT, presto complex query code always assumes it as  INT 
and goes to out of bound exception when old store is queried.
 
 ### What changes were proposed in this PR?
If INT_LENGTH_COMPLEX_CHILD_BYTE_ARRAY encoding is present, parse as INT, else parse as SHORT.
so, that both stores can be queried.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No [upgrade scenario]

    
