### PR TITLE
[CARBONDATA-4081] Fix multiple issues with clean files command

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/util/CleanFilesUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CleanFilesUtil.java
@@ -154,7 +154,8 @@ public class CleanFilesUtil {
     String segmentFilesLocation =
         CarbonTablePath.getSegmentFilesLocation(carbonTable.getTablePath());
     List<String> segmentFiles = Arrays.stream(FileFactory.getCarbonFile(segmentFilesLocation)
-        .listFiles()).map(CarbonFile::getName).collect(Collectors.toList());
+        .listFiles()).map(CarbonFile::getName).filter(segmentFileName -> segmentFileName
+        .endsWith(CarbonTablePath.SEGMENT_EXT)).collect(Collectors.toList());
     // there are no segments present in the Metadata folder. Can return here
     if (segmentFiles.size() == 0) {
       return;

--- a/core/src/main/java/org/apache/carbondata/core/util/TrashUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/TrashUtil.java
@@ -111,7 +111,7 @@ public final class TrashUtil {
         LOGGER.info("Segment: " + segmentPath.getAbsolutePath() + " has been copied to" +
             " the trash folder successfully. Total files copied: " + dataFiles.length);
       } else {
-        LOGGER.info("Segment: " + segmentPath.getAbsolutePath() + " does not exist");
+        LOGGER.info("Segment: " + segmentPath.getName() + " does not exist");
       }
     } catch (IOException e) {
       LOGGER.error("Error while copying the segment: " + segmentPath.getName() + " to the trash" +
@@ -157,11 +157,12 @@ public final class TrashUtil {
     // Deleting the timestamp based subdirectories in the trashfolder by the given timestamp.
     try {
       if (FileFactory.isFileExist(trashPath)) {
-        List<CarbonFile> timestampFolderList = FileFactory.getFolderList(trashPath);
+        CarbonFile[] timestampFolderList = FileFactory.getCarbonFile(trashPath).listFiles();
         for (CarbonFile timestampFolder : timestampFolderList) {
           // If the timeStamp at which the timeStamp subdirectory has expired as per the user
           // defined value, delete the complete timeStamp subdirectory
-          if (isTrashRetentionTimeoutExceeded(Long.parseLong(timestampFolder.getName()))) {
+          if (timestampFolder.isDirectory() && isTrashRetentionTimeoutExceeded(Long
+              .parseLong(timestampFolder.getName()))) {
             FileFactory.deleteAllCarbonFilesOfDir(timestampFolder);
             LOGGER.info("Timestamp subfolder from the Trash folder deleted: " + timestampFolder
                 .getAbsolutePath());
@@ -181,7 +182,7 @@ public final class TrashUtil {
     // if the trash folder exists delete the contents of the trash folder
     try {
       if (FileFactory.isFileExist(trashPath)) {
-        List<CarbonFile> carbonFileList = FileFactory.getFolderList(trashPath);
+        CarbonFile[] carbonFileList = FileFactory.getCarbonFile(trashPath).listFiles();
         for (CarbonFile carbonFile : carbonFileList) {
           FileFactory.deleteAllCarbonFilesOfDir(carbonFile);
         }

--- a/core/src/main/java/org/apache/carbondata/core/util/TrashUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/TrashUtil.java
@@ -153,11 +153,12 @@ public final class TrashUtil {
    * per the user defined retention time
    */
   public static void deleteExpiredDataFromTrash(String tablePath) {
-    String trashPath = CarbonTablePath.getTrashFolderPath(tablePath);
+    CarbonFile trashFolder = FileFactory.getCarbonFile(CarbonTablePath
+        .getTrashFolderPath(tablePath));
     // Deleting the timestamp based subdirectories in the trashfolder by the given timestamp.
     try {
-      if (FileFactory.isFileExist(trashPath)) {
-        CarbonFile[] timestampFolderList = FileFactory.getCarbonFile(trashPath).listFiles();
+      if (trashFolder.isFileExist()) {
+        CarbonFile[] timestampFolderList = trashFolder.listFiles();
         for (CarbonFile timestampFolder : timestampFolderList) {
           // If the timeStamp at which the timeStamp subdirectory has expired as per the user
           // defined value, delete the complete timeStamp subdirectory
@@ -178,11 +179,12 @@ public final class TrashUtil {
    * The below method deletes all the files and folders in the trash folder of a carbon table.
    */
   public static void emptyTrash(String tablePath) {
-    String trashPath = CarbonTablePath.getTrashFolderPath(tablePath);
+    CarbonFile trashFolder = FileFactory.getCarbonFile(CarbonTablePath
+        .getTrashFolderPath(tablePath));
     // if the trash folder exists delete the contents of the trash folder
     try {
-      if (FileFactory.isFileExist(trashPath)) {
-        CarbonFile[] carbonFileList = FileFactory.getCarbonFile(trashPath).listFiles();
+      if (trashFolder.isFileExist()) {
+        CarbonFile[] carbonFileList = trashFolder.listFiles();
         for (CarbonFile carbonFile : carbonFileList) {
           FileFactory.deleteAllCarbonFilesOfDir(carbonFile);
         }

--- a/docs/clean-files.md
+++ b/docs/clean-files.md
@@ -26,6 +26,9 @@ Clean files command is used to remove the Compacted, Marked For Delete ,In Progr
    ```
 The above clean files command will clean Marked For Delete and Compacted segments depending on ```max.query.execution.time``` (default 1 hr) and ``` carbon.trash.retention.days``` (default 7 days). It will also delete the timestamp subdirectories from the trash folder after expiration day(default 7 day, can be configured)
 
+**NOTE**:
+  * Clean files operation not supported on non transactional tables.
+  * Clean files operation not supported on tables with concurrent insert overwrite operation.
 
 ### TRASH FOLDER
 

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonCleanFilesCommand.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonCleanFilesCommand.scala
@@ -54,8 +54,8 @@ case class CarbonCleanFilesCommand(
       throw new MalformedCarbonCommandException("Unsupported operation on non transactional table")
     }
 
-    // only proceed if not a MV and if insert overwrite not in progress
-    if (!carbonTable.isMV && !SegmentStatusManager.isOverwriteInProgressInTable(carbonTable)) {
+    // if insert overwrite not in progress, then do nothing
+    if (!SegmentStatusManager.isOverwriteInProgressInTable(carbonTable)) {
       val preEvent = CleanFilesPreEvent(carbonTable, sparkSession)
       val postEvent = CleanFilesPostEvent(carbonTable, sparkSession, options)
       withEvents(preEvent, postEvent) {

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/cleanfiles/TestCleanFilesCommandPartitionTable.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/cleanfiles/TestCleanFilesCommandPartitionTable.scala
@@ -132,6 +132,7 @@ class TestCleanFilesCommandPartitionTable extends QueryTest with BeforeAndAfterA
     loadData()
     val path = CarbonEnv.getCarbonTable(Some("default"), "cleantest")(sqlContext.sparkSession)
       .getTablePath
+    addRandomFiles(path)
     val trashFolderPath = CarbonTablePath.getTrashFolderPath(path)
     removeSegmentEntryFromTableStatusFile(CarbonEnv.getCarbonTable(Some("default"), "cleantest")(
       sqlContext.sparkSession), "1")
@@ -178,6 +179,7 @@ class TestCleanFilesCommandPartitionTable extends QueryTest with BeforeAndAfterA
 
     val path = CarbonEnv.getCarbonTable(Some("default"), "cleantest")(sqlContext.sparkSession)
       .getTablePath
+    addRandomFiles(path)
     val trashFolderPath = CarbonTablePath.getTrashFolderPath(path)
     removeSegmentEntryFromTableStatusFile(CarbonEnv.getCarbonTable(Some("default"), "cleantest")(
       sqlContext.sparkSession), "1")
@@ -330,6 +332,15 @@ class TestCleanFilesCommandPartitionTable extends QueryTest with BeforeAndAfterA
     sql(s"""INSERT INTO CLEANTEST SELECT 1, 2,"jack","abc"""")
     sql(s"""INSERT INTO CLEANTEST SELECT 1, 2,"johnny","adc"""")
     sql(s"""INSERT INTO CLEANTEST SELECT 1, 2,"Reddit","adc"""")
+  }
+
+  def addRandomFiles(carbonTablePath: String) : Unit = {
+    val f1 = CarbonTablePath.getSegmentFilesLocation(carbonTablePath) +
+      CarbonCommonConstants.FILE_SEPARATOR  + "_.tmp"
+    val f2 = CarbonTablePath.getSegmentFilesLocation(carbonTablePath) +
+      CarbonCommonConstants.FILE_SEPARATOR  + "1_.tmp"
+      FileFactory.createNewFile(f1)
+      FileFactory.createNewFile(f2)
   }
 
 }


### PR DESCRIPTION
 ### Why is this PR needed?
 1. While getting stale segment, we do a list files and take all the files, if there is any folder/file other than .segment file, it will lead to further issues while copying data to the trash folder.

2. In the case when AbstractDFSCarbonFile is created with path and HadoopConf instead of fileStatus and if the file does not exist, since fileStatus is empty ListDirs returns empty result and getAbsolutePath throws file does not exist exception

3. Clean files is not allowed with concurrent insert overwrite in progress, In case with concurrent loading to MV is by default an insert overwrite operation, clean files operation on that MV would fail and throw exception.
 
 ### What changes were proposed in this PR?
1. Added a filter, to only consider the files ending with ".segment"
2. Using listfiles instead of list dirs in the trash folder
3.  No need to throw exceptions, just put a info message in case of such MV tables and continue blocking clean files for such MV.
    
 ### Does this PR introduce any user interface change?
 - No
 

 ### Is any new testcase added?
 - No


    
