### PR TITLE
[CARBONDATA-3998] Fixed file not found exception for hive during insert

### DIFF
--- a/integration/hive/src/main/java/org/apache/carbondata/hive/MapredCarbonInputFormat.java
+++ b/integration/hive/src/main/java/org/apache/carbondata/hive/MapredCarbonInputFormat.java
@@ -158,7 +158,9 @@ public class MapredCarbonInputFormat extends CarbonTableInputFormat<ArrayWritabl
     try {
       splitList = carbonInputFormat.getSplits(jobContext);
     } catch (IOException ex) {
-      if (ex.getMessage().contains("No Index files are present in the table location :")) {
+      LOGGER.error("Unable to get splits: ", ex);
+      if (ex.getMessage().contains("No Index files are present in the table location :") ||
+          ex.getMessage().contains("CarbonData file is not present in the table location")) {
         splitList = new ArrayList<>();
       } else {
         throw ex;

--- a/integration/hive/src/main/java/org/apache/carbondata/hive/MapredCarbonOutputFormat.java
+++ b/integration/hive/src/main/java/org/apache/carbondata/hive/MapredCarbonOutputFormat.java
@@ -100,10 +100,9 @@ public class MapredCarbonOutputFormat<T> extends CarbonTableOutputFormat
         carbonLoadModel.getCarbonDataLoadSchema().getCarbonTable().getPartitionInfo();
     final int partitionColumn =
         partitionInfo != null ? partitionInfo.getColumnSchemaList().size() : 0;
-    String finalOutputPath = FileFactory.getCarbonFile(finalOutPath.toString()).getAbsolutePath();
     if (carbonLoadModel.getCarbonDataLoadSchema().getCarbonTable().isHivePartitionTable()) {
-      carbonLoadModel.getMetrics().addToPartitionPath(finalOutputPath);
-      context.getConfiguration().set("carbon.outputformat.writepath", finalOutputPath);
+      carbonLoadModel.getMetrics().addToPartitionPath(finalOutPath.toString());
+      context.getConfiguration().set("carbon.outputformat.writepath", finalOutPath.toString());
     }
     CarbonTableOutputFormat.setLoadModel(jc, carbonLoadModel);
     org.apache.hadoop.mapreduce.RecordWriter<NullWritable, ObjectArrayWritable> re =
@@ -116,7 +115,8 @@ public class MapredCarbonOutputFormat<T> extends CarbonTableOutputFormat
           if (isHivePartitionedTable) {
             Object[] actualRow = ((CarbonHiveRow) writable).getData();
             Object[] newData = Arrays.copyOf(actualRow, actualRow.length + partitionColumn);
-            String[] partitionValues = finalOutputPath.substring(tablePath.length()).split("/");
+            String[] partitionValues = finalOutPath.toString().substring(tablePath.length())
+                .split("/");
             for (int j = 0, i = actualRow.length; j < partitionValues.length; j++) {
               if (partitionValues[j].contains("=")) {
                 newData[i++] = partitionValues[j].split("=")[1];


### PR DESCRIPTION
 ### Why is this PR needed?
 FileNotFoundException being thrown in hive during insert.
 
 ### What changes were proposed in this PR?
During insert the path in the parameters for write is for staging directory, because carbon is non-native table therefore this directory does not exist. 
When getAbsolutePath is called on this directory, it throws FileNotFound exception. 
Removed the getAbsolutePath call to avoid this.
    
 ### Does this PR introduce any user interface change?
 - No
 - Yes. (please explain the change and update document)

 ### Is any new testcase added?
 - No
 - Yes

    
