### PR TITLE
[CARBONDATA-4148] Reindex failed when SI has stale carbonindexmerge file

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/metadata/SegmentFileStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/SegmentFileStore.java
@@ -831,8 +831,8 @@ public class SegmentFileStore {
    * Gets all index files from this segment
    * @return
    */
-  public Map<String, String> getIndexFiles() {
-    Map<String, String> indexFiles = new HashMap<>();
+  public Set<String> getIndexFiles() {
+    Set<String> indexFiles = new HashSet<>();
     if (segmentFile != null) {
       for (Map.Entry<String, FolderDetails> entry : getLocationMap().entrySet()) {
         String location = entry.getKey();
@@ -841,8 +841,7 @@ public class SegmentFileStore {
         }
         if (entry.getValue().status.equals(SegmentStatus.SUCCESS.getMessage())) {
           for (String indexFile : entry.getValue().getFiles()) {
-            indexFiles.put(location + CarbonCommonConstants.FILE_SEPARATOR + indexFile,
-                entry.getValue().mergeFileName);
+            indexFiles.add(location + CarbonCommonConstants.FILE_SEPARATOR + indexFile);
           }
         }
       }
@@ -854,7 +853,7 @@ public class SegmentFileStore {
    * Gets all index files from this segment
    * @return
    */
-  public Map<String, String> getIndexOrMergeFiles() throws IOException {
+  public Map<String, String> getIndexAndMergeFiles() throws IOException {
     Map<String, String> indexFiles = new HashMap<>();
     if (segmentFile != null) {
       for (Map.Entry<String, FolderDetails> entry : getLocationMap().entrySet()) {
@@ -898,17 +897,9 @@ public class SegmentFileStore {
    * @return
    */
   public List<CarbonFile> getIndexCarbonFiles() {
-    Map<String, String> indexFiles = getIndexFiles();
-    Set<String> files = new HashSet<>();
-    for (Map.Entry<String, String> entry: indexFiles.entrySet()) {
-      Path path = new Path(entry.getKey());
-      files.add(entry.getKey());
-      if (entry.getValue() != null) {
-        files.add(new Path(path.getParent(), entry.getValue()).toString());
-      }
-    }
+    Set<String> indexFiles = getIndexFiles();
     List<CarbonFile> carbonFiles = new ArrayList<>();
-    for (String indexFile : files) {
+    for (String indexFile : indexFiles) {
       CarbonFile carbonFile = FileFactory.getCarbonFile(indexFile);
       if (carbonFile.exists()) {
         carbonFiles.add(carbonFile);
@@ -1348,7 +1339,7 @@ public class SegmentFileStore {
     } else {
       SegmentFileStore segmentFileStore =
           new SegmentFileStore(tablePath, segment.getSegmentFileName());
-      indexFiles = segmentFileStore.getIndexOrMergeFiles().keySet();
+      indexFiles = segmentFileStore.getIndexAndMergeFiles().keySet();
     }
     return indexFiles;
   }

--- a/core/src/main/java/org/apache/carbondata/core/readcommitter/TableStatusReadCommittedScope.java
+++ b/core/src/main/java/org/apache/carbondata/core/readcommitter/TableStatusReadCommittedScope.java
@@ -86,7 +86,7 @@ public class TableStatusReadCommittedScope implements ReadCommittedScope {
     } else {
       SegmentFileStore fileStore =
           new SegmentFileStore(identifier.getTablePath(), segment.getSegmentFileName());
-      indexFiles = fileStore.getIndexOrMergeFiles();
+      indexFiles = fileStore.getIndexAndMergeFiles();
       if (fileStore.getSegmentFile() != null) {
         segment.setSegmentMetaDataInfo(fileStore.getSegmentFile().getSegmentMetaDataInfo());
       }

--- a/core/src/main/java/org/apache/carbondata/core/util/SessionParams.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/SessionParams.java
@@ -24,7 +24,6 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.carbondata.common.constants.LoggerAction;
 import org.apache.carbondata.common.logging.LogServiceFactory;
-import org.apache.carbondata.core.cache.CacheProvider;
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.constants.CarbonLoadOptionConstants;
 import org.apache.carbondata.core.exception.InvalidConfigurationException;
@@ -49,7 +48,7 @@ import org.apache.log4j.Logger;
 public class SessionParams implements Serializable, Cloneable {
 
   private static final Logger LOGGER =
-      LogServiceFactory.getLogService(CacheProvider.class.getName());
+      LogServiceFactory.getLogService(SessionParams.class.getName());
   private static final long serialVersionUID = -7801994600594915264L;
 
   private Map<String, String> sProps;

--- a/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/TestIndexRepair.scala
+++ b/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/TestIndexRepair.scala
@@ -119,6 +119,19 @@ class TestIndexRepair extends QueryTest with BeforeAndAfterAll {
     sql("drop table if exists maintable")
   }
 
+  test("reindex command with stale files") {
+    sql("drop table if exists maintable")
+    sql("CREATE TABLE maintable(a INT, b STRING, c STRING) stored as carbondata")
+    sql("CREATE INDEX indextable1 on table maintable(c) as 'carbondata'")
+    sql("INSERT INTO maintable SELECT 1,'string1', 'string2'")
+    sql("INSERT INTO maintable SELECT 1,'string1', 'string2'")
+    sql("INSERT INTO maintable SELECT 1,'string1', 'string2'")
+    sql("DELETE FROM TABLE INDEXTABLE1 WHERE SEGMENT.ID IN(0,1,2)")
+    sql("REINDEX INDEX TABLE indextable1 ON MAINTABLE WHERE SEGMENT.ID IN (0,1)")
+    assert(sql("select * from maintable where c = 'string2'").count() == 2)
+    sql("drop table if exists maintable")
+  }
+
   test("insert command after deleting segments from SI table") {
     sql("drop table if exists maintable")
     sql("CREATE TABLE maintable(a INT, b STRING, c STRING) stored as carbondata")

--- a/integration/spark/src/main/scala/org/apache/spark/sql/index/CarbonIndexUtil.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/index/CarbonIndexUtil.scala
@@ -502,7 +502,7 @@ object CarbonIndexUtil {
                 if (null == detail || detail.length == 0) {
                   val newDetails = new LoadMetadataDetails
                   newDetails.setLoadName(metadataDetail)
-                  LOGGER.error(
+                  LOGGER.info(
                     "Added in SILoadFailedSegment " + newDetails.getLoadName + " for SI" +
                     " table " + indexTableName + "." + carbonTable.getTableName)
                   failedLoadMetadataDetails.add(newDetails)
@@ -524,7 +524,7 @@ object CarbonIndexUtil {
                         LockUsage.LOCK)
                     if (segmentLockOfProbableOnCompactionSeg.lockWithRetries()) {
                       segmentLocks += segmentLockOfProbableOnCompactionSeg
-                      LOGGER.error(
+                      LOGGER.info(
                         "Added in SILoadFailedSegment " + detail(0).getLoadName + " for SI "
                         + "table " + indexTableName + "." + carbonTable.getTableName)
                       failedLoadMetadataDetails.add(detail(0))

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/standardpartition/StandardPartitionTableCleanTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/standardpartition/StandardPartitionTableCleanTestCase.scala
@@ -69,7 +69,7 @@ class StandardPartitionTableCleanTestCase extends QueryTest with BeforeAndAfterA
       CarbonTablePath.getMetadataPath(carbonTable.getTablePath))
     val segLoad = details.find(_.getLoadName.equals(segmentId)).get
     val seg = new SegmentFileStore(carbonTable.getTablePath, segLoad.getSegmentFile)
-    assert(seg.getIndexOrMergeFiles.size == indexes)
+    assert(seg.getIndexAndMergeFiles.size == indexes)
   }
 
   test("clean up partition table for int partition column") {


### PR DESCRIPTION
 ### Why is this PR needed?
Reindex failed when SI has stale carbonindexmerge file, throw exception FileNotFoundException. This is because  SegmentFileStore.getIndexFiles stores the mapping of indexfile to indexmergefile, when stale carbon indexmergefile exists, indexmergefile will not be null. During merging index file, new indexmergefile will be created with same name as before in the same location. At the end of CarbonIndexFileMergeWriter.writeMergeIndexFileBasedOnSegmentFile, carbon index file will be deleted. Since indexmergefile is stored in the indexFiles list, newly created indexmergefile will be delete also, which leads to FileNotFoundException.
 
 ### What changes were proposed in this PR?
1. SegmentFileStore.getIndexFiles stores the mapping of indexfile to indexmergefile which is redundant.
2. SegmentFileStore.getIndexOrMergeFiles returns both index file and index merge file, so function name is incorrect, rename to getIndexAndMergeFiles.
3. CarbonLoaderUtil.getActiveExecutor actually get active node, so function name is incorrect, rename to getActiveNode, together replace all "executor" with "node" in function assignBlocksByDataLocality.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
