### PR TITLE
[CARBONDATA-4088] Drop metacache didn't clear some cache information …

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -2557,6 +2557,20 @@ public final class CarbonCommonConstants {
           " characters. Please consider long string data type.";
 
   /**
+   * Expiration time for tableInfo cache in CarbonMetadata, after the time configured
+   * since last access to the cache entry, tableInfo will be removed from cache. Recent
+   * access will refresh the timer. At the time when cache is being expired, queries on
+   * the table may fail with NullPointerException.
+   */
+  public static final String CARBON_METACACHE_EXPIRATION_TIME_IN_SECONDS =
+        "carbon.metacache.expiration.seconds";
+
+  /**
+   * By default, the cache in CarbonMetadata will not be expired by time.
+   */
+  public static final long CARBON_METACACHE_EXPIRATION_TIME_IN_SECONDS_DEFAULT = Long.MAX_VALUE;
+
+  /**
    * property which defines the presto query
    */
   @CarbonProperty public static final String IS_QUERY_FROM_PRESTO = "is_query_from_presto";

--- a/core/src/main/java/org/apache/carbondata/core/metadata/CarbonMetadata.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/CarbonMetadata.java
@@ -19,12 +19,15 @@ package org.apache.carbondata.core.metadata;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
 import org.apache.carbondata.core.metadata.schema.table.TableInfo;
 import org.apache.carbondata.core.metadata.schema.table.column.CarbonDimension;
+import org.apache.carbondata.core.util.CarbonProperties;
+
+import net.jodah.expiringmap.ExpirationPolicy;
+import net.jodah.expiringmap.ExpiringMap;
 
 /**
  * Class which persist the information about the tables present the carbon schemas
@@ -39,11 +42,13 @@ public final class CarbonMetadata {
   /**
    * holds the list of tableInfo currently present
    */
-  private Map<String, CarbonTable> tableInfoMap;
+  private ExpiringMap<String, CarbonTable> tableInfoMap;
 
   private CarbonMetadata() {
     // creating a concurrent map as it will be updated by multiple thread
-    tableInfoMap = new ConcurrentHashMap<String, CarbonTable>();
+    tableInfoMap = ExpiringMap.builder()
+        .expiration(CarbonProperties.getInstance().getMetaCacheExpirationTime(), TimeUnit.SECONDS)
+        .expirationPolicy(ExpirationPolicy.ACCESSED).build();
   }
 
   public static CarbonMetadata getInstance() {

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
@@ -2086,6 +2086,27 @@ public final class CarbonProperties {
     return Boolean.parseBoolean(configuredValue);
   }
 
+  public long getMetaCacheExpirationTime() {
+    String configuredValue = CarbonProperties.getInstance()
+        .getProperty(CarbonCommonConstants.CARBON_METACACHE_EXPIRATION_TIME_IN_SECONDS);
+    if (configuredValue == null || configuredValue.equalsIgnoreCase("0")) {
+      return CarbonCommonConstants.CARBON_METACACHE_EXPIRATION_TIME_IN_SECONDS_DEFAULT;
+    }
+    try {
+      long expirationTime = Long.parseLong(configuredValue);
+      LOGGER.info("Value for "
+          + CarbonCommonConstants.CARBON_METACACHE_EXPIRATION_TIME_IN_SECONDS + " is "
+          + expirationTime + ".");
+      return expirationTime;
+    } catch (NumberFormatException e) {
+      LOGGER.warn(configuredValue + " is not a valid input for "
+          + CarbonCommonConstants.CARBON_METACACHE_EXPIRATION_TIME_IN_SECONDS + ", taking "
+          + CarbonCommonConstants.CARBON_METACACHE_EXPIRATION_TIME_IN_SECONDS_DEFAULT
+          + " as default value.");
+      return CarbonCommonConstants.CARBON_METACACHE_EXPIRATION_TIME_IN_SECONDS_DEFAULT;
+    }
+  }
+
   public boolean isSIRepairEnabled(String dbName, String tableName) {
     // Check if user has enabled/disabled the use of property for the current db and table using
     // the set command

--- a/docs/configuration-parameters.md
+++ b/docs/configuration-parameters.md
@@ -149,6 +149,7 @@ This section provides the details of all the configurations required for the Car
 | carbon.max.pagination.lru.cache.size.in.mb | -1 | Maximum memory **(in MB)** upto which the SDK pagination reader can cache the blocklet rows. Suggest to configure as multiple of blocklet size. Default value of -1 means there is no memory limit for caching. Only integer values greater than 0 are accepted. |
 | carbon.partition.max.driver.lru.cache.size | -1 | Maximum memory **(in MB)** upto which driver can cache partition metadata. Beyond this, least recently used data will be removed from cache before loading new set of values.
 | carbon.mapOrderPushDown.<db_name>_<table_name>.column| empty | If order by column is in sort column, specify that sort column here to avoid ordering at map task . |
+| carbon.metacache.expiration.seconds | Long.MAX_VALUE | Expiration time **(in seconds)** for tableInfo cache in CarbonMetadata and tableModifiedTime in CarbonFileMetastore, after the time configured since last access to the cache entry, tableInfo and tableModifiedTime will be removed from each cache. Recent access will refresh the timer. Default value of Long.MAX_VALUE means the cache will not be expired by time. **NOTE:** At the time when cache is being expired, queries on the table may fail with NullPointerException. |
 
 ## Data Mutation Configuration
 | Parameter | Default Value | Description |


### PR DESCRIPTION
…which leads to memory leak

 ### Why is this PR needed?
When there are two spark applications, one drop a table, some cache information of this table stay in another application and cannot be removed with any method like "Drop metacache" command. This leads to memory leak. With the passage of time, memory leak will also accumulate which finally leads to driver OOM. Following are the leak points: 1) tableModifiedTimeStore in CarbonFileMetastore; 2) segmentLockMap in BlockletDataMapIndexStore; 3) absoluteTableIdentifierByteMap in SegmentPropertiesAndSchemaHolder; 4) tableInfoMap in CarbonMetadata.
 
 ### What changes were proposed in this PR?
Using expiring map to cache the table information in CarbonMetadata and modified time in CarbonFileMetaStore so that stale information will be cleared automatically after the expiration time. Operations in BlockletDataMapIndexStore no need to be locked, remove all the logic related to segmentLockMap.
    
 ### Does this PR introduce any user interface change?
 - New configuration carbon.metacache.expiration.seconds is added.

 ### Is any new testcase added?
 - No