### PR TITLE
[CARBONDATA-4023] Create MV failed on table with geospatial index using carbonsession.

### DIFF
--- a/examples/spark/src/main/scala/org/apache/carbondata/examples/GeoTableExampleWithCarbonSession.scala
+++ b/examples/spark/src/main/scala/org/apache/carbondata/examples/GeoTableExampleWithCarbonSession.scala
@@ -87,6 +87,10 @@ object GeoTableExampleWithCarbonSession {
     }
     spark.sql(s"""LOAD DATA local inpath '$path' INTO TABLE geoTable OPTIONS
            |('DELIMITER'= ',')""".stripMargin)
+    // Test for MV creation
+    spark.sql(s"CREATE MATERIALIZED VIEW view1 AS SELECT longitude, latitude FROM geoTable")
+    val result = spark.sql("show materialized views on table geoTable").collectAsList()
+    assert(result.get(0).get(1).toString.equalsIgnoreCase("view1"))
     spark.sql("select *from geoTable").show()
     spark.sql("DROP TABLE IF EXISTS geoTable")
   }

--- a/integration/spark/src/main/scala/org/apache/spark/sql/parser/CarbonSparkSqlParserUtil.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/parser/CarbonSparkSqlParserUtil.scala
@@ -562,8 +562,11 @@ object CarbonSparkSqlParserUtil {
    * @return returns <true> if lower case conversion is needed else <false>
    */
   def needToConvertToLowerCase(key: String): Boolean = {
-    val noConvertList = Array(CarbonCommonConstants.COMPRESSOR, "PATH", "bad_record_path",
+    var noConvertList = Array(CarbonCommonConstants.COMPRESSOR, "PATH", "bad_record_path",
       "timestampformat", "dateformat")
+    if (key.startsWith(CarbonCommonConstants.SPATIAL_INDEX) && key.endsWith(".class")) {
+      noConvertList = noConvertList ++ Array(key)
+    }
     !noConvertList.exists(x => x.equalsIgnoreCase(key))
   }
 


### PR DESCRIPTION
 ### Why is this PR needed?
 Create MV failed on the table with geospatial index using carbonsession.
Failed with, java.lang.ClassNotFoundException: org.apache.carbondata.geo.geohashindex
 
 ### What changes were proposed in this PR?
When geo table is created with carbon session, the spatial properties are normalized and converted to lower case. Added spatial index class into `noConverterList`.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No

    
