### PR TITLE
[CARBONDATA-4212] Fix case sensitive issue with Update query having Alias Table name

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/parser/CarbonSpark2SqlParser.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/parser/CarbonSpark2SqlParser.scala
@@ -260,14 +260,14 @@ class CarbonSpark2SqlParser extends CarbonDDLSqlParser {
       case tab ~ columns ~ rest =>
         // If update is received for complex data types then throw exception
         var finalColumns = List.empty[String]
-        var updateColumns = new ListBuffer[String]()
+        val updateColumns = new ListBuffer[String]()
         columns.foreach { column =>
           if (column.contains('.')) {
             val columnFullName = column.split('.')
-            if (columnFullName.size >= 3) {
+            if (columnFullName.length >= 3) {
               throw new UnsupportedOperationException("Unsupported operation on Complex data types")
-            } else if ((tab._3.isDefined && tab._3.get.equals(columnFullName(0)))
-                || tab._4.table.equals(columnFullName(0))) {
+            } else if ((tab._3.isDefined && tab._3.get.equalsIgnoreCase(columnFullName(0)))
+                || tab._4.table.equalsIgnoreCase(columnFullName(0))) {
               updateColumns += columnFullName(1)
             } else {
               throw new UnsupportedOperationException("Unsupported operation on Complex data types")

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/iud/UpdateCarbonTableTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/iud/UpdateCarbonTableTestCase.scala
@@ -1178,6 +1178,15 @@ class UpdateCarbonTableTestCase extends QueryTest with BeforeAndAfterAll {
     }
   }
 
+  test("update table having alias table name - case insensitive check") {
+    sql("""drop table if exists iud.zerorows""").collect()
+    sql("""create table iud.zerorows (c1 string,c2 int,c3 string,c5 string) STORED AS carbondata""")
+    sql(s"""LOAD DATA LOCAL INPATH '$resourcesPath/IUD/dest.csv' INTO table iud.zerorows""")
+    sql("update iud.zeRorows up_TAble set(up_table.C1)=('abc') where up_TABLE.C2=1")
+    checkAnswer(sql("select * from iud.zerorows where c2=1"),
+     Seq(Row("abc", 1, "aa", "aaa")))
+  }
+
   test("test update atomicity when horizontal compaction fails") {
     sql("drop table if exists iud.zerorows")
     sql("create table iud.zerorows (c1 string,c2 int,c3 string,c5 string) STORED AS carbondata")


### PR DESCRIPTION
 ### Why is this PR needed?
 Update Query having Alias Table name, fails with Unsupported complex types error, even if table does not any.
 
 ### What changes were proposed in this PR?
Check the columnName irrespective of case
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
