### PR TITLE
[CARBONDATA-4105] Select * query fails after a SDK written segment is added by alter table add segment query.

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/indexstore/TableBlockIndexUniqueIdentifier.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/TableBlockIndexUniqueIdentifier.java
@@ -45,7 +45,8 @@ public class TableBlockIndexUniqueIdentifier implements Serializable {
     this.indexFileName = indexFileName;
     this.mergeIndexFileName = mergeIndexFileName;
     this.segmentId = segmentId;
-    this.uniqueName = indexFilePath + CarbonCommonConstants.FILE_SEPARATOR + indexFileName;
+    this.uniqueName = segmentId + CarbonCommonConstants.UNDERSCORE +
+        indexFilePath + CarbonCommonConstants.FILE_SEPARATOR + indexFileName;
   }
 
   public TableBlockIndexUniqueIdentifier(String segmentId) {

--- a/integration/spark/src/test/scala/org/apache/carbondata/sql/commands/TestCarbonDropCacheCommand.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/sql/commands/TestCarbonDropCacheCommand.scala
@@ -69,7 +69,7 @@ class TestCarbonDropCacheCommand extends QueryTest with BeforeAndAfterAll {
       .map(_.getColumnId).toArray
 
     // Check if table index entries are dropped
-    assert(droppedCacheKeys.asScala.exists(key => key.startsWith(tablePath)))
+    assert(droppedCacheKeys.asScala.exists(key => key.contains(tablePath)))
 
     // check if cache does not have any more table index entries
     assert(!cacheAfterDrop.asScala.exists(key => key.startsWith(tablePath)))
@@ -113,7 +113,7 @@ class TestCarbonDropCacheCommand extends QueryTest with BeforeAndAfterAll {
                     CarbonCommonConstants.FILE_SEPARATOR
 
     // Check if table index entries are dropped
-    assert(droppedCacheKeys.asScala.exists(key => key.startsWith(tablePath)))
+    assert(droppedCacheKeys.asScala.exists(key => key.contains(tablePath)))
 
     // check if cache does not have any more table index entries
     assert(!cacheAfterDrop.asScala.exists(key => key.startsWith(tablePath)))

--- a/integration/spark/src/test/scala/org/apache/carbondata/sql/commands/TestCarbonShowCacheCommand.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/sql/commands/TestCarbonShowCacheCommand.scala
@@ -244,8 +244,8 @@ class TestCarbonShowCacheCommand extends QueryTest with BeforeAndAfterAll {
       .getCacheMap
       .keySet()
       .asScala
-      .filter(index => index.startsWith(carbonTablePath))
-    assert(result.exists(index => index.startsWith(
+      .filter(index => index.contains(carbonTablePath))
+    assert(result.exists(index => index.contains(
       carbonTablePath + CarbonCommonConstants.FILE_SEPARATOR + "col3=bb")) && result.size == 2)
     assert(showCache(0).get(2).toString.equalsIgnoreCase("2/5 index files cached"))
     checkAnswer(sql("select * from partitionTable where col3='ee'"), Seq(Row(1, "aa", "ee")))
@@ -255,10 +255,10 @@ class TestCarbonShowCacheCommand extends QueryTest with BeforeAndAfterAll {
       .getCacheMap
       .keySet()
       .asScala
-      .filter(index => index.startsWith(carbonTablePath))
+      .filter(index => index.contains(carbonTablePath))
     assert(result.exists(index =>
-      index.startsWith(carbonTablePath + CarbonCommonConstants.FILE_SEPARATOR + "col3=bb") ||
-      index.startsWith(carbonTablePath + CarbonCommonConstants.FILE_SEPARATOR + "col3=ee") &&
+      index.contains(carbonTablePath + CarbonCommonConstants.FILE_SEPARATOR + "col3=bb") ||
+      index.contains(carbonTablePath + CarbonCommonConstants.FILE_SEPARATOR + "col3=ee") &&
       result.size == 3))
     assert(showCache(0).get(2).toString.equalsIgnoreCase("3/5 index files cached"))
     sql("drop table if exists partitionTable")
@@ -284,8 +284,8 @@ class TestCarbonShowCacheCommand extends QueryTest with BeforeAndAfterAll {
       .getCacheMap
       .keySet()
       .asScala
-      .filter(index => index.startsWith(carbonTablePath))
-    assert(result.exists(index => index.startsWith(
+      .filter(index => index.contains(carbonTablePath))
+    assert(result.exists(index => index.contains(
       carbonTablePath + CarbonCommonConstants.FILE_SEPARATOR + "col3=bb/col4=cc")) &&
            result.size == 1)
     assert(showCache(0).get(2).toString.equalsIgnoreCase("1/5 index files cached"))
@@ -297,11 +297,11 @@ class TestCarbonShowCacheCommand extends QueryTest with BeforeAndAfterAll {
       .getCacheMap
       .keySet()
       .asScala
-      .filter(index => index.startsWith(carbonTablePath))
+      .filter(index => index.contains(carbonTablePath))
     assert(result.exists(
-      index => index.startsWith(
+      index => index.contains(
         carbonTablePath + CarbonCommonConstants.FILE_SEPARATOR + "col3=bb/col4=cc") ||
-               index.startsWith(carbonTablePath + CarbonCommonConstants.FILE_SEPARATOR +
+               index.contains(carbonTablePath + CarbonCommonConstants.FILE_SEPARATOR +
                                 "col3=bb/col4=gg")) &&
            result.size == 2)
     assert(showCache(0).get(2).toString.equalsIgnoreCase("2/5 index files cached"))
@@ -328,8 +328,8 @@ class TestCarbonShowCacheCommand extends QueryTest with BeforeAndAfterAll {
       .getCacheMap
       .keySet()
       .asScala
-      .filter(index => index.startsWith(carbonTablePath))
-    assert(result.exists(index => index.startsWith(
+      .filter(index => index.contains(carbonTablePath))
+    assert(result.exists(index => index.contains(
       carbonTablePath + CarbonCommonConstants.FILE_SEPARATOR + "col3=bb")) && result.size == 2)
     assert(showCache(0).get(2).toString.equalsIgnoreCase("2/5 index files cached"))
     sql("select * from partitionTable").collect()

--- a/integration/spark/src/test/scala/org/apache/carbondata/view/rewrite/TestAllOperationsOnMV.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/view/rewrite/TestAllOperationsOnMV.scala
@@ -726,13 +726,13 @@ class TestAllOperationsOnMV extends QueryTest with BeforeAndAfterEach {
                  "dm" + CarbonCommonConstants.FILE_SEPARATOR
 
     // Check if table index entries are dropped
-    assert(droppedCacheKeys.asScala.exists(key => key.startsWith(tablePath)))
+    assert(droppedCacheKeys.asScala.exists(key => key.contains(tablePath)))
 
     // check if cache does not have any more table index entries
     assert(!cacheAfterDrop.asScala.exists(key => key.startsWith(tablePath)))
 
     // Check if mv index entries are dropped
-    assert(droppedCacheKeys.asScala.exists(key => key.startsWith(mvPath)))
+    assert(droppedCacheKeys.asScala.exists(key => key.contains(mvPath)))
 
     // check if cache does not have any more mv index entries
     assert(!cacheAfterDrop.asScala.exists(key => key.startsWith(mvPath)))


### PR DESCRIPTION
 ### Why is this PR needed?
When a SDK written segment on which read is already performed once, is added through alter table add segment query to a carbon table, then select * query fails after adding it.

In SDK segments the segmentId is the timestamp of the segment. When the SDK segment is read before adding, its indexes are stored in cache. Cache is a map of indexFilePath to Indexes. Now when the same segment is added to carbon table its segment ID is no longer the timestamp but the indexFilePath remains same as it is added externally. Now when we run select * query we get the indexes from the cache, but it is unable to map it to segment, because segment id changes.
 
 ### What changes were proposed in this PR?
Also added segment Id to the key of cache map to make it more unique.

 ### Does this PR introduce any user interface change?
-No

 ### Is any new testcase added?
 - Yes

    
