### PR TITLE
[CARBONDATA-4039] Support Local dictionary for Presto complex datatypes

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/reader/dimension/v3/DimensionChunkReaderV3.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/reader/dimension/v3/DimensionChunkReaderV3.java
@@ -42,6 +42,7 @@ import org.apache.carbondata.core.datastore.page.encoding.EncodingFactory;
 import org.apache.carbondata.core.metadata.blocklet.BlockletInfo;
 import org.apache.carbondata.core.scan.executor.util.QueryUtil;
 import org.apache.carbondata.core.scan.result.vector.ColumnVectorInfo;
+import org.apache.carbondata.core.scan.result.vector.impl.CarbonColumnVectorImpl;
 import org.apache.carbondata.core.util.CarbonMetadataUtil;
 import org.apache.carbondata.core.util.CarbonUtil;
 import org.apache.carbondata.format.DataChunk2;
@@ -296,6 +297,13 @@ public class DimensionChunkReaderV3 extends AbstractDimensionChunkReader {
         }
       }
       BitSet nullBitSet = QueryUtil.getNullBitSet(pageMetadata.presence, this.compressor);
+      // Store local dictionary from rawColumnPage so it can be used while filling the vector
+      if (vectorInfo != null && !vectorInfo.vectorStack.isEmpty()
+          && rawColumnPage.getLocalDictionary() != null) {
+        ((CarbonColumnVectorImpl) (vectorInfo.vectorStack.peek().getColumnVector()))
+            .setLocalDictionary(rawColumnPage.getLocalDictionary());
+      }
+
       ColumnPage decodedPage = decodeDimensionByMeta(pageMetadata, pageData, dataOffset,
           null != rawColumnPage.getLocalDictionary(), vectorInfo, nullBitSet, reusableDataBuffer);
       if (decodedPage != null) {

--- a/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/compress/DirectCompressCodec.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/page/encoding/compress/DirectCompressCodec.java
@@ -28,6 +28,8 @@ import java.util.Map;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.datastore.ReusableDataBuffer;
 import org.apache.carbondata.core.datastore.TableSpec;
+import org.apache.carbondata.core.datastore.chunk.impl.VariableLengthDimensionColumnPage;
+import org.apache.carbondata.core.datastore.chunk.store.DimensionChunkStoreFactory;
 import org.apache.carbondata.core.datastore.compression.Compressor;
 import org.apache.carbondata.core.datastore.compression.CompressorFactory;
 import org.apache.carbondata.core.datastore.page.ColumnPage;
@@ -325,6 +327,20 @@ public class DirectCompressCodec implements ColumnPageCodec {
       int intSizeInBytes = DataTypes.INT.getSizeInBytes();
       int shortSizeInBytes = DataTypes.SHORT.getSizeInBytes();
       int lengthStoredInBytes;
+      // check if local dictionary is enabled for complex primitve type
+      if (!vectorInfo.vectorStack.isEmpty()) {
+        CarbonColumnVectorImpl tempVector =
+            (CarbonColumnVectorImpl) (vectorInfo.vectorStack.peek().getColumnVector());
+        if (tempVector.getLocalDictionary() != null) {
+          DimensionChunkStoreFactory.DimensionStoreType dimStoreType =
+              DimensionChunkStoreFactory.DimensionStoreType.LOCAL_DICT;
+          // This will call fillVector() for local-dict eventually
+          new VariableLengthDimensionColumnPage(pageData, new int[0], new int[0], pageSize,
+              dimStoreType, tempVector.getLocalDictionary(), vectorInfo, pageSize);
+          return;
+        }
+      }
+
       if (vectorInfo.encodings != null && vectorInfo.encodings.size() > 0 && CarbonUtil
           .hasEncoding(vectorInfo.encodings, Encoding.INT_LENGTH_COMPLEX_CHILD_BYTE_ARRAY)) {
         lengthStoredInBytes = intSizeInBytes;
@@ -488,11 +504,11 @@ public class DirectCompressCodec implements ColumnPageCodec {
                 length = ByteBuffer.wrap(pageData, offset, lengthStoredInBytes).getShort();
               }
               offset += lengthStoredInBytes;
-              int surrogateInternal =
-                  ByteUtil.toXorInt(pageData, offset, intSizeInBytes);
               if (length == 0) {
                 vector.putObject(0, null);
               } else {
+                // Calculating surrogate only in case of non-null values
+                int surrogateInternal = ByteUtil.toXorInt(pageData, offset, intSizeInBytes);
                 vector.putObject(0, surrogateInternal - DateDirectDictionaryGenerator.cutOffDate);
               }
               offset += length;

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/vector/CarbonColumnVector.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/vector/CarbonColumnVector.java
@@ -132,4 +132,18 @@ public interface CarbonColumnVector {
   default CarbonColumnVector getColumnVector() {
     return null;
   }
+
+  // Added default implementation for interface,
+  // to avoid implementing presto required functions for spark or core module.
+  default void setPositionCount(int positionCount) {
+    throw new UnsupportedOperationException(
+        "Method can only be called using instance of SliceStreamReader");
+  }
+
+  // Added default implementation for interface,
+  // to avoid implementing presto required functions for spark or core module.
+  default void setIsLocalDictEnabledForComplextype(boolean value) {
+    throw new UnsupportedOperationException(
+        "Method can only be called using instance of SliceStreamReader");
+  }
 }

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/vector/impl/CarbonColumnVectorImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/vector/impl/CarbonColumnVectorImpl.java
@@ -81,6 +81,8 @@ public class CarbonColumnVectorImpl implements CarbonColumnVector {
 
   private List<Integer> childElementsForEachRow;
 
+  private CarbonDictionary localDictionary;
+
   public CarbonColumnVectorImpl(int batchSize, DataType dataType) {
     this.batchSize = batchSize;
     nullBytes = new BitSet(batchSize);
@@ -154,6 +156,14 @@ public class CarbonColumnVectorImpl implements CarbonColumnVector {
       childElementsForEachRow.add(elements);
     }
     setNumberOfChildElementsInEachRow(childElementsForEachRow);
+  }
+
+  public CarbonDictionary getLocalDictionary() {
+    return localDictionary;
+  }
+
+  public void setLocalDictionary(CarbonDictionary localDictionary) {
+    this.localDictionary = localDictionary;
   }
 
   @Override

--- a/integration/presto/src/main/prestodb/org/apache/carbondata/presto/readers/ComplexTypeStreamReader.java
+++ b/integration/presto/src/main/prestodb/org/apache/carbondata/presto/readers/ComplexTypeStreamReader.java
@@ -137,9 +137,9 @@ public class ComplexTypeStreamReader extends CarbonColumnVectorImpl
       }
       // prepare ROW block
       Block rowBlock = RowBlock
-          .fromFieldBlocks(childBlocks.get(0).getPositionCount(), Optional.empty(),
+          .fromFieldBlocks(offsetVector.size(), Optional.empty(),
               childBlocks.toArray(new Block[0]));
-      for (int position = 0; position < childBlocks.get(0).getPositionCount(); position++) {
+      for (int position = 0; position < offsetVector.size(); position++) {
         type.writeObject(builder, rowBlock.getObject(position, Block.class));
       }
       for (CarbonColumnVector child : getChildrenVector()) {

--- a/integration/presto/src/main/prestodb/org/apache/carbondata/presto/readers/SliceStreamReader.java
+++ b/integration/presto/src/main/prestodb/org/apache/carbondata/presto/readers/SliceStreamReader.java
@@ -49,6 +49,10 @@ public class SliceStreamReader extends CarbonColumnVectorImpl implements PrestoV
 
   private boolean isLocalDict;
 
+  private int positionCount;
+
+  private boolean isLocalDictEnabledForComplextype;
+
   public SliceStreamReader(int batchSize, DataType dataType) {
     super(batchSize, dataType);
     this.batchSize = batchSize;
@@ -66,7 +70,8 @@ public class SliceStreamReader extends CarbonColumnVectorImpl implements PrestoV
       } else {
         dataArray = (int[]) getDataArray();
       }
-      return new DictionaryBlock(batchSize, dictionaryBlock, dataArray);
+      positionCount = isLocalDictEnabledForComplextype ? positionCount : batchSize;
+      return new DictionaryBlock(positionCount, dictionaryBlock, dataArray);
     }
   }
 
@@ -100,6 +105,16 @@ public class SliceStreamReader extends CarbonColumnVectorImpl implements PrestoV
     dictionaryBlock = new VariableWidthBlock(dictionary.getDictionarySize(),
         Slices.wrappedBuffer(singleArrayDictValues), dictOffsets, Optional.of(nulls));
     this.isLocalDict = true;
+  }
+
+  @Override
+  public void setPositionCount(int positionCount) {
+    this.positionCount = positionCount;
+  }
+
+  @Override
+  public void setIsLocalDictEnabledForComplextype(boolean value) {
+    this.isLocalDictEnabledForComplextype = value;
   }
 
   @Override

--- a/integration/presto/src/main/prestosql/org/apache/carbondata/presto/readers/ComplexTypeStreamReader.java
+++ b/integration/presto/src/main/prestosql/org/apache/carbondata/presto/readers/ComplexTypeStreamReader.java
@@ -137,9 +137,9 @@ public class ComplexTypeStreamReader extends CarbonColumnVectorImpl
       }
       // prepare ROW block
       Block rowBlock = RowBlock
-          .fromFieldBlocks(childBlocks.get(0).getPositionCount(), Optional.empty(),
+          .fromFieldBlocks(offsetVector.size(), Optional.empty(),
               childBlocks.toArray(new Block[0]));
-      for (int position = 0; position < childBlocks.get(0).getPositionCount(); position++) {
+      for (int position = 0; position < offsetVector.size(); position++) {
         type.writeObject(builder, rowBlock.getObject(position, Block.class));
       }
       for (CarbonColumnVector child : getChildrenVector()) {

--- a/integration/presto/src/main/prestosql/org/apache/carbondata/presto/readers/SliceStreamReader.java
+++ b/integration/presto/src/main/prestosql/org/apache/carbondata/presto/readers/SliceStreamReader.java
@@ -49,6 +49,10 @@ public class SliceStreamReader extends CarbonColumnVectorImpl implements PrestoV
 
   private boolean isLocalDict;
 
+  private int positionCount;
+
+  private boolean isLocalDictEnabledForComplextype;
+
   public SliceStreamReader(int batchSize, DataType dataType) {
     super(batchSize, dataType);
     this.batchSize = batchSize;
@@ -66,7 +70,8 @@ public class SliceStreamReader extends CarbonColumnVectorImpl implements PrestoV
       } else {
         dataArray = (int[]) getDataArray();
       }
-      return new DictionaryBlock(batchSize, dictionaryBlock, dataArray);
+      positionCount = isLocalDictEnabledForComplextype ? positionCount : batchSize;
+      return new DictionaryBlock(positionCount, dictionaryBlock, dataArray);
     }
   }
 
@@ -100,6 +105,16 @@ public class SliceStreamReader extends CarbonColumnVectorImpl implements PrestoV
     dictionaryBlock = new VariableWidthBlock(dictionary.getDictionarySize(),
         Slices.wrappedBuffer(singleArrayDictValues), dictOffsets, Optional.of(nulls));
     this.isLocalDict = true;
+  }
+
+  @Override
+  public void setPositionCount(int positionCount) {
+    this.positionCount = positionCount;
+  }
+
+  @Override
+  public void setIsLocalDictEnabledForComplextype(boolean value) {
+    this.isLocalDictEnabledForComplextype = value;
   }
 
   @Override

--- a/integration/presto/src/test/prestodb/org/apache/carbondata/presto/server/PrestoTestUtil.scala
+++ b/integration/presto/src/test/prestodb/org/apache/carbondata/presto/server/PrestoTestUtil.scala
@@ -114,4 +114,60 @@ object PrestoTestUtil {
       }
     }
   }
