### PR TITLE
[CARBONDATA-4043] Fix data load failure issue for columns added in legacy store

### DIFF
--- a/integration/spark/src/main/java/org/apache/spark/sql/secondaryindex/query/SecondaryIndexQueryResultProcessor.java
+++ b/integration/spark/src/main/java/org/apache/spark/sql/secondaryindex/query/SecondaryIndexQueryResultProcessor.java
@@ -528,6 +528,8 @@ public class SecondaryIndexQueryResultProcessor {
         CarbonCommonConstants.FILE_SEPARATOR, CarbonCommonConstants.SORT_TEMP_FILE_LOCATION);
     sortParameters.setNoDictionarySortColumn(
         CarbonDataProcessorUtil.getNoDictSortColMapping(indexTable));
+    sortParameters.setSortColumnSchemaOrderMapping(
+        CarbonDataProcessorUtil.getSortColSchemaOrderMapping(indexTable));
     finalMerger = new SingleThreadFinalSortFilesMerger(sortTempFileLocation,
         indexTable.getTableName(), sortParameters);
   }

--- a/integration/spark/src/main/java/org/apache/spark/sql/secondaryindex/query/SecondaryIndexQueryResultProcessor.java
+++ b/integration/spark/src/main/java/org/apache/spark/sql/secondaryindex/query/SecondaryIndexQueryResultProcessor.java
@@ -528,7 +528,7 @@ public class SecondaryIndexQueryResultProcessor {
         CarbonCommonConstants.FILE_SEPARATOR, CarbonCommonConstants.SORT_TEMP_FILE_LOCATION);
     sortParameters.setNoDictionarySortColumn(
         CarbonDataProcessorUtil.getNoDictSortColMapping(indexTable));
