### PR TITLE
[CARBONDATA-3997] Fix decimal value reading issue for negative decimal numbers from presto

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/metadata/datatype/DecimalConverterFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/datatype/DecimalConverterFactory.java
@@ -229,26 +229,7 @@ public final class DecimalConverterFactory {
               vector.putNull(j);
               continue;
             }
-            // jump the scale offset
-            offset += 1;
-            // remove scale from the length
-            length -= 1;
-            byte[] row = new byte[length];
-            System.arraycopy(data, offset, row, 0, length);
-            long val;
-            if (length == 1) {
-              val = row[0];
-            } else if (length == 2) {
-              val = ByteUtil.toShort(row, 0);
-            } else if (length == 4) {
-              val = ByteUtil.toInt(row, 0);
-            } else if (length == 3) {
-              val = ByteUtil.valueOf3Bytes(row, 0);
-            } else {
-              // TODO: check if other value can come
-              val = ByteUtil.toLong(row, 0, length);
-            }
-            BigDecimal value = BigDecimal.valueOf(val, scale);
+            BigDecimal value = DataTypeUtil.byteToBigDecimal(data, offset, length);
             if (value.scale() < newMeasureScale) {
               value = value.setScale(newMeasureScale);
             }

--- a/integration/presto/src/test/scala/org/apache/carbondata/presto/integrationtest/PrestoTestNonTransactionalTableFiles.scala
+++ b/integration/presto/src/test/scala/org/apache/carbondata/presto/integrationtest/PrestoTestNonTransactionalTableFiles.scala
@@ -451,7 +451,7 @@ class PrestoTestNonTransactionalTableFiles extends FunSuiteLike with BeforeAndAf
                                            + "\001" + "2019-02-12 03:03:34"
                                            + "\001" + "true"
                                            + "\001" + longChar
-                                           + "\001" + "1.234567"
+                                           + "\001" + "-2.2"
                                            + "\001" + "stringName")
       writer.write(array1)
       writer.write(array2)
@@ -493,7 +493,7 @@ class PrestoTestNonTransactionalTableFiles extends FunSuiteLike with BeforeAndAf
         assert(result.get("timestampfield") == "2019-02-12 03:03:34.000")
         assert(result.get("booleanfield") == true)
         assert(result.get("longstringfield") == longChar)
-        assert(result.get("decimalfield") == "1.23")
+        assert(result.get("decimalfield") == "-2.20")
         assert(result.get("stringchildfield") == "stringName")
       }
     }


### PR DESCRIPTION
 ### Why is this PR needed?
Reading negative decimal numbers gives the wrong value from presto.
 
 ### What changes were proposed in this PR?
 When complex decimal column is stored with DIRECT_COMPRESS codec, `DataTypeUtil#bigDecimalToByte` is used to create a byte array. So, while decoding it, need to use `DataTypeUtil#byteToBigDecimal`to get back the original value.
Originally added a TODO to find what is happening at write step for decimal, handled as part of this issue.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
