### PR TITLE
[CARBONDATA-4014] Support Change Column Comment

### DIFF
--- a/docs/ddl-of-carbondata.md
+++ b/docs/ddl-of-carbondata.md
@@ -49,7 +49,7 @@ CarbonData DDL statements are documented here,which includes:
     * [ADD COLUMNS](#add-columns)
     * [DROP COLUMNS](#drop-columns)
     * [RENAME COLUMN](#change-column-nametype)
-    * [CHANGE COLUMN NAME/TYPE](#change-column-nametype)
+    * [CHANGE COLUMN NAME/TYPE/COMMENT](#change-column-nametype)
     * [MERGE INDEXES](#merge-index)
     * [SET/UNSET](#set-and-unset)
   * [DROP TABLE](#drop-table)
@@ -719,18 +719,23 @@ Users can specify which columns to include and exclude for local dictionary gene
 
      **NOTE:** Drop Complex child column is not supported.
 
-   - #### CHANGE COLUMN NAME/TYPE
+   - #### CHANGE COLUMN NAME/TYPE/COMMENT
    
-     This command is used to change column name and the data type from INT to BIGINT or decimal precision from lower to higher.
+     This command is used to change column name and comment and the data type from INT to BIGINT or decimal precision from lower to higher.
      Change of decimal data type from lower precision to higher precision will only be supported for cases where there is no data loss.
+     Change of comment will only be supported for columns other than the partition column
 
      ```
-     ALTER TABLE [db_name.]table_name CHANGE col_old_name col_new_name column_type
+     ALTER TABLE [db_name.]table_name CHANGE col_old_name col_new_name column_type [COMMENT 'col_comment']
      ```
 
      Valid Scenarios
-     - Invalid scenario - Change of decimal precision from (10,2) to (10,5) is invalid as in this case only scale is increased but total number of digits remains the same.
-     - Valid scenario - Change of decimal precision from (10,2) to (12,3) is valid as the total number of digits are increased by 2 but scale is increased only by 1 which will not lead to any data loss.
+     - Invalid scenarios 
+       * Change of decimal precision from (10,2) to (10,5) is invalid as in this case only scale is increased but total number of digits remains the same.
+       * Change the comment of the partition column
+     - Valid scenarios
+       * Change of decimal precision from (10,2) to (12,3) is valid as the total number of digits are increased by 2 but scale is increased only by 1 which will not lead to any data loss.
+       * Change the comment of columns other than partition column
      - **NOTE:** The allowed range is 38,38 (precision, scale) and is a valid upper case scenario which is not resulting in data loss.
 
      Example1:Change column a1's name to a2 and its data type from INT to BIGINT.
@@ -749,6 +754,11 @@ Users can specify which columns to include and exclude for local dictionary gene
 
      ```
      ALTER TABLE test_db.carbon CHANGE a3 a4 STRING
+     ```
+     Example3:Change column a3's comment to "col_comment".
+     
+     ```
+     ALTER TABLE test_db.carbon CHANGE a3 a3 STRING COMMENT 'col_comment'
      ```
 
      **NOTE:** Once the column is renamed, user has to take care about replacing the fileheader with the new name or changing the column header in csv file.

--- a/integration/spark/src/main/scala/org/apache/spark/sql/catalyst/CarbonParserUtil.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/catalyst/CarbonParserUtil.scala
@@ -1110,8 +1110,7 @@ object CarbonParserUtil {
    */
   def parseDataType(
       dataType: String,
-      values: Option[List[(Int, Int)]],
-      isColumnRename: Boolean): DataTypeInfo = {
+      values: Option[List[(Int, Int)]]): DataTypeInfo = {
     var precision: Int = 0
     var scale: Int = 0
     dataType match {
@@ -1135,11 +1134,7 @@ object CarbonParserUtil {
         }
         DataTypeInfo("decimal", precision, scale)
       case _ =>
-        if (isColumnRename) {
-          DataTypeInfo(DataTypeConverterUtil.convertToCarbonType(dataType).getName.toLowerCase)
-        } else {
-          throw new MalformedCarbonCommandException("Data type provided is invalid.")
-        }
+        DataTypeInfo(DataTypeConverterUtil.convertToCarbonType(dataType).getName.toLowerCase)
     }
   }
 

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchemaCommon.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/carbonTableSchemaCommon.scala
@@ -169,7 +169,8 @@ case class AlterTableDataTypeChangeModel(dataTypeInfo: DataTypeInfo,
     tableName: String,
     columnName: String,
     newColumnName: String,
-    isColumnRename: Boolean)
+    isColumnRename: Boolean,
+    newColumnComment: Option[String] = None)
   extends AlterTableColumnRenameModel(columnName, newColumnName, isColumnRename)
 
 case class AlterTableRenameModel(

--- a/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonSessionUtil.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonSessionUtil.scala
@@ -32,6 +32,7 @@ import org.apache.spark.util.{CarbonReflectionUtils, PartitionCacheKey, Partitio
 
 import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.converter.SparkDataTypeConverterImpl
+import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable
 import org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema
 import org.apache.carbondata.core.util.CarbonUtil
@@ -142,14 +143,16 @@ object CarbonSessionUtil {
       if (!column.isInvisible) {
         val structFiled =
           if (null != column.getColumnProperties &&
-              column.getColumnProperties.get("comment") != null) {
+              column.getColumnProperties.get(CarbonCommonConstants.COLUMN_COMMENT) != null) {
             StructField(column.getColumnName,
               SparkTypeConverter
                 .convertCarbonToSparkDataType(column,
                   carbonTable),
               true,
               // update the column comment if present in the schema
-              new MetadataBuilder().putString("comment", column.getColumnProperties.get("comment"))
+              new MetadataBuilder().putString(
+                CarbonCommonConstants.COLUMN_COMMENT,
+                column.getColumnProperties.get(CarbonCommonConstants.COLUMN_COMMENT))
                 .build())
           } else {
             StructField(column.getColumnName,

--- a/integration/spark/src/main/scala/org/apache/spark/sql/hive/SqlAstBuilderHelper.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/hive/SqlAstBuilderHelper.scala
@@ -44,7 +44,7 @@ trait SqlAstBuilderHelper extends SparkSqlAstBuilder {
 
     val alterTableColRenameAndDataTypeChangeModel =
       AlterTableDataTypeChangeModel(
-        CarbonParserUtil.parseDataType(typeString, values, isColumnRename),
+        CarbonParserUtil.parseDataType(typeString, values),
         CarbonParserUtil.convertDbNameToLowerCase(Option(ctx.tableIdentifier().db).map(_.getText)),
         ctx.tableIdentifier().table.getText.toLowerCase,
         ctx.identifier.getText.toLowerCase,

--- a/integration/spark/src/main/scala/org/apache/spark/sql/parser/CarbonSparkSqlParserUtil.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/parser/CarbonSparkSqlParserUtil.scala
@@ -665,8 +665,7 @@ object CarbonSparkSqlParserUtil {
     val alterTableColRenameAndDataTypeChangeModel =
       AlterTableDataTypeChangeModel(
         CarbonParserUtil.parseDataType(dataType.toLowerCase,
-          values,
-          isColumnRename),
+          values),
         CarbonParserUtil.convertDbNameToLowerCase(dbName),
         table.toLowerCase,
         columnName.toLowerCase,

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/standardpartition/StandardPartitionTableQueryTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/standardpartition/StandardPartitionTableQueryTestCase.scala
@@ -515,12 +515,10 @@ test("Creation of partition table should fail if the colname in table schema and
       sql("alter table onlyPart drop columns(name)")
     }
     assert(ex1.getMessage.contains("alter table drop column is failed, cannot have the table with all columns as partition column"))
-    if (SparkUtil.isSparkVersionXAndAbove("2.2")) {
-      val ex2 = intercept[MalformedCarbonCommandException] {
-        sql("alter table onlyPart change age age bigint")
-      }
-      assert(ex2.getMessage.contains("Alter datatype of the partition column age is not allowed"))
+    val ex2 = intercept[MalformedCarbonCommandException] {
+      sql("alter table onlyPart change age age bigint")
     }
+    assert(ex2.getMessage.contains("Alter on partition column age is not supported"))
     sql("drop table if exists onlyPart")
   }
 

--- a/integration/spark/src/test/scala/org/apache/spark/carbondata/restructure/AlterTableValidationTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/spark/carbondata/restructure/AlterTableValidationTestCase.scala
@@ -366,7 +366,7 @@ class AlterTableValidationTestCase extends QueryTest with BeforeAndAfterAll {
     sql("alter table default.restructure change decimalfield deciMalfield Decimal(11,3)")
     sql("alter table default.restructure change decimalfield deciMalfield Decimal(12,3)")
     intercept[ProcessMetaDataException] {
-      sql("alter table default.restructure change decimalfield deciMalfield Decimal(12,3)")
+      sql("alter table default.restructure change decimalfield deciMalfield Decimal(12,2)")
     }
     intercept[ProcessMetaDataException] {
       sql("alter table default.restructure change decimalfield deciMalfield Decimal(13,1)")


### PR DESCRIPTION
 ### Why is this PR needed?
 Now, we support add column comment in "CREATE TABLE" and "ADD COLUMN". but do not support alter comment of the column, which shall be support in 'CHANGE COLUMN'
 
 ### What changes were proposed in this PR?
Support "ALTER TABLE table_name CHANGE [COLUMN] col_name col_name data_type [COMMENT col_comment]"
    
 ### Does this PR introduce any user interface change?
 - Yes. add CHANGE COLUMN explaination in the ddl document.

 ### Is any new testcase added?
 - Yes

    
