### PR TITLE
[CARBONDATA-4211] Fix - from xx Insert into select fails if an SQL statement contains multiple inserts

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonCatalystOperators.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonCatalystOperators.scala
@@ -67,7 +67,8 @@ case class InsertIntoCarbonTable (table: CarbonDatasourceHadoopRelation,
     partition: Map[String, Option[String]],
     child: LogicalPlan,
     overwrite: Boolean,
-    ifNotExists: Boolean)
+    ifNotExists: Boolean,
+    containsMultipleInserts: Boolean)
   extends Command {
 
     override def output: Seq[Attribute] = {


### PR DESCRIPTION
 ### Why is this PR needed?
 When multiple inserts with single query is used, it fails from SparkPlan with: `java.lang.ClassCastException: GenericInternalRow cannot be cast to UnsafeRow`. 
For every successful insert/load we return Segment ID as a row. For multiple inserts also, we are returning a row containing Segment ID but while processing in spark `ClassCastException` is thrown.
 
 ### What changes were proposed in this PR?
When multiple insert query is given, it has `Union` node in the plan. Based on its presence, made changes to use flag `isMultipleInserts` to call class `UnionCommandExec ` and implemented custom `sideEffectResult` which converts `GenericInternalRow `to `UnsafeRow `and return.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
