### PR TITLE
[CARBONDATA-4000] Presto select query failure right after firing update query.

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/scan/result/vector/impl/directread/ColumnarVectorWrapperDirectWithDeleteDelta.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/vector/impl/directread/ColumnarVectorWrapperDirectWithDeleteDelta.java
@@ -59,6 +59,17 @@ class ColumnarVectorWrapperDirectWithDeleteDelta extends AbstractCarbonColumnarV
   }
 
   @Override
+  public void putObject(int rowId, Object obj) {
+    if (!deletedRows.get(rowId)) {
+      if (nullBits.get(rowId)) {
+        columnVector.putNull(counter++);
+      } else {
+        columnVector.putObject(counter++, obj);
+      }
+    }
+  }
+
+  @Override
   public void putFloat(int rowId, float value) {
     if (!deletedRows.get(rowId)) {
       if (nullBits.get(rowId)) {


### PR DESCRIPTION
 ### Why is this PR needed?
 The putObject() method implementation was missing due to which select query on **struct** complex data type after **update** queries were failing. 
 
 ### What changes were proposed in this PR?
Added implementation in ColumnarVectorWrapperDirectWithDeleteDelta. Earlier without this implementation control went to its parent class AbstractCarbonColumnarVector,java which was unsupported.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No


    