-    sortParameters.setSortColumnSchemaOrderMapping(
+    sortParameters.setSortColumnSchemaOrderMap(
         CarbonDataProcessorUtil.getSortColSchemaOrderMapping(indexTable));
     finalMerger = new SingleThreadFinalSortFilesMerger(sortTempFileLocation,
         indexTable.getTableName(), sortParameters);

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/DataLoadProcessBuilder.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/DataLoadProcessBuilder.java
@@ -246,19 +246,22 @@ public final class DataLoadProcessBuilder {
     List<DataField> dataFields = new ArrayList<>();
     List<DataField> complexDataFields = new ArrayList<>();
     List<DataField> partitionColumns = new ArrayList<>();
+    configuration.setNumberOfSortColumns(carbonTable.getNumberOfSortColumns());
     if (loadModel.isLoadWithoutConverterWithoutReArrangeStep()) {
       // To avoid, reArranging of the data for each row, re arrange the schema itself.
       getReArrangedDataFields(loadModel, carbonTable, dimensions, measures, complexDataFields,
           partitionColumns, dataFields);
     } else {
       getDataFields(loadModel, dimensions, measures, complexDataFields, dataFields);
-      dataFields = updateDataFieldsBasedOnSortColumns(dataFields);
+      if (!(!configuration.isSortTable() || SortScopeOptions.getSortScope(loadModel.getSortScope())
+          .equals(SortScopeOptions.SortScope.NO_SORT))) {
+        dataFields = updateDataFieldsBasedOnSortColumns(dataFields);
+      }
     }
     configuration.setDataFields(dataFields.toArray(new DataField[0]));
     configuration.setBucketingInfo(carbonTable.getBucketingInfo());
     configuration.setBucketHashMethod(carbonTable.getBucketHashMethod());
     configuration.setPreFetch(loadModel.isPreFetch());
-    configuration.setNumberOfSortColumns(carbonTable.getNumberOfSortColumns());
     configuration.setNumberOfNoDictSortColumns(carbonTable.getNumberOfNoDictSortColumns());
     configuration.setDataWritePath(loadModel.getDataWritePath());
     setSortColumnInfo(carbonTable, loadModel, configuration);

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/sort/unsafe/holder/UnsafeFinalMergePageHolder.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/sort/unsafe/holder/UnsafeFinalMergePageHolder.java
@@ -64,7 +64,7 @@ public class UnsafeFinalMergePageHolder implements SortTempChunkHolder {
     this.comparator = new FileMergeSortComparator(tableFieldStat.getIsSortColNoDictFlags(),
         tableFieldStat.getNoDictSchemaDataType(),
         tableFieldStat.getNoDictSortColumnSchemaOrderMapping(),
-        tableFieldStat.getIsSortColSchemaOrderMapping());
+        tableFieldStat.getSortColSchemaOrderMap());
   }
 
   public boolean hasNext() {

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/sort/unsafe/holder/UnsafeFinalMergePageHolder.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/sort/unsafe/holder/UnsafeFinalMergePageHolder.java
@@ -62,7 +62,9 @@ public class UnsafeFinalMergePageHolder implements SortTempChunkHolder {
     this.noDictDataType = rowPages[0].getTableFieldStat().getNoDictDataType();
     LOGGER.info("Processing unsafe inmemory rows page with size : " + actualSize);
     this.comparator = new FileMergeSortComparator(tableFieldStat.getIsSortColNoDictFlags(),
-        tableFieldStat.getNoDictDataType(), tableFieldStat.getNoDictSortColumnSchemaOrderMapping());
+        tableFieldStat.getNoDictSchemaDataType(),
+        tableFieldStat.getNoDictSortColumnSchemaOrderMapping(),
+        tableFieldStat.getIsSortColSchemaOrderMapping());
   }
 
   public boolean hasNext() {

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/sort/unsafe/holder/UnsafeInmemoryHolder.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/sort/unsafe/holder/UnsafeInmemoryHolder.java
@@ -51,7 +51,7 @@ public class UnsafeInmemoryHolder implements SortTempChunkHolder {
         new FileMergeSortComparator(rowPage.getTableFieldStat().getIsSortColNoDictFlags(),
             rowPage.getTableFieldStat().getNoDictSchemaDataType(),
             rowPage.getTableFieldStat().getNoDictSortColumnSchemaOrderMapping(),
-            rowPage.getTableFieldStat().getIsSortColSchemaOrderMapping());
+            rowPage.getTableFieldStat().getSortColSchemaOrderMap());
     this.rowPage.setReadConvertedNoSortField();
   }
 

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/sort/unsafe/holder/UnsafeInmemoryHolder.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/sort/unsafe/holder/UnsafeInmemoryHolder.java
@@ -49,8 +49,9 @@ public class UnsafeInmemoryHolder implements SortTempChunkHolder {
     LOGGER.info("Processing unsafe inmemory rows page with size : " + actualSize);
     this.comparator =
         new FileMergeSortComparator(rowPage.getTableFieldStat().getIsSortColNoDictFlags(),
-            rowPage.getTableFieldStat().getNoDictDataType(),
-            rowPage.getTableFieldStat().getNoDictSortColumnSchemaOrderMapping());
+            rowPage.getTableFieldStat().getNoDictSchemaDataType(),
+            rowPage.getTableFieldStat().getNoDictSortColumnSchemaOrderMapping(),
+            rowPage.getTableFieldStat().getIsSortColSchemaOrderMapping());
     this.rowPage.setReadConvertedNoSortField();
   }
 

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/sort/unsafe/holder/UnsafeSortTempFileChunkHolder.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/sort/unsafe/holder/UnsafeSortTempFileChunkHolder.java
@@ -123,7 +123,7 @@ public class UnsafeSortTempFileChunkHolder implements SortTempChunkHolder {
       this.comparator = new FileMergeSortComparator(tableFieldStat.getIsSortColNoDictFlags(),
           tableFieldStat.getNoDictSchemaDataType(),
           tableFieldStat.getNoDictSortColumnSchemaOrderMapping(),
-          tableFieldStat.getIsSortColSchemaOrderMapping());
+          tableFieldStat.getSortColSchemaOrderMap());
     }
     initialize();
   }

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/sort/unsafe/holder/UnsafeSortTempFileChunkHolder.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/sort/unsafe/holder/UnsafeSortTempFileChunkHolder.java
@@ -121,8 +121,9 @@ public class UnsafeSortTempFileChunkHolder implements SortTempChunkHolder {
           parameters.getNoDictDataType());
     } else {
       this.comparator = new FileMergeSortComparator(tableFieldStat.getIsSortColNoDictFlags(),
-          tableFieldStat.getNoDictDataType(),
-          tableFieldStat.getNoDictSortColumnSchemaOrderMapping());
+          tableFieldStat.getNoDictSchemaDataType(),
+          tableFieldStat.getNoDictSortColumnSchemaOrderMapping(),
+          tableFieldStat.getIsSortColSchemaOrderMapping());
     }
     initialize();
   }

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/steps/DataConverterProcessorStepImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/steps/DataConverterProcessorStepImpl.java
@@ -152,13 +152,13 @@ public class DataConverterProcessorStepImpl extends AbstractDataLoadProcessorSte
     Arrays.sort(convertedSortColumnRanges,
         new RawRowComparator(sortColumnRangeInfo.getSortColumnIndex(),
             sortColumnRangeInfo.getIsSortColumnNoDict(), CarbonDataProcessorUtil
-            .getNoDictDataTypes(configuration.getTableSpec().getCarbonTable())));
+            .getNoDictSortDataTypes(configuration.getTableSpec().getCarbonTable())));
 
     // range partitioner to dispatch rows by sort columns
     this.partitioner = new RangePartitionerImpl(convertedSortColumnRanges,
         new RawRowComparator(sortColumnRangeInfo.getSortColumnIndex(),
             sortColumnRangeInfo.getIsSortColumnNoDict(), CarbonDataProcessorUtil
-            .getNoDictDataTypes(configuration.getTableSpec().getCarbonTable())));
+            .getNoDictSortDataTypes(configuration.getTableSpec().getCarbonTable())));
   }
 
   // only convert sort column fields

