### PR TITLE
[CARBONDATA-4191] update table for primitive column not working when complex child column name and primitive column name match

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/CarbonIUDRule.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/CarbonIUDRule.scala
@@ -41,14 +41,6 @@ class CarbonIUDRule extends Rule[LogicalPlan] with PredicateHelper {
           case Project(pList, child) if !isTransformed =>
             var (dest: Seq[NamedExpression], source: Seq[NamedExpression]) = pList
               .splitAt(pList.size - cols.size)
-            // check complex column
-            cols.foreach { col =>
-              val complexExists = "\"name\":\"" + col + "\""
-              if (dest.exists(m => m.dataType.json.contains(complexExists))) {
-                throw new UnsupportedOperationException(
-                  "Unsupported operation on Complex data type")
-              }
-            }
             // check updated columns exists in table
             val diff = cols.diff(dest.map(_.name.toLowerCase))
             if (diff.nonEmpty) {


### PR DESCRIPTION

 ### Why is this PR needed?
Update primitive column not working when complex column child name and primitive data type name same.
When an update for primitive is received, we are checking in complex child columns if column name matches then returning UnsupportedOperationbException.
 
 ### What changes were proposed in this PR?
Currently, we are ignoring the prefix of all columns and passing only columns/child column info to the update command. 
New Changes: Passing full column(**alias name/table name.columnName**) name which is given by the user and added checks for handling the unsupported update operation of complex columns.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
