### PR TITLE
[CARBONDATA-4167][CARBONDATA-4168] Fix case sensitive issues and input validation for Geo values.

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/SegmentIndexFileStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/SegmentIndexFileStore.java
@@ -197,12 +197,11 @@ public class SegmentIndexFileStore {
    * @throws IOException
    */
   public void readAllIIndexOfSegment(CarbonFile[] carbonFiles) throws IOException {
-    CarbonFile[] carbonIndexFiles = getCarbonIndexFiles(carbonFiles);
-    for (CarbonFile carbonIndexFile : carbonIndexFiles) {
-      if (carbonIndexFile.getName().endsWith(CarbonTablePath.MERGE_INDEX_FILE_EXT)) {
-        readMergeFile(carbonIndexFile.getCanonicalPath());
-      } else if (carbonIndexFile.getName().endsWith(CarbonTablePath.INDEX_FILE_EXT)) {
-        readIndexFile(carbonIndexFile);
+    for (CarbonFile carbonFile : carbonFiles) {
+      if (carbonFile.getName().endsWith(CarbonTablePath.MERGE_INDEX_FILE_EXT)) {
+        readMergeFile(carbonFile.getCanonicalPath());
+      } else if (carbonFile.getName().endsWith(CarbonTablePath.INDEX_FILE_EXT)) {
+        readIndexFile(carbonFile);
       }
     }
   }
@@ -388,23 +387,6 @@ public class SegmentIndexFileStore {
    */
   public static CarbonFile[] getCarbonIndexFiles(String segmentPath, Configuration configuration) {
     return getCarbonIndexFiles(segmentPath, configuration, null);
-  }
-
-  /**
-   * List all the index files of the segment.
-   *
-   * @param carbonFiles
-   * @return
-   */
-  public static CarbonFile[] getCarbonIndexFiles(CarbonFile[] carbonFiles) {
-    List<CarbonFile> indexFiles = new ArrayList<>();
-    for (CarbonFile file: carbonFiles) {
-      if (file.getName().endsWith(CarbonTablePath.INDEX_FILE_EXT) ||
-          file.getName().endsWith(CarbonTablePath.MERGE_INDEX_FILE_EXT)) {
-        indexFiles.add(file);
-      }
-    }
-    return indexFiles.toArray(new CarbonFile[indexFiles.size()]);
   }
 
   /**

--- a/core/src/main/java/org/apache/carbondata/core/writer/CarbonIndexFileMergeWriter.java
+++ b/core/src/main/java/org/apache/carbondata/core/writer/CarbonIndexFileMergeWriter.java
@@ -200,13 +200,12 @@ public class CarbonIndexFileMergeWriter {
       if (readBasedOnUUID) {
         indexFiles = SegmentIndexFileStore
             .getCarbonIndexFiles(segmentPath, FileFactory.getConfiguration(), uuid);
-        fileStore.readAllIIndexOfSegment(segmentPath, uuid);
       } else {
         // The uuid can be different, when we add load from external path.
         indexFiles =
             SegmentIndexFileStore.getCarbonIndexFiles(segmentPath, FileFactory.getConfiguration());
-        fileStore.readAllIIndexOfSegment(segmentPath);
       }
+      fileStore.readAllIIndexOfSegment(indexFiles);
     }
     Map<String, byte[]> indexMap = fileStore.getCarbonIndexMap();
     Map<String, List<String>> mergeToIndexFileMap = fileStore.getCarbonMergeFileToIndexFilesMap();

--- a/geo/src/main/java/org/apache/carbondata/geo/GeoConstants.java
+++ b/geo/src/main/java/org/apache/carbondata/geo/GeoConstants.java
@@ -27,6 +27,9 @@ public class GeoConstants {
   // GeoHash type Spatial Index
   public static final String GEOHASH = "geohash";
 
+  // Regular expression to validate whether the input value is positive integer
+  public static final String POSITIVE_INTEGER_REGEX = "^[+]?\\d*[1-9]\\d*$";
+
   // Regular expression to parse input polygons for IN_POLYGON_LIST
   public static final String POLYGON_REG_EXPRESSION = "(?<=POLYGON \\(\\()(.*?)(?=(\\)\\)))";
 
@@ -35,6 +38,8 @@ public class GeoConstants {
 
   // Regular expression to parse input rangelists for IN_POLYGON_RANGE_LIST
   public static final String RANGELIST_REG_EXPRESSION = "(?<=RANGELIST \\()(.*?)(?=\\))";
+
+  public static final String GRID_SIZE = "gridSize";
 
   // delimiter of input points or ranges
   public static final String DEFAULT_DELIMITER = ",";

--- a/geo/src/main/java/org/apache/carbondata/geo/GeoHashIndex.java
+++ b/geo/src/main/java/org/apache/carbondata/geo/GeoHashIndex.java
@@ -136,18 +136,10 @@ public class GeoHashIndex extends CustomIndex<List<Long[]>> {
     }
     String GRID_SIZE = commonKey + "gridsize";
     String gridSize = properties.get(GRID_SIZE);
-    if (StringUtils.isEmpty(gridSize)) {
-      throw new MalformedCarbonCommandException(
-              String.format("%s property is invalid. %s property must be specified.",
-                      CarbonCommonConstants.SPATIAL_INDEX, GRID_SIZE));
-    }
+    GeoHashUtils.validateGeoProperty(gridSize, GRID_SIZE);
     String CONVERSION_RATIO = commonKey + "conversionratio";
     String conversionRatio = properties.get(CONVERSION_RATIO);
-    if (StringUtils.isEmpty(conversionRatio)) {
-      throw new MalformedCarbonCommandException(
-              String.format("%s property is invalid. %s property must be specified.",
-                      CarbonCommonConstants.SPATIAL_INDEX, CONVERSION_RATIO));
-    }
+    GeoHashUtils.validateGeoProperty(conversionRatio, CONVERSION_RATIO);
 
     // Fill the values to the instance fields
     this.oriLatitude = Double.valueOf(originLatitude);

--- a/geo/src/main/java/org/apache/carbondata/geo/GeoHashUtils.java
+++ b/geo/src/main/java/org/apache/carbondata/geo/GeoHashUtils.java
@@ -95,8 +95,8 @@ public class GeoHashUtils {
       throws MalformedCarbonCommandException {
     if (inputName.equalsIgnoreCase(GeoConstants.GRID_SIZE) && (input == null
         || !Pattern.compile(POSITIVE_INTEGER_REGEX).matcher(input.toString()).find())) {
-      throw new MalformedCarbonCommandException("Expect grid size to be a positive value");
-    } else if (input == null) {
+      throw new MalformedCarbonCommandException("Expect grid size to be a positive integer");
+    } else if (input == null || input.toString().equals("null")) {
       throw new MalformedCarbonCommandException(
           "Expect " + inputName + " to be of " + datatype + " type");
     }

--- a/geo/src/main/java/org/apache/carbondata/geo/scan/expression/PolylineListExpression.java
+++ b/geo/src/main/java/org/apache/carbondata/geo/scan/expression/PolylineListExpression.java
@@ -61,7 +61,8 @@ public class PolylineListExpression extends PolygonExpression {
       // 1. parse the polyline list string and get polygon from each polyline
       List<Geometry> polygonList = new ArrayList<>();
       WKTReader wktReader = new WKTReader();
-      Pattern pattern = Pattern.compile(GeoConstants.POLYLINE_REG_EXPRESSION);
+      Pattern pattern =
+          Pattern.compile(GeoConstants.POLYLINE_REG_EXPRESSION, Pattern.CASE_INSENSITIVE);
       Matcher matcher = pattern.matcher(polygon);
       while (matcher.find()) {
         String matchedStr = matcher.group();
@@ -80,7 +81,7 @@ public class PolylineListExpression extends PolygonExpression {
           List<Long[]> tempRangeList = instance.query(tempPointList);
           GeoHashUtils.validateRangeList(tempRangeList);
           processedRangeList = GeoHashUtils.processRangeList(
-            processedRangeList, tempRangeList, GeoOperationType.OR.toString());
+            processedRangeList, tempRangeList, GeoOperationType.OR);
         }
         ranges = processedRangeList;
       }

--- a/integration/spark/src/main/scala/org/apache/carbondata/geo/GeoUtilUDFs.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/geo/GeoUtilUDFs.scala
@@ -33,34 +33,51 @@ object GeoUtilUDFs {
   }
 }
 
-class GeoIdToGridXyUDF extends (Long => Array[Int]) with Serializable {
-  override def apply(geoId: Long): Array[Int] = {
+class GeoIdToGridXyUDF extends (java.lang.Long => Array[Int]) with Serializable {
+  override def apply(geoId: java.lang.Long): Array[Int] = {
+    GeoHashUtils.validateUDFInputValue(geoId, "geoId", "Long")
     GeoHashUtils.geoID2ColRow(geoId)
   }
 }
 
-class GeoIdToLatLngUDF extends ((Long, Double, Int) => Array[Double]) with Serializable {
-  override def apply(geoId: Long, oriLatitude: Double, gridSize: Int): Array[Double] = {
+class GeoIdToLatLngUDF
+  extends ((java.lang.Long, java.lang.Double, java.lang.Integer) => Array[Double]) with
+    Serializable {
+  override def apply(geoId: java.lang.Long, oriLatitude: java.lang.Double,
+      gridSize: java.lang.Integer): Array[Double] = {
+    GeoHashUtils.validateUDFInputValue(geoId, "geoId", "Long")
+    GeoHashUtils.validateUDFInputValue(oriLatitude, "oriLatitude", "Double")
+    GeoHashUtils.validateUDFInputValue(gridSize, "gridSize", "Integer")
     GeoHashUtils.geoID2LatLng(geoId, oriLatitude, gridSize)
   }
 }
 
-class LatLngToGeoIdUDF extends ((Long, Long, Double, Int) => Long) with Serializable {
-  override def apply(latitude: Long, longitude: Long, oriLatitude: Double, gridSize: Int): Long = {
+class LatLngToGeoIdUDF extends ((java.lang.Long, java.lang.Long,
+  java.lang.Double, java.lang.Integer) => Long) with Serializable {
+  override def apply(latitude: java.lang.Long, longitude: java.lang.Long,
+      oriLatitude: java.lang.Double, gridSize: java.lang.Integer): Long = {
+    GeoHashUtils.validateUDFInputValue(latitude, "latitude", "Long")
+    GeoHashUtils.validateUDFInputValue(longitude, "longitude", "Long")
+    GeoHashUtils.validateUDFInputValue(oriLatitude, "oriLatitude", "Double")
+    GeoHashUtils.validateUDFInputValue(gridSize, "gridSize", "Integer")
     GeoHashUtils.lonLat2GeoID(longitude, latitude, oriLatitude, gridSize)
   }
 }
 
-class ToUpperLayerGeoIdUDF extends (Long => Long) with Serializable {
-  override def apply(geoId: Long): Long = {
+class ToUpperLayerGeoIdUDF extends (java.lang.Long => Long) with Serializable {
+  override def apply(geoId: java.lang.Long): Long = {
+    GeoHashUtils.validateUDFInputValue(geoId, "geoId", "Long")
     GeoHashUtils.convertToUpperLayerGeoId(geoId)
   }
 }
 
-class ToRangeListUDF extends ((String, Double, Int) => mutable.Buffer[Array[Long]])
-  with Serializable {
-  override def apply(polygon: String, oriLatitude: Double,
-                     gridSize: Int): mutable.Buffer[Array[Long]] = {
+class ToRangeListUDF extends ((java.lang.String, java.lang.Double, java.lang.Integer) =>
+  mutable.Buffer[Array[Long]]) with Serializable {
+  override def apply(polygon: java.lang.String, oriLatitude: java.lang.Double,
+      gridSize: java.lang.Integer): mutable.Buffer[Array[Long]] = {
+    GeoHashUtils.validateUDFInputValue(polygon, "polygon", "String")
+    GeoHashUtils.validateUDFInputValue(oriLatitude, "oriLatitude", "Double")
+    GeoHashUtils.validateUDFInputValue(gridSize, "gridSize", "Integer")
     GeoHashUtils.getRangeList(polygon, oriLatitude, gridSize).asScala.map(_.map(Long2long))
   }
 }

--- a/integration/spark/src/main/scala/org/apache/carbondata/geo/GeoUtilUDFs.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/geo/GeoUtilUDFs.scala
@@ -35,7 +35,6 @@ object GeoUtilUDFs {
 
 class GeoIdToGridXyUDF extends (java.lang.Long => Array[Int]) with Serializable {
   override def apply(geoId: java.lang.Long): Array[Int] = {
-    GeoHashUtils.validateUDFInputValue(geoId, "geoId", "Long")
     GeoHashUtils.geoID2ColRow(geoId)
   }
 }
@@ -45,9 +44,6 @@ class GeoIdToLatLngUDF
     Serializable {
   override def apply(geoId: java.lang.Long, oriLatitude: java.lang.Double,
       gridSize: java.lang.Integer): Array[Double] = {
-    GeoHashUtils.validateUDFInputValue(geoId, "geoId", "Long")
-    GeoHashUtils.validateUDFInputValue(oriLatitude, "oriLatitude", "Double")
-    GeoHashUtils.validateUDFInputValue(gridSize, "gridSize", "Integer")
     GeoHashUtils.geoID2LatLng(geoId, oriLatitude, gridSize)
   }
 }
@@ -56,17 +52,12 @@ class LatLngToGeoIdUDF extends ((java.lang.Long, java.lang.Long,
   java.lang.Double, java.lang.Integer) => Long) with Serializable {
   override def apply(latitude: java.lang.Long, longitude: java.lang.Long,
       oriLatitude: java.lang.Double, gridSize: java.lang.Integer): Long = {
-    GeoHashUtils.validateUDFInputValue(latitude, "latitude", "Long")
-    GeoHashUtils.validateUDFInputValue(longitude, "longitude", "Long")
-    GeoHashUtils.validateUDFInputValue(oriLatitude, "oriLatitude", "Double")
-    GeoHashUtils.validateUDFInputValue(gridSize, "gridSize", "Integer")
     GeoHashUtils.lonLat2GeoID(longitude, latitude, oriLatitude, gridSize)
   }
 }
 
 class ToUpperLayerGeoIdUDF extends (java.lang.Long => Long) with Serializable {
   override def apply(geoId: java.lang.Long): Long = {
-    GeoHashUtils.validateUDFInputValue(geoId, "geoId", "Long")
     GeoHashUtils.convertToUpperLayerGeoId(geoId)
   }
 }
@@ -75,9 +66,6 @@ class ToRangeListUDF extends ((java.lang.String, java.lang.Double, java.lang.Int
   mutable.Buffer[Array[Long]]) with Serializable {
   override def apply(polygon: java.lang.String, oriLatitude: java.lang.Double,
       gridSize: java.lang.Integer): mutable.Buffer[Array[Long]] = {
-    GeoHashUtils.validateUDFInputValue(polygon, "polygon", "String")
-    GeoHashUtils.validateUDFInputValue(oriLatitude, "oriLatitude", "Double")
-    GeoHashUtils.validateUDFInputValue(gridSize, "gridSize", "Integer")
     GeoHashUtils.getRangeList(polygon, oriLatitude, gridSize).asScala.map(_.map(Long2long))
   }
 }

--- a/integration/spark/src/main/scala/org/apache/carbondata/geo/InPolygonUDF.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/geo/InPolygonUDF.scala
@@ -46,8 +46,8 @@ class InPolygonListUDF extends ((String, String) => Boolean) with Serializable {
 }
 
 @InterfaceAudience.Internal
-class InPolylineListUDF extends ((String, Float) => Boolean) with Serializable {
-  override def apply(v1: String, v2: Float): Boolean = {
+class InPolylineListUDF extends ((String, java.lang.Float) => Boolean) with Serializable {
+  override def apply(v1: String, v2: java.lang.Float): Boolean = {
     true // Carbon applies the filter. So, Spark do not have to apply filter.
   }
 }

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonDescribeFormattedCommand.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonDescribeFormattedCommand.scala
@@ -78,6 +78,18 @@ private[sql] case class CarbonDescribeFormattedCommand(
               tblProps(s"${ CarbonCommonConstants.SPATIAL_INDEX }.$index.datatype"), ""),
             ("Sources Columns",
               tblProps(s"${ CarbonCommonConstants.SPATIAL_INDEX }.$index.sourcecolumns"), ""))
+          if (tblProps.contains(s"${CarbonCommonConstants.SPATIAL_INDEX}.$index.originlatitude")) {
+            results ++= Seq(("Origin Latitude",
+              tblProps(s"${CarbonCommonConstants.SPATIAL_INDEX}.$index.originlatitude"), ""))
+          }
+          if (tblProps.contains(s"${CarbonCommonConstants.SPATIAL_INDEX}.$index.gridsize")) {
+            results ++= Seq(("Grid Size",
+              tblProps(s"${CarbonCommonConstants.SPATIAL_INDEX}.$index.gridsize"), ""))
+          }
+          if (tblProps.contains(s"${CarbonCommonConstants.SPATIAL_INDEX}.$index.conversionratio")) {
+            results ++= Seq(("Conversion Ratio",
+              tblProps(s"${CarbonCommonConstants.SPATIAL_INDEX}.$index.conversionratio"), ""))
+          }
           if (indexList.length != count) {
             results ++= Seq(("", "", ""))
           }

--- a/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/CarbonFilters.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/CarbonFilters.scala
@@ -243,6 +243,13 @@ object CarbonFilters {
           throw new MalformedCarbonCommandException("Expect two string in polyline list")
         }
         val (columnName, instance) = getGeoHashHandler(relation.carbonTable)
+        if (scala.util.Try(children.last.toString().toFloat).isFailure) {
+          throw new MalformedCarbonCommandException("Expect buffer size to be of float type")
+        }
+        val bufferSize = children.last.toString().toFloat
+        if (bufferSize <= 0) {
+          throw new MalformedCarbonCommandException("Expect buffer size to be a positive value")
+        }
         Some(new PolylineListExpression(children.head.toString(),
           children.last.toString().toFloat, columnName, instance))
       case _: InPolygonRangeListUDF =>

--- a/integration/spark/src/main/scala/org/apache/spark/sql/parser/CarbonSparkSqlParserUtil.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/parser/CarbonSparkSqlParserUtil.scala
@@ -564,7 +564,7 @@ object CarbonSparkSqlParserUtil {
   def needToConvertToLowerCase(key: String): Boolean = {
     var noConvertList = Array(CarbonCommonConstants.COMPRESSOR, "PATH", "bad_record_path",
       "timestampformat", "dateformat")
-    if (key.startsWith(CarbonCommonConstants.SPATIAL_INDEX) && key.endsWith(".class")) {
+    if (key.toLowerCase.startsWith(CarbonCommonConstants.SPATIAL_INDEX) && key.endsWith(".class")) {
       noConvertList = noConvertList ++ Array(key)
     }
     !noConvertList.exists(x => x.equalsIgnoreCase(key))

--- a/integration/spark/src/test/scala/org/apache/carbondata/geo/GeoTest.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/geo/GeoTest.scala
@@ -169,35 +169,35 @@ class GeoTest extends QueryTest with BeforeAndAfterAll with BeforeAndAfterEach {
           s"120.190359 30.315388)', -1)").collect())
     assert(exception2.getMessage.contains("Expect buffer size to be a positive value"))
 
-    // Expect grid size to be a positive value
-    intercept[SparkException](
+    exception2 = intercept[MalformedCarbonCommandException](
       sql(s"select LatLngToGeoId(39930753, 116302895, 39.832277, -50) as geoId").collect())
+    assert(exception2.getMessage.contains("Expect grid size to be a positive integer"))
 
-    // Expect grid size to be a positive value
-    intercept[SparkException](
+    exception2 = intercept[MalformedCarbonCommandException](
       sql(s"select GeoIdToLatLng(855279270226, 39.832277, -50) as LatitudeAndLongitude").collect())
+    assert(exception2.getMessage.contains("Expect grid size to be a positive integer"))
 
-    // Expect grid size to be a positive value
-    intercept[SparkException](
+    exception2 = intercept[MalformedCarbonCommandException](
       sql(s"select ToRangeList('116.321011 40.123503, 116.320311 40.122503,116.321111 40.121503, " +
           s"116.321011 40.123503', 39.832277, 0) as rangeList")
         .collect())
+    assert(exception2.getMessage.contains("Expect grid size to be a positive integer"))
 
-    // Expect geoId to be of Long type
-    intercept[SparkException](
+    exception2 = intercept[MalformedCarbonCommandException](
       sql(s"select GeoIdToGridXy('X') as GridXY").collect())
+    assert(exception2.getMessage.contains("Expect geoId to be of long type"))
 
-    // Expect latitude to be of Long type
-    intercept[SparkException](
+    exception2 = intercept[MalformedCarbonCommandException](
       sql(s"select LatLngToGeoId('X', 'X', 'X', 'X') as geoId").collect())
+    assert(exception2.getMessage.contains("Expect latitude to be of long type"))
 
-    // Expect geoId to be of Long type
-    intercept[SparkException](
+    exception2 = intercept[MalformedCarbonCommandException](
       sql(s"select GeoIdToLatLng('X', 'X', 'X') as LatitudeAndLongitude").collect())
+    assert(exception2.getMessage.contains("Expect geoId to be of long type"))
 
-    // Expect geoId to be of Long type
-    intercept[SparkException](
+    exception2 = intercept[MalformedCarbonCommandException](
       sql(s"select ToUpperLayerGeoId('X') as upperLayerGeoId").collect())
+    assert(exception2.getMessage.contains("Expect geoId to be of long type"))
   }
 
   test("test materialized view with spatial column") {


### PR DESCRIPTION
 ### Why is this PR needed?
1. SPATIAL_INDEX property, POLYGON, LINESTRING, and RANGELIST UDF's are case sensitive.
2. SPATIAL_INDEX.xx.gridSize and SPATIAL_INDEX.xxx.conversionRatio is accepting negative values.
3. Accepting invalid values in geo UDF's.

 ### What changes were proposed in this PR?
1. converted properties to lower case and made UDF's case insensitive.
2. added validation.
3. refactored `readAllIIndexOfSegment ` 
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
