### PR TITLE
[CARBONDATA-4242]Improve cdc performance and introduce new APIs for UPSERT, DELETE, INSERT and UPDATE

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -2670,4 +2670,14 @@ public final class CarbonCommonConstants {
    */
   public static final String CARBON_SPARK3_VERSION = "2.2.0";
 
+  /**
+   * This property is to enable the min max pruning of target carbon table based on input/source
+   * data
+   */
+  @CarbonProperty
+  public static final String CARBON_CDC_MINMAX_PRUNING_ENABLED =
+      "carbon.cdc.minmax.pruning.enabled";
+
+  public static final String CARBON_CDC_MINMAX_PRUNING_ENABLED_DEFAULT = "false";
+
 }

--- a/core/src/main/java/org/apache/carbondata/core/index/IndexInputFormat.java
+++ b/core/src/main/java/org/apache/carbondata/core/index/IndexInputFormat.java
@@ -105,8 +105,6 @@ public class IndexInputFormat extends FileInputFormat<Void, ExtendedBlocklet>
 
   private CdcVO cdcVO;
 
-  private Boolean isCDCJob;
-
   IndexInputFormat() {
 
   }
@@ -339,8 +337,8 @@ public class IndexInputFormat extends FileInputFormat<Void, ExtendedBlocklet>
         missingSISegments.add(in.readUTF());
       }
     }
