### PR TITLE
[CARBONDATA-4184] alter table Set TBLPROPERTIES for RANGE_COLUMN sets unsupported datatype(complex_datatypes/Binary/Boolean/Decimal) as RANGE_COLUMN.

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/catalyst/CarbonParserUtil.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/catalyst/CarbonParserUtil.scala
@@ -589,6 +589,15 @@ object CarbonParserUtil {
     noInvertedIdxCols
   }
 
+  def validateUnsupportedDataTypeForRangeColumn(dataType: String): Boolean = {
+    DataTypes.BINARY.getName.equalsIgnoreCase(dataType) ||
+      DataTypes.BOOLEAN.getName.equalsIgnoreCase(dataType) ||
+      CarbonCommonConstants.ARRAY.equalsIgnoreCase(dataType) ||
+      CarbonCommonConstants.STRUCT.equalsIgnoreCase(dataType) ||
+      CarbonCommonConstants.MAP.equalsIgnoreCase(dataType) ||
+      CarbonCommonConstants.DECIMAL.equalsIgnoreCase(dataType)
+  }
+
   protected def extractInvertedIndexColumns(fields: Seq[Field],
       tableProperties: Map[String, String]): Seq[String] = {
     // check whether the column name is in fields
@@ -684,12 +693,7 @@ object CarbonParserUtil {
         val errorMsg = "range_column: " + rangeColumn +
                        " does not exist in table. Please check the create table statement."
         throw new MalformedCarbonCommandException(errorMsg)
-      } else if (DataTypes.BINARY.getName.equalsIgnoreCase(dataType) ||
-                 DataTypes.BOOLEAN.getName.equalsIgnoreCase(dataType) ||
-                 CarbonCommonConstants.ARRAY.equalsIgnoreCase(dataType) ||
-                 CarbonCommonConstants.STRUCT.equalsIgnoreCase(dataType) ||
-                 CarbonCommonConstants.MAP.equalsIgnoreCase(dataType) ||
-                 CarbonCommonConstants.DECIMAL.equalsIgnoreCase(dataType)) {
+      } else if (validateUnsupportedDataTypeForRangeColumn(dataType)) {
         throw new MalformedCarbonCommandException(
           s"RANGE_COLUMN doesn't support $dataType data type: " + rangeColumn)
       } else {

--- a/integration/spark/src/main/scala/org/apache/spark/util/AlterTableUtil.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/util/AlterTableUtil.scala
@@ -25,7 +25,7 @@ import scala.collection.mutable.ListBuffer
 
 import org.apache.commons.lang3.StringUtils
 import org.apache.spark.sql.{CarbonEnv, SparkSession}
-import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.{CarbonParserUtil, TableIdentifier}
 import org.apache.spark.sql.catalyst.catalog.SessionCatalog
 import org.apache.spark.sql.hive.{CarbonRelation, CarbonSessionCatalogUtil}
 import org.apache.spark.sql.index.CarbonIndexUtil
@@ -652,6 +652,11 @@ object AlterTableUtil {
         throw new MalformedCarbonCommandException(
           s"Table property ${ CarbonCommonConstants.RANGE_COLUMN }: ${ rangeColumnProp }" +
           s" is not exists in the table")
+      }
+      val dataType = rangeColumn.getDataType.getName;
+      if (CarbonParserUtil.validateUnsupportedDataTypeForRangeColumn(dataType)) {
+        throw new MalformedCarbonCommandException(
+          s"RANGE_COLUMN doesn't support $dataType data type: " + rangeColumnProp)
       } else {
         propertiesMap.put(CarbonCommonConstants.RANGE_COLUMN, rangeColumn.getColName)
       }


### PR DESCRIPTION
 ### Why is this PR needed?
Alter table set command was not validating unsupported dataTypes for range column.
 
 
 ### What changes were proposed in this PR?
Added validation for unsupported dataTypes before setting range column value.

    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
