### PR TITLE
[CARBONDATA-4186] Fixed insert failure when partition column present in local sort scope

### DIFF
--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/standardpartition/StandardPartitionTableLoadingTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/standardpartition/StandardPartitionTableLoadingTestCase.scala
@@ -517,6 +517,24 @@ class StandardPartitionTableLoadingTestCase extends QueryTest with BeforeAndAfte
     assert(result.get(0).get(6).equals(dataAndIndexSize._2))
   }
 
+  test("test partition column with different sort scope") {
+    verifySortWithPartition("global_sort")
+    verifySortWithPartition("no_sort")
+    verifySortWithPartition("local_sort")
+  }
+
+  def verifySortWithPartition(scope: String): Unit = {
+    sql("drop table if exists carbon_partition")
+    sql(s"create table carbon_partition(id int, name string, salary double) " +
+        "partitioned by(country string, id1 int)" +
+        s"stored as carbondata tblproperties('sort_scope'='$scope','sort_columns'='country, id')")
+    sql("insert into carbon_partition select 1, 'Ram',3500,'India', 20")
+    checkAnswer(
+      sql("SELECT * FROM carbon_partition"),
+      Seq(Row(1, "Ram", 3500.0, "India", 20))
+    )
+  }
+
   test("test partition with all sort scope") {
     sql("drop table if exists origin_csv")
     sql(

--- a/processing/src/main/java/org/apache/carbondata/processing/util/CarbonDataProcessorUtil.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/util/CarbonDataProcessorUtil.java
@@ -655,7 +655,7 @@ public final class CarbonDataProcessorUtil {
    * @param dataFields
    * @return
    */
-  public static Map<String, DataType[]> getNoDictSortAndNoSortDataTypesAsDataFieldOrder(
+  public static Map<String, DataType[]> getNoDictSortAndNoSortDataTypes(
       DataField[] dataFields) {
     List<DataType> noDictSortType = new ArrayList<>();
     List<DataType> noDictNoSortType = new ArrayList<>();


### PR DESCRIPTION
 ### Why is this PR needed?
 Currently when we create table with partition column and put the same column as part of local sort scope then Insert query fails with ArrayIndexOutOfBounds exception.
 
 ### What changes were proposed in this PR?
Handle ArrayIndexOutOfBound exception, earlier array size was not increasing because data was inconsistence and in the wrong order for sortcolumn and isDimNoDictFlags.
    
 ### Does this PR introduce any user interface change?
 - No
 - Yes. (please explain the change and update document)

 ### Is any new testcase added?
 - Yes

    
