### PR TITLE
[CARBONDATA-4076] Fix MV having Subquery alias used in query projection

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/view/MVManager.java
+++ b/core/src/main/java/org/apache/carbondata/core/view/MVManager.java
@@ -177,7 +177,11 @@ public abstract class MVManager {
               catalog.registerSchema(schema);
             } catch (Exception e) {
               // Ignore the schema
-              LOGGER.error("Error while registering schema", e);
+              LOGGER.error("Error while registering schema for mv: " + schema.getIdentifier()
+                  .getTableName());
+              if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug(e.getMessage());
+              }
             }
           }
           this.catalog = catalog;

--- a/integration/spark/src/test/scala/org/apache/carbondata/view/rewrite/MVCreateTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/view/rewrite/MVCreateTestCase.scala
@@ -414,6 +414,20 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     sql(s"drop materialized view mv32")
   }
 
+  test("test create materialized view having sub-query alias used in projection") {
+    sql("drop materialized view if exists mv_sub")
+    val subQuery = "select empname, sum(result) sum_ut from " +
+                   "(select empname, utilization result from fact_table1) fact_table1 " +
+                   "group by empname"
+    sql("create materialized view mv_sub as " + subQuery)
+    val frame = sql(subQuery)
+    assert(TestUtil.verifyMVHit(frame.queryExecution.optimizedPlan, "mv_sub"))
+    checkAnswer(frame,
+      sql("select empname, sum(result) ut from (select empname, utilization result from " +
+          "fact_table2) fact_table2 group by empname"))
+    sql(s"drop materialized view mv_sub")
+  }
+
   test("test create materialized view with simple and sub group by query with filter on materialized view") {
     sql("create materialized view mv15 as select empname, sum(utilization) from fact_table1 where empname='shivani' group by empname")
     val frame = sql(

--- a/integration/spark/src/test/scala/org/apache/carbondata/view/rewrite/MVCreateTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/view/rewrite/MVCreateTestCase.scala
@@ -428,6 +428,26 @@ class MVCreateTestCase extends QueryTest with BeforeAndAfterAll {
     sql(s"drop materialized view mv_sub")
   }
 
+  test("test create materialized view used as sub-query in actual query") {
+    sql("drop materialized view if exists mv_sub")
+    sql("create materialized view mv_sub as select empname, utilization result from fact_table1")
+    val df1 = sql("select empname, sum(result) sum_ut from " +
+                  "(select empname, utilization result from fact_table1) fact_table1 " +
+                  "group by empname")
+    val df2 = sql("select emp, sum(result) sum_ut from " +
+                  "(select empname emp, utilization result from fact_table1) fact_table1 " +
+                  "group by emp")
+    assert(TestUtil.verifyMVHit(df1.queryExecution.optimizedPlan, "mv_sub"))
+    assert(TestUtil.verifyMVHit(df2.queryExecution.optimizedPlan, "mv_sub"))
+    checkAnswer(df1,
+      sql("select empname, sum(result) ut from (select empname, utilization result from " +
+          "fact_table2) fact_table2 group by empname"))
+    checkAnswer(df2,
+      sql("select emp, sum(result) ut from (select empname emp, utilization result from " +
+          "fact_table2) fact_table2 group by emp"))
+    sql(s"drop materialized view mv_sub")
+  }
+
   test("test create materialized view with simple and sub group by query with filter on materialized view") {
     sql("create materialized view mv15 as select empname, sum(utilization) from fact_table1 where empname='shivani' group by empname")
     val frame = sql(


### PR DESCRIPTION
 ### Why is this PR needed?
 If alias is used in subquery and that alias is used in main query projection, then the query is not hitting MV after creation.

For example:

Select a, sum(b) from (select c, d b from t1)

This is because, currently, we are not checking for subquery alias child node for matching the query. 
 
 ### What changes were proposed in this PR?
1. If the outputList contains Alias, then compare the alias child of subsume/subsumer
2. In GroupbyNoselect, compare the alias.sql subsume/subsumer
3. Added logs for MV Rewrite and matching

    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
