### PR TITLE
[CARBONDATA-4154] Fix various concurrent issues with clean files

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/util/DeleteLoadFolders.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/DeleteLoadFolders.java
@@ -121,8 +121,7 @@ public final class DeleteLoadFolders {
     SegmentUpdateStatusManager updateStatusManager =
         new SegmentUpdateStatusManager(carbonTable, currLoadDetails);
     for (final LoadMetadataDetails oneLoad : loadDetails) {
-      if (loadsToDelete.contains(oneLoad.getLoadName()) && canDeleteThisLoad(oneLoad,
-          isForceDelete, cleanStaleInProgress, carbonTable.getAbsoluteTableIdentifier())) {
+      if (loadsToDelete.contains(oneLoad.getLoadName())) {
         try {
           if (oneLoad.getSegmentFile() != null) {
             String tablePath = carbonTable.getAbsoluteTableIdentifier().getTablePath();
@@ -223,8 +222,8 @@ public final class DeleteLoadFolders {
         return canDelete;
       case INSERT_IN_PROGRESS:
       case INSERT_OVERWRITE_IN_PROGRESS:
-        return canSegmentLockBeAcquired(oneLoad, absoluteTableIdentifier) && canDelete &&
-            cleanStaleInProgress;
+        return canDelete && cleanStaleInProgress && canSegmentLockBeAcquired(oneLoad,
+            absoluteTableIdentifier);
       default:
         return false;
     }
@@ -257,12 +256,12 @@ public final class DeleteLoadFolders {
                 isForceDelete, cleanStaleInProgress, absoluteTableIdentifier)) {
               oneLoad.setVisibility("false");
               loadsToDelete.add(oneLoad.getLoadName());
-              LOGGER.info("Info: Deleted the load " + oneLoad.getLoadName());
+              LOGGER.info("Deleted the load " + oneLoad.getLoadName());
             }
           } else {
             oneLoad.setVisibility("false");
             loadsToDelete.add(oneLoad.getLoadName());
-            LOGGER.info("Info: Deleted the load " + oneLoad.getLoadName());
+            LOGGER.info("Deleted the load " + oneLoad.getLoadName());
           }
         }
       }
@@ -275,10 +274,10 @@ public final class DeleteLoadFolders {
     ICarbonLock segmentLock = CarbonLockFactory.getCarbonLockObj(absoluteTableIdentifier,
         CarbonTablePath.addSegmentPrefix(oneLoad.getLoadName()) + LockUsage.LOCK);
     if (segmentLock.lockWithRetries()) {
-      LOGGER.info("INFO: Segment Lock on segment: " + oneLoad.getLoadName() + "can be acquired.");
+      LOGGER.info("Segment Lock on segment: " + oneLoad.getLoadName() + "can be acquired.");
       return segmentLock.unlock();
     } else {
-      LOGGER.info("INFO: Segment Lock on segment: " + oneLoad.getLoadName() + "can not be" +
+      LOGGER.info("Segment Lock on segment: " + oneLoad.getLoadName() + "can not be" +
           " acquired. Load going on for that load");
     }
     return false;


### PR DESCRIPTION
 ### Why is this PR needed?
There are 2 issues in clean files operation when ran concurrently with multiple load operations:
1. Dry run can show negative space freed for clean files with concurrent load.
2. Accidental deletion of Insert in progress(ongoing load) during clean files operation.

 
 ### What changes were proposed in this PR?
1. To solve the dry run negative result, saving the old metadatadetails before the clean files operation and comparing it with loadmetadetails after the clean files operation and just ignoring any new entry that has been added, basically doing an intersection of new and old metadatadetails to show the correct space freed.
2. In case of load failure issue, there can be scenarios where load in going on(insert in progress state and segment lock is occupied) and as during clean files operation when the final table status lock is removed, there can be scenarios where the load has completed and the segment lock is released but in the clean files in the final list of loadmetadatadetails to be deleted, that load can still be in Insert In Progress state with segment lock released by the load. The clean files operation will delete such loads. To solve this issue, instead of sending a boolean which check if update is required or not in the tablestatus, can send a list of load numbers and will only delete those loadnumbers.
    
 ### Does this PR introduce any user interface change?
 - No
 - Yes. (please explain the change and update document)

 ### Is any new testcase added?
 - No
 - Yes

    
