### PR TITLE
[CARBONDATA-4156] Fix Writing Segment  Min max with all blocks of a segment

### DIFF
--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/testutil/StoreCreator.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/testutil/StoreCreator.java
@@ -51,6 +51,7 @@ import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
 import org.apache.carbondata.core.metadata.schema.table.TableInfo;
 import org.apache.carbondata.core.metadata.schema.table.TableSchema;
 import org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema;
+import org.apache.carbondata.core.segmentmeta.SegmentMetaDataInfoStats;
 import org.apache.carbondata.core.statusmanager.LoadMetadataDetails;
 import org.apache.carbondata.core.statusmanager.SegmentStatus;
 import org.apache.carbondata.core.util.CarbonProperties;
@@ -357,6 +358,8 @@ public class StoreCreator {
     writeLoadMetadata(
         loadModel.getCarbonDataLoadSchema(), loadModel.getTableName(), loadModel.getTableName(),
         new ArrayList<>());
+    SegmentMetaDataInfoStats.getInstance()
+        .clear(loadModel.getTableName(), loadModel.getSegmentId());
   }
 
   public static void writeLoadMetadata(CarbonDataLoadSchema schema, String databaseName,

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/allqueries/TestPruneUsingSegmentMinMax.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/allqueries/TestPruneUsingSegmentMinMax.scala
@@ -61,6 +61,7 @@ class TestPruneUsingSegmentMinMax extends QueryTest with BeforeAndAfterAll {
   test("test if matched segment is only loaded to cache after drop column") {
     createTablesAndLoadData
     checkAnswer(sql("select * from carbon where a=1"), sql("select * from parquet where a=1"))
+    checkAnswer(sql("select * from carbon where a=2"), sql("select * from parquet where a=2"))
     var showCache = sql("show metacache on table carbon").collect()
     assert(showCache(0).get(2).toString.equalsIgnoreCase("1/3 index files cached"))
     checkAnswer(sql("select * from carbon where a=5"), sql("select * from parquet where a=5"))


### PR DESCRIPTION
 ### Why is this PR needed?
[PR-3999](https://github.com/apache/carbondata/pull/3999) has removed some code related to getting segment min max from all blocks. Because of this, if segment has more than one block, currently, it is writing min max considering one block only.
 
 ### What changes were proposed in this PR?
Reverted specific code from above PR. Removed unwanted synchronization for some methods
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
