### PR TITLE
[CARBONDATA-4125] SI compatability issue fix

### DIFF
--- a/integration/spark/src/main/java/org/apache/spark/sql/secondaryindex/load/CarbonInternalLoaderUtil.java
+++ b/integration/spark/src/main/java/org/apache/spark/sql/secondaryindex/load/CarbonInternalLoaderUtil.java
@@ -42,6 +42,7 @@ import org.apache.carbondata.processing.util.CarbonLoaderUtil;
 
 import org.apache.log4j.Logger;
 import org.apache.spark.sql.index.CarbonIndexUtil;
+import org.apache.spark.sql.secondaryindex.command.ErrorMessage;
 
 public class CarbonInternalLoaderUtil {
 
@@ -326,12 +327,20 @@ public class CarbonInternalLoaderUtil {
     return tableStatusUpdateStatus;
   }
 
+  public static boolean checkMainTableSegEqualToSISeg(
+      LoadMetadataDetails[] mainTableLoadMetadataDetails,
+      LoadMetadataDetails[] siTableLoadMetadataDetails) throws ErrorMessage {
+    return checkMainTableSegEqualToSISeg(mainTableLoadMetadataDetails, siTableLoadMetadataDetails,
+        false);
+  }
+
   /**
    * Method to check if main table and SI have same number of valid segments or not
    */
   public static boolean checkMainTableSegEqualToSISeg(
       LoadMetadataDetails[] mainTableLoadMetadataDetails,
-      LoadMetadataDetails[] siTableLoadMetadataDetails) {
+      LoadMetadataDetails[] siTableLoadMetadataDetails, boolean isRegisterIndex)
+      throws ErrorMessage {
     List<String> mainTableSegmentsList = getListOfValidSlices(mainTableLoadMetadataDetails);
     List<String> indexList = getListOfValidSlices(siTableLoadMetadataDetails);
     Collections.sort(mainTableSegmentsList);
@@ -341,6 +350,9 @@ public class CarbonInternalLoaderUtil {
     // than SI Segments
     if (indexList.size() < mainTableSegmentsList.size()) {
       return false;
+    } else if ((indexList.size() > mainTableSegmentsList.size()) && isRegisterIndex) {
+      throw new ErrorMessage("Cannot register index, as the number of Secondary index table "
+          + "segments are more than the main table segments. Try Drop and recreate SI.");
     }
     // There can be cases when the number of segments in the main table are less than the index
     // table. In this case mapping all the segments in main table to SI table.

--- a/integration/spark/src/main/scala/org/apache/spark/sql/index/CarbonIndexUtil.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/index/CarbonIndexUtil.scala
@@ -342,7 +342,7 @@ object CarbonIndexUtil {
    */
   def addOrModifyTableProperty(carbonTable: CarbonTable,
     properties: Map[String, String],
-    needLock: Boolean = true)
+    needLock: Boolean = true, propertyToBeRemoved: String = null)
     (sparkSession: SparkSession): Unit = {
     val tableName = carbonTable.getTableName
     val dbName = carbonTable.getDatabaseName
@@ -373,6 +373,9 @@ object CarbonIndexUtil {
         if (tblPropertiesMap.get(property._1) != null) {
           tblPropertiesMap.put(property._1, property._2)
         }
+      }
+      if (null != propertyToBeRemoved) {
+        tblPropertiesMap.remove(propertyToBeRemoved)
       }
       val tableIdentifier = AlterTableUtil.updateSchemaInfo(
         carbonTable = carbonTable,


### PR DESCRIPTION
 ### Why is this PR needed?
 Currently, while upgrading table store with SI, we have to execute REFRESH tables and REGISTER INDEX command to refresh and register the index to main table. And also, while SI creation, we add a property '**indexTableExists**'  to main table, to identify if table has SI or not. If a table has SI, then we load the index information for that table from Hive {org.apache.spark.sql.secondaryindex.hive.CarbonInternalMetastore#refreshIndexInfo}. **indexTableExists** will be default 'false' to all tables which does not have SI and for SI tables, this property will not be added.

{org.apache.spark.sql.secondaryindex.hive.CarbonInternalMetastore#refreshIndexInfo} will be called on any command to refresh indexInfo. **indexTableExists** property should be either true(Main table) or null (SI), in order to get index information from Hive and set it to carbon table. 

Issue 1:
While upgarding tables with SI, after refresh main table and SI, If user does any operation like Select or Show cache, it is adding **indexTableExists** property to false. After register index and on doing any operation with SI(load or select), {org.apache.spark.sql.secondaryindex.hive.CarbonInternalMetastore#refreshIndexInfo}  is not updating index information to SI table, since **indexTableExists** is false. Hence, load to SI will fail. 

Issue 2:
While upgarding tables with SI, after refresh main table and SI, If user does any operation like Update, alter, delete to SI table, while registering it as a index, it is not validating the alter operations done on that table.
 
 ### What changes were proposed in this PR?
Issue 1:
While registering SI table as a index, check if SI table has **indexTableExists** proeprty and remove it. For already registered index, allow re-register index to remove the property.

Issue 2:
Added validations for checking  if SI has undergone Load/Update/delete/alter opertaion before registering it as a index and throw exception.
  
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No (compatability scenario)


    
