### PR TITLE
[CARBONDATA-4058] create or insert data into the carbon table through …

### DIFF
--- a/integration/hive/src/main/scala/org/apache/carbondata/hive/CarbonHiveMetastoreListener.scala
+++ b/integration/hive/src/main/scala/org/apache/carbondata/hive/CarbonHiveMetastoreListener.scala
@@ -34,6 +34,7 @@ class CarbonHiveMetastoreListener(conf: Configuration) extends MetaStorePreEvent
         val table = preEventContext.asInstanceOf[PreCreateTableEvent].getTable
         val tableProps = table.getParameters
         if (tableProps != null
+          && tableProps.containsKey("spark.sql.sources.provider")
           && (tableProps.get("spark.sql.sources.provider") == "org.apache.spark.sql.CarbonSource"
           || tableProps.get("spark.sql.sources.provider").equalsIgnoreCase("carbondata"))) {
           val numSchemaParts = tableProps.get("spark.sql.sources.schema.numParts")
@@ -65,6 +66,7 @@ class CarbonHiveMetastoreListener(conf: Configuration) extends MetaStorePreEvent
         val table = preEventContext.asInstanceOf[PreAlterTableEvent].getNewTable
         val tableProps = table.getParameters
         if (tableProps != null
+          && tableProps.containsKey("spark.sql.sources.provider")
           && (tableProps.get("spark.sql.sources.provider") == "org.apache.spark.sql.CarbonSource"
           || tableProps.get("spark.sql.sources.provider").equalsIgnoreCase("carbondata"))) {
           val numSchemaParts = tableProps.get("spark.sql.sources.schema.numParts")


### PR DESCRIPTION
…Hive throw NPE

 ### Why is this PR needed?

If the tableprops(in file org/apache/carbondata/hive/CarbonHiveMetastoreListener.scala) does not have org.apache.spark.sql.CarbonSource property, it will throw NPE.
 
 ### What changes were proposed in this PR?

Changed case ALTER_TABLE in CarbonHiveMetastoreListener. Added a property check(org.apache.spark.sql.CarbonSource) in tableprops
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No

    
