### PR TITLE
[CARBONDATA-4206] Support rename SI table

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/indextable/IndexMetadata.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/indextable/IndexMetadata.java
@@ -97,6 +97,17 @@ public class IndexMetadata implements Serializable {
     }
   }
 
+  public void renameIndexWithStatus(String indexProvider, String oldIndexName,
+      String newIndexName, String indexStatus) {
+    if (null != indexProviderMap) {
+      Map<String, String> properties = indexProviderMap.get(indexProvider).remove(oldIndexName);
+      if (properties != null) {
+        properties.put(CarbonCommonConstants.INDEX_STATUS, indexStatus);
+        indexProviderMap.get(indexProvider).put(newIndexName, properties);
+      }
+    }
+  }
+
   public void updateIndexStatus(String indexProvider, String indexName, String indexStatus) {
     if (null != indexProviderMap) {
       indexProviderMap.get(indexProvider).get(indexName)
@@ -161,5 +172,9 @@ public class IndexMetadata implements Serializable {
 
   public String getIndexColumns(String provider, String indexName) {
     return indexProviderMap.get(provider).get(indexName).get(CarbonCommonConstants.INDEX_COLUMNS);
+  }
+
+  public String getIndexStatus(String provider, String indexName) {
+    return indexProviderMap.get(provider).get(indexName).get(CarbonCommonConstants.INDEX_STATUS);
   }
 }

--- a/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/events/AlterTableRenameEventListener.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/events/AlterTableRenameEventListener.scala
@@ -23,7 +23,6 @@ import org.apache.log4j.Logger
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.CarbonEnv
 import org.apache.spark.sql.hive._
-import org.apache.spark.sql.index.CarbonIndexUtil
 
 import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.core.metadata.index.IndexType
@@ -40,11 +39,11 @@ class AlterTableRenameEventListener extends OperationEventListener with Logging 
    */
   override def onEvent(event: Event, operationContext: OperationContext): Unit = {
     event match {
-      case alterTableRenamePreEvent: AlterTableRenamePostEvent =>
-        LOGGER.info("alter table rename Pre event listener called")
-        val alterTableRenameModel = alterTableRenamePreEvent.alterTableRenameModel
-        val carbonTable = alterTableRenamePreEvent.carbonTable
-        val sparkSession = alterTableRenamePreEvent.sparkSession
+      case alterTableRenamePostEvent: AlterTableRenamePostEvent =>
+        LOGGER.info("alter table rename post event listener called")
+        val alterTableRenameModel = alterTableRenamePostEvent.alterTableRenameModel
+        val carbonTable = alterTableRenamePostEvent.carbonTable
+        val sparkSession = alterTableRenamePostEvent.sparkSession
         val oldDatabaseName = carbonTable.getDatabaseName
         val newTableName = alterTableRenameModel.newTableIdentifier.table
         val metastore = CarbonEnv.getInstance(sparkSession).carbonMetaStore


### PR DESCRIPTION
 ### Why is this PR needed?
Currently rename SI table can succeed, but after rename, insert and query on main table failed, throw no such table exception. This is because after SI table renamed, main table's tblproperties didn't get update, it still stores the old SI table name, when refering to SI table, it tries to find the SI table by old name, which leads to no such table exception.
 
 ### What changes were proposed in this PR?
After SI table renamed, update the main table's tblproperties with new SI information.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
