### PR TITLE
[CARBONDATA-4017]Fix the insert issue when the column name contains '\' and fix SI creation issue

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
@@ -1881,7 +1881,9 @@ public final class CarbonUtil {
     gsonBuilder.registerTypeAdapter(DataType.class, new DataTypeAdapter());
 
     Gson gson = gsonBuilder.create();
-    TableInfo tableInfo = gson.fromJson(builder.toString(), TableInfo.class);
+    // if the column name contains backslash in the column name, then fromJson will remove that,
+    // so replace like below to keep the "\" in column name and write the proper name in the schema
+    TableInfo tableInfo = gson.fromJson(builder.toString().replace("\\", "\\\\"), TableInfo.class);
 
     // The tableInfo is deserialize from GSON string, need to update the scale and
     // precision if there are any decimal field, because DecimalType is added in Carbon 1.3,


### PR DESCRIPTION
 ### Why is this PR needed?
 1. when the column name contains the backslash character and the table is created with carbon session , insert fails second time. This is because, the `.fromGson` method takes input string, if that has `\`, it will escape that char, eventhough its valid.
2. when column name has special characters, SI creation fails in parsing.
 
 ### What changes were proposed in this PR?
1. replace the `\` char jason string to `\\`, so that only one character is escaped.
2. Use `CarbonSparkUtil.getRawSchema` to get the schema which wrap `` characters around column names and helps in parsing.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
