### PR TITLE
[CARBONDATA-4193] Fix compaction failure after alter add complex column.

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/scan/collector/impl/RestructureBasedRawResultCollector.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/collector/impl/RestructureBasedRawResultCollector.java
@@ -184,6 +184,7 @@ public class RestructureBasedRawResultCollector extends RawBasedResultCollector 
                 newColumnDefaultValue = byteStream.toByteArray();
               } catch (IOException e) {
                 LOGGER.error(e.getMessage(), e);
+                throw new RuntimeException(e);
               }
               complexTypeKeyArrayWithNewlyAddedColumns[newComplexKeyArrayIndex++] =
                   newColumnDefaultValue;

--- a/core/src/main/java/org/apache/carbondata/core/scan/executor/infos/DimensionInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/executor/infos/DimensionInfo.java
@@ -56,6 +56,17 @@ public class DimensionInfo {
    * count of no dictionary columns not existing in the current block
    */
   private int newNoDictionaryColumnCount;
+
+  /**
+   * count of complex columns not existing in the current block
+   */
+  private int newComplexColumnCount;
+
+  /**
+   * flag to check whether there exist a complex column in the query which
+   * does not exist in the current block
+   */
+  private boolean isComplexColumnAdded;
   /**
   * maintains the block datatype
   */
@@ -114,5 +125,21 @@ public class DimensionInfo {
 
   public void setNewNoDictionaryColumnCount(int newNoDictionaryColumnCount) {
     this.newNoDictionaryColumnCount = newNoDictionaryColumnCount;
+  }
+
+  public boolean isComplexColumnAdded() {
+    return isComplexColumnAdded;
+  }
+
+  public void setComplexColumnAdded(boolean complexColumnAdded) {
+    isComplexColumnAdded = complexColumnAdded;
+  }
+
+  public int getNewComplexColumnCount() {
+    return newComplexColumnCount;
+  }
+
+  public void setNewComplexColumnCount(int newComplexColumnCount) {
+    this.newComplexColumnCount = newComplexColumnCount;
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/scan/executor/util/RestructureUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/executor/util/RestructureUtil.java
@@ -77,6 +77,7 @@ public class RestructureUtil {
     dimensionInfo.dataType = new DataType[queryDimensions.length + measureCount];
     int newDictionaryColumnCount = 0;
     int newNoDictionaryColumnCount = 0;
+    int newNoDictionaryComplexColumnCount = 0;
     // selecting only those dimension which is present in the query
     int dimIndex = 0;
     for (ProjectionDimension queryDimension : queryDimensions) {
@@ -140,6 +141,9 @@ public class RestructureUtil {
           if (queryDimension.getDimension().getDataType() == DataTypes.DATE) {
             dimensionInfo.setDictionaryColumnAdded(true);
             newDictionaryColumnCount++;
+          } else if (queryDimension.getDimension().getDataType().isComplexType()) {
+            dimensionInfo.setComplexColumnAdded(true);
+            newNoDictionaryComplexColumnCount++;
           } else {
             dimensionInfo.setNoDictionaryColumnAdded(true);
             newNoDictionaryColumnCount++;
@@ -150,6 +154,7 @@ public class RestructureUtil {
     }
     dimensionInfo.setNewDictionaryColumnCount(newDictionaryColumnCount);
     dimensionInfo.setNewNoDictionaryColumnCount(newNoDictionaryColumnCount);
+    dimensionInfo.setNewComplexColumnCount(newNoDictionaryComplexColumnCount);
     blockExecutionInfo.setDimensionInfo(dimensionInfo);
     return presentDimension;
   }

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/iterator/DetailQueryResultIterator.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/iterator/DetailQueryResultIterator.java
@@ -42,7 +42,6 @@ public class DetailQueryResultIterator extends AbstractDetailQueryResultIterator
       blockExecutionInfo
           .setComplexColumnParentBlockIndexes(infos.get(0).getComplexColumnParentBlockIndexes());
       blockExecutionInfo.setComplexDimensionInfoMap(infos.get(0).getComplexDimensionInfoMap());
-      blockExecutionInfo.setDimensionInfo(infos.get(0).getDimensionInfo());
     }
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/iterator/DetailQueryResultIterator.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/iterator/DetailQueryResultIterator.java
@@ -42,6 +42,7 @@ public class DetailQueryResultIterator extends AbstractDetailQueryResultIterator
       blockExecutionInfo
           .setComplexColumnParentBlockIndexes(infos.get(0).getComplexColumnParentBlockIndexes());
       blockExecutionInfo.setComplexDimensionInfoMap(infos.get(0).getComplexDimensionInfoMap());
+      blockExecutionInfo.setDimensionInfo(infos.get(0).getDimensionInfo());
     }
   }
 

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
@@ -3481,4 +3481,23 @@ public final class CarbonUtil {
       });
     }
   }
