### PR TITLE
[CARBONDATA-4077] Refactor and Fix Insert into partition issue with FileMergeSortComparator

### DIFF
--- a/integration/spark/src/main/java/org/apache/spark/sql/secondaryindex/query/SecondaryIndexQueryResultProcessor.java
+++ b/integration/spark/src/main/java/org/apache/spark/sql/secondaryindex/query/SecondaryIndexQueryResultProcessor.java
@@ -528,8 +528,6 @@ public class SecondaryIndexQueryResultProcessor {
         CarbonCommonConstants.FILE_SEPARATOR, CarbonCommonConstants.SORT_TEMP_FILE_LOCATION);
     sortParameters.setNoDictionarySortColumn(
         CarbonDataProcessorUtil.getNoDictSortColMapping(indexTable));
-    sortParameters.setSortColumnSchemaOrderMap(
-        CarbonDataProcessorUtil.getSortColSchemaOrderMapping(indexTable));
     finalMerger = new SingleThreadFinalSortFilesMerger(sortTempFileLocation,
         indexTable.getTableName(), sortParameters);
   }

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/sort/unsafe/holder/UnsafeFinalMergePageHolder.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/sort/unsafe/holder/UnsafeFinalMergePageHolder.java
@@ -61,10 +61,10 @@ public class UnsafeFinalMergePageHolder implements SortTempChunkHolder {
     }
     this.noDictDataType = rowPages[0].getTableFieldStat().getNoDictDataType();
     LOGGER.info("Processing unsafe inmemory rows page with size : " + actualSize);
-    this.comparator = new FileMergeSortComparator(tableFieldStat.getIsSortColNoDictFlags(),
-        tableFieldStat.getNoDictSchemaDataType(),
+    this.comparator = new FileMergeSortComparator(tableFieldStat.getNoDictSchemaDataType(),
         tableFieldStat.getNoDictSortColumnSchemaOrderMapping(),
-        tableFieldStat.getSortColSchemaOrderMap());
+        tableFieldStat.getNoDictSortColIdxSchemaOrderMapping(),
+        tableFieldStat.getDictSortColIdxSchemaOrderMapping());
   }
 
   public boolean hasNext() {

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/sort/unsafe/holder/UnsafeInmemoryHolder.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/sort/unsafe/holder/UnsafeInmemoryHolder.java
@@ -48,10 +48,10 @@ public class UnsafeInmemoryHolder implements SortTempChunkHolder {
     this.rowPage = rowPage;
     LOGGER.info("Processing unsafe inmemory rows page with size : " + actualSize);
     this.comparator =
-        new FileMergeSortComparator(rowPage.getTableFieldStat().getIsSortColNoDictFlags(),
-            rowPage.getTableFieldStat().getNoDictSchemaDataType(),
+        new FileMergeSortComparator(rowPage.getTableFieldStat().getNoDictSchemaDataType(),
             rowPage.getTableFieldStat().getNoDictSortColumnSchemaOrderMapping(),
-            rowPage.getTableFieldStat().getSortColSchemaOrderMap());
+            rowPage.getTableFieldStat().getNoDictSortColIdxSchemaOrderMapping(),
+            rowPage.getTableFieldStat().getDictSortColIdxSchemaOrderMapping());
     this.rowPage.setReadConvertedNoSortField();
   }
 

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/sort/unsafe/holder/UnsafeSortTempFileChunkHolder.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/sort/unsafe/holder/UnsafeSortTempFileChunkHolder.java
@@ -120,10 +120,10 @@ public class UnsafeSortTempFileChunkHolder implements SortTempChunkHolder {
       comparator = new IntermediateSortTempRowComparator(parameters.getNoDictionarySortColumn(),
           parameters.getNoDictDataType());
     } else {
-      this.comparator = new FileMergeSortComparator(tableFieldStat.getIsSortColNoDictFlags(),
-          tableFieldStat.getNoDictSchemaDataType(),
+      this.comparator = new FileMergeSortComparator(tableFieldStat.getNoDictSchemaDataType(),
           tableFieldStat.getNoDictSortColumnSchemaOrderMapping(),
-          tableFieldStat.getSortColSchemaOrderMap());
+          tableFieldStat.getNoDictSortColIdxSchemaOrderMapping(),
+          tableFieldStat.getDictSortColIdxSchemaOrderMapping());
     }
     initialize();
   }

