### PR TITLE
[WIP][CARBONDATA-4180] create maintable and do insert before creation of si on maintable then query on si column from presto does not hit SI

### DIFF
--- a/integration/spark/src/main/scala/org/apache/carbondata/indexserver/IndexServer.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/indexserver/IndexServer.scala
@@ -179,6 +179,7 @@ object IndexServer extends ServerInterface {
             request.getInvalidSegments.asScala)
         IndexStoreManager.getInstance()
           .clearInvalidSegments(request.getCarbonTable, request.getInvalidSegments)
+        IndexStoreManager.getInstance().clearIndex(request.getCarbonTable.getTableId)
       }
       if (request.isSIPruningEnabled) {
         new ExtendedBlockletWrapperContainer(Array(DistributedRDDUtils.pruneOnDriver(request)),

--- a/integration/spark/src/main/scala/org/apache/spark/sql/index/CarbonIndexUtil.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/index/CarbonIndexUtil.scala
@@ -38,6 +38,7 @@ import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.datastore.compression.CompressorFactory
 import org.apache.carbondata.core.datastore.impl.FileFactory
 import org.apache.carbondata.core.exception.ConcurrentOperationException
+import org.apache.carbondata.core.index.IndexStoreManager
 import org.apache.carbondata.core.index.status.IndexStatus
 import org.apache.carbondata.core.locks.{CarbonLockFactory, CarbonLockUtil, ICarbonLock, LockUsage}
 import org.apache.carbondata.core.metadata.CarbonMetadata
@@ -471,6 +472,8 @@ object CarbonIndexUtil {
           .stripMargin).collect()
       CarbonHiveIndexMetadataUtil.refreshTable(dbName, tableName, sparkSession)
       CarbonMetadata.getInstance.removeTable(dbName, tableName)
+      // clear the index info from index store cache
+      IndexStoreManager.getInstance().clearIndex(carbonTable.getTableId);
       CarbonMetadata.getInstance.loadTableMetadata(table.getTableInfo)
     } catch {
       case e: Exception =>


### PR DESCRIPTION
 ### Why is this PR needed?
Create maintable and do insert before the creation of si on maintable then query on si column from presto does not hit SI. 
As expected it should hit the SI data map flow but currently, it is fetching results from maintable.
While clearing the invalid segments for each index, CG and FG indexes are added to list(allindexlist at indexstore manager) and not freed after use. 
In the query flow again we are getting all CG and FG indexes from the same list(allindexlist at indexstore manager) which are not updated indexes. Always we should get index information from table level indexmap provider map.
 ### What changes were proposed in this PR?
Clear the indexes entry from the list(allindexlist at indexstore manager) after use and those will be added if not exist from  table level index provider map.
    
 ### Does this PR introduce any user interface change?
 - No
 ### Is any new testcase added?
 - No

    
