### PR TITLE
[CARBONDATA-4095] Fix Select Query with SI filter fails, when columnDrift is Set

### DIFF
--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonInputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonInputFormat.java
@@ -52,7 +52,6 @@ import org.apache.carbondata.core.metadata.schema.table.TableInfo;
 import org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema;
 import org.apache.carbondata.core.profiler.ExplainCollector;
 import org.apache.carbondata.core.readcommitter.ReadCommittedScope;
-import org.apache.carbondata.core.scan.expression.Expression;
 import org.apache.carbondata.core.scan.filter.FilterUtil;
 import org.apache.carbondata.core.scan.filter.resolver.FilterResolverIntf;
 import org.apache.carbondata.core.scan.model.QueryModel;
@@ -686,7 +685,8 @@ public abstract class CarbonInputFormat<T> extends FileInputFormat<Void, T> {
       projectColumns = new String[]{};
     }
     if (indexFilter != null) {
-      checkAndAddImplicitExpression(indexFilter.getExpression(), inputSplit);
+      boolean hasColumnDrift = carbonTable.isTransactionalTable() && carbonTable.hasColumnDrift();
+      checkAndAddImplicitExpression(indexFilter, inputSplit, hasColumnDrift);
     }
     QueryModel queryModel = new QueryModelBuilder(carbonTable)
         .projectColumns(projectColumns)
@@ -704,7 +704,8 @@ public abstract class CarbonInputFormat<T> extends FileInputFormat<Void, T> {
    * This method will create an Implicit Expression and set it as right child in the given
    * expression
    */
-  private void checkAndAddImplicitExpression(Expression expression, InputSplit inputSplit) {
+  private void checkAndAddImplicitExpression(IndexFilter indexFilter, InputSplit inputSplit,
+      boolean hasColumnDrift) {
     if (inputSplit instanceof CarbonMultiBlockSplit) {
       CarbonMultiBlockSplit split = (CarbonMultiBlockSplit) inputSplit;
       List<CarbonInputSplit> splits = split.getAllSplits();
@@ -721,8 +722,13 @@ public abstract class CarbonInputFormat<T> extends FileInputFormat<Void, T> {
       }
       if (!blockIdToBlockletIdMapping.isEmpty()) {
         // create implicit expression and set as right child
-        FilterUtil
-            .createImplicitExpressionAndSetAsRightChild(expression, blockIdToBlockletIdMapping);
+        FilterUtil.createImplicitExpressionAndSetAsRightChild(indexFilter.getExpression(),
+            blockIdToBlockletIdMapping);
+        // process filter expression after adding implicit expression. If hasColumnDrift is false,
+        // then the filter expression will be processed during QueryModelBuilder.build()
+        if (hasColumnDrift) {
+          indexFilter.processFilterExpression();
+        }
       }
     }
   }


### PR DESCRIPTION
 ### Why is this PR needed?
After converting expression to IN Expression for maintable with SI, expression is not processed if  ColumnDrift is enabled. Query fails with NPE during resolveFilter. Exception is added in JIRA
 
 ### What changes were proposed in this PR?
Process the filter expression after adding implicit expression
    
 ### Does this PR introduce any user interface change?
 - No


 ### Is any new testcase added?

 - Yes

    
