### PR TITLE
[CARBONDATA-4034] Improve the time-consuming of Horizontal Compaction for update

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/mutation/HorizontalCompaction.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/mutation/HorizontalCompaction.scala
@@ -130,6 +130,9 @@ object HorizontalCompaction {
       absTableIdentifier,
       segmentUpdateStatusManager,
       compactionTypeIUD)
+    if (LOG.isDebugEnabled) {
+      LOG.debug(s"The segment list for Horizontal Update Compaction is $validSegList")
+    }
 
     if (validSegList.size() == 0) {
       return
@@ -177,6 +180,9 @@ object HorizontalCompaction {
       absTableIdentifier,
       segmentUpdateStatusManager,
       compactionTypeIUD)
+    if (LOG.isDebugEnabled) {
+      LOG.debug(s"The segment list for Horizontal Update Compaction is $deletedBlocksList")
+    }
 
     if (deletedBlocksList.size() == 0) {
       return


### PR DESCRIPTION
 ### Why is this PR needed?
 The horizontal compaction flow will be too slow when updating with lots of segments(or lots of blocks), so we try to analyze and optimize it for time-consuming problem.
 
 ### What changes were proposed in this PR?
In performDeleteDeltaCompaction, optimize the method getSegListIUDCompactionQualified. Combine two traversals of segments which have same process, and use forming delete delta file name instead of listFiles operation.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No
    
