### PR TITLE
[CARBONDATA-4036]Fix special char(`) issue in create table, when column name contains ` character

### DIFF
--- a/integration/spark/src/test/scala/org/apache/carbondata/integration/spark/testsuite/dataload/TestLoadDataGeneral.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/integration/spark/testsuite/dataload/TestLoadDataGeneral.scala
@@ -350,9 +350,10 @@ class TestLoadDataGeneral extends QueryTest with BeforeAndAfterEach {
 
   test("test table creation with special char and other commands") {
     sql("drop table if exists special_char")
-    sql("create table special_char(`i#d` string, `nam(e` string,`ci)&#@!ty` string,`a\be` int, `ag!e` float, `na^me1` Decimal(8,4)) stored as carbondata")
-    sql("insert into special_char values('1','joey','hud', 2, 2.2, 2.3456)")
-    checkAnswer(sql("select * from special_char"), Seq(Row("1","joey","hud", 2, 2.2, 2.3456)))
+    sql("create table special_char(`i#d` string, `nam(e` string,`ci)&#@!ty` string,`a\be` int, `ag!e` float, `na^me1` Decimal(8,4), ```a``bc``!!d``` int) stored as carbondata" +
+        " tblproperties('INVERTED_INDEX'='`a`bc`!!d`', 'SORT_COLUMNS'='`a`bc`!!d`')")
+    sql("insert into special_char values('1','joey','hud', 2, 2.2, 2.3456, 5)")
+    checkAnswer(sql("select * from special_char"), Seq(Row("1","joey","hud", 2, 2.2, 2.3456, 5)))
     val df = sql("describe formatted special_char").collect()
     assert(df.exists(_.get(0).toString.contains("i#d")))
     assert(df.exists(_.get(0).toString.contains("nam(e")))
@@ -360,6 +361,7 @@ class TestLoadDataGeneral extends QueryTest with BeforeAndAfterEach {
     assert(df.exists(_.get(0).toString.contains("a\be")))
     assert(df.exists(_.get(0).toString.contains("ag!e")))
     assert(df.exists(_.get(0).toString.contains("na^me1")))
+    assert(df.exists(_.get(0).toString.contains("`a`bc`!!d`")))
   }
 
   override def afterEach {


### PR DESCRIPTION
 ### Why is this PR needed?
 When a table is created with special character ``` , it fails when parsing to create field object. This is because ` character is used for tokenizing while parsing, and it will use the same char present in column name for parsing and it leads to wrong field object creation.
 
 ### What changes were proposed in this PR?
when the column name contains the ``` , just for parsing , replace the character with `!`  character, then once the parsing is done and the files object is created, then replace again with the original one. This solution is considered so as to avoid the changes in parsing layer, as it might induce other layers of parsing. So this solution is considered. 
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
