### PR TITLE
[CARBONDATA-4010] Doc changes for long strings.

### DIFF
--- a/docs/ddl-of-carbondata.md
+++ b/docs/ddl-of-carbondata.md
@@ -426,7 +426,8 @@ CarbonData DDL statements are documented here,which includes:
    - ##### String longer than 32000 characters
 
      In common scenarios, the length of string is less than 32000,
-     so carbondata stores the length of content using Short to reduce memory and space consumption.
+     so carbondata stores the length of content using Short to reduce memory and space consumption, and it handles the strings
+     which length greater than 32000 as bad record. Refer [bad record handling](https://github.com/apache/carbondata/blob/master/docs/dml-of-carbondata.md#bad-records-handling) section for better understanding.
      To support string longer than 32000 characters, carbondata introduces a table property called `LONG_STRING_COLUMNS`.
      For these columns, carbondata internally stores the length of content using Integer.
 

--- a/docs/ddl-of-carbondata.md
+++ b/docs/ddl-of-carbondata.md
@@ -426,8 +426,8 @@ CarbonData DDL statements are documented here,which includes:
    - ##### String longer than 32000 characters
 
      In common scenarios, the length of string is less than 32000,
-     so carbondata stores the length of content using Short to reduce memory and space consumption, and it handles the strings
-     which length greater than 32000 as bad record. Refer [bad record handling](https://github.com/apache/carbondata/blob/master/docs/dml-of-carbondata.md#bad-records-handling) section for better understanding.
+     so carbondata stores the length of content using Short to reduce memory and space consumption,
+     and it handles strings which have length greater than 32000 as a bad record. Refer [bad record handling](https://github.com/apache/carbondata/blob/master/docs/dml-of-carbondata.md#bad-records-handling) section for better understanding.
      To support string longer than 32000 characters, carbondata introduces a table property called `LONG_STRING_COLUMNS`.
      For these columns, carbondata internally stores the length of content using Integer.
 
@@ -813,7 +813,19 @@ Users can specify which columns to include and exclude for local dictionary gene
        ```
        ALTER TABLE tablename UNSET TBLPROPERTIES('SORT_SCOPE')
        ```
+     - ##### Long String Columns
+       Example to SET Long String Columns:
+       ```
+       ALTER TABLE tablename SET TBLPROPERTIES('LONG_STRING_COLUMNS'='column1')
+       ```
+       **NOTE:** Only string columns can be set to long string columns. Cannot set sort columns to long string columns.
 
+       Example to UNSET Long String Columns:
+       ```
+       ALTER TABLE tablename UNSET TBLPROPERTIES('LONG_STRING_COLUMNS')
+       ```
+       **NOTE:** On unset, long string columns are set to their original datatypes.
+ 
      - ##### SORT COLUMNS
        Example to SET SORT COLUMNS:
        ```


### PR DESCRIPTION
 ### Why is this PR needed?
 Added documentation change for the handling of long strings(length greater than 32000) as bad record and  set/unset of longStringColumns.
 
 ### What changes were proposed in this PR?
 Added documentation change for the handling of long strings(length greater than 32000) as bad record and  set/unset of longStringColumns.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No

    
