### PR TITLE
[CARBONDATA-4107] Added related MV tables Map to fact table and added lock while touchMDTFile

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -1223,6 +1223,11 @@ public final class CarbonCommonConstants {
   public static final String CARBON_ENABLE_MV_DEFAULT = "true";
 
   /**
+   * Related mv table's map for a fact table
+   */
+  public static final String RELATED_MV_TABLES_MAP = "relatedmvtablesmap";
+
+  /**
    * ENABLE_QUERY_STATISTICS
    */
   @CarbonProperty

--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/CarbonTable.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/CarbonTable.java
@@ -68,6 +68,7 @@ import org.apache.carbondata.core.util.path.CarbonTablePath;
 import static org.apache.carbondata.core.util.CarbonUtil.thriftColumnSchemaToWrapperColumnSchema;
 
 import com.google.common.collect.Lists;
+import com.google.gson.Gson;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Writable;
 import org.apache.log4j.Logger;
@@ -1244,6 +1245,15 @@ public class CarbonTable implements Serializable, Writable {
       parentTableName = indexMetadata.getParentTableName();
     }
     return parentTableName;
+  }
+
+  public Map<String, List<String>> getMVTablesMap() {
+    String relatedMVDB = this.getTableInfo().getFactTable().getTableProperties()
+        .get(CarbonCommonConstants.RELATED_MV_TABLES_MAP);
+    if (null == relatedMVDB) {
+      return new HashMap<>();
+    }
+    return new Gson().fromJson(relatedMVDB, Map.class);
   }
 
   /**

--- a/docs/mv-guide.md
+++ b/docs/mv-guide.md
@@ -241,6 +241,12 @@ The current information includes:
  | Refresh Mode          | FULL / INCREMENTAL refresh to MV                          |
  | Refresh Trigger Mode  | ON_COMMIT / ON_MANUAL refresh to MV provided by user |
  | Properties              | Table properties of the materialized view                       |
+
+**NOTE**: For materialized views created
+before [CARBONDATA-4107](https://issues.apache.org/jira/browse/CARBONDATA-4107) issue fix, run
+refresh mv command to add mv name to fact table's table properties and to enable it. If refresh
+command is not executed, the mv and fact tables may not be in sync and query won't use mv for
+pruning.
   
 ## Time Series Support
 

--- a/integration/spark/src/main/scala/org/apache/carbondata/view/MVManagerInSpark.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/view/MVManagerInSpark.scala
@@ -66,6 +66,9 @@ object MVManagerInSpark {
     }
     val viewManager = MVManagerInSpark.get(sparkSession)
     val viewSchemas = new util.ArrayList[MVSchema]()
+    if (!viewManager.hasSchemaOnTable(carbonTable)) {
+      return
+    }
     for (viewSchema <- viewManager.getSchemasOnTable(carbonTable).asScala) {
       if (viewSchema.isRefreshOnManual) {
         viewSchemas.add(viewSchema)

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonDropTableCommand.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonDropTableCommand.scala
@@ -110,7 +110,8 @@ case class CarbonDropTableCommand(
               Option(schema.getIdentifier.getDatabaseName),
               schema.getIdentifier.getTableName,
               ifExistsSet = true,
-              forceDrop = true
+              forceDrop = true,
+              isLockAcquiredOnFactTable = carbonTable.getTableName
             )
         }
         viewDropCommands.foreach(_.processMetadata(sparkSession))

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/view/CarbonCreateMVCommand.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/view/CarbonCreateMVCommand.scala
@@ -99,6 +99,9 @@ case class CarbonCreateMVCommand(
     val viewCatalog = MVManagerInSpark.getOrReloadMVCatalog(session)
     val schema = doCreate(session, identifier, viewManager, viewCatalog)
 
+    // Update the related mv tables property to mv fact tables
+    MVHelper.addOrModifyMVTablesMap(session, schema)
+
     try {
       viewCatalog.registerSchema(schema)
       if (schema.isRefreshOnManual) {

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/view/CarbonRefreshMVCommand.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/view/CarbonRefreshMVCommand.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.execution.command.DataCommand
 import org.apache.carbondata.common.exceptions.sql.{MalformedMVCommandException, NoSuchMVException}
 import org.apache.carbondata.core.view.MVStatus
 import org.apache.carbondata.events.{OperationContext, OperationListenerBus}
-import org.apache.carbondata.view.{MVManagerInSpark, MVRefresher, RefreshMVPostExecutionEvent, RefreshMVPreExecutionEvent}
+import org.apache.carbondata.view.{MVHelper, MVManagerInSpark, MVRefresher, RefreshMVPostExecutionEvent, RefreshMVPreExecutionEvent}
 
 /**
  * Refresh Materialized View Command implementation
@@ -46,6 +46,10 @@ case class CarbonRefreshMVCommand(
         throw new MalformedMVCommandException(
           s"Materialized view ${ databaseName }.${ mvName } does not exist")
     }
+
+    // refresh table property of parent table if needed
+    MVHelper.addOrModifyMVTablesMap(session, schema, isRefreshMV = true)
+
     val table = CarbonEnv.getCarbonTable(Option(databaseName), mvName)(session)
     setAuditTable(table)
 


### PR DESCRIPTION
 ### Why is this PR needed?

 1. After MV support multi-tenancy PR, mv system folder is moved to database level. Hence, during each operation, insert/Load/IUD/show mv/query, we are listing all the databases in the system and collecting mv schemas and checking if there is any mv mapped to the table or not. This will degrade performance of the query, to collect mv schemas from all databases, even though the table has mv or not.
 
 2. When different jvm process call touchMDTFile method, file creation and deletion can happen same time. This may fail the operation.
 
 ### What changes were proposed in this PR?

1. Added a table property **relatedMVTablesMap** to fact tables of MV during MV creation. During any operation, check if the table has MV or not using the added property and if it has, then collect schemas of only related databases. In this way, we can avoid collecting mv schemas for table which dont have MV.

2. Take a Global level lock on system folder location, to update last modified time.

**NOTE:** For compatibilty scenarios, can perform refresh MV operation to update these table properties.
    
 ### Does this PR introduce any user interface change?
 - Yes. 
 For compatibilty scenarios, can perform refresh MV operation to update these table properties.

 ### Is any new testcase added?
 - No

    
