### PR TITLE
[CARBONDATA-4124] Fix Refresh MV which does not exist error message

### DIFF
--- a/integration/spark/src/test/scala/org/apache/carbondata/view/rewrite/TestAllOperationsOnMV.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/view/rewrite/TestAllOperationsOnMV.scala
@@ -702,6 +702,12 @@ class TestAllOperationsOnMV extends QueryTest with BeforeAndAfterEach {
     sql("drop table IF EXISTS maintable")
   }
 
+  test("test refresh mv which does not exists") {
+    intercept[MalformedMVCommandException] {
+      sql("refresh materialized view does_not_exist")
+    }.getMessage.contains("Materialized view default.does_not_exist does not exist")
+  }
+
   test("drop meta cache on mv materialized view table") {
     defaultConfig()
     sql("drop table IF EXISTS maintable")


### PR DESCRIPTION
 ### Why is this PR needed?
 Refreshing MV which does not exist, is not throwing proper carbon error message. It throws Table NOT found message from Spark. This is because, getSchema is returning null, if schema is not present.
 
 ### What changes were proposed in this PR?
1. Check If getSchema is null and throw No such MV exception.
2. While drop table, drop mv and then drop fact table from metastore, to avoid getting Nullpointer exception, when trying to access fact table while drop MV.
    
 ### Does this PR introduce any user interface change?
 - No


 ### Is any new testcase added?

 - Yes

    
