### PR TITLE
[TEMP] [WIP] Transaction manager support

### DIFF
--- a/acid/CARBON_ACIDLogResource.properties
+++ b/acid/CARBON_ACIDLogResource.properties
@@ -1,0 +1,18 @@
+#
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+#
+carbon.acid = {0}

--- a/acid/pom.xml
+++ b/acid/pom.xml
@@ -1,0 +1,190 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.carbondata</groupId>
+    <artifactId>carbondata-parent</artifactId>
+    <version>2.2.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>carbondata-acid</artifactId>
+  <name>Apache CarbonData :: acid</name>
+
+  <properties>
+    <dev.path>${basedir}/../dev</dev.path>
+    <jacoco.append>true</jacoco.append>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.carbondata</groupId>
+      <artifactId>carbondata-format</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.carbondata</groupId>
+      <artifactId>carbondata-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.carbondata</groupId>
+      <artifactId>carbondata-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.scalatest</groupId>
+      <artifactId>scalatest_${scala.binary.version}</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <!--<dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.4</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.xerial.snappy</groupId>
+      <artifactId>snappy-java</artifactId>
+      <version>${snappy.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>net.jodah</groupId>
+      <artifactId>expiringmap</artifactId>
+      <version>0.5.9</version>
+    </dependency>
+    <dependency>
+      <groupId>com.github.luben</groupId>
+      <artifactId>zstd-jni</artifactId>
+      <version>1.3.2-2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jmockit</groupId>
+      <artifactId>jmockit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.zookeeper</groupId>
+      <artifactId>zookeeper</artifactId>
+      <version>3.4.7</version>
+      <exclusions>
+        <exclusion>
+          <groupId>jline</groupId>
+          <artifactId>jline</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.5</version>
+    </dependency>
+    <dependency>
+      <groupId>org.roaringbitmap</groupId>
+      <artifactId>RoaringBitmap</artifactId>
+      <version>0.5.11</version>
+    </dependency>
+    <dependency>
+      <groupId>it.unimi.dsi</groupId>
+      <artifactId>fastutil</artifactId>
+      <version>8.2.3</version>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-all</artifactId>
+      <version>4.1.17.Final</version>
+    </dependency>
+    <dependency>
+      <groupId>org.lz4</groupId>
+      <artifactId>lz4-java</artifactId>
+      <version>1.4.0</version>
+    </dependency>-->
+  </dependencies>
+
+  <build>
+    <sourceDirectory>src/main/java</sourceDirectory>
+    <testSourceDirectory>src/test/java</testSourceDirectory>
+    <resources>
+      <resource>
+        <directory>../acid</directory>
+        <includes>
+          <include>CARBON_ACIDLogResource.properties</include>
+        </includes>
+      </resource>
+      <resource>
+        <!-- Include the properties file to provide the build information. -->
+        <directory>${project.build.directory}/extra-resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>1.2.1</version>
+        <executions>
+          <execution>
+            <phase>generate-resources</phase>
+            <!-- Execute the shell script to generate the CarbonData build information. -->
+            <configuration>
+              <executable>${project.basedir}/../build/carbondata-build-info${script.extension}</executable>
+              <arguments>
+                <argument>${project.build.directory}/extra-resources</argument>
+                <argument>${project.version}</argument>
+              </arguments>
+            </configuration>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  <profiles>
+    <profile>
+      <id>sdvtest</id>
+      <properties>
+        <maven.test.skip>true</maven.test.skip>
+      </properties>
+    </profile>
+  </profiles>
+
+</project>

--- a/acid/src/main/java/org/apache/carbondata/acid/FileBasedSegmentStore.java
+++ b/acid/src/main/java/org/apache/carbondata/acid/FileBasedSegmentStore.java
@@ -1,0 +1,278 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.acid;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.carbondata.acid.transaction.TransactionDetail;
+import org.apache.carbondata.common.logging.LogServiceFactory;
+import org.apache.carbondata.core.constants.CarbonCommonConstants;
+import org.apache.carbondata.core.datastore.impl.FileFactory;
+import org.apache.carbondata.core.fileoperations.AtomicFileOperationFactory;
+import org.apache.carbondata.core.fileoperations.AtomicFileOperations;
+import org.apache.carbondata.core.fileoperations.FileWriteOperation;
+import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
+import org.apache.carbondata.core.statusmanager.LoadMetadataDetails;
+import org.apache.carbondata.core.statusmanager.SegmentStatusManager;
+import org.apache.carbondata.core.util.CarbonUtil;
+import org.apache.carbondata.core.util.path.CarbonTablePath;
+
+import com.google.gson.Gson;
+import org.apache.log4j.Logger;
+
+import static org.apache.carbondata.core.util.CarbonUtil.closeStreams;
+
+/**
+ * Stores all the information related to segments as files.
+ * Table status file, segment file, update status file
+ * TODO: later add merge index file also by this interface to support all the formats.
+ */
+public class FileBasedSegmentStore implements SegmentStore {
+
+  private static final Logger LOGGER =
+      LogServiceFactory.getLogService(SegmentStatusManager.class.getName());
+
+  private TransactionDetail baseTransaction;
+
+  private TransactionDetail currentTransaction;
+
+  public FileBasedSegmentStore(TransactionDetail baseTransaction,
+      TransactionDetail currentTransaction) {
+    this.baseTransaction = baseTransaction;
+    this.currentTransaction = currentTransaction;
+  }
+
+  @Override public void writeSegment(AbsoluteTableIdentifier identifier, SegmentDetailVO segment) {
+    LoadMetadataDetails[] details;
+    try {
+      details = readTableStatusFile(identifier, baseTransaction);
+      if (segment.getSegmentId() == null) {
+        int newSegmentId = createNewSegmentId(details);
+        segment.setSegmentId(String.valueOf(newSegmentId));
+      }
+      List<LoadMetadataDetails> listOfLoadFolderDetails = new ArrayList<>();
+      Collections.addAll(listOfLoadFolderDetails, details);
+      LoadMetadataDetails detail = SegmentManagerHelper.createLoadMetadataDetails(segment);
+      listOfLoadFolderDetails.add(detail);
+      writeLoadDetailsIntoFile(identifier,
+          listOfLoadFolderDetails.toArray(new LoadMetadataDetails[listOfLoadFolderDetails.size()]));
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override public List<SegmentDetailVO> readSegments(AbsoluteTableIdentifier identifier) {
+    try {
+      LoadMetadataDetails[] details = readTableStatusFile(identifier, currentTransaction);
+      List<SegmentDetailVO> detailVOS = new ArrayList<>();
+      for (LoadMetadataDetails detail : details) {
+        detailVOS.add(SegmentManagerHelper.convertToSegmentDetailVO(detail));
+      }
+      return detailVOS;
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public void updateSegments(AbsoluteTableIdentifier identifier, List<SegmentDetailVO> detailVOs) {
+    try {
+      LoadMetadataDetails[] details = readTableStatusFile(identifier, currentTransaction);
+      for (LoadMetadataDetails detail : details) {
+        for (SegmentDetailVO detailVO : detailVOs) {
+          if (detailVO.getSegmentId().equals(detail.getLoadName())) {
+            SegmentManagerHelper.updateLoadMetadataDetails(detailVO, detail);
+          }
+        }
+      }
+      writeLoadDetailsIntoFile(identifier, details);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public void deleteSegments(AbsoluteTableIdentifier identifier, List<String> segmentIDs) {
+
+  }
+
+  /**
+   * This method will get the max segment id
+   *
+   * @param loadMetadataDetails
+   * @return
+   */
+  private int getMaxSegmentId(LoadMetadataDetails[] loadMetadataDetails) {
+    int newSegmentId = -1;
+    for (LoadMetadataDetails loadMetadataDetail : loadMetadataDetails) {
+      try {
+        int loadCount = Integer.parseInt(loadMetadataDetail.getLoadName());
+        if (newSegmentId < loadCount) {
+          newSegmentId = loadCount;
+        }
+      } catch (NumberFormatException ne) {
+        // this case is for compacted folders. For compacted folders Id will be like 0.1, 2.1
+        // consider a case when 12 loads are completed and after that major compaction is triggered.
+        // In this case new compacted folder will be created with name 12.1 and after query time
+        // out all the compacted folders will be deleted and entry will also be removed from the
+        // table status file. In that case also if a new load comes the new segment Id assigned
+        // should be 13 and not 0
+        String loadName = loadMetadataDetail.getLoadName();
+        if (loadName.contains(".")) {
+          int loadCount = Integer.parseInt(loadName.split("\\.")[0]);
+          if (newSegmentId < loadCount) {
+            newSegmentId = loadCount;
+          }
+        }
+      }
+    }
+    return newSegmentId;
+  }
+
+  /**
+   * This method will create new segment id
+   *
+   * @param loadMetadataDetails
+   * @return
+   */
+  private int createNewSegmentId(LoadMetadataDetails[] loadMetadataDetails) {
+    // TODO: doesn't work in concurrent scenario due to lack of table status lock
+    int newSegmentId = getMaxSegmentId(loadMetadataDetails);
+    newSegmentId++;
+    return newSegmentId;
+  }
+
+  private LoadMetadataDetails[] readTableStatusFile(AbsoluteTableIdentifier identifier,
+      TransactionDetail transactionDetail) throws IOException {
+    if (transactionDetail == null) {
+      // for the first time transaction the base transaction will be null, return empty.
+      // for upgrade scenario, user need to manually call register transaction
+      return new LoadMetadataDetails[0];
+    }
+    String tableStatusPath = CarbonTablePath
+        .getTableStatusFilePath(identifier.getTablePath(), transactionDetail.getTransactionId());
+    Gson gsonObjectToRead = new Gson();
+    DataInputStream dataInputStream = null;
+    BufferedReader buffReader = null;
+    InputStreamReader inStream = null;
+    LoadMetadataDetails[] listOfLoadFolderDetailsArray;
+    AtomicFileOperations fileOperation =
+        AtomicFileOperationFactory.getAtomicFileOperations(tableStatusPath);
+    try {
+      if (!FileFactory.isFileExist(tableStatusPath)) {
+        return new LoadMetadataDetails[0];
+      }
+      dataInputStream = fileOperation.openForRead();
+      inStream = new InputStreamReader(dataInputStream,
+          Charset.forName(CarbonCommonConstants.DEFAULT_CHARSET));
+      buffReader = new BufferedReader(inStream);
+      listOfLoadFolderDetailsArray =
+          gsonObjectToRead.fromJson(buffReader, LoadMetadataDetails[].class);
+    } catch (IOException e) {
+      LOGGER.error("Failed to read metadata of load");
+      throw e;
+    } finally {
+      closeStreams(buffReader, inStream, dataInputStream);
+    }
+    // if listOfLoadFolderDetailsArray is null, return empty array
+    if (null == listOfLoadFolderDetailsArray) {
+      return new LoadMetadataDetails[0];
+    }
+    return listOfLoadFolderDetailsArray;
+  }
+
+  // TODO: check all the public method headers and correct it.
+
+  /**
+   * writes load details into a given file at @param dataLoadLocation
+   *
+   * @param identifier
+   * @param listOfLoadFolderDetailsArray
+   * @throws IOException
+   */
+  public void writeLoadDetailsIntoFile(AbsoluteTableIdentifier identifier,
+      LoadMetadataDetails[] listOfLoadFolderDetailsArray) throws IOException {
+    String dataLoadLocation = CarbonTablePath
+        .getTableStatusFilePath(identifier.getTablePath(), currentTransaction.getTransactionId());
+    AtomicFileOperations fileWrite =
+        AtomicFileOperationFactory.getAtomicFileOperations(dataLoadLocation);
+    BufferedWriter brWriter = null;
+    DataOutputStream dataOutputStream = null;
+    Gson gsonObjectToWrite = new Gson();
+    // write the updated data into the metadata file.
+    try {
+      dataOutputStream = fileWrite.openForWrite(FileWriteOperation.OVERWRITE);
+      brWriter = new BufferedWriter(new OutputStreamWriter(dataOutputStream,
+          Charset.forName(CarbonCommonConstants.DEFAULT_CHARSET)));
+
+      String metadataInstance = gsonObjectToWrite.toJson(listOfLoadFolderDetailsArray);
+      brWriter.write(metadataInstance);
+    } catch (IOException ioe) {
+      LOGGER.error("Error message: " + ioe.getLocalizedMessage());
+      throw ioe;
+    } finally {
+      if (null != brWriter) {
+        brWriter.flush();
+      }
+      CarbonUtil.closeStreams(brWriter);
+      fileWrite.close();
+    }
+  }
+
+  public void updateCurrentTableStatusWithNewBase(AbsoluteTableIdentifier identifier,
+      TransactionDetail currentTransaction, TransactionDetail latestCommittedTransaction)
+      throws IOException {
+    // read the table status of latestCommittedTransaction
+    LoadMetadataDetails[] latestCommittedDetails =
+        readTableStatusFile(identifier, latestCommittedTransaction);
+    // read the table status of currentTransaction
+    LoadMetadataDetails[] currentTransactionDetails =
+        readTableStatusFile(identifier, currentTransaction);
+    // filter the load details of currentTransaction.getInvolvedSegments()
+    Set<String> involvedSegments = currentTransaction.getInvolvedSegments();
+    // Add current load details on top of load details of latestCommittedTransaction
+    LoadMetadataDetails[] result =
+        new LoadMetadataDetails[involvedSegments.size() + latestCommittedDetails.length];
+    int index = 0;
+    for (LoadMetadataDetails detail : currentTransactionDetails) {
+      if (involvedSegments.contains(detail.getLoadName())) {
+        result[index++] = detail;
+      }
+      if (index == involvedSegments.size()) break;
+    }
+    if (index != involvedSegments.size()) {
+      throw new RuntimeException(
+          "problem while merging the table status during conflict resolution");
+    }
+    System.arraycopy(latestCommittedDetails, 0, result, index, latestCommittedDetails.length);
+    // overwrite the table status of currentTransaction with new load details
+    writeLoadDetailsIntoFile(identifier, result);
+  }
+}

--- a/acid/src/main/java/org/apache/carbondata/acid/SegmentDetailVO.java
+++ b/acid/src/main/java/org/apache/carbondata/acid/SegmentDetailVO.java
@@ -1,0 +1,260 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.acid;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.carbondata.core.readcommitter.ReadCommittedScope;
+
+public class SegmentDetailVO implements Serializable {
+
+  public static final String SEGMENT_ID = "segmentid";
+
+  public static final String STATUS = "status";
+
+  public static final String LOAD_START_TIME = "load_start_time";
+
+  public static final String LOAD_END_TIME = "load_end_time";
+
+  public static final String IS_DELETED = "is_deleted";
+
+  public static final String DATA_SIZE = "data_size";
+
+  public static final String INDEX_SIZE = "index_size";
+
+  public static final String UPDATE_DELTA_START_TIMESTAMP = "update_delta_start_timestamp";
+
+  public static final String UPDATE_DELTA_END_TIMESTAMP = "update_delta_end_timestamp";
+
+  public static final String UPDATE_STATUS_FILENAME = "update_status_fileName";
+
+  public static final String MODIFICATION_OR_DELETION_TIMESTAMP =
+      "modification_or_deletion_timesStamp";
+
+  public static final String MERGED_SEGMENT_IDS = "merged_segment_ids";
+
+  public static final String VISIBILITY = "visibility";
+
+  public static final String MAJOR_COMPACTED = "major_compacted";
+
+  public static final String FILE_FORMAT = "fileFormat";
+
+  public static final String SEGMENT_FILE_NAME = "segment_file_name";
+
+  public static final String TRANSACTION_ID = "transaction_id";
+
+  private static final long serialVersionUID = 2473467379760429846L;
+
+  public Map<String, Object> fields;
+
+  public SegmentDetailVO() {
+    this.fields = new HashMap<>();
+  }
+
+  public SegmentDetailVO setSegmentId(String segmentId) {
+    fields.put(SEGMENT_ID, segmentId);
+    return this;
+  }
+
+  public String getSegmentId() {
+    Object value = fields.get(SEGMENT_ID);
+    return value != null ? value.toString() : null;
+  }
+
+  public SegmentDetailVO setStatus(String status) {
+    fields.put(STATUS, status);
+    return this;
+  }
+
+  public String getStatus() {
+    Object value = fields.get(STATUS);
+    return value != null ? value.toString() : null;
+  }
+
+  public SegmentDetailVO setLoadStartTime(Long startTime) {
+    fields.put(LOAD_START_TIME, startTime);
+    return this;
+  }
+
+  public Long getLoadStartTime() {
+    Object value = fields.get(LOAD_START_TIME);
+    return value != null ? (Long) value : null;
+  }
+
+  public SegmentDetailVO setLoadEndTime(Long loadEndTime) {
+    fields.put(LOAD_END_TIME, loadEndTime);
+    return this;
+  }
+
+  public Long getLoadEndTime() {
+    Object value = fields.get(LOAD_END_TIME);
+    return value != null ? (Long) value : null;
+  }
+
+  public SegmentDetailVO setIsDeleted(Boolean isDeleted) {
+    fields.put(IS_DELETED, isDeleted);
+    return this;
+  }
+
+  public Boolean getIsDeleted() {
+    Object value = fields.get(IS_DELETED);
+    return value != null ? (Boolean) value : false;
+  }
+
+  public SegmentDetailVO setDataSize(Long dataSize) {
+    fields.put(DATA_SIZE, dataSize);
+    return this;
+  }
+
+  public Long getDataSize() {
+    Object value = fields.get(DATA_SIZE);
+    return value != null ? (Long) value : null;
+  }
+
+  public SegmentDetailVO setIndexSize(Long indexSize) {
+    fields.put(INDEX_SIZE, indexSize);
+    return this;
+  }
+
+  public Long getIndexSize() {
+    Object value = fields.get(INDEX_SIZE);
+    return value != null ? (Long) value : null;
+  }
+
+  public SegmentDetailVO setUpdateDeltaStartTimestamp(Long updateDeltaStartTimestamp) {
+    fields.put(UPDATE_DELTA_START_TIMESTAMP, updateDeltaStartTimestamp);
+    return this;
+  }
+
+  public Long getUpdateDeltaStartTimestamp() {
+    Object value = fields.get(UPDATE_DELTA_START_TIMESTAMP);
+    return value != null ? (Long) value : null;
+  }
+
+  public SegmentDetailVO setUpdateDeltaEndTimestamp(Long updateDeltaEndTimestamp) {
+    fields.put(UPDATE_DELTA_END_TIMESTAMP, updateDeltaEndTimestamp);
+    return this;
+  }
+
+  public Long getUpdateDeltaEndTimestamp() {
+    Object value = fields.get(UPDATE_DELTA_END_TIMESTAMP);
+    return value != null ? (Long) value : null;
+  }
+
+  public SegmentDetailVO setUpdateStatusFilename(String updateStatusFilename) {
+    fields.put(UPDATE_STATUS_FILENAME, updateStatusFilename);
+    return this;
+  }
+
+  public String getUpdateStatusFilename() {
+    Object value = fields.get(UPDATE_STATUS_FILENAME);
+    return value != null ? value.toString() : null;
+  }
+
+  public SegmentDetailVO setModificationOrDeletionTimestamp(Long modificationOrDeletionTimestamp) {
+    fields.put(MODIFICATION_OR_DELETION_TIMESTAMP, modificationOrDeletionTimestamp);
+    return this;
+  }
+
+  public Long getModificationOrDeletionTimestamp() {
+    Object value = fields.get(MODIFICATION_OR_DELETION_TIMESTAMP);
+    return value != null ? (Long) value : null;
+  }
+
+  public SegmentDetailVO setMergedSegmentIds(String mergedSegmentIds) {
+    fields.put(MERGED_SEGMENT_IDS, mergedSegmentIds);
+    return this;
+  }
+
+  public String getMergedSegmentIds() {
+    Object value = fields.get(MERGED_SEGMENT_IDS);
+    return value != null ? value.toString() : null;
+  }
+
+  public SegmentDetailVO setVisibility(boolean visibility) {
+    fields.put(VISIBILITY, visibility);
+    return this;
+  }
+
+  public Boolean getVisibility() {
+    Object value = fields.get(VISIBILITY);
+    return value != null ? (Boolean) value : true;
+  }
+
+  public SegmentDetailVO setMajorCompacted(String majorCompacted) {
+    fields.put(MAJOR_COMPACTED, majorCompacted);
+    return this;
+  }
+
+  public String getMajorCompacted() {
+    Object value = fields.get(MAJOR_COMPACTED);
+    return value != null ? value.toString() : null;
+  }
+
+  public SegmentDetailVO setFileFormat(String fileFormat) {
+    fields.put(FILE_FORMAT, fileFormat);
+    return this;
+  }
+
+  public String getFileFormat() {
+    Object value = fields.get(FILE_FORMAT);
+    return value != null ? value.toString() : null;
+  }
+
+  public SegmentDetailVO setSegmentFileName(String segmentFileName) {
+    fields.put(SEGMENT_FILE_NAME, segmentFileName);
+    return this;
+  }
+
+  public String getSegmentFileName() {
+    Object value = fields.get(SEGMENT_FILE_NAME);
+    return value != null ? value.toString() : null;
+  }
+
+  public String getTransactionId() {
+    Object value = fields.get(TRANSACTION_ID);
+    return value != null ? value.toString() : null;
+  }
+
+  public SegmentDetailVO setTransactionId(String transactionId) {
+    fields.put(TRANSACTION_ID, transactionId);
+    return this;
+  }
+
+  public Map<String, Object> getAllFields() {
+    return fields;
+  }
+
+  @Override public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    SegmentDetailVO detailVO = (SegmentDetailVO) o;
+    return Objects.equals(fields.get(SEGMENT_ID), detailVO.fields.get(SEGMENT_ID));
+  }
+
+  @Override public int hashCode() {
+
+    return Objects.hash(fields.get(SEGMENT_ID));
+  }
+
+  //TODO: reheck if al is present or create new
+}

--- a/acid/src/main/java/org/apache/carbondata/acid/SegmentManager.java
+++ b/acid/src/main/java/org/apache/carbondata/acid/SegmentManager.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.acid;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.carbondata.acid.transaction.TransactionDetail;
+import org.apache.carbondata.common.logging.LogServiceFactory;
+import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
+
+import org.apache.log4j.Logger;
+
+/**
+ * Manages Load/Segment status
+ */
+public class SegmentManager {
+
+  private static final Logger LOG = LogServiceFactory.getLogService(SegmentManager.class.getName());
+
+  private SegmentStore segmentStore;
+
+  public SegmentManager(SegmentStore segmentStore) {
+    this.segmentStore = segmentStore;
+  }
+
+  /**
+   * Get the SegmentStatusReader instance to read the segment metadata files
+   * (table status file, segment file, update status files).
+   *
+   * @param identifier of the table which table status should be read
+   * @return new instance of SegmentStatusReader to read table status.
+   */
+  public SegmentStatusReader getSegmentStatusReader(AbsoluteTableIdentifier identifier) {
+    return new SegmentStatusReader(identifier, segmentStore);
+  }
+
+  /**
+   * Get the SegmentStatusUpdater instance to update/insert the segment metadata files
+   * (table status file, segment file, update status files)
+   * While getting it, acquire lock to avoid any concurrent updates. It is user
+   * responsibility to call {SegmentStatusUpdater.close()} method to release the lock.
+   *
+   * @param identifier of the table for which segment metadata files should update/insert
+   * @return new instance of SegmentStatusUpdater to update/insert table status.
+   */
+  public SegmentStatusUpdater getSegmentStatusUpdater(AbsoluteTableIdentifier identifier) {
+    return new SegmentStatusUpdater(identifier, segmentStore);
+  }
+
+}

--- a/acid/src/main/java/org/apache/carbondata/acid/SegmentManagerHelper.java
+++ b/acid/src/main/java/org/apache/carbondata/acid/SegmentManagerHelper.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.acid;
+
+import java.util.Map;
+
+import org.apache.carbondata.core.statusmanager.FileFormat;
+import org.apache.carbondata.core.statusmanager.LoadMetadataDetails;
+import org.apache.carbondata.core.statusmanager.SegmentStatus;
+
+import org.apache.commons.lang3.StringUtils;
+
+public class SegmentManagerHelper {
+
+  /**
+   * This method will update the load status entry in the table status file
+   */
+  public static SegmentDetailVO updateFailStatusAndGetSegmentVO(String segmentId,
+      String transaction_id) {
+    SegmentDetailVO detailVO = new SegmentDetailVO();
+    detailVO.setSegmentId(segmentId);
+    detailVO.setLoadEndTime(System.currentTimeMillis());
+    detailVO.setStatus(SegmentStatus.MARKED_FOR_DELETE.toString());
+    detailVO.setTransactionId(transaction_id);
+    return detailVO;
+  }
+
+  /**
+   * This method will update the load status entry in the table status file
+   */
+  public static SegmentDetailVO updateFailStatusAndGetSegmentVO(String segmentId) {
+    return updateFailStatusAndGetSegmentVO(segmentId, null);
+  }
+
+  public static SegmentDetailVO createSegmentVO(String segmentId, SegmentStatus status,
+      Long startTime) {
+    SegmentDetailVO detailVO = new SegmentDetailVO();
+    detailVO.setSegmentId(segmentId);
+    if (startTime == 0) {
+      startTime = System.currentTimeMillis();
+    }
+    detailVO.setLoadStartTime(startTime);
+    detailVO.setStatus(status.toString());
+    return detailVO;
+  }
+
+  public static LoadMetadataDetails createLoadMetadataDetails(SegmentDetailVO detailVO) {
+    LoadMetadataDetails details = new LoadMetadataDetails();
+    return updateLoadMetadataDetails(detailVO, details);
+  }
+
+  public static LoadMetadataDetails updateLoadMetadataDetails(SegmentDetailVO detailVO,
+      LoadMetadataDetails details) {
+    Map<String, Object> fields = detailVO.getAllFields();
+    if (fields.get(SegmentDetailVO.STATUS) != null) {
+      details.setSegmentStatus(convertToSegmentStatus(detailVO.getStatus()));
+    }
+    if (fields.get(SegmentDetailVO.SEGMENT_ID) != null) {
+      details.setLoadName(detailVO.getSegmentId());
+    }
+   /* if (fields.get(SegmentDetailVO.MODIFICATION_OR_DELETION_TIMESTAMP) != null) {
+      details.setModificationOrdeletionTimesStamp(detailVO.getModificationOrDeletionTimestamp());
+    }*/
+    if (fields.get(SegmentDetailVO.LOAD_START_TIME) != null) {
+      details.setLoadStartTime(detailVO.getLoadStartTime());
+    }
+    /*if (fields.get(SegmentDetailVO.IS_DELETED) != null) {
+      details.setIsDeleted(String.valueOf(detailVO.getIsDeleted()));
+    }*/
+    if (fields.get(SegmentDetailVO.LOAD_END_TIME) != null) {
+      details.setLoadEndTime(detailVO.getLoadEndTime());
+    }
+    if (fields.get(SegmentDetailVO.SEGMENT_FILE_NAME) != null) {
+      details.setSegmentFile(detailVO.getSegmentFileName());
+    }
+    if (fields.get(SegmentDetailVO.UPDATE_DELTA_END_TIMESTAMP) != null) {
+      details.setUpdateDeltaEndTimestamp(String.valueOf(detailVO.getUpdateDeltaEndTimestamp()));
+    }
+    if (fields.get(SegmentDetailVO.UPDATE_DELTA_START_TIMESTAMP) != null) {
+      details.setUpdateDeltaStartTimestamp(String.valueOf(detailVO.getUpdateDeltaStartTimestamp()));
+    }
+    if (fields.get(SegmentDetailVO.UPDATE_STATUS_FILENAME) != null) {
+      details.setUpdateStatusFileName(detailVO.getUpdateStatusFilename());
+    }
+    if (fields.get(SegmentDetailVO.DATA_SIZE) != null) {
+      details.setDataSize(String.valueOf(detailVO.getDataSize()));
+    }
+    /*if (fields.get(SegmentDetailVO.FILE_FORMAT) != null) {
+      details.setFileFormat(FileFormat.valueOf(detailVO.getFileFormat()));
+    }*/
+    if (fields.get(SegmentDetailVO.INDEX_SIZE) != null) {
+      details.setIndexSize(String.valueOf(detailVO.getIndexSize()));
+    }
+    if (fields.get(SegmentDetailVO.MAJOR_COMPACTED) != null) {
+      details.setMajorCompacted(detailVO.getMajorCompacted());
+    }
+    if (fields.get(SegmentDetailVO.MERGED_SEGMENT_IDS) != null) {
+      details.setMergedLoadName(detailVO.getMergedSegmentIds());
+    }
+    if (fields.get(SegmentDetailVO.VISIBILITY) != null) {
+      details.setVisibility(String.valueOf(detailVO.getVisibility()));
+    }
+    return details;
+  }
+
+  public static SegmentDetailVO convertToSegmentDetailVO(LoadMetadataDetails detail) {
+    SegmentDetailVO detailVO = new SegmentDetailVO();
+    detailVO.setStatus(detail.getSegmentStatus().toString());
+    detailVO.setSegmentId(detail.getLoadName());
+    /*detailVO.setModificationOrDeletionTimestamp(detail.getModificationOrdeletionTimesStamp());
+    detailVO.setLoadStartTime(detail.getLoadStartTime());
+    detailVO.setIsDeleted(Boolean.parseBoolean(detail.getIsDeleted()));*/
+    detailVO.setLoadEndTime(detail.getLoadEndTime());
+    detailVO.setSegmentFileName(detail.getSegmentFile());
+    if (StringUtils.isNotEmpty(detail.getUpdateDeltaEndTimestamp())) {
+      detailVO.setUpdateDeltaEndTimestamp(Long.parseLong(detail.getUpdateDeltaEndTimestamp()));
+    }
+    if (StringUtils.isNotEmpty(detail.getUpdateDeltaStartTimestamp())) {
+      detailVO.setUpdateDeltaStartTimestamp(Long.parseLong(detail.getUpdateDeltaStartTimestamp()));
+    }
+    detailVO.setUpdateStatusFilename(detail.getDataSize());
+    if (StringUtils.isNotEmpty(detail.getUpdateDeltaStartTimestamp())) {
+      detailVO.setDataSize(Long.valueOf(detail.getDataSize()));
+    }
+    if (StringUtils.isNotEmpty(detail.getIndexSize())) {
+      detailVO.setIndexSize(Long.valueOf(detail.getIndexSize()));
+    }
+    detailVO.setFileFormat(detail.getFileFormat().toString());
+    detailVO.setMajorCompacted(detail.isMajorCompacted());
+    detailVO.setMergedSegmentIds(detail.getMergedLoadName());
+    detailVO.setVisibility(Boolean.valueOf(detail.getVisibility()));
+    return detailVO;
+  }
+
+  private static SegmentStatus convertToSegmentStatus(String message) {
+    for (SegmentStatus status : SegmentStatus.values()) {
+      if (status.toString().equalsIgnoreCase(message)) {
+        return status;
+      }
+    }
+    return null;
+  }
+}

--- a/acid/src/main/java/org/apache/carbondata/acid/SegmentStatusReader.java
+++ b/acid/src/main/java/org/apache/carbondata/acid/SegmentStatusReader.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.acid;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.carbondata.core.locks.CarbonLockFactory;
+import org.apache.carbondata.core.locks.ICarbonLock;
+import org.apache.carbondata.core.locks.LockUsage;
+import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
+import org.apache.carbondata.core.metadata.datatype.DataTypes;
+import org.apache.carbondata.core.scan.expression.ColumnExpression;
+import org.apache.carbondata.core.scan.expression.Expression;
+import org.apache.carbondata.core.scan.expression.LiteralExpression;
+import org.apache.carbondata.core.scan.expression.conditional.EqualToExpression;
+import org.apache.carbondata.core.scan.expression.conditional.InExpression;
+import org.apache.carbondata.core.scan.expression.conditional.ListExpression;
+import org.apache.carbondata.core.statusmanager.SegmentStatus;
+import org.apache.carbondata.core.util.path.CarbonTablePath;
+
+/**
+ * Reader for segment/table status/ files.
+ * It uses a segment store interface to read the segment status.
+ */
+public class SegmentStatusReader {
+
+  private final AbsoluteTableIdentifier identifier;
+  private final SegmentStore segmentStore; // can be singleton
+
+  /**
+   * Constructor to create SegmentStatusReader.
+   *
+   * @param identifier   of table to read table status
+   * @param segmentStore Interface implementation of SegmentStore
+   */
+  SegmentStatusReader(AbsoluteTableIdentifier identifier, SegmentStore segmentStore) {
+    this.identifier = identifier;
+    this.segmentStore = segmentStore;
+  }
+}
+
+  /*
+   * It gives the valid segments from the store at this point of time.
+   *
+   * @param identifier
+   * @return
+
+  public SegmentDetailVO getSegment(String segmentId) {
+    List<Expression> filters = new ArrayList<>();
+    filters.add(new EqualToExpression(new ColumnExpression("tableId", DataTypes.STRING),
+        new LiteralExpression(identifier.getCarbonTableIdentifier().getTableId(),
+            DataTypes.STRING)));
+    filters.add(
+        new EqualToExpression(new ColumnExpression(SegmentDetailVO.SEGMENT_ID, DataTypes.STRING),
+            new LiteralExpression(segmentId, DataTypes.STRING)));
+    // TODO: why list here ?
+    List<SegmentDetailVO> segments = segmentStore.getSegments(identifier, filters);
+    if (segments.size() > 0) {
+      //TODO: when it can be more than one ?
+      return segments.get(0);
+    }
+    return null;
+  }
+
+  *
+   * It gives the valid segments from the store at this point of time.
+   *
+   * @param identifier
+   * @return
+
+  public SegmentsHolder getValidSegments() {
+    List<Expression> filters = new ArrayList<>();
+    List<Expression> listExps = new ArrayList<>();
+    listExps.add(new LiteralExpression(SegmentStatus.SUCCESS.toString(), DataTypes.STRING));
+    listExps
+        .add(new LiteralExpression(SegmentStatus.MARKED_FOR_UPDATE.toString(), DataTypes.STRING));
+    listExps.add(
+        new LiteralExpression(SegmentStatus.LOAD_PARTIAL_SUCCESS.toString(), DataTypes.STRING));
+    listExps.add(new LiteralExpression(SegmentStatus.STREAMING.toString(), DataTypes.STRING));
+    listExps
+        .add(new LiteralExpression(SegmentStatus.STREAMING_FINISH.toString(), DataTypes.STRING));
+    filters.add(new InExpression(new ColumnExpression(SegmentDetailVO.STATUS, DataTypes.STRING),
+        new ListExpression(listExps)));
+    filters.add(new EqualToExpression(new ColumnExpression("tableId", DataTypes.STRING),
+        new LiteralExpression(identifier.getCarbonTableIdentifier().getTableId(),
+            DataTypes.STRING)));
+
+    List<SegmentDetailVO> segments = segmentStore.getSegments(identifier, filters);
+
+    return new SegmentsHolder(segments);
+  }
+
+  *
+   * It gives the valid segments from the store at this point of time.
+   *
+   * @param identifier
+   * @return
+
+  public SegmentsHolder getInvalidSegments() {
+    List<Expression> filters = new ArrayList<>();
+    List<Expression> listExps = new ArrayList<>();
+    listExps.add(new LiteralExpression(SegmentStatus.LOAD_FAILURE.toString(), DataTypes.STRING));
+    listExps.add(new LiteralExpression(SegmentStatus.COMPACTED.toString(), DataTypes.STRING));
+    listExps
+        .add(new LiteralExpression(SegmentStatus.MARKED_FOR_DELETE.toString(), DataTypes.STRING));
+    filters.add(new InExpression(new ColumnExpression(SegmentDetailVO.STATUS, DataTypes.STRING),
+        new ListExpression(listExps)));
+    filters.add(new EqualToExpression(new ColumnExpression("tableId", DataTypes.STRING),
+        new LiteralExpression(identifier.getCarbonTableIdentifier().getTableId(),
+            DataTypes.STRING)));
+
+    List<SegmentDetailVO> invalidSegments = segmentStore.getSegments(identifier, filters);
+
+    return new SegmentsHolder(invalidSegments);
+
+    // load metadetails is not exposed to user, db guys no need of it. only for file based it is used.
+  }
+
+  *
+   * It gives the valid segments from the store at this point of time.
+   *
+   * @param identifier
+   * @return
+
+  public SegmentsHolder getAllSegments() {
+    List<Expression> filters = new ArrayList<>();
+    filters.add(new EqualToExpression(new ColumnExpression("tableId", DataTypes.STRING),
+        new LiteralExpression(identifier.getCarbonTableIdentifier().getTableId(),
+            DataTypes.STRING)));
+    List<SegmentDetailVO> allSegments = segmentStore.getSegments(identifier, filters);
+    return new SegmentsHolder(allSegments);
+  }
+
+  *
+   * It gives the history segments from the store.
+   *
+   * @param identifier
+   * @return
+
+  public SegmentsHolder getAllHistorySegments() {
+    // TODO
+    return new SegmentsHolder(new ArrayList<SegmentDetailVO>());
+  }
+
+  *
+   * Return true if the specified `loadName` is in progress, by checking the load lock.
+
+  public static Boolean isLoadInProgress(String loadName) {
+    ICarbonLock segmentLock = CarbonLockFactory.getCarbonLockObj(,
+        CarbonTablePath.addSegmentPrefix(loadName) + LockUsage.LOCK);
+    try {
+      return !segmentLock.lockWithRetries(1, 0);
+    } finally {
+      segmentLock.unlock();
+    }
+  }
+
+
+
+  //  TODO:
+  //  public boolean isOverwriteInProgressInTable()
+  //  public Boolean isCompactionInProgress()
+  //  public long getTableStatusLastModifiedTime()
+
+}
+
+*/

--- a/acid/src/main/java/org/apache/carbondata/acid/SegmentStatusUpdater.java
+++ b/acid/src/main/java/org/apache/carbondata/acid/SegmentStatusUpdater.java
@@ -1,0 +1,244 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.acid;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.carbondata.common.logging.LogServiceFactory;
+import org.apache.carbondata.core.datastore.filesystem.CarbonFile;
+import org.apache.carbondata.core.datastore.impl.FileFactory;
+import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
+import org.apache.carbondata.core.metadata.datatype.DataTypes;
+import org.apache.carbondata.core.scan.expression.ColumnExpression;
+import org.apache.carbondata.core.scan.expression.Expression;
+import org.apache.carbondata.core.scan.expression.LiteralExpression;
+import org.apache.carbondata.core.scan.expression.conditional.EqualToExpression;
+import org.apache.carbondata.core.scan.expression.conditional.InExpression;
+import org.apache.carbondata.core.scan.expression.conditional.ListExpression;
+import org.apache.carbondata.core.statusmanager.SegmentStatus;
+
+import org.apache.log4j.Logger;
+
+
+/**
+ * Updater for table status. It uses the segmentStore interface to update or insert the segment status.
+ */
+public class SegmentStatusUpdater {
+
+
+  private AbsoluteTableIdentifier identifier;
+  private SegmentStore segmentStore;
+
+  private static final Logger LOGGER =
+      LogServiceFactory.getLogService(SegmentStatusUpdater.class.getName());
+
+  public SegmentStatusUpdater(AbsoluteTableIdentifier identifier, SegmentStore segmentStore) {
+    this.identifier = identifier;
+    this.segmentStore = segmentStore;
+  }
+
+  /**
+   * Create a new segment with status load in progress and generate newsegmentId.
+   * * @param detailVO SegmentDetailsVO ,user can pass empty object if no extra parameters need to be updated while creating segment.Otherwise he can pass it with updated parameters
+   *
+   * @return SegmentDetailsVO of newly created segment.
+   */
+  public SegmentDetailVO createNewSegment(SegmentDetailVO detailVO) {
+    return createNewSegment(detailVO, false);
+  }
+
+  /**
+   * Create a new overwrite segment with status overwrite in progress and generate new segmentId.
+   * * @param detailVO SegmentDetailsVO ,user can pass empty object if no extra parameters need to be
+   * updated while creating segment.Otherwise he can pass it with updated parameters
+   *
+   * @return SegmentDetailsVO of newly created overwrite segment.
+   */
+  public SegmentDetailVO createNewOverwriteSegment(SegmentDetailVO detailVO) {
+    return createNewSegment(detailVO, true);
+  }
+
+  /**
+   * Create new segment for loading. It updates segmentId, load start time,
+   * and status as LOAD_IN_PROGRESS
+   */
+  private SegmentDetailVO createNewSegment(SegmentDetailVO detailVO, boolean overwrite) {
+   /* if (detailVO.getStatus() == null) {
+      if (!overwrite) {
+        detailVO.setStatus(SegmentStatus.INSERT_IN_PROGRESS.toString());
+      } else {
+        detailVO.setStatus(SegmentStatus.INSERT_OVERWRITE_IN_PROGRESS.toString());
+      }
+    }
+    if (detailVO.getLoadStartTime() == null) {
+      detailVO.setLoadStartTime(System.currentTimeMillis());
+    }
+    List<Expression> filters = new ArrayList<>();
+    List<Expression> listExps = new ArrayList<>();
+    listExps
+        .add(new LiteralExpression(SegmentStatus.INSERT_IN_PROGRESS.toString(), DataTypes.STRING));
+    listExps.add(new LiteralExpression(SegmentStatus.INSERT_OVERWRITE_IN_PROGRESS.toString(),
+        DataTypes.STRING));
+    filters.add(new InExpression(new ColumnExpression("segmentStatus", DataTypes.STRING),
+        new ListExpression(listExps)));
+    filters.add(new EqualToExpression(new ColumnExpression("tableId", DataTypes.STRING),
+        new LiteralExpression(identifier.getCarbonTableIdentifier().getTableId(),
+            DataTypes.STRING)));
+    // TODO: use the reader interface for getSegments
+    List<SegmentDetailVO> segments = segmentStore.getSegments(identifier, filters);
+    for (SegmentDetailVO detail : segments) {
+      if (detail.getStatus().equals(SegmentStatus.INSERT_OVERWRITE_IN_PROGRESS.toString())
+          && isLoadInProgress(identifier, detail.getSegmentId())) {
+        throw new RuntimeException("Already insert overwrite is in progress");
+      } else if (detailVO.getStatus().equals(SegmentStatus.INSERT_OVERWRITE_IN_PROGRESS.toString())
+          && detail.getStatus().equals(SegmentStatus.INSERT_IN_PROGRESS.toString())
+          && isLoadInProgress(identifier, detail.getSegmentId())) {
+        throw new RuntimeException("Already insert into or load is in progress");
+      }
+    }
+    try {
+      segmentStore.generateSegmentIdAndInsert(identifier, detailVO);
+    } catch (IOException e) {
+      // TODO Create SegmentManagementException
+      throw new RuntimeException(e);
+    }*/
+    return detailVO;
+  }
+
+  /**
+   * After dataloading is completed, this commit should be called. It inserts one new segment
+   * to segment store. After commit success this segment will be available for reading in case of
+   * success status.
+   *
+   * @param identifier
+   * @param detailVO
+   * @return
+   */
+  public boolean commitLoadSegment(SegmentDetailVO detailVO) throws IOException {
+    /*if (detailVO.getSegmentId() == null) {
+      throw new UnsupportedOperationException("SegmentId cannot be null during commit");
+    }
+    List<SegmentDetailVO> detailVOS = new ArrayList<>();
+    detailVOS.add(detailVO);
+    List<CarbonFile> staleFolders = new ArrayList<>();
+    if (detailVO.getStatus() != null && detailVO.getStatus()
+        .equals(SegmentStatus.MARKED_FOR_DELETE.toString())) {
+      addToStaleFolders(identifier, staleFolders, detailVO.getSegmentId());
+    }
+
+    boolean status = segmentStore.updateSegments(identifier, detailVOS);
+    if (!FileFactory.deleteAllCarbonFiles(staleFolders)) {
+      LOGGER.error("Failed to delete stale folder: " + staleFolders.get(0).getAbsolutePath());
+    }
+    return status;*/
+    return false;
+  }
+
+  /**
+   * Uses for committing the overwrite segment(it is the segment created for insert overwrite case).
+   * In this case all old segments need to be invalidated and new segment should be added in a
+   * transaction.
+   *
+   * @param identifier
+   * @param detailVO
+   */
+  // TODO: commit can be used for
+  public boolean commitOverwriteSegment(SegmentDetailVO detailVO) throws IOException {
+    if (detailVO.getSegmentId() == null) {
+      throw new UnsupportedOperationException("SegmentId cannot be null during commit");
+    }
+    List<SegmentDetailVO> detailVOS = new ArrayList<>();
+    detailVOS.add(detailVO);
+    List<CarbonFile> staleFolders = new ArrayList<>();
+    /*if (detailVO.getStatus() != null && detailVO.getStatus()
+        .equals(SegmentStatus.MARKED_FOR_DELETE.toString())) {
+      addToStaleFolders(identifier, staleFolders, detailVO.getSegmentId());
+    }
+
+    for (SegmentDetailVO vo : getAllSegments(identifier).getAllSegments()) {
+      if (!vo.getStatus().equals(SegmentStatus.INSERT_OVERWRITE_IN_PROGRESS.toString()) && !detailVO
+          .getSegmentId().equals(vo.getSegmentId())) {
+        detailVOS.add(new SegmentDetailVO().setSegmentId(vo.getSegmentId())
+            .setStatus(SegmentStatus.MARKED_FOR_DELETE.toString()));
+        addToStaleFolders(identifier, staleFolders, vo.getSegmentId());
+      }
+    }
+    boolean status = segmentStore.updateSegments(identifier, detailVOS);
+    if (!FileFactory.deleteAllCarbonFiles(staleFolders)) {
+      LOGGER.error("Failed to delete stale folder: " + staleFolders.get(0).getAbsolutePath());
+    }
+    return status;*/
+    return false;
+  }
+
+  /**
+   * Segments which are passed will be updated into table status
+   * * @param detailVOs List of SegmentDetailsVO to be updated in table status.
+   *
+   * @return
+   */
+  public boolean updateSegments(List<SegmentDetailVO> detailVOs) throws IOException {
+    /*for (SegmentDetailVO detailVO : detailVOs) {
+      if (detailVO.getSegmentId() == null) {
+        throw new UnsupportedOperationException("SegmentId cannot be null during commit");
+      }
+    }
+
+    boolean status = segmentStore.updateSegments(identifier, detailVOs);
+    return status;*/
+    return false;
+  }
+
+
+
+
+
+
+
+  /*  *//**
+   * Removes/invalidates all the segments which are passed.
+   ** @param segmentIds List of segments to be removed.
+   * @return List of invalid segments.
+   *//*
+  public List<String> deleteSegmentsBySegmentIds(List<String> segmentIds)
+
+  *//**
+   * Removes/invalidates all the segments which are less than passed load time.
+   ** @param loadTime timestamp which is less than it will be removed.
+   * @return Boolean whether deletion success or fail
+   *//*
+  public boolean deleteSegmentsByLoadTime(long loadTime)
+
+//  /**
+//   * It releases the lock and any other resources if it holds.
+//   */
+  //  public void close()
+  //
+  //  /**
+  //   * While opening the updater, it acquires the metadata lock and returns the
+  //   * new SegmentStatusUpdater.
+  //   ** @param identifier   identifier of table to read table status.
+  //   * @param segmentStore Interface implementation of SegmentStore.
+  //   * @return new instance of SegmentStatusUpdater
+  //   */
+  //  static SegmentStatusUpdater open()
+
+
+}

--- a/acid/src/main/java/org/apache/carbondata/acid/SegmentStore.java
+++ b/acid/src/main/java/org/apache/carbondata/acid/SegmentStore.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.acid;
+
+import java.util.List;
+
+import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
+
+/**
+ * Stores all information related to segments.
+ * Implementation can be file based or db based also.
+ */
+public interface SegmentStore {
+
+  /**
+   * Write the current segment info to segment store.
+   *
+   * @param identifier absolute identifier of the table
+   * @param segment    current segment information to be written
+   */
+  void writeSegment(AbsoluteTableIdentifier identifier, SegmentDetailVO segment);
+
+  /**
+   * Read all the segment info from segment store.
+   *
+   * @param identifier absolute identifier of the table
+   * @return list of SegmentDetailVO objects
+   */
+  List<SegmentDetailVO> readSegments(AbsoluteTableIdentifier identifier);
+
+  /**
+   * Update the segments using table identifier.
+   *
+   * @param identifier absolute identifier of the table
+   * @param detailVOs  list of segments information that need to be updated
+   */
+  void updateSegments(AbsoluteTableIdentifier identifier, List<SegmentDetailVO> detailVOs);
+
+  /**
+   * Delete the segments for the corresponding table.
+   * If the filter is null, delete all the segments (example: drop table scenario)
+   * Else delete the segments that matches the segment id given
+   *
+   * @param identifier absolute identifier of the table
+   * @param segmentIDs list of segment id to be deleted. If null, all the segments will be deleted
+   */
+  void deleteSegments(AbsoluteTableIdentifier identifier, List<String> segmentIDs);
+}

--- a/acid/src/main/java/org/apache/carbondata/acid/SegmentStoreFactory.java
+++ b/acid/src/main/java/org/apache/carbondata/acid/SegmentStoreFactory.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.acid;
+
+import org.apache.carbondata.acid.transaction.TransactionDetail;
+import org.apache.carbondata.core.util.CarbonProperties;
+
+/**
+ * Based on the property decides the type of SegmentStore
+ */
+public class SegmentStoreFactory  {
+
+  public static SegmentStore create (TransactionDetail baseTransaction,
+      TransactionDetail currentTransaction) {
+    //TODO: add the custom class property carbon.segment.store.interface
+    String segmentStoreImpl = CarbonProperties.getInstance().getProperty("carbon.segment.store.interface");
+    if (segmentStoreImpl != null) {
+      // TODO: make a new object of the class mentioned in carbon property
+      return null;
+    } else {
+      return new FileBasedSegmentStore(baseTransaction, currentTransaction);
+    }
+  }
+
+}

--- a/acid/src/main/java/org/apache/carbondata/acid/SegmentsHolder.java
+++ b/acid/src/main/java/org/apache/carbondata/acid/SegmentsHolder.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.acid;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.carbondata.core.index.Segment;
+import org.apache.carbondata.core.readcommitter.ReadCommittedScope;
+import org.apache.carbondata.core.statusmanager.LoadMetadataDetails;
+import org.apache.carbondata.core.statusmanager.SegmentStatus;
+
+public class SegmentsHolder implements Serializable {
+
+  //TODO: chnage serial ID for all newly added classes
+  private static final long serialVersionUID = 3232635206406651621L;
+
+  private List<SegmentDetailVO> allSegments;
+  private List<SegmentDetailVO> listOfValidSegments;
+  private List<SegmentDetailVO> listOfInvalidSegments;
+  private List<SegmentDetailVO> listOfStreamSegments;
+  private List<SegmentDetailVO> listOfInProgressSegments;
+  private ReadCommittedScope committedScope;
+
+  public SegmentsHolder(List<SegmentDetailVO> allSegments) {
+    this.allSegments = allSegments;
+    this.listOfValidSegments = new ArrayList<>();
+    this.listOfInvalidSegments = new ArrayList<>();
+    this.listOfStreamSegments = new ArrayList<>();
+    this.listOfInProgressSegments = new ArrayList<>();
+    process();
+  }
+
+  public SegmentsHolder(List<SegmentDetailVO> allSegments, ReadCommittedScope readCommittedScope) {
+    this(allSegments);
+    this.committedScope = readCommittedScope;
+  }
+
+  private void process() {
+    //just directly iterate Array
+    for (SegmentDetailVO segment : allSegments) {
+      if (SegmentStatus.SUCCESS.toString().equals(segment.getStatus())
+          || SegmentStatus.MARKED_FOR_UPDATE.toString().equals(segment.getStatus())
+          || SegmentStatus.LOAD_PARTIAL_SUCCESS.toString().equals(segment.getStatus())
+          || SegmentStatus.STREAMING.toString().equals(segment.getStatus())
+          || SegmentStatus.STREAMING_FINISH.toString().equals(segment.getStatus())) {
+        // TODO Should we check for merged segments? isn't they compacted already?
+        if (SegmentStatus.STREAMING.toString().equals(segment.getStatus())
+            || SegmentStatus.STREAMING_FINISH.toString().equals(segment.getStatus())) {
+          listOfStreamSegments.add(segment);
+          continue;
+        }
+        listOfValidSegments.add(segment);
+      } else if ((SegmentStatus.LOAD_FAILURE.toString().equals(segment.getStatus())
+          || SegmentStatus.COMPACTED.toString().equals(segment.getStatus())
+          || SegmentStatus.MARKED_FOR_DELETE.toString().equals(segment.getStatus()))) {
+        listOfInvalidSegments.add(segment);
+      } else if (SegmentStatus.INSERT_IN_PROGRESS.toString().equals(segment.getStatus())
+          || SegmentStatus.INSERT_OVERWRITE_IN_PROGRESS.toString().equals(segment.getStatus())) {
+        listOfInProgressSegments.add(segment);
+      }
+    }
+  }
+
+  private List<Segment> getSegments(List<SegmentDetailVO> detailVOS,
+      ReadCommittedScope readCommittedScope) {
+    List<Segment> segments = new ArrayList<>();
+    /*for (SegmentDetailVO detailVO : detailVOS) {
+      segments.add(
+          new Segment(detailVO.getSegmentId(), detailVO.getSegmentFileName(), readCommittedScope,
+              detailVO));
+    }*/
+    return segments;
+  }
+
+  public void setReadCommittedScope(ReadCommittedScope committedScope) {
+    this.committedScope = committedScope;
+  }
+
+  public List<Segment> getInvalidSegments() {
+    return getSegments(listOfInvalidSegments, committedScope);
+  }
+
+  public List<Segment> getValidSegments() {
+    return getSegments(listOfValidSegments, committedScope);
+  }
+
+  public List<SegmentDetailVO> getValidSegmentDetailVOs() {
+    return listOfValidSegments;
+  }
+
+  public List<SegmentDetailVO> getInValidSegmentDetailVOs() {
+    return listOfInvalidSegments;
+  }
+
+  public List<Segment> getStreamSegments() {
+    return getSegments(listOfStreamSegments, committedScope);
+  }
+
+  public List<Segment> getListOfInProgressSegments() {
+    return getSegments(listOfInProgressSegments, committedScope);
+  }
+
+  public List<SegmentDetailVO> getAllSegments() {
+    return allSegments;
+  }
+}

--- a/acid/src/main/java/org/apache/carbondata/acid/transaction/CarbonFileBasedTransactionManager.java
+++ b/acid/src/main/java/org/apache/carbondata/acid/transaction/CarbonFileBasedTransactionManager.java
@@ -1,0 +1,279 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.acid.transaction;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.carbondata.acid.FileBasedSegmentStore;
+import org.apache.carbondata.acid.SegmentStore;
+import org.apache.carbondata.acid.SegmentStoreFactory;
+import org.apache.carbondata.core.constants.CarbonCommonConstants;
+import org.apache.carbondata.core.datastore.impl.FileFactory;
+import org.apache.carbondata.core.fileoperations.AtomicFileOperationFactory;
+import org.apache.carbondata.core.fileoperations.AtomicFileOperations;
+import org.apache.carbondata.core.fileoperations.FileWriteOperation;
+import org.apache.carbondata.core.locks.CarbonLockFactory;
+import org.apache.carbondata.core.locks.CarbonLockUtil;
+import org.apache.carbondata.core.locks.ICarbonLock;
+import org.apache.carbondata.core.locks.LockUsage;
+import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
+import org.apache.carbondata.core.util.CarbonUtil;
+
+import com.google.gson.Gson;
+
+import static org.apache.carbondata.core.util.CarbonUtil.closeStreams;
+
+public final class CarbonFileBasedTransactionManager implements TransactionManager {
+
+  private static final InheritableThreadLocal<TransactionDetail> baseTransactionThreadLocal =
+      new InheritableThreadLocal<>();
+
+  private static final InheritableThreadLocal<TransactionDetail> currentTransactionThreadLocal =
+      new InheritableThreadLocal<>();
+
+  private static Map<String, TransactionDetail> tableGroupsLatestTransaction =
+      new ConcurrentHashMap<>();
+
+  @Override
+  public TransactionDetail registerTransaction(boolean isGlobalTransaction,
+      List<TransactionOperation> operations, TableGroupDetail tableGroupDetail) {
+    TransactionDetail detail =
+        new TransactionDetail(UUID.randomUUID().toString(), isGlobalTransaction, operations,
+            tableGroupDetail);
+    baseTransactionThreadLocal.set(getLatestCommittedTransaction(tableGroupDetail));
+    currentTransactionThreadLocal.set(detail);
+    return detail;
+  }
+
+  @Override
+  public void commitTransaction(TransactionDetail transactionDetail) {
+    String lockPath = transactionDetail.getTableGroupDetail().getTransactionFileLockPath();
+    ICarbonLock transactionFileLock =
+        CarbonLockFactory.getCarbonLockObjWithInputPath(LockUsage.TRANSACTION_LOG_LOCK, lockPath);
+    try {
+      int retryCount = CarbonLockUtil
+          .getLockProperty(CarbonCommonConstants.NUMBER_OF_TRIES_FOR_CONCURRENT_LOCK,
+              CarbonCommonConstants.NUMBER_OF_TRIES_FOR_CONCURRENT_LOCK_DEFAULT);
+      int maxTimeout = CarbonLockUtil
+          .getLockProperty(CarbonCommonConstants.MAX_TIMEOUT_FOR_CONCURRENT_LOCK,
+              CarbonCommonConstants.MAX_TIMEOUT_FOR_CONCURRENT_LOCK_DEFAULT);
+      if (transactionFileLock.lockWithRetries(retryCount, maxTimeout)) {
+        transactionDetail.setTimeStamp(new Timestamp(System.currentTimeMillis()));
+        TransactionDetail latestCommittedTransaction =
+            getLatestCommittedTransaction(transactionDetail.getTableGroupDetail());
+        TransactionDetail baseTransaction =
+            getBaseTransaction(transactionDetail.getTableGroupDetail());
+        if (latestCommittedTransaction != null && !baseTransaction.getTransactionId()
+            .equals(latestCommittedTransaction.getTransactionId())) {
+          // If base transaction of current transaction is not same as latest committed transaction,
+          // there can be a conflict due to concurrent operations.
+          // So, check and resolve the conflict.
+          if (!checkAndResolveConflict(baseTransaction,
+              getCurrentTransaction(transactionDetail.getTableGroupDetail()))) {
+            throw new RuntimeException(
+                "Please retry the operation, "
+                    + "unable to commit the transaction due to conflict from concurrent operation");
+          }
+        }
+        TransactionDetail[] transactionDetails =
+            readTransactionLog(transactionDetail.getTableGroupDetail());
+        List<TransactionDetail> details = new ArrayList<>();
+        // Adding it at the HEAD, so that the recent transaction will be on top
+        details.add(transactionDetail);
+        details.addAll(Arrays.asList(transactionDetails));
+        writeTransactionLog(details,
+            transactionDetail.getTableGroupDetail().getTransactionLogAbsolutePath()
+                + CarbonCommonConstants.FILE_SEPARATOR + transactionDetail.getTableGroupDetail()
+                .getTableGroupId() + "_transaction_log");
+      } else {
+        throw new RuntimeException(
+            "Unable to acquire Transaction file lock, please retry the operation");
+      }
+    } catch (IOException ex) {
+      throw new RuntimeException(
+          "Failed to commit the transaction" + ex.getMessage());
+    } finally {
+      CarbonLockUtil.fileUnlock(transactionFileLock, LockUsage.TRANSACTION_LOG_LOCK);
+    }
+    currentTransactionThreadLocal.remove();
+    baseTransactionThreadLocal.remove();
+    tableGroupsLatestTransaction
+        .put(transactionDetail.getTableGroupDetail().getTableGroupId(), transactionDetail);
+  }
+
+  @Override
+  public TransactionDetail getLatestCommittedTransaction(TableGroupDetail tableGroupDetail) {
+    return tableGroupsLatestTransaction.get(tableGroupDetail.getTableGroupId());
+  }
+
+  @Override
+  public TransactionDetail getCurrentTransaction(TableGroupDetail tableGroupDetail) {
+    return currentTransactionThreadLocal.get();
+  }
+
+  @Override
+  public TransactionDetail getBaseTransaction(TableGroupDetail tableGroupDetail) {
+    return baseTransactionThreadLocal.get();
+  }
+
+  @Override
+  public TransactionDetail getTransactionById(String transactionId,
+      TableGroupDetail tableGroupDetail) {
+    // TODO: need to read the file and get the transaction id
+    // can add some cache to avoid IO for every time during time travel operations ?
+    // may be need to keep a map by transaction id and BST by timestamp
+    return null;
+  }
+
+  @Override
+  public TransactionDetail getTransactionByTimeStamp(Timestamp timestamp,
+      TableGroupDetail tableGroupDetail) {
+    // TODO: need to read the file and get the transaction id
+    // can add some cache to avoid IO for every time during time travel operations ?
+    // may be need to keep a map by transaction id and BST by timestamp
+    return null;
+  }
+
+  /**
+   * will be called during the drop table to remove latestCommittedTransaction entry from the map
+   *
+   * @param tableGroupId For a single table, it will be dbName_tableName.
+   *                     For across table, it will the id specified by the user.
+   */
+  @Override
+  public void clearTransactions(String tableGroupId) {
+    tableGroupsLatestTransaction.remove(tableGroupId);
+  }
+
+  private void writeTransactionLog(List<TransactionDetail> details, String path)
+      throws IOException {
+    AtomicFileOperations fileWrite = AtomicFileOperationFactory.getAtomicFileOperations(path);
+    BufferedWriter brWriter = null;
+    DataOutputStream dataOutputStream = null;
+    Gson gsonObjectToWrite = new Gson();
+    // write the updated data into the metadata file.
+    try {
+      dataOutputStream = fileWrite.openForWrite(FileWriteOperation.OVERWRITE);
+      brWriter = new BufferedWriter(
+          new OutputStreamWriter(dataOutputStream, CarbonCommonConstants.DEFAULT_CHARSET));
+      String metadataInstance = gsonObjectToWrite.toJson(details);
+      brWriter.write(metadataInstance);
+    } catch (IOException ioe) {
+      //      LOG.error("Error message: " + ioe.getLocalizedMessage());
+      fileWrite.setFailed();
+      throw ioe;
+    } finally {
+      if (null != brWriter) {
+        brWriter.flush();
+      }
+      CarbonUtil.closeStreams(brWriter);
+      fileWrite.close();
+    }
+  }
+
+  private TransactionDetail[] readTransactionLog(TableGroupDetail tableGroupDetail) {
+    String filePath =
+        tableGroupDetail.getTransactionLogAbsolutePath() + CarbonCommonConstants.UNDERSCORE
+            + tableGroupDetail.getTableGroupId() + "_transaction_log";
+    Gson gsonObjectToRead = new Gson();
+    DataInputStream dataInputStream = null;
+    BufferedReader buffReader = null;
+    InputStreamReader inStream = null;
+    TransactionDetail[] transactionDetails;
+    AtomicFileOperations fileOperation =
+        AtomicFileOperationFactory.getAtomicFileOperations(filePath);
+    try {
+      if (!FileFactory.isFileExist(filePath)) {
+        return new TransactionDetail[0];
+      }
+      dataInputStream = fileOperation.openForRead();
+      inStream = new InputStreamReader(dataInputStream, CarbonCommonConstants.DEFAULT_CHARSET);
+      buffReader = new BufferedReader(inStream);
+      transactionDetails = gsonObjectToRead.fromJson(buffReader, TransactionDetail[].class);
+    } catch (IOException e) {
+      return new TransactionDetail[0];
+    } finally {
+      closeStreams(buffReader, inStream, dataInputStream);
+    }
+    return transactionDetails;
+  }
+
+  private boolean checkAndResolveConflict(TransactionDetail baseTransaction,
+      TransactionDetail currentTransaction) throws IOException {
+    // TODO: Need to see if conflict resolve logic can be improved based on operation type
+    // TODO: for insert overwrite and alter schema,
+    //  list of affected segment may not conflict with current one,
+    //  so need to add check based on operation also.
+    List<TransactionDetail> latestCommittedTransactions =
+        getTransactionsAfterBaseTransaction(baseTransaction);
+    Set<String> latestCommittedTransactionSegments = new HashSet<>();
+    for (TransactionDetail transaction : latestCommittedTransactions) {
+      latestCommittedTransactionSegments.addAll(transaction.getInvolvedSegments());
+    }
+    if (!Collections.disjoint(currentTransaction.getInvolvedSegments(), latestCommittedTransactionSegments)) {
+      return false;
+    }
+    // Update the current table status file,
+    // by adding current transaction on top of latest committed transaction table status file.
+    SegmentStore segmentStore = SegmentStoreFactory.create(currentTransaction, baseTransaction);
+    if (segmentStore instanceof FileBasedSegmentStore) {
+      List<AbsoluteTableIdentifier> identifiers =
+          currentTransaction.getTableGroupDetail().getIdentifiers();
+      for (AbsoluteTableIdentifier identifier : identifiers) {
+        ((FileBasedSegmentStore) segmentStore)
+            .updateCurrentTableStatusWithNewBase(identifier, currentTransaction,
+                getLatestCommittedTransaction(currentTransaction.getTableGroupDetail()));
+      }
+    } else {
+      // TODO: handle for db or other implementation
+    }
+    return true;
+  }
+
+  private List<TransactionDetail> getTransactionsAfterBaseTransaction(
+      TransactionDetail baseTransaction) {
+    TransactionDetail[] transactionDetails =
+        readTransactionLog(baseTransaction.getTableGroupDetail());
+    // latest transactions will be in the beginning of array
+    List<TransactionDetail> latestCommittedTransactions = new ArrayList<>();
+    for (TransactionDetail transaction : transactionDetails) {
+      if (transaction.getTransactionId().equals(baseTransaction.getTransactionId())) {
+        break;
+      }
+      latestCommittedTransactions.add(transaction);
+    }
+    return latestCommittedTransactions;
+  }
+
+}

--- a/acid/src/main/java/org/apache/carbondata/acid/transaction/CarbonTransactionManagerFactory.java
+++ b/acid/src/main/java/org/apache/carbondata/acid/transaction/CarbonTransactionManagerFactory.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.acid.transaction;
+
+import org.apache.carbondata.core.util.CarbonProperties;
+
+public final class CarbonTransactionManagerFactory {
+
+  // class name for db based or other transaction manager interface
+  private static String transactionManagerImplClass =
+      CarbonProperties.getInstance().getProperty("carbon.transaction.manager.interface", null);
+
+  private static TransactionManager INSTANCE;
+
+  private CarbonTransactionManagerFactory() {
+  }
+
+  static {
+    //TODO: Need to add synchronization ? (may be not required as it is not a lazy initialization)
+    if (transactionManagerImplClass == null) {
+      // use the default implementation
+      INSTANCE = new CarbonFileBasedTransactionManager();
+    } else {
+      //TODO: later get from the className and use that implementation
+      INSTANCE = null;
+    }
+  }
+
+  public static TransactionManager getInstance() {
+    return INSTANCE;
+  }
+
+}

--- a/acid/src/main/java/org/apache/carbondata/acid/transaction/TableGroupDetail.java
+++ b/acid/src/main/java/org/apache/carbondata/acid/transaction/TableGroupDetail.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.acid.transaction;
+
+import java.io.Serializable;
+import java.util.List;
+
+import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
+
+// holder of table group information
+public class TableGroupDetail implements Serializable {
+
+  private String tableGroupId;
+
+  private String transactionLogAbsolutePath;
+
+  private String transactionFileLockPath;
+
+  // For across table transaction, there can be more than one identifiers
+  private List<AbsoluteTableIdentifier> identifiers;
+
+  public TableGroupDetail(String tableGroupId, String transactionLogAbsolutePath,
+      String transactionFileLockPath, List<AbsoluteTableIdentifier> identifiers) {
+    this.tableGroupId = tableGroupId;
+    this.transactionLogAbsolutePath = transactionLogAbsolutePath;
+    this.transactionFileLockPath = transactionFileLockPath;
+    this.identifiers = identifiers;
+  }
+
+  public String getTableGroupId() {
+    return tableGroupId;
+  }
+
+  public String getTransactionLogAbsolutePath() {
+    return transactionLogAbsolutePath;
+  }
+
+  public String getTransactionFileLockPath() {
+    return transactionFileLockPath;
+  }
+
+  public List<AbsoluteTableIdentifier> getIdentifiers() {
+    return identifiers;
+  }
+}

--- a/acid/src/main/java/org/apache/carbondata/acid/transaction/TransactionDetail.java
+++ b/acid/src/main/java/org/apache/carbondata/acid/transaction/TransactionDetail.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.acid.transaction;
+
+import java.io.Serializable;
+import java.sql.Timestamp;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import com.google.gson.annotations.Expose;
+import org.apache.htrace.fasterxml.jackson.annotation.JsonIgnore;
+
+// holder for current transaction information
+public class TransactionDetail implements Serializable {
+
+  private String transactionId;
+
+  private boolean isGlobalTransaction;
+
+  private Timestamp timeStamp;
+
+  private List<TransactionOperation> operations;
+
+  // TODO make it invisible in the transaction log
+  private TableGroupDetail tableGroupDetail;
+
+  private Set<String> involvedSegments;
+
+  public TransactionDetail(String transactionId, Boolean isGlobalTransaction,
+      List<TransactionOperation> operations, TableGroupDetail tableGroupDetail) {
+    this.transactionId = transactionId;
+    this.isGlobalTransaction = isGlobalTransaction;
+    this.operations = operations;
+    this.tableGroupDetail = tableGroupDetail;
+  }
+
+  public String getTransactionId() {
+    return transactionId;
+  }
+
+  public Timestamp getTimeStamp() {
+    return timeStamp;
+  }
+
+  public List<TransactionOperation> getOperations() {
+    return operations;
+  }
+
+  public void setTimeStamp(Timestamp timeStamp) {
+    this.timeStamp = timeStamp;
+  }
+
+  public void setInvolvedSegments(Set<String> involvedSegments) {
+    this.involvedSegments = involvedSegments;
+  }
+
+  public void setInvolvedSegments(String segment) {
+    if (this.involvedSegments == null) {
+      this.involvedSegments = new HashSet<>();
+    }
+    involvedSegments.add(segment);
+  }
+
+  public TableGroupDetail getTableGroupDetail() {
+    return tableGroupDetail;
+  }
+
+  public boolean isGlobalTransaction() {
+    return isGlobalTransaction;
+  }
+
+  public Set<String> getInvolvedSegments() {
+    return involvedSegments;
+  }
+}

--- a/acid/src/main/java/org/apache/carbondata/acid/transaction/TransactionManager.java
+++ b/acid/src/main/java/org/apache/carbondata/acid/transaction/TransactionManager.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.acid.transaction;
+
+import java.sql.Timestamp;
+import java.util.List;
+
+// interface for handling transactions
+public interface TransactionManager {
+
+  /**
+   * To register a transaction
+   *
+   * @param isGlobalTransaction If the transaction is across table (or controlled
+   *                            by DDL like START and COMMIT TRANSACTIONS)
+   *                            then isGlobalTransaction should be true.
+   * @param operations          Single transaction can be associated with one or more operations,
+   *                            need to pass that operation types to register the transaction.
+   * @param tableGroupDetail        For a single table, it will be dbName_tableName.
+   *                            For across table, it will be the id specified by the user.
+   * @return TransactionDetail object
+   */
+  TransactionDetail registerTransaction(boolean isGlobalTransaction,
+      List<TransactionOperation> operations, TableGroupDetail tableGroupDetail);
+
+  /**
+   * To commit the transaction
+   *
+   * @param transactionDetail that required to be committed
+   */
+  void commitTransaction(TransactionDetail transactionDetail);
+
+  /**
+   * To get the latest committed transaction for that table group.
+   *
+   * @param tableGroupDetail
+   *
+   * @return TransactionDetail object.
+   */
+  TransactionDetail getLatestCommittedTransaction(TableGroupDetail tableGroupDetail);
+
+  /**
+   * To get the transaction based on transaction id, used for time travel.
+   *
+   * @param transactionId    transaction id of the required transaction
+   * @param tableGroupDetail
+   * @return TransactionDetail object
+   */
+  TransactionDetail getTransactionById(String transactionId, TableGroupDetail tableGroupDetail);
+
+  /**
+   * To get the transaction based on timestamp, used for time travel.
+   *
+   * @param timestamp        timestamp to get the mapping transaction registered at that time.
+   * @param tableGroupDetail
+   * @return TransactionDetail object
+   */
+  TransactionDetail getTransactionByTimeStamp(Timestamp timestamp,
+      TableGroupDetail tableGroupDetail);
+
+  /**
+   *
+   * @param tableGroupDetail
+   * @return
+   */
+  TransactionDetail getCurrentTransaction(TableGroupDetail tableGroupDetail);
+
+  /**
+   *
+   * @param tableGroupDetail
+   * @return
+   */
+  TransactionDetail getBaseTransaction(TableGroupDetail tableGroupDetail);
+
+  /**
+   * In some scenarios(like drop table or table group),
+   * all the transactions and in-memory info about transactions can be cleaned for table group
+   * using this interface
+   *
+   * @param tableGroupId
+   */
+  void clearTransactions(String tableGroupId);
+
+}

--- a/acid/src/main/java/org/apache/carbondata/acid/transaction/TransactionOperation.java
+++ b/acid/src/main/java/org/apache/carbondata/acid/transaction/TransactionOperation.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.acid.transaction;
+
+// operation which need to be recorded for the transaction
+public enum TransactionOperation {
+
+  LOAD,
+
+  INSERT,
+
+  INSERT_OVERWRITE,
+
+  UPDATE,
+
+  DELETE,
+
+  MERGE,
+
+  COMPACTION,
+
+  SCHEMA_CHANGE,
+
+  ADD_SEGMENT,
+
+  DROP_SEGMENT,
+
+  DELETE_SEGMENT,
+
+  INDEX_LOAD,
+
+}

--- a/core/src/main/java/org/apache/carbondata/core/fileoperations/AtomicFileOperationsImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/fileoperations/AtomicFileOperationsImpl.java
@@ -29,7 +29,7 @@ import org.apache.carbondata.core.util.CarbonUtil;
 
 import org.apache.log4j.Logger;
 
-class AtomicFileOperationsImpl implements AtomicFileOperations {
+public class AtomicFileOperationsImpl implements AtomicFileOperations {
 
   /**
    * Logger instance

--- a/core/src/main/java/org/apache/carbondata/core/locks/CarbonLockUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/locks/CarbonLockUtil.java
@@ -55,6 +55,8 @@ public class CarbonLockUtil {
         LOGGER.info("Delete segments lock has been successfully released");
       } else if (lockType.equals(LockUsage.INDEX_STATUS_LOCK)) {
         LOGGER.info("Index status lock has been successfully released");
+      } else if (lockType.equals(LockUsage.TRANSACTION_LOG_LOCK)) {
+        LOGGER.info("Transaction log file lock has been successfully released");
       }
     } else {
       if (lockType.equals(LockUsage.METADATA_LOCK)) {
@@ -67,6 +69,8 @@ public class CarbonLockUtil {
         LOGGER.info("Not able to release the delete segments lock");
       } else if (lockType.equals(LockUsage.INDEX_STATUS_LOCK)) {
         LOGGER.info("Not able to release the index status lock");
+      } else if (lockType.equals(LockUsage.TRANSACTION_LOG_LOCK)) {
+        LOGGER.info("Not able to release the transaction log file lock");
       }
     }
   }

--- a/core/src/main/java/org/apache/carbondata/core/locks/LockUsage.java
+++ b/core/src/main/java/org/apache/carbondata/core/locks/LockUsage.java
@@ -39,5 +39,6 @@ public class LockUsage {
   public static final String CONCURRENT_LOAD_LOCK = "concurrentload.lock";
   public static final String UPDATE_LOCK = "update.lock";
   public static final String INGEST_LOCK = "ingest.lock";
+  public static final String TRANSACTION_LOG_LOCK = "transaction_log.lock";
 
 }

--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/CarbonTable.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/CarbonTable.java
@@ -1286,4 +1286,31 @@ public class CarbonTable implements Serializable, Writable {
     return allIndexes;
   }
 
+  public String getTableGroupId() {
+    //TODO: remove hardcoding of TABLE_GROUP_ID
+    if (tableInfo.getFactTable().getTableProperties().containsKey("TABLE_GROUP_ID")) {
+      return tableInfo.getFactTable().getTableProperties().get("TABLE_GROUP_ID");
+    } else {
+      return tableInfo.getTableUniqueName();
+    }
+  }
+
+  public String getTransactionLogPath() {
+    //TODO: remove hardcoding of TRANSACTION_LOG_PATH
+    if (tableInfo.getFactTable().getTableProperties().containsKey("TRANSACTION_LOG_PATH")) {
+      return tableInfo.getFactTable().getTableProperties().get("TRANSACTION_LOG_PATH");
+    } else {
+      return getMetadataPath();
+    }
+  }
+
+  public String getTransactionFileLockPath() {
+    //TODO: remove hardcoding of TRANSACTION_FILE_LOCK_PATH
+    if (tableInfo.getFactTable().getTableProperties().containsKey("TRANSACTION_FILE_LOCK_PATH")) {
+      return tableInfo.getFactTable().getTableProperties().get("TRANSACTION_FILE_LOCK_PATH");
+    } else {
+      return getTablePath();
+    }
+  }
+
 }

--- a/core/src/main/java/org/apache/carbondata/core/util/path/CarbonTablePath.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/path/CarbonTablePath.java
@@ -209,6 +209,14 @@ public class CarbonTablePath {
     return getMetadataPath(tablePath) + CarbonCommonConstants.FILE_SEPARATOR + TABLE_STATUS_FILE;
   }
 
+  /**
+   * Return absolute path of table status file using version id
+   */
+  public static String getTableStatusFilePath(String tablePath, String versionId) {
+    return getMetadataPath(tablePath) + CarbonCommonConstants.FILE_SEPARATOR + versionId
+        + CarbonCommonConstants.UNDERSCORE + TABLE_STATUS_FILE;
+  }
+
   public static String getTableStatusFilePathWithUUID(String tablePath, String uuid) {
     if (!uuid.isEmpty()) {
       return getTableStatusFilePath(tablePath) + CarbonCommonConstants.UNDERSCORE + uuid;

--- a/integration/spark/pom.xml
+++ b/integration/spark/pom.xml
@@ -120,6 +120,17 @@
     </dependency>
     <dependency>
       <groupId>org.apache.carbondata</groupId>
+      <artifactId>carbondata-acid</artifactId>
+      <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.hive</groupId>
+          <artifactId>hive-exec</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.carbondata</groupId>
       <artifactId>carbondata-lucene</artifactId>
       <version>${project.version}</version>
       <exclusions>

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonDropTableCommand.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonDropTableCommand.scala
@@ -164,6 +164,10 @@ case class CarbonDropTableCommand(
         val file = FileFactory.getCarbonFile(tableLockPath)
         CarbonUtil.deleteFoldersAndFilesSilent(file)
       }
+      // clear the transaction file lock
+      val transactionFileLockPath: String = carbonTable.getTransactionFileLockPath
+      val transactionLockFile = FileFactory.getCarbonFile(transactionFileLockPath)
+      CarbonUtil.deleteFoldersAndFilesSilent(transactionLockFile)
       viewDropCommands.foreach(_.processData(sparkSession))
     }
     Seq.empty

--- a/integration/spark/src/test/scala/org/apache/carbondata/acid/TestLoadFlow.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/acid/TestLoadFlow.scala
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.acid
+
+import java.util
+
+import org.apache.spark.sql.test.util.QueryTest
+import org.scalatest.BeforeAndAfterAll
+
+class TestLoadFlow extends QueryTest with BeforeAndAfterAll {
+
+  val dbName = "ajantha"
+
+  override protected def beforeAll(): Unit = {
+    sql(s"DROP DATABASE IF EXISTS $dbName CASCADE")
+    sql(s"CREATE DATABASE $dbName")
+    sql(s"USE $dbName")
+  }
+
+  override protected def afterAll(): Unit = {
+    sql(s"use default")
+    sql(s"DROP DATABASE $dbName CASCADE")
+  }
+
+  test("Test load flow transaction") {
+    val tableName = "testajtable"
+    sql(s"DROP TABLE IF EXISTS $tableName")
+    sql(s"CREATE TABLE $tableName(empno int, empname String, designation String, " +
+        s"doj Timestamp, workgroupcategory int, workgroupcategoryname String, deptno int, " +
+        s"deptname String, projectcode int, projectjoindate Timestamp, projectenddate Timestamp," +
+        s"attendance int,utilization int, salary int) STORED AS carbondata")
+    sql(s"LOAD DATA INPATH '$resourcesPath/data.csv' INTO TABLE $tableName")
+    sql(s"select * from $tableName").show(200, false)
+    /*sql(s"update $tableName set(empname) = ('hill') where empname = 'bill' ")
+    sql(s"select * from $tableName").show(200, false)
+    sql(s"update $tableName set(empname) = ('jibi') where empname = 'sibi' ")*/
+    sql(s"DROP TABLE $tableName").show(false)
+  }
+
+}

--- a/integration/spark/src/test/scala/org/apache/carbondata/acid/TestTransactionManager.java
+++ b/integration/spark/src/test/scala/org/apache/carbondata/acid/TestTransactionManager.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.acid;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.carbondata.acid.transaction.CarbonTransactionManagerFactory;
+import org.apache.carbondata.acid.transaction.TableGroupDetail;
+import org.apache.carbondata.acid.transaction.TransactionDetail;
+import org.apache.carbondata.acid.transaction.TransactionOperation;
+import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier;
+
+public class TestTransactionManager {
+
+  //TODO: delete this file after the test
+  public static void main(String[] args) {
+
+    List<TransactionOperation> operationList = new ArrayList<>();
+    operationList.add(TransactionOperation.LOAD);
+    operationList.add(TransactionOperation.INSERT);
+    operationList.add(TransactionOperation.DELETE);
+    ArrayList<AbsoluteTableIdentifier> list = new ArrayList<>(1);
+    list.add(AbsoluteTableIdentifier.from("/home/root1/ab/txn"));
+    TableGroupDetail tableGroupDetail =
+        new TableGroupDetail("table1", "/home/root1/ab/txn", "/home/root1/ab/txn",
+            list);
+
+    TransactionDetail detail = CarbonTransactionManagerFactory.getInstance()
+        .registerTransaction(false, operationList, tableGroupDetail);
+
+    System.out.println("Transaction id is :" + detail.getTransactionId());
+
+    // avoid updating table ststus file
+
+    CarbonTransactionManagerFactory.getInstance().commitTransaction(detail);
+
+    operationList = new ArrayList<>();
+    operationList.add(TransactionOperation.UPDATE);
+    TransactionDetail detail1 = CarbonTransactionManagerFactory.getInstance()
+        .registerTransaction(false, operationList,
+            tableGroupDetail);
+    System.out.println("Transaction id is :" + detail1.getTransactionId());
+
+    CarbonTransactionManagerFactory.getInstance().commitTransaction(detail1);
+
+    operationList = new ArrayList<>();
+    operationList.add(TransactionOperation.DELETE);
+    operationList.add(TransactionOperation.INSERT);
+    TransactionDetail detail2 = CarbonTransactionManagerFactory.getInstance()
+        .registerTransaction(false, operationList,
+            tableGroupDetail);
+    System.out.println("Transaction id is :" + detail2.getTransactionId());
+
+    CarbonTransactionManagerFactory.getInstance().commitTransaction(detail2);
+  }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,7 @@
     <module>core</module>
     <module>processing</module>
     <module>hadoop</module>
+    <module>acid</module>
     <module>mv/plan</module>
     <module>index/secondary-index</module>
     <module>index/bloom</module>
@@ -603,6 +604,7 @@
                 <sourceDirectory>${basedir}/geo/src/main/scala</sourceDirectory>
                 <sourceDirectory>${basedir}/processing/src/main/java</sourceDirectory>
                 <sourceDirectory>${basedir}/hadoop/src/main/java</sourceDirectory>
+                <sourceDirectory>${basedir}/acid/src/main/java</sourceDirectory>
                 <sourceDirectory>${basedir}/integration/spark/src/main/scala</sourceDirectory>
                 <sourceDirectory>${basedir}/integration/spark/src/main/spark2.3</sourceDirectory>
                 <sourceDirectory>${basedir}/integration/spark/src/main/java</sourceDirectory>
@@ -675,6 +677,7 @@
                 <sourceDirectory>${basedir}/geo/src/main/scala</sourceDirectory>
                 <sourceDirectory>${basedir}/processing/src/main/java</sourceDirectory>
                 <sourceDirectory>${basedir}/hadoop/src/main/java</sourceDirectory>
+                <sourceDirectory>${basedir}/acid/src/main/java</sourceDirectory>
                 <sourceDirectory>${basedir}/integration/spark/src/main/scala</sourceDirectory>
                 <sourceDirectory>${basedir}/integration/spark/src/main/spark2.4</sourceDirectory>
                 <sourceDirectory>${basedir}/integration/spark/src/main/java</sourceDirectory>


### PR DESCRIPTION
 ### Why is this PR needed?
 Based on the discussion and design document from https://issues.apache.org/jira/browse/CARBONDATA-4171
 
 ### What changes were proposed in this PR?

- Added a new ACID module.
- Defined a transaction manager interface (can support db and table) and implemented a file-based transaction manager to write the transaction log file.
- Defined a segment store interface (can support db and table) and implemented a file-based segment store to write the table status with the transaction id (multiple table status file)
- Handled the basic transaction conflict scenario for the file-based segment store.  
- Lock support for transaction log file

**TODO:**
1. Write wrappers for the segment store interface (segment status updater and reader) and replace them in the current code.
2. Remove table status lock everywhere and changing segment id logic
3. Adding segment id as the return value of each transaction operation to fill the affected segments
4. similar to segment store interface (table status), need to handle for update status file and segment file also
5. Try to decouple data and metadata operation for each transaction command (may be write new classes), so metadata can be supported for other open formats also.
6. Test optimistic concurrency by running parallel transactions (update, compation) and cover all the scenarios. 
On top of these, we can provide time travel SQL support and multi-format support. Across table transaction support
   
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new test case added?
 - No
 - Yes

    
