### PR TITLE
[CARBONDATA-3991]Fix the set modified time function on S3 and Alluxio…

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/AbstractDFSCarbonFile.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/AbstractDFSCarbonFile.java
@@ -420,6 +420,20 @@ public abstract class AbstractDFSCarbonFile implements CarbonFile {
   }
 
   @Override
+  public boolean createNewFile(boolean overwrite) throws IOException {
+    if (!overwrite && fileSystem.exists(path)) {
+      return false;
+    } else {
+      // Pass the permissions during file creation itself
+      fileSystem
+          .create(path, false, fileSystem.getConf().getInt("io.file.buffer.size", 4096),
+              fileSystem.getDefaultReplication(path), fileSystem.getDefaultBlockSize(path), null)
+          .close();
+      return true;
+    }
+  }
+
+  @Override
   public boolean deleteFile() throws IOException {
     return fileSystem.delete(path, true);
   }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/CarbonFile.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/CarbonFile.java
@@ -131,6 +131,8 @@ public interface CarbonFile {
 
   boolean createNewFile(final FsPermission permission) throws IOException;
 
+  boolean createNewFile(final boolean overwrite) throws IOException;
+
   boolean deleteFile() throws IOException;
 
   boolean mkdirs() throws IOException;

--- a/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/LocalCarbonFile.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/LocalCarbonFile.java
@@ -422,6 +422,11 @@ public class LocalCarbonFile implements CarbonFile {
   }
 
   @Override
+  public boolean createNewFile(boolean overwrite) throws IOException {
+    return file.createNewFile();
+  }
+
+  @Override
   public boolean deleteFile() {
     return FileFactory.deleteAllFilesOfDir(file);
   }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/impl/FileFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/impl/FileFactory.java
@@ -297,6 +297,22 @@ public final class FileFactory {
     return getCarbonFile(filePath).deleteFile();
   }
 
+  public static long setLastModifiedTimeToCurrentTime(String filePath) throws IOException {
+    switch (getFileType(filePath)) {
+      case ALLUXIO:
+      case S3:
+        if (getCarbonFile(filePath).getSize() > 0) {
+          throw new IOException("Unsupported setLastModifiedTime operation on NonEmpty File");
+        }
+        getCarbonFile(filePath).createNewFile(true);
+        return getCarbonFile(filePath).getLastModifiedTime();
+      default:
+        long currentTime = System.currentTimeMillis();
+        getCarbonFile(filePath).setLastModifiedTime(currentTime);
+        return currentTime;
+    }
+  }
+
   public static boolean deleteAllFilesOfDir(File path) {
     if (!path.exists()) {
       return true;

--- a/core/src/main/java/org/apache/carbondata/core/view/MVProvider.java
+++ b/core/src/main/java/org/apache/carbondata/core/view/MVProvider.java
@@ -550,9 +550,8 @@ public class MVProvider {
             this.schemaIndexFilePath,
             new FsPermission(FsAction.ALL, FsAction.ALL, FsAction.ALL));
       }
-      long lastModifiedTime = System.currentTimeMillis();
-      FileFactory.getCarbonFile(this.schemaIndexFilePath).setLastModifiedTime(lastModifiedTime);
-      this.lastModifiedTime = lastModifiedTime;
+      this.lastModifiedTime =
+          FileFactory.setLastModifiedTimeToCurrentTime(this.schemaIndexFilePath);
     }
 
   }

--- a/core/src/test/java/org/apache/carbondata/core/carbon/datastorage/filesystem/store/impl/FileFactoryImplUnitTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/carbon/datastorage/filesystem/store/impl/FileFactoryImplUnitTest.java
@@ -21,6 +21,9 @@ import java.io.DataOutputStream;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.datastore.filesystem.CarbonFile;
@@ -40,9 +43,7 @@ import org.junit.Test;
 
 import static junit.framework.TestCase.assertNotNull;
 import static junit.framework.TestCase.fail;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class FileFactoryImplUnitTest {
 
@@ -168,6 +169,19 @@ public class FileFactoryImplUnitTest {
   @Test public void testGetCarbonFile() throws IOException {
     FileFactory.getDataOutputStream(filePath);
     assertNotNull(FileFactory.getCarbonFile(filePath));
+  }
+
+  @Test public void testSetLastModifiedTimeToCurrentTime()
+      throws IOException, ParseException, InterruptedException {
+    File file = new File(filePath);
+    if (file.exists()) {
+      file.delete();
+    }
+    FileFactory.createNewFile(filePath);
+    long lastModifiedTimeBeforeUpdate = FileFactory.getCarbonFile(filePath).getLastModifiedTime();
+    FileFactory.setLastModifiedTimeToCurrentTime(filePath);
+    long lastModifiedTimeAfterUpdate = FileFactory.getCarbonFile(filePath).getLastModifiedTime();
+    assertTrue(lastModifiedTimeAfterUpdate >= lastModifiedTimeBeforeUpdate);
   }
 
   @Test public void testTruncateFile() {

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/cloud/AllDataSourceTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/cloud/AllDataSourceTestCase.scala
@@ -860,6 +860,8 @@ class AllDataSourceTestCase extends QueryTest with BeforeAndAfterAll {
     assert(!CarbonPlanHelper.isCarbonTable(
       TableIdentifier(s"${tableName}_e", Option("alldatasource")), sqlContext.sparkSession))
     assert(new File(tablePath).exists())
+    sql(s"drop table if exists ${tableName}_s")
+    assert(new File(tablePath).exists().equals(false))
   }
 
   def verifyExternalHiveTable(provider: String, tableName: String): Unit = {


### PR DESCRIPTION
… file system

###Why is this PR needed?
If there are some update or create mv in S3 and Alluxio files ,those operations do not take effect. And the other tenant can't find the changes in this operation and cause a data consistency problem.

###What changes were proposed in this PR?
In this PR, we set two function to fix this problem.
1.Create a new file for S3 and Alluxio to set a tag to update.
2.Set a switch case like function to select different scenario in update or create.

###Does this PR introduce any user interface change?
No

###Is any new testcase added?
Yes

 ### Why is this PR needed?
 
 
 ### What changes were proposed in this PR?

    
 ### Does this PR introduce any user interface change?
 - No
 - Yes. (please explain the change and update document)

 ### Is any new testcase added?
 - No
 - Yes

    
