### PR TITLE
[CARBONDATA-4035]Fix MV query issue with aggregation on decimal column

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/view/CarbonCreateMVCommand.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/view/CarbonCreateMVCommand.scala
@@ -327,11 +327,9 @@ case class CarbonCreateMVCommand(
     schema.getProperties.put(MVProperty.REFRESH_MODE, viewRefreshMode)
     schema.getProperties.put(MVProperty.REFRESH_TRIGGER_MODE, viewRefreshTriggerMode)
     if (null != granularity && null != timeSeriesColumn) {
-      schema.setQuery(queryString)
       schema.setTimeSeries(true)
-    } else {
-      schema.setQuery(modularPlan.asCompactSQL)
     }
+    schema.setQuery(queryString)
     try {
       viewManager.createSchema(schema.getIdentifier.getDatabaseName, schema)
     } catch {

--- a/integration/spark/src/test/scala/org/apache/carbondata/view/rewrite/MVCreateTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/view/rewrite/MVCreateTestCase.scala
@@ -1356,6 +1356,7 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     sql("drop table if exists limit_fail")
     sql("drop table IF EXISTS mv_like")
     sql("drop table IF EXISTS maintable")
+    sql("drop table if exists sum_agg_decimal")
   }
 
   test("test create materialized view with add segment") {
@@ -1471,6 +1472,15 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     }.getMessage.contains("Column name cannot be dropped because it exists in mv materialized view: mv1")
     sql("drop table if exists t1")
     sql("drop table if exists t2")
+  }
+
+  test("test sum aggregations on decimal columns") {
+    sql("drop table if exists sum_agg_decimal")
+    sql("create table sum_agg_decimal(salary1 decimal(7,2),salary2 decimal(7,2),salary3 decimal(7,2),salary4 decimal(7,2),empname string) stored as carbondata")
+    sql("drop materialized view if exists decimal_mv")
+    sql("create materialized view decimal_mv as select empname, sum(salary1 - salary2) from sum_agg_decimal group by empname")
+    val df = sql("select empname, sum( salary1 - salary2) from sum_agg_decimal group by empname")
+    assert(TestUtil.verifyMVHit(df.queryExecution.optimizedPlan, "decimal_mv"))
   }
 
   def copy(oldLoc: String, newLoc: String): Unit = {


### PR DESCRIPTION
 ### Why is this PR needed?
 When the aggregation like sum is performed on decimal column similar to MV schema query, the user query is not getting results from MV. Since in MV schema during MV created we prepare the plan on the query string of modular plan(modularPlan.asCompactSQL) which adds multiple cast expression, because of which the semantic equals fails 
 
 ### What changes were proposed in this PR?
During MV creation, to set the query to MV schema, just use the direct query string, instead of compactSQL.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes
 - Yes

    
