### PR TITLE
[CARBONDATA-4064] Fix tpcds query failure with SI

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/optimizer/CarbonSecondaryIndexOptimizer.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/optimizer/CarbonSecondaryIndexOptimizer.scala
@@ -943,7 +943,12 @@ class CarbonSecondaryIndexOptimizer(sparkSession: SparkSession) {
     val filterAttributes = filter.condition collect {
       case attr: AttributeReference => attr.name.toLowerCase
     }
-    val parentTableRelation = MatchIndexableRelation.unapply(filter.child).get
+    // get the parent table logical relation from the filter node
+    val parentRelation = MatchIndexableRelation.unapply(filter.child)
+    if (parentRelation.isEmpty) {
+      return false
+    }
+    val parentTableRelation = parentRelation.get
     val matchingIndexTables = CarbonCostBasedOptimizer.identifyRequiredTables(
       filterAttributes.toSet.asJava,
       CarbonIndexUtil.getSecondaryIndexes(parentTableRelation).mapValues(_.toList.asJava).asJava)


### PR DESCRIPTION
 ### Why is this PR needed?
 TPCDS queries are failing with None.get exception when SI is configured for some tables.
 
 ### What changes were proposed in this PR?
Check if parentRelation is none for filter condition, and return false for checkIfPushDownOrderByLimitAndNotNullFilter

 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No

    
