### PR TITLE
[CARBONDATA-4028] Fix failed to unlock during update

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/mutation/CarbonProjectForDeleteCommand.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/mutation/CarbonProjectForDeleteCommand.scala
@@ -169,8 +169,19 @@ private[sql] case class CarbonProjectForDeleteCommand(
       if (lockStatus) {
         CarbonLockUtil.fileUnlock(metadataLock, LockUsage.METADATA_LOCK)
       }
-      updateLock.unlock()
-      compactionLock.unlock()
+
+      if (updateLock.unlock()) {
+        LOGGER.info(s"updateLock unlocked successfully after delete operation $tableName")
+      } else {
+        LOGGER.error(s"Unable to unlock updateLock for table $tableName after delete operation");
+      }
+
+      if (compactionLock.unlock()) {
+        LOGGER.info(s"compactionLock unlocked successfully after delete operation $tableName")
+      } else {
+        LOGGER.error(s"Unable to unlock compactionLock for " +
+          s"table $tableName after delete operation");
+      }
     }
   }
 


### PR DESCRIPTION

 ### Why is this PR needed?
1. In the update flow, we unpresist dataset before unlocking. unlock will fail once the dataset unpresist is interrupted.
2. cleanStaleDeltaFiles will hold the lock, which degrade the concurrency perf a lot.
 
 ### What changes were proposed in this PR?
1. unlock before unpresisting dataset
2. cleanStaleDeltaFiles won't hold the lock.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No

    
