### PR TITLE
[CARBONDATA-3905] NPE due to null length while querying in Presto

### DIFF
--- a/integration/presto/src/main/prestodb/org/apache/carbondata/presto/readers/SliceStreamReader.java
+++ b/integration/presto/src/main/prestodb/org/apache/carbondata/presto/readers/SliceStreamReader.java
@@ -141,8 +141,10 @@ public class SliceStreamReader extends CarbonColumnVectorImpl implements PrestoV
 
   @Override
   public void putAllByteArray(byte[] data, int offset, int length) {
+    super.putAllByteArray(data, offset, length);
     int[] lengths = getLengths();
     int[] offsets = getOffsets();
+    if (lengths == null) return;
     for (int i = 0; i < lengths.length; i++) {
       if (offsets[i] != 0) {
         putByteArray(i, offsets[i], lengths[i], data);

--- a/integration/presto/src/main/prestosql/org/apache/carbondata/presto/readers/SliceStreamReader.java
+++ b/integration/presto/src/main/prestosql/org/apache/carbondata/presto/readers/SliceStreamReader.java
@@ -141,8 +141,10 @@ public class SliceStreamReader extends CarbonColumnVectorImpl implements PrestoV
 
   @Override
   public void putAllByteArray(byte[] data, int offset, int length) {
+    super.putAllByteArray(data, offset, length);
     int[] lengths = getLengths();
     int[] offsets = getOffsets();
+    if (lengths == null) return;
     for (int i = 0; i < lengths.length; i++) {
       if (offsets[i] != 0) {
         putByteArray(i, offsets[i], lengths[i], data);


### PR DESCRIPTION
 ### Why is this PR needed?
 Earlier the implementation of putAllByteArray() in class SliceStreamReader was added with regards to handling of complex string type columns. This method is also called in case of plain string type.
While querying plain string type the lengths may be equal to null. Hence this check has been added.  
 
 ### What changes were proposed in this PR?
Handled the same
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No


    