+
+  // this method depends on prestodb jdbc PrestoArray class
+  def validateArrayOfPrimitiveTypeDataWithLocalDict(actualResult: List[Map[String, Any]],
+      longChar: String): Unit = {
+    assert(actualResult.size == 3)
+    for (i <- 0 to actualResult.size - 1) {
+      val rowId = actualResult(i)("stringfield")
+      if (rowId == "row1") {
+        val column2 = actualResult(i)("arraystring")
+          .asInstanceOf[PrestoArray]
+          .getArray()
+          .asInstanceOf[Array[Object]]
+        assert(column2(0) == null)
+
+        val column3 = actualResult(i)("arraydate")
+          .asInstanceOf[PrestoArray]
+          .getArray()
+          .asInstanceOf[Array[Object]]
+        assert(column3(0) == null)
+
+        val column4 = actualResult(i)("arrayvarchar")
+          .asInstanceOf[PrestoArray]
+          .getArray()
+          .asInstanceOf[Array[Object]]
+        assert(column4(0) == null)
+      } else if (rowId == "row2") {
+        val column2 = actualResult(i)("arraystring")
+          .asInstanceOf[PrestoArray]
+          .getArray()
+          .asInstanceOf[Array[Object]]
+        assert(column2.sameElements(Array("India", "Japan", "India")))
+
+        val column3 = actualResult(i)("arraydate")
+          .asInstanceOf[PrestoArray]
+          .getArray()
+          .asInstanceOf[Array[Object]]
+        assert(column3.sameElements(Array("2019-03-02", "2020-03-02")))
+      } else if (rowId == "row3") {
+        val column2 = actualResult(i)("arraystring")
+          .asInstanceOf[PrestoArray]
+          .getArray()
+          .asInstanceOf[Array[Object]]
+        assert(column2.sameElements(Array("Iceland")))
+
+        val column3 = actualResult(i)("arraydate")
+          .asInstanceOf[PrestoArray]
+          .getArray()
+          .asInstanceOf[Array[Object]]
+        assert(column3.sameElements(Array("2019-03-02",
+          "2020-03-02",
+          "2021-04-02",
+          "2021-04-03",
+          "2021-04-02")))
+      }
+    }
+  }
 }

