### PR TITLE
[CARBONDATA-4144] During compaction, the segment lock of SI table is not released in abnormal scenarios.

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/load/Compactor.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/load/Compactor.scala
@@ -93,6 +93,11 @@ object Compactor {
             segmentToSegmentTimestampMap, null,
             forceAccessSegment, isCompactionCall = true,
             isLoadToFailedSISegments = false)
+        if (segmentLocks.isEmpty) {
+          LOGGER.error(s"Not able to acquire segment lock on the specific segment. " +
+            s"Load the compacted segment ${validSegments.head} into SI table failed");
+          return
+        }
         allSegmentsLock ++= segmentLocks
         CarbonInternalLoaderUtil.updateLoadMetadataWithMergeStatus(
           indexCarbonTable,

--- a/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/rdd/SecondaryIndexCreator.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/rdd/SecondaryIndexCreator.scala
@@ -460,6 +460,9 @@ object SecondaryIndexCreator {
     } catch {
       case ex: Exception =>
         LOGGER.error("Load to SI table failed", ex)
+        if (isCompactionCall) {
+          segmentLocks.foreach(segmentLock => segmentLock.unlock())
+        }
         FileInternalUtil
           .updateTableStatus(validSegmentList,
             secondaryIndexModel.carbonLoadModel.getDatabaseName,


### PR DESCRIPTION
Why is this PR needed?
When compact operation fails, the segment lock of SI table is not released. Run compaction again, can not get the segment lock of the SI table and compation does nothing, but in the tablestatus file of SI table the merged segment status is set to success and the segmentfile is xxx_null.segments and the vaule of indexsize is 0.

What changes were proposed in this PR?
If an exception occurs, release the obtained segment locks.
If getting segment locks failed, not update the segment status.

Does this PR introduce any user interface change?
No

Is any new testcase added?
No

    
