### PR TITLE
[CARBONDATA-4158]Add Secondary Index as a coarse-grain index and use secondary indexes for Presto queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Some features are marked as experimental because the syntax/implementation might
 2. Accelerating performance using MV on parquet/orc.
 3. Merge API for Spark DataFrame.
 4. Hive write for non-transactional table.
+5. Secondary Index as a Coarse Grain Index in query processing
 
 ##  Integration
 * [Hive](https://github.com/apache/carbondata/blob/master/docs/hive-guide.md)

--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -2317,6 +2317,34 @@ public final class CarbonCommonConstants {
   public static final String CARBON_ENABLE_INDEX_SERVER = "carbon.enable.index.server";
 
   /**
+   * This property is used to support Secondary Index as a Coarse Grain Index.
+   * 1. The default value of this property is false for the spark session. By default, Spark queries
+   * continue to use secondary indexes in the query pruning via spark query plan rewrite. If
+   * user want to use secondary index as a Coarse Grain Index in spark query pruning, need to
+   * explicitly configure this property to true. Setting this configuration to true also avoids the
+   * query plan rewrite.
+   * 2. The default value of this property is true for Presto. By default, Presto queries use
+   * secondary index as a Coarse Grain Index in spark query pruning. If user do not wish to use the
+   * secondary indexes in the query pruning, need to explicitly configure this property to false.
+   *
+   * Property is supported at both session level and carbon level. It can be configured in 2
+   * variants as show below:
+   * 1. Global - carbon.coarse.grain.secondary.index
+   * 2. For a particular table - carbon.coarse.grain.secondary.index.<dbname>.<tablename>
+   * Property when specified along with database name and table name ensures that Secondary Index
+   * as Coarse Grain Index can be enabled/disable for queries on a particular table. Property with
+   * database name and table name has higher precedence over global.
+   */
+  @CarbonProperty(dynamicConfigurable = true)
+  public static final String CARBON_COARSE_GRAIN_SECONDARY_INDEX =
+      "carbon.coarse.grain.secondary.index";
+
+  /**
+   * This default value false is applicable only for the spark session
+   */
+  public static final String CARBON_COARSE_GRAIN_SECONDARY_INDEX_DEFAULT = "false";
+
+  /**
    * Configured property to enable/disable prepriming in index server
    */
   public static final String CARBON_INDEXSEVER_ENABLE_PREPRIMING =

--- a/core/src/main/java/org/apache/carbondata/core/index/AbstractIndexJob.java
+++ b/core/src/main/java/org/apache/carbondata/core/index/AbstractIndexJob.java
@@ -37,8 +37,18 @@ public abstract class AbstractIndexJob implements IndexJob {
   }
 
   @Override
+  public Object[] execute(String sql) {
+    return new Object[0];
+  }
+
+  @Override
   public List<ExtendedBlocklet> execute(IndexInputFormat indexInputFormat,
       Configuration configuration) {
     return null;
+  }
+
+  @Override
+  public Long executeCountJob(IndexInputFormat indexInputFormat, Configuration configuration) {
+    return 0L;
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/index/IndexFilter.java
+++ b/core/src/main/java/org/apache/carbondata/core/index/IndexFilter.java
@@ -134,7 +134,7 @@ public class IndexFilter implements Serializable {
     }
   }
 
-  private Set<String> extractColumnExpressions(Expression expression) {
+  public static Set<String> extractColumnExpressions(Expression expression) {
     Set<String> columnExpressionList = new HashSet<>();
     for (Expression expressions: expression.getChildren()) {
       if (expressions != null && expressions.getChildren() != null

--- a/core/src/main/java/org/apache/carbondata/core/index/IndexInputFormat.java
+++ b/core/src/main/java/org/apache/carbondata/core/index/IndexInputFormat.java
@@ -96,6 +96,8 @@ public class IndexInputFormat extends FileInputFormat<Void, ExtendedBlocklet>
   // Whether AsyncCall to the Index Server(true in the case of pre-priming)
   private boolean isAsyncCall;
 
+  private boolean isSIPruningEnabled;
+
   IndexInputFormat() {
 
   }
@@ -258,6 +260,7 @@ public class IndexInputFormat extends FileInputFormat<Void, ExtendedBlocklet>
     out.writeBoolean(isWriteToFile);
     out.writeBoolean(isCountStarJob);
     out.writeBoolean(isAsyncCall);
+    out.writeBoolean(isSIPruningEnabled);
   }
 
   @Override
@@ -305,6 +308,7 @@ public class IndexInputFormat extends FileInputFormat<Void, ExtendedBlocklet>
     this.isWriteToFile = in.readBoolean();
     this.isCountStarJob = in.readBoolean();
     this.isAsyncCall = in.readBoolean();
+    this.isSIPruningEnabled = in.readBoolean();
   }
 
   private void initReadCommittedScope() throws IOException {
@@ -340,6 +344,14 @@ public class IndexInputFormat extends FileInputFormat<Void, ExtendedBlocklet>
    */
   public boolean isJobToClearIndexes() {
     return isJobToClearIndexes;
+  }
+
+  public boolean isSIPruningEnabled() {
+    return isSIPruningEnabled;
+  }
+
+  public void setSIPruningEnabled(boolean SIPruningEnabled) {
+    isSIPruningEnabled = SIPruningEnabled;
   }
 
   public String getTaskGroupId() {
@@ -428,7 +440,7 @@ public class IndexInputFormat extends FileInputFormat<Void, ExtendedBlocklet>
 
   public void createIndexChooser() throws IOException {
     if (null != filterResolverIntf) {
-      this.indexChooser = new IndexChooser(table);
+      this.indexChooser = new IndexChooser(table, isSIPruningEnabled);
     }
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/index/IndexJob.java
+++ b/core/src/main/java/org/apache/carbondata/core/index/IndexJob.java
@@ -35,6 +35,8 @@ public interface IndexJob extends Serializable {
 
   void execute(CarbonTable carbonTable, FileInputFormat<Void, BlockletIndexWrapper> format);
 
+  Object[] execute(String sql);
+
   List<ExtendedBlocklet> execute(IndexInputFormat indexInputFormat, Configuration configuration);
 
   Long executeCountJob(IndexInputFormat indexInputFormat, Configuration configuration);

--- a/core/src/main/java/org/apache/carbondata/core/index/IndexStoreManager.java
+++ b/core/src/main/java/org/apache/carbondata/core/index/IndexStoreManager.java
@@ -37,7 +37,6 @@ import org.apache.carbondata.core.indexstore.SegmentPropertiesFetcher;
 import org.apache.carbondata.core.indexstore.blockletindex.BlockletIndexFactory;
 import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
 import org.apache.carbondata.core.metadata.CarbonMetadata;
-import org.apache.carbondata.core.metadata.index.IndexType;
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
 import org.apache.carbondata.core.metadata.schema.table.IndexSchema;
 import org.apache.carbondata.core.mutate.UpdateVO;
@@ -95,13 +94,10 @@ public final class IndexStoreManager {
         .getIndexesMap().entrySet()) {
       for (Map.Entry<String, Map<String, String>> indexEntry : providerEntry.getValue()
           .entrySet()) {
-        if (!indexEntry.getValue().get(CarbonCommonConstants.INDEX_PROVIDER)
-            .equalsIgnoreCase(IndexType.SI.getIndexProviderName())) {
-          IndexSchema indexSchema = new IndexSchema(indexEntry.getKey(),
-              indexEntry.getValue().get(CarbonCommonConstants.INDEX_PROVIDER));
-          indexSchema.setProperties(indexEntry.getValue());
-          indexes.add(getIndex(carbonTable, indexSchema));
-        }
+        IndexSchema indexSchema = new IndexSchema(indexEntry.getKey(),
+            indexEntry.getValue().get(CarbonCommonConstants.INDEX_PROVIDER));
+        indexSchema.setProperties(indexEntry.getValue());
+        indexes.add(getIndex(carbonTable, indexSchema));
       }
     }
     return indexes;

--- a/core/src/main/java/org/apache/carbondata/core/index/IndexUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/index/IndexUtil.java
@@ -201,6 +201,12 @@ public class IndexUtil {
     }
   }
 
+  public static Object[] getPositionReferences(String sql) {
+    IndexJob indexJob = (IndexJob) createIndexJob(
+        "org.apache.spark.sql.secondaryindex.jobs.StringProjectionQueryJob");
+    return indexJob.execute(sql);
+  }
+
   private static FileInputFormat createIndexJob(CarbonTable carbonTable,
       IndexExprWrapper indexExprWrapper, List<Segment> validSegments, String clsName) {
     try {
@@ -276,8 +282,7 @@ public class IndexUtil {
       List<Segment> validSegments, List<Segment> invalidSegments, IndexLevel level,
       List<String> segmentsToBeRefreshed, Configuration configuration) {
     return executeIndexJob(carbonTable, resolver, indexJob, partitionsToPrune, validSegments,
-        invalidSegments, level, false, segmentsToBeRefreshed, false,
-        configuration);
+        invalidSegments, level, false, segmentsToBeRefreshed, false, false, configuration);
   }
 
   /**
@@ -289,7 +294,7 @@ public class IndexUtil {
       FilterResolverIntf resolver, IndexJob indexJob, List<PartitionSpec> partitionsToPrune,
       List<Segment> validSegments, List<Segment> invalidSegments, IndexLevel level,
       Boolean isFallbackJob, List<String> segmentsToBeRefreshed, boolean isCountJob,
-      Configuration configuration) {
+      boolean isSIPruningEnabled, Configuration configuration) {
     List<String> invalidSegmentNo = new ArrayList<>();
     for (Segment segment : invalidSegments) {
       invalidSegmentNo.add(segment.getSegmentNo());
@@ -302,6 +307,7 @@ public class IndexUtil {
       indexInputFormat.setCountStarJob();
       indexInputFormat.setIsWriteToFile(false);
     }
+    indexInputFormat.setSIPruningEnabled(isSIPruningEnabled);
     return indexJob.execute(indexInputFormat, configuration);
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/index/secondaryindex/CarbonCostBasedOptimizer.java
+++ b/core/src/main/java/org/apache/carbondata/core/index/secondaryindex/CarbonCostBasedOptimizer.java
@@ -15,15 +15,63 @@
  * limitations under the License.
  */
 
-package org.apache.spark.sql.secondaryindex.optimizer;
+package org.apache.carbondata.core.index.secondaryindex;
 
+import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.carbondata.common.logging.LogServiceFactory;
+import org.apache.carbondata.core.constants.CarbonCommonConstants;
+import org.apache.carbondata.core.metadata.index.IndexType;
+import org.apache.carbondata.core.metadata.schema.indextable.IndexMetadata;
+import org.apache.carbondata.core.metadata.schema.table.TableInfo;
+
+import org.apache.log4j.Logger;
+
 public class CarbonCostBasedOptimizer {
+  private static final Logger LOGGER =
+      LogServiceFactory.getLogService(CarbonCostBasedOptimizer.class.getName());
+  private static Map<String, List<String>> getSecondaryIndexes(TableInfo tableInfo) {
+    Map<String, List<String>> indexes = new HashMap<>();
+    String indexMeta =
+        tableInfo.getFactTable().getTableProperties().get(tableInfo.getFactTable().getTableId());
+    IndexMetadata indexMetadata = null;
+    if (null != indexMeta) {
+      try {
+        indexMetadata = IndexMetadata.deserialize(indexMeta);
+      } catch (IOException e) {
+        LOGGER.error("Error deserializing index metadata", e);
+      }
+    }
+    if (indexMetadata != null) {
+      String provider = IndexType.SI.getIndexProviderName();
+      if (!indexMetadata.isIndexTable() && (null != indexMetadata.getIndexesMap().get(provider))) {
+        for (Map.Entry<String, Map<String, String>> entry : indexMetadata.getIndexesMap()
+            .get(provider).entrySet()) {
+          Map<String, String> indexProperties = entry.getValue();
+          indexes.put(entry.getKey(),
+              Arrays.asList(indexProperties.get(CarbonCommonConstants.INDEX_COLUMNS).split(",")));
+        }
+      }
+    }
+    return indexes;
+  }
+
+  public static List<String> identifyRequiredTables(Set<String> filterAttributes,
+      TableInfo tableInfo) {
+    Map<String, List<String>> indexTableInfos = getSecondaryIndexes(tableInfo);
+    if (indexTableInfos.isEmpty()) {
+      return new ArrayList<>();
+    }
+    return identifyRequiredTables(filterAttributes, indexTableInfos);
+  }
+
   public static List<String> identifyRequiredTables(Set<String> filterAttributes,
       Map<String, List<String>> indexTableInfos) {
     List<String> matchedIndexTables = new ArrayList<>();

--- a/core/src/main/java/org/apache/carbondata/core/metadata/index/IndexType.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/index/IndexType.java
@@ -20,7 +20,7 @@ package org.apache.carbondata.core.metadata.index;
 public enum IndexType {
   LUCENE("org.apache.carbondata.index.lucene.LuceneFineGrainIndexFactory", "lucene"),
   BLOOMFILTER("org.apache.carbondata.index.bloom.BloomCoarseGrainIndexFactory", "bloomfilter"),
-  SI("", "si");
+  SI("org.apache.carbondata.index.secondary.SecondaryIndexFactory", "si");
 
 
   /**
@@ -57,6 +57,8 @@ public enum IndexType {
       return LUCENE;
     } else if (BLOOMFILTER.isEqual(indexProviderName)) {
       return BLOOMFILTER;
+    } else if (SI.isEqual(indexProviderName)) {
+      return SI;
     } else {
       throw new UnsupportedOperationException("Unknown index provider" + indexProviderName);
     }

--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/indextable/IndexTableInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/indextable/IndexTableInfo.java
@@ -157,15 +157,18 @@ public class IndexTableInfo implements Serializable {
     return toGson(indexTableInfos);
   }
 
-  public static String enableIndex(String oldIndexIno, String indexName) {
-    IndexTableInfo[] indexTableInfos = fromGson(oldIndexIno);
+  public static void setIndexStatus(IndexTableInfo[] indexTableInfos, String indexName,
+      IndexStatus status) {
     for (IndexTableInfo indexTableInfo : indexTableInfos) {
       if (indexTableInfo.tableName.equalsIgnoreCase(indexName)) {
-        Map<String, String> oldIndexProperties = indexTableInfo.indexProperties;
-        oldIndexProperties.put(CarbonCommonConstants.INDEX_STATUS, IndexStatus.ENABLED.name());
-        indexTableInfo.setIndexProperties(oldIndexProperties);
+        indexTableInfo.indexProperties.put(CarbonCommonConstants.INDEX_STATUS, status.name());
       }
     }
+  }
+
+  public static String setIndexStatus(String oldIndexInfo, String indexName, IndexStatus status) {
+    IndexTableInfo[] indexTableInfos = fromGson(oldIndexInfo);
+    setIndexStatus(indexTableInfos, indexName, status);
     return toGson(indexTableInfos);
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/scan/expression/ExpressionResult.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/expression/ExpressionResult.java
@@ -24,10 +24,8 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.TimeZone;
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
-import org.apache.carbondata.core.keygenerator.directdictionary.timestamp.DateDirectDictionaryGenerator;
 import org.apache.carbondata.core.metadata.datatype.DataType;
 import org.apache.carbondata.core.metadata.datatype.DataTypes;
 import org.apache.carbondata.core.scan.expression.exception.FilterIllegalMemberException;
@@ -172,25 +170,9 @@ public class ExpressionResult implements Comparable<ExpressionResult> {
     try {
       DataType dataType = this.getDataType();
       if (dataType == DataTypes.DATE || dataType == DataTypes.TIMESTAMP) {
-        String format = CarbonUtil.getFormatFromProperty(this.getDataType());
-        SimpleDateFormat parser = new SimpleDateFormat(format);
-        if (this.getDataType() == DataTypes.DATE) {
-          parser.setTimeZone(TimeZone.getTimeZone("GMT"));
-        }
-        if (value instanceof Timestamp) {
-          return parser.format((Timestamp) value);
-        } else if (value instanceof java.sql.Date) {
-          return parser.format((java.sql.Date) value);
-        } else if (value instanceof Long) {
-          if (isLiteral) {
-            return parser.format(new Timestamp((long) value / 1000));
-          }
-          return parser.format(new Timestamp((long) value));
-        } else if (value instanceof Integer) {
-          long date = ((int) value) * DateDirectDictionaryGenerator.MILLIS_PER_DAY;
-          return parser.format(new java.sql.Date(date));
-        }
-        return value.toString();
+        return CarbonUtil
+            .getFormattedDateOrTimestamp(CarbonUtil.getFormatFromProperty(dataType), dataType,
+                value, isLiteral);
       } else {
         return value.toString();
       }

--- a/core/src/main/java/org/apache/carbondata/core/scan/expression/LiteralExpression.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/expression/LiteralExpression.java
@@ -17,9 +17,12 @@
 
 package org.apache.carbondata.core.scan.expression;
 
+import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.metadata.datatype.DataType;
+import org.apache.carbondata.core.metadata.datatype.DataTypes;
 import org.apache.carbondata.core.scan.filter.intf.ExpressionType;
 import org.apache.carbondata.core.scan.filter.intf.RowIntf;
+import org.apache.carbondata.core.util.CarbonUtil;
 
 public class LiteralExpression extends LeafExpression {
 
@@ -58,7 +61,19 @@ public class LiteralExpression extends LeafExpression {
 
   @Override
   public String getStatement() {
-    return value == null ? null : value.toString();
+    boolean quoteString = false;
+    Object val = value;
+    if (val != null) {
+      if (dataType == DataTypes.STRING || val instanceof String) {
+        quoteString = true;
+      } else if (dataType == DataTypes.TIMESTAMP || dataType == DataTypes.DATE) {
+        val = CarbonUtil.getFormattedDateOrTimestamp(dataType == DataTypes.TIMESTAMP ?
+            CarbonCommonConstants.CARBON_TIMESTAMP_DEFAULT_FORMAT :
+            CarbonCommonConstants.CARBON_DATE_DEFAULT_FORMAT, dataType, value, true);
+        quoteString = true;
+      }
+    }
+    return val == null ? null : quoteString ? "'" + val.toString() + "'" : val.toString();
   }
 
   /**

--- a/core/src/main/java/org/apache/carbondata/core/scan/expression/conditional/NotEqualsExpression.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/expression/conditional/NotEqualsExpression.java
@@ -102,6 +102,6 @@ public class NotEqualsExpression extends BinaryConditionalExpression {
 
   @Override
   public String getStatement() {
-    return left.getStatement() + " <> " + right.getStatement();
+    return left.getStatement() + (isNotNull ? " is not " : " <> ") + right.getStatement();
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonProperties.java
@@ -2188,6 +2188,34 @@ public final class CarbonProperties {
   }
 
   /**
+   * Check whether coarse grain secondary index is enabled or not. If property is not configured,
+   * default value {@link CarbonCommonConstants#CARBON_COARSE_GRAIN_SECONDARY_INDEX_DEFAULT} is
+   * returned
+   */
+  public boolean isCoarseGrainSecondaryIndex(String dbName, String tableName) {
+    return isCoarseGrainSecondaryIndex(dbName, tableName,
+        CarbonCommonConstants.CARBON_COARSE_GRAIN_SECONDARY_INDEX_DEFAULT);
+  }
+
+  /**
+   * Check whether coarse grain secondary index is enabled or not. If property is not configured,
+   * input default value is returned
+   */
+  public boolean isCoarseGrainSecondaryIndex(String dbName, String tableName, String defaultValue) {
+    String configuredValue = getProperty(
+        CarbonCommonConstants.CARBON_COARSE_GRAIN_SECONDARY_INDEX + "." + dbName + "." + tableName);
+    if (configuredValue == null) {
+      configuredValue =
+          getProperty(CarbonCommonConstants.CARBON_COARSE_GRAIN_SECONDARY_INDEX, defaultValue);
+    }
+    boolean isCoarseGrainSecondaryIndex = Boolean.parseBoolean(configuredValue);
+    if (isCoarseGrainSecondaryIndex) {
+      LOGGER.info("Coarse grain secondary index is enabled for " + dbName + "." + tableName);
+    }
+    return isCoarseGrainSecondaryIndex;
+  }
+
+  /**
    * for test to print current configuration
    */
   @Override

--- a/core/src/main/java/org/apache/carbondata/core/util/SessionParams.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/SessionParams.java
@@ -144,6 +144,7 @@ public class SessionParams implements Serializable, Cloneable {
       case CARBON_ENABLE_INDEX_SERVER:
       case CARBON_QUERY_STAGE_INPUT:
       case CARBON_ENABLE_MV:
+      case CARBON_COARSE_GRAIN_SECONDARY_INDEX:
         isValid = CarbonUtil.validateBoolean(value);
         if (!isValid) {
           throw new InvalidConfigurationException("Invalid value " + value + " for key " + key);
@@ -217,7 +218,10 @@ public class SessionParams implements Serializable, Cloneable {
           }
         } else if (key.startsWith(CarbonCommonConstants.CARBON_INDEX_VISIBLE)) {
           isValid = true;
-        } else if (key.startsWith(CarbonCommonConstants.CARBON_LOAD_INDEXES_PARALLEL)) {
+        } else if (key.startsWith(CarbonCommonConstants.CARBON_LOAD_INDEXES_PARALLEL) || (
+            key.startsWith(CARBON_COARSE_GRAIN_SECONDARY_INDEX) && key.split("\\.").length == 7)) {
+          // validate the value field when property key is with database name and table name.
+          // Like, carbon.coarse.grain.secondary.index.<dbname>.<tablename>
           isValid = CarbonUtil.validateBoolean(value);
           if (!isValid) {
             throw new InvalidConfigurationException("Invalid value " + value + " for key " + key);

--- a/docs/index/secondary-index-guide.md
+++ b/docs/index/secondary-index-guide.md
@@ -217,3 +217,32 @@ Note: This command is not supported with other concurrent operations.
 ## Complex DataType support on SI
 Currently, only complex Array types are supported for creating secondary indexes. Nested Array
 support and other complex types support will be supported in the future.
+
+## Secondary Index as a Coarse Grain Index in query processing (Experimental)
+Secondary Indexes are used in main table query pruning by rewriting the Spark plan during course of 
+query execution. It is not possible to use Secondary Indexes in the query pruning when the query is 
+fired from engines other than Spark (i.e., Presto, Hive etc). To address this issue, 
+Secondary Index is implemented as a Coarse Grain Index similar to Bloom. Coarse Grain Index pruning 
+happens right after default pruning of the table being queried. A new property is introduced at 
+session level and carbon level to support Secondary Index as a Coarse Grain Index. It can be 
+configured in two variants as show below:
+1. Configure globally - ```carbon.coarse.grain.secondary.index```
+2. Configure for a particular table - ```carbon.coarse.grain.secondary.index.<dbname>.<tablename>```
+
+Property when specified along with database name and table name ensures that Secondary Index as 
+Coarse Grain Index can be enabled/disable for query pruning on a particular table. It has higher 
+precedence over global configuration.
+
+The default value of the property is ```false``` for the Spark session. By default, Spark 
+queries continue to use Secondary Indexes in the query pruning via spark query plan rewrite. If 
+user want to use Secondary Index as a Coarse Grain Index in spark query pruning, need to explicitly 
+configure the property to ```true```. Setting the configuration to ```true``` also avoids the 
+query plan rewrite. Since the feature is newly introduced, unless existing queries are working with 
+Coarse Grain Secondary Index, and the performance improvement is evident, It is recommended to 
+avoid using this property for the existing customers using the Secondary Indexes with Spark queries. 
+
+The default value of this property is ```true``` for Presto. By default, Presto queries use 
+Secondary Index as a Coarse Grain Index in spark query pruning. If user do not wish to use the 
+Secondary Indexes in the query pruning, need to explicitly configure this property to ```false```.
+
+Note: This feature is not supported with the Secondary Index tables created on the older versions.

--- a/integration/flink/src/test/scala/org/apache/carbon/flink/TestCarbonWriter.scala
+++ b/integration/flink/src/test/scala/org/apache/carbon/flink/TestCarbonWriter.scala
@@ -214,7 +214,7 @@ class TestCarbonWriter extends QueryTest with BeforeAndAfterAll{
         """
           |Table Scan on test_flink
           | - total: 1 blocks, 1 blocklets
-          | - filter: (intfield <> null and intfield = 99)
+          | - filter: (intfield is not null and intfield = 99)
           | - pruned by Main Index
           |    - skipped: 0 blocks, 0 blocklets
           | - pruned by CG Index

--- a/integration/presto/src/main/prestodb/org/apache/carbondata/presto/CarbondataPageSourceProvider.java
+++ b/integration/presto/src/main/prestodb/org/apache/carbondata/presto/CarbondataPageSourceProvider.java
@@ -18,6 +18,7 @@
 package org.apache.carbondata.presto;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
@@ -82,6 +83,9 @@ public class CarbondataPageSourceProvider extends HivePageSourceProvider {
         new HdfsEnvironment.HdfsContext(session, carbonSplit.getDatabase(), carbonSplit.getTable()),
         new Path(carbonSplit.getSchema().getProperty("tablePath")));
     configuration = carbonTableReader.updateS3Properties(configuration);
+    for (Map.Entry<Object, Object> entry : carbonSplit.getSchema().entrySet()) {
+      configuration.set(entry.getKey().toString(), entry.getValue().toString());
+    }
     CarbonTable carbonTable = getCarbonTable(carbonSplit, configuration);
     boolean isDirectVectorFill = carbonTableReader.config.getPushRowFilter() == null ||
         carbonTableReader.config.getPushRowFilter().equalsIgnoreCase("false");

--- a/integration/presto/src/main/prestodb/org/apache/carbondata/presto/CarbondataSplitManager.java
+++ b/integration/presto/src/main/prestodb/org/apache/carbondata/presto/CarbondataSplitManager.java
@@ -146,6 +146,9 @@ public class CarbondataSplitManager extends HiveSplitManager {
         new HdfsEnvironment.HdfsContext(session, schemaTableName.getSchemaName(),
             schemaTableName.getTableName()), new Path(location));
     configuration = carbonTableReader.updateS3Properties(configuration);
+    for (Map.Entry<String, String> entry : table.getStorage().getSerdeParameters().entrySet()) {
+      configuration.set(entry.getKey(), entry.getValue());
+    }
     // set the hadoop configuration to thread local, so that FileFactory can use it.
     ThreadLocalSessionInfo.setConfigurationToCurrentThread(configuration);
     CarbonTableCacheModel cache =

--- a/integration/presto/src/main/prestodb/org/apache/carbondata/presto/impl/CarbonTableReader.java
+++ b/integration/presto/src/main/prestodb/org/apache/carbondata/presto/impl/CarbonTableReader.java
@@ -20,6 +20,7 @@ package org.apache.carbondata.presto.impl;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -35,12 +36,16 @@ import org.apache.carbondata.core.datastore.filesystem.CarbonFile;
 import org.apache.carbondata.core.datastore.impl.FileFactory;
 import org.apache.carbondata.core.index.IndexFilter;
 import org.apache.carbondata.core.index.IndexStoreManager;
+import org.apache.carbondata.core.index.status.IndexStatus;
 import org.apache.carbondata.core.indexstore.PartitionSpec;
 import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
 import org.apache.carbondata.core.metadata.CarbonMetadata;
 import org.apache.carbondata.core.metadata.SegmentFileStore;
 import org.apache.carbondata.core.metadata.converter.SchemaConverter;
 import org.apache.carbondata.core.metadata.converter.ThriftWrapperSchemaConverterImpl;
+import org.apache.carbondata.core.metadata.index.IndexType;
+import org.apache.carbondata.core.metadata.schema.indextable.IndexMetadata;
+import org.apache.carbondata.core.metadata.schema.indextable.IndexTableInfo;
 import org.apache.carbondata.core.metadata.schema.PartitionInfo;
 import org.apache.carbondata.core.metadata.schema.partition.PartitionType;
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
@@ -223,6 +228,7 @@ public class CarbonTableReader {
         CarbonMetadata.getInstance().loadTableMetadata(wrapperTableInfo);
         CarbonTable carbonTable = Objects.requireNonNull(CarbonMetadata.getInstance()
             .getCarbonTable(table.getSchemaName(), table.getTableName()), "carbontable is null");
+        refreshIndexInfo(carbonTable, config);
         cache = new CarbonTableCacheModel(modifiedTime, carbonTable);
         // cache the table
         carbonCache.get().put(table, cache);
@@ -231,6 +237,51 @@ public class CarbonTableReader {
       return cache;
     } catch (Exception ex) {
       throw new RuntimeException(ex);
+    }
+  }
+
+  private void refreshIndexInfo(CarbonTable carbonTable, Configuration config) {
+    Map<String, Map<String, Map<String, String>>> indexTableMap = new ConcurrentHashMap<>();
+    String indexInfo = config.get("indexInfo", IndexTableInfo.toGson(new IndexTableInfo[0]));
+    String parentTableName = config.get("parentTableName", "");
+    String parentTableId = config.get("parentTableId", "");
+    String parentTablePath = config.get("parentTablePath", "");
+    boolean isIndexTable = Boolean.getBoolean(config.get("isIndexTable", "false"));
+    IndexTableInfo[] indexTableInfos = IndexTableInfo.fromGson(indexInfo);
+    for (IndexTableInfo indexTableInfo : indexTableInfos) {
+      Map<String, String> indexProperties = indexTableInfo.getIndexProperties();
+      String indexProvider;
+      if (indexProperties != null) {
+        indexProvider = indexProperties.get(CarbonCommonConstants.INDEX_PROVIDER);
+      } else {
+        // in case if SI table has been created before the change CARBONDATA-3765,
+        // indexProperties variable will not be present. On direct upgrade of SI store,
+        // indexProperties will be null, in that case, create indexProperties from indexCols
+        // For details, refer
+        // {@link org.apache.spark.sql.secondaryindex.hive.CarbonInternalMetastore#refreshIndexInfo}
+        indexProperties = new HashMap<>();
+        indexProperties.put(CarbonCommonConstants.INDEX_COLUMNS,
+            String.join(",", indexTableInfo.getIndexCols()));
+        indexProvider = IndexType.SI.getIndexProviderName();
+        indexProperties.put(CarbonCommonConstants.INDEX_PROVIDER, indexProvider);
+        indexProperties.put(CarbonCommonConstants.INDEX_STATUS, IndexStatus.DISABLED.name());
+      }
+      if (indexTableMap.get(indexProvider) == null) {
+        Map<String, Map<String, String>> indexTableInfoMap = new HashMap<>();
+        indexTableInfoMap.put(indexTableInfo.getTableName(), indexProperties);
+        indexTableMap.put(indexProvider, indexTableInfoMap);
+      } else {
+        indexTableMap.get(indexProvider).put(indexTableInfo.getTableName(), indexProperties);
+      }
+    }
+    IndexMetadata indexMetadata =
+        new IndexMetadata(indexTableMap, parentTableName, isIndexTable, parentTablePath,
+            parentTableId);
+    try {
+      carbonTable.getTableInfo().getFactTable().getTableProperties()
+          .put(carbonTable.getCarbonTableIdentifier().getTableId(), indexMetadata.serialize());
+    } catch (IOException e) {
+      LOGGER.error("Error serializing index metadata", e);
     }
   }
 
@@ -270,6 +321,11 @@ public class CarbonTableReader {
     config.set("query.id", queryId);
     CarbonInputFormat.setTransactionalTable(config, carbonTable.isTransactionalTable());
     CarbonInputFormat.setTableInfo(config, carbonTable.getTableInfo());
+    if (CarbonProperties.getInstance().isCoarseGrainSecondaryIndex(tableInfo.getDatabaseName(),
+        tableInfo.getFactTable().getTableName(), "true")) {
+      CarbonInputFormat
+          .checkAndSetSecondaryIndexPruning(carbonTable.getTableInfo(), filters, config);
+    }
 
     JobConf jobConf = new JobConf(config);
     try {

--- a/integration/presto/src/main/prestosql/org/apache/carbondata/presto/CarbondataPageSourceProvider.java
+++ b/integration/presto/src/main/prestosql/org/apache/carbondata/presto/CarbondataPageSourceProvider.java
@@ -18,6 +18,7 @@
 package org.apache.carbondata.presto;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
@@ -84,6 +85,9 @@ public class CarbondataPageSourceProvider extends HivePageSourceProvider {
         new HdfsEnvironment.HdfsContext(session, carbonSplit.getDatabase(), carbonSplit.getTable()),
         new Path(carbonSplit.getSchema().getProperty("tablePath")));
     configuration = carbonTableReader.updateS3Properties(configuration);
+    for (Map.Entry<Object, Object> entry : carbonSplit.getSchema().entrySet()) {
+      configuration.set(entry.getKey().toString(), entry.getValue().toString());
+    }
     CarbonTable carbonTable = getCarbonTable(carbonSplit, configuration);
     boolean isDirectVectorFill = carbonTableReader.config.getPushRowFilter() == null ||
         carbonTableReader.config.getPushRowFilter().equalsIgnoreCase("false");

--- a/integration/presto/src/main/prestosql/org/apache/carbondata/presto/CarbondataSplitManager.java
+++ b/integration/presto/src/main/prestosql/org/apache/carbondata/presto/CarbondataSplitManager.java
@@ -152,6 +152,9 @@ public class CarbondataSplitManager extends HiveSplitManager {
         new HdfsEnvironment.HdfsContext(session, schemaTableName.getSchemaName(),
             schemaTableName.getTableName()), new Path(location));
     configuration = carbonTableReader.updateS3Properties(configuration);
+    for (Map.Entry<String, String> entry : table.getStorage().getSerdeParameters().entrySet()) {
+      configuration.set(entry.getKey(), entry.getValue());
+    }
     // set the hadoop configuration to thread local, so that FileFactory can use it.
     ThreadLocalSessionInfo.setConfigurationToCurrentThread(configuration);
     CarbonTableCacheModel cache =

--- a/integration/spark/src/main/scala/org/apache/carbondata/index/secondary/SecondaryIndex.java
+++ b/integration/spark/src/main/scala/org/apache/carbondata/index/secondary/SecondaryIndex.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.index.secondary;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.carbondata.common.logging.LogServiceFactory;
+import org.apache.carbondata.core.constants.CarbonCommonConstants;
+import org.apache.carbondata.core.datastore.block.SegmentProperties;
+import org.apache.carbondata.core.index.IndexUtil;
+import org.apache.carbondata.core.index.dev.IndexModel;
+import org.apache.carbondata.core.index.dev.cgindex.CoarseGrainIndex;
+import org.apache.carbondata.core.indexstore.Blocklet;
+import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
+import org.apache.carbondata.core.scan.expression.Expression;
+import org.apache.carbondata.core.scan.filter.executer.FilterExecutor;
+import org.apache.carbondata.core.scan.filter.resolver.FilterResolverIntf;
+import org.apache.carbondata.core.util.path.CarbonTablePath;
+import org.apache.carbondata.index.secondary.SecondaryIndexModel.PositionReferenceInfo;
+
+import org.apache.log4j.Logger;
+
+/**
+ * Secondary Index to prune at blocklet level.
+ */
+public class SecondaryIndex extends CoarseGrainIndex {
+  private static final Logger LOGGER =
+      LogServiceFactory.getLogService(SecondaryIndex.class.getName());
+  private String indexName;
+  private String currentSegmentId;
+  private List<String> validSegmentIds;
+  private PositionReferenceInfo positionReferenceInfo;
+
+  @Override
+  public void init(IndexModel indexModel) {
+    assert (indexModel instanceof SecondaryIndexModel);
+    SecondaryIndexModel model = (SecondaryIndexModel) indexModel;
+    indexName = model.getIndexName();
+    currentSegmentId = model.getCurrentSegmentId();
+    validSegmentIds = model.getValidSegmentIds();
+    positionReferenceInfo = model.getPositionReferenceInfo();
+  }
+
+  private Set<String> getPositionReferences(String databaseName, String indexName,
+      Expression expression) {
+    /* If the position references are not obtained yet(i.e., prune happening for the first valid
+    segment), then get them from the given index table with the given filter from all the valid
+    segments at once and store them as map of segmentId to set of position references in that
+    particular segment. Upon the subsequent prune for other segments, return the position
+    references for the respective segment from the map directly */
+    if (!positionReferenceInfo.isFetched()) {
+      Object[] rows = IndexUtil.getPositionReferences(String
+          .format("select distinct positionReference from %s.%s where insegment('%s') and %s",
+              databaseName, indexName, String.join(",", validSegmentIds),
+              expression.getStatement()));
+      for (Object row : rows) {
+        String positionReference = (String) row;
+        int blockletPathIndex = positionReference.indexOf("/");
+        String blockletPath = positionReference.substring(blockletPathIndex + 1);
+        int segEndIndex = blockletPath.lastIndexOf(CarbonCommonConstants.DASH);
+        int segStartIndex = blockletPath.lastIndexOf(CarbonCommonConstants.DASH, segEndIndex - 1);
+        Set<String> blockletPaths = positionReferenceInfo.getSegmentToPosReferences()
+            .computeIfAbsent(blockletPath.substring(segStartIndex + 1, segEndIndex),
+                k -> new HashSet<>());
+        blockletPaths.add(blockletPath);
+      }
+      positionReferenceInfo.setFetched(true);
+    }
+    Set<String> blockletPaths =
+        positionReferenceInfo.getSegmentToPosReferences().get(currentSegmentId);
+    return blockletPaths != null ? blockletPaths : new HashSet<>();
+  }
+
+  @Override
+  public List<Blocklet> prune(FilterResolverIntf filterExp, SegmentProperties segmentProperties,
+      FilterExecutor filterExecutor, CarbonTable carbonTable) {
+    Set<String> blockletPaths = getPositionReferences(carbonTable.getDatabaseName(), indexName,
+        filterExp.getFilterExpression());
+    List<Blocklet> blocklets = new ArrayList<>();
+    for (String blockletPath : blockletPaths) {
+      blockletPath = blockletPath.substring(blockletPath.indexOf(CarbonCommonConstants.DASH) + 1)
+          .replace(CarbonCommonConstants.UNDERSCORE, CarbonTablePath.BATCH_PREFIX);
+      int blockletIndex = blockletPath.lastIndexOf("/");
+      blocklets.add(new Blocklet(blockletPath.substring(0, blockletIndex),
+          blockletPath.substring(blockletIndex + 1)));
+    }
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug(String
+          .format("Secondary Index pruned blocklet count for segment %s is %d ", currentSegmentId,
+              blocklets.size()));
+    }
+    return blocklets;
+  }
+
+  @Override
+  public boolean isScanRequired(FilterResolverIntf filterExp) {
+    return true;
+  }
+
+  @Override
+  public void clear() {
+  }
+
+  @Override
+  public void finish() {
+  }
+}

--- a/integration/spark/src/main/scala/org/apache/carbondata/index/secondary/SecondaryIndexFactory.java
+++ b/integration/spark/src/main/scala/org/apache/carbondata/index/secondary/SecondaryIndexFactory.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.index.secondary;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.carbondata.common.annotations.InterfaceAudience;
+import org.apache.carbondata.common.exceptions.sql.MalformedIndexCommandException;
+import org.apache.carbondata.common.logging.LogServiceFactory;
+import org.apache.carbondata.core.datastore.block.SegmentProperties;
+import org.apache.carbondata.core.features.TableOperation;
+import org.apache.carbondata.core.index.IndexFilter;
+import org.apache.carbondata.core.index.IndexInputSplit;
+import org.apache.carbondata.core.index.IndexMeta;
+import org.apache.carbondata.core.index.Segment;
+import org.apache.carbondata.core.index.dev.IndexBuilder;
+import org.apache.carbondata.core.index.dev.IndexWriter;
+import org.apache.carbondata.core.index.dev.cgindex.CoarseGrainIndex;
+import org.apache.carbondata.core.index.dev.cgindex.CoarseGrainIndexFactory;
+import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
+import org.apache.carbondata.core.metadata.schema.table.IndexSchema;
+import org.apache.carbondata.core.scan.filter.intf.ExpressionType;
+import org.apache.carbondata.events.Event;
+import org.apache.carbondata.index.secondary.SecondaryIndexModel.PositionReferenceInfo;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.log4j.Logger;
+
+/**
+ * Index Factory for Secondary Index.
+ */
+@InterfaceAudience.Internal
+public class SecondaryIndexFactory extends CoarseGrainIndexFactory {
+  private static final Logger LOGGER =
+      LogServiceFactory.getLogService(SecondaryIndexFactory.class.getName());
+  private IndexMeta indexMeta;
+
+  public SecondaryIndexFactory(CarbonTable carbonTable, IndexSchema indexSchema)
+      throws MalformedIndexCommandException {
+    super(carbonTable, indexSchema);
+    List<ExpressionType> operations = new ArrayList<>(Arrays.asList(ExpressionType.values()));
+    indexMeta = new IndexMeta(indexSchema.getIndexName(),
+        carbonTable.getIndexedColumns(indexSchema.getIndexColumns()), operations);
+    LOGGER.info("Created Secondary Index Factory instance for " + indexSchema.getIndexName());
+  }
+
+  @Override
+  public IndexWriter createWriter(Segment segment, String shardName,
+      SegmentProperties segmentProperties) throws IOException {
+    throw new UnsupportedOperationException("Not supported for Secondary Index");
+  }
+
+  @Override
+  public IndexBuilder createBuilder(Segment segment, String shardName,
+      SegmentProperties segmentProperties) throws IOException {
+    throw new UnsupportedOperationException("Not supported for Secondary Index");
+  }
+
+  @Override
+  public IndexMeta getMeta() {
+    return indexMeta;
+  }
+
+  private Map<Segment, List<CoarseGrainIndex>> getIndexes(List<Segment> segments,
+      PositionReferenceInfo positionReferenceInfo) throws IOException {
+    Map<Segment, List<CoarseGrainIndex>> indexes = new HashMap<>();
+    List<String> allSegmentIds =
+        segments.stream().map(Segment::getSegmentNo).collect(Collectors.toList());
+    for (Segment segment : segments) {
+      indexes.put(segment, this.getIndexes(segment, allSegmentIds, positionReferenceInfo));
+    }
+    return indexes;
+  }
+
+  private List<CoarseGrainIndex> getIndexes(Segment segment, List<String> allSegmentIds,
+      PositionReferenceInfo positionReferenceInfo) throws IOException {
+    List<CoarseGrainIndex> indexes = new ArrayList<>();
+    SecondaryIndex secondaryIndex = new SecondaryIndex();
+    secondaryIndex.init(
+        new SecondaryIndexModel(getIndexSchema().getIndexName(), segment.getSegmentNo(),
+            allSegmentIds, positionReferenceInfo, segment.getConfiguration()));
+    indexes.add(secondaryIndex);
+    return indexes;
+  }
+
+  @Override
+  public Map<Segment, List<CoarseGrainIndex>> getIndexes(List<Segment> segments, IndexFilter filter)
+      throws IOException {
+    return getIndexes(segments, new PositionReferenceInfo());
+  }
+
+  @Override
+  public Map<Segment, List<CoarseGrainIndex>> getIndexes(List<Segment> segments,
+      Set<Path> partitionLocations, IndexFilter filter) throws IOException {
+    return getIndexes(segments, new PositionReferenceInfo());
+  }
+
+  @Override
+  public List<CoarseGrainIndex> getIndexes(Segment segment) throws IOException {
+    List<String> allSegmentIds = new ArrayList<>();
+    allSegmentIds.add(segment.getSegmentNo());
+    return getIndexes(segment, allSegmentIds, new PositionReferenceInfo());
+  }
+
+  @Override
+  public List<CoarseGrainIndex> getIndexes(Segment segment, Set<Path> partitionLocations)
+      throws IOException {
+    return getIndexes(segment);
+  }
+
+  @Override
+  public List<CoarseGrainIndex> getIndexes(IndexInputSplit distributable) throws IOException {
+    throw new UnsupportedOperationException("Not supported for Secondary Index");
+  }
+
+  @Override
+  public List<IndexInputSplit> toDistributable(Segment segment) {
+    throw new UnsupportedOperationException("Not supported for Secondary Index");
+  }
+
+  @Override
+  public void fireEvent(Event event) {
+  }
+
+  @Override
+  public void clear(String segment) {
+  }
+
+  @Override
+  public synchronized void clear() {
+  }
+
+  @Override
+  public void deleteIndexData(Segment segment) throws IOException {
+  }
+
+  @Override
+  public void deleteIndexData() {
+  }
+
+  @Override
+  public boolean willBecomeStale(TableOperation operation) {
+    return false;
+  }
+
+  @Override
+  public String getCacheSize() {
+    return "0:0";
+  }
+}

--- a/integration/spark/src/main/scala/org/apache/carbondata/index/secondary/SecondaryIndexModel.java
+++ b/integration/spark/src/main/scala/org/apache/carbondata/index/secondary/SecondaryIndexModel.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.index.secondary;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.carbondata.core.index.dev.IndexModel;
+
+import org.apache.hadoop.conf.Configuration;
+
+/**
+ * Secondary Index Model. it is used to initialize the Secondary Index Coarse Grain Index
+ */
+public class SecondaryIndexModel extends IndexModel {
+  private final String indexName; // Secondary Index name
+  private final String currentSegmentId; // Segment Id to prune
+  private final List<String> validSegmentIds; // Valid segment Ids for Secondary Index pruning
+  private final PositionReferenceInfo positionReferenceInfo; // Position reference information
+
+  public SecondaryIndexModel(String indexName, String currentSegmentId,
+      List<String> validSegmentIds, PositionReferenceInfo positionReferenceInfo,
+      Configuration configuration) {
+    super(null, configuration);
+    this.indexName = indexName;
+    this.currentSegmentId = currentSegmentId;
+    this.validSegmentIds = validSegmentIds;
+    this.positionReferenceInfo = positionReferenceInfo;
+  }
+
+  public String getIndexName() {
+    return indexName;
+  }
+
+  public String getCurrentSegmentId() {
+    return currentSegmentId;
+  }
+
+  public List<String> getValidSegmentIds() {
+    return validSegmentIds;
+  }
+
+  public PositionReferenceInfo getPositionReferenceInfo() {
+    return positionReferenceInfo;
+  }
+
+  /**
+   * Position Reference information. One instance of position reference information is shared across
+   * all the {@link SecondaryIndex} instances for the particular query pruning with the given index
+   * filter. This ensures to run a single sql query to get position references from the valid
+   * segments of the given secondary index table with given index filter and populate them in map.
+   * First secondary index segment prune in the query will run the sql query for position
+   * references and store them in map. And subsequent segments prune in the same query can avoid
+   * the individual sql for position references within the respective segment and return position
+   * references from the map directly
+   */
+  public static class PositionReferenceInfo {
+    /**
+     * Indicates whether position references are available or not. Initially it is false. It is set
+     * to true during the first secondary index segment prune after sql query for position
+     * references from the valid segments (passed in the {@link SecondaryIndexModel}) of the
+     * secondary index table. Those obtained position references are used to populate
+     * {@link #segmentToPosReferences} map
+     */
+    private boolean fetched;
+    /**
+     * Map of Segment Id to set of position references within that segment. First secondary index
+     * segment prune populates this map and the subsequent segment prune will return the position
+     * references for the respective segment from this map directly without further sql query for
+     * position references in the segment
+     */
+    private final Map<String, Set<String>> segmentToPosReferences = new HashMap<>();
+
+    public boolean isFetched() {
+      return fetched;
+    }
+
+    public void setFetched(boolean fetched) {
+      this.fetched = fetched;
+    }
+
+    public Map<String, Set<String>> getSegmentToPosReferences() {
+      return segmentToPosReferences;
+    }
+  }
+}

--- a/integration/spark/src/main/scala/org/apache/carbondata/indexserver/DistributedShowCacheRDD.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/indexserver/DistributedShowCacheRDD.scala
@@ -72,7 +72,7 @@ class DistributedShowCacheRDD(@transient private val ss: SparkSession,
                 .getCarbonTable
                 .getTableUniqueName
             } else {
-              index.getIndexSchema.getRelationIdentifier.getDatabaseName + "_" + index
+              index.getTable.getAbsoluteTableIdentifier.getDatabaseName + "_" + index
                 .getIndexSchema.getIndexName
             }
             if (executorCache) {

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
@@ -95,6 +95,9 @@ class CarbonEnv {
     // TODO: move it to proper place, it should be registered by indexSchema implementation
     sparkSession.udf.register("text_match", new TextMatchUDF)
     sparkSession.udf.register("text_match_with_limit", new TextMatchMaxDocUDF)
+    sparkSession.udf.register("insegment", new (String => Boolean) with Serializable {
+      override def apply(v1: String): Boolean = true
+    })
 
     // register udf for spatial index filters of querying
     GeoUdfRegister.registerQueryFilterUdf(sparkSession)

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/index/CarbonCreateIndexCommand.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/index/CarbonCreateIndexCommand.scala
@@ -225,7 +225,9 @@ case class CarbonCreateIndexCommand(
               new IndexTableInfo(parentTable.getDatabaseName, indexModel.indexName,
                 indexSchema.getProperties),
               false)
-            val enabledIndexInfo = IndexTableInfo.enableIndex(indexInfo, indexModel.indexName)
+            val enabledIndexInfo = IndexTableInfo.setIndexStatus(indexInfo,
+              indexModel.indexName,
+              IndexStatus.ENABLED)
 
             // set index information in parent table. Create it if it is null.
             val parentIndexMetadata = if (

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/index/CarbonRefreshIndexCommand.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/index/CarbonRefreshIndexCommand.scala
@@ -115,7 +115,9 @@ case class CarbonRefreshIndexCommand(
         LOGGER.info(s"Acquired the metadata lock for table " +
                     s"${ parentTable.getDatabaseName}.${ parentTable.getTableName }")
         val oldIndexInfo = parentTable.getIndexInfo
-        val updatedIndexInfo = IndexTableInfo.enableIndex(oldIndexInfo, indexName)
+        val updatedIndexInfo = IndexTableInfo.setIndexStatus(oldIndexInfo,
+          indexName,
+          IndexStatus.ENABLED)
 
         // set index information in parent table
         val parentIndexMetadata = parentTable.getIndexMetadata

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/strategy/CarbonDataSourceScan.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/strategy/CarbonDataSourceScan.scala
@@ -54,7 +54,8 @@ case class CarbonDataSourceScan(
     @transient pushedDownFilters: Seq[Expression],
     directScanSupport: Boolean,
     @transient extraRDD: Option[(RDD[InternalRow], Boolean)] = None,
-    tableIdentifier: Option[TableIdentifier] = None)
+    tableIdentifier: Option[TableIdentifier] = None,
+    segmentIds: Option[String] = None)
   extends DataSourceScanExec with ColumnarBatchScan {
 
   override lazy val supportsBatch: Boolean = {
@@ -129,7 +130,8 @@ case class CarbonDataSourceScan(
       relation.carbonTable.getTableInfo.serialize(),
       relation.carbonTable.getTableInfo,
       new CarbonInputMetrics,
-      selectedPartitions)
+      selectedPartitions,
+      segmentIds = segmentIds)
     carbonRdd.setVectorReaderSupport(supportsBatch)
     carbonRdd.setDirectScanSupport(supportsBatch && directScanSupport)
     extraRDD.map(_._1.union(carbonRdd)).getOrElse(carbonRdd)

--- a/integration/spark/src/main/scala/org/apache/spark/sql/hive/execution/command/CarbonHiveCommands.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/hive/execution/command/CarbonHiveCommands.scala
@@ -130,7 +130,8 @@ object CarbonSetCommand {
       if (keySplits.length == 6 || keySplits.length == 4) {
         sessionParams.addProperty(key.toString, value)
       }
-    } else if (key.equalsIgnoreCase(CarbonCommonConstants.CARBON_REORDER_FILTER)) {
+    } else if (key.equalsIgnoreCase(CarbonCommonConstants.CARBON_REORDER_FILTER) ||
+               key.startsWith(CarbonCommonConstants.CARBON_COARSE_GRAIN_SECONDARY_INDEX)) {
       sessionParams.addProperty(key, value)
     } else if (isCarbonProperty) {
       sessionParams.addProperty(key, value)

--- a/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/jobs/StringProjectionQueryJob.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/jobs/StringProjectionQueryJob.scala
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.secondaryindex.jobs
+
+import org.apache.spark.sql.util.SparkSQLUtil
+
+import org.apache.carbondata.core.index.AbstractIndexJob
+
+/**
+ * Spark job to run the sql and get the values of string projection column.
+ * Note: Expects a string column as projection in sql.
+ */
+class StringProjectionQueryJob extends AbstractIndexJob {
+  override def execute(sql: String): Array[Object] = {
+    SparkSQLUtil
+      .getSparkSession
+      .sql(sql)
+      .rdd
+      .map(row => row.get(0).asInstanceOf[String])
+      .collect
+      .asInstanceOf[Array[Object]]
+  }
+}

--- a/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/load/Compactor.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/load/Compactor.scala
@@ -32,6 +32,7 @@ import org.apache.spark.sql.secondaryindex.util.SecondaryIndexUtil
 import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.datastore.impl.FileFactory
+import org.apache.carbondata.core.index.status.IndexStatus
 import org.apache.carbondata.core.locks.ICarbonLock
 import org.apache.carbondata.core.metadata.index.IndexType
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable
@@ -161,6 +162,11 @@ object Compactor {
                  | SET SERDEPROPERTIES ('isSITableEnabled' = 'false')
                """.stripMargin).collect()
           }
+          CarbonIndexUtil.updateIndexStatusInBatch(carbonMainTable,
+            siCompactionIndexList,
+            IndexType.SI,
+            IndexStatus.DISABLED,
+            sparkSession)
           throw ex
       } finally {
         // once compaction is success, release the segment locks

--- a/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/optimizer/CarbonSITransformationRule.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/optimizer/CarbonSITransformationRule.scala
@@ -29,6 +29,7 @@ import org.apache.spark.util.SparkUtil
 import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.metadata.index.IndexType
+import org.apache.carbondata.core.util.CarbonProperties
 import org.apache.carbondata.spark.util.CarbonSparkUtil
 
 /**
@@ -47,11 +48,13 @@ class CarbonSITransformationRule(sparkSession: SparkSession)
     plan.collect {
       case l: LogicalRelation if (!hasSecondaryIndexTable &&
                                   l.relation.isInstanceOf[CarbonDatasourceHadoopRelation]) =>
-        hasSecondaryIndexTable = l.relation
-                       .asInstanceOf[CarbonDatasourceHadoopRelation]
-                       .carbonTable
-                       .getIndexTableNames(IndexType.SI.getIndexProviderName).size() > 0
-
+        val carbonTable = l.relation.asInstanceOf[CarbonDatasourceHadoopRelation].carbonTable
+        hasSecondaryIndexTable = if (!CarbonProperties.getInstance()
+          .isCoarseGrainSecondaryIndex(carbonTable.getDatabaseName, carbonTable.getTableName)) {
+          carbonTable.getIndexTableNames(IndexType.SI.getIndexProviderName).size() > 0
+        } else {
+          false
+        }
     }
     if (hasSecondaryIndexTable && checkIfRuleNeedToBeApplied(plan)) {
       secondaryIndexOptimizer.transformFilterToJoin(plan, isProjectionNeeded(plan))

--- a/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/optimizer/CarbonSecondaryIndexOptimizer.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/optimizer/CarbonSecondaryIndexOptimizer.scala
@@ -36,6 +36,7 @@ import org.apache.spark.sql.secondaryindex.optimizer.NodeType.NodeType
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.datastore.impl.FileFactory
+import org.apache.carbondata.core.index.secondaryindex.CarbonCostBasedOptimizer
 import org.apache.carbondata.core.util.CarbonProperties
 
 class SIFilterPushDownOperation(nodeType: NodeType)

--- a/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/rdd/SecondaryIndexCreator.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/rdd/SecondaryIndexCreator.scala
@@ -38,8 +38,10 @@ import org.apache.spark.sql.util.SparkSQLUtil
 import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.datastore.impl.FileFactory
+import org.apache.carbondata.core.index.status.IndexStatus
 import org.apache.carbondata.core.locks.{CarbonLockFactory, ICarbonLock, LockUsage}
 import org.apache.carbondata.core.metadata.{CarbonTableIdentifier, SegmentFileStore}
+import org.apache.carbondata.core.metadata.index.IndexType
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable
 import org.apache.carbondata.core.segmentmeta.SegmentMetaDataInfo
 import org.apache.carbondata.core.statusmanager.{LoadMetadataDetails, SegmentStatus, SegmentStatusManager}
@@ -484,6 +486,12 @@ object SecondaryIndexCreator {
               .getDatabaseName
           }.${ secondaryIndexModel.secondaryIndex.indexName } SET
              |SERDEPROPERTIES ('isSITableEnabled' = 'false')""".stripMargin).collect()
+        CarbonIndexUtil.updateIndexStatus(secondaryIndexModel.carbonTable,
+          secondaryIndexModel.secondaryIndex.indexName,
+          IndexType.SI,
+          IndexStatus.DISABLED,
+          true,
+          secondaryIndexModel.sqlContext.sparkSession)
       }
       // close the executor service
       if (null != executorService) {

--- a/integration/spark/src/test/scala/org/apache/carbondata/index/bloom/BloomCoarseGrainIndexSuite.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/index/bloom/BloomCoarseGrainIndexSuite.scala
@@ -733,7 +733,7 @@ class BloomCoarseGrainIndexSuite extends QueryTest with BeforeAndAfterAll with B
       """
         |Table Scan on carbon_bloom
         | - total: 3 blocks, 3 blocklets
-        | - filter: (num1 <> null and num1 = 1)
+        | - filter: (num1 is not null and num1 = 1)
         | - pruned by Main Index
         |    - skipped: 1 blocks, 1 blocklets
         | - pruned by CG Index
@@ -752,7 +752,7 @@ class BloomCoarseGrainIndexSuite extends QueryTest with BeforeAndAfterAll with B
       """
         |Table Scan on carbon_bloom
         | - total: 3 blocks, 3 blocklets
-        | - filter: (dictstring <> null and dictstring = S21)
+        | - filter: (dictstring is not null and dictstring = 'S21')
         | - pruned by Main Index
         |    - skipped: 1 blocks, 1 blocklets
         | - pruned by CG Index

--- a/integration/spark/src/test/scala/org/apache/carbondata/integration/spark/testsuite/complexType/TestArrayContainsPushDown.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/integration/spark/testsuite/complexType/TestArrayContainsPushDown.scala
@@ -48,11 +48,11 @@ class TestArrayContainsPushDown extends QueryTest with BeforeAndAfterAll {
 
     checkExistence(sql(" explain select * from complex1 where array_contains(arr,'sd')"),
       true,
-      "PushedFilters: [arr = sd]")
+      "PushedFilters: [arr = 'sd']")
 
     checkExistence(sql(" explain select count(*) from complex1 where array_contains(arr,'sd')"),
       true,
-      "PushedFilters: [arr = sd]")
+      "PushedFilters: [arr = 'sd']")
 
     checkAnswer(sql(" select * from complex1 where array_contains(arr,'sd')"),
       Seq(Row(mutable.WrappedArray.make(Array("sd", "df", "gh"))),
@@ -263,13 +263,13 @@ class TestArrayContainsPushDown extends QueryTest with BeforeAndAfterAll {
       sql("explain select * from complex1 " +
           "where array_contains(arr,cast('2018-01-01 00:00:00' as timestamp))"),
       true,
-      "PushedFilters: [arr = 1514793600000000]")
+      "PushedFilters: [arr = '2018-01-01 00:00:00']")
 
     checkExistence(
       sql("explain select count(*) from complex1 " +
           "where array_contains(arr,cast('2018-01-01 00:00:00' as timestamp))"),
       true,
-      "PushedFilters: [arr = 1514793600000000]")
+      "PushedFilters: [arr = '2018-01-01 00:00:00']")
 
     checkAnswer(
       sql("select * from complex1 " +
@@ -295,13 +295,13 @@ class TestArrayContainsPushDown extends QueryTest with BeforeAndAfterAll {
     checkExistence(
       sql("explain select * from complex1 where array_contains(arr,cast('2018-01-01' as date))"),
       true,
-      "PushedFilters: [arr = 17532]")
+      "PushedFilters: [arr = '2018-01-01']")
 
     checkExistence(
       sql("explain select count(*) from complex1 " +
           "where array_contains(arr,cast('2018-01-01' as date))"),
       true,
-      "PushedFilters: [arr = 17532]")
+      "PushedFilters: [arr = '2018-01-01']")
 
     checkAnswer(sql(" select * from complex1 where array_contains(arr,cast('2018-01-01' as date))"),
       Seq(Row(mutable.WrappedArray.make(

--- a/processing/src/main/java/org/apache/carbondata/processing/index/IndexWriterListener.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/index/IndexWriterListener.java
@@ -34,6 +34,7 @@ import org.apache.carbondata.core.index.TableIndex;
 import org.apache.carbondata.core.index.dev.IndexFactory;
 import org.apache.carbondata.core.index.dev.IndexWriter;
 import org.apache.carbondata.core.metadata.CarbonTableIdentifier;
+import org.apache.carbondata.core.metadata.index.IndexType;
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable;
 import org.apache.carbondata.core.metadata.schema.table.column.CarbonColumn;
 import org.apache.carbondata.processing.store.TablePage;
@@ -73,9 +74,10 @@ public class IndexWriterListener {
     }
     tblIdentifier = carbonTable.getCarbonTableIdentifier();
     for (TableIndex tableIndex : tableIndices) {
-      // register it only if it is not lazy index, for lazy index, user
+      // register it only if it is not lazy index and not secondary index. For lazy index, user
       // will rebuild the index manually
-      if (!tableIndex.getIndexSchema().isLazy()) {
+      if (!tableIndex.getIndexSchema().isLazy() && !tableIndex.getIndexSchema().getProviderName()
+          .equals(IndexType.SI.getIndexProviderName())) {
         IndexFactory factory = tableIndex.getIndexFactory();
         register(factory, segmentId, taskNo, segmentProperties);
       }


### PR DESCRIPTION
 ### Why is this PR needed?
At present, secondary indexes are leveraged for query pruning via spark plan modification. This approach is tightly coupled with spark because the plan modification is specific to spark engine. In order to use secondary indexes for Presto or Hive queries, it is not feasible to modify the query plans as we desire in the current approach. Thus need arises for an engine agnostic approach to use secondary indexes in query pruning.
 
 ### What changes were proposed in this PR?
1. Add Secondary Index as a coarse grain index.
2. Add a new insegment() UDF to support query within the particular segments
3. Control the use of Secondary Index as a coarse grain index pruning with property('carbon.coarse.grain.secondary.index')
4. Use Index Server driver for Secondary Index pruning
5. Use Secondary Indexes with Presto Queries

 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No
    
