### PR TITLE
 [CARBONDATA-4149] Fix query issues after alter add empty partition location

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/indexstore/ExtendedBlocklet.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/ExtendedBlocklet.java
@@ -167,7 +167,8 @@ public class ExtendedBlocklet extends Blocklet {
    * @param uniqueLocation
    * @throws IOException
    */
-  public void serializeData(DataOutput out, Map<String, Short> uniqueLocation, boolean isCountJob)
+  public void serializeData(DataOutput out, Map<String, Short> uniqueLocation, boolean isCountJob,
+      boolean isExternalPath)
       throws IOException {
     super.write(out);
     if (isCountJob) {
@@ -197,7 +198,7 @@ public class ExtendedBlocklet extends Blocklet {
           inputSplit.setWriteDetailInfo(false);
         }
         inputSplit.serializeFields(dos, uniqueLocation);
-        out.writeBoolean(inputSplit.getSegment().isExternalSegment());
+        out.writeBoolean(isExternalPath);
         out.writeInt(ebos.size());
         out.write(ebos.getBuffer(), 0, ebos.size());
       }
@@ -226,8 +227,8 @@ public class ExtendedBlocklet extends Blocklet {
     boolean isSplitPresent = in.readBoolean();
     if (isSplitPresent) {
       String filePath = getPath();
-      boolean isExternalSegment = in.readBoolean();
-      if (!isExternalSegment) {
+      boolean isExternalPath = in.readBoolean();
+      if (!isExternalPath) {
         setFilePath(tablePath + filePath);
       } else {
         setFilePath(filePath);

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/ExtendedBlockletWrapper.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/ExtendedBlockletWrapper.java
@@ -121,8 +121,9 @@ public class ExtendedBlockletWrapper implements Writable, Serializable {
     DataOutputStream stream = new DataOutputStream(bos);
     try {
       for (ExtendedBlocklet extendedBlocklet : extendedBlockletList) {
+        boolean isExternalPath = !extendedBlocklet.getFilePath().startsWith(tablePath);
         extendedBlocklet.setFilePath(extendedBlocklet.getFilePath().replace(tablePath, ""));
-        extendedBlocklet.serializeData(stream, uniqueLocations, isCountJob);
+        extendedBlocklet.serializeData(stream, uniqueLocations, isCountJob, isExternalPath);
       }
       byte[] input = bos.toByteArray();
       return new SnappyCompressor().compressByte(input, input.length);

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
@@ -2797,6 +2797,10 @@ public final class CarbonUtil {
         }
       }
     } else {
+      if (isPartitionTable) {
+        // segment id can be null for external added partition path, so get id from blockname.
+        segmentId = CarbonTablePath.DataFileUtil.getSegmentNo(blockName);
+      }
       blockId = filePath.substring(0, filePath.length() - blockName.length()).replace("/", "#")
           + CarbonCommonConstants.FILE_SEPARATOR + "Segment_" + segmentId
           + CarbonCommonConstants.FILE_SEPARATOR + blockName;

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonMergerRDD.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonMergerRDD.scala
@@ -102,19 +102,13 @@ class CarbonMergerRDD[K, V](
   // checks for added partition specs with external path.
   // after compaction, location path to be updated with table path.
   def checkAndUpdatePartitionLocation(partitionSpec: PartitionSpec) : PartitionSpec = {
-    breakable {
-      if (partitionSpec != null) {
-        carbonLoadModel.getLoadMetadataDetails.asScala.foreach(loadMetaDetail => {
-          if (loadMetaDetail.getPath != null &&
-              loadMetaDetail.getPath.split(",").contains(partitionSpec.getLocation.toString)) {
-            val updatedPartitionLocation = CarbonDataProcessorUtil
-              .createCarbonStoreLocationForPartition(
-                carbonLoadModel.getCarbonDataLoadSchema.getCarbonTable,
-                partitionSpec.getPartitions.toArray.mkString(File.separator))
-            partitionSpec.setLocation(updatedPartitionLocation)
-            break()
-          }
-        })
+    if (partitionSpec != null) {
+      if (!partitionSpec.getLocation.toString.startsWith(carbonLoadModel.getTablePath)) {
+        val updatedPartitionLocation = CarbonDataProcessorUtil
+          .createCarbonStoreLocationForPartition(
+            carbonLoadModel.getCarbonDataLoadSchema.getCarbonTable,
+            partitionSpec.getPartitions.toArray.mkString(File.separator))
+        partitionSpec.setLocation(updatedPartitionLocation)
       }
     }
     partitionSpec

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonTableCompactor.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonTableCompactor.scala
@@ -272,16 +272,10 @@ class CarbonTableCompactor(
         compactionCallableModel.compactedPartitions = Some(partitionSpecs)
       }
       partitionSpecs.foreach(partitionSpec => {
-        breakable {
-          carbonLoadModel.getLoadMetadataDetails.asScala.foreach(loadMetaDetail => {
-            if (loadMetaDetail.getPath != null &&
-                loadMetaDetail.getPath.split(",").contains(partitionSpec.getLocation.toString)) {
-              // if partition spec added is external path,
-              // after compaction location path to be updated with table path.
-              updatePartitionSpecs.add(partitionSpec)
-              break()
-            }
-          })
+        if (!partitionSpec.getLocation.toString.startsWith(carbonLoadModel.getTablePath)) {
+          // if partition spec added is external path,
+          // after compaction location path to be updated with table path.
+          updatePartitionSpecs.add(partitionSpec)
         }
       })
     }


### PR DESCRIPTION
 ### Why is this PR needed?
Query with SI after add partition based on empty location on partition table gives incorrect results.
pr- 4107 fixes the issue for add partition if the location is not empty. 
 
 ### What changes were proposed in this PR?
while creating blockid, get segment number from the file name for the external partition. This blockid will be added to SI and used for pruning. To identify as an external partition during the compaction process, instead of checking with loadmetapath, checking with filepath.startswith(tablepath) format.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
