### PR TITLE
[CARBONDATA-4208] Wrong Exception received for complex child long string columns

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/column/ColumnSchema.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/schema/table/column/ColumnSchema.java
@@ -37,6 +37,7 @@ import org.apache.carbondata.core.metadata.encoder.Encoding;
 import org.apache.carbondata.core.metadata.schema.table.Writable;
 import org.apache.carbondata.core.metadata.schema.table.WritableUtil;
 import org.apache.carbondata.core.preagg.TimeSeriesUDF;
+import org.apache.carbondata.core.util.CarbonUtil;
 
 /**
  * Store the information about the column meta data present the table
@@ -589,8 +590,7 @@ public class ColumnSchema implements Serializable, Writable, Cloneable {
    * @return
    */
   public boolean isComplexColumn() {
-    return this.getColumnName()
-        .contains(".val") || this.getColumnName().contains(".");
+    return CarbonUtil.isComplexColumn(this.getColumnName());
   }
 
   public ColumnSchema clone() {

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
@@ -3500,4 +3500,12 @@ public final class CarbonUtil {
       dataOutputStream.write(CarbonCommonConstants.EMPTY_BYTE_ARRAY);
     }
   }
+
+  /**
+   * returns whether column is complex column based on column name for child column
+   * @return true if column is complex
+   */
+  public static boolean isComplexColumn(String colName) {
+    return colName.contains(".val") || colName.contains(CarbonCommonConstants.POINT);
+  }
 }

--- a/integration/spark/src/main/scala/org/apache/spark/sql/catalyst/CarbonParserUtil.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/catalyst/CarbonParserUtil.scala
@@ -449,6 +449,10 @@ object CarbonParserUtil {
     var tmpStr: String = ""
     varcharCols.foreach {
       column =>
+        if (CarbonUtil.isComplexColumn(column)) {
+          val errMsg = s"Complex child column $column cannot be set as LONG_STRING_COLUMNS"
+          throw new MalformedCarbonCommandException(errMsg)
+        }
         tmpStr = column.toUpperCase
         duplicateColumnErr.get(tmpStr) match {
           case None => duplicateColumnErr.put(tmpStr, 1)


### PR DESCRIPTION
 ### Why is this PR needed?
When we create a table with complex columns with child columns with long string data type then receiving column not found in table exception. Normally it should throw an exception in the above case by saying that complex child columns will not support long string data type.
 
 ### What changes were proposed in this PR?
Added a case if complex child column has long string data type then throw correct exception.
Exception: MalformedCarbonCommandException
Exception Message: Complex child column <parent column.childcolumn> cannot be set as LONG_STRING_COLUMNS
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
