### PR TITLE
[CARBONDATA-4117][[CARBONDATA-4123] cg index and bloom index query issue with Index server

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/index/IndexUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/index/IndexUtil.java
@@ -257,6 +257,7 @@ public class IndexUtil {
         for (ExtendedBlocklet blocklet : prunedBlocklet) {
           blocklet.getDetailInfo();
           blocklet.setIndexUniqueId(wrapper.getUniqueId());
+          blocklet.setCgIndexPresent(true);
         }
         extendedBlocklets.addAll(prunedBlocklet);
       }

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/ExtendedBlocklet.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/ExtendedBlocklet.java
@@ -48,6 +48,8 @@ public class ExtendedBlocklet extends Blocklet {
 
   private String segmentNo;
 
+  private boolean isCgIndexPresent = false;
+
   public ExtendedBlocklet() {
 
   }
@@ -191,7 +193,8 @@ public class ExtendedBlocklet extends Blocklet {
         DataOutputStream dos = new DataOutputStream(ebos);
         inputSplit.setFilePath(null);
         inputSplit.setBucketId(null);
-        if (inputSplit.isBlockCache()) {
+        // serialize detail info when it is blocklet cache or cgIndex is present.
+        if (inputSplit.isBlockCache() && !isCgIndexPresent) {
           inputSplit.updateFooterOffset();
           inputSplit.updateBlockLength();
           inputSplit.setWriteDetailInfo(false);
@@ -246,5 +249,9 @@ public class ExtendedBlocklet extends Blocklet {
       this.inputSplit =
           new CarbonInputSplit(serializeLen, in, getFilePath(), locations, getBlockletId());
     }
+  }
+
+  public void setCgIndexPresent(boolean cgIndexPresent) {
+    isCgIndexPresent = cgIndexPresent;
   }
 }


### PR DESCRIPTION
 ### Why is this PR needed?
 1. Test cg index query with Index server fails with NPE.  While initializing the index model, a parsing error is thrown when trying to uncompress with snappy.
 2. Bloom index query with Index server giving incorrect results when splits have >1 blocklets. Blocklet level details are not serialized for index server as it is considered as block level cache.
 
 ### What changes were proposed in this PR?
1. Have set segment and schema details to `BlockletIndexInputSplit `object.  While writing minmax object, write byte size instead of position.
2. Creating BlockletIndex when bloom filter is used, so in `createBlocklet `step `isBlockCache` is set to false.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No

    
