### PR TITLE
[CARBONDATA-4143] Enable UT with index server and fix related issues

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/index/IndexUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/index/IndexUtil.java
@@ -302,7 +302,7 @@ public class IndexUtil {
       List<Segment> validSegments, List<Segment> invalidSegments, IndexLevel level,
       List<String> segmentsToBeRefreshed, Configuration configuration) {
     return executeIndexJob(carbonTable, resolver, indexJob, partitionsToPrune, validSegments,
-        invalidSegments, level, false, segmentsToBeRefreshed, false, false, configuration);
+        invalidSegments, level, false, segmentsToBeRefreshed, false, false, configuration, null);
   }
 
   /**
@@ -314,7 +314,7 @@ public class IndexUtil {
       FilterResolverIntf resolver, IndexJob indexJob, List<PartitionSpec> partitionsToPrune,
       List<Segment> validSegments, List<Segment> invalidSegments, IndexLevel level,
       Boolean isFallbackJob, List<String> segmentsToBeRefreshed, boolean isCountJob,
-      boolean isSIPruningEnabled, Configuration configuration) {
+      boolean isSIPruningEnabled, Configuration configuration, Set<String> missingSISegments) {
     List<String> invalidSegmentNo = new ArrayList<>();
     for (Segment segment : invalidSegments) {
       invalidSegmentNo.add(segment.getSegmentNo());
@@ -323,6 +323,9 @@ public class IndexUtil {
     IndexInputFormat indexInputFormat =
         new IndexInputFormat(carbonTable, resolver, validSegments, invalidSegmentNo,
             partitionsToPrune, false, level, isFallbackJob, false);
+    if (missingSISegments != null) {
+      indexInputFormat.setMissingSISegments(missingSISegments);
+    }
     if (isCountJob) {
       indexInputFormat.setCountStarJob();
       indexInputFormat.setIsWriteToFile(false);

--- a/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/TestCacheOperationsForSI.scala
+++ b/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/TestCacheOperationsForSI.scala
@@ -86,7 +86,8 @@ class TestCacheOperationsForSI extends QueryTest with BeforeAndAfterAll {
     sql(s"DROP TABLE $tableName")
   }
 
-  test("Test SI for Show Cache") {
+  // Exclude when running with index server, as show cache rows count varies.
+  test("Test SI for Show Cache", true) {
     val tableName = "t2"
     val indexName = "index1"
 

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/load/DataLoadProcessBuilderOnSpark.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/load/DataLoadProcessBuilderOnSpark.scala
@@ -145,6 +145,8 @@ object DataLoadProcessBuilderOnSpark {
       configuration.getDataLoadProperty(CarbonCommonConstants.LOAD_GLOBAL_SORT_PARTITIONS))
     if (numPartitions <= 0) {
       numPartitions = convertRDD.partitions.length
+    } else if (System.getProperty("useIndexServer") != null) {
+      convertRDD.partitions
     }
 
     // Because if the number of partitions greater than 1, there will be action operator(sample) in

--- a/integration/spark/src/main/scala/org/apache/spark/sql/hive/DistributionUtil.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/hive/DistributionUtil.scala
@@ -91,9 +91,14 @@ object DistributionUtil {
 
   def getExecutors(sparkContext: SparkContext): Map[String, Seq[String]] = {
     val bm = sparkContext.env.blockManager
-    bm.master.getPeers(bm.blockManagerId)
+    val executorMap = bm.master.getPeers(bm.blockManagerId)
       .groupBy(blockManagerId => blockManagerId.host).map {
       case (host, blockManagerIds) => (host, blockManagerIds.map(_.executorId))
+    }
+    if (executorMap.isEmpty && bm.blockManagerId.executorId.equalsIgnoreCase("driver")) {
+      Map("localhost" -> Seq("1"))
+    } else {
+      executorMap
     }
   }
 

--- a/integration/spark/src/main/scala/org/apache/spark/sql/test/SparkTestQueryExecutor.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/test/SparkTestQueryExecutor.scala
@@ -26,6 +26,7 @@ import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.datastore.impl.FileFactory
 import org.apache.carbondata.core.util.CarbonProperties
+import org.apache.carbondata.indexserver.IndexServer
 
 /**
  * This class is a sql executor of unit test case for spark version 2.x.
@@ -81,6 +82,15 @@ object SparkTestQueryExecutor {
     ResourceRegisterAndCopier.
       copyResourcesifNotExists(hdfsUrl, s"$integrationPath/spark/src/test/resources",
         s"$integrationPath//spark-common-cluster-test/src/test/resources/testdatafileslist.txt")
+  }
+  if (System.getProperty("useIndexServer") != null) {
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.CARBON_INDEX_SERVER_IP, "localhost")
+      .addProperty(CarbonCommonConstants.CARBON_INDEX_SERVER_PORT, "9998")
+      .addProperty(CarbonCommonConstants.CARBON_ENABLE_INDEX_SERVER, "true")
+      .addProperty(CarbonCommonConstants.CARBON_DISABLE_INDEX_SERVER_FALLBACK, "true")
+      .addProperty(CarbonCommonConstants.CARBON_MAX_EXECUTOR_THREADS_FOR_BLOCK_PRUNING, "1")
+    IndexServer.main(Array())
   }
   FileFactory.getConfiguration.
     set("dfs.client.block.write.replace-datanode-on-failure.policy", "NEVER")

--- a/integration/spark/src/main/scala/org/apache/spark/sql/test/util/CarbonFunSuite.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/test/util/CarbonFunSuite.scala
@@ -44,4 +44,20 @@ private[spark] abstract class CarbonFunSuite extends FunSuite {
     }
   }
 
+  protected def test(testName : scala.Predef.String, ignoreForIndexServer: Boolean,
+                     testTags : org.scalatest.Tag*)
+                    (testFun : => Unit): Unit = {
+    if (ignoreForIndexServer) {
+      // To skip testcase when useIndexServer property is set.
+      if (System.getProperty("useIndexServer") == null) {
+        super.test(testName)(testFun)
+      }
+    } else {
+      // To run the testcase only when useIndexServer property is set.
+      if (System.getProperty("useIndexServer") != null) {
+        super.test(testName)(testFun)
+      }
+    }
+  }
+
 }

--- a/integration/spark/src/test/scala/org/apache/carbondata/geo/GeoQueryTest.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/geo/GeoQueryTest.scala
@@ -139,7 +139,9 @@ class GeoQueryTest extends QueryTest with BeforeAndAfterAll with BeforeAndAfterE
     checkAnswer(df, Seq(Row(64, 79, "1"), Row(39, 37, "2")))
   }
 
-  test("test block pruning with polygon join query") {
+  // Exclude when running with index server, as pruning info for explain command
+  // not set with index server.
+  test("test block pruning with polygon join query", true) {
     createTable()
     sql(s"insert into $geoTable select 855280799612,1,2,116285807,40084087")
     sql(s"insert into $geoTable select 855283635086,1,2,116372142,40129503")
@@ -223,7 +225,10 @@ class GeoQueryTest extends QueryTest with BeforeAndAfterAll with BeforeAndAfterE
     ).getMessage.contains("Join condition having left column polygon is not GeoId column")
   }
 
-  test("test block pruning on spatial and polygon table with in_polygon_join_range_list udf") {
+  // Exclude when running with index server, as pruning info for explain command
+  // not set with index server.
+  test("test block pruning on spatial and polygon table with in_polygon_join_range_list udf",
+    true) {
    createTable()
     sql(s"insert into $geoTable select 855280799612,1,2,116285807,40084087")
     sql(s"insert into $geoTable select 855283635086,1,2,116372142,40129503")

--- a/integration/spark/src/test/scala/org/apache/carbondata/geo/GeoTest.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/geo/GeoTest.scala
@@ -365,7 +365,8 @@ class GeoTest extends QueryTest with BeforeAndAfterAll with BeforeAndAfterEach {
       result)
   }
 
-  test("test block pruning for polygon query") {
+  // Exclude when running with index server as it uses UNKNOWN expression to prune.
+  test("test block pruning for polygon query", true) {
     createTable()
     sql(s"insert into $table1 select 855280799612,1575428400000,116285807,40084087")
     sql(s"insert into $table1 select 855283635086,1575428400000,116372142,40129503")

--- a/integration/spark/src/test/scala/org/apache/carbondata/index/bloom/BloomCoarseGrainIndexSuite.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/index/bloom/BloomCoarseGrainIndexSuite.scala
@@ -392,8 +392,10 @@ class BloomCoarseGrainIndexSuite extends QueryTest with BeforeAndAfterAll with B
     sql(s"DROP TABLE IF EXISTS $bloomSampleTable")
   }
 
+  // Exclude when running with index server, as pruning info for explain command
+  // not set with index server.
   test("test bloom index: " +
-       "multiple indexes with each on one column vs one index on multiple columns") {
+       "multiple indexes with each on one column vs one index on multiple columns", true) {
     val iterations = 1
     // 500000 lines will result to 3 blocklets and bloomfilter index will prune 2 blocklets.
     val index11 = "index11"
@@ -642,7 +644,9 @@ class BloomCoarseGrainIndexSuite extends QueryTest with BeforeAndAfterAll with B
       "BloomFilter does not support binary datatype column: cust_id"  ))
   }
 
-  test("test create bloom index on newly added column") {
+  // Exclude when running with index server, as pruning info for explain command
+  // not set with index server.
+  test("test create bloom index on newly added column", true) {
     // Fix the loading cores to ensure number of buckets.
     CarbonProperties.getInstance().addProperty("carbon.number.of.cores.while.loading", "1")
 

--- a/integration/spark/src/test/scala/org/apache/carbondata/index/lucene/LuceneFineGrainIndexSuite.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/index/lucene/LuceneFineGrainIndexSuite.scala
@@ -550,7 +550,9 @@ class LuceneFineGrainIndexSuite extends QueryTest with BeforeAndAfterAll {
     sql("drop index dm on table index_test_overwrite")
   }
 
-  test("explain query with lucene index") {
+  // Exclude when running with index server, as pruning info for explain command
+  // not set with index server.
+  test("explain query with lucene index", true) {
     sql("drop table if exists main")
     CarbonProperties.getInstance().addProperty(CarbonCommonConstants.BLOCKLET_SIZE, "8")
     sql(

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/allqueries/TestPruneUsingSegmentMinMax.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/allqueries/TestPruneUsingSegmentMinMax.scala
@@ -36,7 +36,8 @@ class TestPruneUsingSegmentMinMax extends QueryTest with BeforeAndAfterAll {
     sql("drop table if exists parquet")
   }
 
-  test("test if matched segment is only loaded to cache") {
+  // Exclude when running with index server, as show cache result varies.
+  test("test if matched segment is only loaded to cache", true) {
     createTablesAndLoadData
     checkAnswer(sql("select * from carbon where a=1"), sql("select * from parquet where a=1"))
     val showCache = sql("show metacache on table carbon").collect()
@@ -58,7 +59,8 @@ class TestPruneUsingSegmentMinMax extends QueryTest with BeforeAndAfterAll {
     // scalastyle:on lineLength
   }
 
-  test("test if matched segment is only loaded to cache after drop column") {
+  // Exclude when running with index server, as show cache result varies.
+  test("test if matched segment is only loaded to cache after drop column", true) {
     createTablesAndLoadData
     checkAnswer(sql("select * from carbon where a=1"), sql("select * from parquet where a=1"))
     checkAnswer(sql("select * from carbon where a=2"), sql("select * from parquet where a=2"))
@@ -78,7 +80,8 @@ class TestPruneUsingSegmentMinMax extends QueryTest with BeforeAndAfterAll {
     drop
   }
 
-  test("test if matched segment is only loaded to cache after add column") {
+  // Exclude when running with index server, as show cache result varies.
+  test("test if matched segment is only loaded to cache after add column", true) {
     createTablesAndLoadData
     sql("alter table carbon add columns(g decimal(3,2))")
     sql("insert into carbon values" +
@@ -92,7 +95,8 @@ class TestPruneUsingSegmentMinMax extends QueryTest with BeforeAndAfterAll {
     drop
   }
 
-  test("test segment pruning after update operation") {
+  // Exclude when running with index server, as show cache result varies.
+  test("test segment pruning after update operation", true) {
     createTablesAndLoadData
     checkAnswer(sql("select a from carbon where a=1"), Seq(Row(1)))
     var showCache = sql("show metacache on table carbon").collect()
@@ -108,7 +112,8 @@ class TestPruneUsingSegmentMinMax extends QueryTest with BeforeAndAfterAll {
     drop
   }
 
-  test("alter set/unset sort column properties") {
+  // Exclude when running with index server, as show cache result varies.
+  test("alter set/unset sort column properties", true) {
     createTablesAndLoadData
     sql(s"alter table carbon set tblproperties('sort_scope'='local_sort', 'sort_columns'='a')")
     sql("insert into carbon values" +

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/alterTable/TestAlterTableAddColumns.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/alterTable/TestAlterTableAddColumns.scala
@@ -259,7 +259,8 @@ class TestAlterTableAddColumns extends QueryTest with BeforeAndAfterAll {
     }
   }
 
-  test("Test alter add for arrays enabling local dictionary") {
+  // Exclude when running with index server as the returned rows order may vary
+  test("Test alter add for arrays enabling local dictionary", true) {
     import scala.collection.mutable.WrappedArray.make
     createTableForComplexTypes("LOCAL_DICTIONARY_INCLUDE", "ARRAY")
     // For the previous segments the default value for newly added array column is null

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/alterTable/TestAlterTableSortColumnsProperty.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/alterTable/TestAlterTableSortColumnsProperty.scala
@@ -693,7 +693,9 @@ class TestAlterTableSortColumnsProperty extends QueryTest with BeforeAndAfterAll
           "where smallIntField = 2 and charField is not null order by floatField"))
   }
 
-  test("bloom filter") {
+  // Exclude when running with index server, as pruning info for explain command
+  // not set with index server.
+  test("bloom filter", true) {
     CarbonProperties.getInstance()
       .addProperty(CarbonCommonConstants.ENABLE_QUERY_STATISTICS, "true")
     val tableName = "alter_sc_bloom"

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestRenameTableWithIndex.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestRenameTableWithIndex.scala
@@ -38,7 +38,9 @@ class TestRenameTableWithIndex extends QueryTest with BeforeAndAfterAll {
       .addProperty(CarbonCommonConstants.ENABLE_QUERY_STATISTICS, "true")
   }
 
-  test("Creating a bloomfilter, SI indexSchema,then table rename") {
+  // Exclude when running with index server, as pruning info for explain command
+  // not set with index server.
+  test("Creating a bloomfilter indexSchema,then table rename", true) {
     sql(
       s"""
          | CREATE TABLE carbon_table(

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/index/CGIndexTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/index/CGIndexTestCase.scala
@@ -418,7 +418,9 @@ class CGIndexTestCase extends QueryTest with BeforeAndAfterAll {
       sql("select * from normal_test where name='n502670' and city='c2670'"))
   }
 
-  test("test invisible index during query") {
+  // Exclude when running with index server, as pruning info for explain command
+  // not set with index server.
+  test("test invisible index during query", true) {
     val tableName = "index_test"
     val indexName1 = "index1"
     val indexName2 = "index2"

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/index/FGIndexTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/index/FGIndexTestCase.scala
@@ -508,7 +508,9 @@ class FGIndexTestCase extends QueryTest with BeforeAndAfterAll {
       sql("select * from normal_test where name='n502670' or city='c2670'"))
   }
 
-  test("test invisible indexSchema during query") {
+  // Exclude when running with index server, as pruning info for explain command
+  // not set with index server.
+  test("test invisible indexSchema during query", true) {
     val tableName = "index_test"
     val indexName1 = "index1"
     val indexName2 = "index2"


### PR DESCRIPTION
 ### Why is this PR needed?
enable to run UT with index server.
Fix below issues:
1. With index server enabled, select query gives incorrect result with SI when parent and child table segments are not in sync.
2. When reindex is triggered, if stale files are present in the segment directory the segment file is being written with incorrect file names. (both valid index and stale mergeindex file names). As a result, duplicate data is present in SI table but there are no error/incorrect query results.
 
 ### What changes were proposed in this PR?
usage of flag `useIndexServer`. excluded some of the test cases to not run with index server.
1. While pruning from index server, `missingSISegments` values were not getting considered. Have passed down and set those values to filter.
2. Before loading data to SI segment, added changes to delete the segment directory if already present.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes
    
