### PR TITLE
[CARBONDATA-4161] Describe complex columns

### DIFF
--- a/docs/ddl-of-carbondata.md
+++ b/docs/ddl-of-carbondata.md
@@ -43,6 +43,10 @@ CarbonData DDL statements are documented here,which includes:
   * [External Table on non-transactional table location](#create-external-table-on-non-transactional-table-data-location)
 * [CREATE DATABASE](#create-database)
 * [TABLE MANAGEMENT](#table-management)
+  * [DESCRIBE COMMAND](#describe-command)
+    * [DESCRIBE TABLE](#describe-table)
+    * [DESCRIBE COLUMN](#describe-column)
+    * [DESCRIBE COLUMN SHORT](#describe-column-short)
   * [SHOW TABLE](#show-table)
   * [ALTER TABLE](#alter-table)
     * [RENAME TABLE](#rename-table)
@@ -645,6 +649,78 @@ CarbonData DDL statements are documented here,which includes:
   ```
 
 ## TABLE MANAGEMENT  
+
+### DESCRIBE COMMAND
+
+- #### DESCRIBE TABLE
+  Describe table displays the metadata information of a table. Using extended or formatted in the syntax will display the detailed information of a table.
+
+  ```
+  [DESC | DESCRIBE] [TABLE] [EXTENDED | Formatted ] [db_name.]table_name
+  ```
+
+- #### DESCRIBE COLUMN
+  The column definitions for complex types will be long in DESCRIBE table command, and it becomes difficult to read in nested format.
+  The DESCRIBE COLUMN command uses special formatting for complex type columns to make the output readable.
+  
+  ```
+  [DESCRIBE | DESC] COLUMN fieldname[.nestedFieldNames] ON [TABLE] [db_name.]table_name;
+  ```
+  Examples: 
+  ```
+    DESCRIBE COLUMN locationinfo on complexcarbontable;
+    
+    +------------------------------+----------------------------------------------------------------------------------------------+-------------------+
+    |col_name                      |data_type                                                                                     |comment            |
+    +------------------------------+----------------------------------------------------------------------------------------------+-------------------+
+    |locationinfo                  |array                                                                                         |this is an array   |
+    |## Children of locationinfo:  |                                                                                              |                   |
+    |item                          |struct<activeprovince:string,activecity:map<string,string>,activestreet:array<string>>        |null               |
+    +------------------------------+----------------------------------------------------------------------------------------------+-------------------+
+    
+    DESCRIBE COLUMN locationinfo.item on complexcarbontable
+    
+    +-----------------------------------+------------------+-------+
+    |col_name                           |data_type         |comment|
+    +-----------------------------------+------------------+-------+
+    |locationinfo.item                  |struct            |null   |
+    |## Children of locationinfo.item:  |                  |       |
+    |activeprovince                     |string            |null   |
+    |activecity                         |map<string,string>|null   |
+    |activestreet                       |array<string>     |null   |
+    +-----------------------------------+------------------+-------+
+
+    DESCRIBE COLUMN locationinfo.item.activecity on complexcarbontable
+    
+    +----------------------------------------------+---------+-------+
+    |col_name                                      |data_type|comment|
+    +----------------------------------------------+---------+-------+
+    |locationinfo.item.activecity                  |map      |null   |
+    |## Children of locationinfo.item.activecity:  |         |       |
+    |key                                           |string   |null   |
+    |value                                         |string   |null   |
+    +----------------------------------------------+---------+-------+
+  ```
+- #### DESCRIBE COLUMN SHORT
+
+    This command is used to display short version of table complex columns.
+  ```
+  [DESCRIBE | DESC] SHORT [db_name.]table_name;
+  ```
+  Example: 
+  ```
+    DESCRIBE SHORT complexcarbontable;
+    
+    +-------------------+----------+----------------+
+    |           col_name| data_type|         comment|
+    +-------------------+----------+----------------+
+    |deviceinformationid|   integer|            null|
+    |         channelsid|   map<..>|            null|
+    |             mobile|struct<..>|            null|
+    |       locationinfo| array<..>|            null|
+    |        gamepointid|    double|            null|
+    +-------------------+----------+----------------+
+  ```
 
 ### SHOW TABLE
 

--- a/integration/spark/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/catalyst/CarbonDDLSqlParser.scala
@@ -43,6 +43,7 @@ abstract class CarbonDDLSqlParser extends AbstractCarbonSparkSQLParser {
   protected val CLASS = carbonKeyWord("CLASS")
   protected val CLEAN = carbonKeyWord("CLEAN")
   protected val COLS = carbonKeyWord("COLS")
+  protected val COLUMN = carbonKeyWord("COLUMN")
   protected val COLUMNS = carbonKeyWord("COLUMNS")
   protected val COMPACT = carbonKeyWord("COMPACT")
   protected val FINISH = carbonKeyWord("FINISH")

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonAddLoadCommand.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonAddLoadCommand.scala
@@ -72,14 +72,8 @@ case class CarbonAddLoadCommand(
   private val LOGGER = LogServiceFactory.getLogService(this.getClass.getCanonicalName)
 
   override def processMetadata(sparkSession: SparkSession): Seq[Row] = {
-    Checker.validateTableExists(databaseNameOp, tableName, sparkSession)
-    val relation = CarbonEnv
-      .getInstance(sparkSession)
-      .carbonMetaStore
-      .lookupRelation(databaseNameOp, tableName)(sparkSession)
-      .asInstanceOf[CarbonRelation]
-    val tableSchema = StructType.fromAttributes(relation.output)
-    val carbonTable = relation.carbonTable
+    val (tableSchema, carbonTable) = Checker.getSchemaAndTable(sparkSession, databaseNameOp,
+      tableName)
     setAuditTable(carbonTable)
     if (!carbonTable.getTableInfo.isTransactionalTable) {
       throw new MalformedCarbonCommandException("Unsupported operation on non transactional table")

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/describeTable/TestDescribeTable.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/describeTable/TestDescribeTable.scala
@@ -17,9 +17,11 @@
 package org.apache.carbondata.spark.testsuite.describeTable
 
 import org.apache.spark.sql.Row
+import org.apache.spark.sql.catalyst.analysis.NoSuchTableException
 import org.apache.spark.sql.test.util.QueryTest
 import org.scalatest.BeforeAndAfterAll
 
+import org.apache.carbondata.common.exceptions.sql.{MalformedCarbonCommandException, MalformedIndexCommandException}
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.util.CarbonProperties
 
@@ -40,6 +42,18 @@ class TestDescribeTable extends QueryTest with BeforeAndAfterAll {
         "Dec2Col1 BigInt, Dec2Col2 String, Dec2Col3 Bigint, Dec2Col4 Decimal) STORED AS carbondata")
     sql("CREATE TABLE Desc2(" +
         "Dec2Col1 BigInt, Dec2Col2 String, Dec2Col3 Bigint, Dec2Col4 Decimal) STORED AS carbondata")
+    sql("drop table if exists complexcarbontable")
+    sql("create table complexcarbontable(deviceInformationId int, " +
+        "channelsId map<string,string>, mobile struct<imei:string, imsi:string>," +
+        "MAC array<string> COMMENT 'this is an array'," +
+        "locationinfo array<struct<ActiveAreaId:int, ActiveCountry:string, " +
+        "ActiveProvince:string, Activecity:map<string,string>, " +
+        "ActiveDistrict:string, ActiveStreet:array<string>>>," +
+        "proddate struct<productionDate:string,activeDeactivedate:array<string>>, gamePointId " +
+        "double,contractNumber struct<num:double,contract:map<string,array<string>>>," +
+        "decimalColumn map<string,struct<d:decimal(10,3), s:struct<im:string>>>) " +
+        "STORED AS carbondata"
+    )
   }
 
   test("test describe table") {
@@ -72,11 +86,144 @@ class TestDescribeTable extends QueryTest with BeforeAndAfterAll {
     assert(descPar.exists(_.toString().contains("Partition Parameters:")))
   }
 
+  test("test describe column field name") {
+    // describe primitive column
+    var desc = sql("describe column deviceInformationId on complexcarbontable").collect()
+    assert(desc(0).get(0).asInstanceOf[String].trim.equals("deviceInformationId"))
+    assert(desc(0).get(1).asInstanceOf[String].trim.equals("integer"))
+
+    // describe simple map
+    /*
+    +----------------------------+---------+-------+
+    |col_name                    |data_type|comment|
+    +----------------------------+---------+-------+
+    |channelsId                  |map      |null   |
+    |## Children of channelsId:  |         |       |
+    |key                         |string   |null   |
+    |value                       |string   |null   |
+    +----------------------------+---------+-------+
+    */
+    desc = sql("desc column channelsId on complexcarbontable").collect()
+    assert(desc(2).get(0).asInstanceOf[String].trim.equals("key"))
+    assert(desc(2).get(1).asInstanceOf[String].trim.equals("string"))
+    assert(desc(3).get(0).asInstanceOf[String].trim.equals("value"))
+    assert(desc(3).get(1).asInstanceOf[String].trim.equals("string"))
+
+    // describe struct
+    desc = sql("describe column mobile on complexcarbontable").collect()
+    assert(desc(2).get(0).asInstanceOf[String].trim.equals("imei"))
+    assert(desc(3).get(0).asInstanceOf[String].trim.equals("imsi"))
+
+    // describe array
+    desc = sql("describe column MAC on complexcarbontable").collect()
+    assert(desc(0).get(2).asInstanceOf[String].trim.equals("this is an array"))
+    assert(desc(2).get(0).asInstanceOf[String].trim.equals("item"))
+    assert(desc(2).get(1).asInstanceOf[String].trim.equals("string"))
+
+    // describe struct<string,array<string>>
+    desc = sql("describe column proddate on complexcarbontable").collect()
+    assert(desc(2).get(0).asInstanceOf[String].trim.equals("productiondate"))
+    assert(desc(2).get(1).asInstanceOf[String].trim.equals("string"))
+    assert(desc(3).get(0).asInstanceOf[String].trim.equals("activedeactivedate"))
+    assert(desc(3).get(1).asInstanceOf[String].trim.equals("array<string>"))
+
+    desc = sql("describe column proddate.activeDeactivedate on complexcarbontable").collect()
+    assert(desc(2).get(0).asInstanceOf[String].trim.equals("item"))
+    assert(desc(2).get(1).asInstanceOf[String].trim.equals("string"))
+
+    // describe array<struct<int,string,string,map<string,string>,string,array<string>>>
+    desc = sql("describe column locationinfo on complexcarbontable").collect()
+    assert(desc(2).get(0).asInstanceOf[String].trim.equals("item"))
+    assert(desc(2).get(1).asInstanceOf[String].trim.equals(
+        "struct<activeareaid:int,activecountry:string,activeprovince:string," +
+        "activecity:map<string,string>,activedistrict:string,activestreet:array<string>>"))
+
+    desc = sql("describe column locationinfo.item on complexcarbontable").collect()
+    assert(desc(5).get(0).asInstanceOf[String].trim.equals("activecity"))
+    assert(desc(5).get(1).asInstanceOf[String].trim.equals("map<string,string>"))
+    assert(desc(7).get(0).asInstanceOf[String].trim.equals("activestreet"))
+    assert(desc(7).get(1).asInstanceOf[String].trim.equals("array<string>"))
+
+    desc = sql("describe column locationinfo.item.Activecity on complexcarbontable").collect()
+    assert(desc(2).get(0).asInstanceOf[String].trim.equals("key"))
+    assert(desc(3).get(0).asInstanceOf[String].trim.equals("value"))
+
+    desc = sql("describe column locationinfo.item.ActiveStreet on complexcarbontable").collect()
+    assert(desc(2).get(0).asInstanceOf[String].trim.equals("item"))
+    assert(desc(2).get(1).asInstanceOf[String].trim.equals("string"))
+
+    // describe struct<double,map<string,array<string>>>
+    desc = sql("describe column contractNumber on complexcarbontable").collect()
+    assert(desc(2).get(0).asInstanceOf[String].trim.equals("num"))
+    assert(desc(2).get(1).asInstanceOf[String].trim.equals("double"))
+    assert(desc(3).get(0).asInstanceOf[String].trim.equals("contract"))
+    assert(desc(3).get(1).asInstanceOf[String].trim.equals("map<string,array<string>>"))
+
+    desc = sql("describe column contractNumber.contract on complexcarbontable").collect()
+    assert(desc(3).get(0).asInstanceOf[String].trim.equals("value"))
+    assert(desc(3).get(1).asInstanceOf[String].trim.equals("array<string>"))
+
+    desc = sql("describe column contractNumber.contract.value on complexcarbontable").collect()
+    assert(desc(2).get(0).asInstanceOf[String].trim.equals("item"))
+    assert(desc(2).get(1).asInstanceOf[String].trim.equals("string"))
+
+    // describe map<string,struct<decimal(10,3),struct<string>>>
+    desc = sql("describe column decimalcolumn on complexcarbontable").collect()
+    assert(desc(3).get(0).asInstanceOf[String].trim.equals("value"))
+    assert(desc(3).get(1).asInstanceOf[String].trim
+      .equals("struct<d:decimal(10,3),s:struct<im:string>>"))
+
+    desc = sql("describe column decimalcolumn.value on complexcarbontable").collect()
+    assert(desc(3).get(0).asInstanceOf[String].trim.equals("s"))
+    assert(desc(3).get(1).asInstanceOf[String].trim.equals("struct<im:string>"))
+
+    desc = sql("describe column decimalcolumn.value.s on complexcarbontable").collect()
+    assert(desc(2).get(0).asInstanceOf[String].trim.equals("im"))
+    assert(desc(2).get(1).asInstanceOf[String].trim.equals("string"))
+  }
+
+  test("test describe with invalid table and field names") {
+    // describe column with invalid table name
+    var exception1 = intercept[NoSuchTableException](sql(
+      "describe column decimalcolumn on invalidTable"))
+    assert(exception1.getMessage.contains(
+      "Table or view 'invalidTable' not found in database 'default'"))
+
+    // describe short with invalid table name
+    exception1 = intercept[NoSuchTableException](sql(
+      "describe short invalidTable"))
+    assert(exception1.getMessage.contains(
+      "Table or view 'invalidTable' not found in database 'default'"))
+
+    // describe column with invalid field name
+    var exception2 = intercept[MalformedCarbonCommandException](sql(
+      "describe column invalidField on complexcarbontable"))
+    assert(exception2.getMessage.contains(
+      "Column invalidField does not exists in the table default.complexcarbontable"))
+
+    // describe column with invalid child names
+    exception2 = intercept[MalformedCarbonCommandException](sql(
+      "describe column MAC.one on complexcarbontable"))
+    assert(exception2.getMessage.contains(
+      "one is invalid child name for column mac of table: complexcarbontable"))
+  }
+
+  test("test describe short table format") {
+    val desc = sql("desc short complexcarbontable").collect()
+    assert(desc(1).get(0).asInstanceOf[String].trim.equals("channelsid"))
+    assert(desc(1).get(1).asInstanceOf[String].trim.equals("map<..>"))
+    assert(desc(2).get(0).asInstanceOf[String].trim.equals("mobile"))
+    assert(desc(2).get(1).asInstanceOf[String].trim.equals("struct<..>"))
+    assert(desc(3).get(0).asInstanceOf[String].trim.equals("mac"))
+    assert(desc(3).get(1).asInstanceOf[String].trim.equals("array<..>"))
+  }
+
   override def afterAll: Unit = {
     sql("DROP TABLE Desc1")
     sql("DROP TABLE Desc2")
     sql("drop table if exists a")
     sql("drop table if exists b")
+    sql("drop table if exists complexcarbontable")
     CarbonProperties.getInstance().addProperty(CarbonCommonConstants.COMPRESSOR,
       CarbonCommonConstants.DEFAULT_COMPRESSOR)
   }


### PR DESCRIPTION
 ### Why is this PR needed?
 Currently describe formatted displays the column information of a table and some additional information. When complex types such as  ARRAY, STRUCT, and MAP types are present in the table, column definition can be long and it’s difficult to read in a nested format.
 
 ### What changes were proposed in this PR?
The DESCRIBE output can be formatted to avoid long lines for multiple fields. We can pass the column name to the command and visualize its structure with child fields.
    
 ### Does this PR introduce any user interface change?
 - Yes ,
DDL Commands:
```
DESCRIBE COLUMN fieldname ON [db_name.]table_name;
DESCRIBE short [db_name.]table_name;
```

 ### Is any new testcase added?
 - Yes

    
