### PR TITLE
[CARBONDATA-4175] [CARBONDATA-4162] Leverage Secondary Index till segment level.

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/index/IndexFilter.java
+++ b/core/src/main/java/org/apache/carbondata/core/index/IndexFilter.java
@@ -66,6 +66,8 @@ public class IndexFilter implements Serializable {
   // limit value used for row scanning, collected when carbon.mapOrderPushDown is enabled
   private int limit = -1;
 
+  private Set<String> missingSISegments;
+
   public IndexFilter(CarbonTable table, Expression expression) {
     this(table, expression, false);
   }
@@ -282,5 +284,13 @@ public class IndexFilter implements Serializable {
     } catch (Exception e) {
       throw new RuntimeException("Error while resolving filter expression", e);
     }
+  }
+
+  public void setMissingSISegments(Set<String> missingSISegments) {
+    this.missingSISegments = missingSISegments;
+  }
+
+  public Set<String> getMissingSISegments() {
+    return missingSISegments;
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/index/Segment.java
+++ b/core/src/main/java/org/apache/carbondata/core/index/Segment.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
+import org.apache.carbondata.core.indexstore.ExtendedBlocklet;
 import org.apache.carbondata.core.metadata.schema.table.Writable;
 import org.apache.carbondata.core.mutate.UpdateVO;
 import org.apache.carbondata.core.readcommitter.ReadCommittedScope;
@@ -95,6 +96,8 @@ public class Segment implements Serializable, Writable {
    * Segment metadata info
    */
   private SegmentMetaDataInfo segmentMetaDataInfo;
+
+  private List<ExtendedBlocklet> defaultIndexPrunedBlocklets;
 
   public Segment() {
 
@@ -416,5 +419,13 @@ public class Segment implements Serializable, Writable {
 
   public boolean isExternalSegment() {
     return isExternalSegment;
+  }
+
+  public void setDefaultIndexPrunedBlocklets(List<ExtendedBlocklet> prunedBlocklets) {
+    defaultIndexPrunedBlocklets = prunedBlocklets;
+  }
+
+  public List<ExtendedBlocklet> getDefaultIndexPrunedBlocklets() {
+    return defaultIndexPrunedBlocklets;
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/index/dev/IndexFactory.java
+++ b/core/src/main/java/org/apache/carbondata/core/index/dev/IndexFactory.java
@@ -202,4 +202,5 @@ public abstract class IndexFactory<T extends Index> {
   public String getCacheSize() {
     return null;
   }
+
 }

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RowLevelFilterExecutorImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RowLevelFilterExecutorImpl.java
@@ -585,7 +585,9 @@ public class RowLevelFilterExecutorImpl implements FilterExecutor {
         }
       } else {
         GenericQueryType complexType = complexDimensionInfoMap.get(dimensionChunkIndex[i]);
-        complexType.fillRequiredBlockData(rawBlockletColumnChunks);
+        if (complexType != null) {
+          complexType.fillRequiredBlockData(rawBlockletColumnChunks);
+        }
       }
     }
 

--- a/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/TestIndexRepair.scala
+++ b/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/TestIndexRepair.scala
@@ -45,10 +45,8 @@ class TestIndexRepair extends QueryTest with BeforeAndAfterAll {
     val preDeleteSegments = sql("SHOW SEGMENTS FOR TABLE INDEXTABLE1").count()
     sql("DELETE FROM TABLE INDEXTABLE1 WHERE SEGMENT.ID IN(0,1)")
     sql("CLEAN FILES FOR TABLE INDEXTABLE1 options('force'='true')")
-    sql(s"""ALTER TABLE default.indextable1 SET
-           |SERDEPROPERTIES ('isSITableEnabled' = 'false')""".stripMargin)
     val df1 = sql("select * from maintable where c = 'string2'").queryExecution.sparkPlan
-    assert(!isFilterPushedDownToSI(df1))
+    assert(isFilterPushedDownToSI(df1))
     val postDeleteSegments = sql("SHOW SEGMENTS FOR TABLE INDEXTABLE1").count()
     assert(preDeleteSegments!=postDeleteSegments)
     sql("REINDEX INDEX TABLE indextable1 ON MAINTABLE")
@@ -73,10 +71,8 @@ class TestIndexRepair extends QueryTest with BeforeAndAfterAll {
     val preDeleteSegments = sql("SHOW SEGMENTS FOR TABLE test.INDEXTABLE1").count()
     sql("DELETE FROM TABLE test.INDEXTABLE1 WHERE SEGMENT.ID IN(0,1,2)")
     sql("CLEAN FILES FOR TABLE test.INDEXTABLE1 options('force'='true')")
-    sql(s"""ALTER TABLE test.indextable1 SET
-           |SERDEPROPERTIES ('isSITableEnabled' = 'false')""".stripMargin)
     val df1 = sql("select * from test.maintable where c = 'string2'").queryExecution.sparkPlan
-    assert(!isFilterPushedDownToSI(df1))
+    assert(isFilterPushedDownToSI(df1))
     val postDeleteSegments = sql("SHOW SEGMENTS FOR TABLE test.INDEXTABLE1").count()
     assert(preDeleteSegments!=postDeleteSegments)
     sql("REINDEX INDEX TABLE indextable1 ON test.MAINTABLE")
@@ -102,15 +98,13 @@ class TestIndexRepair extends QueryTest with BeforeAndAfterAll {
     sql("CLEAN FILES FOR TABLE INDEXTABLE1 options('force'='true')")
     val postDeleteSegments = sql("SHOW SEGMENTS FOR TABLE INDEXTABLE1").count()
     assert(preDeleteSegments!=postDeleteSegments)
-    sql(s"""ALTER TABLE default.indextable1 SET
-           |SERDEPROPERTIES ('isSITableEnabled' = 'false')""".stripMargin)
     val df1 = sql("select * from maintable where c = 'string2'").queryExecution.sparkPlan
-    assert(!isFilterPushedDownToSI(df1))
+    assert(isFilterPushedDownToSI(df1))
     sql("REINDEX INDEX TABLE indextable1 ON MAINTABLE WHERE SEGMENT.ID IN (0,1)")
     val postFirstRepair = sql("SHOW SEGMENTS FOR TABLE INDEXTABLE1").count()
     assert(postDeleteSegments + 2 == postFirstRepair)
     val df2 = sql("select * from maintable where c = 'string2'").queryExecution.sparkPlan
-    assert(!isFilterPushedDownToSI(df2))
+    assert(isFilterPushedDownToSI(df2))
     sql("REINDEX INDEX TABLE indextable1 ON MAINTABLE WHERE SEGMENT.ID IN (2)")
     val postRepairSegments = sql("SHOW SEGMENTS FOR TABLE INDEXTABLE1").count()
     assert(preDeleteSegments == postRepairSegments)
@@ -128,7 +122,7 @@ class TestIndexRepair extends QueryTest with BeforeAndAfterAll {
     sql("INSERT INTO maintable SELECT 1,'string1', 'string2'")
     sql("DELETE FROM TABLE INDEXTABLE1 WHERE SEGMENT.ID IN(0,1,2)")
     sql("REINDEX INDEX TABLE indextable1 ON MAINTABLE WHERE SEGMENT.ID IN (0,1)")
-    assert(sql("select * from maintable where c = 'string2'").count() == 2)
+    assert(sql("select * from maintable where c = 'string2'").count() == 3)
     sql("drop table if exists maintable")
   }
 
@@ -146,10 +140,8 @@ class TestIndexRepair extends QueryTest with BeforeAndAfterAll {
     sql("CLEAN FILES FOR TABLE INDEXTABLE1 options('force'='true')")
     val postDeleteSegments = sql("SHOW SEGMENTS FOR TABLE INDEXTABLE1").count()
     assert(preDeleteSegments!=postDeleteSegments)
-    sql(s"""ALTER TABLE default.indextable1 SET
-           |SERDEPROPERTIES ('isSITableEnabled' = 'false')""".stripMargin)
     val df1 = sql("select * from maintable where c = 'string2'").queryExecution.sparkPlan
-    assert(!isFilterPushedDownToSI(df1))
+    assert(isFilterPushedDownToSI(df1))
     sql("INSERT INTO maintable SELECT 1,'string1', 'string2'")
     val postLoadSegments = sql("SHOW SEGMENTS FOR TABLE INDEXTABLE1").count()
     assert(preDeleteSegments + 1 == postLoadSegments)

--- a/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/TestSIWithComplexArrayType.scala
+++ b/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/TestSIWithComplexArrayType.scala
@@ -16,11 +16,13 @@
  */
 package org.apache.carbondata.spark.testsuite.secondaryindex
 
+import scala.collection.mutable
+
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.test.util.QueryTest
 import org.scalatest.BeforeAndAfterEach
 
-import org.apache.carbondata.core.constants.{CarbonCommonConstants, CarbonCommonConstantsInternal}
+import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.util.CarbonProperties
 import org.apache.carbondata.spark.testsuite.secondaryindex.TestSecondaryIndexUtils.isFilterPushedDownToSI
 
@@ -53,8 +55,11 @@ class TestSIWithComplexArrayType extends QueryTest with BeforeAndAfterEach {
     sql(
       "ALTER TABLE complextable ADD COLUMNS(arr2 array<string>)")
     sql("insert into complextable select 3,array('china'), 'f',array('hello','world')")
-    sql("insert into complextable select 4,array('india'),'g',array('iron','man','jarvis')")
+    sql("insert into complextable select 4,array('India'),'g',array('iron','man','jarvis')")
 
+    checkAnswer(sql("select * from complextable where array_contains(arr2,'iron')"),
+      Seq(Row("4", mutable.WrappedArray.make(Array("India")), "g",
+        mutable.WrappedArray.make(Array("iron", "man", "jarvis")))))
     val result1 = sql("select * from complextable where array_contains(arr2,'iron')")
     val result2 = sql("select * from complextable where arr2[0]='iron'")
     sql("create index index_11 on table complextable(arr2) as 'carbondata'")

--- a/integration/spark/src/main/scala/org/apache/carbondata/index/secondary/SecondaryIndexFactory.java
+++ b/integration/spark/src/main/scala/org/apache/carbondata/index/secondary/SecondaryIndexFactory.java
@@ -101,6 +101,9 @@ public class SecondaryIndexFactory extends CoarseGrainIndexFactory {
     secondaryIndex.init(
         new SecondaryIndexModel(getIndexSchema().getIndexName(), segment.getSegmentNo(),
             allSegmentIds, positionReferenceInfo, segment.getConfiguration()));
+    secondaryIndex.setDefaultIndexPrunedBlocklet(segment.getDefaultIndexPrunedBlocklets());
+    secondaryIndex.validateSegmentList(getCarbonTable().getTablePath()
+        .replace(getCarbonTable().getTableName(), getIndexSchema().getIndexName()));
     indexes.add(secondaryIndex);
     return indexes;
   }

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/index/ShowIndexesCommand.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/index/ShowIndexesCommand.scala
@@ -79,29 +79,9 @@ case class ShowIndexesCommand(
           val siIterator = secondaryIndex.get.entrySet().iterator()
           while (siIterator.hasNext) {
             val indexInfo = siIterator.next()
-            try {
-              val isSITableEnabled = sparkSession.sessionState.catalog
-                .getTableMetadata(TableIdentifier(indexInfo.getKey, dbNameOp)).storage.properties
-                .getOrElse("isSITableEnabled", "true").equalsIgnoreCase("true")
-              if (isSITableEnabled) {
-                finalIndexList = finalIndexList :+
-                                 (indexInfo.getKey, "carbondata", indexInfo.getValue
-                                   .get(CarbonCommonConstants.INDEX_COLUMNS), "NA", "enabled", "NA")
-              } else {
-                finalIndexList = finalIndexList :+
-                                 (indexInfo.getKey, "carbondata", indexInfo.getValue
-                                   .get(CarbonCommonConstants
-                                     .INDEX_COLUMNS), "NA", "disabled", "NA")
-              }
-            } catch {
-              case ex: Exception =>
-                LOGGER.error(s"Access storage properties from hive failed for index table: ${
-                  indexInfo.getKey
-                }")
-                finalIndexList = finalIndexList :+
-                                 (indexInfo.getKey, "carbondata", indexInfo.getValue
-                                   .get(CarbonCommonConstants.INDEX_COLUMNS), "NA", "UNKNOWN", "NA")
-            }
+            finalIndexList = finalIndexList :+
+                (indexInfo.getKey, "carbondata", indexInfo.getValue
+                    .get(CarbonCommonConstants.INDEX_COLUMNS), "NA", "enabled", "NA")
           }
         }
 

--- a/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/load/Compactor.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/load/Compactor.scala
@@ -159,20 +159,6 @@ object Compactor {
       } catch {
         case ex: Exception =>
           LOGGER.error(s"Compaction failed for SI table ${secondaryIndex.indexName}", ex)
-          // If any compaction is failed then make all SI disabled which are success.
-          // They will be enabled in next load
-          siCompactionIndexList.foreach { indexCarbonTable =>
-            sparkSession.sql(
-              s"""
-                 | ALTER TABLE ${carbonLoadModel.getDatabaseName}.${indexCarbonTable.getTableName}
-                 | SET SERDEPROPERTIES ('isSITableEnabled' = 'false')
-               """.stripMargin).collect()
-          }
-          CarbonIndexUtil.updateIndexStatusInBatch(carbonMainTable,
-            siCompactionIndexList,
-            IndexType.SI,
-            IndexStatus.DISABLED,
-            sparkSession)
           throw ex
       } finally {
         // once compaction is success, release the segment locks

--- a/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/rdd/SecondaryIndexCreator.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/rdd/SecondaryIndexCreator.scala
@@ -465,24 +465,6 @@ object SecondaryIndexCreator {
             sc.sparkSession)
         throw ex
     } finally {
-      // if some segments are skipped, disable the SI table so that
-      // SILoadEventListenerForFailedSegments will take care to load to these segments in next
-      // consecutive load to main table.
-      if (!skippedSegments.isEmpty) {
-        secondaryIndexModel.sqlContext.sparkSession.sql(
-          s"""ALTER TABLE ${
-            secondaryIndexModel
-              .carbonLoadModel
-              .getDatabaseName
-          }.${ secondaryIndexModel.secondaryIndex.indexName } SET
-             |SERDEPROPERTIES ('isSITableEnabled' = 'false')""".stripMargin).collect()
-        CarbonIndexUtil.updateIndexStatus(secondaryIndexModel.carbonTable,
-          secondaryIndexModel.secondaryIndex.indexName,
-          IndexType.SI,
-          IndexStatus.DISABLED,
-          true,
-          secondaryIndexModel.sqlContext.sparkSession)
-      }
       // close the executor service
       if (null != executorService) {
         executorService.shutdownNow()


### PR DESCRIPTION
 ### Why is this PR needed?
 In the existing architecture, if the parent(main) table and SI table don’t have the same valid segments then we disable the SI table. And then from the next query onwards, we scan and prune only the parent table until we trigger the next load or REINDEX command (as these commands will make the parent and SI table segments in sync). Because of this, queries take more time to give the result when SI is disabled.
 
 ### What changes were proposed in this PR?
1. Instead of disabling the SI table(when parent and child table segments are not in sync) we will do pruning on SI tables for all the valid segments(segments with status success, marked for update and load partial success) and the rest of the segments will be pruned by the parent table.
2. As of now, query on the SI table can be pruned in two ways:
     a) With SI as data map.
     b) WIth spark plan rewrite.
     This PR contains changes to support both methods of SI to leverage till segment level.

 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
