### PR TITLE
[CARBONDATA-4188] Fixed select query with small table page size after alter add column.

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RangeValueFilterExecutorImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RangeValueFilterExecutorImpl.java
@@ -375,9 +375,7 @@ public class RangeValueFilterExecutorImpl implements FilterExecutor {
     // false, in that scenario the default values of the column should be shown.
     // select all rows if dimension does not exists in the current block
     if (!isDimensionPresentInCurrentBlock) {
-      int numberOfRows = blockChunkHolder.getDataBlock().numRows();
-      return FilterUtil.createBitSetGroupWithDefaultValue(
-          blockChunkHolder.getDataBlock().numberOfPages(), numberOfRows, true);
+      return FilterUtil.createBitSetGroupWithColumnChunk(blockChunkHolder, true);
     }
 
     int chunkIndex = segmentProperties.getDimensionOrdinalToChunkMapping()

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RestructureExcludeFilterExecutorImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RestructureExcludeFilterExecutorImpl.java
@@ -50,10 +50,8 @@ public class RestructureExcludeFilterExecutorImpl extends RestructureEvaluatorIm
   @Override
   public BitSetGroup applyFilter(RawBlockletColumnChunks rawBlockletColumnChunks,
       boolean useBitsetPipeLine) {
-    int numberOfRows = rawBlockletColumnChunks.getDataBlock().numRows();
-    return FilterUtil
-        .createBitSetGroupWithDefaultValue(rawBlockletColumnChunks.getDataBlock().numberOfPages(),
-            numberOfRows, !isDefaultValuePresentInFilterValues);
+    return FilterUtil.createBitSetGroupWithColumnChunk(rawBlockletColumnChunks,
+        !isDefaultValuePresentInFilterValues);
   }
 
   @Override

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RestructureIncludeFilterExecutorImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RestructureIncludeFilterExecutorImpl.java
@@ -49,10 +49,8 @@ public class RestructureIncludeFilterExecutorImpl extends RestructureEvaluatorIm
   @Override
   public BitSetGroup applyFilter(RawBlockletColumnChunks rawBlockletColumnChunks,
       boolean useBitsetPipeLine) {
-    int numberOfRows = rawBlockletColumnChunks.getDataBlock().numRows();
-    return FilterUtil.createBitSetGroupWithDefaultValue(
-        rawBlockletColumnChunks.getDataBlock().numberOfPages(),
-        numberOfRows, isDefaultValuePresentInFilterValues);
+    return FilterUtil.createBitSetGroupWithColumnChunk(rawBlockletColumnChunks,
+        isDefaultValuePresentInFilterValues);
   }
 
   @Override

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RowLevelRangeGreaterThanEqualFilterExecutorImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RowLevelRangeGreaterThanEqualFilterExecutorImpl.java
@@ -217,10 +217,8 @@ public class RowLevelRangeGreaterThanEqualFilterExecutorImpl extends RowLevelFil
       boolean useBitsetPipeLine) throws IOException {
     // select all rows if dimension does not exists in the current block
     if (!isDimensionPresentInCurrentBlock[0] && !isMeasurePresentInCurrentBlock[0]) {
-      int numberOfRows = rawBlockletColumnChunks.getDataBlock().numRows();
       return FilterUtil
-          .createBitSetGroupWithDefaultValue(rawBlockletColumnChunks.getDataBlock().numberOfPages(),
-              numberOfRows, true);
+          .createBitSetGroupWithColumnChunk(rawBlockletColumnChunks, true);
     }
 
     if (isDimensionPresentInCurrentBlock[0]) {

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RowLevelRangeGreaterThanFilterExecutorImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RowLevelRangeGreaterThanFilterExecutorImpl.java
@@ -275,10 +275,8 @@ public class RowLevelRangeGreaterThanFilterExecutorImpl extends RowLevelFilterEx
       boolean useBitsetPipeLine) throws IOException {
     // select all rows if dimension does not exists in the current block
     if (!isDimensionPresentInCurrentBlock[0] && !isMeasurePresentInCurrentBlock[0]) {
-      int numberOfRows = rawBlockletColumnChunks.getDataBlock().numRows();
       return FilterUtil
-          .createBitSetGroupWithDefaultValue(rawBlockletColumnChunks.getDataBlock().numberOfPages(),
-              numberOfRows, true);
+          .createBitSetGroupWithColumnChunk(rawBlockletColumnChunks, true);
     }
     if (isDimensionPresentInCurrentBlock[0]) {
       int chunkIndex =

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RowLevelRangeLessThanEqualFilterExecutorImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RowLevelRangeLessThanEqualFilterExecutorImpl.java
@@ -217,10 +217,8 @@ public class RowLevelRangeLessThanEqualFilterExecutorImpl extends RowLevelFilter
       boolean useBitsetPipeLine) throws IOException {
     // select all rows if dimension does not exists in the current block
     if (!isDimensionPresentInCurrentBlock[0] && !isMeasurePresentInCurrentBlock[0]) {
-      int numberOfRows = rawBlockletColumnChunks.getDataBlock().numRows();
       return FilterUtil
-          .createBitSetGroupWithDefaultValue(rawBlockletColumnChunks.getDataBlock().numberOfPages(),
-              numberOfRows, true);
+          .createBitSetGroupWithColumnChunk(rawBlockletColumnChunks, true);
     }
     if (isDimensionPresentInCurrentBlock[0]) {
       int chunkIndex =

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RowLevelRangeLessThanFilterExecutorImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/RowLevelRangeLessThanFilterExecutorImpl.java
@@ -214,10 +214,8 @@ public class RowLevelRangeLessThanFilterExecutorImpl extends RowLevelFilterExecu
       boolean useBitsetPipeLine) throws IOException {
     // select all rows if dimension does not exists in the current block
     if (!isDimensionPresentInCurrentBlock[0] && !isMeasurePresentInCurrentBlock[0]) {
-      int numberOfRows = rawBlockletColumnChunks.getDataBlock().numRows();
       return FilterUtil
-          .createBitSetGroupWithDefaultValue(rawBlockletColumnChunks.getDataBlock().numberOfPages(),
-              numberOfRows, true);
+          .createBitSetGroupWithColumnChunk(rawBlockletColumnChunks, true);
     }
     if (isDimensionPresentInCurrentBlock[0]) {
       int chunkIndex =


### PR DESCRIPTION
 ### Why is this PR needed?
Select query on table with long string data type and small page size throws ArrayIndexOutOfBoudException after alter add columns.

Query fails because after changing the schema, the number of rows set in bitsetGroup(RestructureIncludeFilterExecutorImpl.applyFilter()) for pages is not correct.
 
 ### What changes were proposed in this PR?
Set the correct number of rows inside every page of bitsetGroup.
    
 ### Does this PR introduce any user interface change?
 - No
 - Yes. (please explain the change and update document)

 ### Is any new testcase added?
 - No

    