+
+  public static void updateNullValueBasedOnDatatype(DataOutputStream dataOutputStream,
+      DataType dataType) throws IOException {
+    if (dataType == DataTypes.STRING || dataType == DataTypes.VARCHAR) {
+      if (DataTypeUtil.isByteArrayComplexChildColumn(dataType)) {
+        dataOutputStream.writeInt(CarbonCommonConstants.MEMBER_DEFAULT_VAL_ARRAY.length);
+      } else {
+        dataOutputStream.writeShort(CarbonCommonConstants.MEMBER_DEFAULT_VAL_ARRAY.length);
+      }
+      dataOutputStream.write(CarbonCommonConstants.MEMBER_DEFAULT_VAL_ARRAY);
+    } else {
+      if (DataTypeUtil.isByteArrayComplexChildColumn(dataType)) {
+        dataOutputStream.writeInt(CarbonCommonConstants.EMPTY_BYTE_ARRAY.length);
+      } else {
+        dataOutputStream.writeShort(CarbonCommonConstants.EMPTY_BYTE_ARRAY.length);
+      }
+      dataOutputStream.write(CarbonCommonConstants.EMPTY_BYTE_ARRAY);
+    }
+  }
 }

--- a/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/TestSIWithComplexArrayType.scala
+++ b/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/TestSIWithComplexArrayType.scala
@@ -45,7 +45,7 @@ class TestSIWithComplexArrayType extends QueryTest with BeforeAndAfterEach {
     sql("drop table if exists complextable5")
   }
 
