### PR TITLE
[CARBONDATA-4016] NPE and FileNotFound in Show Segments and Insert Stage

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/statusmanager/LoadMetadataDetails.java
+++ b/core/src/main/java/org/apache/carbondata/core/statusmanager/LoadMetadataDetails.java
@@ -492,6 +492,9 @@ public class LoadMetadataDetails implements Serializable {
     if (!StringUtils.isEmpty(updateDeltaEndTimestamp)) {
       return convertTimeStampToLong(updateDeltaEndTimestamp);
     }
-    return convertTimeStampToLong(timestamp);
+    if (!StringUtils.isEmpty(timestamp)) {
+      return convertTimeStampToLong(timestamp);
+    }
+    return CarbonCommonConstants.SEGMENT_LOAD_TIME_DEFAULT;
   }
 }


### PR DESCRIPTION
 ### Why is this PR needed?
 1. Insert Stage,  While Spark read Stages which are writting by Flink in the meanwhile, JSONFORMAT EXCEPTION maybe be thrown as the stage file is in writing.
 2. Show Segments with STAGE, when read stages which are writting by Flink or deleting by spark. JSONFORMAT EXCEPTION will be thrown as the stage file is in writing.
 3. Show Segment will load partition info for non-partition table, leading to bad performance, which shall be avoided.
 4. In getLastModifiedTime of TableStatus, if the timestamp is empty, getLastModifiedTime throw Exception. Accoding to getLoadEndTime(), we shall return -1.
 
 ### What changes were proposed in this PR?
 1. Insert Stage,  add RETRY to read stage file.
 2. Show Segments with STAGE, add RETRY to read stage.
 3. Show Segment load partition only for partition table
 4. getLastModifiedTime return -1 if the timestamp is empty.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No

    
