### PR TITLE
[CARBONDATA-4214] inserting NULL value when timestamp value received from FROM_UNIXTIME(0)

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/management/CommonLoadUtils.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/management/CommonLoadUtils.scala
@@ -781,9 +781,8 @@ object CommonLoadUtils {
         internalRowOriginal
       }
       for (index <- timeStampIndex) {
-        if (internalRow.getLong(index) == 0) {
-          internalRow.setNullAt(index)
-        } else {
+        // timestmap value can be set other than null/empty case
+        if (!internalRow.isNullAt(index)) {
           internalRow.setLong(
             index,
             internalRow.getLong(index) / TimeStampGranularityTypeValue.MILLIS_SECONDS.getValue)


### PR DESCRIPTION
 ### Why is this PR needed?
Filling null in case of timestamp value is received from **FROM_UNIXTIME(0)** as spark original insert rdd value[internalRow] received in this case zero. if the original column value[internalRow] is zero then in insert flow adding NULL and giving NULL to spark. When query happens on the same column received NULL value instead of timestamp value.

Problem code:
 ```
        if (internalRow.getLong(index) == 0) { 
         internalRow.setNullAt(index)       
        } 
```
 ### What changes were proposed in this PR?
Removed the null filling check for zero value case and if internalRow value is non null/empty then only set the internalRow timestamp value.
    
 ### Does this PR introduce any user interface change?
 - No


 ### Is any new testcase added?

 - Yes

    
