### PR TITLE
[CARBONDATA-4042]Launch same number of task as select query for insert into select and ctas cases when target table is of no_sort

### DIFF
--- a/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/TestSIWithSecondaryIndex.scala
+++ b/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/TestSIWithSecondaryIndex.scala
@@ -89,7 +89,7 @@ class TestSIWithSecondaryIndex extends QueryTest with BeforeAndAfterAll {
     sql("insert into table1 select 'xx', '2', 'china' union all select 'xx', '1', 'india'")
     sql("create index table1_index on table table1(id, country) as 'carbondata' properties" +
         "('sort_scope'='global_sort', 'Global_sort_partitions'='3')")
-    checkAnswerWithoutSort(sql("select id, country from table1_index"),
+    checkAnswer(sql("select id, country from table1_index"),
       Seq(Row("1", "india"), Row("2", "china")))
     // check for valid sort_scope
     checkExistence(sql("describe formatted table1_index"), true, "Sort Scope global_sort")
@@ -112,7 +112,7 @@ class TestSIWithSecondaryIndex extends QueryTest with BeforeAndAfterAll {
     sql("create index table11_index on table table11(id, country) as 'carbondata' properties" +
         "('sort_scope'='global_sort', 'Global_sort_partitions'='3')")
     sql("insert into table11 select 'xx', '2', 'china' union all select 'xx', '1', 'india'")
-    checkAnswerWithoutSort(sql("select id, country from table11_index"),
+    checkAnswer(sql("select id, country from table11_index"),
       Seq(Row("1", "india"), Row("2", "china")))
     // check for valid sort_scope
     checkExistence(sql("describe formatted table11_index"), true, "Sort Scope global_sort")
@@ -128,7 +128,7 @@ class TestSIWithSecondaryIndex extends QueryTest with BeforeAndAfterAll {
         "('sort_scope'='global_sort', 'Global_sort_partitions'='3')")
     sql("insert into partition_carbon_table select 'xx', '2', 'china', '2020' " +
         "union all select 'xx', '1', 'india', '2021'")
-    checkAnswerWithoutSort(sql("select id, country from partition_carbon_table_index"),
+    checkAnswer(sql("select id, country from partition_carbon_table_index"),
       Seq(Row("1", "india"), Row("2", "china")))
     // check for valid sort_scope
     checkExistence(sql("describe formatted partition_carbon_table_index"),
@@ -138,7 +138,7 @@ class TestSIWithSecondaryIndex extends QueryTest with BeforeAndAfterAll {
     sql("create index partition_carbon_table_index on table partition_carbon_table(" +
         "id, country) as 'carbondata' properties" +
         "('sort_scope'='global_sort', 'Global_sort_partitions'='3')")
-    checkAnswerWithoutSort(sql("select id, country from partition_carbon_table_index"),
+    checkAnswer(sql("select id, country from partition_carbon_table_index"),
       Seq(Row("1", "india"), Row("2", "china")))
     // check for valid sort_scope
     checkExistence(sql("describe formatted partition_carbon_table_index"),
@@ -155,7 +155,7 @@ class TestSIWithSecondaryIndex extends QueryTest with BeforeAndAfterAll {
     sql("drop index if exists complextable_index_1 on complextable")
     sql("create index complextable_index_1 on table complextable(country, name) " +
         "as 'carbondata' properties('sort_scope'='global_sort', 'Global_sort_partitions'='3')")
-    checkAnswerWithoutSort(sql("select country,name from complextable_index_1"),
+    checkAnswer(sql("select country,name from complextable_index_1"),
       Seq(Row("china", "b"), Row("china", "v"), Row("india", "v"), Row("pak", "v"), Row("us", "b")))
     // check for valid sort_scope
     checkExistence(sql("describe formatted complextable_index_1"), true, "Sort Scope global_sort")

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/NewCarbonDataLoadRDD.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/NewCarbonDataLoadRDD.scala
@@ -258,7 +258,7 @@ class NewDataFrameLoaderRDD[K, V](
     @transient private val ss: SparkSession,
     result: DataLoadResult[K, V],
     carbonLoadModel: CarbonLoadModel,
-    prev: DataLoadCoalescedRDD[_],
+    prev: CarbonRDD[_],
     segmentMetaDataAccumulator: CollectionAccumulator[Map[String, SegmentMetaDataInfo]]
     ) extends CarbonRDD[(K, V)](ss, prev) {
 


### PR DESCRIPTION
  ### Why is this PR needed?
 At present, When we do insert into table select from or create table as select from, we lauch one single task per node. Whereas when we do a simple select * from table query, tasks launched are equal to number of carbondata files(CARBON_TASK_DISTRIBUTION default is CARBON_TASK_DISTRIBUTION_BLOCK). 
<p> Thus, slows down the load performance of insert into select and ctas cases.
Refer [Community discussion regd. task lauch](http://apache-carbondata-dev-mailing-list-archive.1130556.n5.nabble.com/Discussion-Query-Regarding-Task-launch-mechanism-for-data-load-operations-tt98711.html)

 ### What changes were proposed in this PR?
1. Lauch the same number of tasks as in select query for insert into select and ctas cases when the target table is of no-sort.
2. Replaced all checkAnswerWithoutSort with checkAnswer in TestSIWithSecondaryIndex to fix random UT failure issues in that file.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No
