### PR TITLE
[CARBONDATA-4155] Fix Create table like table with MV

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonCreateTableLikeCommand.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonCreateTableLikeCommand.scala
@@ -26,6 +26,7 @@ import org.apache.spark.sql.execution.command.MetadataCommand
 
 import org.apache.carbondata.common.exceptions.sql.MalformedCarbonCommandException
 import org.apache.carbondata.common.logging.LogServiceFactory
+import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.metadata.schema.{SchemaEvolution, SchemaEvolutionEntry}
 import org.apache.carbondata.core.metadata.schema.table.{TableInfo, TableSchema}
 
@@ -58,6 +59,9 @@ case class CarbonCreateTableLikeCommand(
     dstTableSchema.getTableProperties.remove(srcTable.getTableId)
     dstTableSchema.setTableName(targetTable.table)
     dstTableSchema.setTableId(UUID.randomUUID().toString)
+
+    // remove mv related info from source table tblProperties
+    dstTableSchema.getTableProperties.remove(CarbonCommonConstants.RELATED_MV_TABLES_MAP)
 
     val schemaEvol: SchemaEvolution = new SchemaEvolution
     val schEntryList: util.List[SchemaEvolutionEntry] = new util.ArrayList[SchemaEvolutionEntry]


### PR DESCRIPTION
 ### Why is this PR needed?
 PR-4076 has added a new table property to fact table. While executing create table like command, this property is not excluded, which leads to parsing exception.
 
 ### What changes were proposed in this PR?
Remove MV related info from destination table properties
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