-    this.isCDCJob = in.readBoolean();
-    if (this.isCDCJob) {
+    boolean isCDCJob = in.readBoolean();
+    if (isCDCJob) {
       this.cdcVO = new CdcVO();
       cdcVO.readFields(in);
     }

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/Blocklet.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/Blocklet.java
@@ -31,7 +31,7 @@ import org.apache.hadoop.io.Writable;
 public class Blocklet implements Writable, Serializable {
 
   /** file path of this blocklet */
-  private String filePath;
+  protected String filePath;
 
   /** id to identify the blocklet inside the block (it is a sequential number) */
   private String blockletId;

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/ExtendedBlocklet.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/ExtendedBlocklet.java
@@ -187,7 +187,7 @@ public class ExtendedBlocklet extends Blocklet {
       out.writeLong(inputSplit.getIndexRow().getInt(BlockletIndexRowIndexes.ROW_COUNT_INDEX));
       out.writeUTF(inputSplit.getSegmentId());
     } else if (indexInputFormat.getCdcVO() != null) {
-      // In case of CDC, we ust need the filepath and the min max of the blocklet, so just serialize
+      // In case of CDC, we just need the filepath and the min max of the blocklet,so just serialize
       // these data to reduce less network transfer cost and faster cache access from index server.
       out.writeUTF(inputSplit.getFilePath());
       List<Integer> indexesToFetch = indexInputFormat.getCdcVO().getIndexesToFetch();
@@ -247,7 +247,7 @@ public class ExtendedBlocklet extends Blocklet {
     } else if (cdcVO != null) {
       filePath = in.readUTF();
       this.columnToMinMaxMapping = new HashMap<>();
-      for (Map.Entry<String, Integer> entry : cdcVO.getColumnToIndexMap().entrySet()) {
+      for (String column : cdcVO.getColumnToIndexMap().keySet()) {
         List<FilePathMinMaxVO> minMaxOfColumnInList = new ArrayList<>();
         int minLength = in.readInt();
         byte[] minValuesForBlocklets = new byte[minLength];
@@ -257,7 +257,7 @@ public class ExtendedBlocklet extends Blocklet {
         in.readFully(maxValuesForBlocklets);
         minMaxOfColumnInList
             .add(new FilePathMinMaxVO(filePath, minValuesForBlocklets, maxValuesForBlocklets));
-        this.columnToMinMaxMapping.put(entry.getKey(), minMaxOfColumnInList);
+        this.columnToMinMaxMapping.put(column, minMaxOfColumnInList);
       }
       return;
     }

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/ExtendedBlockletWrapper.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/ExtendedBlockletWrapper.java
@@ -36,6 +36,7 @@ import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.datastore.compression.SnappyCompressor;
 import org.apache.carbondata.core.datastore.filesystem.CarbonFile;
 import org.apache.carbondata.core.datastore.impl.FileFactory;
+import org.apache.carbondata.core.index.IndexInputFormat;
 import org.apache.carbondata.core.metadata.schema.table.Writable;
 import org.apache.carbondata.core.mutate.CdcVO;
 import org.apache.carbondata.core.stream.ExtendedByteArrayInputStream;
@@ -66,21 +67,20 @@ public class ExtendedBlockletWrapper implements Writable, Serializable {
 
   }
 
-  public ExtendedBlockletWrapper(List<ExtendedBlocklet> extendedBlockletList, String tablePath,
-      String queryId, boolean isWriteToFile, boolean isCountJob, CdcVO cdcVO) {
+  public ExtendedBlockletWrapper(List<ExtendedBlocklet> extendedBlockletList,
+      IndexInputFormat indexInputFormat) {
     Map<String, Short> uniqueLocations = new HashMap<>();
-    byte[] bytes =
-        convertToBytes(tablePath, uniqueLocations, extendedBlockletList, isCountJob, cdcVO);
+    byte[] bytes = convertToBytes(indexInputFormat, uniqueLocations, extendedBlockletList);
     int serializeAllowedSize = Integer.parseInt(CarbonProperties.getInstance()
         .getProperty(CarbonCommonConstants.CARBON_INDEX_SERVER_SERIALIZATION_THRESHOLD,
             CarbonCommonConstants.CARBON_INDEX_SERVER_SERIALIZATION_THRESHOLD_DEFAULT)) * 1024;
     DataOutputStream stream = null;
     // if data size is more then data will be written in file and file name will be sent from
     // executor to driver, in case of any failure data will send through network
-    if (bytes.length > serializeAllowedSize && isWriteToFile) {
+    if (bytes.length > serializeAllowedSize && indexInputFormat.isWriteToFile()) {
       final String fileName = UUID.randomUUID().toString();
       String folderPath = CarbonUtil.getIndexServerTempPath()
-              + CarbonCommonConstants.FILE_SEPARATOR + queryId;
+              + CarbonCommonConstants.FILE_SEPARATOR + indexInputFormat.getQueryId();
       try {
         final CarbonFile carbonFile = FileFactory.getCarbonFile(folderPath);
         boolean isFolderExists = true;
@@ -117,16 +117,16 @@ public class ExtendedBlockletWrapper implements Writable, Serializable {
     }
   }
 
-  private byte[] convertToBytes(String tablePath, Map<String, Short> uniqueLocations,
-      List<ExtendedBlocklet> extendedBlockletList, boolean isCountJob, CdcVO cdcVO) {
+  private byte[] convertToBytes(IndexInputFormat indexInputFormat,
+      Map<String, Short> uniqueLocations, List<ExtendedBlocklet> extendedBlockletList) {
     ByteArrayOutputStream bos = new ExtendedByteArrayOutputStream();
     DataOutputStream stream = new DataOutputStream(bos);
+    String tablePath = indexInputFormat.getCarbonTable().getTablePath();
     try {
       for (ExtendedBlocklet extendedBlocklet : extendedBlockletList) {
         boolean isExternalPath = !extendedBlocklet.getFilePath().startsWith(tablePath);
         extendedBlocklet.setFilePath(extendedBlocklet.getFilePath().replace(tablePath, ""));
-        extendedBlocklet
-            .serializeData(stream, uniqueLocations, isCountJob, isExternalPath, cdcVO);
+        extendedBlocklet.serializeData(stream, uniqueLocations, indexInputFormat, isExternalPath);
       }
       byte[] input = bos.toByteArray();
       return new SnappyCompressor().compressByte(input, input.length);

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockIndex.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockIndex.java
@@ -886,7 +886,7 @@ public class BlockIndex extends CoarseGrainIndex
     }
   }
 
-  private byte[][] getMinMaxValue(IndexRow row, int index) {
+  public static byte[][] getMinMaxValue(IndexRow row, int index) {
     IndexRow minMaxRow = row.getRow(index);
     byte[][] minMax = new byte[minMaxRow.getColumnCount()][];
     for (int i = 0; i < minMax.length; i++) {
@@ -895,7 +895,7 @@ public class BlockIndex extends CoarseGrainIndex
     return minMax;
   }
 
-  private boolean[] getMinMaxFlag(IndexRow row, int index) {
+  public static boolean[] getMinMaxFlag(IndexRow row, int index) {
     IndexRow minMaxFlagRow = row.getRow(index);
     boolean[] minMaxFlag = new boolean[minMaxFlagRow.getColumnCount()];
     for (int i = 0; i < minMaxFlag.length; i++) {

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockIndex.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockIndex.java
@@ -67,6 +67,8 @@ import org.apache.carbondata.core.util.CarbonUtil;
 import org.apache.carbondata.core.util.DataFileFooterConverter;
 import org.apache.carbondata.core.util.path.CarbonTablePath;
 
+import static org.apache.carbondata.core.util.CarbonUtil.getMinMaxValue;
+
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.fs.Path;
@@ -886,16 +888,7 @@ public class BlockIndex extends CoarseGrainIndex
     }
   }
 
-  public static byte[][] getMinMaxValue(IndexRow row, int index) {
-    IndexRow minMaxRow = row.getRow(index);
-    byte[][] minMax = new byte[minMaxRow.getColumnCount()][];
-    for (int i = 0; i < minMax.length; i++) {
-      minMax[i] = minMaxRow.getByteArray(i);
-    }
-    return minMax;
-  }
-
-  public static boolean[] getMinMaxFlag(IndexRow row, int index) {
+  private static boolean[] getMinMaxFlag(IndexRow row, int index) {
     IndexRow minMaxFlagRow = row.getRow(index);
     boolean[] minMaxFlag = new boolean[minMaxFlagRow.getColumnCount()];
     for (int i = 0; i < minMaxFlag.length; i++) {

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockIndex.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockIndex.java
@@ -888,7 +888,7 @@ public class BlockIndex extends CoarseGrainIndex
     }
   }
 
-  private static boolean[] getMinMaxFlag(IndexRow row, int index) {
+  private boolean[] getMinMaxFlag(IndexRow row, int index) {
     IndexRow minMaxFlagRow = row.getRow(index);
     boolean[] minMaxFlag = new boolean[minMaxFlagRow.getColumnCount()];
     for (int i = 0; i < minMaxFlag.length; i++) {

--- a/core/src/main/java/org/apache/carbondata/core/mutate/CdcVO.java
+++ b/core/src/main/java/org/apache/carbondata/core/mutate/CdcVO.java
@@ -34,11 +34,6 @@ import org.apache.hadoop.io.Writable;
 public class CdcVO implements Serializable, Writable {
 
   /**
-   * This collection contains columns and its min-max for each blocklet
-   */
-  private Map<String, List<FilePathMinMaxVO>> columnToMinMaxMapping;
-
-  /**
    * This collection contains column to index mapping which give info about the index for a column
    * in IndexRow object to fetch min max
    */
@@ -46,17 +41,11 @@ public class CdcVO implements Serializable, Writable {
 
   private List<Integer> indexesToFetch;
 
-  public CdcVO(Map<String, List<FilePathMinMaxVO>> columnToMinMaxMapping,
-      Map<String, Integer> columnToIndexMap) {
-    this.columnToMinMaxMapping = columnToMinMaxMapping;
+  public CdcVO(Map<String, Integer> columnToIndexMap) {
     this.columnToIndexMap = columnToIndexMap;
   }
 
   public CdcVO() {
-  }
-
-  public Map<String, List<FilePathMinMaxVO>> getColumnToMinMaxMapping() {
-    return columnToMinMaxMapping;
   }
 
   public Map<String, Integer> getColumnToIndexMap() {

--- a/core/src/main/java/org/apache/carbondata/core/mutate/CdcVO.java
+++ b/core/src/main/java/org/apache/carbondata/core/mutate/CdcVO.java
@@ -39,6 +39,9 @@ public class CdcVO implements Serializable, Writable {
    */
   private Map<String, Integer> columnToIndexMap;
 
+  /**
+   * This list will contain the column indexes to fetch from the min max row in blocklet
+   */
   private List<Integer> indexesToFetch;
 
   public CdcVO(Map<String, Integer> columnToIndexMap) {

--- a/core/src/main/java/org/apache/carbondata/core/mutate/CdcVO.java
+++ b/core/src/main/java/org/apache/carbondata/core/mutate/CdcVO.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.core.mutate;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.hadoop.io.Writable;
+
+/**
+ * VO object which contains the info used in CDC case during cache loading in Index server
+ */
+public class CdcVO implements Serializable, Writable {
+
+  /**
+   * This collection contains columns and its min-max for each blocklet
+   */
+  private Map<String, List<FilePathMinMaxVO>> columnToMinMaxMapping;
+
+  /**
+   * This collection contains column to index mapping which give info about the index for a column
+   * in IndexRow object to fetch min max
+   */
+  private Map<String, Integer> columnToIndexMap;
+
+  private List<Integer> indexesToFetch;
+
+  public CdcVO(Map<String, List<FilePathMinMaxVO>> columnToMinMaxMapping,
+      Map<String, Integer> columnToIndexMap) {
+    this.columnToMinMaxMapping = columnToMinMaxMapping;
+    this.columnToIndexMap = columnToIndexMap;
+  }
+
+  public CdcVO() {
+  }
+
+  public Map<String, List<FilePathMinMaxVO>> getColumnToMinMaxMapping() {
+    return columnToMinMaxMapping;
+  }
+
+  public Map<String, Integer> getColumnToIndexMap() {
+    return columnToIndexMap;
+  }
+
+  public List<Integer> getIndexesToFetch() {
+    return indexesToFetch;
+  }
+
+  @Override
+  public void write(DataOutput dataOutput) throws IOException {
+    Collection<Integer> indexesToFetch = columnToIndexMap.values();
+    dataOutput.writeInt(indexesToFetch.size());
+    for (Integer index : indexesToFetch) {
+      dataOutput.writeInt(index);
+      dataOutput.writeInt(index);
+    }
+  }
+
+  @Override
+  public void readFields(DataInput dataInput) throws IOException {
+    this.indexesToFetch = new ArrayList<>();
+    int lengthOfIndexes = dataInput.readInt();
+    for (int i = 0; i < lengthOfIndexes; i++) {
+      indexesToFetch.add(dataInput.readInt());
+    }
+  }
+}

--- a/core/src/main/java/org/apache/carbondata/core/mutate/FilePathMinMaxVO.java
+++ b/core/src/main/java/org/apache/carbondata/core/mutate/FilePathMinMaxVO.java
@@ -17,10 +17,12 @@
 
 package org.apache.carbondata.core.mutate;
 
+import java.io.Serializable;
+
 /**
  * VO class for filePath and Min Max for each blocklet
  */
-public class FilePathMinMaxVO {
+public class FilePathMinMaxVO implements Serializable {
 
   private String filePath;
 

--- a/core/src/main/java/org/apache/carbondata/core/mutate/FilePathMinMaxVO.java
+++ b/core/src/main/java/org/apache/carbondata/core/mutate/FilePathMinMaxVO.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.core.mutate;
+
+/**
+ * VO class for filePath and Min Max for each blocklet
+ */
+public class FilePathMinMaxVO {
+
+  private String filePath;
+
+  private byte[] min;
+
+  private byte[] max;
+
+  public FilePathMinMaxVO(String filePath, byte[] min, byte[] max) {
+    this.filePath = filePath;
+    this.min = min;
+    this.max = max;
+  }
+
+  public String getFilePath() {
+    return filePath;
+  }
+
+  public void setFilePath(String filePath) {
+    this.filePath = filePath;
+  }
+
+  public byte[] getMin() {
+    return min;
+  }
+
+  public void setMin(byte[] min) {
+    this.min = min;
+  }
+
+  public byte[] getMax() {
+    return max;
+  }
+
+  public void setMax(byte[] max) {
+    this.max = max;
+  }
+}

--- a/core/src/main/java/org/apache/carbondata/core/range/BlockMinMaxTree.java
+++ b/core/src/main/java/org/apache/carbondata/core/range/BlockMinMaxTree.java
@@ -1,0 +1,213 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.core.range;
+
+import java.io.Serializable;
+import java.nio.charset.Charset;
+import java.util.Set;
+
+import org.apache.carbondata.core.metadata.datatype.DataType;
+import org.apache.carbondata.core.util.ByteUtil;
+import org.apache.carbondata.core.util.DataTypeUtil;
+import org.apache.carbondata.core.util.comparator.SerializableComparator;
+
+import static org.apache.carbondata.core.constants.CarbonCommonConstants.DEFAULT_CHARSET;
+
+/**
+ * This class prepares a tree for pruning using min-max of block
+ */
+public class BlockMinMaxTree implements Serializable {
+
+  private MinMaxNode root;
+
+  private final boolean isPrimitiveAndNotDate;
+  private final boolean isDimensionColumn;
+  private final DataType joinDataType;
+  private final SerializableComparator comparator;
+
+  public BlockMinMaxTree(boolean isPrimitiveAndNotDate, boolean isDimensionColumn,
+      DataType joinDataType, SerializableComparator comparator) {
+    this.isPrimitiveAndNotDate = isPrimitiveAndNotDate;
+    this.isDimensionColumn = isDimensionColumn;
+    this.joinDataType = joinDataType;
+    this.comparator = comparator;
+  }
+
+  public MinMaxNode getRoot() {
+    return root;
+  }
+
+  public void insert(MinMaxNode newMinMaxNode) {
+    root = insert(getRoot(), newMinMaxNode);
+  }
+
+  MinMaxNode insert(MinMaxNode root, MinMaxNode newMinMaxNode) {
+    /* 1. check if the root null, then insert and make new node
+     * 2. check if the new node completely overlaps with the root, where minCompare and maxCompare
+     * both are zero, if yes add the filepaths and return
+     * 3. if root is less than new node, check if the root has right subtree,
+     *    if(yes) {
+     *       replace the right node with the newnode's min and max based on comparison and then
+     *        call insert with right node as new root and newnode
+     *         insert(root.getRight, newnode)
+     *     } else {
+     *       make the new node as right node and set right node and return
+     *     }
+     * 4. if root is more than new node, check if the root has left subtree,
+     *    if(yes) {
+     *       replace the left node with the newnode's min and max based on comparison and then
+     *        call insert with left node as new root and newnode
+     *         insert(root.getLeft, newnode)
+     *     } else {
+     *       make the new node as left node and set left node and return
+     *     }
+     * */
+    if (root == null) {
+      root = newMinMaxNode;
+      return root;
+    }
+
+    if (compareNodesBasedOnMinMax(root, newMinMaxNode) == 0) {
+      root.addFilePats(newMinMaxNode.getFilePaths());
+      return root;
+    }
+
+    if (compareNodesBasedOnMinMax(root, newMinMaxNode) < 0) {
+      if (root.getRightSubTree() == null) {
+        root.setRightSubTree(newMinMaxNode);
+        root.setRightSubTreeMax(newMinMaxNode.getMax());
+        root.setRightSubTreeMin(newMinMaxNode.getMin());
+      } else {
+        if (compareMinMax(root.getRightSubTreeMax(), newMinMaxNode.getMax()) < 0) {
+          root.setRightSubTreeMax(newMinMaxNode.getMax());
+        }
+        if (compareMinMax(root.getRightSubTreeMin(), newMinMaxNode.getMin()) > 0) {
+          root.setRightSubTreeMin(newMinMaxNode.getMin());
+        }
+        insert(root.getRightSubTree(), newMinMaxNode);
+      }
+    } else {
+      if (root.getLeftSubTree() == null) {
+        root.setLeftSubTree(newMinMaxNode);
+        root.setLeftSubTreeMax(newMinMaxNode.getMax());
+        root.setLeftSubTreeMin(newMinMaxNode.getMin());
+      } else {
+        if (compareMinMax(root.getLeftSubTreeMax(), newMinMaxNode.getMax()) < 0) {
+          root.setLeftSubTreeMax(newMinMaxNode.getMax());
+        }
+        if (compareMinMax(root.getLeftSubTreeMin(), newMinMaxNode.getMin()) > 0) {
+          root.setLeftSubTreeMin(newMinMaxNode.getMin());
+        }
+        insert(root.getLeftSubTree(), newMinMaxNode);
+      }
+    }
+    return root;
+  }
+
+  private int compareNodesBasedOnMinMax(MinMaxNode root, MinMaxNode newMinMaxNode) {
+    int minCompare = compareMinMax(root.getMin(), newMinMaxNode.getMin());
+    int maxCompare = compareMinMax(root.getMax(), newMinMaxNode.getMax());
+    if (minCompare == 0) {
+      return maxCompare;
+    } else {
+      return minCompare;
+    }
+  }
+
+  private int compareMinMax(Object key1, Object key2) {
+    if (isDimensionColumn) {
+      if (isPrimitiveAndNotDate) {
+        return comparator.compare(key1, key2);
+      } else {
+        return ByteUtil.UnsafeComparer.INSTANCE
+            .compareTo(key1.toString().getBytes(Charset.forName(DEFAULT_CHARSET)),
+                key2.toString().getBytes(Charset.forName(DEFAULT_CHARSET)));
+      }
+    } else {
+      return comparator.compare(key1, key2);
+    }
+  }
+
+  /**
+   * This method returns the list of carbondata files where the input fieldValue might present
+   */
+  public Set<String> getMatchingFiles(byte[] fieldValue, Set<String> matchedFilesSet) {
+    getMatchingFiles(getRoot(), fieldValue, matchedFilesSet);
+    return matchedFilesSet;
+  }
+
+  private void getMatchingFiles(MinMaxNode root, byte[] fieldValue, Set<String> matchedFilesSet) {
+    Object data;
+    if (root == null) {
+      return;
+    }
+    if (isDimensionColumn) {
+      if (isPrimitiveAndNotDate) {
+        data = DataTypeUtil.getDataBasedOnDataTypeForNoDictionaryColumn(fieldValue, joinDataType);
+      } else {
+        // for string comparator is Unsafe comparator, so cannot include in common code
+        getMatchingFilesForString(root, fieldValue, matchedFilesSet);
+        return;
+      }
+    } else {
+      data = DataTypeUtil.getMeasureObjectFromDataType(fieldValue, joinDataType);
+    }
+
+    if (comparator.compare(data, root.getMax()) <= 0
+        && comparator.compare(data, root.getMin()) >= 0) {
+      matchedFilesSet.addAll(root.getFilePaths());
+    }
+
+    if (root.getLeftSubTree() != null && comparator.compare(data, root.getLeftSubTreeMax()) <= 0
+        && comparator.compare(data, root.getLeftSubTreeMin()) >= 0) {
+      getMatchingFiles(root.getLeftSubTree(), fieldValue, matchedFilesSet);
+    }
+
+    if (root.getRightSubTree() != null && comparator.compare(data, root.getRightSubTreeMax()) <= 0
+        && comparator.compare(data, root.getRightSubTreeMin()) >= 0) {
+      getMatchingFiles(root.getRightSubTree(), fieldValue, matchedFilesSet);
+    }
+  }
+
+  private void getMatchingFilesForString(MinMaxNode root, byte[] fieldValue,
+      Set<String> matchedFilesSet) {
+    if (root == null) {
+      return;
+    }
+    if (ByteUtil.UnsafeComparer.INSTANCE
+        .compareTo(fieldValue, root.getMin().toString().getBytes(Charset.forName(DEFAULT_CHARSET)))
+        >= 0 && ByteUtil.UnsafeComparer.INSTANCE
+        .compareTo(fieldValue, root.getMax().toString().getBytes(Charset.forName(DEFAULT_CHARSET)))
+        <= 0) {
+      matchedFilesSet.addAll(root.getFilePaths());
+    }
+    if (root.getLeftSubTree() != null && ByteUtil.UnsafeComparer.INSTANCE.compareTo(fieldValue,
+        root.getLeftSubTreeMin().toString().getBytes(Charset.forName(DEFAULT_CHARSET))) >= 0 &&
+        ByteUtil.UnsafeComparer.INSTANCE.compareTo(fieldValue,
+            root.getLeftSubTreeMax().toString().getBytes(Charset.forName(DEFAULT_CHARSET))) <= 0) {
+      getMatchingFilesForString(root.getLeftSubTree(), fieldValue, matchedFilesSet);
+    }
+
+    if (root.getRightSubTree() != null && ByteUtil.UnsafeComparer.INSTANCE.compareTo(fieldValue,
+        root.getRightSubTreeMin().toString().getBytes(Charset.forName(DEFAULT_CHARSET))) >= 0 &&
+        ByteUtil.UnsafeComparer.INSTANCE.compareTo(fieldValue,
+            root.getRightSubTreeMax().toString().getBytes(Charset.forName(DEFAULT_CHARSET))) <= 0) {
+      getMatchingFilesForString(root.getRightSubTree(), fieldValue, matchedFilesSet);
+    }
+  }
+}

--- a/core/src/main/java/org/apache/carbondata/core/range/BlockMinMaxTree.java
+++ b/core/src/main/java/org/apache/carbondata/core/range/BlockMinMaxTree.java
@@ -56,7 +56,7 @@ public class BlockMinMaxTree implements Serializable {
     root = insert(getRoot(), newMinMaxNode);
   }
 
-  MinMaxNode insert(MinMaxNode root, MinMaxNode newMinMaxNode) {
+  private MinMaxNode insert(MinMaxNode root, MinMaxNode newMinMaxNode) {
     /* 1. check if the root null, then insert and make new node
      * 2. check if the new node completely overlaps with the root, where minCompare and maxCompare
      * both are zero, if yes add the filepaths and return

--- a/core/src/main/java/org/apache/carbondata/core/range/MinMaxNode.java
+++ b/core/src/main/java/org/apache/carbondata/core/range/MinMaxNode.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.core.range;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Each node to be inserted in BlockMinMaxTree for pruning.
+ */
+public class MinMaxNode implements Serializable {
+
+  // list of files present in same range of min max of this node
+  private List<String> filePaths = new ArrayList<>();
+
+  private Object min;
+
+  private Object max;
+
+  private MinMaxNode leftSubTree;
+  private MinMaxNode rightSubTree;
+  private Object leftSubTreeMax;
+  private Object leftSubTreeMin;
+  private Object rightSubTreeMax;
+  private Object rightSubTreeMin;
+
+  public MinMaxNode(String filePaths, Object min, Object max) {
+    this.filePaths.add(filePaths);
+    this.min = min;
+    this.max = max;
+  }
+
+  public void addFilePats(List<String> filePaths) {
+    this.filePaths.addAll(filePaths);
+  }
+
+  public List<String> getFilePaths() {
+    return filePaths;
+  }
+
+  public void setFilePaths(List<String> filePaths) {
+    this.filePaths = filePaths;
+  }
+
+  public Object getMin() {
+    return min;
+  }
+
+  public void setMin(Object min) {
+    this.min = min;
+  }
+
+  public Object getMax() {
+    return max;
+  }
+
+  public void setMax(Object max) {
+    this.max = max;
+  }
+
+  public MinMaxNode getLeftSubTree() {
+    return leftSubTree;
+  }
+
+  public void setLeftSubTree(MinMaxNode leftSubTree) {
+    this.leftSubTree = leftSubTree;
+  }
+
+  public MinMaxNode getRightSubTree() {
+    return rightSubTree;
+  }
+
+  public void setRightSubTree(MinMaxNode rightSubTree) {
+    this.rightSubTree = rightSubTree;
+  }
+
+  public Object getLeftSubTreeMax() {
+    return leftSubTreeMax;
+  }
+
+  public void setLeftSubTreeMax(Object leftSubTreeMax) {
+    this.leftSubTreeMax = leftSubTreeMax;
+  }
+
+  public Object getLeftSubTreeMin() {
+    return leftSubTreeMin;
+  }
+
+  public void setLeftSubTreeMin(Object leftSubTreeMin) {
+    this.leftSubTreeMin = leftSubTreeMin;
+  }
+
+  public Object getRightSubTreeMax() {
+    return rightSubTreeMax;
+  }
+
+  public void setRightSubTreeMax(Object rightSubTreeMax) {
+    this.rightSubTreeMax = rightSubTreeMax;
+  }
+
+  public Object getRightSubTreeMin() {
+    return rightSubTreeMin;
+  }
+
+  public void setRightSubTreeMin(Object rightSubTreeMin) {
+    this.rightSubTreeMin = rightSubTreeMin;
+  }
+
+}

--- a/core/src/main/java/org/apache/carbondata/core/scan/expression/conditional/CDCBlockImplicitExpression.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/expression/conditional/CDCBlockImplicitExpression.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.core.scan.expression.conditional;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.carbondata.core.scan.expression.Expression;
+import org.apache.carbondata.core.scan.expression.ExpressionResult;
+import org.apache.carbondata.core.scan.filter.intf.ExpressionType;
+import org.apache.carbondata.core.scan.filter.intf.RowIntf;
+
+/**
+ * This expression will be added to Index filter when CDC pruning is enabled.
+ */
+public class CDCBlockImplicitExpression extends Expression {
+
+  Set<String> blocksToScan;
+
+  public CDCBlockImplicitExpression(String blockPathValues) {
+    blocksToScan =
+        Arrays.stream(blockPathValues.split(",")).map(String::trim).collect(Collectors.toSet());
+  }
+
+  @Override
+  public ExpressionResult evaluate(RowIntf value) {
+    throw new UnsupportedOperationException("Not allowed on Implicit expression");
+  }
+
+  @Override
+  public ExpressionType getFilterExpressionType() {
+    return ExpressionType.IMPLICIT;
+  }
+
+  @Override
+  public void findAndSetChild(Expression oldExpr, Expression newExpr) {
+
+  }
+
+  @Override
+  public String getString() {
+    return null;
+  }
+
+  @Override
+  public String getStatement() {
+    return null;
+  }
+
+  public Set<String> getBlocksToScan() {
+    return blocksToScan;
+  }
+}

--- a/core/src/main/java/org/apache/carbondata/core/scan/expression/conditional/CDCBlockImplicitExpression.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/expression/conditional/CDCBlockImplicitExpression.java
@@ -50,7 +50,7 @@ public class CDCBlockImplicitExpression extends Expression {
 
   @Override
   public void findAndSetChild(Expression oldExpr, Expression newExpr) {
-
+    throw new UnsupportedOperationException("Not allowed on Implicit expression");
   }
 
   @Override

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/FilterUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/FilterUtil.java
@@ -55,6 +55,7 @@ import org.apache.carbondata.core.scan.expression.logical.AndExpression;
 import org.apache.carbondata.core.scan.expression.logical.OrExpression;
 import org.apache.carbondata.core.scan.expression.logical.TrueExpression;
 import org.apache.carbondata.core.scan.filter.executer.AndFilterExecutorImpl;
+import org.apache.carbondata.core.scan.filter.executer.CDCBlockImplicitExecutorImpl;
 import org.apache.carbondata.core.scan.filter.executer.DimColumnExecutorFilterInfo;
 import org.apache.carbondata.core.scan.filter.executer.ExcludeFilterExecutorImpl;
 import org.apache.carbondata.core.scan.filter.executer.FalseFilterExecutor;
@@ -195,6 +196,12 @@ public final class FilterUtil {
             if (filterExecutor != null) {
               return filterExecutor;
             }
+          }
+          if (filterExpressionResolverTree
+              .getFilterExpression() instanceof CDCBlockImplicitExpression) {
+            return new CDCBlockImplicitExecutorImpl(
+                ((CDCBlockImplicitExpression) filterExpressionResolverTree.getFilterExpression())
+                    .getBlocksToScan());
           }
           return new RowLevelFilterExecutorImpl(
               ((RowLevelFilterResolverImpl) filterExpressionResolverTree)

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/CDCBlockImplicitExecutorImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/CDCBlockImplicitExecutorImpl.java
@@ -38,12 +38,8 @@ public class CDCBlockImplicitExecutorImpl implements FilterExecutor, ImplicitCol
   @Override
   public BitSet isFilterValuesPresentInBlockOrBlocklet(byte[][] maxValue, byte[][] minValue,
       String uniqueBlockPath, boolean[] isMinMaxSet) {
-    boolean isScanRequired = false;
     BitSet bitSet = new BitSet(1);
     if (blocksToScan.contains(uniqueBlockPath)) {
-      isScanRequired = true;
-    }
-    if (isScanRequired) {
       bitSet.set(0);
     }
     return bitSet;

--- a/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/CDCBlockImplicitExecutorImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/filter/executer/CDCBlockImplicitExecutorImpl.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.core.scan.filter.executer;
+
+import java.util.BitSet;
+import java.util.Set;
+
+import org.apache.carbondata.core.scan.filter.intf.RowIntf;
+import org.apache.carbondata.core.scan.processor.RawBlockletColumnChunks;
+import org.apache.carbondata.core.util.BitSetGroup;
+
+/**
+ * This filter executor class will be called when the CDC pruning is enabled.
+ */
+public class CDCBlockImplicitExecutorImpl implements FilterExecutor, ImplicitColumnFilterExecutor {
+
+  private final Set<String> blocksToScan;
+
+  public CDCBlockImplicitExecutorImpl(Set<String> blocksToScan) {
+    this.blocksToScan = blocksToScan;
+  }
+
+  @Override
+  public BitSet isFilterValuesPresentInBlockOrBlocklet(byte[][] maxValue, byte[][] minValue,
+      String uniqueBlockPath, boolean[] isMinMaxSet) {
+    boolean isScanRequired = false;
+    BitSet bitSet = new BitSet(1);
+    if (blocksToScan.contains(uniqueBlockPath)) {
+      isScanRequired = true;
+    }
+    if (isScanRequired) {
+      bitSet.set(0);
+    }
+    return bitSet;
+  }
+
+  @Override
+  public Boolean isFilterValuesPresentInAbstractIndex(byte[][] maxValue, byte[][] minValue,
+      boolean[] isMinMaxSet) {
+    throw new UnsupportedOperationException("Unsupported operation");
+  }
+
+  @Override
+  public BitSetGroup applyFilter(RawBlockletColumnChunks rawBlockletColumnChunks,
+      boolean useBitsetPipeLine) {
+    throw new UnsupportedOperationException("Unsupported operation");
+  }
+
+  @Override
+  public BitSet prunePages(RawBlockletColumnChunks rawBlockletColumnChunks) {
+    throw new UnsupportedOperationException("Unsupported operation");
+  }
+
+  @Override
+  public boolean applyFilter(RowIntf value, int dimOrdinalMax) {
+    throw new UnsupportedOperationException("Unsupported operation");
+  }
+
+  @Override
+  public BitSet isScanRequired(byte[][] blockMaxValue, byte[][] blockMinValue,
+      boolean[] isMinMaxSet) {
+    throw new UnsupportedOperationException("Unsupported operation");
+  }
+
+  @Override
+  public void readColumnChunks(RawBlockletColumnChunks rawBlockletColumnChunks) {
+    throw new UnsupportedOperationException("Unsupported operation");
+  }
+}

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
@@ -70,6 +70,7 @@ import org.apache.carbondata.core.exception.InvalidConfigurationException;
 import org.apache.carbondata.core.index.Segment;
 import org.apache.carbondata.core.indexstore.BlockletDetailInfo;
 import org.apache.carbondata.core.indexstore.blockletindex.SegmentIndexFileStore;
+import org.apache.carbondata.core.indexstore.row.IndexRow;
 import org.apache.carbondata.core.keygenerator.directdictionary.timestamp.DateDirectDictionaryGenerator;
 import org.apache.carbondata.core.localdictionary.generator.ColumnLocalDictionaryGenerator;
 import org.apache.carbondata.core.localdictionary.generator.LocalDictionaryGenerator;
@@ -3507,5 +3508,18 @@ public final class CarbonUtil {
    */
   public static boolean isComplexColumn(String colName) {
     return colName.contains(".val") || colName.contains(CarbonCommonConstants.POINT);
+  }
+
+  /**
+   * This method returns the minmax value from the index row object
+   * @return minmax byte array
+   */
+  public static byte[][] getMinMaxValue(IndexRow row, int index) {
+    IndexRow minMaxRow = row.getRow(index);
+    byte[][] minMax = new byte[minMaxRow.getColumnCount()][];
+    for (int i = 0; i < minMax.length; i++) {
+      minMax[i] = minMaxRow.getByteArray(i);
+    }
+    return minMax;
   }
 }

--- a/docs/configuration-parameters.md
+++ b/docs/configuration-parameters.md
@@ -50,7 +50,8 @@ This section provides the details of all the configurations required for the Car
 | carbon.timeseries.first.day.of.week | SUNDAY | This parameter configures which day of the week to be considered as first day of the week. Because first day of the week will be different in different parts of the world. |
 | carbon.enable.tablestatus.backup | false | In cloud object store scenario, overwriting table status file is not an atomic operation since it uses rename API. Thus, it is possible that table status is corrupted if process crashed when overwriting the table status file. To protect from file corruption, user can enable this property. |
 | carbon.trash.retention.days | 7 | This parameter specifies the number of days after which the timestamp based subdirectories are expired in the trash folder. Allowed Min value = 0, Allowed Max Value = 365 days|
-| carbon.clean.file.force.allowed | false | This paramter specifies if the clean files operation with force option is allowed or not.|
+| carbon.clean.file.force.allowed | false | This parameter specifies if the clean files operation with force option is allowed or not.|
+| carbon.cdc.minmax.pruning.enabled | false | This parameter defines whether the min max pruning to be performed on the target table based on the source data. enable it when data is not sparsed across target table and when pruning will be better based on use case.|
 
 ## Data Loading Configuration
 

--- a/docs/configuration-parameters.md
+++ b/docs/configuration-parameters.md
@@ -51,7 +51,7 @@ This section provides the details of all the configurations required for the Car
 | carbon.enable.tablestatus.backup | false | In cloud object store scenario, overwriting table status file is not an atomic operation since it uses rename API. Thus, it is possible that table status is corrupted if process crashed when overwriting the table status file. To protect from file corruption, user can enable this property. |
 | carbon.trash.retention.days | 7 | This parameter specifies the number of days after which the timestamp based subdirectories are expired in the trash folder. Allowed Min value = 0, Allowed Max Value = 365 days|
 | carbon.clean.file.force.allowed | false | This parameter specifies if the clean files operation with force option is allowed or not.|
-| carbon.cdc.minmax.pruning.enabled | false | This parameter defines whether the min max pruning to be performed on the target table based on the source data. Enable it when data is not sparse across target table and when pruning will be better based on use case.|
+| carbon.cdc.minmax.pruning.enabled | false | This parameter defines whether the min max pruning to be performed on the target table based on the source data. It will be useful when data is not sparse across target table which results in better pruning.|
 
 ## Data Loading Configuration
 

--- a/docs/configuration-parameters.md
+++ b/docs/configuration-parameters.md
@@ -51,7 +51,7 @@ This section provides the details of all the configurations required for the Car
 | carbon.enable.tablestatus.backup | false | In cloud object store scenario, overwriting table status file is not an atomic operation since it uses rename API. Thus, it is possible that table status is corrupted if process crashed when overwriting the table status file. To protect from file corruption, user can enable this property. |
 | carbon.trash.retention.days | 7 | This parameter specifies the number of days after which the timestamp based subdirectories are expired in the trash folder. Allowed Min value = 0, Allowed Max Value = 365 days|
 | carbon.clean.file.force.allowed | false | This parameter specifies if the clean files operation with force option is allowed or not.|
-| carbon.cdc.minmax.pruning.enabled | false | This parameter defines whether the min max pruning to be performed on the target table based on the source data. enable it when data is not sparsed across target table and when pruning will be better based on use case.|
+| carbon.cdc.minmax.pruning.enabled | false | This parameter defines whether the min max pruning to be performed on the target table based on the source data. Enable it when data is not sparse across target table and when pruning will be better based on use case.|
 
 ## Data Loading Configuration
 

--- a/docs/scd-and-cdc-guide.md
+++ b/docs/scd-and-cdc-guide.md
@@ -15,7 +15,7 @@
     limitations under the License.
 -->
 
-# Upsert into a Carbon DataSet using Merge 
+# Upsert into a Carbon DataSet using Merge and UPSERT APIs
 
 ## SCD and CDC Scenarios
 Change Data Capture (CDC), is to apply all data changes generated from an external data set 
@@ -25,7 +25,7 @@ table needs to be applied to a target table.
 Slowly Changing Dimensions (SCD), are the dimensions in which the data changes slowly, rather 
 than changing regularly on a time basis.
 
-SCD and CDC data changes can be merged to a carbon dataset online using the data frame level `MERGE` API.
+SCD and CDC data changes can be merged to a carbon dataset online using the data frame level `MERGE`, `UPSERT`, `UPDATE`, `DELETE` and `INSERT` APIs.
 
 #### MERGE API
 
@@ -43,6 +43,38 @@ Below API merges the datasets online and applies the actions as per the conditio
           .execute()
 ```
 
+### UPSERT API
+Below API upsert the input source dataset onto the target carbondata table based on the key column and dataset provided by the user or the application.
+
+```
+  targetDS.upsert(sourceDS, <key_column>)
+          .execute()
+```
+
+### DELETE API
+Below API deletes the data present in the target carbondata table based on the key column and dataset provided by the user or the application.
+
+```
+  targetDS.delete(sourceDS, <key_column>)
+          .execute()
+```
+
+### UPDATE API
+Below API updates the data present in the target carbondata table based on the key column and dataset provided by the user or the application.
+
+```
+  targetDS.update(sourceDS, <key_column>)
+          .execute()
+```
+
+### INSERT API
+Below API inserts the input source dataset onto the target carbondata table based on the key column and dataset provided by the user or the application.
+
+```
+  targetDS.insert(sourceDS, <key_column>)
+          .execute()
+```
+
 #### MERGE API Operation Semantics
 Below is the detailed description of the `merge` API operation.
 * `merge` will merge the datasets based on a condition.
@@ -54,6 +86,10 @@ Below is the detailed description of the `merge` API operation.
 * `whenNotMatched` clause is executed when a source row does not match any target row based on the match condition.
    * `whenNotMatched` clause can have only the `insertExpr` action. The new row is generated based on the specified column and corresponding expressions. Users do not need to specify all the columns in the target table. For unspecified target columns, NULL is inserted.
 * `whenNotMatchedAndExistsOnlyOnTarget` clause is executed when row does not match source and exists only in target. This clause can have only delete action.
+
+#### UPSERT API Operation Semantics
+* `upsert`, `delete`, `insert` and `update` APIs will help to perform specified operations on the target carbondata table.
+* All the APIs expects two parameters source dataset and the key column on which the merge has to be performed.
 
 #### MERGE SQL
 
@@ -90,7 +126,9 @@ clauses can have at most one UPDATE and one DELETE action, These clauses have th
     * To insert all the columns of the target carbondata table with the corresponding columns of the source dataset, use INSERT *. This is equivalent to INSERT (col1 [, col2 ...]) VALUES (source.col1 [, source.col2 ...]) for all the columns of the target carbondata table. Therefore, this action assumes that the source table has the same columns as those in the target table, otherwise the query will throw an error.
 * `not_matched_action` can be INSERT *  | INSERT (column1 [, column2 ...]) VALUES (value1 [, value2 ...])
 
+**Note: Merge SQL is not yet supported for the UPSERT, DELETE, INSERT and UPDATE APIs.**
 ##### Example code to implement cdc/scd scenario
 
-Please refer example class [MergeTestCase](https://github.com/apache/carbondata/blob/master/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/merge/MergeTestCase.scala) to understand and implement scd and cdc scenarios using api.
-Please refer example class [DataMergeIntoExample](https://github.com/apache/carbondata/blob/master/examples/spark/src/main/scala/org/apache/carbondata/examples/DataMergeIntoExample.scala) to understand and implement scd and cdc scenarios using sql.
+* Please refer example class [MergeTestCase](https://github.com/apache/carbondata/blob/master/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/merge/MergeTestCase.scala) to understand and implement scd and cdc scenarios using APIs.
+* Please refer example class [DataMergeIntoExample](https://github.com/apache/carbondata/blob/master/examples/spark/src/main/scala/org/apache/carbondata/examples/DataMergeIntoExample.scala) to understand and implement scd and cdc scenarios using sql. 
+* Please refer example class [DataUPSERTExample](https://github.com/apache/carbondata/blob/master/examples/spark/src/main/scala/org/apache/carbondata/examples/DataUPSERTExample.scala) to understand and implement cdc using UPSERT APIs.

--- a/examples/spark/src/main/scala/org/apache/carbondata/examples/DataUPSERTExample.scala
+++ b/examples/spark/src/main/scala/org/apache/carbondata/examples/DataUPSERTExample.scala
@@ -59,7 +59,7 @@ object UPSERTExample {
           StructField("value", StringType))))
     spark.sql("select * from target").show(false)
     // upsert API updates a and b, inserts e and g
-    target.as("A").merge(cdc.as("B"), "key", "upsert").execute()
+    target.as("A").upsert(cdc.as("B"), "key").execute()
     spark.sql("select * from target").show(false)
 
     cdc =
@@ -70,7 +70,7 @@ object UPSERTExample {
         StructType(Seq(StructField("key", StringType),
           StructField("value", StringType))))
     // delete API, deletes a and e
-    target.as("A").merge(cdc.as("B"), "key", "delete").execute()
+    target.as("A").delete(cdc.as("B"), "key").execute()
     spark.sql("select * from target").show(false)
 
     cdc =
@@ -80,7 +80,7 @@ object UPSERTExample {
         StructType(Seq(StructField("key", StringType),
           StructField("value", StringType))))
     // update API, updates g
-    target.as("A").merge(cdc.as("B"), "key", "update").execute()
+    target.as("A").update(cdc.as("B"), "key").execute()
     spark.sql("select * from target").show(false)
 
     cdc =
@@ -91,7 +91,7 @@ object UPSERTExample {
         StructType(Seq(StructField("key", StringType),
           StructField("value", StringType))))
     // insert API, inserts z and x.
-    target.as("A").merge(cdc.as("B"), "key", "insert").execute()
+    target.as("A").insert(cdc.as("B"), "key"  ).execute()
 
     spark.sql("select * from target").show(false)
   }

--- a/examples/spark/src/main/scala/org/apache/carbondata/examples/DataUPSERTExample.scala
+++ b/examples/spark/src/main/scala/org/apache/carbondata/examples/DataUPSERTExample.scala
@@ -27,7 +27,7 @@ import org.apache.carbondata.examples.util.ExampleUtils
 /**
  * Example for UPSERT APIs
  */
-object UPSERTExample {
+object DataUPSERTExample {
 
   def main(args: Array[String]): Unit = {
     val spark = ExampleUtils.createSparkSession("DataUPSERTExample")

--- a/examples/spark/src/main/scala/org/apache/carbondata/examples/DataUPSERTExample.scala
+++ b/examples/spark/src/main/scala/org/apache/carbondata/examples/DataUPSERTExample.scala
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.examples
+
+import scala.collection.JavaConverters._
+
+import org.apache.spark.sql.{Row, SaveMode, SparkSession}
+import org.apache.spark.sql.CarbonSession.DataSetMerge
+import org.apache.spark.sql.types.{StringType, StructField, StructType}
+
+import org.apache.carbondata.examples.util.ExampleUtils
+
+/**
+ * Example for UPSERT APIs
+ */
+object DataUPSERTExample {
+
+  def main(args: Array[String]): Unit = {
+    val spark = ExampleUtils.createSparkSession("DataUPSERTExample")
+    performUPSERT(spark)
+  }
+
+  def performUPSERT(spark: SparkSession): Unit = {
+    spark.sql("drop table if exists target")
+    val initframe = spark.createDataFrame(Seq(
+      Row("a", "0"),
+      Row("b", "1"),
+      Row("c", "2"),
+      Row("d", "3")
+    ).asJava, StructType(Seq(StructField("key", StringType), StructField("value", StringType))))
+    initframe.write
+      .format("carbondata")
+      .option("tableName", "target")
+      .mode(SaveMode.Overwrite)
+      .save()
+    val target = spark.read.format("carbondata").option("tableName", "target").load()
+    var cdc =
+      spark.createDataFrame(Seq(
+        Row("a", "7"),
+        Row("b", null),
+        Row("g", null),
+        Row("e", "3")
+      ).asJava,
+        StructType(Seq(StructField("key", StringType),
+          StructField("value", StringType))))
+    spark.sql("select * from target").show(false)
+    // upsert API updates a and b, inserts e and g
+    target.as("A").merge(cdc.as("B"), "key", "upsert").execute()
+    spark.sql("select * from target").show(false)
+
+    cdc =
+      spark.createDataFrame(Seq(
+        Row("a", "7"),
+        Row("e", "3")
+      ).asJava,
+        StructType(Seq(StructField("key", StringType),
+          StructField("value", StringType))))
+    // delete API, deletes a and e
+    target.as("A").merge(cdc.as("B"), "key", "delete").execute()
+    spark.sql("select * from target").show(false)
+
+    cdc =
+      spark.createDataFrame(Seq(
+        Row("g", "56")
+      ).asJava,
+        StructType(Seq(StructField("key", StringType),
+          StructField("value", StringType))))
+    // update API, updates g
+    target.as("A").merge(cdc.as("B"), "key", "update").execute()
+    spark.sql("select * from target").show(false)
+
+    cdc =
+      spark.createDataFrame(Seq(
+        Row("z", "234"),
+        Row("x", "2")
+      ).asJava,
+        StructType(Seq(StructField("key", StringType),
+          StructField("value", StringType))))
+    // insert API, inserts z and x.
+    target.as("A").merge(cdc.as("B"), "key", "insert").execute()
+
+    spark.sql("select * from target").show(false)
+  }
+
+}

--- a/examples/spark/src/main/scala/org/apache/carbondata/examples/DataUPSERTExample.scala
+++ b/examples/spark/src/main/scala/org/apache/carbondata/examples/DataUPSERTExample.scala
@@ -27,7 +27,7 @@ import org.apache.carbondata.examples.util.ExampleUtils
 /**
  * Example for UPSERT APIs
  */
-object DataUPSERTExample {
+object UPSERTExample {
 
   def main(args: Array[String]): Unit = {
     val spark = ExampleUtils.createSparkSession("DataUPSERTExample")

--- a/integration/spark/src/main/common2.3and2.4/org/apache/spark/sql/SparkVersionAdapter.scala
+++ b/integration/spark/src/main/common2.3and2.4/org/apache/spark/sql/SparkVersionAdapter.scala
@@ -26,12 +26,12 @@ import org.apache.spark.serializer.Serializer
 import org.apache.spark.sql.catalyst.{CarbonParserUtil, InternalRow, TableIdentifier}
 import org.apache.spark.sql.catalyst.analysis.{Analyzer, UnresolvedRelation}
 import org.apache.spark.sql.catalyst.encoders.RowEncoder
-import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeMap, AttributeSeq, Expression, NamedExpression, SortOrder}
-import org.apache.spark.sql.catalyst.expressions.codegen.{ExprCode, GeneratePredicate}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeSeq, Expression, InterpretedPredicate, NamedExpression, SortOrder}
+import org.apache.spark.sql.catalyst.expressions.codegen.GeneratePredicate
 import org.apache.spark.sql.catalyst.parser.ParserUtils.operationNotAllowed
 import org.apache.spark.sql.catalyst.parser.SqlBaseParser.{BucketSpecContext, ColTypeListContext, CreateTableHeaderContext, LocationSpecContext, QueryContext, SkewSpecContext, TablePropertyListContext}
 import org.apache.spark.sql.catalyst.plans.{logical, JoinType, QueryPlan}
-import org.apache.spark.sql.catalyst.plans.logical.{ColumnStat, InsertIntoTable, Join, LogicalPlan, OneRowRelation, Statistics}
+import org.apache.spark.sql.catalyst.plans.logical.{InsertIntoTable, Join, LogicalPlan, OneRowRelation}
 import org.apache.spark.sql.catalyst.plans.physical.SinglePartition
 import org.apache.spark.sql.catalyst.util.DateTimeUtils
 import org.apache.spark.sql.execution.{QueryExecution, ShuffledRowRDD, SparkPlan, SQLExecution, UnaryExecNode}
@@ -427,6 +427,9 @@ trait SparkVersionAdapter {
     s.typeName
   }
 
+  def evaluateWithPredicate(exp: Expression, schema: Seq[Attribute], row: InternalRow): Any = {
+    InterpretedPredicate.create(exp, schema).expression.eval(row)
+  }
 }
 
 case class CarbonBuildSide(buildSide: BuildSide) {

--- a/integration/spark/src/main/scala/org/apache/carbondata/indexserver/DistributedPruneRDD.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/indexserver/DistributedPruneRDD.scala
@@ -126,8 +126,7 @@ private[indexserver] class DistributedPruneRDD(@transient private val ss: SparkS
         SparkEnv.get.blockManager.blockManagerId.executorId
       }"
       val value = (executorIP + "_" + cacheSize.toString, new ExtendedBlockletWrapper(f.toList
-        .asJava, indexInputFormat.getCarbonTable.getTablePath, indexInputFormat.getQueryId,
-        indexInputFormat.isWriteToFile, indexInputFormat.isCountStarJob, indexInputFormat.getCdcVO))
+        .asJava, indexInputFormat))
       Iterator(value)
     }
   }

--- a/integration/spark/src/main/scala/org/apache/carbondata/indexserver/DistributedPruneRDD.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/indexserver/DistributedPruneRDD.scala
@@ -127,7 +127,7 @@ private[indexserver] class DistributedPruneRDD(@transient private val ss: SparkS
       }"
       val value = (executorIP + "_" + cacheSize.toString, new ExtendedBlockletWrapper(f.toList
         .asJava, indexInputFormat.getCarbonTable.getTablePath, indexInputFormat.getQueryId,
-        indexInputFormat.isWriteToFile, indexInputFormat.isCountStarJob))
+        indexInputFormat.isWriteToFile, indexInputFormat.isCountStarJob, indexInputFormat.getCdcVO))
       Iterator(value)
     }
   }

--- a/integration/spark/src/main/scala/org/apache/carbondata/indexserver/DistributedRDDUtils.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/indexserver/DistributedRDDUtils.scala
@@ -427,6 +427,6 @@ object DistributedRDDUtils {
       new java.util.ArrayList(),
       new java.util.ArrayList())
     new ExtendedBlockletWrapper(blocklets, request.getCarbonTable.getTablePath, request.getQueryId,
-      request.isWriteToFile, request.isCountStarJob)
+      request.isWriteToFile, request.isCountStarJob, request.getCdcVO)
   }
 }

--- a/integration/spark/src/main/scala/org/apache/carbondata/indexserver/DistributedRDDUtils.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/indexserver/DistributedRDDUtils.scala
@@ -426,7 +426,6 @@ object DistributedRDDUtils {
       request.getValidSegments,
       new java.util.ArrayList(),
       new java.util.ArrayList())
-    new ExtendedBlockletWrapper(blocklets, request.getCarbonTable.getTablePath, request.getQueryId,
-      request.isWriteToFile, request.isCountStarJob, request.getCdcVO)
+    new ExtendedBlockletWrapper(blocklets, request)
   }
 }

--- a/integration/spark/src/main/scala/org/apache/carbondata/indexserver/IndexJobs.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/indexserver/IndexJobs.scala
@@ -89,7 +89,7 @@ class DistributedIndexJob extends AbstractIndexJob {
         }
         client.getSplits(indexFormat)
           .getExtendedBlocklets(indexFormat.getCarbonTable.getTablePath, indexFormat
-            .getQueryId, indexFormat.isCountStarJob)
+            .getQueryId, indexFormat.isCountStarJob, null)
       } finally {
         if (null != splitFolderPath && !splitFolderPath.deleteFile()) {
           LOGGER.error("Problem while deleting the temp directory:"
@@ -163,7 +163,7 @@ class EmbeddedIndexJob extends AbstractIndexJob {
     indexFormat.setIsWriteToFile(false)
     indexFormat.setFallbackJob()
     val splits = IndexServer.getSplits(indexFormat).getExtendedBlocklets(indexFormat
-      .getCarbonTable.getTablePath, indexFormat.getQueryId, indexFormat.isCountStarJob)
+      .getCarbonTable.getTablePath, indexFormat.getQueryId, indexFormat.isCountStarJob, null)
     // Fire a job to clear the cache from executors as Embedded mode does not maintain the cache.
     if (!indexFormat.isJobToClearIndexes) {
       IndexServer.invalidateSegmentCache(indexFormat.getCarbonTable, indexFormat

--- a/integration/spark/src/main/scala/org/apache/carbondata/indexserver/IndexJobs.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/indexserver/IndexJobs.scala
@@ -88,8 +88,7 @@ class DistributedIndexJob extends AbstractIndexJob {
           IndexServer.getClient
         }
         client.getSplits(indexFormat)
-          .getExtendedBlocklets(indexFormat.getCarbonTable.getTablePath, indexFormat
-            .getQueryId, indexFormat.isCountStarJob, null)
+          .getExtendedBlocklets(indexFormat)
       } finally {
         if (null != splitFolderPath && !splitFolderPath.deleteFile()) {
           LOGGER.error("Problem while deleting the temp directory:"
@@ -162,8 +161,7 @@ class EmbeddedIndexJob extends AbstractIndexJob {
     val originalJobDesc = spark.sparkContext.getLocalProperty("spark.job.description")
     indexFormat.setIsWriteToFile(false)
     indexFormat.setFallbackJob()
-    val splits = IndexServer.getSplits(indexFormat).getExtendedBlocklets(indexFormat
-      .getCarbonTable.getTablePath, indexFormat.getQueryId, indexFormat.isCountStarJob, null)
+    val splits = IndexServer.getSplits(indexFormat).getExtendedBlocklets(indexFormat)
     // Fire a job to clear the cache from executors as Embedded mode does not maintain the cache.
     if (!indexFormat.isJobToClearIndexes) {
       IndexServer.invalidateSegmentCache(indexFormat.getCarbonTable, indexFormat

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
@@ -704,6 +704,8 @@ class CarbonScanRDD[T: ClassTag](
     if (indexFilter != null) {
       indexFilter.setTable(CarbonTable.buildFromTableInfo(tableInfo))
       val children = indexFilter.getExpression.getChildren
+      // if the children of the filter contains CDCBlockImplicitExpression, set that to true
+      // expression here, as we don't need this in executor evaluation
       children.asScala.zipWithIndex.foreach { case (child, index) =>
         if (child.isInstanceOf[CDCBlockImplicitExpression]) {
           indexFilter.getExpression.getChildren.set(index, new TrueExpression(null))

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
@@ -52,9 +52,9 @@ import org.apache.carbondata.core.metadata.datatype.DataTypes
 import org.apache.carbondata.core.metadata.schema.table.{CarbonTable, TableInfo}
 import org.apache.carbondata.core.metadata.schema.table.column.{CarbonColumn, CarbonDimension}
 import org.apache.carbondata.core.readcommitter.ReadCommittedScope
-import org.apache.carbondata.core.scan.expression.Expression
-import org.apache.carbondata.core.scan.expression.conditional.ImplicitExpression
-import org.apache.carbondata.core.scan.expression.logical.AndExpression
+import org.apache.carbondata.core.scan.expression.{BinaryExpression, Expression}
+import org.apache.carbondata.core.scan.expression.conditional.{CDCBlockImplicitExpression, ImplicitExpression}
+import org.apache.carbondata.core.scan.expression.logical.{AndExpression, TrueExpression}
 import org.apache.carbondata.core.scan.filter.FilterUtil
 import org.apache.carbondata.core.scan.model.QueryModel
 import org.apache.carbondata.core.stats.{QueryStatistic, QueryStatisticsConstants}
@@ -699,16 +699,39 @@ class CarbonScanRDD[T: ClassTag](
 
   private def prepareInputFormatForExecutor(conf: Configuration): CarbonInputFormat[Object] = {
     CarbonInputFormat.setCarbonReadSupport(conf, readSupportClz)
-    val tableInfo1 = getTableInfo
-    CarbonInputFormat.setTableInfo(conf, tableInfo1)
+    val tableInfo = getTableInfo
+    CarbonInputFormat.setTableInfo(conf, tableInfo)
     if (indexFilter != null) {
-      indexFilter.setTable(CarbonTable.buildFromTableInfo(tableInfo1))
+      indexFilter.setTable(CarbonTable.buildFromTableInfo(tableInfo))
+      val children = indexFilter.getExpression.getChildren
+      children.asScala.zipWithIndex.foreach { case (child, index) =>
+        if (child.isInstanceOf[CDCBlockImplicitExpression]) {
+          indexFilter.getExpression.getChildren.set(index, new TrueExpression(null))
+          setCDCExpressionToTrue(indexFilter)
+        }
+      }
     }
     CarbonInputFormat.setFilterPredicates(conf, indexFilter)
-    CarbonInputFormat.setDatabaseName(conf, tableInfo1.getDatabaseName)
-    CarbonInputFormat.setTableName(conf, tableInfo1.getFactTable.getTableName)
+    CarbonInputFormat.setDatabaseName(conf, tableInfo.getDatabaseName)
+    CarbonInputFormat.setTableName(conf, tableInfo.getFactTable.getTableName)
     CarbonInputFormat.setDataTypeConverter(conf, dataTypeConverterClz)
     createInputFormat(conf)
+  }
+
+  /**
+   * When min max pruning is enabled in merge operation, CDCBlockImplicitExpression will be present
+   * which will be used for pruning in driver side. For executor make this as true expression.
+   * @param indexFilter
+   */
+  def setCDCExpressionToTrue(indexFilter: IndexFilter): Unit = {
+    if (indexFilter.getExpression.asInstanceOf[BinaryExpression].getLeft
+      .isInstanceOf[CDCBlockImplicitExpression]) {
+      indexFilter.setExpression(new AndExpression(new TrueExpression(null),
+        indexFilter.getExpression.asInstanceOf[BinaryExpression].getRight))
+    } else {
+      indexFilter.setExpression(new AndExpression(
+        indexFilter.getExpression.asInstanceOf[BinaryExpression].getLeft, new TrueExpression(null)))
+    }
   }
 
   private def createFileInputFormat(conf: Configuration): CarbonFileInputFormat[Object] = {

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/util/CarbonSparkUtil.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/util/CarbonSparkUtil.scala
@@ -58,6 +58,13 @@ object CarbonSparkUtil {
     }
   }
 
+  def collectNonCarbonRelation(plan: LogicalPlan): Seq[LogicalRelation] = {
+    plan.collect {
+      case l: LogicalRelation =>
+        l
+    }
+  }
+
   /**
    * return's the formatted column comment if column comment is present else empty("")
    *

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
@@ -82,7 +82,7 @@ class CarbonEnv {
 
     sparkSession.udf.register("getTupleId", () => "")
     sparkSession.udf.register("getPositionId", () => "")
-    sparkSession.udf.register("block_paths", new BlockPathsUDF)
+    sparkSession.udf.register("getBlockPaths", new BlockPathsUDF)
     // add NI as a temp function, for queries to not hit SI table, it will be added as HiveSimpleUDF
     CreateFunctionCommand(
       databaseName = None,

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
@@ -26,6 +26,7 @@ import org.apache.spark.sql.catalyst.analysis.{NoSuchDatabaseException, NoSuchTa
 import org.apache.spark.sql.catalyst.catalog.SessionCatalog
 import org.apache.spark.sql.events.{MergeBloomIndexEventListener, MergeIndexEventListener}
 import org.apache.spark.sql.execution.command.CreateFunctionCommand
+import org.apache.spark.sql.execution.command.mutation.merge.udf.BlockPathsUDF
 import org.apache.spark.sql.hive._
 import org.apache.spark.sql.listeners._
 import org.apache.spark.sql.profiler.Profiler
@@ -81,6 +82,7 @@ class CarbonEnv {
 
     sparkSession.udf.register("getTupleId", () => "")
     sparkSession.udf.register("getPositionId", () => "")
+    sparkSession.udf.register("block_paths", new BlockPathsUDF)
     // add NI as a temp function, for queries to not hit SI table, it will be added as HiveSimpleUDF
     CreateFunctionCommand(
       databaseName = None,

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSession.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSession.scala
@@ -25,7 +25,7 @@ import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.sql.SparkSession.Builder
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.execution.QueryExecution
-import org.apache.spark.sql.execution.command.mutation.merge.{MergeDataSetBuilder, UpsertBuilder}
+import org.apache.spark.sql.execution.command.mutation.merge.{MergeDataSetBuilder, MergeOperationType, UpsertBuilder}
 import org.apache.spark.sql.internal.{SessionState, SharedState}
 import org.apache.spark.sql.profiler.{Profiler, SQLStart}
 import org.apache.spark.sql.util.SparkSQLUtil
@@ -294,7 +294,26 @@ object CarbonSession {
       new MergeDataSetBuilder(ds, srcDS, expr, ds.sparkSession)
     }
 
-    def merge(srcDS: Dataset[Row], keyColumn: String, operationType: String): UpsertBuilder = {
+    def update(srcDS: Dataset[Row], keyColumn: String): UpsertBuilder = {
+      merge(srcDS, keyColumn, MergeOperationType.UPDATE.toString)
+    }
+
+    def delete(srcDS: Dataset[Row], keyColumn: String): UpsertBuilder = {
+      merge(srcDS, keyColumn, MergeOperationType.DELETE.toString)
+    }
+
+    def insert(srcDS: Dataset[Row], keyColumn: String): UpsertBuilder = {
+      merge(srcDS, keyColumn, MergeOperationType.INSERT.toString)
+    }
+
+    def upsert(srcDS: Dataset[Row], keyColumn: String): UpsertBuilder = {
+      merge(srcDS, keyColumn, MergeOperationType.UPSERT.toString)
+    }
+
+    private def merge(
+        srcDS: Dataset[Row],
+        keyColumn: String,
+        operationType: String): UpsertBuilder = {
       new UpsertBuilder(ds, srcDS, keyColumn, operationType, ds.sparkSession)
     }
 

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSession.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonSession.scala
@@ -25,7 +25,7 @@ import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.sql.SparkSession.Builder
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.execution.QueryExecution
-import org.apache.spark.sql.execution.command.mutation.merge.MergeDataSetBuilder
+import org.apache.spark.sql.execution.command.mutation.merge.{MergeDataSetBuilder, UpsertBuilder}
 import org.apache.spark.sql.internal.{SessionState, SharedState}
 import org.apache.spark.sql.profiler.{Profiler, SQLStart}
 import org.apache.spark.sql.util.SparkSQLUtil
@@ -293,5 +293,10 @@ object CarbonSession {
     def merge(srcDS: Dataset[Row], expr: Column): MergeDataSetBuilder = {
       new MergeDataSetBuilder(ds, srcDS, expr, ds.sparkSession)
     }
+
+    def merge(srcDS: Dataset[Row], keyColumn: String, operationType: String): UpsertBuilder = {
+      new UpsertBuilder(ds, srcDS, keyColumn, operationType, ds.sparkSession)
+    }
+
   }
 }

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/mutation/merge/CarbonMergeDataSetCommand.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/mutation/merge/CarbonMergeDataSetCommand.scala
@@ -20,37 +20,43 @@ import java.util
 import java.util.UUID
 
 import scala.collection.JavaConverters._
+import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
+import scala.util.control.Breaks._
 
 import org.apache.hadoop.fs.Path
-import org.apache.hadoop.mapreduce.{Job, JobID, TaskAttemptID, TaskID, TaskType}
+import org.apache.hadoop.mapreduce.{JobID, TaskAttemptID, TaskID, TaskType}
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat
 import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.{AnalysisException, CarbonThreadUtil, Column, DataFrame, Dataset, Row, SparkSession}
+import org.apache.spark.sql.{AnalysisException, CarbonDatasourceHadoopRelation, CarbonToSparkAdapter, Column, DataFrame, Dataset, Row, SparkSession}
 import org.apache.spark.sql.avro.AvroFileFormatFactory
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
-import org.apache.spark.sql.catalyst.expressions.{Attribute, EqualTo, Expression, GenericInternalRow, GenericRowWithSchema}
-import org.apache.spark.sql.execution.LogicalRDD
+import org.apache.spark.sql.catalyst.expressions.{Attribute, EqualTo, Expression, GenericInternalRow}
+import org.apache.spark.sql.catalyst.plans.logical.SubqueryAlias
+import org.apache.spark.sql.execution.{CastExpressionOptimization, LogicalRDD, ProjectExec}
 import org.apache.spark.sql.execution.command.{DataCommand, ExecutionErrors, UpdateTableModel}
-import org.apache.spark.sql.execution.command.management.CarbonInsertIntoCommand
 import org.apache.spark.sql.execution.command.mutation.HorizontalCompaction
 import org.apache.spark.sql.functions._
-import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
+import org.apache.spark.sql.types.{DateType, IntegerType, StringType, StructField, StructType}
 import org.apache.spark.sql.util.SparkSQLUtil
-import org.apache.spark.unsafe.types.UTF8String
 import org.apache.spark.util.{AccumulatorContext, AccumulatorMetadata, LongAccumulator}
 
 import org.apache.carbondata.common.logging.LogServiceFactory
-import org.apache.carbondata.core.constants.{CarbonCommonConstants, CarbonLoadOptionConstants}
+import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.datastore.impl.FileFactory
-import org.apache.carbondata.core.index.Segment
+import org.apache.carbondata.core.index.{IndexChooser, IndexInputFormat, IndexStoreManager, IndexUtil}
+import org.apache.carbondata.core.indexstore.blockletindex.{BlockIndex, BlockletIndexRowIndexes}
+import org.apache.carbondata.core.metadata.datatype.DataTypes
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable
-import org.apache.carbondata.core.mutate.CarbonUpdateUtil
+import org.apache.carbondata.core.metadata.schema.table.column.CarbonColumn
+import org.apache.carbondata.core.mutate.{CdcVO, FilePathMinMaxVO}
+import org.apache.carbondata.core.range.{BlockMinMaxTree, MinMaxNode}
 import org.apache.carbondata.core.statusmanager.SegmentStatusManager
-import org.apache.carbondata.core.util.path.CarbonTablePath
-import org.apache.carbondata.events.OperationContext
+import org.apache.carbondata.core.util.{ByteUtil, CarbonProperties, CarbonUtil, DataTypeUtil}
+import org.apache.carbondata.core.util.comparator.{Comparator, SerializableComparator}
+import org.apache.carbondata.indexserver.IndexServer
 import org.apache.carbondata.processing.loading.FailureCauses
 import org.apache.carbondata.spark.util.CarbonSparkUtil
 
@@ -63,7 +69,9 @@ import org.apache.carbondata.spark.util.CarbonSparkUtil
 case class CarbonMergeDataSetCommand(
     targetDsOri: Dataset[Row],
     srcDS: Dataset[Row],
-    var mergeMatches: MergeDataSetMatches)
+    var mergeMatches: MergeDataSetMatches = null,
+    keyColumn: String = null,
+    operationType: String = null)
   extends DataCommand {
 
   val LOGGER = LogServiceFactory.getLogService(this.getClass.getName)
@@ -79,58 +87,466 @@ case class CarbonMergeDataSetCommand(
    */
   override def processData(sparkSession: SparkSession): Seq[Row] = {
     val relations = CarbonSparkUtil.collectCarbonRelation(targetDsOri.logicalPlan)
-    // Target dataset must be backed by carbondata table.
+    val st = System.currentTimeMillis()
+    val targetDsAliasName = targetDsOri.logicalPlan match {
+      case alias: SubqueryAlias =>
+        alias.alias
+      case _ => null
+    }
+    val sourceAliasName = srcDS.logicalPlan match {
+      case alias: SubqueryAlias =>
+        alias.alias
+      case _ => null
+    }
     if (relations.length != 1) {
       throw new UnsupportedOperationException(
         "Carbon table supposed to be present in merge dataset")
     }
+    // Target dataset must be backed by carbondata table.
+    val targetCarbonTable = relations.head.carbonRelation.carbonTable
+    // select only the required columns, it can avoid lot of and shuffling.
+    val targetDs = if (mergeMatches == null && operationType != null) {
+      targetDsOri.select(keyColumn)
+    } else {
+      // Get all the required columns of targetDS by going through all match conditions and actions.
+      val columns = getSelectExpressionsOnExistingDF(targetDsOri, mergeMatches, sparkSession)
+      targetDsOri.select(columns: _*)
+    }
+    // decide join type based on match conditions or based on merge operation type
+    val joinType = if (mergeMatches == null && operationType != null) {
+      MergeOperationType.withName(operationType.toUpperCase) match {
+        case MergeOperationType.UPDATE | MergeOperationType.DELETE =>
+          "inner"
+        case MergeOperationType.UPSERT =>
+          "right_outer"
+        case MergeOperationType.INSERT =>
+          null
+      }
+    } else {
+      decideJoinType
+    }
+
+    val joinColumns = if (mergeMatches == null) {
+      Seq(keyColumn)
+    } else {
+      mergeMatches.joinExpr.expr.collect {
+        case unresolvedAttribute: UnresolvedAttribute if unresolvedAttribute.nameParts.nonEmpty =>
+          // Let's say the join condition will be something like A.id = B.id, then it will be an
+          // EqualTo expression, with left expression as UnresolvedAttribute(A.id) and right will
+          // be a Literal(B.id). Since we need the column name here, we can directly check the left
+          // which is UnresolvedAttribute. We take nameparts from UnresolvedAttribute which is an
+          // ArrayBuffer containing "A" and "id", since "id" is column name, we take
+          // nameparts.tail.head which gives us "id" column name.
+          unresolvedAttribute.nameParts.tail.head
+      }.distinct
+    }
+
+    // repartition the srsDs, if the target has bucketing and the bucketing columns contains join
+    // columns
+    val repartitionedSrcDs =
+      if (targetCarbonTable.getBucketingInfo != null &&
+          targetCarbonTable.getBucketingInfo
+            .getListOfColumns
+            .asScala
+            .map(_.getColumnName).containsSlice(joinColumns)) {
+        srcDS.repartition(targetCarbonTable.getBucketingInfo.getNumOfRanges,
+          joinColumns.map(srcDS.col): _*)
+      } else {
+      srcDS
+      }
+
+    // cache the source data as we will be scanning multiple times
+    repartitionedSrcDs.cache()
+    val deDuplicatedRecords = repartitionedSrcDs.count()
+    LOGGER.info(s"Number of records from source data: $deDuplicatedRecords")
+    // Create accumulators to log the stats
+    val stats = Stats(createLongAccumulator("insertedRows"),
+      createLongAccumulator("updatedRows"),
+      createLongAccumulator("deletedRows"))
+    // check if its just upsert/update/delete/insert operation and go to UpsertHandler
+    var finalCarbonFilesToScan: Array[String] = Array.empty[String]
+    // the pruning will happen when the join type is not full_outer, in case of full_outer,
+    // we will be needing all the records from left table which is target table, so no need to prune
+    // target table based on min max of source table.
+    val isMinMaxPruningEnabled = CarbonProperties.getInstance()
+      .getProperty(CarbonCommonConstants.CARBON_CDC_MINMAX_PRUNING_ENABLED,
+        CarbonCommonConstants.CARBON_CDC_MINMAX_PRUNING_ENABLED_DEFAULT).toBoolean
+    var didNotPrune = false
+    breakable {
+      if (isMinMaxPruningEnabled && joinType != null && !joinType.equalsIgnoreCase("full_outer")) {
+        // if the index server is enabled, call index server to cache the index and get all the
+        // blocklets of the target table. If the index server disabled, just call the getSplits of
+        // the driver side to cache and get the splits. These CarbonInputSplits basically contain
+        // the filePaths and the min max of each columns.
+        val ssm = new SegmentStatusManager(targetCarbonTable.getAbsoluteTableIdentifier)
+        val isDistributedPruningEnabled: Boolean = CarbonProperties.getInstance
+          .isDistributedPruningEnabled(targetCarbonTable.getDatabaseName,
+            targetCarbonTable.getTableName)
+        val validSegments = ssm.getValidAndInvalidSegments.getValidSegments
+        val defaultIndex = IndexStoreManager.getInstance.getDefaultIndex(targetCarbonTable)
+        // 1. identify if src is partition table, if both src and target target for partition table
+        // on same column(s), then only get the src partitions and send those partitions to scan in
+        // target handling only for carbon src dataset now
+        val srcDataSetRelations = CarbonSparkUtil.collectCarbonRelation(srcDS.logicalPlan)
+        val partitionsToConsider =
+          if (srcDataSetRelations.lengthCompare(1) == 0 &&
+              srcDataSetRelations.head.isInstanceOf[CarbonDatasourceHadoopRelation]) {
+            val srcCarbonTable = srcDataSetRelations.head.carbonRelation.carbonTable
+            if (srcCarbonTable.isHivePartitionTable) {
+              CarbonMergeDataSetUtil.getPartitionSpecToConsiderForPruning(
+                sparkSession,
+                srcCarbonTable,
+                targetCarbonTable)
+            } else {
+              null
+            }
+          } else {
+            val nonCarbonRelations = CarbonSparkUtil.collectNonCarbonRelation(srcDS.logicalPlan)
+            // when the relations are not empty, it means the source dataset is prepared from table
+            if (nonCarbonRelations.nonEmpty &&
+                nonCarbonRelations.head.catalogTable.isDefined &&
+                nonCarbonRelations.head.catalogTable.get.partitionColumnNames != null) {
+              CarbonMergeDataSetUtil.getPartitionSpecToConsiderForPruning(
+                sparkSession,
+                null,
+                targetCarbonTable,
+                nonCarbonRelations.head.catalogTable.get.identifier)
+            } else {
+              null
+            }
+          }
+
+        // 1. get all the join columns of equal to conditions or equi joins
+        var targetKeyColumns: mutable.Set[String] = mutable.Set.empty[String]
+        if (mergeMatches != null) {
+          mergeMatches.joinExpr.expr.collect {
+            case EqualTo(left, right) =>
+              left match {
+                case attribute: UnresolvedAttribute if right.isInstanceOf[UnresolvedAttribute] =>
+                  val leftAlias = attribute.nameParts.head
+                  if (targetDsAliasName != null) {
+                    if (targetDsAliasName.equalsIgnoreCase(leftAlias)) {
+                      targetKeyColumns += attribute.nameParts.tail.head
+                    } else {
+                      targetKeyColumns +=
+                      right.asInstanceOf[UnresolvedAttribute].nameParts.tail.head
+                    }
+                  } else {
+                    if (leftAlias.equalsIgnoreCase(targetCarbonTable.getTableName)) {
+                      targetKeyColumns += attribute.nameParts.tail.head
+                    } else {
+                      targetKeyColumns +=
+                      right.asInstanceOf[UnresolvedAttribute].nameParts.tail.head
+                    }
+                  }
+                case _ =>
+              }
+          }
+        } else {
+          targetKeyColumns += keyColumn
+        }
+        val joinCarbonColumns = targetKeyColumns.collect {
+          case column => targetCarbonTable.getColumnByName(column)
+        }
+
+        LOGGER
+          .info(s"Key columns for join are: ${ joinCarbonColumns.map(_.getColName).mkString(",") }")
+
+        var columnToIndexMap: util.Map[String, Integer] = new util.LinkedHashMap[String, Integer]
+        // get the min max cache column and based on that determine the index to check in min-max
+        // array or Index Row
+        val minMaxColumns = targetCarbonTable.getMinMaxCachedColumnsInCreateOrder
+        if (minMaxColumns.size() != 0) {
+          if (minMaxColumns.size() ==
+              targetCarbonTable.getTableInfo.getFactTable.getListOfColumns.size() ||
+              minMaxColumns.size() == 1 && minMaxColumns.get(0).equalsIgnoreCase("All columns")) {
+            joinCarbonColumns.foreach { column =>
+              if (column.isDimension) {
+                columnToIndexMap.put(column.getColName, column.getOrdinal)
+              } else {
+                columnToIndexMap.put(column.getColName,
+                  targetCarbonTable.getVisibleDimensions.size() + column.getOrdinal)
+              }
+            }
+          } else {
+            // handing case where only some columns are present as cached columns and check if those
+            // columns has the target key columns or join columns
+            val joinColumnsPresentInMinMaxCacheCols = joinCarbonColumns.map(_.getColName)
+              .intersect(minMaxColumns.asScala.toSet)
+            if (joinColumnsPresentInMinMaxCacheCols.isEmpty ||
+                joinColumnsPresentInMinMaxCacheCols.size == joinCarbonColumns.size) {
+              // 1. if none of the join columns are present in cache columns, then all blocklets
+              // will be selected, so pruning is not required
+              // 2. when one of the columns is not present in cache columns, no need to prune, as it
+              // may lead to wrong data due to different filter conditions like OR
+              didNotPrune = true
+              break()
+            }
+          }
+        }
+
+        var columnMinMaxInBlocklet: util.LinkedHashMap[String, util.List[FilePathMinMaxVO]] = null
+        val colTosplitsFilePathAndMinMaxMap: mutable.Map[String, util.List[FilePathMinMaxVO]] =
+          if (isDistributedPruningEnabled) {
+            val indexFormat = new IndexInputFormat(targetCarbonTable, null, validSegments,
+              Nil.asJava, partitionsToConsider, false, null, false, false)
+            columnMinMaxInBlocklet = new util.LinkedHashMap[String, util.List[FilePathMinMaxVO]]
+            val cdcVO = new CdcVO(columnMinMaxInBlocklet, columnToIndexMap)
+            indexFormat.setCdcVO(cdcVO)
+            IndexServer.getClient.getSplits(indexFormat)
+              .getExtendedBlocklets(indexFormat.getCarbonTable.getTablePath, indexFormat.getQueryId,
+                indexFormat.isCountStarJob, indexFormat.getCdcVO)
+              .asScala
+              .flatMap { blocklet =>
+                blocklet.getColumnToMinMaxMapping.asScala.map {
+                  case (columnName, minMaxListWithFilePath) =>
+                    val filePathMinMaxList = columnMinMaxInBlocklet.get(columnName)
+                    if (filePathMinMaxList != null) {
+                      filePathMinMaxList.addAll(minMaxListWithFilePath)
+                      columnMinMaxInBlocklet.put(columnName, filePathMinMaxList)
+                    } else {
+                      columnMinMaxInBlocklet.put(columnName, minMaxListWithFilePath)
+                    }
+                }
+              }
+            columnMinMaxInBlocklet.asScala
+          } else {
+            if (targetCarbonTable.isTransactionalTable) {
+              val indexExprWrapper = IndexChooser.getDefaultIndex(targetCarbonTable, null)
+              IndexUtil.loadIndexes(targetCarbonTable, indexExprWrapper, validSegments)
+            }
+            val blocklets = defaultIndex.prune(validSegments, null, partitionsToConsider).asScala
+            columnMinMaxInBlocklet = new util.LinkedHashMap[String, util.List[FilePathMinMaxVO]]
+            columnToIndexMap.asScala.foreach {
+              case (columnName, index) =>
+                val filePathAndMinMaxList = new util.ArrayList[FilePathMinMaxVO]()
+                blocklets.map { blocklet =>
+                  val filePathMinMax = new FilePathMinMaxVO(blocklet.getFilePath,
+                    BlockIndex.getMinMaxValue(blocklet
+                      .getInputSplit
+                      .getIndexRow,
+                      BlockletIndexRowIndexes.MIN_VALUES_INDEX)(index),
+                    BlockIndex.getMinMaxValue(blocklet
+                      .getInputSplit
+                      .getIndexRow,
+                      BlockletIndexRowIndexes.MAX_VALUES_INDEX)(index))
+                  filePathAndMinMaxList.add(filePathMinMax)
+                }
+                columnMinMaxInBlocklet.put(columnName, filePathAndMinMaxList)
+            }
+            columnMinMaxInBlocklet.asScala
+          }
+
+        LOGGER.info("Finished getting splits from driver or index server")
+
+        // 2. get the tuple of filepath, min, max of the columns required, the min max should be
+        // converted to actual value based on the datatype logic collection to store only block and
+        // block level min and max
+        val fileMinMaxMapListOfAllJoinColumns: mutable.ArrayBuffer[(mutable.Map[String,
+          (AnyRef, AnyRef)], CarbonColumn)] =
+        mutable.ArrayBuffer.empty[(mutable.Map[String, (AnyRef, AnyRef)], CarbonColumn)]
+
+        val joinColumnsToComparatorMap:
+          mutable.LinkedHashMap[CarbonColumn, SerializableComparator] =
+          mutable.LinkedHashMap.empty[CarbonColumn, SerializableComparator]
+        joinCarbonColumns.map { joinColumn =>
+          val joinDataType = joinColumn.getDataType
+          val isPrimitiveAndNotDate = DataTypeUtil.isPrimitiveColumn(joinDataType) &&
+                                      (joinDataType != DataTypes.DATE)
+          val comparator = if (isPrimitiveAndNotDate) {
+            Comparator.getComparator(joinDataType)
+          } else if (joinDataType == DataTypes.STRING) {
+            null
+          } else {
+            Comparator.getComparatorByDataTypeForMeasure(joinDataType)
+          }
+          joinColumnsToComparatorMap += (joinColumn -> comparator)
+        }
+
+        // 3. prepare (filepath, (min, max)) at a block level.
+        CarbonMergeDataSetUtil.addFilePathAndMinMaxTuples(colTosplitsFilePathAndMinMaxMap,
+          targetCarbonTable,
+          joinColumnsToComparatorMap,
+          fileMinMaxMapListOfAllJoinColumns)
+
+        // 4. prepare mapping of column and a range tree based on filepath, min and max for that
+        // column. Here assumption is join expression columns will be less in actual use case.
+        // Basically a primary column
+        val joinColumnToTreeMapping: mutable.LinkedHashMap[CarbonColumn, BlockMinMaxTree] =
+        mutable.LinkedHashMap.empty[CarbonColumn, BlockMinMaxTree]
+        fileMinMaxMapListOfAllJoinColumns.foreach { case (fileMinMaxMap, joinCarbonColumn) =>
+          val joinDataType = joinCarbonColumn.getDataType
+          val isDimension = joinCarbonColumn.isDimension
+          val isPrimitiveAndNotDate = DataTypeUtil.isPrimitiveColumn(joinDataType) &&
+                                      (joinDataType != DataTypes.DATE)
+          val comparator = joinColumnsToComparatorMap(joinCarbonColumn)
+          val rangeIntervalTree = new BlockMinMaxTree(isPrimitiveAndNotDate,
+            isDimension, joinDataType, comparator)
+          fileMinMaxMap.foreach { case (filePath, minMax) =>
+            rangeIntervalTree.insert(new MinMaxNode(filePath, minMax._1, minMax._2))
+          }
+          joinColumnToTreeMapping += ((joinCarbonColumn, rangeIntervalTree))
+        }
+
+        // 5.from srcRDD, do map and then for each row search in min max tree prepared above and
+        // find the file paths to scan.
+        val timeStampFormat = CarbonProperties.getInstance()
+          .getProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT,
+            CarbonCommonConstants.CARBON_TIMESTAMP_DEFAULT_FORMAT);
+
+        joinCarbonColumns.foreach { joinColumn =>
+          val srcDeduplicatedRDD = repartitionedSrcDs.select(joinColumn.getColName).rdd
+          finalCarbonFilesToScan ++= srcDeduplicatedRDD.mapPartitions { iter =>
+            val filesPerTask = new util.HashSet[String]()
+            new Iterator[util.HashSet[String]] {
+              override def hasNext: Boolean = {
+                iter.hasNext
+              }
+
+              override def next(): util.HashSet[String] = {
+                val row = iter.next()
+                joinColumnToTreeMapping
+                  .foreach { joinColumnWithRangeTree =>
+                    val joinCarbonColumn = joinColumnWithRangeTree._1
+                    val rangeIntervalTree = joinColumnWithRangeTree._2
+                    val joinDataType = joinCarbonColumn.getDataType
+                    val isDimension = joinCarbonColumn.isDimension
+                    val isPrimitiveAndNotDate = DataTypeUtil.isPrimitiveColumn(joinDataType) &&
+                                                (joinDataType != DataTypes.DATE)
+                    val fieldIndex = row.fieldIndex(joinCarbonColumn.getColName)
+                    val fieldValue = if (!row.isNullAt(fieldIndex)) {
+                      if (isDimension) {
+                        if (joinDataType != DataTypes.DATE) {
+                          DataTypeUtil.getBytesBasedOnDataTypeForNoDictionaryColumn(row
+                            .getAs(fieldIndex)
+                            .toString,
+                            joinDataType, timeStampFormat)
+                        } else {
+                          // if date, then get the key from direct dict generator and then get bytes
+                          val actualValue = row.getAs(fieldIndex)
+                          val dateSurrogateValue = CastExpressionOptimization
+                            .typeCastStringToLong(actualValue, DateType).asInstanceOf[Int]
+                          ByteUtil.convertIntToBytes(dateSurrogateValue)
+                        }
+                      } else {
+                        CarbonUtil.getValueAsBytes(joinDataType, row.getAs(fieldIndex))
+                      }
+                    } else {
+                      // here handling for null values
+                      val value: Long = 0
+                      if (isDimension) {
+                        if (isPrimitiveAndNotDate) {
+                          CarbonCommonConstants.EMPTY_BYTE_ARRAY
+                        } else {
+                          CarbonCommonConstants.MEMBER_DEFAULT_VAL_ARRAY
+                        }
+                      } else {
+                        val nullValueForMeasure = if ((joinDataType eq DataTypes.BOOLEAN) ||
+                                                      (joinDataType eq DataTypes.BYTE)) {
+                          value.toByte
+                        } else if (joinDataType eq DataTypes.SHORT) {
+                          value.toShort
+                        } else if (joinDataType eq DataTypes.INT) {
+                          value.toInt
+                        } else if ((joinDataType eq DataTypes.LONG) ||
+                                   (joinDataType eq DataTypes.TIMESTAMP)) {
+                          value
+                        } else if (joinDataType eq DataTypes.DOUBLE) {
+                          0d
+                        } else if (joinDataType eq DataTypes.FLOAT) {
+                          0f
+                        } else if (DataTypes.isDecimal(joinDataType)) {
+                          value
+                        }
+                        CarbonUtil.getValueAsBytes(joinDataType, nullValueForMeasure)
+                      }
+                    }
+                    rangeIntervalTree.getMatchingFiles(fieldValue, filesPerTask)
+                  }
+                filesPerTask
+              }
+            }
+          }.flatMap(_.asScala.toList).map(filePath => (filePath, 0)).reduceByKey((m, n) => m + n)
+            .collect().map(_._1)
+        }
+
+        LOGGER.info(s"Finished min-max pruning. Carbondata files to scan during merge is: ${
+          finalCarbonFilesToScan.length
+        }")
+      }
+    }
+
+    // check if its just upsert/update/delete/insert operation and go to UpsertHandler
+    if (mergeMatches == null && operationType != null) {
+      val isInsertOperation = operationType.equalsIgnoreCase(MergeOperationType.INSERT.toString)
+      val frame = if (isMinMaxPruningEnabled && !didNotPrune) {
+        // if min-max pruning is enabled then we need to add blockUDFs filter to scan only the
+        // pruned carbondata files from target carbon table.
+        if (!isInsertOperation) {
+          targetDs
+            .withColumn(CarbonCommonConstants.CARBON_IMPLICIT_COLUMN_TUPLEID, expr("getTupleId()"))
+            .where(s"block_paths('${finalCarbonFilesToScan.mkString(",")}')")
+            .join(repartitionedSrcDs.select(keyColumn),
+              expr(s"$targetDsAliasName.$keyColumn = $sourceAliasName.$keyColumn"),
+              joinType)
+        } else {
+          null
+        }
+      } else {
+        if (!isInsertOperation) {
+          targetDs
+            .withColumn(CarbonCommonConstants.CARBON_IMPLICIT_COLUMN_TUPLEID, expr("getTupleId()"))
+            .join(repartitionedSrcDs.select(keyColumn),
+              expr(s"$targetDsAliasName.$keyColumn = $sourceAliasName.$keyColumn"),
+              joinType)
+        } else {
+          null
+        }
+      }
+      val mergeHandler: MergeHandler =
+        MergeOperationType.withName(operationType.toUpperCase) match {
+        case MergeOperationType.UPSERT =>
+          UpsertHandler(sparkSession, frame, targetCarbonTable, stats, repartitionedSrcDs)
+        case MergeOperationType.UPDATE =>
+          UpdateHandler(sparkSession, frame, targetCarbonTable, stats, repartitionedSrcDs)
+        case MergeOperationType.DELETE =>
+          DeleteHandler(sparkSession, frame, targetCarbonTable, stats, repartitionedSrcDs)
+        case MergeOperationType.INSERT =>
+          InsertHandler(sparkSession, frame, targetCarbonTable, stats, repartitionedSrcDs)
+        }
+
+      // execute merge handler
+      mergeHandler.handleMerge()
+      LOGGER.info(
+        " Time taken to merge data  :: " + (System.currentTimeMillis() - st))
+      // clear the cached src
+      repartitionedSrcDs.unpersist()
+      return Seq()
+    }
     // validate the merge matches and actions.
     validateMergeActions(mergeMatches, targetDsOri, sparkSession)
-    val carbonTable = relations.head.carbonRelation.carbonTable
     val hasDelAction = mergeMatches.matchList
       .exists(_.getActions.exists(_.isInstanceOf[DeleteAction]))
     val hasUpdateAction = mergeMatches.matchList
       .exists(_.getActions.exists(_.isInstanceOf[UpdateAction]))
     val (insertHistOfUpdate, insertHistOfDelete) = getInsertHistoryStatus(mergeMatches)
-    // Get all the required columns of targetDS by going through all match conditions and actions.
-    val columns = getSelectExpressionsOnExistingDF(targetDsOri, mergeMatches, sparkSession)
-    // select only the required columns, it can avoid lot of and shuffling.
-    val targetDs = targetDsOri.select(columns: _*)
     // Update the update mapping with unfilled columns.From here on system assumes all mappings
     // are existed.
     mergeMatches = updateMappingIfNotExists(mergeMatches, targetDs)
     // Lets generate all conditions combinations as one column and add them as 'status'.
     val condition = generateStatusColumnWithAllCombinations(mergeMatches)
 
-    // decide join type based on match conditions
-    val joinType = decideJoinType
-
-    val joinColumns = mergeMatches.joinExpr.expr.collect {
-      case unresolvedAttribute: UnresolvedAttribute if unresolvedAttribute.nameParts.nonEmpty =>
-        // Let's say the join condition will be something like A.id = B.id, then it will be an
-        // EqualTo expression, with left expression as UnresolvedAttribute(A.id) and right will
-        // be a Literal(B.id). Since we need the column name here, we can directly check the left
-        // which is UnresolvedAttribute. We take nameparts from UnresolvedAttribute which is an
-        // ArrayBuffer containing "A" and "id", since "id" is column name, we take
-        // nameparts.tail.head which gives us "id" column name.
-        unresolvedAttribute.nameParts.tail.head
-    }.distinct
-
-    // repartition the srsDs, if the target has bucketing and the bucketing columns contains join
-    // columns
-    val repartitionedSrcDs =
-      if (carbonTable.getBucketingInfo != null &&
-          carbonTable.getBucketingInfo
-            .getListOfColumns
-            .asScala
-            .map(_.getColumnName).containsSlice(joinColumns)) {
-        srcDS.repartition(carbonTable.getBucketingInfo.getNumOfRanges,
-          joinColumns.map(srcDS.col): _*)
-      } else {
-      srcDS
-    }
     // Add the getTupleId() udf to get the tuple id to generate delete delta.
-    val frame =
+    val frame = if (isMinMaxPruningEnabled && !didNotPrune) {
+      targetDs
+        .withColumn(CarbonCommonConstants.CARBON_IMPLICIT_COLUMN_TUPLEID, expr("getTupleId()"))
+        .withColumn("exist_on_target", lit(1))
+        .where(s"block_paths('${finalCarbonFilesToScan.mkString(",")}')")
+        .join(repartitionedSrcDs.withColumn("exist_on_src", lit(1)),
+          mergeMatches.joinExpr,
+          joinType)
+        .withColumn(status_on_mergeds, condition)
+    } else {
       targetDs
         .withColumn(CarbonCommonConstants.CARBON_IMPLICIT_COLUMN_TUPLEID, expr("getTupleId()"))
         .withColumn("exist_on_target", lit(1))
@@ -138,31 +554,30 @@ case class CarbonMergeDataSetCommand(
           mergeMatches.joinExpr,
           joinType)
         .withColumn(status_on_mergeds, condition)
+    }
     if (LOGGER.isDebugEnabled) {
       frame.explain()
     }
     val tableCols =
-      carbonTable.getCreateOrderColumn.asScala.map(_.getColName).
+      targetCarbonTable.getCreateOrderColumn.asScala.map(_.getColName).
         filterNot(_.equalsIgnoreCase(CarbonCommonConstants.DEFAULT_INVISIBLE_DUMMY_MEASURE))
     val header = tableCols.mkString(",")
 
+    val frameWithoutStatusCol = frame.drop(status_on_mergeds)
     val projections: Seq[Seq[MergeProjection]] = mergeMatches.matchList.map { m =>
       m.getActions.map {
         case u: UpdateAction => MergeProjection(tableCols,
-          status_on_mergeds,
-          frame,
+          frameWithoutStatusCol,
           relations.head,
           sparkSession,
           u)
         case i: InsertAction => MergeProjection(tableCols,
-          status_on_mergeds,
-          frame,
+          frameWithoutStatusCol,
           relations.head,
           sparkSession,
           i)
         case d: DeleteAction => MergeProjection(tableCols,
-          status_on_mergeds,
-          frame,
+          frameWithoutStatusCol,
           relations.head,
           sparkSession,
           d)
@@ -170,22 +585,17 @@ case class CarbonMergeDataSetCommand(
       }.filter(_ != null)
     }
 
-    val st = System.currentTimeMillis()
-    // Create accumulators to log the stats
-    val stats = Stats(createLongAccumulator("insertedRows"),
-      createLongAccumulator("updatedRows"),
-      createLongAccumulator("deletedRows"))
     val targetSchema = StructType(tableCols.map { f =>
       relations.head.carbonRelation.schema.find(_.name.equalsIgnoreCase(f)).get
     } ++ Seq(StructField(status_on_mergeds, IntegerType)))
-    val (processedRDD, deltaPath) = processIUD(sparkSession, frame, carbonTable, projections,
+    val (processedRDD, deltaPath) = processIUD(sparkSession, frame, targetCarbonTable, projections,
       targetSchema, stats)
 
     val executorErrors = ExecutionErrors(FailureCauses.NONE, "")
     val trxMgr = TranxManager(System.currentTimeMillis())
 
     val mutationAction = MutationActionFactory.getMutationAction(sparkSession,
-      carbonTable, hasDelAction, hasUpdateAction,
+      targetCarbonTable, hasDelAction, hasUpdateAction,
       insertHistOfUpdate, insertHistOfDelete)
 
     val loadDF = Dataset.ofRows(sparkSession,
@@ -198,12 +608,8 @@ case class CarbonMergeDataSetCommand(
       val deltaRdd = AvroFileFormatFactory.readAvro(sparkSession, deltaPath)
       val tuple = mutationAction.handleAction(deltaRdd, executorErrors, trxMgr)
       FileFactory.deleteAllCarbonFilesOfDir(FileFactory.getCarbonFile(deltaPath))
-      if (!CarbonUpdateUtil.updateSegmentStatus(tuple._1.asScala.asJava,
-        carbonTable,
-        trxMgr.getLatestTrx.toString, false, false)) {
-        LOGGER.error("writing of update status file failed")
-        throw new CarbonMergeDataSetException("writing of update status file failed")
-      }
+      MergeUtil.updateSegmentStatusAfterUpdateOrDelete(targetCarbonTable,
+        trxMgr.getLatestTrx, tuple)
       Some(UpdateTableModel(isUpdate = true, trxMgr.getLatestTrx,
         executorErrors, tuple._2, Option.empty))
     } else {
@@ -211,28 +617,14 @@ case class CarbonMergeDataSetCommand(
     }
 
     val dataFrame = loadDF.select(tableCols.map(col): _*)
-    CarbonInsertIntoCommand(databaseNameOp = Some(carbonTable.getDatabaseName),
-      tableName = carbonTable.getTableName,
-      options = Map("fileheader" -> header),
-      isOverwriteTable = false,
-      dataFrame.queryExecution.logical,
-      carbonTable.getTableInfo,
-      Map.empty,
-      Map.empty,
-      new OperationContext,
-      updateTableModel
-    ).run(sparkSession)
+    MergeUtil.insertDataToTargetTable(sparkSession,
+      targetCarbonTable,
+      header,
+      updateTableModel,
+      dataFrame)
 
     if (hasDelAction && count == 0) {
-      val loadMetaDataDetails = SegmentStatusManager.readTableStatusFile(CarbonTablePath
-        .getTableStatusFilePath(carbonTable.getTablePath))
-      CarbonUpdateUtil.updateTableMetadataStatus(loadMetaDataDetails.map(loadMetadataDetail =>
-        new Segment(loadMetadataDetail.getMergedLoadName,
-          loadMetadataDetail.getSegmentFile)).toSet.asJava,
-        carbonTable,
-        trxMgr.getLatestTrx.toString,
-        true,
-        true, new util.ArrayList[Segment]())
+      MergeUtil.updateStatusIfJustDeleteOperation(targetCarbonTable, trxMgr.getLatestTrx)
     }
     LOGGER.info(s"Total inserted rows: ${stats.insertedRows.sum}")
     LOGGER.info(s"Total updated rows: ${stats.updatedRows.sum}")
@@ -240,12 +632,14 @@ case class CarbonMergeDataSetCommand(
     LOGGER.info(
       " Time taken to merge data  :: " + (System.currentTimeMillis() - st))
 
-  // Load the history table if the insert history table action is added by user.
-    HistoryTableLoadHelper.loadHistoryTable(sparkSession, relations.head, carbonTable,
+    // Load the history table if the insert history table action is added by user.
+    HistoryTableLoadHelper.loadHistoryTable(sparkSession, relations.head, targetCarbonTable,
       trxMgr, mutationAction, mergeMatches)
     // Do IUD Compaction.
     HorizontalCompaction.tryHorizontalCompaction(
-      sparkSession, carbonTable)
+      sparkSession, targetCarbonTable)
+    // clear the cached src
+    repartitionedSrcDs.unpersist()
     Seq.empty
   }
 
@@ -289,7 +683,6 @@ case class CarbonMergeDataSetCommand(
       targetSchema: StructType,
       stats: Stats): (RDD[InternalRow], String) = {
     val frameCols = frame.queryExecution.analyzed.output
-    val status = frameCols.length - 1
     val tupleId = frameCols.zipWithIndex
       .find(_._1.name.equalsIgnoreCase(CarbonCommonConstants.CARBON_IMPLICIT_COLUMN_TUPLEID)).get._2
     val insertedRows = stats.insertedRows
@@ -308,7 +701,10 @@ case class CarbonMergeDataSetCommand(
         StructField(status_on_mergeds, IntegerType)))
     val factory = AvroFileFormatFactory.getAvroWriter(sparkSession, job, schema)
     val config = SparkSQLUtil.broadCastHadoopConf(sparkSession.sparkContext, job.getConfiguration)
-    (frame.rdd.mapPartitionsWithIndex { case (index, iter) =>
+    val expr = frame.queryExecution.sparkPlan.asInstanceOf[ProjectExec].projectList.last
+    val frameWithoutStatusCol = frame.drop(status_on_mergeds)
+    val colSchemaWithoutStatusCol = frameWithoutStatusCol.queryExecution.logical.output
+    (frameWithoutStatusCol.queryExecution.toRdd.mapPartitionsWithIndex { case (index, iter) =>
       val confB = config.value.value
       val task = new TaskID(new JobID(uuid, 0), TaskType.MAP, index)
       val attemptID = new TaskAttemptID(task, index)
@@ -318,16 +714,23 @@ case class CarbonMergeDataSetCommand(
       val projLen = projections.length
         new Iterator[InternalRow] {
           val queue = new util.LinkedList[InternalRow]()
-          override def hasNext: Boolean = if (!queue.isEmpty || iter.hasNext) true else {
-            writer.close()
-            false
+
+          override def hasNext: Boolean = {
+            if (!queue.isEmpty || iter.hasNext) {
+              true
+            } else {
+              writer.close()
+              false
+            }
           }
 
           override def next(): InternalRow = {
-            if (!queue.isEmpty) return queue.poll()
+            if (!queue.isEmpty) {
+              return queue.poll()
+            }
             val row = iter.next()
-            val rowWithSchema = row.asInstanceOf[GenericRowWithSchema]
-            val is = row.get(status)
+            val is = CarbonToSparkAdapter.evaluateWithPredicate(expr,
+              colSchemaWithoutStatusCol, row)
             var isUpdate = false
             var isDelete = false
             var insertedCount = 0
@@ -335,18 +738,24 @@ case class CarbonMergeDataSetCommand(
               val isInt = is.asInstanceOf[Int]
               var i = 0
               while (i < projLen) {
-                if ((isInt & (1 << i)) == (1 << i)) projections(i).foreach { p =>
-                  if (!p.isDelete) {
-                    if (p.isUpdate) isUpdate = p.isUpdate
-                    queue.add(p(rowWithSchema))
-                    insertedCount += 1
-                  } else isDelete = true
+                if ((isInt & (1 << i)) == (1 << i)) {
+                  projections(i).foreach { p =>
+                    if (!p.isDelete) {
+                      if (p.isUpdate) {
+                        isUpdate = p.isUpdate
+                      }
+                      queue.add(p.getInternalRowFromIndex(row, is.asInstanceOf[Int]))
+                      insertedCount += 1
+                    } else {
+                      isDelete = true
+                    }
+                  }
                 }
                 i = i + 1
               }
             }
             val newArray = new Array[Any](2)
-            newArray(0) = UTF8String.fromString(row.getString(tupleId))
+            newArray(0) = row.getUTF8String(tupleId)
             if (isUpdate && isDelete) {
               newArray(1) = 102
               writer.write(new GenericInternalRow(newArray))
@@ -364,16 +773,15 @@ case class CarbonMergeDataSetCommand(
               writer.write(new GenericInternalRow(newArray))
             }
             insertedRows.add(insertedCount)
-            if (!queue.isEmpty) queue.poll() else {
+            if (!queue.isEmpty) {
+              queue.poll()
+            } else {
               val values = new Array[Any](targetSchema.length)
               new GenericInternalRow(values)
             }
           }
         }
-      }.filter { row =>
-      val status = row.get(targetSchema.length-1, IntegerType)
-      status != null
-    }, path)
+    }.filter { row => !row.isNullAt(targetSchema.length - 1)}, path)
   }
 
   private def createLongAccumulator(name: String) = {

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/mutation/merge/CarbonMergeDataSetUtil.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/mutation/merge/CarbonMergeDataSetUtil.scala
@@ -21,17 +21,28 @@ import java.util
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 
-import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.{CarbonDatasourceHadoopRelation, Dataset, Row, SparkSession}
 import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
+import org.apache.spark.sql.catalyst.expressions.EqualTo
+import org.apache.spark.sql.execution.CastExpressionOptimization
 import org.apache.spark.sql.optimizer.CarbonFilters
+import org.apache.spark.sql.types.DateType
 
+import org.apache.carbondata.core.constants.CarbonCommonConstants
+import org.apache.carbondata.core.index.{IndexChooser, IndexInputFormat, IndexStoreManager, IndexUtil}
 import org.apache.carbondata.core.indexstore.PartitionSpec
+import org.apache.carbondata.core.indexstore.blockletindex.BlockletIndexRowIndexes
 import org.apache.carbondata.core.metadata.datatype.DataTypes
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable
 import org.apache.carbondata.core.metadata.schema.table.column.CarbonColumn
-import org.apache.carbondata.core.mutate.FilePathMinMaxVO
-import org.apache.carbondata.core.util.{ByteUtil, CarbonUtil, DataTypeUtil}
+import org.apache.carbondata.core.mutate.{CdcVO, FilePathMinMaxVO}
+import org.apache.carbondata.core.range.BlockMinMaxTree
+import org.apache.carbondata.core.statusmanager.SegmentStatusManager
+import org.apache.carbondata.core.util.{ByteUtil, CarbonProperties, CarbonUtil, DataTypeUtil}
 import org.apache.carbondata.core.util.comparator.SerializableComparator
+import org.apache.carbondata.indexserver.IndexServer
+import org.apache.carbondata.spark.util.CarbonSparkUtil
 
 /**
  * The utility class for Merge operations
@@ -206,5 +217,249 @@ object CarbonMergeDataSetUtil {
       null
     }
     partitionsToConsider.asJava
+  }
+
+  /**
+   * This method get the files to scan by searching the tree prepared for each column with its
+   * min-max
+   * @param joinCarbonColumns join carbon columns
+   * @param joinColumnToTreeMapping mapping of join column to interval tree
+   * @param repartitionedSrcDs source dataset
+   * @return carbondata files required to scan
+   */
+  def getFilesToScan(
+      joinCarbonColumns: mutable.Set[CarbonColumn],
+      joinColumnToTreeMapping: mutable.LinkedHashMap[CarbonColumn, BlockMinMaxTree],
+      repartitionedSrcDs: Dataset[Row]): Array[String] = {
+    var finalCarbonFilesToScan: Array[String] = Array.empty[String]
+    val timeStampFormat = CarbonProperties.getInstance()
+      .getProperty(CarbonCommonConstants.CARBON_TIMESTAMP_FORMAT,
+        CarbonCommonConstants.CARBON_TIMESTAMP_DEFAULT_FORMAT);
+    joinCarbonColumns.foreach { joinColumn =>
+      val srcDeduplicatedRDD = repartitionedSrcDs.select(joinColumn.getColName).rdd
+      finalCarbonFilesToScan ++= srcDeduplicatedRDD.mapPartitions { iter =>
+        val filesPerTask = new util.HashSet[String]()
+        new Iterator[util.HashSet[String]] {
+          override def hasNext: Boolean = {
+            iter.hasNext
+          }
+
+          override def next(): util.HashSet[String] = {
+            val row = iter.next()
+            joinColumnToTreeMapping
+              .foreach { joinColumnWithRangeTree =>
+                val joinCarbonColumn = joinColumnWithRangeTree._1
+                val rangeIntervalTree = joinColumnWithRangeTree._2
+                val joinDataType = joinCarbonColumn.getDataType
+                val isDimension = joinCarbonColumn.isDimension
+                val isPrimitiveAndNotDate = DataTypeUtil.isPrimitiveColumn(joinDataType) &&
+                                            (joinDataType != DataTypes.DATE)
+                val fieldIndex = row.fieldIndex(joinCarbonColumn.getColName)
+                val fieldValue = if (!row.isNullAt(fieldIndex)) {
+                  if (isDimension) {
+                    if (joinDataType != DataTypes.DATE) {
+                      DataTypeUtil.getBytesBasedOnDataTypeForNoDictionaryColumn(row
+                        .getAs(fieldIndex)
+                        .toString,
+                        joinDataType, timeStampFormat)
+                    } else {
+                      // if date, then get the key from direct dict generator and then get bytes
+                      val actualValue = row.getAs(fieldIndex)
+                      val dateSurrogateValue = CastExpressionOptimization
+                        .typeCastStringToLong(actualValue, DateType).asInstanceOf[Int]
+                      ByteUtil.convertIntToBytes(dateSurrogateValue)
+                    }
+                  } else {
+                    CarbonUtil.getValueAsBytes(joinDataType, row.getAs(fieldIndex))
+                  }
+                } else {
+                  // here handling for null values
+                  val value: Long = 0
+                  if (isDimension) {
+                    if (isPrimitiveAndNotDate) {
+                      CarbonCommonConstants.EMPTY_BYTE_ARRAY
+                    } else {
+                      CarbonCommonConstants.MEMBER_DEFAULT_VAL_ARRAY
+                    }
+                  } else {
+                    val nullValueForMeasure = if ((joinDataType eq DataTypes.BOOLEAN) ||
+                                                  (joinDataType eq DataTypes.BYTE)) {
+                      value.toByte
+                    } else if (joinDataType eq DataTypes.SHORT) {
+                      value.toShort
+                    } else if (joinDataType eq DataTypes.INT) {
+                      value.toInt
+                    } else if ((joinDataType eq DataTypes.LONG) ||
+                               (joinDataType eq DataTypes.TIMESTAMP)) {
+                      value
+                    } else if (joinDataType eq DataTypes.DOUBLE) {
+                      0d
+                    } else if (joinDataType eq DataTypes.FLOAT) {
+                      0f
+                    } else if (DataTypes.isDecimal(joinDataType)) {
+                      value
+                    }
+                    CarbonUtil.getValueAsBytes(joinDataType, nullValueForMeasure)
+                  }
+                }
+                rangeIntervalTree.getMatchingFiles(fieldValue, filesPerTask)
+              }
+            filesPerTask
+          }
+        }
+      }.flatMap(_.asScala.toList).map(filePath => (filePath, 0)).reduceByKey((m, n) => m + n)
+        .collect().map(_._1)
+    }
+    finalCarbonFilesToScan
+  }
+
+  /**
+   * This method gets the key columnsrequired for joining based on merge condition
+   * @param keyColumn key columns if specified in the upsert APIs
+   * @param targetDsAliasName target table alias name
+   * @param targetCarbonTable target carbon table
+   * @param mergeMatches merge match conditions from the user
+   * @return set of key columns required to be used in pruning
+   */
+  def getTargetTableKeyColumns(
+      keyColumn: String,
+      targetDsAliasName: String,
+      targetCarbonTable: CarbonTable,
+      mergeMatches: MergeDataSetMatches): mutable.Set[String] = {
+    var targetKeyColumns: mutable.Set[String] = mutable.Set.empty[String]
+    if (mergeMatches != null) {
+      mergeMatches.joinExpr.expr.collect {
+        case EqualTo(left, right) =>
+          left match {
+            case attribute: UnresolvedAttribute if right.isInstanceOf[UnresolvedAttribute] =>
+              val leftAlias = attribute.nameParts.head
+              if (targetDsAliasName != null) {
+                if (targetDsAliasName.equalsIgnoreCase(leftAlias)) {
+                  targetKeyColumns += attribute.nameParts.tail.head
+                } else {
+                  targetKeyColumns +=
+                  right.asInstanceOf[UnresolvedAttribute].nameParts.tail.head
+                }
+              } else {
+                if (leftAlias.equalsIgnoreCase(targetCarbonTable.getTableName)) {
+                  targetKeyColumns += attribute.nameParts.tail.head
+                } else {
+                  targetKeyColumns +=
+                  right.asInstanceOf[UnresolvedAttribute].nameParts.tail.head
+                }
+              }
+            case _ =>
+          }
+      }
+      targetKeyColumns
+    } else {
+      targetKeyColumns += keyColumn
+    }
+  }
+
+  /**
+   * This method get the blocklets and cache either in driver or index server and returns column
+   * FilePathMinMaxVO object
+   * @param targetCarbonTable target carbondata table
+   * @param repartitionedSrcDs source dataset
+   * @param columnMinMaxInBlocklet mapping of column to it's min max in each blocklet
+   * @param columnToIndexMap mapping of column to its index to fetch from the index row
+   * @param sparkSession spark session
+   * @return mapping of column to FilePathMinMaxVO object which contains filepath and min, max
+   */
+  def getSplitsAndLoadToCache(
+      targetCarbonTable: CarbonTable,
+      repartitionedSrcDs: Dataset[Row],
+      columnMinMaxInBlocklet: util.LinkedHashMap[String, util.List[FilePathMinMaxVO]],
+      columnToIndexMap: util.Map[String, Integer],
+      sparkSession: SparkSession): mutable.Map[String, util.List[FilePathMinMaxVO]] = {
+    val isDistributedPruningEnabled: Boolean = CarbonProperties.getInstance
+      .isDistributedPruningEnabled(targetCarbonTable.getDatabaseName,
+        targetCarbonTable.getTableName)
+    // if the index server is enabled, call index server to cache the index and get all the
+    // blocklets of the target table. If the index server disabled, just call the getSplits of
+    // the driver side to cache and get the splits. These CarbonInputSplits basically contain
+    // the filePaths and the min max of each columns.
+    val ssm = new SegmentStatusManager(targetCarbonTable.getAbsoluteTableIdentifier)
+    val validSegments = ssm.getValidAndInvalidSegments.getValidSegments
+    val defaultIndex = IndexStoreManager.getInstance.getDefaultIndex(targetCarbonTable)
+
+    // 1. identify if src is partition table, if both src and target target for partition table
+    // on same column(s), then only get the src partitions and send those partitions to scan in
+    // target handling only for carbon src dataset now
+    val srcDataSetRelations = CarbonSparkUtil.collectCarbonRelation(repartitionedSrcDs.logicalPlan)
+    val partitionsToConsider =
+      if (srcDataSetRelations.lengthCompare(1) == 0 &&
+          srcDataSetRelations.head.isInstanceOf[CarbonDatasourceHadoopRelation]) {
+        val srcCarbonTable = srcDataSetRelations.head.carbonRelation.carbonTable
+        if (srcCarbonTable.isHivePartitionTable) {
+          CarbonMergeDataSetUtil.getPartitionSpecToConsiderForPruning(
+            sparkSession,
+            srcCarbonTable,
+            targetCarbonTable)
+        } else {
+          null
+        }
+      } else {
+        val nonCarbonRelations = CarbonSparkUtil.collectNonCarbonRelation(repartitionedSrcDs
+          .logicalPlan)
+        // when the relations are not empty, it means the source dataset is prepared from table
+        if (nonCarbonRelations.nonEmpty &&
+            nonCarbonRelations.head.catalogTable.isDefined &&
+            nonCarbonRelations.head.catalogTable.get.partitionColumnNames != null) {
+          CarbonMergeDataSetUtil.getPartitionSpecToConsiderForPruning(
+            sparkSession,
+            null,
+            targetCarbonTable,
+            nonCarbonRelations.head.catalogTable.get.identifier)
+        } else {
+          null
+        }
+      }
+
+    if (isDistributedPruningEnabled) {
+      val indexFormat = new IndexInputFormat(targetCarbonTable, null, validSegments,
+        Nil.asJava, partitionsToConsider, false, null, false, false)
+      val cdcVO = new CdcVO(columnToIndexMap)
+      indexFormat.setCdcVO(cdcVO)
+      IndexServer.getClient.getSplits(indexFormat).getExtendedBlocklets(indexFormat).asScala
+        .flatMap { blocklet =>
+          blocklet.getColumnToMinMaxMapping.asScala.map {
+            case (columnName, minMaxListWithFilePath) =>
+              val filePathMinMaxList = columnMinMaxInBlocklet.get(columnName)
+              if (filePathMinMaxList != null) {
+                filePathMinMaxList.addAll(minMaxListWithFilePath)
+                columnMinMaxInBlocklet.put(columnName, filePathMinMaxList)
+              } else {
+                columnMinMaxInBlocklet.put(columnName, minMaxListWithFilePath)
+              }
+          }
+        }
+      columnMinMaxInBlocklet.asScala
+    } else {
+      if (targetCarbonTable.isTransactionalTable) {
+        val indexExprWrapper = IndexChooser.getDefaultIndex(targetCarbonTable, null)
+        IndexUtil.loadIndexes(targetCarbonTable, indexExprWrapper, validSegments)
+      }
+      val blocklets = defaultIndex.prune(validSegments, null, partitionsToConsider).asScala
+      columnToIndexMap.asScala.foreach {
+        case (columnName, index) =>
+          val filePathAndMinMaxList = new util.ArrayList[FilePathMinMaxVO]()
+          blocklets.map { blocklet =>
+            val filePathMinMax = new FilePathMinMaxVO(blocklet.getFilePath,
+              CarbonUtil.getMinMaxValue(blocklet
+                .getInputSplit
+                .getIndexRow,
+                BlockletIndexRowIndexes.MIN_VALUES_INDEX)(index),
+              CarbonUtil.getMinMaxValue(blocklet
+                .getInputSplit
+                .getIndexRow,
+                BlockletIndexRowIndexes.MAX_VALUES_INDEX)(index))
+            filePathAndMinMaxList.add(filePathMinMax)
+          }
+          columnMinMaxInBlocklet.put(columnName, filePathAndMinMaxList)
+      }
+      columnMinMaxInBlocklet.asScala
+    }
   }
 }

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/mutation/merge/CarbonMergeDataSetUtil.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/mutation/merge/CarbonMergeDataSetUtil.scala
@@ -1,0 +1,206 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.command.mutation.merge
+
+import java.util
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.TableIdentifier
+import org.apache.spark.sql.optimizer.CarbonFilters
+
+import org.apache.carbondata.core.indexstore.PartitionSpec
+import org.apache.carbondata.core.metadata.datatype.DataTypes
+import org.apache.carbondata.core.metadata.schema.table.CarbonTable
+import org.apache.carbondata.core.metadata.schema.table.column.CarbonColumn
+import org.apache.carbondata.core.mutate.FilePathMinMaxVO
+import org.apache.carbondata.core.util.{ByteUtil, CarbonUtil, DataTypeUtil}
+import org.apache.carbondata.core.util.comparator.SerializableComparator
+
+/**
+ * The utility class for Merge operations
+ */
+object CarbonMergeDataSetUtil {
+
+  /**
+   * This method reads the splits and make (blockPath, (min, max)) tuple to to min max pruning of
+   * the src dataset
+   *
+   * @param colTosplitsFilePathAndMinMaxMap   CarbonInputSplit whose min max cached in driver or
+   *                                          the index server
+   * @param fileMinMaxMapListOfAllJoinColumns collection to hold the filepath and min max of all the
+   *                                          join columns involved
+   */
+  def addFilePathAndMinMaxTuples(
+      colTosplitsFilePathAndMinMaxMap: mutable.Map[String, util.List[FilePathMinMaxVO]],
+      carbonTable: CarbonTable,
+      joinColumnsToComparatorMap: mutable.LinkedHashMap[CarbonColumn, SerializableComparator],
+      fileMinMaxMapListOfAllJoinColumns: mutable.ArrayBuffer[(mutable.Map[String, (AnyRef, AnyRef)],
+        CarbonColumn)]): Unit = {
+    joinColumnsToComparatorMap.foreach { case (joinColumn, comparator) =>
+      val fileMinMaxMap: mutable.Map[String, (AnyRef, AnyRef)] =
+        collection.mutable.Map.empty[String, (AnyRef, AnyRef)]
+      val joinDataType = joinColumn.getDataType
+      val isDimension = joinColumn.isDimension
+      val isPrimitiveAndNotDate = DataTypeUtil.isPrimitiveColumn(joinDataType) &&
+                                  (joinDataType != DataTypes.DATE)
+      colTosplitsFilePathAndMinMaxMap(joinColumn.getColName).asScala.foreach {
+        filePathMinMiax =>
+          val filePath = filePathMinMiax.getFilePath
+          val minBytes = filePathMinMiax.getMin
+          val maxBytes = filePathMinMiax.getMax
+          val uniqBlockPath = if (carbonTable.isHivePartitionTable) {
+            // While data loading to SI created on Partition table, on
+            // partition directory, '/' will be
+            // replaced with '#', to support multi level partitioning. For example, BlockId will be
+            // look like `part1=1#part2=2/xxxxxxxxx`. During query also, blockId should be
+            // replaced by '#' in place of '/', to match and prune data on SI table.
+            CarbonUtil.getBlockId(carbonTable.getAbsoluteTableIdentifier,
+              filePath,
+              "",
+              true,
+              false,
+              true)
+          } else {
+            filePath.substring(filePath.lastIndexOf("/Part") + 1)
+          }
+          if (isDimension) {
+            if (isPrimitiveAndNotDate) {
+              val minValue = DataTypeUtil.getDataBasedOnDataTypeForNoDictionaryColumn(minBytes,
+                joinDataType)
+              val maxValue = DataTypeUtil.getDataBasedOnDataTypeForNoDictionaryColumn(maxBytes,
+                joinDataType)
+              // check here if present in map, if it is, compare and update min and amx
+              if (fileMinMaxMap.contains(uniqBlockPath)) {
+                val isMinLessThanMin =
+                  comparator.compare(fileMinMaxMap(uniqBlockPath)._1, minValue) > 0
+                val isMaxMoreThanMax =
+                  comparator.compare(maxValue, fileMinMaxMap(uniqBlockPath)._2) > 0
+                updateMapIfRequiredBasedOnMinMax(fileMinMaxMap,
+                  minValue,
+                  maxValue,
+                  uniqBlockPath,
+                  isMinLessThanMin,
+                  isMaxMoreThanMax)
+              } else {
+                fileMinMaxMap += (uniqBlockPath -> (minValue, maxValue))
+              }
+            } else {
+              if (fileMinMaxMap.contains(uniqBlockPath)) {
+                val isMinLessThanMin = ByteUtil.UnsafeComparer.INSTANCE
+                                         .compareTo(fileMinMaxMap(uniqBlockPath)._1
+                                           .asInstanceOf[String].getBytes(), minBytes) > 0
+                val isMaxMoreThanMax = ByteUtil.UnsafeComparer.INSTANCE
+                                         .compareTo(maxBytes, fileMinMaxMap(uniqBlockPath)._2
+                                           .asInstanceOf[String].getBytes()) > 0
+                updateMapIfRequiredBasedOnMinMax(fileMinMaxMap,
+                  new String(minBytes),
+                  new String(maxBytes),
+                  uniqBlockPath,
+                  isMinLessThanMin,
+                  isMaxMoreThanMax)
+              } else {
+                fileMinMaxMap += (uniqBlockPath -> (new String(minBytes), new String(maxBytes)))
+              }
+            }
+          } else {
+            val maxValue = DataTypeUtil.getMeasureObjectFromDataType(maxBytes, joinDataType)
+            val minValue = DataTypeUtil.getMeasureObjectFromDataType(minBytes, joinDataType)
+            if (fileMinMaxMap.contains(uniqBlockPath)) {
+              val isMinLessThanMin =
+                comparator.compare(fileMinMaxMap(uniqBlockPath)._1, minValue) > 0
+              val isMaxMoreThanMin =
+                comparator.compare(maxValue, fileMinMaxMap(uniqBlockPath)._2) > 0
+              updateMapIfRequiredBasedOnMinMax(fileMinMaxMap,
+                minValue,
+                maxValue,
+                uniqBlockPath,
+                isMinLessThanMin,
+                isMaxMoreThanMin)
+            } else {
+              fileMinMaxMap += (uniqBlockPath -> (minValue, maxValue))
+            }
+          }
+      }
+      fileMinMaxMapListOfAllJoinColumns += ((fileMinMaxMap, joinColumn))
+    }
+  }
+
+  /**
+   * This method updates the min max map of the block if the value is less than min or more
+   * than max
+   */
+  private def updateMapIfRequiredBasedOnMinMax(fileMinMaxMap: mutable.Map[String, (AnyRef, AnyRef)],
+      minValue: AnyRef,
+      maxValue: AnyRef,
+      uniqBlockPath: String,
+      isMinLessThanMin: Boolean,
+      isMaxMoreThanMin: Boolean): Unit = {
+    (isMinLessThanMin, isMaxMoreThanMin) match {
+      case (true, true) => fileMinMaxMap(uniqBlockPath) = (minValue, maxValue)
+      case (true, false) => fileMinMaxMap(uniqBlockPath) = (minValue,
+        fileMinMaxMap(uniqBlockPath)._2)
+      case (false, true) => fileMinMaxMap(uniqBlockPath) = (fileMinMaxMap(uniqBlockPath)._1,
+        maxValue)
+      case _ =>
+    }
+  }
+
+  /**
+   * This method returns the partitions required to scan in the target table based on the
+   * partitions present in the src table or dataset
+   */
+  def getPartitionSpecToConsiderForPruning(sparkSession: SparkSession,
+      srcCarbonTable: CarbonTable,
+      targetCarbonTable: CarbonTable,
+      identifier: TableIdentifier = null): util.List[PartitionSpec] = {
+    val partitionsToConsider = if (targetCarbonTable.isHivePartitionTable) {
+      // handle the case of multiple partition columns in src and target and subset of
+      //  partition columns
+      val srcTableIdentifier = if (identifier == null) {
+        TableIdentifier(srcCarbonTable.getTableName, Some(srcCarbonTable.getDatabaseName))
+      } else {
+        identifier
+      }
+      val srcPartitions = CarbonFilters.getPartitions(
+        Seq.empty,
+        sparkSession,
+        srcTableIdentifier)
+        .map(_.toList.flatMap(_.getPartitions.asScala))
+        .orNull
+      // get all the partitionSpec of target table which intersects with source partitions
+      // example if the target has partitions as a=1/b=2/c=3, and src has e=1/a=1/b=2/d=4
+      // we will consider the specific target partition as intersect gives results and also we
+      // don't want to go very fine grain for partitions as location will be a single for nested
+      // partitions.
+      CarbonFilters.getPartitions(
+        Seq.empty,
+        sparkSession,
+        TableIdentifier(
+          targetCarbonTable.getTableName,
+          Some(targetCarbonTable.getDatabaseName))).map(_.toList.filter {
+        partitionSpec =>
+          partitionSpec.getPartitions.asScala.intersect(srcPartitions).nonEmpty
+      }).orNull
+    } else {
+      null
+    }
+    partitionsToConsider.asJava
+  }
+}

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/mutation/merge/MergeHandler.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/mutation/merge/MergeHandler.scala
@@ -152,7 +152,7 @@ case class UpdateHandler(
     srcDS: DataFrame) extends MergeHandler(sparkSession, frame, targetCarbonTable, stats, srcDS) {
 
   override def handleMerge(): Unit = {
-    assert(frame != null)
+    assert(frame != null, "The dataframe used to perform merge can be only for insert operation")
     val factTimestamp = System.currentTimeMillis()
     val executorErrors = ExecutionErrors(FailureCauses.NONE, "")
     val (deltaRdd, path) = performTagging
@@ -175,7 +175,7 @@ case class DeleteHandler(
     stats: Stats,
     srcDS: DataFrame) extends MergeHandler(sparkSession, frame, targetCarbonTable, stats, srcDS) {
   override def handleMerge(): Unit = {
-    assert(frame != null)
+    assert(frame != null, "The dataframe used to perform merge can be only for insert operation")
     val factTimestamp = System.currentTimeMillis()
     val executorErrors = ExecutionErrors(FailureCauses.NONE, "")
     val (deleteRDD, path) = performTagging
@@ -206,7 +206,7 @@ case class UpsertHandler(
     stats: Stats,
     srcDS: DataFrame) extends MergeHandler(sparkSession, frame, targetCarbonTable, stats, srcDS) {
   override def handleMerge(): Unit = {
-    assert(frame != null)
+    assert(frame != null, "The dataframe used to perform merge can be only for insert operation")
     val factTimestamp = System.currentTimeMillis()
     val executorErrors = ExecutionErrors(FailureCauses.NONE, "")
     val (updateDataRDD, path) = performTagging

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/mutation/merge/MergeHandler.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/mutation/merge/MergeHandler.scala
@@ -1,0 +1,213 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.command.mutation.merge
+
+import java.util
+import java.util.UUID
+
+import scala.collection.JavaConverters._
+
+import org.apache.hadoop.fs.Path
+import org.apache.hadoop.mapreduce.{JobID, TaskAttemptID, TaskID, TaskType}
+import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat
+import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.{DataFrame, Row, SparkSession}
+import org.apache.spark.sql.avro.AvroFileFormatFactory
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
+import org.apache.spark.sql.execution.command.{ExecutionErrors, UpdateTableModel}
+import org.apache.spark.sql.execution.command.mutation.HorizontalCompaction
+import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.types.{StringType, StructField}
+import org.apache.spark.sql.util.SparkSQLUtil
+
+import org.apache.carbondata.core.constants.CarbonCommonConstants
+import org.apache.carbondata.core.datastore.impl.FileFactory
+import org.apache.carbondata.core.index.Segment
+import org.apache.carbondata.core.metadata.schema.table.CarbonTable
+import org.apache.carbondata.core.mutate.SegmentUpdateDetails
+import org.apache.carbondata.processing.loading.FailureCauses
+import org.apache.carbondata.spark.util.CarbonSparkUtil
+
+/**
+ * This class handles the merge actions of UPSERT, UPDATE, DELETE, INSERT
+ */
+abstract class MergeHandler(sparkSession: SparkSession,
+    frame: DataFrame,
+    targetCarbonTable: CarbonTable,
+    stats: Stats,
+    srcDS: DataFrame) {
+
+  protected def performTagging: (RDD[Row], String) = {
+    val tupleId = frame.queryExecution.analyzed.output.zipWithIndex
+      .find(_._1.name.equalsIgnoreCase(CarbonCommonConstants.CARBON_IMPLICIT_COLUMN_TUPLEID)).get._2
+    val schema =
+      org.apache.spark.sql.types.StructType(Seq(
+        StructField(CarbonCommonConstants.CARBON_IMPLICIT_COLUMN_TUPLEID, StringType)))
+    val job = CarbonSparkUtil.createHadoopJob()
+    job.setOutputKeyClass(classOf[Void])
+    job.setOutputValueClass(classOf[InternalRow])
+    val insertedRows = stats.insertedRows
+    val updatedRows = stats.updatedRows
+    val uuid = UUID.randomUUID.toString
+    job.setJobID(new JobID(uuid, 0))
+    val path = targetCarbonTable.getTablePath + CarbonCommonConstants.FILE_SEPARATOR + "avro"
+    FileOutputFormat.setOutputPath(job, new Path(path))
+    val factory = AvroFileFormatFactory.getAvroWriter(sparkSession, job, schema)
+    val config = SparkSQLUtil.broadCastHadoopConf(sparkSession.sparkContext, job.getConfiguration)
+    frame.queryExecution.toRdd.mapPartitionsWithIndex { case (index, iterator) =>
+      val confB = config.value.value
+      val task = new TaskID(new JobID(uuid, 0), TaskType.MAP, index)
+      val attemptID = new TaskAttemptID(task, index)
+      val context = new TaskAttemptContextImpl(confB, attemptID)
+      val writer = factory.newInstance(path + CarbonCommonConstants.FILE_SEPARATOR + task.toString,
+        schema, context)
+      new Iterator[InternalRow] {
+        override def hasNext: Boolean = {
+          if (iterator.hasNext) {
+            true
+          } else {
+            writer.close()
+            false
+          }
+        }
+
+        override def next(): InternalRow = {
+          val row = iterator.next()
+          val newArray = new Array[Any](1)
+          val tupleID = row.getUTF8String(tupleId)
+          if (tupleID == null) {
+            insertedRows.add(1)
+          } else {
+            newArray(0) = tupleID
+            writer.write(new GenericInternalRow(newArray))
+            updatedRows.add(1)
+          }
+          null
+        }
+      }
+    }.count()
+    val deltaRdd = AvroFileFormatFactory.readAvro(sparkSession, path)
+    (deltaRdd, path)
+  }
+
+  protected def triggerAction(factTimestamp: Long,
+      executorErrors: ExecutionErrors,
+      deltaRdd: RDD[Row],
+      deltaPath: String): (util.List[SegmentUpdateDetails], Seq[Segment]) = {
+    val tuple = MergeUtil.triggerAction(sparkSession,
+      targetCarbonTable,
+      factTimestamp,
+      executorErrors,
+      deltaRdd)
+    FileFactory.deleteAllCarbonFilesOfDir(FileFactory.getCarbonFile(deltaPath))
+    MergeUtil.updateSegmentStatusAfterUpdateOrDelete(targetCarbonTable, factTimestamp, tuple)
+    tuple
+  }
+
+  protected def insertDataToTargetTable(updateTableModel: Option[UpdateTableModel]): Seq[Row] = {
+    val tableCols =
+      targetCarbonTable.getCreateOrderColumn.asScala.map(_.getColName).
+        filterNot(_.equalsIgnoreCase(CarbonCommonConstants.DEFAULT_INVISIBLE_DUMMY_MEASURE))
+    val header = tableCols.mkString(",")
+    val dataFrame = srcDS.select(tableCols.map(col): _*)
+    MergeUtil.insertDataToTargetTable(sparkSession,
+      targetCarbonTable,
+      header,
+      updateTableModel,
+      dataFrame)
+  }
+
+  protected def tryHorizontalCompaction(): Unit = {
+    // Do IUD Compaction.
+    HorizontalCompaction.tryHorizontalCompaction(
+      sparkSession, targetCarbonTable)
+  }
+
+  def handleMerge()
+}
+
+case class UpdateHandler(sparkSession: SparkSession,
+    frame: DataFrame,
+    targetCarbonTable: CarbonTable,
+    stats: Stats,
+    srcDS: DataFrame) extends MergeHandler(sparkSession, frame, targetCarbonTable, stats, srcDS) {
+
+  override def handleMerge(): Unit = {
+    assert(frame != null)
+    val factTimestamp = System.currentTimeMillis()
+    val executorErrors = ExecutionErrors(FailureCauses.NONE, "")
+    val (deltaRdd, path) = performTagging
+    if (deltaRdd.isEmpty()) {
+      return
+    }
+    val tuple = triggerAction(factTimestamp, executorErrors, deltaRdd, path)
+    val updateTableModel = Some(UpdateTableModel(isUpdate = true, factTimestamp,
+      executorErrors, tuple._2, Option.empty))
+    insertDataToTargetTable(updateTableModel)
+    tryHorizontalCompaction()
+  }
+
+}
+
+case class DeleteHandler(sparkSession: SparkSession,
+    frame: DataFrame,
+    targetCarbonTable: CarbonTable,
+    stats: Stats,
+    srcDS: DataFrame) extends MergeHandler(sparkSession, frame, targetCarbonTable, stats, srcDS) {
+  override def handleMerge(): Unit = {
+    assert(frame != null)
+    val factTimestamp = System.currentTimeMillis()
+    val executorErrors = ExecutionErrors(FailureCauses.NONE, "")
+    val (deleteRDD, path) = performTagging
+    if (deleteRDD.isEmpty()) {
+      return
+    }
+    triggerAction(factTimestamp, executorErrors, deleteRDD, path)
+    MergeUtil.updateStatusIfJustDeleteOperation(targetCarbonTable, factTimestamp)
+    tryHorizontalCompaction()
+  }
+}
+
+case class InsertHandler(sparkSession: SparkSession,
+    frame: DataFrame,
+    targetCarbonTable: CarbonTable,
+    stats: Stats,
+    srcDS: DataFrame) extends MergeHandler(sparkSession, frame, targetCarbonTable, stats, srcDS) {
+  override def handleMerge(): Unit = {
+    insertDataToTargetTable(None)
+  }
+}
+
+case class UpsertHandler(sparkSession: SparkSession,
+    frame: DataFrame,
+    targetCarbonTable: CarbonTable,
+    stats: Stats,
+    srcDS: DataFrame) extends MergeHandler(sparkSession, frame, targetCarbonTable, stats, srcDS) {
+  override def handleMerge(): Unit = {
+    assert(frame != null)
+    val factTimestamp = System.currentTimeMillis()
+    val executorErrors = ExecutionErrors(FailureCauses.NONE, "")
+    val (updateDataRDD, path) = performTagging
+    val tuple = triggerAction(factTimestamp, executorErrors, updateDataRDD, path)
+    val updateTableModel = Some(UpdateTableModel(isUpdate = true, factTimestamp,
+      executorErrors, tuple._2, Option.empty))
+    insertDataToTargetTable(updateTableModel)
+    tryHorizontalCompaction()
+  }
+}

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/mutation/merge/MergeHandler.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/mutation/merge/MergeHandler.scala
@@ -47,7 +47,8 @@ import org.apache.carbondata.spark.util.CarbonSparkUtil
 /**
  * This class handles the merge actions of UPSERT, UPDATE, DELETE, INSERT
  */
-abstract class MergeHandler(sparkSession: SparkSession,
+abstract class MergeHandler(
+    sparkSession: SparkSession,
     frame: DataFrame,
     targetCarbonTable: CarbonTable,
     stats: Stats,
@@ -106,7 +107,8 @@ abstract class MergeHandler(sparkSession: SparkSession,
     (deltaRdd, path)
   }
 
-  protected def triggerAction(factTimestamp: Long,
+  protected def triggerAction(
+      factTimestamp: Long,
       executorErrors: ExecutionErrors,
       deltaRdd: RDD[Row],
       deltaPath: String): (util.List[SegmentUpdateDetails], Seq[Segment]) = {
@@ -142,7 +144,8 @@ abstract class MergeHandler(sparkSession: SparkSession,
   def handleMerge()
 }
 
-case class UpdateHandler(sparkSession: SparkSession,
+case class UpdateHandler(
+    sparkSession: SparkSession,
     frame: DataFrame,
     targetCarbonTable: CarbonTable,
     stats: Stats,
@@ -165,7 +168,8 @@ case class UpdateHandler(sparkSession: SparkSession,
 
 }
 
-case class DeleteHandler(sparkSession: SparkSession,
+case class DeleteHandler(
+    sparkSession: SparkSession,
     frame: DataFrame,
     targetCarbonTable: CarbonTable,
     stats: Stats,
@@ -184,7 +188,8 @@ case class DeleteHandler(sparkSession: SparkSession,
   }
 }
 
-case class InsertHandler(sparkSession: SparkSession,
+case class InsertHandler(
+    sparkSession: SparkSession,
     frame: DataFrame,
     targetCarbonTable: CarbonTable,
     stats: Stats,
@@ -194,7 +199,8 @@ case class InsertHandler(sparkSession: SparkSession,
   }
 }
 
-case class UpsertHandler(sparkSession: SparkSession,
+case class UpsertHandler(
+    sparkSession: SparkSession,
     frame: DataFrame,
     targetCarbonTable: CarbonTable,
     stats: Stats,

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/mutation/merge/MergeOperationType.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/mutation/merge/MergeOperationType.scala
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.command.mutation.merge
+
+/**
+ * Operation Type for the merge APIs
+ */
+object MergeOperationType extends Enumeration {
+
+  type MergeOperationType = Value
+
+  val UPSERT: MergeOperationType.Value = Value("UPSERT")
+
+  val UPDATE: MergeOperationType.Value = Value("UPDATE")
+
+  val DELETE: MergeOperationType.Value = Value("DELETE")
+
+  val INSERT: MergeOperationType.Value = Value("INSERT")
+
+}

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/mutation/merge/MergeUtil.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/mutation/merge/MergeUtil.scala
@@ -39,6 +39,14 @@ object MergeUtil {
 
   val LOGGER = LogServiceFactory.getLogService(this.getClass.getName)
 
+  /**
+   * This method triggers the merge action based calling merge handler
+   * @param carbonTable target carbon table
+   * @param factTimestamp the timestamp used for update and delete actions
+   * @param executorErrors executor errors returned from the operations like update and delete
+   * @param update RDD[ROW] which contains the rows to update or delete
+   * @return the segment list and the metadata details of the segments updated or deleted
+   */
   def triggerAction(sparkSession: SparkSession,
       carbonTable: CarbonTable,
       factTimestamp: Long,
@@ -56,6 +64,12 @@ object MergeUtil {
     tupleProcessed1
   }
 
+  /**
+   * This method updates the segment status after update or delete operation
+   * @param targetCarbonTable target carbon table
+   * @param factTimeStamp timestamp to update in the status which is used in update/delete operation
+   * @param tuple contains the segment list and the metadata details of the segments updated/deleted
+   */
   def updateSegmentStatusAfterUpdateOrDelete(targetCarbonTable: CarbonTable,
       factTimeStamp: Long,
       tuple: (util.List[SegmentUpdateDetails], Seq[Segment])): Unit = {
@@ -66,6 +80,14 @@ object MergeUtil {
     }
   }
 
+  /**
+   * This methods inserts the data to target carbon table.
+   * @param targetCarbonTable target carbon table to insert
+   * @param header            header of the data to be inserted
+   * @param updateTableModel  updated model if any for insert
+   * @param dataFrame         datframe to write into target carbon table.
+   * @return the segmentID created afterthis insert operation.
+   */
   def insertDataToTargetTable(sparkSession: SparkSession,
       targetCarbonTable: CarbonTable,
       header: String,
@@ -84,6 +106,12 @@ object MergeUtil {
     ).run(sparkSession)
   }
 
+  /**
+   * This method is to update the status only for delete operation.
+   * @param targetCarbonTable target carbon table
+   * @param factTimestamp timestamp to update in the status which is used in update/delete operation
+   * @return whether update status is successful or not
+   */
   def updateStatusIfJustDeleteOperation(targetCarbonTable: CarbonTable,
       factTimestamp: Long): Boolean = {
     val loadMetaDataDetails = SegmentStatusManager.readTableStatusFile(CarbonTablePath

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/mutation/merge/MergeUtil.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/mutation/merge/MergeUtil.scala
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.command.mutation.merge
+
+import java.util
+
+import scala.collection.JavaConverters._
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.{DataFrame, Row, SparkSession}
+import org.apache.spark.sql.execution.command.{ExecutionErrors, UpdateTableModel}
+import org.apache.spark.sql.execution.command.management.CarbonInsertIntoCommand
+import org.apache.spark.sql.execution.command.mutation.DeleteExecution
+
+import org.apache.carbondata.common.logging.LogServiceFactory
+import org.apache.carbondata.core.index.Segment
+import org.apache.carbondata.core.metadata.schema.table.CarbonTable
+import org.apache.carbondata.core.mutate.{CarbonUpdateUtil, SegmentUpdateDetails}
+import org.apache.carbondata.core.statusmanager.SegmentStatusManager
+import org.apache.carbondata.core.util.path.CarbonTablePath
+import org.apache.carbondata.events.OperationContext
+
+
+object MergeUtil {
+
+  val LOGGER = LogServiceFactory.getLogService(this.getClass.getName)
+
+  def triggerAction(sparkSession: SparkSession,
+      carbonTable: CarbonTable,
+      factTimestamp: Long,
+      executorErrors: ExecutionErrors,
+      update: RDD[Row]): (util.List[SegmentUpdateDetails], Seq[Segment]) = {
+    val tuple1 = DeleteExecution.deleteDeltaExecutionInternal(Some(carbonTable.getDatabaseName),
+      carbonTable.getTableName,
+      sparkSession, update,
+      factTimestamp.toString,
+      isUpdateOperation = true, executorErrors, Some(0))
+    MutationActionFactory.checkErrors(executorErrors)
+    val tupleProcessed1 = DeleteExecution.processSegments(executorErrors, tuple1._1, carbonTable,
+      factTimestamp.toString, tuple1._2)
+    MutationActionFactory.checkErrors(executorErrors)
+    tupleProcessed1
+  }
+
+  def updateSegmentStatusAfterUpdateOrDelete(targetCarbonTable: CarbonTable,
+      factTimeStamp: Long,
+      tuple: (util.List[SegmentUpdateDetails], Seq[Segment])): Unit = {
+    if (!CarbonUpdateUtil.updateSegmentStatus(tuple._1, targetCarbonTable,
+      factTimeStamp.toString, false, false)) {
+      LOGGER.error("writing of update status file failed")
+      throw new CarbonMergeDataSetException("writing of update status file failed")
+    }
+  }
+
+  def insertDataToTargetTable(sparkSession: SparkSession,
+      targetCarbonTable: CarbonTable,
+      header: String,
+      updateTableModel: Option[UpdateTableModel],
+      dataFrame: DataFrame): Seq[Row] = {
+    CarbonInsertIntoCommand(databaseNameOp = Some(targetCarbonTable.getDatabaseName),
+      tableName = targetCarbonTable.getTableName,
+      options = Map("fileheader" -> header),
+      isOverwriteTable = false,
+      dataFrame.queryExecution.logical,
+      targetCarbonTable.getTableInfo,
+      Map.empty,
+      Map.empty,
+      new OperationContext,
+      updateTableModel
+    ).run(sparkSession)
+  }
+
+  def updateStatusIfJustDeleteOperation(targetCarbonTable: CarbonTable,
+      factTimestamp: Long): Boolean = {
+    val loadMetaDataDetails = SegmentStatusManager.readTableStatusFile(CarbonTablePath
+      .getTableStatusFilePath(targetCarbonTable.getTablePath))
+    CarbonUpdateUtil.updateTableMetadataStatus(loadMetaDataDetails.map(loadMetadataDetail =>
+      new Segment(loadMetadataDetail.getMergedLoadName,
+        loadMetadataDetail.getSegmentFile)).toSet.asJava,
+      targetCarbonTable,
+      factTimestamp.toString,
+      true,
+      true, new util.ArrayList[Segment]())
+  }
+}

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/mutation/merge/MutationAction.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/mutation/merge/MutationAction.scala
@@ -52,16 +52,7 @@ abstract class MutationAction(sparkSession: SparkSession, carbonTable: CarbonTab
       val status = row.get(1)
       status != null && condition(status.asInstanceOf[Int])
     }
-    val tuple1 = DeleteExecution.deleteDeltaExecutionInternal(Some(carbonTable.getDatabaseName),
-      carbonTable.getTableName,
-      sparkSession, update,
-      factTimestamp.toString,
-      true, executorErrors, Some(0))
-    MutationActionFactory.checkErrors(executorErrors)
-    val tupleProcessed1 = DeleteExecution.processSegments(executorErrors, tuple1._1, carbonTable,
-      factTimestamp.toString, tuple1._2)
-    MutationActionFactory.checkErrors(executorErrors)
-    tupleProcessed1
+    MergeUtil.triggerAction(sparkSession, carbonTable, factTimestamp, executorErrors, update)
   }
 
 }

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/mutation/merge/UpsertBuilder.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/mutation/merge/UpsertBuilder.scala
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.command.mutation.merge
+
+import org.apache.spark.sql.{Column, Dataset, Row, SparkSession}
+
+class UpsertBuilder(existingDsOri: Dataset[Row], currDs: Dataset[Row],
+    keyColumn: String, operationType: String, sparkSession: SparkSession) {
+
+  def build(): CarbonMergeDataSetCommand = {
+    CarbonMergeDataSetCommand(existingDsOri, currDs, null, keyColumn, operationType)
+  }
+
+  def execute(): Unit = {
+    build().run(sparkSession)
+  }
+}

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/mutation/merge/udf/BlockPathsUDF.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/mutation/merge/udf/BlockPathsUDF.scala
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.command.mutation.merge.udf
+
+import org.apache.spark.sql.sources.Filter
+
+import org.apache.carbondata.common.annotations.InterfaceAudience
+
+@InterfaceAudience.Internal
+class BlockPathsUDF extends (String => Boolean) with Serializable {
+  override def apply(v1: String): Boolean = {
+    v1.nonEmpty
+  }
+
+}

--- a/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/CarbonFilters.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/CarbonFilters.scala
@@ -23,7 +23,7 @@ import scala.collection.JavaConverters._
 import scala.util.Try
 
 import org.apache.spark.sql.{CarbonBoundReference, CarbonDatasourceHadoopRelation, CarbonEnv,
-  Dataset, SparkSession, SparkUnknownExpression}
+  SparkSession, SparkUnknownExpression}
 import org.apache.spark.sql.carbondata.execution.datasources.CarbonSparkDataSourceUtil
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.catalog.CatalogTablePartition
@@ -33,6 +33,7 @@ import org.apache.spark.sql.catalyst.expressions.{And, ArrayContains, Attribute,
   ScalaUDF, StartsWith, StringTrim}
 import org.apache.spark.sql.catalyst.expressions.{Expression => SparkExpression}
 import org.apache.spark.sql.execution.CastExpressionOptimization
+import org.apache.spark.sql.execution.command.mutation.merge.udf.BlockPathsUDF
 import org.apache.spark.sql.hive.{CarbonHiveIndexMetadataUtil, CarbonSessionCatalogUtil}
 import org.apache.spark.sql.types.{ArrayType, BooleanType, DecimalType, DoubleType, FloatType,
   IntegerType, LongType, MapType, StringType, StructType, TimestampType}
@@ -47,9 +48,9 @@ import org.apache.carbondata.core.metadata.datatype.{DataType, DataTypes}
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable
 import org.apache.carbondata.core.scan.expression.{ColumnExpression, Expression,
   LiteralExpression, MatchExpression}
-import org.apache.carbondata.core.scan.expression.conditional.{EqualToExpression,
-  GreaterThanEqualToExpression, GreaterThanExpression, ImplicitExpression, InExpression,
-  LessThanEqualToExpression, LessThanExpression, ListExpression, NotEqualsExpression,
+import org.apache.carbondata.core.scan.expression.conditional.{CDCBlockImplicitExpression,
+  EqualToExpression, GreaterThanEqualToExpression, GreaterThanExpression, ImplicitExpression,
+  InExpression, LessThanEqualToExpression, LessThanExpression, ListExpression, NotEqualsExpression,
   NotInExpression, StartsWithExpression}
 import org.apache.carbondata.core.scan.expression.logical.{AndExpression, FalseExpression,
   OrExpression}
@@ -286,6 +287,11 @@ object CarbonFilters {
         val (columnName, instance) = getGeoHashHandler(relation.carbonTable)
         Some(new PolygonRangeListExpression(children.head.toString(), children.last.toString(),
           columnName, instance))
+      case _: BlockPathsUDF =>
+        if (children.size > 1) {
+          throw new MalformedCarbonCommandException("Expect one string in polygon")
+        }
+        Some(new CDCBlockImplicitExpression(children.head.toString()))
       case _ => None
     }
   }

--- a/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/CarbonFilters.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/CarbonFilters.scala
@@ -289,7 +289,8 @@ object CarbonFilters {
           columnName, instance))
       case _: BlockPathsUDF =>
         if (children.size > 1) {
-          throw new MalformedCarbonCommandException("Expect one string in polygon")
+          throw new MalformedCarbonCommandException(
+            "Expected one comma separated values of block paths")
         }
         Some(new CDCBlockImplicitExpression(children.head.toString()))
       case _ => None

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/merge/MergeTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/merge/MergeTestCase.scala
@@ -808,7 +808,7 @@ class MergeTestCase extends QueryTest with BeforeAndAfterAll {
         StructType(Seq(StructField("key", StringType),
           StructField("value", IntegerType), StructField("country", StringType))))
     // upsert API
-    target.as("A").merge(cdc.as("B"), "key", "upsert").execute()
+    target.as("A").upsert(cdc.as("B"), "key").execute()
     checkAnswer(sql("select * from target"),
       Seq(Row("a", 7, "CHINA"), Row("b", 1, "UK"), Row("g", null, "UK"), Row("e", 3, "US"),
         Row("c", 2, "INDIA"), Row("d", 3, "US")))
@@ -820,7 +820,7 @@ class MergeTestCase extends QueryTest with BeforeAndAfterAll {
         StructType(Seq(StructField("key", StringType),
           StructField("value", IntegerType), StructField("country", StringType))))
     // delete API
-    target.as("A").merge(cdc.as("B"), "key", "delete").execute()
+    target.as("A").delete(cdc.as("B"), "key").execute()
     checkAnswer(sql("select * from target"),
       Seq(Row("b", 1, "UK"), Row("g", null, "UK"), Row("c", 2, "INDIA"), Row("d", 3, "US")))
     // update API
@@ -830,7 +830,7 @@ class MergeTestCase extends QueryTest with BeforeAndAfterAll {
       ).asJava,
         StructType(Seq(StructField("key", StringType),
           StructField("value", IntegerType), StructField("country", StringType))))
-    target.as("A").merge(cdc.as("B"), "key", "update").execute()
+    target.as("A").update(cdc.as("B"), "key").execute()
     checkAnswer(sql("select * from target"),
       Seq(Row("b", 1, "UK"), Row("g", 8, "RUSSIA"), Row("c", 2, "INDIA"), Row("d", 3, "US")))
     // insert API
@@ -841,7 +841,7 @@ class MergeTestCase extends QueryTest with BeforeAndAfterAll {
       ).asJava,
         StructType(Seq(StructField("key", StringType),
           StructField("value", IntegerType), StructField("country", StringType))))
-    target.as("A").merge(cdc.as("B"), "key", "insert").execute()
+    target.as("A").insert(cdc.as("B"), "key").execute()
     checkAnswer(sql("select * from target"),
       Seq(Row("b", 1, "UK"), Row("g", 8, "RUSSIA"), Row("c", 2, "INDIA"), Row("d", 3, "US"),
         Row("j", 2, "RUSSIA"), Row("k", 0, "INDIA")))
@@ -871,7 +871,7 @@ class MergeTestCase extends QueryTest with BeforeAndAfterAll {
         StructType(Seq(StructField("key", StringType),
           StructField("value", StringType))))
     // upsert API
-    target.as("A").merge(cdc.as("B"), "key", "upsert").execute()
+    target.as("A").upsert(cdc.as("B"), "key").execute()
     checkAnswer(sql("select * from target"),
       Seq(Row("a", "7"), Row("b", null), Row("g", null), Row("e", "3"), Row("c", "2"),
         Row("d", "3")))
@@ -884,7 +884,7 @@ class MergeTestCase extends QueryTest with BeforeAndAfterAll {
         StructType(Seq(StructField("key", StringType),
           StructField("value", StringType))))
     // delete API
-    target.as("A").merge(cdc.as("B"), "key", "delete").execute()
+    target.as("A").delete(cdc.as("B"), "key").execute()
     checkAnswer(sql("select * from target"),
       Seq(Row("b", null), Row("g", null), Row("c", "2"), Row("d", "3")))
 
@@ -895,7 +895,7 @@ class MergeTestCase extends QueryTest with BeforeAndAfterAll {
         StructType(Seq(StructField("key", StringType),
           StructField("value", StringType))))
     // update API
-    target.as("A").merge(cdc.as("B"), "key", "update").execute()
+    target.as("A").update(cdc.as("B"), "key").execute()
     checkAnswer(sql("select * from target"),
       Seq(Row("b", null), Row("g", "56"), Row("c", "2"), Row("d", "3")))
 
@@ -907,7 +907,7 @@ class MergeTestCase extends QueryTest with BeforeAndAfterAll {
         StructType(Seq(StructField("key", StringType),
           StructField("value", StringType))))
     // insert API
-    target.as("A").merge(cdc.as("B"), "key", "insert").execute()
+    target.as("A").insert(cdc.as("B"), "key").execute()
 
     checkAnswer(sql("select * from target"),
       Seq(Row("b", null), Row("g", "56"), Row("c", "2"), Row("d", "3"), Row("z", "234"),


### PR DESCRIPTION
 ### Why is this PR needed?
 1.	In the exiting solution, when we perform join of the source and target dataset for tagging records to delete, update and insert records, we were scanning all the data of target table and then perform join with source dataset. But it can happen that the source data is less and its range may cover only some 100s of Carbondata files out of 1000s of files in the target table. So pruning is main bottleneck here, so scanning all records and involving in join results in so much of shuffle and reduces performance.
2.	Source data caching was not there, caching source data will help to improve its multiple scans and since input source data will be of less size, we can persist the dataset.
3.	When we were performing join, we used to first get the Row object and then operate on it and then for each datatype casting happens to convert to spark datatype and then covert to InternalRow object for further processing of joined data. This will add extra deserializeToObject and map nodes in DAG and increase time.
4.	Initially during tagging records(Join operation), we were preparing a new projection of required columns, which basically involves operations of preparing an internal row object as explained in point 3, and then apply eval function on each row to prepare a projection, so this basically applying same eval of expression on joined data, a repeated work and increases time.
5.	In join operation we were using all the columns of source dataset and the required columns of target table like, join key column and other columns of tupleID, status_on_mergeds etc. So when we there will be so many columns in the table, then it will increase the execution time due to lot of data shuffling.
6.	The current APIs of merge are little bit complex and generalized and confusing to user for simple Upsert, delete and insert operations.

 
 ### What changes were proposed in this PR?
1.	Add a pruning logic before the join operations. Compare the incoming row with an interval based tree data structure which contains the Carbondata file path and min and max to identify the Carbondata file where the incoming row can be present, so that in some use case scenario which will be explained in later section, can give benefit and help to scan less files rather than blindly scanning all the Carbondata files in the target table.
2.	Cache the incoming source dataset srcDS.cache(), so that the cached data will be used in all the operations and speed will be improved. Uncache() after the merge operation
3.	Instead of operating on row object and then converting to InternalRow, directly operate on the InternalRow object to avoid the data type conversions.
4.	Instead of evaluating the expression again based on required project columns on matching conditions and making new projection, directly identify the indexes required for output row and then directly access these indices on the incoming internal row object after step3, so evaluation is avoided and array access with indices will give O(1) performance.
5.	During join or the tagging of records, do not include all the column data, just include the join key columns and identify the tupleIDs to delete and the rows to insert, this will avoid lot of shuffle and improve performance significantly.
6.	Introduce new APIs for UPSERT, UPDATE, DELETE and INSERT and make the user exposed APIs simple. So now user just needs to give the key column for join, source dataset and the operation type as mentioned above. These new APIs will make use of all the improvements mentioned above and avoid unnecessary operations of the existing merge APIs.  
    
 ### Does this PR introduce any user interface change?
 - No
 - Yes. (please explain the change and update document)

 ### Is any new testcase added?
 - Yes

    
