### PR TITLE
[Carbondata-3999] Fix permission issue of indexServerTmp directory

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
@@ -3250,14 +3250,13 @@ public final class CarbonUtil {
   public static CarbonFile createTempFolderForIndexServer(String queryId)
           throws IOException {
     final String path = getIndexServerTempPath();
+    if (!FileFactory.isFileExist(path)) {
+      // Create the new index server temp directory if it does not exist
+      LOGGER.info("Creating Index Server temp folder:" + path);
+      FileFactory.createDirectoryAndSetPermission(path,
+              new FsPermission(FsAction.ALL, FsAction.ALL, FsAction.ALL));
+    }
     if (queryId == null) {
-      if (!FileFactory.isFileExist(path)) {
-        // Create the new index server temp directory if it does not exist
-        LOGGER.info("Creating Index Server temp folder:" + path);
-        FileFactory
-                .createDirectoryAndSetPermission(path,
-                        new FsPermission(FsAction.ALL, FsAction.ALL, FsAction.ALL));
-      }
       return null;
     }
     CarbonFile file = FileFactory.getCarbonFile(path + CarbonCommonConstants.FILE_SEPARATOR


### PR DESCRIPTION
 ### Why is this PR needed?
When dir "/indexservertmp" is not existing,then select query with indexserver will create a dir "/indexservertmp/[queryid]" with permission 755,and the permission of dir "/indexservertmp" is also 755,it will cause permission issue.

 
 ### What changes were proposed in this PR?
When select query with indexserver,first check if the dir "/indexservertmp" is existing,and if not,then create dir "/indexservertmp" with permission 777

 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No


    
