### PR TITLE
[CARBONDATA-4189] alter table validation issues

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/catalyst/CarbonParserUtil.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/catalyst/CarbonParserUtil.scala
@@ -630,7 +630,7 @@ object CarbonParserUtil {
   protected def extractDimAndMsrFields(fields: Seq[Field], indexFields: Seq[Field],
       tableProperties: Map[String, String]):
   (Seq[Field], Seq[Field], Seq[String], Seq[String], Seq[String]) = {
-    var dimFields: LinkedHashSet[Field] = LinkedHashSet[Field]()
+    var dimFields: Seq[Field] = Seq[Field]()
     var msrFields: Seq[Field] = Seq[Field]()
     var noDictionaryDims: Seq[String] = Seq[String]()
     var varcharCols: Seq[String] = Seq[String]()
@@ -708,9 +708,9 @@ object CarbonParserUtil {
     allFields.foreach { field =>
       if (field.dataType.get.toUpperCase.equals("TIMESTAMP")) {
         noDictionaryDims :+= field.column
-        dimFields += field
+        dimFields :+= field
       } else if (isDetectAsDimensionDataType(field.dataType.get)) {
-        dimFields += field
+        dimFields :+= field
         // consider all String and binary cols as noDictionaryDims by default
         if ((DataTypes.STRING.getName.equalsIgnoreCase(field.dataType.get)) ||
             (DataTypes.BINARY.getName.equalsIgnoreCase(field.dataType.get))) {
@@ -724,7 +724,7 @@ object CarbonParserUtil {
                                                     field.column}}in sort_columns.")
       } else if (sortKeyDimsTmp.exists(x => x.equalsIgnoreCase(field.column))) {
         noDictionaryDims :+= field.column
-        dimFields += field
+        dimFields :+= field
       } else {
         msrFields :+= field
       }
@@ -736,7 +736,7 @@ object CarbonParserUtil {
     } else {
       tableProperties.put(CarbonCommonConstants.SORT_COLUMNS, sortKeyDimsTmp.mkString(","))
     }
-    (dimFields.toSeq, msrFields, noDictionaryDims, sortKeyDimsTmp, varcharCols)
+    (dimFields, msrFields, noDictionaryDims, sortKeyDimsTmp, varcharCols)
   }
 
   def isDefaultMeasure(dataType: Option[String]): Boolean = {

--- a/integration/spark/src/main/scala/org/apache/spark/util/AlterTableUtil.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/util/AlterTableUtil.scala
@@ -907,14 +907,17 @@ object AlterTableUtil {
     val colSchemas = carbonTable.getTableInfo.getFactTable.getListOfColumns.asScala
     longStringCols.foreach { col =>
       if (!colSchemas.exists(x => x.getColumnName.equalsIgnoreCase(col))) {
-        val errorMsg = "LONG_STRING_COLUMNS column: " + col +
-                       " does not exist in table. Please check the DDL."
+        val errorMsg = s"LONG_STRING_COLUMNS column: $col does not exist in table. Please check " +
+                       s"the DDL."
         throw new MalformedCarbonCommandException(errorMsg)
       } else if (colSchemas.exists(x => x.getColumnName.equalsIgnoreCase(col) &&
-                                          !x.getDataType.toString
-                                            .equalsIgnoreCase("STRING"))) {
-        val errMsg = "LONG_STRING_COLUMNS column: " + col +
-                     " is not a string datatype column"
+                                        x.isComplexColumn)) {
+        val errMsg = s"Complex child column $col cannot be set as LONG_STRING_COLUMNS."
+        throw new MalformedCarbonCommandException(errMsg)
+      } else if (colSchemas.exists(x => x.getColumnName.equalsIgnoreCase(col) &&
+                                        !x.getDataType.toString
+                                          .equalsIgnoreCase("STRING"))) {
+        val errMsg = s"LONG_STRING_COLUMNS column: $col is not a string datatype column"
         throw new MalformedCarbonCommandException(errMsg)
       }
     }


### PR DESCRIPTION
 ### Why is this PR needed?
1) Alter table duplicate columns check for dimensions/complex columns missed
2) Alter table properties with long strings for complex columns should not support
 
 ### What changes were proposed in this PR?
1) Changed the dimension columns list type in preparing dimensions columns [LinkedHashSet to Scala Seq] for handling the duplicate columns 
2) Added check for throwing an exception in case of long strings for complex columns
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
