### PR TITLE
[CARBONDATA-4008]Fixed IN filter on date column is returning 0 results when 'carbon.push.rowfilters.for.vector' is true

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/hive/SqlAstBuilderHelper.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/hive/SqlAstBuilderHelper.scala
@@ -18,14 +18,13 @@
 package org.apache.spark.sql.hive
 
 import org.apache.spark.sql.catalyst.CarbonParserUtil
-import org.apache.spark.sql.catalyst.parser.ParserUtils.{string, withOrigin}
 import org.apache.spark.sql.catalyst.parser.SqlBaseParser
-import org.apache.spark.sql.catalyst.parser.SqlBaseParser.{AddTableColumnsContext, ChangeColumnContext, CreateTableContext, ShowTablesContext}
+import org.apache.spark.sql.catalyst.parser.SqlBaseParser.{AddTableColumnsContext, ChangeColumnContext, CreateTableContext}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.SparkSqlAstBuilder
 import org.apache.spark.sql.execution.command.{AlterTableAddColumnsModel, AlterTableDataTypeChangeModel}
 import org.apache.spark.sql.execution.command.schema.{CarbonAlterTableAddColumnCommand, CarbonAlterTableColRenameDataTypeChangeCommand}
-import org.apache.spark.sql.execution.command.table.{CarbonExplainCommand, CarbonShowTablesCommand}
+import org.apache.spark.sql.execution.command.table.CarbonExplainCommand
 import org.apache.spark.sql.parser.CarbonSpark2SqlParser
 import org.apache.spark.sql.types.DecimalType
 


### PR DESCRIPTION
 ### Why is this PR needed?
 IN filter on date column is returning 0 results when 'carbon.push.rowfilters.for.vector' is set to true. `RowLevelFilterExecutorImpl.applyFilter()` calls `createRow()` and applies filter at row level with `expression.evaluate(row)` invocation. `expression` in this case is `InExpression`. But `createRow()` missed to fill the date column value. Thus expression always evaluates to false and returns 0 rows.
 
 ### What changes were proposed in this PR?
1. Filled the date column value in `createRow()`.
2. Have removed unused imports introduced in previous PR.(SqlAstBuilderHelper.scala)
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
