### PR TITLE
[CARBONDATA-4066] data mismatch observed with SI and without SI when SI global sort and SI segment merge is true

### DIFF
--- a/integration/spark/src/test/resources/secindex/array.csv
+++ b/integration/spark/src/test/resources/secindex/array.csv
@@ -1,4 +1,4 @@
-1,'abc',china$india$us
-2,'xyz',sri$can
-3,'mno',rus$china
-4,'lok',hk$bang
+1,abc,china$india$us
+2,xyz,sri$can
+3,mno,rus$china
+4,lok,hk$bang


### PR DESCRIPTION

 ### Why is this PR needed?
 data mismatch observed with SI and without SI when SI global sort and SI segment merge is true. After merge si data files position reference is also sorted and due to this pointing to wrong position reference causing data mismatch with SI and without SI
 
 ### What changes were proposed in this PR?
no need to calculate the position references after data files merge should use existed position reference column from SI table.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
