### PR TITLE
[CARBONDATA-4093] Added logs for MV and method to verify if mv is in Sync during query

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/view/MVManager.java
+++ b/core/src/main/java/org/apache/carbondata/core/view/MVManager.java
@@ -75,6 +75,10 @@ public abstract class MVManager {
     return false;
   }
 
+  public boolean isMVInSyncWithParentTables(MVSchema mvSchema) throws IOException {
+    return schemaProvider.isViewCanBeEnabled(mvSchema, true);
+  }
+
   /**
    * It gives all mv schemas of a given table.
    * For show mv command.
@@ -114,7 +118,16 @@ public abstract class MVManager {
   public List<MVSchema> getSchemas() throws IOException {
     List<MVSchema> schemas = new ArrayList<>();
     for (String database : this.getDatabases()) {
-      schemas.addAll(this.getSchemas(database));
+      try {
+        schemas.addAll(this.getSchemas(database));
+      } catch (IOException ex) {
+        throw ex;
+      } catch (Exception ex) {
+        LOGGER.error("Exception Occurred: Skipping MV schemas from database: " + database);
+        if (LOGGER.isDebugEnabled()) {
+          LOGGER.debug(ex.getMessage());
+        }
+      }
     }
     return schemas;
   }
@@ -234,7 +247,16 @@ public abstract class MVManager {
   public List<MVStatusDetail> getEnabledStatusDetails() throws IOException {
     List<MVStatusDetail> statusDetails = new ArrayList<>();
     for (String database : this.getDatabases()) {
-      statusDetails.addAll(this.getEnabledStatusDetails(database));
+      try {
+        statusDetails.addAll(this.getEnabledStatusDetails(database));
+      } catch (IOException ex) {
+        throw ex;
+      } catch (Exception ex) {
+        LOGGER.error("Exception Occurred: Skipping MV schemas from database: " + database);
+        if (LOGGER.isDebugEnabled()) {
+          LOGGER.debug(ex.getMessage());
+        }
+      }
     }
     return statusDetails;
   }

--- a/integration/spark/src/main/scala/org/apache/carbondata/view/MVCatalogInSpark.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/view/MVCatalogInSpark.scala
@@ -82,6 +82,10 @@ case class MVCatalogInSpark(session: SparkSession)
     enabledSchemas.toArray
   }
 
+  def isMVInSync(mvSchema: MVSchema): Boolean = {
+    viewManager.isMVInSyncWithParentTables(mvSchema)
+  }
+
   /**
    * Registers the data produced by the logical representation of the given [[DataFrame]]. Unlike
    * `RDD.cache()`, the default storage level is set to be `MEMORY_AND_DISK` because recomputing

--- a/integration/spark/src/main/scala/org/apache/carbondata/view/MVManagerInSpark.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/view/MVManagerInSpark.scala
@@ -31,12 +31,7 @@ class MVManagerInSpark(session: SparkSession) extends MVManager {
   override def getDatabases: util.List[String] = {
     CarbonThreadUtil.threadSet(CarbonCommonConstants.CARBON_ENABLE_MV, "true")
     try {
-      val databaseList = session.catalog.listDatabases()
-      val databaseNameList = new util.ArrayList[String]()
-      for (database <- databaseList.collect()) {
-        databaseNameList.add(database.name)
-      }
-      databaseNameList
+      session.sessionState.catalog.listDatabases().asJava
     } finally {
       CarbonThreadUtil.threadUnset(CarbonCommonConstants.CARBON_ENABLE_MV)
     }

--- a/processing/src/main/java/org/apache/carbondata/processing/sort/sortdata/SortParameters.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/sort/sortdata/SortParameters.java
@@ -522,9 +522,11 @@ public class SortParameters implements Serializable {
           columnIdxMap.get("noDictSortIdxBasedOnSchemaInRow"));
       parameters.setDictSortColIdxSchemaOrderMapping(
           columnIdxMap.get("dictSortIdxBasedOnSchemaInRow"));
+      parameters.setNoDictSchemaDataType(CarbonDataProcessorUtil
+          .getNoDictDataTypesAsDataFieldOrder(configuration.getDataFields()));
       parameters.setMeasureDataType(configuration.getMeasureDataTypeAsDataFieldOrder());
       parameters.setNoDictDataType(CarbonDataProcessorUtil
-          .getNoDictDataTypesAsDataFieldOrder(configuration.getDataFields()));
+          .getNoDictSortDataTypesAsDataFieldOrder(configuration.getDataFields()));
       Map<String, DataType[]> noDictSortAndNoSortDataTypes = CarbonDataProcessorUtil
           .getNoDictSortAndNoSortDataTypesAsDataFieldOrder(configuration.getDataFields());
       parameters.setNoDictSortDataType(noDictSortAndNoSortDataTypes.get("noDictSortDataTypes"));

--- a/processing/src/main/java/org/apache/carbondata/processing/util/CarbonDataProcessorUtil.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/util/CarbonDataProcessorUtil.java
@@ -396,12 +396,28 @@ public final class CarbonDataProcessorUtil {
   }
 
   /**
-   * get visible no dictionary dimensions as per data field order
+   * Get visible no dictionary sort dimensions as per data field order
+   */
+  public static DataType[] getNoDictDataTypesAsDataFieldOrder(DataField[] dataFields) {
+    List<DataType> type = new ArrayList<>();
+    for (DataField dataField : dataFields) {
+      if (!dataField.getColumn().isInvisible() && dataField.getColumn().isDimension()) {
+        if (!dataField.getColumn().hasEncoding(Encoding.DICTIONARY)
+            && dataField.getColumn().getColumnSchema().getDataType() != DataTypes.DATE) {
+          type.add(dataField.getColumn().getColumnSchema().getDataType());
+        }
+      }
+    }
+    return type.toArray(new DataType[type.size()]);
+  }
+
+  /**
+   * get visible no dictionary sort dimensions as per data field order
    *
    * @param dataFields
    * @return
    */
-  public static DataType[] getNoDictDataTypesAsDataFieldOrder(DataField[] dataFields) {
+  public static DataType[] getNoDictSortDataTypesAsDataFieldOrder(DataField[] dataFields) {
     List<DataType> type = new ArrayList<>();
     for (DataField dataField : dataFields) {
       if (!dataField.getColumn().isInvisible() && dataField.getColumn().isDimension()) {


### PR DESCRIPTION
 ### Why is this PR needed?
 Added logs for MV and method to verify if mv is in Sync during query
 
 ### What changes were proposed in this PR?
1. Move MV Enable Check to beginning to avoid transform logical plan
2. Add Logger if exception is occurred during fetching mv schema
3. Check if MV is in Sync and allow Query rewrite
4. Reuse reading LoadMetadetails to get mergedLoadMapping
5. Set NO-Dict Schema types for insert-partition flow - missed from [CARBONDATA-4077]

    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
