### PR TITLE
[CARBONDATA-4149] Fix query issues after alter add partition. 

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/indexstore/PartitionSpec.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/PartitionSpec.java
@@ -76,6 +76,11 @@ public class PartitionSpec implements Serializable, Writable {
     return locationPath;
   }
 
+  public void setLocation(String location) {
+    locationPath = new Path(location);
+    this.location = location;
+  }
+
   public String getUuid() {
     return uuid;
   }

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonMergerRDD.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonMergerRDD.scala
@@ -17,7 +17,7 @@
 
 package org.apache.carbondata.spark.rdd
 
-import java.io.IOException
+import java.io.{File, IOException}
 import java.util
 import java.util.{Collections, List}
 import java.util.concurrent.atomic.AtomicInteger
@@ -25,6 +25,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.reflect.classTag
+import scala.util.control.Breaks.{break, breakable}
 
 import org.apache.hadoop.mapreduce.{InputSplit, Job}
 import org.apache.spark._
@@ -96,6 +97,27 @@ class CarbonMergerRDD[K, V](
 
   def makeBroadCast(splits: util.List[CarbonInputSplit]): Unit = {
     broadCastSplits = sparkContext.broadcast(new CarbonInputSplitWrapper(splits))
+  }
+
+  // checks for added partition specs with external path.
+  // after compaction, location path to be updated with table path.
+  def checkAndUpdatePartitionLocation(partitionSpec: PartitionSpec) : PartitionSpec = {
+    breakable {
+      if (partitionSpec != null) {
+        carbonLoadModel.getLoadMetadataDetails.asScala.foreach(loadMetaDetail => {
+          if (loadMetaDetail.getPath != null &&
+              loadMetaDetail.getPath.split(",").contains(partitionSpec.getLocation.toString)) {
+            val updatedPartitionLocation = CarbonDataProcessorUtil
+              .createCarbonStoreLocationForPartition(
+                carbonLoadModel.getCarbonDataLoadSchema.getCarbonTable,
+                partitionSpec.getPartitions.toArray.mkString(File.separator))
+            partitionSpec.setLocation(updatedPartitionLocation)
+            break()
+          }
+        })
+      }
+    }
+    partitionSpec
   }
 
   override def internalCompute(theSplit: Partition, context: TaskContext): Iterator[(K, V)] = {
@@ -210,6 +232,7 @@ class CarbonMergerRDD[K, V](
         val tempStoreLoc = CarbonDataProcessorUtil.getLocalDataFolderLocation(
           carbonTable, carbonLoadModel.getTaskNo, mergeNumber, true, false)
 
+       checkAndUpdatePartitionLocation(partitionSpec)
         if (carbonTable.getSortScope == SortScopeOptions.SortScope.NO_SORT ||
           rawResultIteratorMap.get(CarbonCompactionUtil.UNSORTED_IDX).size() == 0) {
 

--- a/processing/src/main/java/org/apache/carbondata/processing/merger/CarbonDataMergerUtil.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/merger/CarbonDataMergerUtil.java
@@ -824,9 +824,9 @@ public final class CarbonDataMergerUtil {
       //check if this load is an already merged load.
       if (null != segment.getMergedLoadName()) {
         segments
-            .add(Segment.getSegment(segment.getMergedLoadName(), segment.getSegmentFile(), null));
+            .add(new Segment(segment.getMergedLoadName(), segment.getSegmentFile(), null, segment));
       } else {
-        segments.add(Segment.getSegment(segment.getLoadName(), segment.getSegmentFile(), null));
+        segments.add(new Segment(segment.getLoadName(), segment.getSegmentFile(), null, segment));
       }
     }
     return segments;

--- a/processing/src/main/java/org/apache/carbondata/processing/util/CarbonDataProcessorUtil.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/util/CarbonDataProcessorUtil.java
@@ -687,6 +687,16 @@ public final class CarbonDataProcessorUtil {
   }
 
   /**
+   * This method will get the store location for the given path, partition spec
+   *
+   * @return data directory path
+   */
+  public static String createCarbonStoreLocationForPartition(CarbonTable carbonTable,
+      String partition) {
+    return carbonTable.getTablePath() + CarbonCommonConstants.FILE_SEPARATOR + partition;
+  }
+
+  /**
    * initialise data type for measures for their storage format
    */
   public static DataType[] initDataType(CarbonTable carbonTable, String tableName,


### PR DESCRIPTION
 ### Why is this PR needed?
 Query with SI after add partition based on location on partition table gives incorrect results. 
1. While pruning, if it's an external segment, it should use `ExternalSegmentResolver `, and no need to use `ImplicitIncludeFilterExecutor `as an external segment is not added in the SI table.
2. If the partition table has external partitions, after compaction the new files are loaded to the external path.
3. Data is not loaded to the child table(MV) after executing add partition command

 ### What changes were proposed in this PR?
1. add path to `loadMetadataDetails `for external partition. It is used to identify it as an external segment.
2. After compaction, to not maintain any link to the external partition, the compacted files will be added as a new partition in the table. To update partition spec details in hive metastore, (drop partition + add partition) operations performed.
3. Add Load Pre and Post listener's in CarbonAlterTableAddHivePartitionCommand to trigger data load to materialized view.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
