### PR TITLE
[CARBONDATA-4078] Add external segment and query with index server fails

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/index/IndexInputFormat.java
+++ b/core/src/main/java/org/apache/carbondata/core/index/IndexInputFormat.java
@@ -418,6 +418,10 @@ public class IndexInputFormat extends FileInputFormat<Void, ExtendedBlocklet>
     return validSegments;
   }
 
+  public void setValidSegments(List<Segment> validSegments) {
+    this.validSegments = validSegments;
+  }
+
   public void createIndexChooser() throws IOException {
     if (null != filterResolverIntf) {
       this.indexChooser = new IndexChooser(table);

--- a/integration/spark/src/main/scala/org/apache/carbondata/indexserver/IndexJobs.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/indexserver/IndexJobs.scala
@@ -47,6 +47,11 @@ class DistributedIndexJob extends AbstractIndexJob {
 
   override def execute(indexFormat: IndexInputFormat,
       configuration: Configuration): util.List[ExtendedBlocklet] = {
+    // get only carbon segments.
+    if (indexFormat.getValidSegments != null) {
+      indexFormat.setValidSegments(indexFormat.getValidSegments.asScala
+        .filter(segment => segment.isCarbonSegment).toList.asJava)
+    }
     if (LOGGER.isDebugEnabled) {
       val messageSize = SizeEstimator.estimate(indexFormat)
       LOGGER.debug(s"Size of message sent to Index Server: $messageSize")

--- a/integration/spark/src/main/scala/org/apache/spark/sql/listeners/PrePrimingListener.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/listeners/PrePrimingListener.scala
@@ -33,9 +33,11 @@ object PrePrimingEventListener extends OperationEventListener {
       operationContext: OperationContext): Unit = {
     val prePrimingEvent = event.asInstanceOf[IndexServerLoadEvent]
     val carbonTable = prePrimingEvent.carbonTable
+    // get only carbon segments.
+    val validSegments = prePrimingEvent.segment.filter(segment => segment.isCarbonSegment).asJava
     val indexInputFormat = new IndexInputFormat(carbonTable,
       null,
-      prePrimingEvent.segment.asJava,
+      validSegments,
       prePrimingEvent.invalidSegment.asJava,
       null,
       false,


### PR DESCRIPTION
 ### Why is this PR needed?
Query after adding an external segment to carbon table tries to `getSplits `from Index server and throws an exception as it cannot read the external(orc/parquet) file format.
When the fallback mode is disabled, it throws an exception and fails.
 
### What changes were proposed in this PR?
To avoid the exception, filtered only valid carbon segments to cache in the index server.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No, tested in cluster.

    