--- a/integration/presto/src/test/prestosql/org/apache/carbondata/presto/server/PrestoTestUtil.scala
+++ b/integration/presto/src/test/prestosql/org/apache/carbondata/presto/server/PrestoTestUtil.scala
@@ -114,4 +114,60 @@ object PrestoTestUtil {
       }
     }
   }
+
+  // this method depends on prestosql jdbc PrestoArray class
+  def validateArrayOfPrimitiveTypeDataWithLocalDict(actualResult: List[Map[String, Any]],
+      longChar: String): Unit = {
+    assert(actualResult.size == 3)
+    for (i <- 0 to actualResult.size - 1) {
+      val rowId = actualResult(i)("stringfield")
+      if (rowId == "row1") {
+        val column2 = actualResult(i)("arraystring")
+          .asInstanceOf[PrestoArray]
+          .getArray()
+          .asInstanceOf[Array[Object]]
+        assert(column2(0) == null)
+
+        val column3 = actualResult(i)("arraydate")
+          .asInstanceOf[PrestoArray]
+          .getArray()
+          .asInstanceOf[Array[Object]]
+        assert(column3(0) == null)
+
+        val column4 = actualResult(i)("arrayvarchar")
+          .asInstanceOf[PrestoArray]
+          .getArray()
+          .asInstanceOf[Array[Object]]
+        assert(column4(0) == null)
+      } else if (rowId == "row2") {
+        val column2 = actualResult(i)("arraystring")
+          .asInstanceOf[PrestoArray]
+          .getArray()
+          .asInstanceOf[Array[Object]]
+        assert(column2.sameElements(Array("India", "Japan", "India")))
+
+        val column3 = actualResult(i)("arraydate")
+          .asInstanceOf[PrestoArray]
+          .getArray()
+          .asInstanceOf[Array[Object]]
+        assert(column3.sameElements(Array("2019-03-02", "2020-03-02")))
+      } else if (rowId == "row3") {
+        val column2 = actualResult(i)("arraystring")
+          .asInstanceOf[PrestoArray]
+          .getArray()
+          .asInstanceOf[Array[Object]]
+        assert(column2.sameElements(Array("Iceland")))
+
+        val column3 = actualResult(i)("arraydate")
+          .asInstanceOf[PrestoArray]
+          .getArray()
+          .asInstanceOf[Array[Object]]
+        assert(column3.sameElements(Array("2019-03-02",
+          "2020-03-02",
+          "2021-04-02",
+          "2021-04-03",
+          "2021-04-02")))
+      }
+    }
+  }
 }


### PR DESCRIPTION
 ### Why is this PR needed?
 Enable local-dictionary for presto complex types.
 
 ### What changes were proposed in this PR?
As local dictionary is only supported in case of strings, while we fill primitive type - VariableLengthDimensionColumnPage is instantiated which in turn calls fillVector().

- Dictionary block is created with positionCount set from batchSize whose default value is 32000. Since it is a complex primitive type its value will never get updated from CarbondataPageSource. So will have to update it during the loading of that page along with other child pages.

- Calculate surrogate value for date type only in case of non-null values. Doing otherwise might cause exception in case of null values.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
