### PR TITLE
[CARBONDATA-4026] Fix Thread leakage while Loading

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/statusmanager/StageInputCollector.java
+++ b/core/src/main/java/org/apache/carbondata/core/statusmanager/StageInputCollector.java
@@ -66,7 +66,13 @@ public class StageInputCollector {
     if (stageInputFiles.size() > 0) {
       int numThreads = Math.min(Math.max(stageInputFiles.size(), 1), 10);
       ExecutorService executorService = Executors.newFixedThreadPool(numThreads);
-      return createInputSplits(executorService, stageInputFiles);
+      try {
+        return createInputSplits(executorService, stageInputFiles);
+      } finally {
+        if (executorService != null && !executorService.isShutdown()) {
+          executorService.shutdownNow();
+        }
+      }
     } else {
       return new ArrayList<>(0);
     }

--- a/integration/flink/src/test/scala/org/apache/carbon/flink/TestCarbonPartitionWriter.scala
+++ b/integration/flink/src/test/scala/org/apache/carbon/flink/TestCarbonPartitionWriter.scala
@@ -18,7 +18,7 @@
 package org.apache.carbon.flink
 
 import java.text.SimpleDateFormat
-import java.util.concurrent.Executors
+import java.util.concurrent.{Executors, TimeUnit}
 import java.util.{Base64, Properties}
 
 import org.apache.flink.api.common.restartstrategy.RestartStrategies
@@ -202,6 +202,7 @@ class TestCarbonPartitionWriter extends QueryTest with BeforeAndAfterAll{
         }).get()
       }
       checkAnswer(sql(s"SELECT count(1) FROM $tableName"), Seq(Row(1000)))
+      executorService.shutdownNow()
     }
   }
 

--- a/integration/spark/src/test/scala/org/apache/spark/carbondata/TestStreamingTableOpName.scala
+++ b/integration/spark/src/test/scala/org/apache/spark/carbondata/TestStreamingTableOpName.scala
@@ -244,6 +244,7 @@ class TestStreamingTableOpName extends QueryTest with BeforeAndAfterAll {
       val msg = intercept[Exception] {
         future.get()
       }
+      pool.shutdownNow()
       assert(msg.getMessage.contains("is not a streaming table"))
     } finally {
       if (server != null) {


### PR DESCRIPTION

 ### Why is this PR needed?
 A few code of Inserting/Loading/InsertStage/IndexServer won't shutdown executorservice. leads to thread leakage which will degrade the performance of the driver and executor.
 
 ### What changes were proposed in this PR?
Shutdown executorservices as soon as finish using them.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No

    
