### PR TITLE
[CARBONDATA-4068] handled set long string on MT for column on which SI is already created.

### DIFF
--- a/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/TestSIWithSecondaryIndex.scala
+++ b/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/TestSIWithSecondaryIndex.scala
@@ -428,6 +428,19 @@ class TestSIWithSecondaryIndex extends QueryTest with BeforeAndAfterAll {
     assert(df.exists(_.get(0).toString.contains("nam(e")))
   }
 
+  test("test change data type from string to long string of SI column") {
+    sql("drop table if exists maintable")
+    sql("create table maintable (a string,b string,c int) STORED AS carbondata ")
+    sql("create index indextable on table maintable(b) AS 'carbondata'")
+    sql("insert into maintable values('k','x',2)")
+    val exception = intercept[RuntimeException] {
+      sql("ALTER TABLE maintable SET TBLPROPERTIES('long_String_columns'='b')")
+    }
+    assert(exception.getMessage.contains("col b is part of index indextable. " +
+      "LONG_STRING_COLUMNS cannot be part of index table."))
+    sql("drop table if exists maintable")
+  }
+
   override def afterAll {
     dropIndexAndTable()
   }


### PR DESCRIPTION
 ### Why is this PR needed?
 Currently  set column as long string on which SI is already created is allowed. This operation should not be allowed because SI doesn't support long strings.
 
 ### What changes were proposed in this PR?
Handled set long string on SI columns and throws the exception.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
