### PR TITLE
[CARBONDATA-4030] Fix issue in concurrent SI global sort

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/strategy/CarbonLateDecodeStrategy.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/strategy/CarbonLateDecodeStrategy.scala
@@ -627,9 +627,7 @@ private[sql] class CarbonLateDecodeStrategy extends SparkStrategy {
           .getFactTable
           .getTableProperties
         val isPosIDRequested = if (tblProperties.containsKey("isPositionIDRequested")) {
-          val flag = java.lang.Boolean.parseBoolean(tblProperties.get("isPositionIDRequested"))
-          tblProperties.remove("isPositionIDRequested")
-          flag
+          java.lang.Boolean.parseBoolean(tblProperties.get("isPositionIDRequested"))
         } else {
           false
         }


### PR DESCRIPTION
 ### Why is this PR needed?
 when concurrent SI global sort is in progress, one load was removing the table property added by the other load. So, the global sort insert for one load was failing with error that unable to find position id in the projection.
 
 ### What changes were proposed in this PR?
Keep the table properties for main table when SI global sort load is done.  No need to remove it.
Tested other scenarios on main table like compaction, insert and select. 
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No [concurrent scenario]

    
