### PR TITLE
[CARBONDATA-4057] Support Complex DataType when Save DataFrame with MODE.OVERWRITE

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonDataFrameWriter.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonDataFrameWriter.scala
@@ -74,6 +74,9 @@ class CarbonDataFrameWriter(sqlContext: SQLContext, val dataFrame: DataFrame) {
       case decimal: DecimalType => s"decimal(${decimal.precision}, ${decimal.scale})"
       case BooleanType => CarbonType.BOOLEAN.getName
       case BinaryType => CarbonType.BINARY.getName
+      case ArrayType(elementType, _) => sparkType.simpleString
+      case StructType(fields) => sparkType.simpleString
+      case MapType(keyType, valueType, _) => sparkType.simpleString
       case other => CarbonException.analysisException(s"unsupported type: $other")
     }
   }


### PR DESCRIPTION
 ### Why is this PR needed?
 Currently, when save dataframe with MODE.OVERWRITE, createtable will be triggered. But complex type isn't supported.
Which weaks the functionality of dataframe save in carbondata format.
 
 ### What changes were proposed in this PR?
Add the converter of ARRAY/MAP/STRUCT in CarbonDataFrameWriter.convertToCarbonType
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
