### PR TITLE
[CARBONDATA-4059] added testcase for custom compaction, compression and range column for SI table

### DIFF
--- a/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/TestCreateIndexWithLoadAndCompaction.scala
+++ b/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/TestCreateIndexWithLoadAndCompaction.scala
@@ -256,6 +256,86 @@ class TestCreateIndexWithLoadAndCompaction extends QueryTest with BeforeAndAfter
     sql("drop table if exists table1")
   }
 
+  test("test compaction on SI table") {
+    sql("drop table if exists table1")
+    sql("create table table1(c1 int,c2 string,c3 string) stored as carbondata")
+    sql("create index idx1 on table table1(c3) as 'carbondata'")
+    for (i <- 0 until 5) {
+      sql(s"insert into table1 values(${i + 1},'a$i','b$i')")
+    }
+    var ex = intercept[Exception] {
+      sql("ALTER TABLE idx1 COMPACT 'CUSTOM' WHERE SEGMENT.ID IN (1,2,3)")
+    }
+    assert(ex.getMessage.contains("Unsupported alter operation on carbon table: Compaction not supported on SI table"))
+    ex = intercept[Exception] {
+      sql("ALTER TABLE idx1 COMPACT 'minor'")
+    }
+    assert(ex.getMessage.contains("Unsupported alter operation on carbon table: Compaction not supported on SI table"))
+    sql("drop table if exists table1")
+  }
+
+  test("test custom compaction on main table which have SI tables") {
+    sql("drop table if exists table1")
+    sql("create table table1(c1 int,c2 string,c3 string) stored as carbondata")
+    sql("create index idx1 on table table1(c3) as 'carbondata'")
+    for (i <- 0 until 5) {
+      sql(s"insert into table1 values(${i + 1},'a$i','b$i')")
+    }
+    sql("ALTER TABLE table1 COMPACT 'CUSTOM' WHERE SEGMENT.ID IN (1,2,3)")
+
+    val segments = sql("SHOW SEGMENTS FOR TABLE idx1")
+    val segInfos = segments.collect().map { each =>
+      ((each.toSeq) (0).toString, (each.toSeq) (1).toString)
+    }
+    assert(segInfos.length == 6)
+    assert(segInfos.contains(("0", "Success")))
+    assert(segInfos.contains(("1", "Compacted")))
+    assert(segInfos.contains(("2", "Compacted")))
+    assert(segInfos.contains(("3", "Compacted")))
+    assert(segInfos.contains(("1.1", "Success")))
+    assert(segInfos.contains(("4", "Success")))
+    checkAnswer(sql("select * from table1 where c3='b2'"), Seq(Row(3, "a2", "b2")))
+    sql("drop table if exists table1")
+  }
+
+  test("test minor compaction on table with non-empty segment list" +
+    "and custom compaction with empty segment list") {
+    sql("drop table if exists table1")
+    sql("create table table1(c1 int,c2 string,c3 string) stored as carbondata")
+    sql("create index idx1 on table table1(c3) as 'carbondata'")
+    for (i <- 0 until 3) {
+      sql(s"insert into table1 values(${i + 1},'a$i','b$i')")
+    }
+    var ex = intercept[Exception] {
+      sql("ALTER TABLE table1 COMPACT 'minor' WHERE SEGMENT.ID IN (1,2)")
+    }
+    assert(ex.getMessage.contains("Custom segments not supported when doing MINOR compaction"))
+    ex = intercept[Exception] {
+      sql("ALTER TABLE table1 COMPACT 'custom'")
+    }
+    assert(ex.getMessage.contains("Segment ids should not be empty when doing CUSTOM compaction"))
+    sql("drop table if exists table1")
+  }
+
+  test("test custom compaction with global sort SI") {
+    sql("drop table if exists table1")
+    sql("create table table1(c1 int,c2 string,c3 string) stored as carbondata")
+    sql("create index idx1 on table table1(c3) as 'carbondata' " +
+      "properties('sort_scope'='global_sort', 'Global_sort_partitions'='1')")
+    for (i <- 0 until 3) {
+      sql(s"insert into table1 values(${i + 1},'a$i','b$i')")
+    }
+    sql("ALTER TABLE table1 COMPACT 'CUSTOM' WHERE SEGMENT.ID IN (1,2)")
+
+    val segments = sql("SHOW SEGMENTS FOR TABLE idx1")
+    val segInfos = segments.collect().map { each =>
+      ((each.toSeq) (0).toString, (each.toSeq) (1).toString)
+    }
+    assert(segInfos.length == 4)
+    checkAnswer(sql("select * from table1 where c3='b2'"), Seq(Row(3, "a2", "b2")))
+    sql("drop table if exists table1")
+  }
+
   override def afterAll: Unit = {
     sql("drop table if exists index_test")
     sql("drop table if exists seccust1")

--- a/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/TestSIWithRangeColumn.scala
+++ b/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/TestSIWithRangeColumn.scala
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.spark.testsuite.secondaryindex
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.test.util.QueryTest
+
+class TestSIWithRangeColumn extends QueryTest {
+  test("test SI on range column with and without global sort") {
+    sql("drop table if exists carbon_range_column")
+    sql(
+      """
+        | CREATE TABLE carbon_range_column(id INT, name STRING, city STRING, age INT)
+        | STORED AS carbondata
+        | TBLPROPERTIES(
+        | 'SORT_SCOPE'='LOCAL_SORT', 'SORT_COLUMNS'='name, city', 'range_column'='city')
+      """.stripMargin)
+    sql("CREATE INDEX range_si on carbon_range_column(city) as 'carbondata'")
+    sql("INSERT into carbon_range_column values(1,'nko','blr',25)")
+    checkAnswer(sql("SELECT count(*) FROM range_si"), Seq(Row(1)))
+    checkAnswer(sql("SELECT name FROM carbon_range_column where city='blr'"), Seq(Row("nko")))
+    sql("drop index if exists range_si on carbon_range_column")
+    sql("CREATE INDEX range_si on carbon_range_column(city) as 'carbondata'" +
+      " PROPERTIES('sort_scope'='global_sort', 'Global_sort_partitions'='1')")
+    checkAnswer(sql("SELECT count(*) FROM range_si"), Seq(Row(1)))
+    sql("drop table if exists carbon_range_column")
+  }
+
+  test("test SI creation with range column") {
+    sql("drop table if exists carbon_range_column")
+    sql(
+      """
+        | CREATE TABLE carbon_range_column(id INT, name STRING, city STRING, age INT)
+        | STORED AS carbondata
+        | TBLPROPERTIES(
+        | 'SORT_SCOPE'='LOCAL_SORT', 'SORT_COLUMNS'='name, city', 'range_column'='city')
+      """.stripMargin)
+    val ex = intercept[Exception] {
+      sql("CREATE INDEX range_si on carbon_range_column(city) as 'carbondata' " +
+      "PROPERTIES('range_column'='city')")
+    }
+    assert(ex.getMessage.contains("Unsupported Table property in index creation: range_column"))
+  }
+
+  test("test compaction on range column with SI") {
+    sql("drop table if exists table1")
+    sql("create table table1(c1 int,c2 string,c3 string) stored as carbondata" +
+      " TBLPROPERTIES('range_column'='c3')")
+    sql("create index idx1 on table table1(c3) as 'carbondata'")
+    for (i <- 0 until 5) {
+      sql(s"insert into table1 values(${i + 1},'a$i','b$i')")
+    }
+    sql("ALTER TABLE table1 COMPACT 'MINOR'")
+
+    val segments = sql("SHOW SEGMENTS FOR TABLE idx1")
+    val segInfos = segments.collect().map { each =>
+      (each.toSeq.head.toString, (each.toSeq) (1).toString)
+    }
+    assert(segInfos.length == 6)
+    assert(segInfos.contains(("0", "Compacted")))
+    assert(segInfos.contains(("1", "Compacted")))
+    assert(segInfos.contains(("2", "Compacted")))
+    assert(segInfos.contains(("3", "Compacted")))
+    assert(segInfos.contains(("0.1", "Success")))
+    assert(segInfos.contains(("4", "Success")))
+    checkAnswer(sql("select * from table1 where c3='b2'"), Seq(Row(3, "a2", "b2")))
+    sql("drop table if exists table1")
+  }
+}

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonAlterTableCompactionCommand.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonAlterTableCompactionCommand.scala
@@ -102,6 +102,10 @@ case class CarbonAlterTableCompactionCommand(
         throw new MalformedCarbonCommandException(
           "Unsupported alter operation on carbon table")
     }
+    if (table.isIndexTable) {
+      throw new MalformedCarbonCommandException(
+        "Unsupported alter operation on carbon table: Compaction not supported on SI table")
+    }
     if (compactionType == CompactionType.UPGRADE_SEGMENT) {
       val tableStatusLock = CarbonLockFactory
         .getCarbonLockObj(table.getAbsoluteTableIdentifier, LockUsage.TABLE_STATUS_LOCK)

--- a/integration/spark/src/test/scala/org/apache/carbondata/integration/spark/testsuite/dataload/TestLoadDataWithCompression.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/integration/spark/testsuite/dataload/TestLoadDataWithCompression.scala
@@ -598,6 +598,49 @@ class TestLoadDataWithCompression extends QueryTest with BeforeAndAfterEach with
     assertResult(compressorName)(tableColumnCompressor2)
   }
 
+  test("test data loading with different compresser snd SI") {
+    for (comp <- compressors) {
+      CarbonProperties.getInstance().addProperty(CarbonCommonConstants.ENABLE_OFFHEAP_SORT, "true")
+      CarbonProperties.getInstance().addProperty(CarbonCommonConstants.COMPRESSOR, comp)
+      createTable(columnCompressor = comp)
+      sql(s"create index si_with_compresser on table $tableName(stringDictField) as " +
+        s"'carbondata' properties('carbon.column.compressor'='$comp')")
+      loadData()
+      checkAnswer(sql(s"SELECT count(*) FROM si_with_compresser"), Seq(Row(8)))
+      val carbonTable = CarbonEnv.getCarbonTable(
+        Option("default"), "si_with_compresser")(sqlContext.sparkSession)
+      val tableColumnCompressor = carbonTable.getTableInfo
+        .getFactTable
+        .getTableProperties
+        .get(CarbonCommonConstants.COMPRESSOR)
+      assertResult(comp)(tableColumnCompressor)
+      sql(s"drop index if exists si_with_compresser on $tableName")
+    }
+  }
+
+  test("test data loading with different compresser on MT and SI table with global sort") {
+    var index = 2;
+    for (comp <- compressors) {
+      CarbonProperties.getInstance().addProperty(CarbonCommonConstants.ENABLE_OFFHEAP_SORT, "true")
+      CarbonProperties.getInstance().addProperty(CarbonCommonConstants.COMPRESSOR, comp)
+      createTable()
+      sql(s"create index si_with_compresser on table $tableName(stringDictField) as " +
+        s"'carbondata' properties('carbon.column.compressor'='${compressors(index)}', " +
+        s"'sort_scope'='global_sort', 'Global_sort_partitions'='3')")
+      loadData()
+      checkAnswer(sql(s"SELECT count(*) FROM si_with_compresser"), Seq(Row(8)))
+      val carbonTable = CarbonEnv.getCarbonTable(
+        Option("default"), "si_with_compresser")(sqlContext.sparkSession)
+      val tableColumnCompressor = carbonTable.getTableInfo
+        .getFactTable
+        .getTableProperties
+        .get(CarbonCommonConstants.COMPRESSOR)
+      assertResult(compressors(index))(tableColumnCompressor)
+      index = index-1
+      sql(s"drop index if exists si_with_compresser on $tableName")
+    }
+  }
+
   private def generateAllDataTypeFiles(lineNum: Int, csvDir: String,
       saveMode: SaveMode = SaveMode.Overwrite): Unit = {
     val tsFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss")


### PR DESCRIPTION
 ### Why is this PR needed?
 Currently compaction is allowed on SI table. Because of this if only SI table is compacted and running filter query query on main table is causing more data scan of SI table which will causing performance degradation.
 
 ### What changes were proposed in this PR?
Block the direct compaction on SI table and add FTs for compaction scenario of SI.
Added FT for compression and range column on SI table.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
