### PR TITLE
[CARBONDATA-4213] Fix update/delete issue in index server

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/mutate/CarbonUpdateUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/mutate/CarbonUpdateUtil.java
@@ -580,7 +580,7 @@ public class CarbonUpdateUtil {
     for (Map.Entry<String, Long> eachSeg : segmentBlockCount.entrySet()) {
 
       if (eachSeg.getValue() == 0) {
-        segmentsToBeDeleted.add(new Segment(eachSeg.getKey(), ""));
+        segmentsToBeDeleted.add(new Segment(eachSeg.getKey(), (String) null));
       }
 
     }

--- a/core/src/main/java/org/apache/carbondata/core/readcommitter/TableStatusReadCommittedScope.java
+++ b/core/src/main/java/org/apache/carbondata/core/readcommitter/TableStatusReadCommittedScope.java
@@ -83,7 +83,7 @@ public class TableStatusReadCommittedScope implements ReadCommittedScope {
   public Map<String, String> getCommittedIndexFile(Segment segment) throws IOException {
     Map<String, String> indexFiles;
     SegmentFileStore fileStore = null;
-    if (segment.getSegmentFileName() != null) {
+    if (segment.getSegmentFileName() != null && !segment.getSegmentFileName().isEmpty()) {
       fileStore = new SegmentFileStore(identifier.getTablePath(), segment.getSegmentFileName());
     }
     if (segment.getSegmentFileName() == null || fileStore.getSegmentFile() == null) {


### PR DESCRIPTION
 ### Why is this PR needed?
 During update/delete, the segment file in the segment would come as an empty string due to which it was not able to read the segment file.
 
 ### What changes were proposed in this PR?
1.  Changed the empty string to NULL
2.  Added empty segment file condition while creating  SegmentFileStore.
    
 ### Does this PR introduce any user interface change?
 - No
 - Yes. (please explain the change and update document)

 ### Is any new testcase added?
 - No
 - Yes

    
