### PR TITLE
[CARBONDATA-4082] Fix alter table add segment query on adding a segment having delete delta files.

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/util/path/CarbonTablePath.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/path/CarbonTablePath.java
@@ -43,7 +43,7 @@ public class CarbonTablePath {
   private static final String FACT_DIR = "Fact";
   public static final String SEGMENT_PREFIX = "Segment_";
   private static final String PARTITION_PREFIX = "Part";
-  private static final String DATA_PART_PREFIX = "part-";
+  public static final String DATA_PART_PREFIX = "part-";
   public static final String BATCH_PREFIX = "_batchno";
   public static final String TRASH_DIR = ".Trash";
   private static final String LOCK_DIR = "LockFiles";

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonFileInputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonFileInputFormat.java
@@ -293,10 +293,9 @@ public class CarbonFileInputFormat<T> extends CarbonInputFormat<T> implements Se
 
     String expectedDeleteDeltaFileName = null;
     if (segmentFileName != null && !segmentFileName.isEmpty()) {
-      int startIndex = segmentFileName.indexOf(CarbonCommonConstants.HYPHEN);
       int endIndex = segmentFileName.indexOf(CarbonCommonConstants.UNDERSCORE);
-      if (startIndex != -1 && endIndex != -1) {
-        expectedDeleteDeltaFileName = segmentFileName.substring(startIndex + 1, endIndex);
+      if (endIndex != -1) {
+        expectedDeleteDeltaFileName = segmentFileName.substring(0, endIndex);
       }
     }
     String deleteDeltaFullFileName = null;

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonOutputCommitter.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonOutputCommitter.java
@@ -199,7 +199,7 @@ public class CarbonOutputCommitter extends FileOutputCommitter {
           uniqueId = overwritePartitions(loadModel, newMetaEntry, uuid);
         }
       } else {
-        CarbonLoaderUtil.recordNewLoadMetadata(newMetaEntry, loadModel, false, false, uuid);
+        CarbonLoaderUtil.recordNewLoadMetadata(newMetaEntry, loadModel, false, false, uuid, false);
       }
       commitJobFinal(context, loadModel, operationContext, carbonTable, uniqueId);
     } else {
@@ -305,7 +305,7 @@ public class CarbonOutputCommitter extends FileOutputCommitter {
     if (overwriteSet) {
       uniqueId = overwritePartitions(loadModel, newMetaEntry, uuid);
     } else {
-      CarbonLoaderUtil.recordNewLoadMetadata(newMetaEntry, loadModel, false, false, uuid);
+      CarbonLoaderUtil.recordNewLoadMetadata(newMetaEntry, loadModel, false, false, uuid, false);
     }
     if (operationContext != null) {
       operationContext
@@ -342,7 +342,7 @@ public class CarbonOutputCommitter extends FileOutputCommitter {
       // Commit the removed partitions in carbon store.
       CarbonLoaderUtil.recordNewLoadMetadata(newMetaEntry, loadModel, false, false, uuid,
           Segment.toSegmentList(toBeDeletedSegments, null),
-          Segment.toSegmentList(toBeUpdatedSegments, null));
+          Segment.toSegmentList(toBeUpdatedSegments, null), false);
       return uniqueId;
     }
     return null;

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableOutputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableOutputFormat.java
@@ -47,6 +47,7 @@ import org.apache.carbondata.core.util.DataLoadMetrics;
 import org.apache.carbondata.core.util.DataTypeUtil;
 import org.apache.carbondata.core.util.ObjectSerializationUtil;
 import org.apache.carbondata.core.util.ThreadLocalSessionInfo;
+import org.apache.carbondata.core.util.path.CarbonTablePath;
 import org.apache.carbondata.core.writer.CarbonDeleteDeltaWriterImpl;
 import org.apache.carbondata.hadoop.internal.ObjectArrayWritable;
 import org.apache.carbondata.processing.loading.ComplexDelimitersEnum;
@@ -578,7 +579,11 @@ public class CarbonTableOutputFormat extends FileOutputFormat<NullWritable, Obje
           blockName = CarbonUpdateUtil.getBlockName(
               (tuple.split(CarbonCommonConstants.FILE_SEPARATOR)
                       [TupleIdEnum.BLOCK_ID.getTupleIdIndex()]));
-
+          // formatting blockName to create deleteDelta File of same name as created for
+          // transactional tables
+          String[] blockNameSplits = blockName.split(CarbonCommonConstants.UNDERSCORE);
+          blockName = CarbonTablePath.DATA_PART_PREFIX + blockNameSplits[0] +
+                  CarbonTablePath.BATCH_PREFIX + blockNameSplits[1];
           if (!blockToDeleteDeltaBlockMapping.containsKey(blockName)) {
             blockDetails = new DeleteDeltaBlockDetails(blockName);
             blockToDeleteDeltaBlockMapping.put(blockName, blockDetails);

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDataRDDFactory.scala
@@ -740,7 +740,7 @@ object CarbonDataRDDFactory {
         updateModel.get.deletedSegments.asJava)
     }
     done = done && CarbonLoaderUtil.recordNewLoadMetadata(metadataDetails, carbonLoadModel, false,
-      overwriteTable, uuid)
+      overwriteTable, uuid, false)
     if (!done) {
       val errorMessage = s"Dataload failed due to failure in table status updation for" +
                          s" ${carbonLoadModel.getTableName}"

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/mutation/DeleteExecution.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/mutation/DeleteExecution.scala
@@ -399,7 +399,7 @@ object DeleteExecution {
 
     // this is delete flow so no need of putting timestamp in the status file.
     if (CarbonUpdateUtil
-          .updateSegmentStatus(blockUpdateDetailsList, carbonTable, timestamp, false) &&
+          .updateSegmentStatus(blockUpdateDetailsList, carbonTable, timestamp, false, false) &&
         CarbonUpdateUtil
           .updateTableMetadataStatus(segmentDetails,
             carbonTable,

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/mutation/merge/CarbonMergeDataSetCommand.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/mutation/merge/CarbonMergeDataSetCommand.scala
@@ -200,7 +200,7 @@ case class CarbonMergeDataSetCommand(
       FileFactory.deleteAllCarbonFilesOfDir(FileFactory.getCarbonFile(deltaPath))
       if (!CarbonUpdateUtil.updateSegmentStatus(tuple._1.asScala.asJava,
         carbonTable,
-        trxMgr.getLatestTrx.toString, false)) {
+        trxMgr.getLatestTrx.toString, false, false)) {
         LOGGER.error("writing of update status file failed")
         throw new CarbonMergeDataSetException("writing of update status file failed")
       }

--- a/processing/src/main/java/org/apache/carbondata/processing/merger/CarbonDataMergerUtil.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/merger/CarbonDataMergerUtil.java
@@ -1072,7 +1072,7 @@ public final class CarbonDataMergerUtil {
       } else return false;
     }
 
-    CarbonUpdateUtil.updateSegmentStatus(segmentUpdateDetails, table, timestamp, true);
+    CarbonUpdateUtil.updateSegmentStatus(segmentUpdateDetails, table, timestamp, true, false);
 
     // Update the Table Status.
     String metaDataFilepath = table.getMetadataPath();


### PR DESCRIPTION
 ### Why is this PR needed?
When a segment is added to a carbon table by alter table add segment query and that segment also have a deleteDelta file present in it, then on querying the carbon table the deleted rows are coming in the result.
 
 ### What changes were proposed in this PR?
Updating the tableStatus and tableUpdateStatus files in correct way for the segments having delta delta files.

 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
