### PR TITLE
[CARBONDATA-4153] Fix DoNot Push down not equal to filter with Cast on SI

### DIFF
--- a/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/TestSIWithSecondaryIndex.scala
+++ b/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/TestSIWithSecondaryIndex.scala
@@ -653,6 +653,22 @@ class TestSIWithSecondaryIndex extends QueryTest with BeforeAndAfterAll {
     sql("drop table if exists maintable")
   }
 
+  test("test SI with donot push down not equal to filter with Cast") {
+    sql("drop table if exists maintable")
+    sql("create table maintable (a string,b string,c string) STORED AS carbondata ")
+    sql("insert into maintable values ('aa', '3', 'cc')")
+    sql("create index indextable on table maintable(b) AS 'carbondata'")
+    val df1 = sql("select * from maintable where b!=2")
+    val df2 = sql("select * from maintable where b!='2'")
+    if (isFilterPushedDownToSI(df1.queryExecution.sparkPlan) &&
+        isFilterPushedDownToSI(df2.queryExecution.sparkPlan)) {
+      assert(false)
+    } else {
+      assert(true)
+    }
+    sql("drop table if exists maintable")
+  }
+
   def createAndInsertDataIntoTable(): Unit = {
     sql("drop table if exists maintable2")
     sql("create table maintable2 (a string,b string,c int) STORED AS carbondata ")

--- a/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/optimizer/CarbonSecondaryIndexOptimizer.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/optimizer/CarbonSecondaryIndexOptimizer.scala
@@ -513,6 +513,8 @@ class CarbonSecondaryIndexOptimizer(sparkSession: SparkSession) {
     val doNotPushToSI = condition match {
       case IsNotNull(child: AttributeReference) => !pushDownNotNullFilter
       case Not(EqualTo(left: AttributeReference, right: Literal)) => true
+      case Not(EqualTo(left: Cast, right: Literal))
+        if left.child.isInstanceOf[AttributeReference] => true
       case Not(Like(left: AttributeReference, right: Literal)) => true
       case Not(In(left: AttributeReference, right: Seq[Expression])) => true
       case Not(Contains(left: AttributeReference, right: Literal)) => true


### PR DESCRIPTION
 ### Why is this PR needed?
NOT EQUAL TO filter on SI index column, should not be pushed down to SI table.
Currently, where x!='2' is not pushing down to SI, but where x!=2 is pushed down to SI.

This is because "x != 2" will be wrapped in a CAST expression like NOT EQUAL TO(cast(x as int) = 2).
 
 ### What changes were proposed in this PR?
Handle CAST case while checking DONOT PUSH DOWN to SI
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
