### PR TITLE
[CARBONDATA-3991]Fix the set modified time function on S3 and Alluxio…

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/AbstractDFSCarbonFile.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/AbstractDFSCarbonFile.java
@@ -420,6 +420,24 @@ public abstract class AbstractDFSCarbonFile implements CarbonFile {
   }
 
   @Override
+  public boolean createNewFile(boolean overwrite, FsPermission permission) throws IOException {
+    if (!overwrite && fileSystem.exists(path)) {
+      return false;
+    } else {
+      if (permission == null) {
+        permission =
+            FsPermission.getFileDefault().applyUMask(FsPermission.getUMask(fileSystem.getConf()));
+      }
+      // Pass the permissions during file creation itself
+      fileSystem
+          .create(path, permission, true, fileSystem.getConf().getInt("io.file.buffer.size", 4096),
+              fileSystem.getDefaultReplication(path), fileSystem.getDefaultBlockSize(path), null)
+          .close();
+      return true;
+    }
+  }
+
+  @Override
   public boolean deleteFile() throws IOException {
     return fileSystem.delete(path, true);
   }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/CarbonFile.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/CarbonFile.java
@@ -131,6 +131,8 @@ public interface CarbonFile {
 
   boolean createNewFile(final FsPermission permission) throws IOException;
 
+  boolean createNewFile(boolean overwrite, final FsPermission permission) throws IOException;
+
   boolean deleteFile() throws IOException;
 
   boolean mkdirs() throws IOException;

--- a/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/LocalCarbonFile.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/filesystem/LocalCarbonFile.java
@@ -422,6 +422,15 @@ public class LocalCarbonFile implements CarbonFile {
   }
 
   @Override
+  public boolean createNewFile(boolean overwrite, final FsPermission permission)
+      throws IOException {
+    if (overwrite) {
+      return file.createNewFile();
+    }
+    return false;
+  }
+
+  @Override
   public boolean deleteFile() {
     return FileFactory.deleteAllFilesOfDir(file);
   }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/impl/FileFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/impl/FileFactory.java
@@ -293,6 +293,32 @@ public final class FileFactory {
     return getCarbonFile(filePath).createNewFile(permission);
   }
 
+  public static boolean createNewFile(String filePath, Boolean overwrite,
+      final FsPermission permission) throws IOException {
+    return getCarbonFile(filePath).createNewFile(overwrite, permission);
+  }
+
+  public static long changeLastModifiedTimeToCurrentTime(String filePath) throws IOException {
+    switch (getFileType(filePath)) {
+      case S3:
+      case ALLUXIO:
+        if (getCarbonFile(filePath).getSize() > 0) {
+          throw new IOException("Unsupported setLastModifiedTime operation on NonEmpty File");
+        }
+        createNewFile(filePath, true, null);
+        return getCarbonFile(filePath).getLastModifiedTime();
+      case HDFS:
+      case LOCAL:
+      case CUSTOM:
+      case VIEWFS:
+      case HDFS_LOCAL:
+      default:
+        long currentModifiedTime = System.currentTimeMillis();
+        FileFactory.getCarbonFile(filePath).setLastModifiedTime(currentModifiedTime);
+        return currentModifiedTime;
+    }
+  }
+
   public static boolean deleteFile(String filePath) throws IOException {
     return getCarbonFile(filePath).deleteFile();
   }

--- a/core/src/main/java/org/apache/carbondata/core/view/MVProvider.java
+++ b/core/src/main/java/org/apache/carbondata/core/view/MVProvider.java
@@ -546,13 +546,11 @@ public class MVProvider {
             new FsPermission(FsAction.ALL, FsAction.ALL, FsAction.ALL));
       }
       if (!FileFactory.isFileExist(this.schemaIndexFilePath)) {
-        FileFactory.createNewFile(
-            this.schemaIndexFilePath,
+        FileFactory.createNewFile(this.schemaIndexFilePath,
             new FsPermission(FsAction.ALL, FsAction.ALL, FsAction.ALL));
       }
-      long lastModifiedTime = System.currentTimeMillis();
-      FileFactory.getCarbonFile(this.schemaIndexFilePath).setLastModifiedTime(lastModifiedTime);
-      this.lastModifiedTime = lastModifiedTime;
+      this.lastModifiedTime =
+          FileFactory.changeLastModifiedTimeToCurrentTime(this.schemaIndexFilePath);
     }
 
   }

--- a/integration/hive/src/main/java/org/apache/carbondata/hive/util/HiveCarbonUtil.java
+++ b/integration/hive/src/main/java/org/apache/carbondata/hive/util/HiveCarbonUtil.java
@@ -257,7 +257,7 @@ public class HiveCarbonUtil {
         .fromWrapperToExternalTableInfo(tableInfo, tableInfo.getDatabaseName(),
             tableInfo.getFactTable().getTableName()));
     thriftWriter.close();
-    FileFactory.getCarbonFile(schemaFilePath).setLastModifiedTime(System.currentTimeMillis());
+    FileFactory.changeLastModifiedTimeToCurrentTime(schemaFilePath);
   }
 
   public static HiveMetaHook getMetaHook() {

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonInsertFromStageCommand.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonInsertFromStageCommand.scala
@@ -507,9 +507,9 @@ case class CarbonInsertFromStageCommand(
         override def call(): (CarbonFile, CarbonFile, Boolean) = {
           try {
             // Get the loading files path
-            val stageLoadingFile =
-              FileFactory.getCarbonFile(stagePath +
-                File.separator + files._1.getName + CarbonTablePath.LOADING_FILE_SUFFIX);
+            val stageLoadingFilePath = stagePath + File.separator + files._1.getName +
+              CarbonTablePath.LOADING_FILE_SUFFIX
+            val stageLoadingFile = FileFactory.getCarbonFile(stageLoadingFilePath)
             // Try to create loading files
             // make isFailed to be true if createNewFile return false.
             // the reason can be file exists or exceptions.
@@ -517,7 +517,7 @@ case class CarbonInsertFromStageCommand(
             // if file exists, modify the lastmodifiedtime of the file.
             if (isFailed) {
               // make isFailed to be true if setLastModifiedTime return false.
-              isFailed = !stageLoadingFile.setLastModifiedTime(System.currentTimeMillis());
+              isFailed = FileFactory.changeLastModifiedTimeToCurrentTime(stageLoadingFilePath) <= 0
             }
             (files._1, files._2, isFailed)
           } catch {

--- a/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonFileMetastore.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonFileMetastore.scala
@@ -430,8 +430,7 @@ class CarbonFileMetastore extends CarbonMetaStore {
     thriftWriter.open(FileWriteOperation.OVERWRITE)
     thriftWriter.write(thriftTableInfo)
     thriftWriter.close()
-    val modifiedTime = System.currentTimeMillis()
-    FileFactory.getCarbonFile(schemaFilePath).setLastModifiedTime(modifiedTime)
+    val modifiedTime = FileFactory.changeLastModifiedTimeToCurrentTime(schemaFilePath)
     updateSchemasUpdatedTime(identifier.getCarbonTableIdentifier.getTableId, modifiedTime)
     identifier.getTablePath
   }


### PR DESCRIPTION
… file system

 ### Why is this PR needed?
 If there are some update or create mv in S3 and Alluxio files ,those operations do not take effect. And the other tenant can't find the changes in this operation and cause a data consistency problem.
 
 ### What changes were proposed in this PR?
In this PR, we set two function to fix this problem.
1.Create a new file for S3 and Alluxio to set a tag to update.
2.Set a switch case like function to select different scenario in update or create.

    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
