### PR TITLE
[CARBONDATA-4046] Handled multiple partition columns for partition cache

### DIFF
--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/standardpartition/StandardPartitionTableLoadingTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/standardpartition/StandardPartitionTableLoadingTestCase.scala
@@ -618,6 +618,21 @@ class StandardPartitionTableLoadingTestCase extends QueryTest with BeforeAndAfte
     CarbonProperties.getInstance().addProperty("carbon.read.partition.hive.direct", "true")
   }
 
+  test("test partition cache on multiple columns") {
+    CarbonProperties.getInstance().addProperty("carbon.read.partition.hive.direct", "false")
+    sql("drop table if exists partition_cache")
+    sql("create table partition_cache(a string) partitioned by(b int, c String) stored as carbondata")
+    sql("insert into partition_cache select 'k',1,'nihal'")
+    checkAnswer(sql("select count(*) from partition_cache where b = 1"), Seq(Row(1)))
+    sql("select * from partition_cache where b = 1").collect()
+    val carbonTable = CarbonMetadata.getInstance().getCarbonTable("default", "partition_cache")
+    val partitionSpecs: util.List[CatalogTablePartition] = PartitionCacheManager.getIfPresent(
+      PartitionCacheKey(carbonTable.getTableId, carbonTable.getTablePath, 1L))
+    assert(partitionSpecs.size == 1)
+    assert(partitionSpecs.get(0).spec.size == 2)
+    CarbonProperties.getInstance().addProperty("carbon.read.partition.hive.direct", "true")
+  }
+
   test("test partition caching after load") {
     CarbonProperties.getInstance().addProperty("carbon.read.partition.hive.direct", "false")
     sql("drop table if exists partition_cache")


### PR DESCRIPTION
 ### Why is this PR needed?
 Currently when property `carbon.read.partition.hive.direct` is false then select count * fails on table which contains multiple partition columns.
 Handled open points of PR- [3908](https://github.com/apache/carbondata/pull/3908)
 1. Subtraction of the different data types.
 2. If the final cache is empty and the invalid segment list is non-empty then clear the cache.
 
 ### What changes were proposed in this PR?
Handled multiple partition columns.
 1. Handled subtraction of the different data types.
 2. If the final cache is empty and the invalid segment list is non-empty then clear the cache.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
