### PR TITLE
[CARBONDATA-4146]Query fails and the error message "unable to get file status" is displayed. query is normal after the "drop metacache on table" command is executed.

### DIFF
--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonTableCompactor.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonTableCompactor.scala
@@ -107,6 +107,9 @@ class CarbonTableCompactor(
         }
       }
       try {
+        // need to be cleared for multiple compactions.
+        // only contains the segmentIds which have to be compacted.
+        compactedSegments.clear()
         scanSegmentsAndSubmitJob(validSegments, compactedSegments, compactedLoad)
       } catch {
         case e: Exception =>
@@ -296,26 +299,50 @@ class CarbonTableCompactor(
 
     if (finalMergeStatus) {
       val mergedLoadNumber = CarbonDataMergerUtil.getLoadNumberFromLoadName(mergedLoadName)
-      var segmentFilesForIUDCompact = new util.ArrayList[Segment]()
       var segmentFileName: String = null
+
+      val mergeIndex = CarbonProperties.getInstance().getProperty(
+        CarbonCommonConstants.CARBON_MERGE_INDEX_IN_SEGMENT,
+        CarbonCommonConstants.CARBON_MERGE_INDEX_IN_SEGMENT_DEFAULT).toBoolean
+
+      if (compactionType != CompactionType.IUD_DELETE_DELTA && mergeIndex) {
+        MergeIndexUtil.mergeIndexFilesOnCompaction(compactionCallableModel)
+      }
+
       if (carbonTable.isHivePartitionTable) {
-        val readPath =
-          CarbonTablePath.getSegmentFilesLocation(carbonLoadModel.getTablePath) +
-          CarbonCommonConstants.FILE_SEPARATOR + carbonLoadModel.getFactTimeStamp + ".tmp"
-        // Merge all partition files into a single file.
-        segmentFileName =
-          mergedLoadNumber + "_" + carbonLoadModel.getFactTimeStamp
-        val segmentFile = SegmentFileStore
-          .mergeSegmentFiles(readPath,
-            segmentFileName,
-            CarbonTablePath.getSegmentFilesLocation(carbonLoadModel.getTablePath))
-        if (segmentFile != null) {
-          SegmentFileStore
-            .moveFromTempFolder(segmentFile,
-              carbonLoadModel.getFactTimeStamp + ".tmp",
-              carbonLoadModel.getTablePath)
+        if (mergeIndex) {
+          val segmentTmpFileName = carbonLoadModel.getFactTimeStamp + CarbonTablePath.SEGMENT_EXT
+          segmentFileName = mergedLoadNumber + "_" + segmentTmpFileName
+          val segmentTmpFile = FileFactory.getCarbonFile(
+            CarbonTablePath.getSegmentFilePath(carbonTable.getTablePath, segmentTmpFileName))
+          if (!segmentTmpFile.renameForce(
+            CarbonTablePath.getSegmentFilePath(carbonTable.getTablePath, segmentFileName))) {
+            throw new Exception(s"Rename segment file from ${segmentTmpFileName} " +
+              s"to ${segmentFileName} failed.")
+          }
+          val tmpPath =
+            CarbonTablePath.getSegmentFilesLocation(carbonLoadModel.getTablePath) +
+              CarbonCommonConstants.FILE_SEPARATOR + carbonLoadModel.getFactTimeStamp + ".tmp"
+          FileFactory.deleteAllCarbonFilesOfDir(FileFactory.getCarbonFile(tmpPath))
+        } else {
+          val readPath =
+            CarbonTablePath.getSegmentFilesLocation(carbonLoadModel.getTablePath) +
+              CarbonCommonConstants.FILE_SEPARATOR + carbonLoadModel.getFactTimeStamp + ".tmp"
+          // Merge all partition files into a single file.
+          segmentFileName =
+            mergedLoadNumber + "_" + carbonLoadModel.getFactTimeStamp
+          val segmentFile = SegmentFileStore
+            .mergeSegmentFiles(readPath,
+              segmentFileName,
+              CarbonTablePath.getSegmentFilesLocation(carbonLoadModel.getTablePath))
+          if (segmentFile != null) {
+            SegmentFileStore
+              .moveFromTempFolder(segmentFile,
+                carbonLoadModel.getFactTimeStamp + ".tmp",
+                carbonLoadModel.getTablePath)
+          }
+          segmentFileName = segmentFileName + CarbonTablePath.SEGMENT_EXT
         }
-        segmentFileName = segmentFileName + CarbonTablePath.SEGMENT_EXT
       } else {
         // Get the segment files each updated segment in case of IUD compaction
         val segmentMetaDataInfo = CommonLoadUtils.getSegmentMetaDataInfoFromAccumulator(
@@ -360,10 +387,6 @@ class CarbonTableCompactor(
         throw new Exception(s"Compaction failed to update metadata for table" +
                             s" ${ carbonLoadModel.getDatabaseName }." +
                             s"${ carbonLoadModel.getTableName }")
-      }
-
-      if (compactionType != CompactionType.IUD_DELETE_DELTA) {
-        MergeIndexUtil.mergeIndexFilesOnCompaction(compactionCallableModel)
       }
 
       val compactionLoadStatusPostEvent = AlterTableCompactionPostStatusUpdateEvent(sc.sparkSession,

--- a/processing/src/main/java/org/apache/carbondata/processing/merger/CompactionResultSortProcessor.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/merger/CompactionResultSortProcessor.java
@@ -190,7 +190,12 @@ public class CompactionResultSortProcessor extends AbstractResultProcessor {
       LOGGER.error(e.getLocalizedMessage(), e);
       throw e;
     } finally {
-      if (partitionSpec != null) {
+      boolean isMergeIndex = Boolean.parseBoolean(CarbonProperties.getInstance().getProperty(
+          CarbonCommonConstants.CARBON_MERGE_INDEX_IN_SEGMENT,
+          CarbonCommonConstants.CARBON_MERGE_INDEX_IN_SEGMENT_DEFAULT));
+      // mergeIndex is true, the segment file not need to be written
+      // and will be written during merging index
+      if (partitionSpec != null && !isMergeIndex) {
         try {
           SegmentFileStore
               .writeSegmentFile(carbonLoadModel.getTablePath(), carbonLoadModel.getTaskNo(),

--- a/processing/src/main/java/org/apache/carbondata/processing/merger/RowResultMergerProcessor.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/merger/RowResultMergerProcessor.java
@@ -34,6 +34,7 @@ import org.apache.carbondata.core.metadata.schema.table.column.CarbonColumn;
 import org.apache.carbondata.core.scan.result.iterator.RawResultIterator;
 import org.apache.carbondata.core.scan.wrappers.ByteArrayWrapper;
 import org.apache.carbondata.core.util.ByteUtil;
+import org.apache.carbondata.core.util.CarbonProperties;
 import org.apache.carbondata.processing.exception.SliceMergerException;
 import org.apache.carbondata.processing.loading.model.CarbonLoadModel;
 import org.apache.carbondata.processing.loading.sort.CarbonPriorityQueue;
@@ -185,7 +186,12 @@ public class RowResultMergerProcessor extends AbstractResultProcessor {
         if (isDataPresent) {
           this.dataHandler.closeHandler();
         }
-        if (partitionSpec != null) {
+        boolean isMergeIndex = Boolean.parseBoolean(CarbonProperties.getInstance().getProperty(
+            CarbonCommonConstants.CARBON_MERGE_INDEX_IN_SEGMENT,
+            CarbonCommonConstants.CARBON_MERGE_INDEX_IN_SEGMENT_DEFAULT));
+        // mergeIndex is true, the segment file not need to be written
+        // and will be written during merging index
+        if (partitionSpec != null && !isMergeIndex) {
           SegmentFileStore.writeSegmentFile(loadModel.getTablePath(), loadModel.getTaskNo(),
               partitionSpec.getLocation().toString(), loadModel.getFactTimeStamp() + "",
               partitionSpec.getPartitions());


### PR DESCRIPTION
Why is this PR needed?
During compact execution, the status of the new segment is set to success before index files are merged.
After index files are merged, the carbonindex files are deleted.
As a result, the query task cannot find the cached carbonindex files.

What changes were proposed in this PR?
Set the status of the new segment to succeeded after index files are merged.

Does this PR introduce any user interface change?
No

Is any new testcase added?
No