### PR TITLE
[CARBONDATA-4011] drop index table is failed with table not found exception

### DIFF
--- a/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/DropTableTest.scala
+++ b/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/DropTableTest.scala
@@ -74,4 +74,16 @@ class DropTableTest extends QueryTest with BeforeAndAfterAll {
     assert(exception.getMessage.contains("Index with name indtestdrop does not exist"))
     sql("drop table if exists testDrop")
   }
+
+  test("test drop index command after refresh the index for empty index table") {
+    sql("drop table if exists testDrop")
+    sql("create table testDrop (a string, b string, c string) STORED AS carbondata")
+    sql("create index helloIndex1 on table testDrop (c) AS 'carbondata' properties" +
+        "('table_blocksize'='1')")
+    assert(!sql("show indexes on testDrop").collect().isEmpty)
+    sql("refresh index helloIndex1 on table testDrop")
+    sql("drop index helloIndex1 on table testDrop")
+    assert(sql("show indexes on testDrop").collect().isEmpty)
+    sql("drop table if exists testDrop")
+  }
 }

--- a/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/command/SICreationCommand.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/command/SICreationCommand.scala
@@ -315,7 +315,7 @@ private[sql] case class CarbonCreateSecondaryIndexCommand(
       //        val tablePath = tableIdentifier.getTablePath
       val carbonSchemaString = catalog.generateTableSchemaString(tableInfo, tableIdentifier)
       // set index information in index table
-      val indexTableMeta = new IndexMetadata(indexTableName, true, carbonTable.getTablePath)
+      val indexTableMeta = new IndexMetadata(tableName, true, carbonTable.getTablePath)
       tableInfo.getFactTable.getTableProperties
         .put(tableInfo.getFactTable.getTableId, indexTableMeta.serialize)
       // set index information in parent table


### PR DESCRIPTION
 ### Why is this PR needed?
 drop index table is failed with table not found exception.
 Passing index table name instead of main table name while creating the SI. 
When creating an empty main table and empty SI table and then drop only SI table causing problem. 
If we load any data into maintable then the same field is updating in table refresh flow.  But currently, we have not loaded data into tables, we just create table and then dropping hence the issue.
_Problem code:_
```
     val indexTableMeta = new IndexMetadata(indexTableName, true, carbonTable.getTablePath)
```
 ### What changes were proposed in this PR?
Pass the main table name instead of index table name while creating the index metadata in SI creation flow.
   _Fixed code:_ 
```
     val indexTableMeta = new IndexMetadata(mainTableName, true, carbonTable.getTablePath)
```
 ### Does this PR introduce any user interface change?
 - No
 - Yes. (please explain the change and update document)

 ### Is any new testcase added?
 - Yes

    