--- a/processing/src/main/java/org/apache/carbondata/processing/merger/CompactionResultSortProcessor.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/merger/CompactionResultSortProcessor.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
@@ -480,8 +481,14 @@ public class CompactionResultSortProcessor extends AbstractResultProcessor {
     boolean[] noDictionarySortColumnMapping = CarbonDataProcessorUtil
         .getNoDictSortColMapping(carbonTable);
     sortParameters.setNoDictionarySortColumn(noDictionarySortColumnMapping);
-    sortParameters.setSortColumnSchemaOrderMap(
-        CarbonDataProcessorUtil.getSortColSchemaOrderMapping(carbonTable));
+    Map<String, int[]> columnIdxMap = CarbonDataProcessorUtil
+        .getColumnIdxBasedOnSchemaInRow(carbonTable);
+    sortParameters.setNoDictSortColumnSchemaOrderMapping(
+        columnIdxMap.get("columnIdxBasedOnSchemaInRow"));
+    sortParameters.setNoDictSortColIdxSchemaOrderMapping(
+        columnIdxMap.get("noDictSortIdxBasedOnSchemaInRow"));
+    sortParameters.setDictSortColIdxSchemaOrderMapping(
+        columnIdxMap.get("dictSortIdxBasedOnSchemaInRow"));
     String[] sortTempFileLocation = CarbonDataProcessorUtil.arrayAppend(tempStoreLocation,
         CarbonCommonConstants.FILE_SEPARATOR, CarbonCommonConstants.SORT_TEMP_FILE_LOCATION);
     finalMerger =

--- a/processing/src/main/java/org/apache/carbondata/processing/sort/sortdata/FileMergeSortComparator.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/sort/sortdata/FileMergeSortComparator.java
@@ -18,8 +18,6 @@
 package org.apache.carbondata.processing.sort.sortdata;
 
 import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
 
 import org.apache.carbondata.core.metadata.datatype.DataType;
 import org.apache.carbondata.core.util.ByteUtil;
@@ -28,8 +26,6 @@ import org.apache.carbondata.core.util.comparator.SerializableComparator;
 import org.apache.carbondata.processing.loading.row.IntermediateSortTempRow;
 
 public class FileMergeSortComparator implements Comparator<IntermediateSortTempRow> {
-
-  private boolean[] isSortColumnNoDictionary;
 
   /**
    * Datatype of all the no-dictionary columns in the table in schema order
@@ -42,21 +38,25 @@ public class FileMergeSortComparator implements Comparator<IntermediateSortTempR
   private int[] noDictPrimitiveIndex;
 
   /**
-   * Sort and Dictionary info of all the columns in schema order
+   * Index of the No-Dict Sort columns in schema order for final merge step of sorting.
    */
-  private final Map<Integer, List<Boolean>> sortColumnSchemaOrderMap;
+  private int[] noDictSortColIdxSchemaOrderMapping;
+
+  /**
+   * Index of the dict Sort columns in schema order for final merge step of sorting.
+   */
+  private int[] dictSortColIdxSchemaOrderMapping;
 
   /**
    * Comparator for IntermediateSortTempRow for compatibility cases where column added in old
    * version and it is sort column
-   * @param isSortColumnNoDictionary isSortColumnNoDictionary
    */
-  public FileMergeSortComparator(boolean[] isSortColumnNoDictionary, DataType[] noDictDataTypes,
-      int[] columnIdBasedOnSchemaInRow, Map<Integer, List<Boolean>> sortColumnSchemaOrderMap) {
-    this.isSortColumnNoDictionary = isSortColumnNoDictionary;
+  public FileMergeSortComparator(DataType[] noDictDataTypes, int[] columnIdBasedOnSchemaInRow,
+      int[] noDictSortColIdxSchemaOrderMapping, int[] dictSortColIdxSchemaOrderMapping) {
     this.noDictDataTypes = noDictDataTypes;
     this.noDictPrimitiveIndex = columnIdBasedOnSchemaInRow;
-    this.sortColumnSchemaOrderMap = sortColumnSchemaOrderMap;
+    this.noDictSortColIdxSchemaOrderMapping = noDictSortColIdxSchemaOrderMapping;
+    this.dictSortColIdxSchemaOrderMapping = dictSortColIdxSchemaOrderMapping;
   }
 
   /**
@@ -68,8 +68,8 @@ public class FileMergeSortComparator implements Comparator<IntermediateSortTempR
    * 1. only Dictionary sort column data
    * 2. dictionary sort and dictionary no-sort column data
    * On this temp data row, we have to identify the sort column data and only compare those.
-   * From the sortColumnSchemaOrderMap, get the sort column and dict info. If the column
-   * is sort column, then perform the comparison, else increment the respective index.
+   * Use noDictSortColIdxSchemaOrderMapping and dictSortColIdxSchemaOrderMapping to get
+   * the indexes of sort column in schema order
    */
   @Override
   public int compare(IntermediateSortTempRow rowA, IntermediateSortTempRow rowB) {
@@ -78,51 +78,47 @@ public class FileMergeSortComparator implements Comparator<IntermediateSortTempR
     int nonDictIndex = 0;
     int noDicTypeIdx = 0;
     int schemaRowIdx = 0;
-    int sortIndex = 0;
 
-    for (Map.Entry<Integer, List<Boolean>> schemaEntry : sortColumnSchemaOrderMap.entrySet()) {
-      boolean isSortColumn = schemaEntry.getValue().get(0);
-      boolean isDictColumn = schemaEntry.getValue().get(1);
-      if (isSortColumn) {
-        if (isSortColumnNoDictionary[sortIndex++]) {
-          if (DataTypeUtil.isPrimitiveColumn(noDictDataTypes[noDicTypeIdx])) {
-            // use data types based comparator for the no dictionary measure columns
-            SerializableComparator comparator =
-                org.apache.carbondata.core.util.comparator.Comparator
-                    .getComparator(noDictDataTypes[noDicTypeIdx]);
-            int difference = comparator
-                .compare(rowA.getNoDictSortDims()[noDictPrimitiveIndex[schemaRowIdx]],
-                    rowB.getNoDictSortDims()[noDictPrimitiveIndex[schemaRowIdx]]);
-            schemaRowIdx++;
-            if (difference != 0) {
-              return difference;
-            }
-          } else {
-            byte[] byteArr1 = (byte[]) rowA.getNoDictSortDims()[nonDictIndex];
-            byte[] byteArr2 = (byte[]) rowB.getNoDictSortDims()[nonDictIndex];
+    // compare no-Dict sort columns
+    for (int i = 0; i < noDictSortColIdxSchemaOrderMapping.length; i++) {
+      if (DataTypeUtil
+          .isPrimitiveColumn(noDictDataTypes[noDictSortColIdxSchemaOrderMapping[noDicTypeIdx]])) {
+        // use data types based comparator for the no dictionary measure columns
+        SerializableComparator comparator = org.apache.carbondata.core.util.comparator.Comparator
+            .getComparator(noDictDataTypes[noDictSortColIdxSchemaOrderMapping[noDicTypeIdx]]);
+        int difference = comparator
+            .compare(rowA.getNoDictSortDims()[noDictPrimitiveIndex[schemaRowIdx]],
+                rowB.getNoDictSortDims()[noDictPrimitiveIndex[schemaRowIdx]]);
+        schemaRowIdx++;
+        if (difference != 0) {
+          return difference;
+        }
+      } else {
+        byte[] byteArr1 =
+            (byte[]) rowA.getNoDictSortDims()[noDictSortColIdxSchemaOrderMapping[nonDictIndex]];
+        byte[] byteArr2 =
+            (byte[]) rowB.getNoDictSortDims()[noDictSortColIdxSchemaOrderMapping[nonDictIndex]];
 
-            int difference = ByteUtil.UnsafeComparer.INSTANCE.compareTo(byteArr1, byteArr2);
-            if (difference != 0) {
-              return difference;
-            }
-          }
-        } else {
-          int dimFieldA = rowA.getDictSortDims()[dictIndex];
-          int dimFieldB = rowB.getDictSortDims()[dictIndex];
-
-          diff = dimFieldA - dimFieldB;
-          if (diff != 0) {
-            return diff;
-          }
+        int difference = ByteUtil.UnsafeComparer.INSTANCE.compareTo(byteArr1, byteArr2);
+        if (difference != 0) {
+          return difference;
         }
       }
-      if (isDictColumn) {
-        dictIndex++;
-      } else {
-        nonDictIndex++;
-        noDicTypeIdx++;
+      nonDictIndex++;
+      noDicTypeIdx++;
+    }
+    // compare dict sort columns
+    for (int i = 0; i < dictSortColIdxSchemaOrderMapping.length; i++) {
+      int dimFieldA = rowA.getDictSortDims()[dictSortColIdxSchemaOrderMapping[dictIndex]];
+      int dimFieldB = rowB.getDictSortDims()[dictSortColIdxSchemaOrderMapping[dictIndex]];
+      dictIndex++;
+
+      diff = dimFieldA - dimFieldB;
+      if (diff != 0) {
+        return diff;
       }
     }
+
     return diff;
   }
 }

--- a/processing/src/main/java/org/apache/carbondata/processing/sort/sortdata/SortTempFileChunkHolder.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/sort/sortdata/SortTempFileChunkHolder.java
@@ -105,10 +105,10 @@ public class SortTempFileChunkHolder implements Comparable<SortTempFileChunkHold
 
   public SortTempFileChunkHolder(SortParameters sortParameters) {
     this.tableFieldStat = new TableFieldStat(sortParameters);
-    this.comparator = new FileMergeSortComparator(tableFieldStat.getIsSortColNoDictFlags(),
-        tableFieldStat.getNoDictSchemaDataType(),
+    this.comparator = new FileMergeSortComparator(tableFieldStat.getNoDictSchemaDataType(),
         tableFieldStat.getNoDictSortColumnSchemaOrderMapping(),
-        tableFieldStat.getSortColSchemaOrderMap());
+        tableFieldStat.getNoDictSortColIdxSchemaOrderMapping(),
+        tableFieldStat.getDictSortColIdxSchemaOrderMapping());
     this.sortTempRowUpdater = tableFieldStat.getSortTempRowUpdater();
   }
 
@@ -132,10 +132,10 @@ public class SortTempFileChunkHolder implements Comparable<SortTempFileChunkHold
                 true));
     this.convertToActualField = convertToActualField;
     if (this.convertToActualField) {
-      this.comparator = new FileMergeSortComparator(tableFieldStat.getIsSortColNoDictFlags(),
-          tableFieldStat.getNoDictSchemaDataType(),
+      this.comparator = new FileMergeSortComparator(tableFieldStat.getNoDictSchemaDataType(),
           tableFieldStat.getNoDictSortColumnSchemaOrderMapping(),
-          tableFieldStat.getSortColSchemaOrderMap());
+          tableFieldStat.getNoDictSortColIdxSchemaOrderMapping(),
+          tableFieldStat.getDictSortColIdxSchemaOrderMapping());
     } else {
       this.comparator =
           new IntermediateSortTempRowComparator(tableFieldStat.getIsSortColNoDictFlags(),

--- a/processing/src/main/java/org/apache/carbondata/processing/sort/sortdata/TableFieldStat.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/sort/sortdata/TableFieldStat.java
@@ -20,7 +20,6 @@ package org.apache.carbondata.processing.sort.sortdata;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 import org.apache.carbondata.core.metadata.datatype.DataType;
@@ -83,7 +82,15 @@ public class TableFieldStat implements Serializable {
 
   private DataType[] noDictSchemaDataType;
 
-  private Map<Integer, List<Boolean>> sortColSchemaOrderMap;
+  /**
+   * Index of the no dict Sort columns in schema order used for final merge step of sorting.
+   */
+  private int[] noDictSortColIdxSchemaOrderMapping;
+
+  /**
+   * Index of the dict Sort columns in schema order for final merge step of sorting.
+   */
+  private int[] dictSortColIdxSchemaOrderMapping;
 
   public TableFieldStat(SortParameters sortParameters) {
     int noDictDimCnt = sortParameters.getNoDictionaryCount();
@@ -106,7 +113,9 @@ public class TableFieldStat implements Serializable {
     this.noDictSortDataType = sortParameters.getNoDictSortDataType();
     this.noDictNoSortDataType = sortParameters.getNoDictNoSortDataType();
     this.noDictSchemaDataType = sortParameters.getNoDictSchemaDataType();
-    this.sortColSchemaOrderMap = sortParameters.getSortColumnSchemaOrderMap();
+    this.noDictSortColIdxSchemaOrderMapping =
+        sortParameters.getNoDictSortColIdxSchemaOrderMapping();
+    this.dictSortColIdxSchemaOrderMapping = sortParameters.getDictSortColIdxSchemaOrderMapping();
     for (boolean flag : isVarcharDimFlags) {
       if (flag) {
         varcharDimCnt++;
@@ -359,11 +368,15 @@ public class TableFieldStat implements Serializable {
     return otherCols;
   }
 
-  public Map<Integer, List<Boolean>> getSortColSchemaOrderMap() {
-    return sortColSchemaOrderMap;
-  }
-
   public DataType[] getNoDictSchemaDataType() {
     return noDictSchemaDataType;
+  }
+
+  public int[] getNoDictSortColIdxSchemaOrderMapping() {
+    return noDictSortColIdxSchemaOrderMapping;
+  }
+
+  public int[] getDictSortColIdxSchemaOrderMapping() {
+    return dictSortColIdxSchemaOrderMapping;
   }
 }

--- a/processing/src/test/java/org/apache/carbondata/processing/sort/sortdata/FileMergeSortComparatorTest.java
+++ b/processing/src/test/java/org/apache/carbondata/processing/sort/sortdata/FileMergeSortComparatorTest.java
@@ -86,25 +86,20 @@ public class FileMergeSortComparatorTest {
         && noDictDataTypes[1].equals(DataTypes.STRING) && noDictDataTypes[2]
         .equals(DataTypes.LONG));
 
-    // test getSortColSchemaOrderMapping
-    Map<Integer, List<Boolean>> sortColSchemaOrderMapping =
-        CarbonDataProcessorUtil.getSortColSchemaOrderMapping(carbonTable);
-    assert (sortColSchemaOrderMapping.get(0).get(0).equals(false) && sortColSchemaOrderMapping
-        .get(0).get(1).equals(false));
-    assert (sortColSchemaOrderMapping.get(1).get(0).equals(true) && sortColSchemaOrderMapping.get(1)
-        .get(1).equals(false));
-    assert (sortColSchemaOrderMapping.get(2).get(0).equals(true) && sortColSchemaOrderMapping
-        .get(2).get(1).equals(false));
-    assert (sortColSchemaOrderMapping.get(3).get(0).equals(true) && sortColSchemaOrderMapping.get(3)
-        .get(1).equals(true));
-
     // test comparator
-    boolean[] isSortColNoDict = { true, false };
-    int[] columnIdxBasedOnSchemaInRow =
+    Map<String, int[]> columnIdxMap =
         CarbonDataProcessorUtil.getColumnIdxBasedOnSchemaInRow(carbonTable);
+    int[] columnIdxBasedOnSchemaInRows = columnIdxMap.get("columnIdxBasedOnSchemaInRow");
+    int[] noDictSortIdxBasedOnSchemaInRows = columnIdxMap.get("noDictSortIdxBasedOnSchemaInRow");
+    int[] dictSortIdxBasedOnSchemaInRows = columnIdxMap.get("dictSortIdxBasedOnSchemaInRow");
+ 
+    assert (noDictSortIdxBasedOnSchemaInRows.length == 2 && noDictSortIdxBasedOnSchemaInRows[0] == 1
+        && noDictSortIdxBasedOnSchemaInRows[1] == 2);
+    assert (dictSortIdxBasedOnSchemaInRows.length == 1 && dictSortIdxBasedOnSchemaInRows[0] == 0);
+
     FileMergeSortComparator comparator =
-        new FileMergeSortComparator(isSortColNoDict, noDictDataTypes, columnIdxBasedOnSchemaInRow,
-            sortColSchemaOrderMapping);
+        new FileMergeSortComparator(noDictDataTypes, columnIdxBasedOnSchemaInRows,
+            noDictSortIdxBasedOnSchemaInRows, dictSortIdxBasedOnSchemaInRows);
 
     // prepare data for final sort
     int[] dictSortDims1 = { 1 };


### PR DESCRIPTION
 ### Why is this PR needed?
 From [PR-3995](https://github.com/apache/carbondata/pull/3995) changes, insert into partition flow scenario is missed. Using Map for getting Dict/No-Dict sort column info during final sort task will affect load performance, if number of sort columns is more.
 
 ### What changes were proposed in this PR?
1. Handled the insert into partition flow
2. Refactored the code, to use list of only Dict/No-Dict sort column indexes instead of Map to fix performance issue.

    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
