### PR TITLE
[CARBONDATA-4111] Filter query having invalid results after add segment to table having SI with Indexserver

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/index/Segment.java
+++ b/core/src/main/java/org/apache/carbondata/core/index/Segment.java
@@ -79,7 +79,7 @@ public class Segment implements Serializable, Writable {
   /**
    * Path of segment where it exists
    */
-  private transient String segmentPath;
+  private String segmentPath;
 
   /**
    * Properties of the segment.
@@ -162,6 +162,7 @@ public class Segment implements Serializable, Writable {
     this.segmentFileName = segmentFileName;
     this.readCommittedScope = readCommittedScope;
     this.loadMetadataDetails = loadMetadataDetails;
+    this.segmentPath = loadMetadataDetails.getPath();
     if (loadMetadataDetails.getIndexSize() != null) {
       this.indexSize = Long.parseLong(loadMetadataDetails.getIndexSize());
     }
@@ -377,6 +378,12 @@ public class Segment implements Serializable, Writable {
       out.writeUTF(segmentString);
     }
     out.writeLong(indexSize);
+    if (segmentPath == null) {
+      out.writeBoolean(false);
+    } else {
+      out.writeBoolean(true);
+      out.writeUTF(segmentPath);
+    }
   }
 
   @Override
@@ -394,6 +401,9 @@ public class Segment implements Serializable, Writable {
       this.segmentString = in.readUTF();
     }
     this.indexSize = in.readLong();
+    if (in.readBoolean()) {
+      this.segmentPath = in.readUTF();
+    }
   }
 
   public SegmentMetaDataInfo getSegmentMetaDataInfo() {

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/ExtendedBlocklet.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/ExtendedBlocklet.java
@@ -25,6 +25,8 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.carbondata.core.datastore.filesystem.LocalCarbonFile;
+import org.apache.carbondata.core.datastore.impl.FileFactory;
 import org.apache.carbondata.core.index.Segment;
 import org.apache.carbondata.core.indexstore.blockletindex.BlockletIndexRowIndexes;
 import org.apache.carbondata.core.indexstore.row.IndexRow;
@@ -221,7 +223,18 @@ public class ExtendedBlocklet extends Blocklet {
       indexUniqueId = in.readUTF();
     }
     String filePath = getPath();
-    if (filePath.startsWith(File.separator)) {
+    boolean isLocalFile = FileFactory.getCarbonFile(filePath) instanceof LocalCarbonFile;
+
+    // For external segment, table path need not be appended to filePath as contains has full path
+    // Example filepath for ext segment:
+    //  1. /home/user/carbondata/integration/spark/newsegmentpath
+    //  2. hdfs://hacluster/opt/newsegmentpath/
+    // Example filepath for loaded segment: /Fact/Part/Segment0
+    // To identify a filePath as ext segment path,
+    // for other storage systems (hdfs,s3): filePath doesn't start with File separator.
+    // for ubuntu storage: it starts with File separator, so check if given path exists or not.
+    if ((!isLocalFile && filePath.startsWith(File.separator)) || (isLocalFile && !FileFactory
+        .isFileExist(filePath))) {
       setFilePath(tablePath + filePath);
     } else {
       setFilePath(filePath);

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/SegmentWrapperContainer.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/SegmentWrapperContainer.java
@@ -31,6 +31,9 @@ public class SegmentWrapperContainer implements Writable {
 
   private SegmentWrapper[] segmentWrappers;
 
+  public SegmentWrapperContainer() {
+  }
+
   public SegmentWrapperContainer(SegmentWrapper[] segmentWrappers) {
     this.segmentWrappers = segmentWrappers;
   }

--- a/integration/spark/src/main/java/org/apache/spark/sql/secondaryindex/load/CarbonInternalLoaderUtil.java
+++ b/integration/spark/src/main/java/org/apache/spark/sql/secondaryindex/load/CarbonInternalLoaderUtil.java
@@ -51,7 +51,8 @@ public class CarbonInternalLoaderUtil {
   public static List<String> getListOfValidSlices(LoadMetadataDetails[] details) {
     List<String> activeSlices = new ArrayList<>(CarbonCommonConstants.DEFAULT_COLLECTION_SIZE);
     for (LoadMetadataDetails oneLoad : details) {
-      if (SegmentStatus.SUCCESS.equals(oneLoad.getSegmentStatus())
+      // External added segments are not loaded to SI
+      if (oneLoad.getPath() == null && SegmentStatus.SUCCESS.equals(oneLoad.getSegmentStatus())
           || SegmentStatus.LOAD_PARTIAL_SUCCESS.equals(oneLoad.getSegmentStatus())
           || SegmentStatus.MARKED_FOR_UPDATE.equals(oneLoad.getSegmentStatus())) {
         activeSlices.add(oneLoad.getLoadName());

--- a/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/events/SILoadEventListenerForFailedSegments.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/events/SILoadEventListenerForFailedSegments.scala
@@ -48,6 +48,11 @@ class SILoadEventListenerForFailedSegments extends OperationEventListener with L
           val loadTablePostStatusUpdateEvent = event.asInstanceOf[LoadTablePostStatusUpdateEvent]
           val carbonLoadModel = loadTablePostStatusUpdateEvent.getCarbonLoadModel
           val sparkSession = SparkSession.getActiveSession.get
+          // Avoid loading segment to SI for add load command
+          if (operationContext.getProperty("isAddLoad") != null &&
+            operationContext.getProperty("isAddLoad").toString.toBoolean) {
+            return
+          }
           if (CarbonProperties.getInstance().isSIRepairEnabled(carbonLoadModel.getDatabaseName,
             carbonLoadModel.getTableName)) {
           // when Si creation and load to main table are parallel, get the carbonTable from the


### PR DESCRIPTION
 ### Why is this PR needed?
When the index server is enabled, filter query on SI column after alter table add sdk segment to maintable throws `NoSuchMethodException`  and the rows added by sdk segment are not returned in the result.
 
 ### What changes were proposed in this PR?
Added segment path in index server flow, as it is used to identify external segment in filter resolver step. 
No need to load to SI, if it is an add load command.
Default constructor for `SegmentWrapperContainer` declared.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No

    
