### PR TITLE
[CARBONDATA-4056] Added global sort for data files merge operation in SI segments.

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/rdd/SecondaryIndexCreator.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/rdd/SecondaryIndexCreator.scala
@@ -214,20 +214,6 @@ object SecondaryIndexCreator {
                   } else {
                     null
                   }
-
-                  def findCarbonScanRDD(rdd: RDD[_], currentSegmentFileName: String): Unit = {
-                    rdd match {
-                      case carbonScanRDD: CarbonScanRDD[_] =>
-                        carbonScanRDD.setValidateSegmentToAccess(false)
-                        if (currentSegmentFileName != null) {
-                          carbonScanRDD.setCurrentSegmentFileName(currentSegmentFileName)
-                        }
-                      case others =>
-                        others.dependencies
-                          .foreach { x => findCarbonScanRDD(x.rdd, currentSegmentFileName) }
-                    }
-                  }
-
                   findCarbonScanRDD(dataFrame.rdd, currentSegmentFileName)
                   // accumulator to collect segment metadata
                   val segmentMetaDataAccumulator = sc.sparkSession.sqlContext
@@ -495,6 +481,19 @@ object SecondaryIndexCreator {
           segmentLock.unlock()
         })
       }
+    }
+  }
+
+  def findCarbonScanRDD(rdd: RDD[_], currentSegmentFileName: String): Unit = {
+    rdd match {
+      case carbonScanRDD: CarbonScanRDD[_] =>
+        carbonScanRDD.setValidateSegmentToAccess(false)
+        if (currentSegmentFileName != null) {
+          carbonScanRDD.setCurrentSegmentFileName(currentSegmentFileName)
+        }
+      case others =>
+        others.dependencies
+          .foreach { x => findCarbonScanRDD(x.rdd, currentSegmentFileName) }
     }
   }
 


### PR DESCRIPTION
### Why is this PR needed?
 Earlier global sort was not supported during data files merge operation of SI segments. So if some SI is created with global sort and value of carbon.si.segment.merge is true, it merges the data files in SI segments but disorder the globally sorted data.
 
 ### What changes were proposed in this PR?
Added global sort for data files merge operation in SI segments.

 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
