### PR TITLE
[HOTFIX] Fix Random CI Failures of HiveCarbonTest 

### DIFF
--- a/integration/hive/src/test/java/org/apache/carbondata/hive/HiveTestUtils.java
+++ b/integration/hive/src/test/java/org/apache/carbondata/hive/HiveTestUtils.java
@@ -46,6 +46,11 @@ public abstract class HiveTestUtils {
     try {
       File rootPath = new File(HiveTestUtils.class.getResource("/").getPath() + "../../../..");
       String targetLoc = rootPath.getAbsolutePath() + "/integration/hive/target/warehouse";
+      String metadatadbLoc = rootPath.getAbsolutePath() + "/integration/hive/target/metastore_db";
+      File file = new File(metadatadbLoc);
+      if (file.exists()) {
+        file.delete();
+      }
       hiveEmbeddedServer2 = new HiveEmbeddedServer2();
       hiveEmbeddedServer2.start(targetLoc);
       int port = hiveEmbeddedServer2.getFreePort();


### PR DESCRIPTION
 ### Why is this PR needed?
 HiveCarbonTest will fails randomly, the exception message is as below:
Dictionary 'metastore_db' exists. However, it does not contain the expected 'service.properties' file.
The root cause maybe there is stale metastore_db dictionary in the filesystem.
 
 ### What changes were proposed in this PR?
 Clean the metastore_db dictionary before testcase running.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No