### PR TITLE
[CARBONDATA-4176] Fail to achive AK/SK when create table on S3/OBS

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
@@ -394,7 +394,7 @@ object CarbonEnv {
       tmpPath = tmpPath + "_" + tableId
     }
     val path = new Path(tmpPath)
-    val fs = path.getFileSystem(sparkSession.sparkContext.hadoopConfiguration)
+    val fs = path.getFileSystem(sparkSession.sessionState.newHadoopConf())
     fs.makeQualified(path).toString
   }
 


### PR DESCRIPTION
 ### Why is this PR needed?
 Due to the failure to obtain aksk, create table operation failed.
 
 ### What changes were proposed in this PR?
Change "session.sparkContext.hadoopConfiguration" to "session.sessionState.newHadoopConf()"
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No

    
