### PR TITLE
[CARBONDATA-4100] Fix SI segments are in inconsistent state with maintable after concurrent(Load&Compaction) operation

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/index/CarbonIndexUtil.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/index/CarbonIndexUtil.scala
@@ -37,6 +37,7 @@ import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.datastore.compression.CompressorFactory
 import org.apache.carbondata.core.datastore.impl.FileFactory
+import org.apache.carbondata.core.exception.ConcurrentOperationException
 import org.apache.carbondata.core.locks.{CarbonLockFactory, CarbonLockUtil, ICarbonLock, LockUsage}
 import org.apache.carbondata.core.metadata.index.IndexType
 import org.apache.carbondata.core.metadata.schema.indextable.IndexMetadata
@@ -393,10 +394,10 @@ object CarbonIndexUtil {
   }
 
   def processSIRepair(indexTableName: String, carbonTable: CarbonTable,
-    carbonLoadModel: CarbonLoadModel, indexMetadata: IndexMetadata,
-      mainTableDetails: List[LoadMetadataDetails], secondaryIndexProvider: String,
-                      repairLimit: Int)
-  (sparkSession: SparkSession) : Unit = {
+      carbonLoadModel: CarbonLoadModel, indexMetadata: IndexMetadata,
+      secondaryIndexProvider: String, repairLimit: Int,
+      segments: Option[List[String]] = Option.empty,
+      isLoadOrCompaction: Boolean = false)(sparkSession: SparkSession): Unit = {
     // when Si creation and load to main table are parallel, get the carbonTable from the
     // metastore which will have the latest index Info
     val metaStore = CarbonEnv.getInstance(sparkSession).carbonMetaStore
@@ -406,81 +407,94 @@ object CarbonIndexUtil {
       .asInstanceOf[CarbonRelation]
       .carbonTable
 
-    val siTblLoadMetadataDetails: Array[LoadMetadataDetails] =
-      SegmentStatusManager.readLoadMetadata(indexTable.getMetadataPath)
     var segmentLocks: ListBuffer[ICarbonLock] = ListBuffer.empty
-    if (!CarbonInternalLoaderUtil.checkMainTableSegEqualToSISeg(
-      mainTableDetails.toArray,
-      siTblLoadMetadataDetails)) {
-      val indexColumns = indexMetadata.getIndexColumns(secondaryIndexProvider,
-        indexTableName)
-      val indexModel = IndexModel(Some(carbonTable.getDatabaseName),
-        indexMetadata.getParentTableName,
-        indexColumns.split(",").toList,
-        indexTableName)
-
-      // var details = SegmentStatusManager.readLoadMetadata(indexTable.getMetadataPath)
-      // If it empty, then no need to do further computations because the
-      // tabletstatus might not have been created and hence next load will take care
-      if (siTblLoadMetadataDetails.isEmpty) {
-        Seq.empty
-      }
-
-      val failedLoadMetadataDetails: java.util.List[LoadMetadataDetails] = new util
-      .ArrayList[LoadMetadataDetails]()
-
-      // read the details of SI table and get all the failed segments during SI
-      // creation which are MARKED_FOR_DELETE or invalid INSERT_IN_PROGRESS
-      siTblLoadMetadataDetails.foreach {
-        case loadMetaDetail: LoadMetadataDetails =>
-          if (loadMetaDetail.getSegmentStatus == SegmentStatus.MARKED_FOR_DELETE &&
-            checkIfMainTableLoadIsValid(mainTableDetails.toArray,
-              loadMetaDetail.getLoadName) && repairLimit > failedLoadMetadataDetails.size() ) {
-            failedLoadMetadataDetails.add(loadMetaDetail)
-          } else if ((loadMetaDetail.getSegmentStatus ==
-            SegmentStatus.INSERT_IN_PROGRESS ||
-            loadMetaDetail.getSegmentStatus ==
-              SegmentStatus.INSERT_OVERWRITE_IN_PROGRESS) &&
-            checkIfMainTableLoadIsValid(mainTableDetails.toArray,
-              loadMetaDetail.getLoadName) && repairLimit > failedLoadMetadataDetails.size()) {
-            val segmentLock = CarbonLockFactory
-              .getCarbonLockObj(indexTable.getAbsoluteTableIdentifier,
-                CarbonTablePath.addSegmentPrefix(loadMetaDetail.getLoadName) +
-                  LockUsage.LOCK)
-            try {
-              if (segmentLock.lockWithRetries(1, 0)) {
-                LOGGER
-                  .info("SIFailedLoadListener: Acquired segment lock on segment:" +
-                    loadMetaDetail.getLoadName)
-                failedLoadMetadataDetails.add(loadMetaDetail)
-              }
-            } finally {
-              segmentLock.unlock()
-              LOGGER
-                .info("SIFailedLoadListener: Released segment lock on segment:" +
-                  loadMetaDetail.getLoadName)
+    val compactionLock = CarbonLockFactory.getCarbonLockObj(
+      carbonTable.getAbsoluteTableIdentifier,
+      LockUsage.COMPACTION_LOCK)
+    try {
+      // In some cases, SI table segment might be in COMPACTED state and main table
+      // compaction might be still in progress. In those cases, we can try to take compaction lock
+      // on main table and then compare and add SI segments to failedLoads, to avoid repair
+      // SI SUCCESS loads.
+      if (compactionLock.lockWithRetries()) {
+        var mainTableDetails = try {
+          SegmentStatusManager.readTableStatusFile(CarbonTablePath.getTableStatusFilePath(
+            carbonTable.getTablePath))
+        } catch {
+          case exception: Exception =>
+            if (!isLoadOrCompaction) {
+              throw exception
             }
+            return;
+        }
+        carbonLoadModel.setLoadMetadataDetails(mainTableDetails.toList.asJava)
+        if (segments.isDefined) {
+          mainTableDetails = mainTableDetails.filter(
+            loadMetaDataDetails => segments.get.contains(loadMetaDataDetails.getLoadName))
+        }
+        val siTblLoadMetadataDetails: Array[LoadMetadataDetails] =
+          SegmentStatusManager.readLoadMetadata(indexTable.getMetadataPath)
+        if (!CarbonInternalLoaderUtil.checkMainTableSegEqualToSISeg(
+          mainTableDetails,
+          siTblLoadMetadataDetails)) {
+          val indexColumns = indexMetadata.getIndexColumns(secondaryIndexProvider,
+            indexTableName)
+          val indexModel = IndexModel(Some(carbonTable.getDatabaseName),
+            indexMetadata.getParentTableName,
+            indexColumns.split(",").toList,
+            indexTableName)
+
+          // If it empty, then no need to do further computations because the
+          // tabletstatus might not have been created and hence next load will take care
+          if (siTblLoadMetadataDetails.isEmpty) {
+            Seq.empty
           }
-      }
-      val carbonLock = CarbonLockFactory.getCarbonLockObj(
-        carbonTable.getAbsoluteTableIdentifier,
-        LockUsage.COMPACTION_LOCK)
-      try {
-        // In some cases, SI table segment might be in COMPACTED state and main table
-        // compaction might be still in progress. In those cases, we can try to take compaction lock
-        // on main table and then compare and add SI segments to failedLoads, to avoid repair
-        // SI SUCCESS loads.
-        if (carbonLock.lockWithRetries(3, 0)) {
-          val newMainTableDetails = SegmentStatusManager.readLoadMetadata(carbonTable
-            .getMetadataPath)
+
+          val failedLoadMetadataDetails: java.util.List[LoadMetadataDetails] = new util
+          .ArrayList[LoadMetadataDetails]()
+
+          // read the details of SI table and get all the failed segments during SI
+          // creation which are MARKED_FOR_DELETE or invalid INSERT_IN_PROGRESS
+          siTblLoadMetadataDetails.foreach {
+            case loadMetaDetail: LoadMetadataDetails =>
+              val isMainTableLoadValid = checkIfMainTableLoadIsValid(mainTableDetails,
+                loadMetaDetail.getLoadName)
+              if (loadMetaDetail.getSegmentStatus == SegmentStatus.MARKED_FOR_DELETE &&
+                  isMainTableLoadValid && repairLimit > failedLoadMetadataDetails.size()) {
+                failedLoadMetadataDetails.add(loadMetaDetail)
+              } else if ((loadMetaDetail.getSegmentStatus ==
+                          SegmentStatus.INSERT_IN_PROGRESS ||
+                          loadMetaDetail.getSegmentStatus ==
+                          SegmentStatus.INSERT_OVERWRITE_IN_PROGRESS) &&
+                         isMainTableLoadValid && repairLimit > failedLoadMetadataDetails.size()) {
+                val segmentLock = CarbonLockFactory
+                  .getCarbonLockObj(indexTable.getAbsoluteTableIdentifier,
+                    CarbonTablePath.addSegmentPrefix(loadMetaDetail.getLoadName) +
+                    LockUsage.LOCK)
+                try {
+                  if (segmentLock.lockWithRetries(1, 0)) {
+                    LOGGER
+                      .info("SIFailedLoadListener: Acquired segment lock on segment:" +
+                            loadMetaDetail.getLoadName)
+                    failedLoadMetadataDetails.add(loadMetaDetail)
+                  }
+                } finally {
+                  segmentLock.unlock()
+                  LOGGER
+                    .info("SIFailedLoadListener: Released segment lock on segment:" +
+                          loadMetaDetail.getLoadName)
+                }
+              }
+          }
+
           // check for the skipped segments. compare the main table and SI table table
           // status file and get the skipped segments if any
-          CarbonInternalLoaderUtil.getListOfValidSlices(newMainTableDetails).asScala
+          CarbonInternalLoaderUtil.getListOfValidSlices(mainTableDetails).asScala
             .foreach(metadataDetail => {
               if (repairLimit > failedLoadMetadataDetails.size()) {
                 val detail = siTblLoadMetadataDetails
                   .filter(metadata => metadata.getLoadName.equals(metadataDetail))
-                val mainTableDetail = newMainTableDetails
+                val mainTableDetail = mainTableDetails
                   .filter(metadata => metadata.getLoadName.equals(metadataDetail))
                 if (null == detail || detail.length == 0) {
                   val newDetails = new LoadMetadataDetails
@@ -516,68 +530,71 @@ object CarbonIndexUtil {
                 }
               }
             })
-        } else {
-          LOGGER.error(
-            "Unable to obtain compaction lock for table" + carbonTable.getTableUniqueName)
+
+          try {
+            if (!failedLoadMetadataDetails.isEmpty) {
+              // in the case when in SI table a segment is deleted and it's entry is
+              // deleted from the tablestatus file, the corresponding .segment file from
+              // the metadata folder should also be deleted as it contains the
+              // mergefilename which does not exist anymore as the segment is deleted.
+              deleteStaleSegmentFileIfPresent(carbonLoadModel,
+                indexTable,
+                failedLoadMetadataDetails)
+              CarbonIndexUtil
+                .LoadToSITable(sparkSession,
+                  carbonLoadModel,
+                  indexTableName,
+                  isLoadToFailedSISegments = true,
+                  indexModel,
+                  carbonTable, indexTable, false, failedLoadMetadataDetails)
+            }
+
+            // get updated main table segments and si table segments
+            val mainTblLoadMetadataDetails: Array[LoadMetadataDetails] =
+              SegmentStatusManager.readLoadMetadata(carbonTable.getMetadataPath)
+            val siTblLoadMetadataDetails: Array[LoadMetadataDetails] =
+              SegmentStatusManager.readLoadMetadata(indexTable.getMetadataPath)
+
+            // check if main table has load in progress and SI table has no load
+            // in progress entry, then no need to enable the SI table
+            // Only if the valid segments of maintable match the valid segments of SI
+            // table then we can enable the SI for query
+            if (CarbonInternalLoaderUtil
+                  .checkMainTableSegEqualToSISeg(mainTblLoadMetadataDetails,
+                    siTblLoadMetadataDetails)
+                && CarbonInternalLoaderUtil.checkInProgLoadInMainTableAndSI(carbonTable,
+              mainTblLoadMetadataDetails, siTblLoadMetadataDetails)) {
+              // enable the SI table if it was disabled earlier due to failure during SI
+              // creation time
+              sparkSession.sql(
+                s"""ALTER TABLE ${ carbonLoadModel.getDatabaseName }.$indexTableName SET
+                   |SERDEPROPERTIES ('isSITableEnabled' = 'true')""".stripMargin).collect()
+            }
+          } catch {
+            case ex: Exception =>
+              // in case of SI load only for for failed segments, catch the exception, but
+              // do not fail the main table load, as main table segments should be available
+              // for query
+              LOGGER.error(s"Load to SI table to $indexTableName is failed " +
+                           s"or SI table ENABLE is failed. ", ex)
+              Seq.empty
+          } finally {
+            segmentLocks.foreach {
+              segmentLock => segmentLock.unlock()
+            }
+          }
         }
-      } finally {
-        carbonLock.unlock()
+      } else {
+        LOGGER.error(s"Didn't check failed segments for index [$indexTableName] as compaction " +
+                     s"is progress on ${ carbonTable.getTableUniqueName }. " +
+                     s"Please call SI repair again")
+        if (!isLoadOrCompaction) {
+          throw new ConcurrentOperationException(carbonTable.getDatabaseName,
+            carbonTable.getTableName, "compaction", "reindex command")
+        }
       }
-      try {
-        if (!failedLoadMetadataDetails.isEmpty) {
-          // in the case when in SI table a segment is deleted and it's entry is
-          // deleted from the tablestatus file, the corresponding .segment file from
-          // the metadata folder should also be deleted as it contains the
-          // mergefilename which does not exist anymore as the segment is deleted.
-          deleteStaleSegmentFileIfPresent(carbonLoadModel,
-            indexTable,
-            failedLoadMetadataDetails)
-          CarbonIndexUtil
-            .LoadToSITable(sparkSession,
-              carbonLoadModel,
-              indexTableName,
-              isLoadToFailedSISegments = true,
-              indexModel,
-              carbonTable, indexTable, false, failedLoadMetadataDetails)
-
-          // get the current load metadata details of the index table
-          // details = SegmentStatusManager.readLoadMetadata(indexTable.getMetadataPath)
-        }
-
-        // get updated main table segments and si table segments
-        val mainTblLoadMetadataDetails: Array[LoadMetadataDetails] =
-          SegmentStatusManager.readLoadMetadata(carbonTable.getMetadataPath)
-        val siTblLoadMetadataDetails: Array[LoadMetadataDetails] =
-          SegmentStatusManager.readLoadMetadata(indexTable.getMetadataPath)
-
-        // check if main table has load in progress and SI table has no load
-        // in progress entry, then no need to enable the SI table
-        // Only if the valid segments of maintable match the valid segments of SI
-        // table then we can enable the SI for query
-        if (CarbonInternalLoaderUtil
-          .checkMainTableSegEqualToSISeg(mainTblLoadMetadataDetails,
-            siTblLoadMetadataDetails)
-          && CarbonInternalLoaderUtil.checkInProgLoadInMainTableAndSI(carbonTable,
-          mainTblLoadMetadataDetails, siTblLoadMetadataDetails)) {
-          // enable the SI table if it was disabled earlier due to failure during SI
-          // creation time
-          sparkSession.sql(
-            s"""ALTER TABLE ${carbonLoadModel.getDatabaseName}.$indexTableName SET
-               |SERDEPROPERTIES ('isSITableEnabled' = 'true')""".stripMargin).collect()
-        }
-      } catch {
-        case ex: Exception =>
-          // in case of SI load only for for failed segments, catch the exception, but
-          // do not fail the main table load, as main table segments should be available
-          // for query
-          LOGGER.error(s"Load to SI table to $indexTableName is failed " +
-            s"or SI table ENABLE is failed. ", ex)
-          Seq.empty
-      } finally {
-        segmentLocks.foreach {
-          segmentLock => segmentLock.unlock()
-        }
-      }
+    } finally {
+      compactionLock.unlock()
     }
     Seq.empty
   }

--- a/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/events/SILoadEventListenerForFailedSegments.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/events/SILoadEventListenerForFailedSegments.scala
@@ -27,7 +27,6 @@ import org.apache.spark.sql.index.CarbonIndexUtil
 
 import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.core.metadata.index.IndexType
-import org.apache.carbondata.core.statusmanager.SegmentStatusManager
 import org.apache.carbondata.core.util.CarbonProperties
 import org.apache.carbondata.events.{Event, OperationContext, OperationEventListener}
 import org.apache.carbondata.processing.loading.events.LoadEvents.LoadTablePostStatusUpdateEvent
@@ -70,13 +69,11 @@ class SILoadEventListenerForFailedSegments extends OperationEventListener with L
               carbonLoadModel.getTableName + " are : " + maxSegmentRepairLimit)
             // if there are no index tables for a given fact table do not perform any action
             if (indexTables.nonEmpty) {
-              val mainTableDetails =
-                SegmentStatusManager.readLoadMetadata(carbonTable.getMetadataPath)
               indexTables.foreach {
                 indexTableName =>
                   CarbonIndexUtil.processSIRepair(indexTableName, carbonTable, carbonLoadModel,
-                    indexMetadata, mainTableDetails.toList, secondaryIndexProvider,
-                    maxSegmentRepairLimit)(sparkSession)
+                    indexMetadata, secondaryIndexProvider,
+                    maxSegmentRepairLimit, isLoadOrCompaction = true)(sparkSession)
               }
             }
           }


### PR DESCRIPTION
 ### Why is this PR needed?
 When Concurrent LOAD and COMPACTION is in progress on main table having SI, SILoadEventListenerForFailedSegments listener is called to repair SI failed segments if any. It will compare SI and main table segment status, if there is a mismatch, then it will add that specific load to failedLoads to be re-loaded again.

During Compaction, SI will be updated first and then maintable. So, in some cases, SI segment will be in compacted state and main table will be in SUCCESS state(the compaction can be still in progress or due to some operation failure). SI index repair will add those segments to failedLoads, by checking if segment lock can be acquired. But, if maintable compaction is finished by the time, SI repair comparison is done, then also, it can acquire segment lock and add those load to failedLoad(even though main table load is COMPACTED). After the concurrent operation is finished, some segments of SI are marked as INSERT_IN_PROGRESS. This will lead to inconsistent state between SI and mainTable segments.
 
 ### What changes were proposed in this PR?
Acquire compaction lock on maintable(to ensure compaction is not running), and then compare SI and main table load details, to repair SI segments.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No (concurrent scenario)

    
