### PR TITLE
[CARBONDATA-4202] Fix issue when refresh main table with MV

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/view/MVManager.java
+++ b/core/src/main/java/org/apache/carbondata/core/view/MVManager.java
@@ -142,7 +142,12 @@ public abstract class MVManager {
   }
 
   public MVSchema getSchema(String databaseName, String viewName) throws IOException {
-    return schemaProvider.getSchema(this, databaseName, viewName);
+    return schemaProvider.getSchema(this, databaseName, viewName, false);
+  }
+
+  public MVSchema getSchema(String databaseName, String viewName, boolean isRegisterMV)
+      throws IOException {
+    return schemaProvider.getSchema(this, databaseName, viewName, isRegisterMV);
   }
 
   /**

--- a/integration/spark/src/main/scala/org/apache/carbondata/view/MVCatalogInSpark.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/view/MVCatalogInSpark.scala
@@ -82,6 +82,10 @@ case class MVCatalogInSpark(session: SparkSession)
     enabledSchemas.toArray
   }
 
+  def getAllSchemas: Array[MVSchemaWrapper] = {
+    viewSchemas.toArray
+  }
+
   def isMVInSync(mvSchema: MVSchema): Boolean = {
     viewManager.isMVInSyncWithParentTables(mvSchema)
   }

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/management/RefreshCarbonTableCommand.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/management/RefreshCarbonTableCommand.scala
@@ -84,6 +84,9 @@ case class RefreshCarbonTableCommand(
       if (FileFactory.isFileExist(schemaFilePath)) {
         // read TableInfo
         val tableInfo = SchemaReader.getTableInfo(identifier)
+        // remove mv related info from source table properties
+        tableInfo.getFactTable
+          .getTableProperties.remove(CarbonCommonConstants.RELATED_MV_TABLES_MAP)
         // refresh the column schema in case of store before V3
         refreshColumnSchema(tableInfo)
 


### PR DESCRIPTION
 ### Why is this PR needed?
 When trying to register a table of old store which has MV, it fails parser error(syntax issue while creating table). It is trying to create table with `relatedmvtablesmap` property which is not valid.
 
 ### What changes were proposed in this PR?
- Removed `relatedmvtablesmap` from table properties in `RefreshCarbonTableCommand`
- After Main table has registered, to register MV made changes to get the schema from the system folder and register.
    
 ### Does this PR introduce any user interface change?
 - No
 - Yes. (please explain the change and update document)

 ### Is any new testcase added?
 - Yes

    
