### PR TITLE
[CARBONDATA-4094] : Fix fallback count(*) issue on partition table with index server

### DIFF
--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonInputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonInputFormat.java
@@ -404,6 +404,10 @@ public abstract class CarbonInputFormat<T> extends FileInputFormat<Void, T> {
       }
       return indexJob.executeCountJob(indexInputFormat, configuration);
     } catch (Exception e) {
+      if (CarbonProperties.getInstance().isFallBackDisabled()) {
+        LOG.error("Fallback is disabled");
+        throw e;
+      }
       LOG.error("Failed to get count from index server. Initializing fallback", e);
       IndexJob indexJob = IndexUtil.getEmbeddedJob();
       return indexJob.executeCountJob(indexInputFormat, configuration);

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonCountStar.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonCountStar.scala
@@ -63,7 +63,7 @@ case class CarbonCountStar(
           sparkSession,
           TableIdentifier(
             carbonTable.getTableName,
-            Some(carbonTable.getDatabaseName))).map(_.asJava).orNull, false),
+            Some(carbonTable.getDatabaseName))).map(_.toList.asJava).orNull, false),
       carbonTable)
 
     if (CarbonProperties.isQueryStageInputEnabled) {


### PR DESCRIPTION
 ### Why is this PR needed?
The used asJava converts to java "in place", without copying the whole data to save time and memory and it just simply wraps the scala collection with a class that conforms to the java interface and  thus java serializer is not able to serialize it. 
 
 ### What changes were proposed in this PR?
Converting it to list, so that it is able to serialize a list.
    
 ### Does this PR introduce any user interface change?
 - No


 ### Is any new testcase added?
 - No


    
