### PR TITLE
[Carbondata-3999] Fix permission issue in /tmp/indexservertmp directory.

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
@@ -3250,14 +3250,14 @@ public final class CarbonUtil {
   public static CarbonFile createTempFolderForIndexServer(String queryId)
           throws IOException {
     final String path = getIndexServerTempPath();
+    if (!FileFactory.isFileExist(path)) {
+      // Create the new index server temp directory if it does not exist
+      LOGGER.info("Creating Index Server temp folder:" + path);
+      FileFactory
+              .createDirectoryAndSetPermission(path,
+                      new FsPermission(FsAction.ALL, FsAction.ALL, FsAction.ALL));
+    }
     if (queryId == null) {
-      if (!FileFactory.isFileExist(path)) {
-        // Create the new index server temp directory if it does not exist
-        LOGGER.info("Creating Index Server temp folder:" + path);
-        FileFactory
-                .createDirectoryAndSetPermission(path,
-                        new FsPermission(FsAction.ALL, FsAction.ALL, FsAction.ALL));
-      }
       return null;
     }
     CarbonFile file = FileFactory.getCarbonFile(path + CarbonCommonConstants.FILE_SEPARATOR

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonFileInputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonFileInputFormat.java
@@ -279,7 +279,8 @@ public class CarbonFileInputFormat<T> extends CarbonInputFormat<T> implements Se
   private String[] getDeleteDeltaFiles(String segmentFilePath, List<String> allDeleteDeltaFiles) {
     List<String> deleteDeltaFiles = new ArrayList<>();
     String segmentFileName = null;
-    String[] pathElements = segmentFilePath.split(Pattern.quote(File.separator));
+    segmentFilePath = segmentFilePath.replace("\\", "/");
+    String[] pathElements = segmentFilePath.split(CarbonCommonConstants.FILE_SEPARATOR);
     if (ArrayUtils.isNotEmpty(pathElements)) {
       segmentFileName = pathElements[pathElements.length - 1];
     }

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableOutputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableOutputFormat.java
@@ -17,7 +17,6 @@
 
 package org.apache.carbondata.hadoop.api;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -29,7 +28,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.regex.Pattern;
 
 import org.apache.carbondata.common.exceptions.DeprecatedFeatureException;
 import org.apache.carbondata.common.logging.LogServiceFactory;
@@ -576,7 +574,8 @@ public class CarbonTableOutputFormat extends FileOutputFormat<NullWritable, Obje
         String blockName;
         for (String tuple : tupleId) {
           blockName = CarbonUpdateUtil.getBlockName(
-              (tuple.split(Pattern.quote(File.separator))[TupleIdEnum.BLOCK_ID.getTupleIdIndex()]));
+              (tuple.split(CarbonCommonConstants.FILE_SEPARATOR)
+                      [TupleIdEnum.BLOCK_ID.getTupleIdIndex()]));
 
           if (!blockToDeleteDeltaBlockMapping.containsKey(blockName)) {
             blockDetails = new DeleteDeltaBlockDetails(blockName);

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/util/CarbonVectorizedRecordReader.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/util/CarbonVectorizedRecordReader.java
@@ -58,7 +58,6 @@ public class CarbonVectorizedRecordReader extends AbstractRecordReader<Object> {
 
   private static final Logger LOGGER =
       LogServiceFactory.getLogService(CarbonVectorizedRecordReader.class.getName());
-  private static final int DEFAULT_BATCH_SIZE = 4 * 1024;
 
   private CarbonColumnarBatch carbonColumnarBatch;
 
@@ -194,7 +193,7 @@ public class CarbonVectorizedRecordReader extends AbstractRecordReader<Object> {
       }
       carbonColumnarBatch = new CarbonColumnarBatch(vectors,
           CarbonV3DataFormatConstants.NUMBER_OF_ROWS_PER_BLOCKLET_COLUMN_PAGE_DEFAULT,
-          new boolean[DEFAULT_BATCH_SIZE]);
+          new boolean[CarbonV3DataFormatConstants.NUMBER_OF_ROWS_PER_BLOCKLET_COLUMN_PAGE_DEFAULT]);
     }
   }
 


### PR DESCRIPTION
 ### Why is this PR needed?
When dir "/indexservertmp" is not existing,then select query with indexserver will create a dir "/indexservertmp/[queryid]" with permission 755,and the permission of dir "/indexservertmp" is also 755,it will cause permission issue.
 
  ### What changes were proposed in this PR?
When select query with indexserver,first check if the dir "/indexservertmp" is existing,and if not,then create dir "/indexservertmp" with permission 777
  
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No

    
