### PR TITLE
[CARBONDATA-4099] Fixed select query on main table with a SI table in case of concurrent load, compact and clean files operation

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/events/CleanFilesPostEventListener.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/events/CleanFilesPostEventListener.scala
@@ -28,6 +28,7 @@ import org.apache.spark.sql.index.CarbonIndexUtil
 import org.apache.spark.sql.optimizer.CarbonFilters
 
 import org.apache.carbondata.common.logging.LogServiceFactory
+import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.datastore.impl.FileFactory
 import org.apache.carbondata.core.indexstore.PartitionSpec
 import org.apache.carbondata.core.locks.{CarbonLockFactory, ICarbonLock, LockUsage}
@@ -133,16 +134,16 @@ class CleanFilesPostEventListener extends OperationEventListener with Logging {
           val carbonFile = FileFactory
             .getCarbonFile(CarbonTablePath
               .getSegmentPath(indexTable.getTablePath, detail.getLoadName))
+          LOGGER.info(s"Deleting segment folder: ${carbonFile.getName}")
           CarbonUtil.deleteFoldersAndFiles(carbonFile)
         }
         unnecessarySegmentsOfSI.foreach { detail =>
           detail.setSegmentStatus(segToStatusMap(detail.getLoadName))
           detail.setVisibility("false")
         }
-
         SegmentStatusManager.writeLoadDetailsIntoFile(
-          indexTable.getMetadataPath + CarbonTablePath.TABLE_STATUS_FILE,
-          unnecessarySegmentsOfSI.toArray)
+          indexTable.getMetadataPath + CarbonCommonConstants.FILE_SEPARATOR +
+            CarbonTablePath.TABLE_STATUS_FILE, indexTableMetadataDetails.toArray)
       } else {
         LOGGER.error("Unable to get the lock file for main/Index table. Please try again later")
       }


### PR DESCRIPTION
 ### Why is this PR needed?
 There were 2 issues in the clean files post event listener:
1. In concurrent cases, while writing entry back to the table status file, wrong path was given, due to which table status file was not updated in the case of SI table.
2. While writing the loadmetadetails to the table status file during concurrent scenarios, we were only writing the unwanted segments and not all the segments, which could make segments stale in the SI table
Due to these 2 issues, when selet query is executed on SI table, the tablestatus would have entry for a segment but it's carbondata file would be deleted, thus throwing an IO Exception.
 
 ### What changes were proposed in this PR?
Added correct table status path as well sending the correct loadmetadatadetails to be updated in the table status file. Now when select query is fired on the SI table, it will not throw carbondata file not found exception
    
 ### Does this PR introduce any user interface change?
 - No


 ### Is any new testcase added?
 - No


    
