### PR TITLE
[CARBONDATA-4053] Fix alter table rename column failed when column name is "a"

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/util/AlterTableUtil.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/util/AlterTableUtil.scala
@@ -332,12 +332,24 @@ object AlterTableUtil {
       tableProperties: mutable.Map[String, String],
       oldColumnName: String,
       newColumnName: String): Unit = {
+    val columnNameProperties = Set("NO_INVERTED_INDEX",
+      "INVERTED_INDEX",
+      "INDEX_COLUMNS",
+      "COLUMN_META_CACHE",
+      "LOCAL_DICTIONARY_INCLUDE",
+      "LOCAL_DICTIONARY_EXCLUDE",
+      "RANGE_COLUMN",
+      "SORT_COLUMNS",
+      "LONG_STRING_COLUMNS",
+      "BUCKET_COLUMNS")
     tableProperties.foreach { tableProperty =>
-      if (tableProperty._2.contains(oldColumnName)) {
+      if (columnNameProperties.contains(tableProperty._1.toUpperCase)) {
         val tablePropertyKey = tableProperty._1
         val tablePropertyValue = tableProperty._2
-        tableProperties
-          .put(tablePropertyKey, tablePropertyValue.replace(oldColumnName, newColumnName))
+        val newTablePropertyValue = tablePropertyValue.split(",").map(
+          s => if (s.equalsIgnoreCase(oldColumnName)) newColumnName else s
+        ).mkString(",")
+        tableProperties.put(tablePropertyKey, newTablePropertyValue)
       }
     }
   }

--- a/integration/spark/src/test/scala/org/apache/spark/carbondata/restructure/vectorreader/AlterTableColumnRenameTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/spark/carbondata/restructure/vectorreader/AlterTableColumnRenameTestCase.scala
@@ -38,6 +38,16 @@ class AlterTableColumnRenameTestCase extends QueryTest with BeforeAndAfterAll {
     assert(null == carbonTable.getColumnByName("empname"))
   }
 
+  test("CARBONDATA-4053 test rename column, column name in table properties changed correctly") {
+    sql("create table simple_table(a string, aa1 string) stored as carbondata" +
+        " tblproperties(\"sort_columns\"=\"a,aa1\")")
+    sql("alter table simple_table change a a1 string")
+    val carbonTable = CarbonMetadata.getInstance().getCarbonTable("default", "simple_table")
+    val sort_columns = carbonTable.getTableInfo.getFactTable.getTableProperties.get("sort_columns")
+    assert(sort_columns.equals("a1,aa1"))
+    sql("drop table simple_table")
+  }
+
   test("test only column rename operation with datatype change also") {
     dropTable()
     createTable()
@@ -137,7 +147,7 @@ class AlterTableColumnRenameTestCase extends QueryTest with BeforeAndAfterAll {
   test("compaction after column rename and count") {
     dropTable()
     createNonPartitionTableAndLoad()
-    for(i <- 0 to 2) {
+    for (i <- 0 to 2) {
       loadToTable()
     }
     val df1 = sql("select empname,deptno from rename")
@@ -403,6 +413,7 @@ class AlterTableColumnRenameTestCase extends QueryTest with BeforeAndAfterAll {
     sql("DROP TABLE IF EXISTS test_rename")
     sql("DROP TABLE IF EXISTS test_rename_compact")
     sql("DROP TABLE IF EXISTS test_alter")
+    sql("DROP TABLE IF EXISTS simple_table")
   }
 
   def testChangeColumnWithComment(tableName: String): Unit = {


### PR DESCRIPTION
 ### Why is this PR needed?
Alter table rename column failed because incorrectly replace the content in tblproperties by new column name, which the content is not related to column name.
 
 ### What changes were proposed in this PR?
Instead of calling replace method on property value directly, first filter out the properties which related to column name, then find the matched old column name, replace it with new name.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
