### PR TITLE
[CARBONDATA-4217] Fix rename SI table, other applications didn't get reflected issue

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/schema/CarbonAlterTableRenameCommand.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/schema/CarbonAlterTableRenameCommand.scala
@@ -156,6 +156,8 @@ private[sql] case class CarbonAlterTableRenameCommand(
           originalIndexStatusBeforeDisable, newTableName)(sparkSession)
         metastore.lookupRelation(Some(oldDatabaseName), newTableName)(sparkSession)
           .asInstanceOf[CarbonRelation]
+        AlterTableUtil.updateSchemaInfo(parentTable, null,
+          metastore.getThriftTableInfo(parentTable))(sparkSession)
       } else {
         val alterTableRenamePostEvent: AlterTableRenamePostEvent = AlterTableRenamePostEvent(
           carbonTable,

--- a/integration/spark/src/main/scala/org/apache/spark/sql/index/CarbonIndexUtil.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/index/CarbonIndexUtil.scala
@@ -472,7 +472,6 @@ object CarbonIndexUtil {
           indexName, newIndexName, status.name())
       }
       val newIndexInfo = table.getIndexInfo
-      indexMetadata.updateIndexStatus(indexType.getIndexProviderName, indexName, status.name())
       table.getTableInfo
         .getFactTable
         .getTableProperties


### PR DESCRIPTION
 ### Why is this PR needed?
After one application rename SI table, other application cannot be reflected of this change, which leads to query on SI column failed.
 
 ### What changes were proposed in this PR?
After update index info of parent table, persist schema info so that other applications can refresh table metadata in time.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No Tested in cluster.

    
