### PR TITLE
[CARBONDATA-4022] Fix invalid path issue for segment added through alter table add segment query.

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/indexstore/ExtendedBlocklet.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/ExtendedBlocklet.java
@@ -20,6 +20,7 @@ package org.apache.carbondata.core.indexstore;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.DataOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -219,7 +220,12 @@ public class ExtendedBlocklet extends Blocklet {
     if (in.readBoolean()) {
       indexUniqueId = in.readUTF();
     }
-    setFilePath(tablePath + getPath());
+    String filePath = getPath();
+    if (filePath.startsWith(File.separator)) {
+      setFilePath(tablePath + filePath);
+    } else {
+      setFilePath(filePath);
+    }
     boolean isSplitPresent = in.readBoolean();
     if (isSplitPresent) {
       // getting the length of the data


### PR DESCRIPTION
 ### Why is this PR needed?
Segment Added through alter table add segment query doesn't require tablepath in its filepath, because the segment is present at some external location which is not inside the table.
 
 ### What changes were proposed in this PR?
Filepath for normal segments (which are not added through alter table add segment query) is tablePath + filePath. But for segments added through alter table add segment query doesn't require tablePath, so we directly use the filePath of the segment.

 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No

    
