### PR TITLE
[CARBONDATA-4112] Data mismatch issue in SI global sort merge scenario.

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/util/SecondaryIndexUtil.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/util/SecondaryIndexUtil.scala
@@ -678,9 +678,15 @@ object SecondaryIndexUtil {
       .collectionAccumulator[Map[String, SegmentMetaDataInfo]]
     validSegments.foreach { segment =>
       outputModel.setSegmentId(segment.getSegmentNo)
-      val dataFrame = SparkSQLUtil.createInputDataFrame(
+      // As this dataframe is created to merge the data files of SI segment. So no need to calculate
+      // positionReference column again, as it is already calculated during SI segment load from
+      // main table. Also set the CARBON_INPUT_SEGMENTS property to the current SI segment to be
+      // merged to avoid querying whole table.
+      val dataFrame = SecondaryIndexCreator.dataFrameOfSegments(
         sparkSession,
-        indexCarbonTable)
+        indexCarbonTable,
+        "*",
+        Array(segment.getSegmentNo))
       SecondaryIndexCreator.findCarbonScanRDD(dataFrame.rdd, null)
       val segList : java.util.List[Segment] = new util.ArrayList[Segment]()
       segList.add(segment)


### PR DESCRIPTION
 ### Why is this PR needed?
When the data files of a SI segment are merged. it results in having more number of rows in SI table than main table.
 
 ### What changes were proposed in this PR?
CARBON_INPUT_SEGMENT property was not set before creating the dataframe from SI segment. So it was creating dataframe from all the rows in the table, not only from a particular segment.

### Does this PR introduce any user interface change?
 - No
 
 -  ### Is any new testcase added?
 - Yes

    