-  test("Test alter add array column before creating SI") {
+  test("Test restructured array<string> and existing string column as index columns on SI with compaction") {
     sql("drop table if exists complextable")
     sql("create table complextable (id string, country array<string>, name string) stored as carbondata")
     sql("insert into complextable select 1,array('china', 'us'), 'b'")
@@ -60,11 +60,12 @@ class TestSIWithComplexArrayType extends QueryTest with BeforeAndAfterEach {
     checkAnswer(sql("select * from complextable where array_contains(arr2,'iron')"),
       Seq(Row("4", mutable.WrappedArray.make(Array("India")), "g",
         mutable.WrappedArray.make(Array("iron", "man", "jarvis")))))
-    val result1 = sql("select * from complextable where array_contains(arr2,'iron')")
-    val result2 = sql("select * from complextable where arr2[0]='iron'")
-    sql("create index index_11 on table complextable(arr2) as 'carbondata'")
-    val df1 = sql(" select * from complextable where array_contains(arr2,'iron')")
-    val df2 = sql(" select * from complextable where arr2[0]='iron'")
+    val result1 = sql("select * from complextable where array_contains(arr2,'iron') and name='g'")
+    val result2 = sql("select * from complextable where arr2[0]='iron' and name='f'")
+    sql("create index index_11 on table complextable(arr2, name) as 'carbondata'")
+    sql("alter table complextable compact 'minor'")
+    val df1 = sql(" select * from complextable where array_contains(arr2,'iron') and name='g'")
+    val df2 = sql(" select * from complextable where arr2[0]='iron' and name='f'")
     if (!isFilterPushedDownToSI(df1.queryExecution.sparkPlan)) {
       assert(false)
     } else {
@@ -85,7 +86,49 @@ class TestSIWithComplexArrayType extends QueryTest with BeforeAndAfterEach {
     checkAnswer(result2, df2)
   }
 
-  test("test array<string> on secondary index") {
+  test("Test restructured array<string> and string columns as index columns on SI with compaction") {
+    sql("drop table if exists complextable")
+    sql("create table complextable (id string, country array<string>, name string) stored as carbondata")
+    sql("insert into complextable select 1,array('china', 'us'), 'b'")
+    sql("insert into complextable select 2,array('pak'), 'v'")
+
+    sql("drop index if exists index_11 on complextable")
+    sql(
+      "ALTER TABLE complextable ADD COLUMNS(arr2 array<string>)")
+    sql("ALTER TABLE complextable ADD COLUMNS(addr string)")
+    sql("insert into complextable select 3,array('china'), 'f',array('hello','world'),'china'")
+    sql("insert into complextable select 4,array('India'),'g',array('iron','man','jarvis'),'India'")
+
+    checkAnswer(sql("select * from complextable where array_contains(arr2,'iron')"),
+      Seq(Row("4", mutable.WrappedArray.make(Array("India")), "g",
+        mutable.WrappedArray.make(Array("iron", "man", "jarvis")), "India")))
+    val result1 = sql("select * from complextable where array_contains(arr2,'iron') and addr='India'")
+    val result2 = sql("select * from complextable where arr2[0]='iron' and addr='china'")
+    sql("create index index_11 on table complextable(arr2, addr) as 'carbondata'")
+    sql("alter table complextable compact 'minor'")
+    val df1 = sql(" select * from complextable where array_contains(arr2,'iron') and addr='India'")
+    val df2 = sql(" select * from complextable where arr2[0]='iron' and addr='china'")
+    if (!isFilterPushedDownToSI(df1.queryExecution.sparkPlan)) {
+      assert(false)
+    } else {
+      assert(true)
+    }
+    if (!isFilterPushedDownToSI(df2.queryExecution.sparkPlan)) {
+      assert(false)
+    } else {
+      assert(true)
+    }
+    val doNotHitSIDf = sql(" select * from complextable where array_contains(arr2,'iron') and array_contains(arr2,'man')")
+    if (isFilterPushedDownToSI(doNotHitSIDf.queryExecution.sparkPlan)) {
+      assert(false)
+    } else {
+      assert(true)
+    }
+    checkAnswer(result1, df1)
+    checkAnswer(result2, df2)
+  }
+
+  test("test array<string> on secondary index with compaction") {
     sql("create table complextable (id string, country array<string>, name string) stored as carbondata")
     sql("insert into complextable select 1,array('china', 'us'), 'b'")
     sql("insert into complextable select 2,array('pak'), 'v'")
@@ -95,6 +138,7 @@ class TestSIWithComplexArrayType extends QueryTest with BeforeAndAfterEach {
     val result2 = sql(" select * from complextable where country[0]='china'")
     sql("drop index if exists index_1 on complextable")
     sql("create index index_1 on table complextable(country) as 'carbondata'")
+    sql("alter table complextable compact 'minor'")
     val df1 = sql(" select * from complextable where array_contains(country,'china')")
     val df2 = sql(" select * from complextable where country[0]='china'")
     if (!isFilterPushedDownToSI(df1.queryExecution.sparkPlan)) {
@@ -117,7 +161,7 @@ class TestSIWithComplexArrayType extends QueryTest with BeforeAndAfterEach {
     checkAnswer(result2, df2)
   }
 
-  test("test array<string> and string as index columns on secondary index") {
+  test("test array<string> and string as index columns on secondary index with compaction") {
     sql("create table complextable (id string, country array<string>, name string) stored as carbondata")
     sql("insert into complextable select 1, array('china', 'us'), 'b'")
     sql("insert into complextable select 2, array('pak'), 'v'")
@@ -126,6 +170,7 @@ class TestSIWithComplexArrayType extends QueryTest with BeforeAndAfterEach {
     val result = sql(" select * from complextable where array_contains(country,'china') and name='f'")
     sql("drop index if exists index_1 on complextable")
     sql("create index index_1 on table complextable(country, name) as 'carbondata'")
+    sql("alter table complextable compact 'minor'")
     val df = sql(" select * from complextable where array_contains(country,'china') and name='f'")
     if (!isFilterPushedDownToSI(df.queryExecution.sparkPlan)) {
       assert(false)

--- a/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/command/SICreationCommand.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/command/SICreationCommand.scala
@@ -680,18 +680,24 @@ private[sql] case class CarbonCreateSecondaryIndexCommand(
       dataType: DataType = null): ColumnSchema = {
     val columnSchema = new ColumnSchema()
     val encodingList = parentColumnSchema.getEncodingList
+    var colPropMap = parentColumnSchema.getColumnProperties
     // if data type is arrayType, then store the column as its CHILD data type in SI
     if (DataTypes.isArrayType(parentColumnSchema.getDataType)) {
       columnSchema.setDataType(dataType)
+      if (colPropMap == null) {
+        colPropMap = new java.util.HashMap[String, String]()
+      }
+      colPropMap.put("isParentColumnComplex", "true")
+      columnSchema.setColumnProperties(colPropMap)
       if (dataType == DataTypes.DATE) {
         encodingList.add(Encoding.DIRECT_DICTIONARY)
         encodingList.add(Encoding.DICTIONARY)
       }
     } else {
       columnSchema.setDataType(parentColumnSchema.getDataType)
+      columnSchema.setColumnProperties(colPropMap)
     }
     columnSchema.setColumnName(parentColumnSchema.getColumnName)
-    columnSchema.setColumnProperties(parentColumnSchema.getColumnProperties)
     columnSchema.setEncodingList(encodingList)
     columnSchema.setColumnUniqueId(parentColumnSchema.getColumnUniqueId)
     columnSchema.setColumnReferenceId(parentColumnSchema.getColumnReferenceId)

--- a/integration/spark/src/test/resources/secindex/array2.csv
+++ b/integration/spark/src/test/resources/secindex/array2.csv
@@ -1,0 +1,4 @@
+1,abc,china$india$us,hello$world
+2,xyz,sri$can,iron$man$jarvis
+3,mno,rus$china,ex$ex2
+4,lok,hk$bang,ex$ex3

--- a/processing/src/main/java/org/apache/carbondata/processing/datatypes/PrimitiveDataType.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/datatypes/PrimitiveDataType.java
@@ -414,22 +414,7 @@ public class PrimitiveDataType implements GenericDataType<Object> {
 
   private void updateNullValue(DataOutputStream dataOutputStream, BadRecordLogHolder logHolder)
       throws IOException {
-    if (this.carbonDimension.getDataType() == DataTypes.STRING
-        || this.carbonDimension.getDataType() == DataTypes.VARCHAR) {
-      if (DataTypeUtil.isByteArrayComplexChildColumn(dataType)) {
-        dataOutputStream.writeInt(CarbonCommonConstants.MEMBER_DEFAULT_VAL_ARRAY.length);
-      } else {
-        dataOutputStream.writeShort(CarbonCommonConstants.MEMBER_DEFAULT_VAL_ARRAY.length);
-      }
-      dataOutputStream.write(CarbonCommonConstants.MEMBER_DEFAULT_VAL_ARRAY);
-    } else {
-      if (DataTypeUtil.isByteArrayComplexChildColumn(dataType)) {
-        dataOutputStream.writeInt(CarbonCommonConstants.EMPTY_BYTE_ARRAY.length);
-      } else {
-        dataOutputStream.writeShort(CarbonCommonConstants.EMPTY_BYTE_ARRAY.length);
-      }
-      dataOutputStream.write(CarbonCommonConstants.EMPTY_BYTE_ARRAY);
-    }
+    CarbonUtil.updateNullValueBasedOnDatatype(dataOutputStream, this.carbonDimension.getDataType());
     String message = logHolder.getColumnMessageMap().get(carbonDimension.getColName());
     if (null == message) {
       message = CarbonDataProcessorUtil


### PR DESCRIPTION
 ### Why is this PR needed?
1. When we perform compaction after alter add a complex column, the query fails with `ArrayIndexOutOfBounds `exception.
While converting and adding row after merge step in `WriteStepRowUtil.fromMergerRow`, As complex dimension is present, the `complexKeys ` array is accessed but doesnt have any values in array and throws exception.
2. Creating SI with globalsort on newly added complex column throws TreenodeException (`Caused by: java.lang.RuntimeException: Couldn't find positionId#172 in [arr2#153]`)
 
 ### What changes were proposed in this PR?
1. While restructuring row, added changes to fill  `complexKeys `  with default values(null values to children) according to the latest schema.
   In SI queryresultprocessor, used the column property `isParentColumnComplex `to identify any complex type. If complex index column not present in the parent table block, assigned the SI row value to empty bytes.
2. For SI with globalsort, In case of complex type projection, TableProperties object in `carbonEnv `is not same as in `carbonTable `object and hence requiredColumns is not updated with positionId.  So updating tableproperties from carbon env itself.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
