### PR TITLE
[CARBONDATA-4163] Support adding of single-level complex columns(array/struct)  

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/scan/executor/util/QueryUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/executor/util/QueryUtil.java
@@ -280,6 +280,11 @@ public class QueryUtil {
 
   private static void fillParentDetails(Map<Integer, Integer> dimensionToBlockIndexMap,
       CarbonDimension dimension, Map<Integer, GenericQueryType> complexTypeMap) {
+    // If the dimension is added via alter add command then it doesn't exist in any
+    // of the blocks as it is not yet updated. Hence return
+    if (!dimensionToBlockIndexMap.containsKey(dimension.getOrdinal())) {
+      return;
+    }
     int parentBlockIndex = dimensionToBlockIndexMap.get(dimension.getOrdinal());
     GenericQueryType parentQueryType;
     if (DataTypes.isArrayType(dimension.getDataType())) {

--- a/docs/ddl-of-carbondata.md
+++ b/docs/ddl-of-carbondata.md
@@ -694,8 +694,11 @@ CarbonData DDL statements are documented here,which includes:
      ```
      ALTER TABLE carbon ADD COLUMNS (a1 INT, b1 STRING) TBLPROPERTIES('DEFAULT.VALUE.a1'='10')
      ```
-      **NOTE:** Add Complex datatype columns is not supported.
-
+      **NOTE:** Adding of only single-level Complex datatype columns(only array and struct) is supported.
+      Example - 
+      ```
+      ALTER TABLE <table-name> ADD COLUMNS(arrField array<array<int>>, structField struct<id1:string,name1:string>)
+      ```
 Users can specify which columns to include and exclude for local dictionary generation after adding new columns. These will be appended with the already existing local dictionary include and exclude columns of main table respectively.
      
      ```

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/schema/CarbonAlterTableAddColumnCommand.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/schema/CarbonAlterTableAddColumnCommand.scala
@@ -85,6 +85,8 @@ private[sql] case class CarbonAlterTableAddColumnCommand(
       timeStamp = System.currentTimeMillis
       val schemaEvolutionEntry = new org.apache.carbondata.core.metadata.schema.SchemaEvolutionEntry
       schemaEvolutionEntry.setTimeStamp(timeStamp)
+      // filter out complex children columns
+      newCols = newCols.filter(x => !x.isComplexColumn)
       schemaEvolutionEntry.setAdded(newCols.toList.asJava)
       val thriftTable = schemaConverter
         .fromWrapperToExternalTableInfo(wrapperTableInfo, dbName, tableName)

--- a/integration/spark/src/main/scala/org/apache/spark/sql/parser/CarbonSparkSqlParserUtil.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/parser/CarbonSparkSqlParserUtil.scala
@@ -683,12 +683,6 @@ object CarbonSparkSqlParserUtil {
       fields: List[Field],
       tblProp: Option[List[(String, String)]]
   ): CarbonAlterTableAddColumnCommand = {
-    fields.foreach { f =>
-      if (CarbonParserUtil.isComplexType(f.dataType.get)) {
-        throw new MalformedCarbonCommandException(
-          s"Add column is unsupported for complex datatype column: ${ f.column }")
-      }
-    }
     val tableProps = if (tblProp.isDefined) {
       tblProp.get.groupBy(_._1.toLowerCase).foreach(f =>
         if (f._2.size > 1) {

--- a/integration/spark/src/test/scala/org/apache/spark/carbondata/restructure/AlterTableValidationTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/spark/carbondata/restructure/AlterTableValidationTestCase.scala
@@ -248,16 +248,6 @@ class AlterTableValidationTestCase extends QueryTest with BeforeAndAfterAll {
     }
   }
 
-  test("test adding complex datatype column") {
-    try {
-      sql("alter table restructure add columns(arr array<string>)")
-      assert(false, "Exception should be thrown for complex column add")
-    } catch {
-      case e: Exception =>
-        println(e.getMessage)
-    }
-  }
-
   test("test drop and add same column with different datatype and default value") {
     sql("alter table restructure drop columns(empname)")
     sql(


### PR DESCRIPTION
 ### Why is this PR needed?
This PR enables adding of single-level complex columns(only array and struct) to carbon table.
Command - 
ALTER TABLE <table_name> ADD COLUMNS(arr1 ARRAY (double) )
ALTER TABLE <table_name> ADD COLUMNS(struct1 STRUCT<a:int, b:string>)
The default value for the column in case of old rows will be **null**.
 
 ### What changes were proposed in this PR?
1. Create instances of ColumnSchema for each of the children, By doing this each child column will have its own ordinal. 
The new columns are first identified and stored in a flat structure. 
For example, for **arr1 array(int)** --> 2 column schemas are created - arr1 and arr1.val. First being the parent and second being its child. Each of which will have its own ordinals.
2. Later while updating the Schema evolution entry we only account for the newly added parent columns while disregarding children columns (As they are no longer required. Otherwise we will have the child as a separate column in the schema ).
3. Using the schema evolution entry the final schema is updated. Since ColumnSchemas are stored as a flat structure we later convert them to a nested structure of type Dimensions.

 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
