### PR TITLE
[CARBONDATA-4004] [CARBONDATA-4012] Issue with select after update command

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/compress/DirectCompressCodec.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/compress/DirectCompressCodec.java
@@ -277,6 +277,11 @@ public class DirectCompressCodec implements ColumnPageCodec {
         vector = ColumnarVectorWrapperDirectFactory
             .getDirectVectorWrapperFactory(vectorInfo, parentVector, vectorInfo.invertedIndex,
                 nullBits, vectorInfo.deletedRows, true, false);
+        // In case of update there will be two wrappers enclosing columnVector
+        if (vector.getColumnVector() != null
+            && vector.getColumnVector().getColumnVector() != null) {
+          vector = vector.getColumnVector();
+        }
         fillVectorBasedOnType(pageData, vector, vectorDataType, pageDataType, pageSize,
             vectorInfo, nullBits);
       } else {

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/vector/impl/directread/ColumnarVectorWrapperDirectWithDeleteDelta.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/vector/impl/directread/ColumnarVectorWrapperDirectWithDeleteDelta.java
@@ -242,4 +242,8 @@ class ColumnarVectorWrapperDirectWithDeleteDelta extends AbstractCarbonColumnarV
       columnVector.putArray(counter++, offset, length);
     }
   }
+
+  public CarbonColumnVector getColumnVector() {
+    return this.columnVector;
+  }
 }

--- a/docs/prestosql-guide.md
+++ b/docs/prestosql-guide.md
@@ -300,6 +300,8 @@ carbondata files.
 
 ### Supported features of presto carbon
 Presto carbon only supports reading the carbon table which is written by spark carbon or carbon SDK. 
+Regarding complex datatypes- currently reading of only Array and Struct datatypes are supported, 
+while Map datatype is not yet supported.
 During reading, it supports the non-distributed index like block index and bloom index.
 It doesn't support Materialized View as it needs query plan to be changed and presto does not allow it.
 Also, Presto carbon supports streaming segment read from streaming table created by spark.

--- a/integration/presto/src/main/prestodb/org/apache/carbondata/presto/readers/SliceStreamReader.java
+++ b/integration/presto/src/main/prestodb/org/apache/carbondata/presto/readers/SliceStreamReader.java
@@ -125,6 +125,17 @@ public class SliceStreamReader extends CarbonColumnVectorImpl implements PrestoV
   }
 
   @Override
+  public void putAllByteArray(byte[] data, int offset, int length) {
+    int[] lengths = getLengths();
+    int[] offsets = getOffsets();
+    for (int i = 0; i < lengths.length; i++) {
+      if (offsets[i] != 0) {
+        putByteArray(i, offsets[i], lengths[i], data);
+      }
+    }
+  }
+
+  @Override
   public void putNull(int rowId) {
     if (dictionaryBlock == null) {
       builder.appendNull();

--- a/integration/presto/src/main/prestosql/org/apache/carbondata/presto/readers/SliceStreamReader.java
+++ b/integration/presto/src/main/prestosql/org/apache/carbondata/presto/readers/SliceStreamReader.java
@@ -125,6 +125,17 @@ public class SliceStreamReader extends CarbonColumnVectorImpl implements PrestoV
   }
 
   @Override
+  public void putAllByteArray(byte[] data, int offset, int length) {
+    int[] lengths = getLengths();
+    int[] offsets = getOffsets();
+    for (int i = 0; i < lengths.length; i++) {
+      if (offsets[i] != 0) {
+        putByteArray(i, offsets[i], lengths[i], data);
+      }
+    }
+  }
+
+  @Override
   public void putNull(int rowId) {
     if (dictionaryBlock == null) {
       builder.appendNull();


### PR DESCRIPTION
 ### Why is this PR needed?
 During vector filling, due to missing implementation of putAllByteArray() method in sliceStreamReader.java, its implementation in parent class CarbonColumnVectorImpl was called.
 Hence in presto on firing select query on string column, all rows never showed up. And on select query on multiple columns - exceptions were thrown.
Similarly for getColumnVector(), implementation was missing -  while reading struct datatype columns.

 ### What changes were proposed in this PR?
Implemented the missing methods.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No

    
