### PR TITLE
[CARBONDATA-4141] Index Server is not caching indexes for external tables with sdk segments.

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletIndexFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletIndexFactory.java
@@ -452,8 +452,12 @@ public class BlockletIndexFactory extends CoarseGrainIndexFactory
       BlockletIndexInputSplit distributable = new BlockletIndexInputSplit();
       distributable.setSegment(segment);
       distributable.setIndexSchema(INDEX_SCHEMA);
-      distributable.setSegmentPath(CarbonTablePath.getSegmentPath(identifier.getTablePath(),
-          segment.getSegmentNo()));
+      if (!(getCarbonTable().isTransactionalTable())) {
+        distributable.setSegmentPath(identifier.getTablePath());
+      } else {
+        distributable.setSegmentPath(
+            CarbonTablePath.getSegmentPath(identifier.getTablePath(), segment.getSegmentNo()));
+      }
       distributableList.add(new IndexInputSplitWrapper(UUID.randomUUID().toString(),
           distributable).getDistributable());
     } catch (Exception e) {


### PR DESCRIPTION
 ### Why is this PR needed?
Indexes cached in Executor cache are not dropped when drop table is called for external table with SDK segments. Because, external tables with sdk segments will not have metadata like table status file. So in drop table command we send zero segments to indexServer clearIndexes job, which clears nothing from executor side. So when we drop this type of table, executor side indexes are not dropped. Now when we again create external table with same location and do select * or select count(*), it will not cache the indexes for this table, because indexes with same loaction are already present. Now show metacache on this newly created table will use new tableId , but indexes present have the old tableId, whose table is already dropped. So show metacache will return nothing, because of tableId mismatch.
 
 ### What changes were proposed in this PR?
Prepared the validSegments from indexFiles present at external table location and send it to IndexServer clearIndexes job through IndexInputFormat.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No

    
