### PR TITLE
[CARBONDATA-4084]Fixed data corruption issue after fallback of Local dictionary

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/localdictionary/generator/ColumnLocalDictionaryGenerator.java
+++ b/core/src/main/java/org/apache/carbondata/core/localdictionary/generator/ColumnLocalDictionaryGenerator.java
@@ -34,10 +34,16 @@ public class ColumnLocalDictionaryGenerator implements LocalDictionaryGenerator 
    */
   private DictionaryStore dictionaryHolder;
 
+  /**
+   * number of bytes used for storing the length of the dictionary value
+   */
+  private int lvLength;
+
   public ColumnLocalDictionaryGenerator(int threshold, int lvLength) {
     // adding 1 to threshold for null value
     int newThreshold = threshold + 1;
     this.dictionaryHolder = new MapBasedDictionaryStore(newThreshold);
+    this.lvLength = lvLength;
     ByteBuffer byteBuffer = ByteBuffer.allocate(
         lvLength + CarbonCommonConstants.MEMBER_DEFAULT_VAL_ARRAY.length);
 
@@ -85,5 +91,10 @@ public class ColumnLocalDictionaryGenerator implements LocalDictionaryGenerator 
   @Override
   public byte[] getDictionaryKeyBasedOnValue(int value) {
     return this.dictionaryHolder.getDictionaryKeyBasedOnValue(value);
+  }
+
+  @Override
+  public int getLVLength() {
+    return this.lvLength;
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/localdictionary/generator/LocalDictionaryGenerator.java
+++ b/core/src/main/java/org/apache/carbondata/core/localdictionary/generator/LocalDictionaryGenerator.java
@@ -46,4 +46,10 @@ public interface LocalDictionaryGenerator {
    * @return dictionary key based on value
    */
   byte[] getDictionaryKeyBasedOnValue(int value);
+
+  /**
+   * @return number of bytes used for storing the length of the dictionary value
+   * for String type 2 Bytes and Long String 4 bytes
+   */
+  int getLVLength();
 }


### PR DESCRIPTION
 ### Why is this PR needed?
 Data is getting corrupted when fallback happens for local dictionary encoded page.
 
 ### What changes were proposed in this PR?
In LVByteBufferColumnPage Length getting added inside put method. In case of fallback when reverse lookup is done and encoded page is replaced with actual value[Dictionary values]. As actual Dictionary value is already present in LV format again one more length is getting added[LLV], so during query it's showing extra character for those columns
    
 ### Does this PR introduce any user interface change?
 - No


 ### Is any new testcase added?
 - No


    
