### PR TITLE
[CARBONDATA-3965]Fixed float variable target datatype in case of adaptive encoding

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/adaptive/AdaptiveDeltaFloatingCodec.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/adaptive/AdaptiveDeltaFloatingCodec.java
@@ -288,13 +288,6 @@ public class AdaptiveDeltaFloatingCodec extends AdaptiveCodec {
           for (int i = 0; i < size; i += intSizeInBytes) {
             vector.putFloat(rowId++, (max - ByteUtil.toIntLittleEndian(pageData, i)) / floatFactor);
           }
-        } else if (pageDataType == DataTypes.LONG) {
-          // complex primitive float type can enter here.
-          int size = pageSize * longSizeInBytes;
-          for (int i = 0; i < size; i += longSizeInBytes) {
-            vector.putFloat(rowId++,
-                (float) ((max - ByteUtil.toLongLittleEndian(pageData, i)) / factor));
-          }
         } else {
           throw new RuntimeException("internal error: " + this.toString());
         }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/adaptive/AdaptiveFloatingCodec.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/adaptive/AdaptiveFloatingCodec.java
@@ -276,12 +276,6 @@ public class AdaptiveFloatingCodec extends AdaptiveCodec {
           for (int i = 0; i < size; i += intSizeInBytes) {
             vector.putFloat(rowId++, (ByteUtil.toIntLittleEndian(pageData, i) / floatFactor));
           }
-        } else if (pageDataType == DataTypes.LONG) {
-          // complex primitive float type can enter here.
-          int size = pageSize * longSizeInBytes;
-          for (int i = 0; i < size; i += longSizeInBytes) {
-            vector.putFloat(rowId++, (float) (ByteUtil.toLongLittleEndian(pageData, i) / factor));
-          }
         } else {
           throw new RuntimeException("internal error: " + this.toString());
         }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/statistics/PrimitivePageStatsCollector.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/statistics/PrimitivePageStatsCollector.java
@@ -256,7 +256,7 @@ public class PrimitivePageStatsCollector implements ColumnPageStatsCollector, Si
   }
 
   private int getDecimalCount(float value) {
-    return getDecimalCount((double) value);
+    return getDecimalCount(Double.parseDouble(Float.toString(value)));
   }
 
   @Override

--- a/integration/spark/src/test/scala/org/apache/carbondata/integration/spark/testsuite/complexType/TestAdaptiveComplexType.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/integration/spark/testsuite/complexType/TestAdaptiveComplexType.scala
@@ -574,4 +574,13 @@ trait TestAdaptiveComplexType extends QueryTest with BeforeAndAfterAll {
       "5555555.9559, 1.2345678991234568E16, 3444.999")
   }
 
+  test("test adaptive encoding with float as complex primitive, Encoding FLOAT --> SHORT") {
+    sql("drop table if exists floatComplexPrimitive")
+    sql("create table floatComplexPrimitive (arrayField array<float>) using carbon ")
+    sql("insert into floatComplexPrimitive values (array(null, 5.121))")
+    checkAnswer(sql("select * from floatComplexPrimitive"),
+      Seq(Row(mutable.WrappedArray.make(Array(null, 5.121f)))))
+    sql("drop table if exists floatComplexPrimitive")
+  }
+
 }


### PR DESCRIPTION
 ### Why is this PR needed?
 Currently, float variables are using long value 8 bytes to store float data.
 
 ### What changes were proposed in this PR?
Handled the float variables to consider the target data type based on the given value.
    
 ### Does this PR introduce any user interface change?
 - No
 - Yes. (please explain the change and update document)

 ### Is any new testcase added?
 - Yes

    
