### PR TITLE
[CARBONDATA-4096] SDK read fails from cluster and sdk read filter query on sort column giving wrong result with IndexServer

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/index/IndexInputFormat.java
+++ b/core/src/main/java/org/apache/carbondata/core/index/IndexInputFormat.java
@@ -154,8 +154,12 @@ public class IndexInputFormat extends FileInputFormat<Void, ExtendedBlocklet>
         if (indexLevel == null) {
           TableIndex defaultIndex = IndexStoreManager.getInstance()
               .getIndex(table, distributable.getDistributable().getIndexSchema());
-          blocklets = defaultIndex
-              .prune(segmentsToLoad, new IndexFilter(filterResolverIntf), partitions);
+          IndexFilter filter = new IndexFilter(filterResolverIntf);
+          filter.setTable(table);
+          if (filterResolverIntf != null) {
+            filter.setExpression(filterResolverIntf.getFilterExpression());
+          }
+          blocklets = defaultIndex.prune(segmentsToLoad, filter, partitions);
           blocklets = IndexUtil
               .pruneIndexes(table, filterResolverIntf, segmentsToLoad, partitions, blocklets,
                   indexChooser);


### PR DESCRIPTION
 ### Why is this PR needed?
 1) Create a table and read from sdk written files fails in cluster with `java.nio.file.NoSuchFileException: hdfs:/hacluster/user/hive/warehouse/carbon.store/default/sdk`.
2) After fixing the above path issue, filter query on sort column gives the wrong result with IndexServer.
 
 ### What changes were proposed in this PR?
1) In `getAllDeleteDeltaFiles` , used CarbonFiles.listFiles instead of Files.walk to handle custom file types.
2) In PruneWithFilter ,  `isResolvedOnSegment`  is used in filterResolver step. Have set table and expression on executor side, so indexserver can use this in filterResolver step.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No, verified in the cluster.

    
