### PR TITLE
[CARBONDATA-4173][CARBONDATA-4174] Fix inverted index query issue and handle exception for desc column

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/datastore/columnar/ByteArrayBlockIndexerStorage.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/columnar/ByteArrayBlockIndexerStorage.java
@@ -47,14 +47,8 @@ public class ByteArrayBlockIndexerStorage extends BlockIndexerStorage<byte[][]> 
   private ByteArrayColumnWithRowId[] createColumnWithRowId(byte[][] dataPage,
       boolean isNoDictionary) {
     ByteArrayColumnWithRowId[] columnWithIndexes = new ByteArrayColumnWithRowId[dataPage.length];
-    if (isNoDictionary) {
-      for (short i = 0; i < columnWithIndexes.length; i++) {
-        columnWithIndexes[i] = new ByteArrayColumnWithRowId(dataPage[i], i);
-      }
-    } else {
-      for (short i = 0; i < columnWithIndexes.length; i++) {
-        columnWithIndexes[i] = new ByteArrayColumnWithRowId(dataPage[i], i);
-      }
+    for (short i = 0; i < columnWithIndexes.length; i++) {
+      columnWithIndexes[i] = new ByteArrayColumnWithRowId(dataPage[i], i, isNoDictionary);
     }
     return columnWithIndexes;
   }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/columnar/ByteArrayColumnWithRowId.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/columnar/ByteArrayColumnWithRowId.java
@@ -26,9 +26,12 @@ public class ByteArrayColumnWithRowId implements Comparable<ByteArrayColumnWithR
 
   private short rowId;
 
-  ByteArrayColumnWithRowId(byte[] column, short rowId) {
+  private boolean isNoDictionary;
+
+  ByteArrayColumnWithRowId(byte[] column, short rowId, boolean isNoDictionary) {
     this.column = column;
     this.rowId = rowId;
+    this.isNoDictionary = isNoDictionary;
   }
 
   public byte[] getColumn() {
@@ -41,8 +44,13 @@ public class ByteArrayColumnWithRowId implements Comparable<ByteArrayColumnWithR
 
   @Override
   public int compareTo(ByteArrayColumnWithRowId o) {
-    return UnsafeComparer.INSTANCE
-        .compareTo(column, 2, column.length - 2, o.column, 2, o.column.length - 2);
+    if (isNoDictionary) {
+      return UnsafeComparer.INSTANCE
+          .compareTo(column, 2, column.length - 2, o.column, 2, o.column.length - 2);
+    } else {
+      return UnsafeComparer.INSTANCE
+          .compareTo(column, 0, column.length, o.column, 0, o.column.length);
+    }
   }
 
   @Override

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/describeTable/TestDescribeTable.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/describeTable/TestDescribeTable.scala
@@ -205,7 +205,27 @@ class TestDescribeTable extends QueryTest with BeforeAndAfterAll {
     exception2 = intercept[MalformedCarbonCommandException](sql(
       "describe column MAC.one on complexcarbontable"))
     assert(exception2.getMessage.contains(
-      "one is invalid child name for column mac of table: complexcarbontable"))
+      "one is invalid child name for column MAC of table: complexcarbontable"))
+
+    exception2 = intercept[MalformedCarbonCommandException](sql(
+      "describe column deviceInformationId.x on complexcarbontable"))
+    assert(exception2.getMessage.contains(
+      "x is invalid child name for column deviceInformationId of table: complexcarbontable"))
+
+    exception2 = intercept[MalformedCarbonCommandException](sql(
+      "describe column mobile.imei.x on complexcarbontable"))
+    assert(exception2.getMessage.contains(
+      "x is invalid child name for column mobile.imei of table: complexcarbontable"))
+
+    exception2 = intercept[MalformedCarbonCommandException](sql(
+      "describe column MAC.item.x on complexcarbontable"))
+    assert(exception2.getMessage.contains(
+      "x is invalid child name for column MAC.item of table: complexcarbontable"))
+
+    exception2 = intercept[MalformedCarbonCommandException](sql(
+      "describe column channelsId.key.x on complexcarbontable"))
+    assert(exception2.getMessage.contains(
+      "x is invalid child name for column channelsId.key of table: complexcarbontable"))
   }
 
   test("test describe short table format") {


### PR DESCRIPTION
 ### Why is this PR needed?
1. After creating an Inverted index on the dimension column, some of the filter queries give incorrect results.
2. handle exception for higher level non-existing children column in desc column.
 
 ### What changes were proposed in this PR?
1. While sorting byte arrays with inverted index, we use `compareTo `method of `ByteArrayColumnWithRowId`.  Here, it was sorting based on the last byte only. Made changes to sort properly based on the entire byte length when dictionary is used.
2. handled exception and added in testcase.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