--- a/processing/src/main/java/org/apache/carbondata/processing/merger/CompactionResultSortProcessor.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/merger/CompactionResultSortProcessor.java
@@ -480,6 +480,8 @@ public class CompactionResultSortProcessor extends AbstractResultProcessor {
     boolean[] noDictionarySortColumnMapping = CarbonDataProcessorUtil
         .getNoDictSortColMapping(carbonTable);
     sortParameters.setNoDictionarySortColumn(noDictionarySortColumnMapping);
+    sortParameters.setSortColumnSchemaOrderMapping(
+        CarbonDataProcessorUtil.getSortColSchemaOrderMapping(carbonTable));
     String[] sortTempFileLocation = CarbonDataProcessorUtil.arrayAppend(tempStoreLocation,
         CarbonCommonConstants.FILE_SEPARATOR, CarbonCommonConstants.SORT_TEMP_FILE_LOCATION);
     finalMerger =

--- a/processing/src/main/java/org/apache/carbondata/processing/merger/CompactionResultSortProcessor.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/merger/CompactionResultSortProcessor.java
@@ -480,7 +480,7 @@ public class CompactionResultSortProcessor extends AbstractResultProcessor {
     boolean[] noDictionarySortColumnMapping = CarbonDataProcessorUtil
         .getNoDictSortColMapping(carbonTable);
     sortParameters.setNoDictionarySortColumn(noDictionarySortColumnMapping);
-    sortParameters.setSortColumnSchemaOrderMapping(
+    sortParameters.setSortColumnSchemaOrderMap(
         CarbonDataProcessorUtil.getSortColSchemaOrderMapping(carbonTable));
     String[] sortTempFileLocation = CarbonDataProcessorUtil.arrayAppend(tempStoreLocation,
         CarbonCommonConstants.FILE_SEPARATOR, CarbonCommonConstants.SORT_TEMP_FILE_LOCATION);

--- a/processing/src/main/java/org/apache/carbondata/processing/sort/sortdata/FileMergeSortComparator.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/sort/sortdata/FileMergeSortComparator.java
@@ -29,23 +29,26 @@ public class FileMergeSortComparator implements Comparator<IntermediateSortTempR
 
   private boolean[] isSortColumnNoDictionary;
 
-  private DataType[] noDicSortDataTypes;
+  private DataType[] noDictDataTypes;
 
   /**
    * Index of the no dict Sort columns in the carbonRow for final merge step of sorting.
    */
   private int[] noDictPrimitiveIndex;
 
+  private boolean[] sortColumnSchemaOrderMapping;
+
   /**
    * Comparator for IntermediateSortTempRow for compatibility cases where column added in old
    * version and it is sort column
    * @param isSortColumnNoDictionary isSortColumnNoDictionary
    */
-  public FileMergeSortComparator(boolean[] isSortColumnNoDictionary, DataType[] noDicSortDataTypes,
-      int[] columnIdBasedOnSchemaInRow) {
+  public FileMergeSortComparator(boolean[] isSortColumnNoDictionary, DataType[] noDictDataTypes,
+      int[] columnIdBasedOnSchemaInRow, boolean[] sortColumnSchemaOrderMapping) {
     this.isSortColumnNoDictionary = isSortColumnNoDictionary;
-    this.noDicSortDataTypes = noDicSortDataTypes;
+    this.noDictDataTypes = noDictDataTypes;
     this.noDictPrimitiveIndex = columnIdBasedOnSchemaInRow;
+    this.sortColumnSchemaOrderMapping = sortColumnSchemaOrderMapping;
   }
 
   @Override
@@ -55,40 +58,43 @@ public class FileMergeSortComparator implements Comparator<IntermediateSortTempR
     int nonDictIndex = 0;
     int noDicTypeIdx = 0;
     int schemaRowIdx = 0;
+    int sortIndex = 0;
 
-    for (boolean isNoDictionary : isSortColumnNoDictionary) {
+    for (boolean isSortColumn : sortColumnSchemaOrderMapping) {
+      if (isSortColumn) {
+        if (isSortColumnNoDictionary[sortIndex++]) {
+          if (DataTypeUtil.isPrimitiveColumn(noDictDataTypes[noDicTypeIdx])) {
+            // use data types based comparator for the no dictionary measure columns
+            SerializableComparator comparator =
+                org.apache.carbondata.core.util.comparator.Comparator
+                    .getComparator(noDictDataTypes[noDicTypeIdx]);
+            int difference = comparator
+                .compare(rowA.getNoDictSortDims()[noDictPrimitiveIndex[schemaRowIdx]],
+                    rowB.getNoDictSortDims()[noDictPrimitiveIndex[schemaRowIdx]]);
+            schemaRowIdx++;
+            if (difference != 0) {
+              return difference;
+            }
+          } else {
+            byte[] byteArr1 = (byte[]) rowA.getNoDictSortDims()[nonDictIndex];
+            byte[] byteArr2 = (byte[]) rowB.getNoDictSortDims()[nonDictIndex];
 
-      if (isNoDictionary) {
-        if (DataTypeUtil.isPrimitiveColumn(noDicSortDataTypes[noDicTypeIdx])) {
-          // use data types based comparator for the no dictionary measure columns
-          SerializableComparator comparator = org.apache.carbondata.core.util.comparator.Comparator
-              .getComparator(noDicSortDataTypes[noDicTypeIdx]);
-          int difference = comparator
-              .compare(rowA.getNoDictSortDims()[noDictPrimitiveIndex[schemaRowIdx]],
-                  rowB.getNoDictSortDims()[noDictPrimitiveIndex[schemaRowIdx]]);
-          schemaRowIdx++;
-          if (difference != 0) {
-            return difference;
+            int difference = ByteUtil.UnsafeComparer.INSTANCE.compareTo(byteArr1, byteArr2);
+            if (difference != 0) {
+              return difference;
+            }
           }
+          nonDictIndex++;
+          noDicTypeIdx++;
         } else {
-          byte[] byteArr1 = (byte[]) rowA.getNoDictSortDims()[nonDictIndex];
-          byte[] byteArr2 = (byte[]) rowB.getNoDictSortDims()[nonDictIndex];
+          int dimFieldA = rowA.getDictSortDims()[dictIndex];
+          int dimFieldB = rowB.getDictSortDims()[dictIndex];
+          dictIndex++;
 
-          int difference = ByteUtil.UnsafeComparer.INSTANCE.compareTo(byteArr1, byteArr2);
-          if (difference != 0) {
-            return difference;
+          diff = dimFieldA - dimFieldB;
+          if (diff != 0) {
+            return diff;
           }
-        }
-        nonDictIndex++;
-        noDicTypeIdx++;
-      } else {
-        int dimFieldA = rowA.getDictSortDims()[dictIndex];
-        int dimFieldB = rowB.getDictSortDims()[dictIndex];
-        dictIndex++;
-
-        diff = dimFieldA - dimFieldB;
-        if (diff != 0) {
-          return diff;
         }
       }
     }

--- a/processing/src/main/java/org/apache/carbondata/processing/sort/sortdata/SortParameters.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/sort/sortdata/SortParameters.java
@@ -103,6 +103,10 @@ public class SortParameters implements Serializable {
   // used while writing the row to sort temp file where nosort nodict columns are handled seperately
   private DataType[] noDictNoSortDataType;
 
+  private DataType[] noDictSchemaDataType;
+
+  private boolean[] sortColumnSchemaOrderMapping;
+
   /**
    * To know how many columns are of high cardinality.
    */
@@ -200,6 +204,8 @@ public class SortParameters implements Serializable {
     parameters.noDictActualPosition = noDictActualPosition;
     parameters.noDictSortColumnSchemaOrderMapping = noDictSortColumnSchemaOrderMapping;
     parameters.isInsertWithoutReArrangeFlow = isInsertWithoutReArrangeFlow;
+    parameters.noDictSchemaDataType = noDictSchemaDataType;
+    parameters.sortColumnSchemaOrderMapping = sortColumnSchemaOrderMapping;
     return parameters;
   }
 
@@ -519,7 +525,11 @@ public class SortParameters implements Serializable {
           .getColumnIdxBasedOnSchemaInRow(parameters.getCarbonTable()));
       parameters.setMeasureDataType(configuration.getMeasureDataType());
       parameters.setNoDictDataType(CarbonDataProcessorUtil
-          .getNoDictDataTypes(configuration.getTableSpec().getCarbonTable()));
+          .getNoDictSortDataTypes(configuration.getTableSpec().getCarbonTable()));
+      parameters.setSortColumnSchemaOrderMapping(
+          CarbonDataProcessorUtil.getSortColSchemaOrderMapping(parameters.carbonTable));
+      parameters.setNoDictSchemaDataType(
+          CarbonDataProcessorUtil.getNoDictDataTypes(parameters.carbonTable));
       Map<String, DataType[]> noDictSortAndNoSortDataTypes = CarbonDataProcessorUtil
           .getNoDictSortAndNoSortDataTypes(configuration.getTableSpec().getCarbonTable());
       parameters.setNoDictSortDataType(noDictSortAndNoSortDataTypes.get("noDictSortDataTypes"));
@@ -606,13 +616,17 @@ public class SortParameters implements Serializable {
         .getMeasureDataType(parameters.getMeasureColCount(), parameters.getCarbonTable());
     parameters.setMeasureDataType(type);
     parameters.setNoDictDataType(CarbonDataProcessorUtil
-        .getNoDictDataTypes(carbonTable));
+        .getNoDictSortDataTypes(carbonTable));
     Map<String, DataType[]> noDictSortAndNoSortDataTypes = CarbonDataProcessorUtil
         .getNoDictSortAndNoSortDataTypes(parameters.getCarbonTable());
     parameters.setNoDictSortDataType(noDictSortAndNoSortDataTypes.get("noDictSortDataTypes"));
     parameters.setNoDictNoSortDataType(noDictSortAndNoSortDataTypes.get("noDictNoSortDataTypes"));
     parameters.setNoDictionarySortColumn(CarbonDataProcessorUtil
         .getNoDictSortColMapping(parameters.getCarbonTable()));
+    parameters.setSortColumnSchemaOrderMapping(
+        CarbonDataProcessorUtil.getSortColSchemaOrderMapping(parameters.carbonTable));
+    parameters.setNoDictSchemaDataType(
+        CarbonDataProcessorUtil.getNoDictDataTypes(parameters.carbonTable));
     parameters.setNoDictSortColumnSchemaOrderMapping(CarbonDataProcessorUtil
         .getColumnIdxBasedOnSchemaInRow(parameters.getCarbonTable()));
     TableSpec tableSpec = new TableSpec(carbonTable, false);
@@ -685,5 +699,21 @@ public class SortParameters implements Serializable {
 
   public void setNoDictActualPosition(int[] noDictActualPosition) {
     this.noDictActualPosition = noDictActualPosition;
+  }
+
+  public DataType[] getNoDictSchemaDataType() {
+    return noDictSchemaDataType;
+  }
+
+  public void setNoDictSchemaDataType(DataType[] noDictSchemaDataType) {
+    this.noDictSchemaDataType = noDictSchemaDataType;
+  }
+
+  public void setSortColumnSchemaOrderMapping(boolean[] sortColumnSchemaOrderMapping) {
+    this.sortColumnSchemaOrderMapping = sortColumnSchemaOrderMapping;
+  }
+
+  public boolean[] getSortColumnSchemaOrderMapping() {
+    return sortColumnSchemaOrderMapping;
   }
 }

--- a/processing/src/main/java/org/apache/carbondata/processing/sort/sortdata/SortParameters.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/sort/sortdata/SortParameters.java
@@ -19,6 +19,7 @@ package org.apache.carbondata.processing.sort.sortdata;
 
 import java.io.File;
 import java.io.Serializable;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.carbondata.common.logging.LogServiceFactory;
@@ -103,9 +104,12 @@ public class SortParameters implements Serializable {
   // used while writing the row to sort temp file where nosort nodict columns are handled seperately
   private DataType[] noDictNoSortDataType;
 
+  // no dictionary columns in schema order participating in sort
+  // used while performing final sort of intermediate files
   private DataType[] noDictSchemaDataType;
 
-  private boolean[] sortColumnSchemaOrderMapping;
+  // Sort and Dictionary info of all the columns in schema order, used in final sort
+  private Map<Integer, List<Boolean>> sortColumnSchemaOrderMap;
 
   /**
    * To know how many columns are of high cardinality.
@@ -205,7 +209,7 @@ public class SortParameters implements Serializable {
     parameters.noDictSortColumnSchemaOrderMapping = noDictSortColumnSchemaOrderMapping;
     parameters.isInsertWithoutReArrangeFlow = isInsertWithoutReArrangeFlow;
     parameters.noDictSchemaDataType = noDictSchemaDataType;
-    parameters.sortColumnSchemaOrderMapping = sortColumnSchemaOrderMapping;
+    parameters.sortColumnSchemaOrderMap = sortColumnSchemaOrderMap;
     return parameters;
   }
 
@@ -526,7 +530,7 @@ public class SortParameters implements Serializable {
       parameters.setMeasureDataType(configuration.getMeasureDataType());
       parameters.setNoDictDataType(CarbonDataProcessorUtil
           .getNoDictSortDataTypes(configuration.getTableSpec().getCarbonTable()));
-      parameters.setSortColumnSchemaOrderMapping(
+      parameters.setSortColumnSchemaOrderMap(
           CarbonDataProcessorUtil.getSortColSchemaOrderMapping(parameters.carbonTable));
       parameters.setNoDictSchemaDataType(
           CarbonDataProcessorUtil.getNoDictDataTypes(parameters.carbonTable));
@@ -623,7 +627,7 @@ public class SortParameters implements Serializable {
     parameters.setNoDictNoSortDataType(noDictSortAndNoSortDataTypes.get("noDictNoSortDataTypes"));
     parameters.setNoDictionarySortColumn(CarbonDataProcessorUtil
         .getNoDictSortColMapping(parameters.getCarbonTable()));
-    parameters.setSortColumnSchemaOrderMapping(
+    parameters.setSortColumnSchemaOrderMap(
         CarbonDataProcessorUtil.getSortColSchemaOrderMapping(parameters.carbonTable));
     parameters.setNoDictSchemaDataType(
         CarbonDataProcessorUtil.getNoDictDataTypes(parameters.carbonTable));
@@ -709,11 +713,11 @@ public class SortParameters implements Serializable {
     this.noDictSchemaDataType = noDictSchemaDataType;
   }
 
-  public void setSortColumnSchemaOrderMapping(boolean[] sortColumnSchemaOrderMapping) {
-    this.sortColumnSchemaOrderMapping = sortColumnSchemaOrderMapping;
+  public void setSortColumnSchemaOrderMap(Map<Integer, List<Boolean>> sortColumnSchemaOrderMap) {
+    this.sortColumnSchemaOrderMap = sortColumnSchemaOrderMap;
   }
 
-  public boolean[] getSortColumnSchemaOrderMapping() {
-    return sortColumnSchemaOrderMapping;
+  public Map<Integer, List<Boolean>> getSortColumnSchemaOrderMap() {
+    return sortColumnSchemaOrderMap;
   }
 }

--- a/processing/src/main/java/org/apache/carbondata/processing/sort/sortdata/SortTempFileChunkHolder.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/sort/sortdata/SortTempFileChunkHolder.java
@@ -108,7 +108,7 @@ public class SortTempFileChunkHolder implements Comparable<SortTempFileChunkHold
     this.comparator = new FileMergeSortComparator(tableFieldStat.getIsSortColNoDictFlags(),
         tableFieldStat.getNoDictSchemaDataType(),
         tableFieldStat.getNoDictSortColumnSchemaOrderMapping(),
-        tableFieldStat.getIsSortColSchemaOrderMapping());
+        tableFieldStat.getSortColSchemaOrderMap());
     this.sortTempRowUpdater = tableFieldStat.getSortTempRowUpdater();
   }
 
@@ -135,7 +135,7 @@ public class SortTempFileChunkHolder implements Comparable<SortTempFileChunkHold
       this.comparator = new FileMergeSortComparator(tableFieldStat.getIsSortColNoDictFlags(),
           tableFieldStat.getNoDictSchemaDataType(),
           tableFieldStat.getNoDictSortColumnSchemaOrderMapping(),
-          tableFieldStat.getIsSortColSchemaOrderMapping());
+          tableFieldStat.getSortColSchemaOrderMap());
     } else {
       this.comparator =
           new IntermediateSortTempRowComparator(tableFieldStat.getIsSortColNoDictFlags(),

--- a/processing/src/main/java/org/apache/carbondata/processing/sort/sortdata/SortTempFileChunkHolder.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/sort/sortdata/SortTempFileChunkHolder.java
@@ -106,7 +106,9 @@ public class SortTempFileChunkHolder implements Comparable<SortTempFileChunkHold
   public SortTempFileChunkHolder(SortParameters sortParameters) {
     this.tableFieldStat = new TableFieldStat(sortParameters);
     this.comparator = new FileMergeSortComparator(tableFieldStat.getIsSortColNoDictFlags(),
-        tableFieldStat.getNoDictDataType(), tableFieldStat.getNoDictSortColumnSchemaOrderMapping());
+        tableFieldStat.getNoDictSchemaDataType(),
+        tableFieldStat.getNoDictSortColumnSchemaOrderMapping(),
+        tableFieldStat.getIsSortColSchemaOrderMapping());
     this.sortTempRowUpdater = tableFieldStat.getSortTempRowUpdater();
   }
 
@@ -130,9 +132,10 @@ public class SortTempFileChunkHolder implements Comparable<SortTempFileChunkHold
                 true));
     this.convertToActualField = convertToActualField;
     if (this.convertToActualField) {
-      this.comparator = new FileMergeSortComparator(
-          tableFieldStat.getIsSortColNoDictFlags(), tableFieldStat.getNoDictDataType(),
-          tableFieldStat.getNoDictSortColumnSchemaOrderMapping());
+      this.comparator = new FileMergeSortComparator(tableFieldStat.getIsSortColNoDictFlags(),
+          tableFieldStat.getNoDictSchemaDataType(),
+          tableFieldStat.getNoDictSortColumnSchemaOrderMapping(),
+          tableFieldStat.getIsSortColSchemaOrderMapping());
     } else {
       this.comparator =
           new IntermediateSortTempRowComparator(tableFieldStat.getIsSortColNoDictFlags(),

--- a/processing/src/main/java/org/apache/carbondata/processing/sort/sortdata/TableFieldStat.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/sort/sortdata/TableFieldStat.java
@@ -20,6 +20,7 @@ package org.apache.carbondata.processing.sort.sortdata;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import org.apache.carbondata.core.metadata.datatype.DataType;
@@ -82,7 +83,7 @@ public class TableFieldStat implements Serializable {
 
   private DataType[] noDictSchemaDataType;
 
-  private boolean[] isSortColSchemaOrderMapping;
+  private Map<Integer, List<Boolean>> sortColSchemaOrderMap;
 
   public TableFieldStat(SortParameters sortParameters) {
     int noDictDimCnt = sortParameters.getNoDictionaryCount();
@@ -105,7 +106,7 @@ public class TableFieldStat implements Serializable {
     this.noDictSortDataType = sortParameters.getNoDictSortDataType();
     this.noDictNoSortDataType = sortParameters.getNoDictNoSortDataType();
     this.noDictSchemaDataType = sortParameters.getNoDictSchemaDataType();
-    this.isSortColSchemaOrderMapping = sortParameters.getSortColumnSchemaOrderMapping();
+    this.sortColSchemaOrderMap = sortParameters.getSortColumnSchemaOrderMap();
     for (boolean flag : isVarcharDimFlags) {
       if (flag) {
         varcharDimCnt++;
@@ -358,8 +359,8 @@ public class TableFieldStat implements Serializable {
     return otherCols;
   }
 
-  public boolean[] getIsSortColSchemaOrderMapping() {
-    return isSortColSchemaOrderMapping;
+  public Map<Integer, List<Boolean>> getSortColSchemaOrderMap() {
+    return sortColSchemaOrderMap;
   }
 
   public DataType[] getNoDictSchemaDataType() {

--- a/processing/src/main/java/org/apache/carbondata/processing/sort/sortdata/TableFieldStat.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/sort/sortdata/TableFieldStat.java
@@ -80,6 +80,10 @@ public class TableFieldStat implements Serializable {
    */
   private int[] noDictSortColumnSchemaOrderMapping;
 
+  private DataType[] noDictSchemaDataType;
+
+  private boolean[] isSortColSchemaOrderMapping;
+
   public TableFieldStat(SortParameters sortParameters) {
     int noDictDimCnt = sortParameters.getNoDictionaryCount();
     int dictDimCnt = sortParameters.getDimColCount() - noDictDimCnt;
@@ -100,6 +104,8 @@ public class TableFieldStat implements Serializable {
     this.noDictDataType = sortParameters.getNoDictDataType();
     this.noDictSortDataType = sortParameters.getNoDictSortDataType();
     this.noDictNoSortDataType = sortParameters.getNoDictNoSortDataType();
+    this.noDictSchemaDataType = sortParameters.getNoDictSchemaDataType();
+    this.isSortColSchemaOrderMapping = sortParameters.getSortColumnSchemaOrderMapping();
     for (boolean flag : isVarcharDimFlags) {
       if (flag) {
         varcharDimCnt++;
@@ -352,4 +358,11 @@ public class TableFieldStat implements Serializable {
     return otherCols;
   }
 
+  public boolean[] getIsSortColSchemaOrderMapping() {
+    return isSortColSchemaOrderMapping;
+  }
+
+  public DataType[] getNoDictSchemaDataType() {
+    return noDictSchemaDataType;
+  }
 }

--- a/processing/src/test/java/org/apache/carbondata/processing/sort/sortdata/FileMergeSortComparatorTest.java
+++ b/processing/src/test/java/org/apache/carbondata/processing/sort/sortdata/FileMergeSortComparatorTest.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.processing.sort.sortdata;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.apache.carbondata.core.constants.CarbonCommonConstants;
+import org.apache.carbondata.core.metadata.datatype.DataType;
+import org.apache.carbondata.core.metadata.datatype.DataTypes;
+import org.apache.carbondata.core.metadata.encoder.Encoding;
+import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
+import org.apache.carbondata.core.metadata.schema.table.TableInfo;
+import org.apache.carbondata.core.metadata.schema.table.TableSchema;
+import org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema;
+import org.apache.carbondata.processing.loading.row.IntermediateSortTempRow;
+import org.apache.carbondata.processing.util.CarbonDataProcessorUtil;
+
+import org.junit.Test;
+
+public class FileMergeSortComparatorTest {
+
+  static ColumnSchema getDimensionColumn(String colName, Boolean isSortColumn, Boolean isDictColumn,
+      DataType dataType) {
+    ColumnSchema dimColumn = new ColumnSchema();
+    dimColumn.setColumnName(colName);
+    dimColumn.setDataType(dataType);
+    dimColumn.setColumnUniqueId(UUID.randomUUID().toString());
+    dimColumn.setDimensionColumn(true);
+    List<Encoding> encodeList =
+        new ArrayList<Encoding>(CarbonCommonConstants.DEFAULT_COLLECTION_SIZE);
+    if (isDictColumn) {
+      encodeList.add(Encoding.DICTIONARY);
+    }
+    dimColumn.setEncodingList(encodeList);
+    if (isSortColumn) {
+      dimColumn.setSortColumn(true);
+    }
+    return dimColumn;
+  }
+
+  static TableSchema getTableSchema() {
+    TableSchema tableSchema = new TableSchema();
+    List<ColumnSchema> columnSchemaList = new ArrayList<ColumnSchema>();
+      columnSchemaList.add(getDimensionColumn("col1", false, false, DataTypes.INT));
+    columnSchemaList.add(getDimensionColumn("col2", true, false, DataTypes.STRING));
+    columnSchemaList.add(getDimensionColumn("col3", true, false, DataTypes.LONG));
+    columnSchemaList.add(getDimensionColumn("col4", true, true, DataTypes.STRING));
+    tableSchema.setListOfColumns(columnSchemaList);
+    tableSchema.setTableId(UUID.randomUUID().toString());
+    tableSchema.setTableName("carbonTestTable");
+    return tableSchema;
+  }
+
+  static private TableInfo getTableInfo() {
+    TableInfo info = new TableInfo();
+    info.setDatabaseName("carbonTestDatabase");
+    info.setTableUniqueName("carbonTestDatabase_carbonTestTable");
+    info.setFactTable(getTableSchema());
+    info.setTablePath("testore");
+    return info;
+  }
+
+  @Test
+  public void testFileMergeSortComparator() {
+    CarbonTable carbonTable = CarbonTable.buildFromTableInfo(getTableInfo());
+    // test get noDictDataTypes
+    DataType[] noDictDataTypes = CarbonDataProcessorUtil.getNoDictDataTypes(carbonTable);
+    assert (noDictDataTypes.length == 3 && noDictDataTypes[0].equals(DataTypes.INT)
+        && noDictDataTypes[1].equals(DataTypes.STRING) && noDictDataTypes[2]
+        .equals(DataTypes.LONG));
+
+    // test getSortColSchemaOrderMapping
+    Map<Integer, List<Boolean>> sortColSchemaOrderMapping =
+        CarbonDataProcessorUtil.getSortColSchemaOrderMapping(carbonTable);
+    assert (sortColSchemaOrderMapping.get(0).get(0).equals(false) && sortColSchemaOrderMapping
+        .get(0).get(1).equals(false));
+    assert (sortColSchemaOrderMapping.get(1).get(0).equals(true) && sortColSchemaOrderMapping.get(1)
+        .get(1).equals(false));
+    assert (sortColSchemaOrderMapping.get(2).get(0).equals(true) && sortColSchemaOrderMapping
+        .get(2).get(1).equals(false));
+    assert (sortColSchemaOrderMapping.get(3).get(0).equals(true) && sortColSchemaOrderMapping.get(3)
+        .get(1).equals(true));
+
+    // test comparator
+    boolean[] isSortColNoDict = { true, false };
+    int[] columnIdxBasedOnSchemaInRow =
+        CarbonDataProcessorUtil.getColumnIdxBasedOnSchemaInRow(carbonTable);
+    FileMergeSortComparator comparator =
+        new FileMergeSortComparator(isSortColNoDict, noDictDataTypes, columnIdxBasedOnSchemaInRow,
+            sortColSchemaOrderMapping);
+
+    // prepare data for final sort
+    int[] dictSortDims1 = { 1 };
+    Object[] noDictSortDims1 = { 1, new byte[] { 98, 99, 104 }, 2 };
+    byte[] noSortDimsAndMeasures1 = {};
+    IntermediateSortTempRow row1 =
+        new IntermediateSortTempRow(dictSortDims1, noDictSortDims1, noSortDimsAndMeasures1);
+
+    int[] dictSortDims = { 1 };
+    Object[] noDictSortDims = { 2, new byte[] { 98, 99, 100 }, 1 };
+    byte[] noSortDimsAndMeasures = {};
+    IntermediateSortTempRow row2 =
+        new IntermediateSortTempRow(dictSortDims, noDictSortDims, noSortDimsAndMeasures);
+
+    assert (comparator.compare(row1, row2) > 0);
+  }
+
+}


### PR DESCRIPTION
 ### Why is this PR needed?

When dimension is added in older versions like 1.1, by default it will be sort column. In sort step we assume data will be coming as sort column in the beginning. But the added column will be at last eventhough sort column. So, while building the dataload configurations for loading data, we rearrange the columns(dimensions and datafields) in order to bring the sort column to beginning and no-sort to last and revert them back to schema order before FinalMerge/DataWriter step.

Issue:
Data loading is failing because of castException in data writing step in case of NO_SORT and in final sort step in case of LOCAL_SORT.

1. NO_SORT:
    In this flow, datafields are rearranged based on sort columns order, which is not required. 

2. LOCAL_SORT:
    During FinalMerge, we assume intermediate row data will have only sort column data in schema order. But intermediate sort row data can contain no-dictionary and dictionary data also. So, the information about the actual index of sort column data is insufficient. 
 
 ### What changes were proposed in this PR?
1. NO_SORT:
   Update datafields based on sort columns only if the table is a sort table and sort columns are configured.

2. LOCAL_SORT:
    Collect the sort column info from all the dimensions into a map and identify the sort column index using it and compare only sort column data in final merge.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No

    
