### PR TITLE
[CARBONDATA-4055]Fix creation of empty segment directory and meta entry when there is no update/insert data

### DIFF
--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -315,7 +315,8 @@ object CarbonDataRDDFactory {
     try {
       if (!carbonLoadModel.isCarbonTransactionalTable || segmentLock.lockWithRetries()) {
         if (updateModel.isDefined && dataFrame.get.rdd.isEmpty()) {
-          // if the rowToBeUpdated is empty, do nothing
+          // if the rowToBeUpdated is empty, mark created segment as marked for delete and return
+          CarbonLoaderUtil.updateTableStatusForFailure(carbonLoadModel, "")
         } else {
           status = if (scanResultRdd.isDefined) {
             val colSchema = carbonLoadModel


### PR DESCRIPTION
 ### Why is this PR needed?
1. After #3999 when an update happens on the table, a new segment is created for updated data. But when there is no data to update, still the segments are created and the table status has in progress entries for those empty segments. This leads to unnecessary segment dirs and an increase in table status entries.
2. after this, clean files don't clean these empty segments.
3. when the source table do not have data, CTAS will result in same problem mentioned.
 
 ### What changes were proposed in this PR?
1.when the data is not present during update, make the segment as marked for delete so that the clean files take care to delete the segment, for cats already handled, added test cases.

 ### Does this PR introduce any user interface change?
 - No

 ### Is any new test case added?
 - Yes

    
