### PR TITLE
[CARBONDATA-3987] Handled filter and IUD operation for pagination reader in SDK

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -2610,4 +2610,6 @@ public final class CarbonCommonConstants {
   @CarbonProperty(dynamicConfigurable = true)
   public static final String CARBON_MAP_ORDER_PUSHDOWN = "carbon.mapOrderPushDown";
 
+  public static final String CARBON_SDK_EMPTY_METADATA_PATH = "emptyMetadataFolder";
+
 }

--- a/sdk/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonIUD.java
+++ b/sdk/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonIUD.java
@@ -33,6 +33,8 @@ import java.util.stream.Stream;
 
 import org.apache.carbondata.common.exceptions.sql.InvalidLoadOptionException;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
+import org.apache.carbondata.core.datastore.filesystem.CarbonFile;
+import org.apache.carbondata.core.datastore.impl.FileFactory;
 import org.apache.carbondata.core.metadata.datatype.DataType;
 import org.apache.carbondata.core.metadata.datatype.Field;
 import org.apache.carbondata.core.scan.expression.ColumnExpression;
@@ -44,6 +46,7 @@ import org.apache.carbondata.core.scan.expression.logical.OrExpression;
 import org.apache.carbondata.hadoop.api.CarbonTableOutputFormat;
 import org.apache.carbondata.hadoop.internal.ObjectArrayWritable;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.mapreduce.RecordWriter;
@@ -121,6 +124,18 @@ public class CarbonIUD {
     for (Map.Entry<String, Map<String, Set<String>>> path : this.filterColumnToValueMappingForDelete
         .entrySet()) {
       deleteExecution(path.getKey());
+      createEmptyMetadataFile(path.getKey());
+    }
+  }
+
+  private void createEmptyMetadataFile(String path) throws IOException {
+    if (!StringUtils.isEmpty(path)) {
+      path = path + CarbonCommonConstants.FILE_SEPARATOR +
+          CarbonCommonConstants.CARBON_SDK_EMPTY_METADATA_PATH;
+      CarbonFile emptySDKDirectory = FileFactory.getCarbonFile(path);
+      if (!emptySDKDirectory.exists()) {
+        emptySDKDirectory.mkdirs();
+      }
     }
   }
 
@@ -199,6 +214,7 @@ public class CarbonIUD {
         .entrySet()) {
       if (this.updateColumnToValueMapping.containsKey(path.getKey())) {
         updateExecution(path.getKey());
+        createEmptyMetadataFile(path.getKey());
       }
     }
   }


### PR DESCRIPTION
 ### Why is this PR needed?
 Currently, SDK pagination reader is not supported for the filter expression and also returning the wrong result after performing IUD operation through SDK.
 
 ### What changes were proposed in this PR?
1. In case of filter present or update/delete operation get the total rows in splits after building the carbon reader else get the row count from the details info of each splits.
2. Handled ArrayIndexOutOfBoundException and return zero in case of `rowCountInSplits.size() == 0`
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
