### PR TITLE
[CARBONDATA-4040] Fix data mismatch incase of compaction failure and retry success

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/mutate/CarbonUpdateUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/mutate/CarbonUpdateUtil.java
@@ -631,7 +631,7 @@ public class CarbonUpdateUtil {
       String updatedSegmentFile = SegmentFileStore
           .writeSegmentFile(table, segment.getSegmentNo(), UUID,
               CarbonTablePath.getSegmentPath(table.getTablePath(), segment.getSegmentNo()),
-              segment.getSegmentMetaDataInfo());
+              segment.getSegmentMetaDataInfo(), true);
       segmentFilesNotToDelete.add(updatedSegmentFile);
       segmentFilesToBeUpdatedLatest.add(new Segment(segment.getSegmentNo(), updatedSegmentFile));
     }

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -744,12 +744,12 @@ object CarbonDataRDDFactory {
         var segmentFiles: Seq[CarbonFile] = Seq.empty[CarbonFile]
 
         val segmentMetaDataInfo = segmentMetaDataInfoMap.get(segment.getSegmentNo)
-        val segmentFileName = SegmentFileStore.writeSegmentFile(
-          carbonTable,
+        val segmentFileName = SegmentFileStore.writeSegmentFile(carbonTable,
           segment.getSegmentNo,
           String.valueOf(System.currentTimeMillis()),
           load.getPath,
-          segmentMetaDataInfo)
+          segmentMetaDataInfo,
+          true)
 
         if (segmentFile != null) segmentFiles ++= FileFactory.getCarbonFile(
           SegmentFileStore.getSegmentFilePath(carbonTable.getTablePath, segmentFile)) :: Nil

--- a/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/util/SecondaryIndexUtil.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/util/SecondaryIndexUtil.scala
@@ -207,13 +207,13 @@ object SecondaryIndexUtil {
             validSegmentsToUse.toList.asJava,
             indexCarbonTable)
           mergedSegments.asScala.map { seg =>
-            val file = SegmentFileStore.writeSegmentFile(
-              indexCarbonTable,
+            val file = SegmentFileStore.writeSegmentFile(indexCarbonTable,
               seg.getLoadName,
               segmentIdToLoadStartTimeMapping(seg.getLoadName).toString,
               carbonLoadModel.getFactTimeStamp.toString,
               null,
-              null)
+              null,
+              false)
             val segment = new Segment(seg.getLoadName, file)
             SegmentFileStore.updateTableStatusFile(indexCarbonTable,
               seg.getLoadName,


### PR DESCRIPTION
 ### Why is this PR needed?
 For compaction, we don't register in-progress segment. so, when unable to get a table status lock. compaction can fail. That time compaction partial segment needs to be cleaned. If the partial segment is failed to clean up due to unable to get lock or IO issues. When the user retries the compaction. carbon uses the same segment id. so while writing the segment file for new compaction. list only the files mapping to the current compaction, not all the files which contain stale files.
 
 ### What changes were proposed in this PR?
While writing the segment file, consider index files belongs to the current load only in the segment folder.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No [As it happens in concurrent scenario randomly, manually verified]


    
