### PR TITLE
[CARBONDATA-4145] Query fails and the message "File does not exist: xxx.carbondata" is displayed

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/rdd/CarbonSIRebuildRDD.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/rdd/CarbonSIRebuildRDD.scala
@@ -215,7 +215,7 @@ class CarbonSIRebuildRDD[K, V](
 
         // add task completion listener to clean up the resources
         context.addTaskCompletionListener { _ =>
-          close(splitList)
+          close()
         }
         try {
           // fire a query and get the results.
@@ -271,7 +271,7 @@ class CarbonSIRebuildRDD[K, V](
           throw e
       }
 
-      private def close(splits: util.List[CarbonInputSplit]): Unit = {
+      private def close(): Unit = {
         deleteLocalDataFolders()
         // close all the query executor service and clean up memory acquired during query processing
         if (null != exec) {
@@ -283,12 +283,6 @@ class CarbonSIRebuildRDD[K, V](
         if (null != processor) {
           LOGGER.info("Closing compaction processor instance to clean up loading resources")
           processor.close()
-        }
-
-        // delete all the old data files which are used for merging
-        splits.asScala.foreach { split =>
-          val carbonFile = FileFactory.getCarbonFile(split.getFilePath)
-          carbonFile.delete()
         }
       }
 


### PR DESCRIPTION
Why is this PR needed?
If an exception occurs when the refresh index command is executed, a task has been successful. The new query will be failed.
Reason: After the compaction task is executed successfully, the old carbondata files are deleted. If other exception occurs, the deleted files are missing.
This PR will fix this issue.

What changes were proposed in this PR?
When all tasks are successful, the driver deletes the old carbondata files.

Does this PR introduce any user interface change?
No

Is any new testcase added?
No