### PR TITLE
[CARBONDATA-4122] Use CarbonFile API instead of java File API for Flink CarbonLocalWriter

### DIFF
--- a/docs/flink-integration-guide.md
+++ b/docs/flink-integration-guide.md
@@ -23,7 +23,7 @@ limitations under the License.
 ## Usage scenarios
 
   The CarbonData flink integration module is used to connect Flink and Carbon. The module provides 
-  a set of Flink BulkWriter implementations (CarbonLocalWriter and CarbonS3Writer). The data is processed 
+  a set of Flink BulkWriter implementations (CarbonLocalWriter (for Local and HDFS filesystems) and CarbonS3Writer). The data is processed 
   by the Flink, and finally written into the stage directory of the target table by the CarbonXXXWriter. 
 
   By default, those data in table stage directory, can not be immediately queried, those data can be queried 
@@ -79,6 +79,7 @@ limitations under the License.
     // Set the carbon properties here, such as date format, store location, etc.
      
     // Create carbon bulk writer factory. Two writer types are supported: 'Local' and 'S3'.
+    // Use CarbonWriterFactory.builder("Local") for Local and Hdfs File systems
     val writerFactory = CarbonWriterFactory.builder("Local").build(
       databaseName,
       tableName,


### PR DESCRIPTION
 ### Why is this PR needed?
Currently, only two writer's(Local & S3) is supported for flink carbon streaming support. If user wants to ingest data from flink as a carbon format, directly into HDFS carbon table, there is no writer type to support it.
 
 ### What changes were proposed in this PR?
Since the code for writing flink stage data will be same for Local and Hdfs FileSystems, we can use the existing CarbonLocalWriter to write data into hdfs, by using CarbonFile API instead of java File API.

Changed code to use CarbonFile API instead of java.io.File.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No

    
