### PR TITLE
[WIP]Secondary Index based pruning without spark query plan modification

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -2311,6 +2311,11 @@ public final class CarbonCommonConstants {
   @CarbonProperty(dynamicConfigurable = true)
   public static final String CARBON_ENABLE_INDEX_SERVER = "carbon.enable.index.server";
 
+  @CarbonProperty(dynamicConfigurable = true)
+  public static final String CARBON_SI_REWRITE_PLAN = "carbon.si.rewrite.plan";
+
+  public static final String CARBON_SI_REWRITE_PLAN_DEFAULT = "true";
+
   /**
    * Configured property to enable/disable prepriming in index server
    */

--- a/core/src/main/java/org/apache/carbondata/core/datastore/row/CarbonRow.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/row/CarbonRow.java
@@ -93,4 +93,17 @@ public class CarbonRow implements Serializable {
   public void clearData() {
     this.data = null;
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    CarbonRow carbonRow = (CarbonRow) o;
+    return Arrays.equals(data, carbonRow.data);
+  }
+
+  @Override
+  public int hashCode() {
+    return Arrays.hashCode(data);
+  }
 }

--- a/core/src/main/java/org/apache/carbondata/core/index/dev/secondaryindex/SIExpressionTree.java
+++ b/core/src/main/java/org/apache/carbondata/core/index/dev/secondaryindex/SIExpressionTree.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.core.index.dev.secondaryindex;
+
+import java.io.Serializable;
+
+import org.apache.carbondata.core.scan.expression.Expression;
+
+public class SIExpressionTree {
+
+  public interface CarbonSIExpression extends Serializable {
+  }
+
+  public static class CarbonSIBinaryExpression implements CarbonSIExpression {
+    public NodeType nodeType;
+    public CarbonSIExpression leftSIExpression;
+    public CarbonSIExpression rightSIExpression;
+
+    public CarbonSIBinaryExpression(NodeType nodeType, CarbonSIExpression leftSIExpression,
+        CarbonSIExpression righSIExpression) {
+      this.nodeType = nodeType;
+      this.leftSIExpression = leftSIExpression;
+      this.rightSIExpression = righSIExpression;
+    }
+  }
+
+  public static class CarbonSIUnaryExpression implements CarbonSIExpression {
+    public String tableName;
+    public Expression expression;
+
+    public CarbonSIUnaryExpression(String tableName, Expression expression) {
+      this.tableName = tableName;
+      this.expression = expression;
+    }
+  }
+
+  public enum NodeType {
+    Or, And
+  }
+}

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
@@ -279,6 +279,7 @@ public final class CarbonProperties {
     validateIndexServerSerializationThreshold();
     validateAndGetLocalDictionarySizeThresholdInMB();
     validateTrashFolderRetentionTime();
+    validateSIRewritePlan();
   }
 
   /**
@@ -2185,6 +2186,34 @@ public final class CarbonProperties {
         getInstance().getProperty(CarbonCommonConstants.CARBON_REORDER_FILTER,
         CarbonCommonConstants.CARBON_REORDER_FILTER_DEFAULT)
     );
+  }
+
+  /**
+   * Check whether SI rewrite plan is enabled or not
+   */
+  public boolean isEnabledSIRewritePlan(String dbName, String tableName) {
+    String configuredValue = getSessionPropertyValue(
+        CarbonCommonConstants.CARBON_SI_REWRITE_PLAN + "." + dbName + "." + tableName);
+    if (configuredValue == null) {
+      configuredValue = getProperty(CarbonCommonConstants.CARBON_SI_REWRITE_PLAN);
+    }
+    boolean isEnabledSIRewrite = Boolean.parseBoolean(configuredValue);
+    if (isEnabledSIRewrite) {
+      LOGGER.info("SI Rewrite Plan is enabled for " + dbName + "." + tableName);
+    }
+    return isEnabledSIRewrite;
+  }
+
+  private void validateSIRewritePlan() {
+    String configuredValue =
+        carbonProperties.getProperty(CarbonCommonConstants.CARBON_SI_REWRITE_PLAN);
+    if (!CarbonUtil.validateBoolean(configuredValue)) {
+      LOGGER.warn(String.format("The secondary index rewrite plan value \"%s\" is invalid. "
+              + "Using the default value \"%s\"", configuredValue,
+          CarbonCommonConstants.CARBON_SI_REWRITE_PLAN_DEFAULT));
+      carbonProperties.setProperty(CarbonCommonConstants.CARBON_SI_REWRITE_PLAN,
+          CarbonCommonConstants.CARBON_SI_REWRITE_PLAN_DEFAULT);
+    }
   }
 
   /**

--- a/core/src/main/java/org/apache/carbondata/core/util/SessionParams.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/SessionParams.java
@@ -144,6 +144,7 @@ public class SessionParams implements Serializable, Cloneable {
       case CARBON_ENABLE_INDEX_SERVER:
       case CARBON_QUERY_STAGE_INPUT:
       case CARBON_ENABLE_MV:
+      case CARBON_SI_REWRITE_PLAN:
         isValid = CarbonUtil.validateBoolean(value);
         if (!isValid) {
           throw new InvalidConfigurationException("Invalid value " + value + " for key " + key);

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonInputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonInputFormat.java
@@ -211,6 +211,11 @@ public abstract class CarbonInputFormat<T> extends FileInputFormat<Void, T> {
     configuration.set(CARBON_TRANSACTIONAL_TABLE, String.valueOf(isTransactionalTable));
   }
 
+  public static void setIndexTablesScanTree(Configuration configuration,
+      String indexTablesScanTree) {
+    configuration.set(IndexUtil.CARBON_INDEX_TABLES_SCAN_TREE, indexTablesScanTree);
+  }
+
   /**
    * It sets unresolved filter expression.
    */

--- a/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/TestBroadCastSIFilterPushJoinWithUDF.scala
+++ b/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/TestBroadCastSIFilterPushJoinWithUDF.scala
@@ -388,33 +388,21 @@ class TestBroadCastSIFilterPushJoinWithUDF extends QueryTest with BeforeAndAfter
   test("test udf on filter - concat") {
     carbonQuery = sql("select concat_ws(deptname)from udfValidation where concat_ws(deptname) IS NOT NULL or concat_ws(deptname) is null")
     hiveQuery = sql("select concat_ws(deptname)from udfHive where concat_ws(deptname) IS NOT NULL or concat_ws(deptname) is null")
-    if (isFilterPushedDownToSI(carbonQuery.queryExecution.executedPlan)) {
-      assert(true)
-    } else {
-      assert(false)
-    }
+    assert(!isFilterPushedDownToSI(carbonQuery.queryExecution.executedPlan))
     checkAnswer(carbonQuery, hiveQuery)
   }
 
   test("test udf on filter - find_in_set") {
     carbonQuery = sql("select find_in_set(deptname,'o')from udfValidation where find_in_set(deptname,'o') =0 or find_in_set(deptname,'a') is null")
     hiveQuery = sql("select find_in_set(deptname,'o')from udfHive where find_in_set(deptname,'o') =0 or find_in_set(deptname,'a') is null")
-    if (isFilterPushedDownToSI(carbonQuery.queryExecution.executedPlan)) {
-      assert(true)
-    } else {
-      assert(false)
-    }
+    assert(!isFilterPushedDownToSI(carbonQuery.queryExecution.executedPlan))
     checkAnswer(carbonQuery, hiveQuery)
   }
 
   test("test udf on filter - agg") {
     carbonQuery = sql("select max(length(deptname)),min(length(designation)),avg(length(empname)),count(length(empname)),sum(length(deptname)),variance(length(designation)) from udfValidation where length(empname)=6 or length(empname) is NULL")
     hiveQuery = sql("select max(length(deptname)),min(length(designation)),avg(length(empname)),count(length(empname)),sum(length(deptname)),variance(length(designation)) from udfHive where length(empname)=6 or length(empname) is NULL")
-    if (isFilterPushedDownToSI(carbonQuery.queryExecution.executedPlan)) {
-      assert(true)
-    } else {
-      assert(false)
-    }
+    assert(!isFilterPushedDownToSI(carbonQuery.queryExecution.executedPlan))
     checkAnswer(carbonQuery, hiveQuery)
   }
 

--- a/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/TestNIQueryWithIndex.scala
+++ b/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/TestNIQueryWithIndex.scala
@@ -148,16 +148,15 @@ class TestNIQueryWithIndex extends QueryTest with BeforeAndAfterAll{
       sql("set carbon.si.lookup.partialstring=true")
       val ch21 = sql("select * from seccust where c_phone like '25%989-741-2988'")
       // startsWith & endsWith so SI -yes
-      assert(checkSIColumnsSize(ch21, 3)) // size = length, startsWith and EndsWith
+      assert(checkSIColumnsSize(ch21, 2)) // size = startsWith and EndsWith
 
       val ch22 = sql("select count(*) from seccust where c_phone like '%989-741-2988'")
       // endsWith so, SI - Yes
       assert(checkSIColumnsSize(ch22, 1)) // size = EndsWith
 
       val ch23 = sql("select count(*) from seccust where c_phone like '25%989-741%2988'")
-      // Query startsWith & Contains & endsWith so SI - Yes (his is combined with Like, hence SI
-      // - YES)
-      assert(checkSIColumnsSize(ch23, 1))
+      // Like so, SI - No
+      assert(!isIndexTablePresent(ch23))
 
       val ch24 = sql("select * from seccust where c_phone='25-989-741-2988'")
       // Query has EqualTo - So SI = Yes
@@ -174,14 +173,14 @@ class TestNIQueryWithIndex extends QueryTest with BeforeAndAfterAll{
     try {
       sql("set carbon.si.lookup.partialstring=false")
       val ch11 = sql("select count(*) from seccust where c_phone like '25%989-741-2988'")
-      assert(checkSIColumnsSize(ch11, 2)) // pushed filter = length, startsWith
+      assert(checkSIColumnsSize(ch11, 1)) // pushed filter = startsWith
 
       val ch12 = sql("select count(*) from seccust where c_phone like '%989-741-2988'")
       // endsWith so SI - No
       assert(!isIndexTablePresent(ch12))
 
-      val ch13 = sql("select count(*) from seccust where c_phone like '25%989-741%2988'") //
-      // startsWith & Contains & endsWith so SI - Yes But this is combined with Like So--NO
+      val ch13 = sql("select count(*) from seccust where c_phone like '25%989-741%2988'")
+      // Like so SI - No
       assert(!isIndexTablePresent(ch13))
 
       val ch14 = sql("select count(*) from seccust where c_phone='25-989-741-2988' and c_mktsegment like '%BUILDING'")
@@ -190,7 +189,7 @@ class TestNIQueryWithIndex extends QueryTest with BeforeAndAfterAll{
 
       val ch15 = sql("select count(*) from seccust where c_phone='25-989-741-2988' and c_mktsegment like 'BUI%LDING'")
       // equals on c_phone of I1, I2 & (length & startsWith & endswith) on c_mktsegment of I2 so SI - Yes
-      assert(checkSIColumnsSize(ch15, 3)) // size = EqualTo on c_phone, length, StartsWith
+      assert(checkSIColumnsSize(ch15, 2)) // size = EqualTo on c_phone, StartsWith
 
       val ch16 = sql("select * from seccust where c_phone='25-989-741-2988'")
       // Query has EqualTo so SI - Yes

--- a/integration/spark/src/main/scala/org/apache/carbondata/indexserver/DistributedRDDUtils.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/indexserver/DistributedRDDUtils.scala
@@ -16,25 +16,38 @@
  */
 package org.apache.carbondata.indexserver
 
+import java.util
 import java.util.concurrent.ConcurrentHashMap
 
 import scala.collection.JavaConverters._
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.mapreduce.InputSplit
-import org.apache.spark.Partition
+import org.apache.spark.{CarbonInputMetrics, Partition}
+import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.util.SparkSQLUtil
 
 import org.apache.carbondata.common.logging.LogServiceFactory
-import org.apache.carbondata.core.index.{IndexInputSplit, IndexStoreManager, Segment}
+import org.apache.carbondata.core.constants.CarbonCommonConstants
+import org.apache.carbondata.core.datastore.row.CarbonRow
+import org.apache.carbondata.core.index.{IndexFilter, IndexInputFormat, IndexInputSplit, IndexStoreManager, Segment}
 import org.apache.carbondata.core.index.dev.expr.IndexInputSplitWrapper
+import org.apache.carbondata.core.index.dev.secondaryindex.SIExpressionTree.{CarbonSIBinaryExpression, CarbonSIExpression, CarbonSIUnaryExpression, NodeType}
 import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier
+import org.apache.carbondata.core.metadata.datatype.DataTypes
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable
 import org.apache.carbondata.core.readcommitter.{LatestFilesReadCommittedScope, TableStatusReadCommittedScope}
+import org.apache.carbondata.core.scan.expression.ColumnExpression
+import org.apache.carbondata.core.scan.expression.conditional.{ImplicitExpression, InExpression}
+import org.apache.carbondata.core.scan.expression.logical.AndExpression
 import org.apache.carbondata.core.statusmanager.SegmentUpdateStatusManager
 import org.apache.carbondata.core.util.CarbonProperties
 import org.apache.carbondata.events.{IndexServerLoadEvent, OperationContext, OperationListenerBus}
+import org.apache.carbondata.hadoop.CarbonProjection
 import org.apache.carbondata.hadoop.util.CarbonInputFormatUtil
+import org.apache.carbondata.spark.rdd.CarbonScanRDD
+import org.apache.carbondata.store.CarbonRowReadSupport
 
 object DistributedRDDUtils {
   private val LOGGER = LogServiceFactory.getLogService(this.getClass.getCanonicalName)
@@ -167,6 +180,71 @@ object DistributedRDDUtils {
   def invalidateTableMapping(tableUniqueName: String): Unit = {
     synchronized {
       tableToExecutorMapping.remove(tableUniqueName)
+    }
+  }
+
+  def traverseSIExpressionTree(expressionTree: CarbonSIExpression,
+      warehousePath: String,
+      database: String): RDD[CarbonRow] = {
+    expressionTree match {
+      case binaryExpression: CarbonSIBinaryExpression =>
+        val left: RDD[CarbonRow] = traverseSIExpressionTree(binaryExpression
+          .leftSIExpression, warehousePath, database)
+        val right: RDD[CarbonRow] = traverseSIExpressionTree(binaryExpression
+          .rightSIExpression, warehousePath, database)
+        if (binaryExpression.nodeType == NodeType.And) {
+          left.intersection(right)
+        } else {
+          left.union(right)
+        }
+      case unaryExpression: CarbonSIUnaryExpression =>
+        val indexTable = IndexStoreManager.getInstance
+          .getCarbonTable(AbsoluteTableIdentifier.from(
+            warehousePath + '/' + unaryExpression.tableName, database, unaryExpression.tableName))
+        LOGGER.info(s"Selected SI table - ${ indexTable.getTableName }")
+        new CarbonScanRDD[CarbonRow](SparkSQLUtil.getSparkSession,
+          new CarbonProjection(Array(CarbonCommonConstants.POSITION_REFERENCE)),
+          new IndexFilter(indexTable, unaryExpression.expression),
+          indexTable.getAbsoluteTableIdentifier,
+          indexTable.getTableInfo.serialize,
+          indexTable.getTableInfo,
+          new CarbonInputMetrics,
+          null,
+          null,
+          classOf[CarbonRowReadSupport])
+      case _ => null
+    }
+  }
+
+  def pruneWithSITables(request: IndexInputFormat): Unit = {
+    val carbonTable = request.getCarbonTable
+    val warehousePath = carbonTable.getTablePath
+      .substring(0, carbonTable.getTablePath.lastIndexOf('/'))
+    val finalRdd = traverseSIExpressionTree(request.getIndexTablesScanTree,
+      warehousePath,
+      carbonTable.getCarbonTableIdentifier.getDatabaseName)
+    if (finalRdd != null) {
+      val rows = finalRdd.collect()
+      if (!rows.isEmpty) {
+        // Append the positionId to filter
+        val blockIdToBlockletMap: java.util.Map[java.lang.String, java.util.Set[java.lang
+        .Integer]] = new util.HashMap()
+        rows.map(row => {
+          val blockletPath = row.getString(0)
+          val blockletIdIndex = blockletPath.lastIndexOf('/')
+          val blockPath = blockletPath.substring(0, blockletIdIndex)
+          val blocketIdSet = blockIdToBlockletMap.getOrDefault(blockPath, new util.HashSet())
+          blocketIdSet.add(blockletPath.substring(blockletIdIndex + 1).toInt)
+          blockIdToBlockletMap.put(blockPath, blocketIdSet)
+        })
+        LOGGER.info(s"Added implicit expression. BlockIdToBlockletMap size - ${
+          blockIdToBlockletMap.size()
+        }")
+        val modExp = new AndExpression(request.getFilterResolverIntf.getFilterExpression,
+          new InExpression(new ColumnExpression(CarbonCommonConstants.POSITION_ID,
+            DataTypes.STRING), new ImplicitExpression(blockIdToBlockletMap)))
+        request.setFilterResolverIntf(new IndexFilter(request.getCarbonTable, modExp).getResolver)
+      }
     }
   }
 

--- a/integration/spark/src/main/scala/org/apache/carbondata/indexserver/IndexServer.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/indexserver/IndexServer.scala
@@ -175,6 +175,7 @@ object IndexServer extends ServerInterface {
           .invalidateSegmentMapping(request.getCarbonTable.getTableUniqueName,
             request.getInvalidSegments.asScala)
       }
+      DistributedRDDUtils.pruneWithSITables(request)
       val splits = new DistributedPruneRDD(sparkSession, request).collect()
       if (!request.isFallbackJob) {
         DistributedRDDUtils.updateExecutorCacheSize(splits.map(_._1).toSet)
@@ -262,8 +263,6 @@ object IndexServer extends ServerInterface {
           server.stop()
         }
       })
-      CarbonProperties.getInstance().addProperty(CarbonCommonConstants
-        .CARBON_ENABLE_INDEX_SERVER, "true")
       CarbonProperties.getInstance().addNonSerializableProperty(CarbonCommonConstants
         .IS_DRIVER_INSTANCE, "true")
       // when restart index service clean the tmp folder

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
@@ -45,6 +45,7 @@ import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.datastore.block.Distributable
 import org.apache.carbondata.core.datastore.impl.FileFactory
 import org.apache.carbondata.core.index.{IndexFilter, Segment}
+import org.apache.carbondata.core.index.dev.secondaryindex.SIExpressionTree.CarbonSIExpression
 import org.apache.carbondata.core.indexstore.PartitionSpec
 import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier
 import org.apache.carbondata.core.metadata.schema.table.{CarbonTable, TableInfo}
@@ -83,7 +84,8 @@ class CarbonScanRDD[T: ClassTag](
     @transient val partitionNames: Seq[PartitionSpec],
     val dataTypeConverterClz: Class[_ <: DataTypeConverter] = classOf[SparkDataTypeConverterImpl],
     val readSupportClz: Class[_ <: CarbonReadSupport[_]] = SparkReadSupport.readSupportClass,
-    @transient var splits: java.util.List[InputSplit] = null)
+    @transient var splits: java.util.List[InputSplit] = null,
+    val indexTablesScanTree: CarbonSIExpression = null)
   extends CarbonRDDWithTableInfo[T](spark, Nil, serializedTableInfo) {
 
   private val queryId = sparkContext.getConf.get("queryId", System.nanoTime() + "")
@@ -621,6 +623,8 @@ class CarbonScanRDD[T: ClassTag](
     }
 
     CarbonInputFormat.setTransactionalTable(conf, tableInfo.isTransactionalTable)
+    CarbonInputFormat.setIndexTablesScanTree(conf,
+      ObjectSerializationUtil.convertObjectToString(indexTablesScanTree))
     createInputFormat(conf)
   }
 

--- a/integration/spark/src/main/scala/org/apache/spark/sql/index/CarbonIndexUtil.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/index/CarbonIndexUtil.scala
@@ -125,10 +125,9 @@ object CarbonIndexUtil {
     indexesTables
   }
 
-  def getSecondaryIndexes(relation: CarbonDatasourceHadoopRelation): scala.collection.mutable
+  def getSecondaryIndexesMap(carbonTable: CarbonTable): scala.collection.mutable
   .Map[String, Array[String]] = {
     val indexes = scala.collection.mutable.Map[String, Array[String]]()
-    val carbonTable = relation.carbonRelation.carbonTable
     val indexInfo = carbonTable.getIndexInfo(IndexType.SI.getIndexProviderName)
     if (null != indexInfo) {
       IndexTableInfo.fromGson(indexInfo).foreach { indexTableInfo =>


### PR DESCRIPTION
 ### Why is this PR needed?
This PR is to enable Carbon to make use of secondary indexes without plan rewrite.
 
 ### What changes were proposed in this PR?
Build index table scan tree on JDBC. Tree nodes consist of which SI table to scan with what index filter conditions. Pass the tree to index server so as to scan appropriate index tables. 
             Upon get splits for main table, Index Server driver scans the secondary index tables based on the tree received from JDBC. Modify the filter expresssion for maintable to include blockletIds returned from SI tables and prune the main table query. This approach works only with Index Server. 
Added a carbon property to switch between existing method of leveraging Secondary Index with plan rewrite and the new method being proposed in this PR. Default being the existing behavior.

 ### Does this PR introduce any user interface change?
 - No
 - Yes. (please explain the change and update document)

 ### Is any new testcase added?
 - No
 - Yes

    
