### PR TITLE
[CARBONDATA-4087] Handled issue with huge data(exceeding 32K records) after enabling local dictionary in Presto

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/LocalDictDimensionDataChunkStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/store/impl/LocalDictDimensionDataChunkStore.java
@@ -25,6 +25,7 @@ import org.apache.carbondata.core.datastore.chunk.store.DimensionDataChunkStore;
 import org.apache.carbondata.core.scan.result.vector.CarbonColumnVector;
 import org.apache.carbondata.core.scan.result.vector.CarbonDictionary;
 import org.apache.carbondata.core.scan.result.vector.ColumnVectorInfo;
+import org.apache.carbondata.core.scan.result.vector.impl.CarbonColumnVectorImpl;
 import org.apache.carbondata.core.scan.result.vector.impl.directread.ColumnarVectorWrapperDirectFactory;
 import org.apache.carbondata.core.scan.result.vector.impl.directread.ConvertibleVector;
 import org.apache.carbondata.core.util.CarbonUtil;
@@ -84,6 +85,11 @@ public class LocalDictDimensionDataChunkStore implements DimensionDataChunkStore
     vector = ColumnarVectorWrapperDirectFactory
         .getDirectVectorWrapperFactory(vectorInfo, vector, invertedIndex, nullBitset,
             vectorInfo.deletedRows, false, false);
+    // this check is in case of array of string type
+    if (vectorInfo.vector.getType().isComplexType()
+        && ((CarbonColumnVectorImpl) dictionaryVector).getIntArraySize() < rowsNum) {
+      ((CarbonColumnVectorImpl) dictionaryVector).increaseIntArraySize(rowsNum);
+    }
     for (int i = 0; i < rowsNum; i++) {
       int surrogate = CarbonUtil.getSurrogateInternal(data, i * columnValueSize, columnValueSize);
       // If complex string primitive value is null then surrogate will be unequal to

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/vector/impl/CarbonColumnVectorImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/vector/impl/CarbonColumnVectorImpl.java
@@ -509,6 +509,14 @@ public class CarbonColumnVectorImpl implements CarbonColumnVector {
     return lengths;
   }
 
+  public int getIntArraySize() {
+    return ints.length;
+  }
+
+  public void increaseIntArraySize(int size) {
+    this.ints = new int[size];
+  }
+
   public int[] getOffsets() {
     return offsets;
   }

--- a/integration/presto/src/test/prestodb/org/apache/carbondata/presto/server/PrestoTestUtil.scala
+++ b/integration/presto/src/test/prestodb/org/apache/carbondata/presto/server/PrestoTestUtil.scala
@@ -170,4 +170,22 @@ object PrestoTestUtil {
       }
     }
   }
+
+  // this method depends on prestodb jdbc PrestoArray class
+  def validateHugeDataForArrayWithLocalDict(actualResult: List[Map[String, Any]]): Unit = {
+    assert(actualResult.size == 100 * 1000)
+    val data1 = actualResult(actualResult.size - 2)("arraystring")
+      .asInstanceOf[PrestoArray]
+      .getArray()
+      .asInstanceOf[Array[Object]]
+    val data2 = actualResult(actualResult.size - 1)("arraystring")
+      .asInstanceOf[PrestoArray]
+      .getArray()
+      .asInstanceOf[Array[Object]]
+    assert(data1.size == 3)
+    assert(data2.size == 1)
+
+    assert(data1.sameElements(Array("India", "China", "Japan")))
+    assert(data2.sameElements(Array("Korea")))
+  }
 }

--- a/integration/presto/src/test/prestosql/org/apache/carbondata/presto/server/PrestoTestUtil.scala
+++ b/integration/presto/src/test/prestosql/org/apache/carbondata/presto/server/PrestoTestUtil.scala
@@ -170,4 +170,23 @@ object PrestoTestUtil {
       }
     }
   }
+
+    // this method depends on prestosql jdbc PrestoArray class
+    def validateHugeDataForArrayWithLocalDict(actualResult: List[Map[String, Any]]): Unit = {
+      assert(actualResult.size == 100 * 1000)
+      val data1 = actualResult(actualResult.size - 2)("arraystring")
+        .asInstanceOf[PrestoArray]
+        .getArray()
+        .asInstanceOf[Array[Object]]
+      val data2 = actualResult(actualResult.size - 1)("arraystring")
+        .asInstanceOf[PrestoArray]
+        .getArray()
+        .asInstanceOf[Array[Object]]
+      assert(data1.size == 3)
+      assert(data2.size == 1)
+
+      assert(data1.sameElements(Array("India", "China", "Japan")))
+      assert(data2.sameElements(Array("Korea")))
+    }
+
 }

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonAddLoadCommand.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonAddLoadCommand.scala
@@ -93,7 +93,7 @@ case class CarbonAddLoadCommand(
     var givenPath = options.getOrElse(
       "path", throw new UnsupportedOperationException("PATH is mandatory"))
     // remove file separator if already present
-    if (givenPath.charAt(givenPath.length - 1) == CarbonCommonConstants.FILE_SEPARATOR) {
+    if (givenPath.charAt(givenPath.length - 1) == '/') {
       givenPath = givenPath.substring(0, givenPath.length - 1)
     }
     val inputPath = givenPath

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/addsegment/AddSegmentTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/addsegment/AddSegmentTestCase.scala
@@ -74,10 +74,12 @@ class AddSegmentTestCase extends QueryTest with BeforeAndAfterAll {
     checkAnswer(sql("select count(*) from addsegment1"), Seq(Row(20)))
     checkAnswer(sql("select count(empname) from addsegment1"), Seq(Row(20)))
 
+    // cannot add segment from same path file again so deleting previously added segment
+    sql("delete from table addsegment1 where segment.id in (2)")
     sql(s"alter table addsegment1 add segment options('path'='$newPathWithLineSeparator', " +
         s"'format'='carbon')")
       .collect()
-    checkAnswer(sql("select count(*) from addsegment1"), Seq(Row(30)))
+    checkAnswer(sql("select count(*) from addsegment1"), Seq(Row(20)))
     FileFactory.deleteAllFilesOfDir(new File(newPath))
   }
 


### PR DESCRIPTION
 ### Why is this PR needed?
After enabling local dictionary, this issue appears while doing SELECT on array(varchar) types, for data exceeding the batch size - 32k.
The int array used to store the surrogate values of dictionary has a default size of 32K only. ArrayOutOfBounds exception is thrown if the page size exceeds 32k.  
 
 ### What changes were proposed in this PR?
If its size is not sufficient to accommodate all the string values then increase the default size to the desired page size.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
