### PR TITLE
[CARBONDATA-4002] Fix removal of columns from table schema.

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
@@ -3302,13 +3302,12 @@ public final class CarbonUtil {
     // so just take all other columns at once.
     int otherColumnStartIndex = -1;
     for (int i = 0; i < columns.size(); i++) {
-      if (columns.get(i).getColumnProperties() != null) {
-        String isSortColumn =
-            columns.get(i).getColumnProperties().get(CarbonCommonConstants.SORT_COLUMNS);
-        if ((isSortColumn != null) && (isSortColumn.equalsIgnoreCase("true"))) {
-          // add sort column dimensions
-          sortColumns.add(columns.get(i));
-        }
+      Map<String, String> columnProperties = columns.get(i).getColumnProperties();
+      if (columnProperties != null
+          && columnProperties.get(CarbonCommonConstants.SORT_COLUMNS) != null
+          && columnProperties.get(CarbonCommonConstants.SORT_COLUMNS).equalsIgnoreCase("true")) {
+        // add sort column dimensions
+        sortColumns.add(columns.get(i));
       } else if ((columns.get(i).getData_type() == org.apache.carbondata.format.DataType.ARRAY
           || columns.get(i).getData_type() == org.apache.carbondata.format.DataType.STRUCT
           || columns.get(i).getData_type() == org.apache.carbondata.format.DataType.MAP || (!columns

--- a/integration/spark/src/main/scala/org/apache/spark/util/AlterTableUtil.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/util/AlterTableUtil.scala
@@ -442,7 +442,9 @@ object AlterTableUtil {
         // update schema for long string columns
         updateSchemaForLongStringColumns(thriftTable, longStringColumns.get)
       } else if (propKeys.exists(_.equalsIgnoreCase("long_string_columns") && !set)) {
-        updateSchemaForLongStringColumns(thriftTable, "")
+        if (tblPropertiesMap.exists(prop => prop._1.equalsIgnoreCase("long_string_columns"))) {
+          updateSchemaForLongStringColumns(thriftTable, "")
+        }
       }
       // below map will be used for cache invalidation. As tblProperties map is getting modified
       // in the next few steps the original map need to be retained for any decision making


### PR DESCRIPTION
 ### Why is this PR needed?
When we change the value of sort_columns property and then perform a alter table query to unset long_string_columns. It results in removal of columns from table schema.
 
 
 ### What changes were proposed in this PR?
Added fix to avoid removal of columns from table schema.

    
 ### Does this PR introduce any user interface change?
 - No


 ### Is any new testcase added?
 - Yes

    
