### PR TITLE
[CARBONDATA-4090] After compaction interrupted accidentally, compact …

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/reader/CarbonFooterReaderV3.java
+++ b/core/src/main/java/org/apache/carbondata/core/reader/CarbonFooterReaderV3.java
@@ -19,13 +19,18 @@ package org.apache.carbondata.core.reader;
 
 import java.io.IOException;
 
+import org.apache.carbondata.common.logging.LogServiceFactory;
 import org.apache.carbondata.format.FileFooter3;
+
+import org.apache.log4j.Logger;
 
 /**
  * Below class to read file footer of version3
  * carbon data file
  */
 public class CarbonFooterReaderV3 {
+  private static final Logger LOGGER =
+      LogServiceFactory.getLogService(CarbonFooterReaderV3.class.getName());
 
   //Fact file path
   private String filePath;
@@ -45,14 +50,19 @@ public class CarbonFooterReaderV3 {
    * @throws IOException
    */
   public FileFooter3 readFooterVersion3() throws IOException {
-    ThriftReader thriftReader = openThriftReader(filePath);
-    thriftReader.open();
+    try {
+      ThriftReader thriftReader = openThriftReader(filePath);
+      thriftReader.open();
 
-    // Set the offset from where it should read
-    thriftReader.setReadOffset(footerOffset);
-    FileFooter3 footer = (FileFooter3) thriftReader.read();
-    thriftReader.close();
-    return footer;
+      // Set the offset from where it should read
+      thriftReader.setReadOffset(footerOffset);
+      FileFooter3 footer = (FileFooter3) thriftReader.read();
+      thriftReader.close();
+      return footer;
+    } catch (Exception e) {
+      LOGGER.error("Failed to read footer in file: " + filePath, e);
+      throw e;
+    }
   }
 
   /**


### PR DESCRIPTION
…again and still fail, third time compaction can succeed but the new segment for SI table data size and index size is zero

 ### Why is this PR needed?
When compaction interrupted accidentally, the segment status is "Insert in Progress" and there will be stale files left in the new segment folder. Next time compaction will read the stale files. If some stale file is not complete, then compaction will fail always.
 
 ### What changes were proposed in this PR?
At the begining of compaction, segment folder should have no any stale files. So check the segment folder at the begining, if folder already exists, delete it and create it again.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No