### PR TITLE
[CARBONDATA-4204][CARBONDATA-4231] Fix add segment error message, index server failed testcases and dataload fail error on update

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
@@ -119,6 +119,7 @@ class CarbonEnv {
     val threadLevelCarbonSessionInfo = new CarbonSessionInfo()
     if (currentThreadSessionInfo != null) {
       threadLevelCarbonSessionInfo.setThreadParams(currentThreadSessionInfo.getThreadParams)
+      threadLevelCarbonSessionInfo.setSessionParams(currentThreadSessionInfo.getSessionParams)
     }
     ThreadLocalSessionInfo.setCarbonSessionInfo(threadLevelCarbonSessionInfo)
     ThreadLocalSessionInfo.setConfigurationToCurrentThread(

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonAddLoadCommand.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonAddLoadCommand.scala
@@ -89,6 +89,9 @@ case class CarbonAddLoadCommand(
 
     var givenPath = options.getOrElse(
       "path", throw new UnsupportedOperationException("PATH is mandatory"))
+    if (givenPath.length == 0) {
+      throw new UnsupportedOperationException("PATH cannot be empty")
+    }
     // remove file separator if already present
     if (givenPath.charAt(givenPath.length - 1) == '/') {
       givenPath = givenPath.substring(0, givenPath.length - 1)

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/addsegment/AddSegmentTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/addsegment/AddSegmentTestCase.scala
@@ -1120,6 +1120,15 @@ class AddSegmentTestCase extends QueryTest with BeforeAndAfterAll {
     assert(ex.getMessage.contains("can not add same segment path repeatedly"))
   }
 
+  test("Test add segment with empty path") {
+    createCarbonTable()
+    val ex = intercept[Exception] {
+      sql("alter table addsegment1 add segment " +
+          s"options('path'='', 'format'='carbon')").collect()
+    }
+    assert(ex.getMessage.contains("PATH cannot be empty"))
+  }
+
   def getDataSize(path: String): String = {
     val allFiles = FileFactory.getCarbonFile(path).listFiles(new CarbonFileFilter {
       override def accept(file: CarbonFile): Boolean = {

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/alterTable/TestAlterTableAddColumns.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/alterTable/TestAlterTableAddColumns.scala
@@ -277,8 +277,7 @@ class TestAlterTableAddColumns extends QueryTest with BeforeAndAfterAll {
     }
   }
 
-  // Exclude when running with index server as the returned rows order may vary
-  test("Test alter add for arrays enabling local dictionary", true) {
+  test("Test alter add for arrays enabling local dictionary") {
     import scala.collection.mutable.WrappedArray.make
     createTableForComplexTypes("LOCAL_DICTIONARY_INCLUDE", "ARRAY")
     // For the previous segments the default value for newly added array column is null
@@ -289,15 +288,15 @@ class TestAlterTableAddColumns extends QueryTest with BeforeAndAfterAll {
     sql(
       "insert into alter_com values(2,array(9,0),array(1,2,3),array('hello','world'),array(6,7)," +
       "array(8,9), named_struct('a',1,'b','abcde') )")
-    val rows = sql("select * from alter_com").collect()
-    assert(rows(6)(0) == 2)
-    assert(rows(6)(1) == make(Array(9, 0)))
-    assert(rows(6)(2) == make(Array(1, 2, 3)))
-    assert(rows(6)(3) == make(Array("hello", "world")))
-    assert(rows(6)(4) == make(Array(6, 7)))
-    assert(rows(6)(5) == make(Array(8, 9)))
-    assert(rows(6)(6) == Row(1, "abcde"))
-    assert(rows.size == 7)
+    sql("select * from alter_com").show(false)
+    checkAnswer(sql("select * from alter_com where array_contains(arr4,6)"),
+      Seq(Row(2,
+        make(Array(9, 0)),
+        make(Array(1, 2, 3)),
+        make(Array("hello", "world")),
+        make(Array(6, 7)),
+        make(Array(8, 9)),
+        Row(1, "abcde"))))
 
     val addedColumns = addedColumnsInSchemaEvolutionEntry("alter_com")
     assert(addedColumns.size == 5)

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestRenameTableWithIndex.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/createTable/TestRenameTableWithIndex.scala
@@ -121,8 +121,10 @@ class TestRenameTableWithIndex extends QueryTest with BeforeAndAfterAll {
       true, "dm_carbon_si")
   }
 
+  // Exclude when running with index server, as pruning info for explain command
+  // not set with index server.
   test("rename index table success, insert new record success" +
-       " and query hit new index table") {
+       " and query hit new index table", true) {
     sql("create table if not exists x1 (imei string, mac string) stored as carbondata")
     sql("create index idx_x1_mac on table x1(mac) as 'carbondata'")
     sql("alter table idx_x1_mac rename to idx_x1_mac1")
@@ -135,8 +137,10 @@ class TestRenameTableWithIndex extends QueryTest with BeforeAndAfterAll {
     sql("DROP TABLE IF EXISTS x1")
   }
 
+  // Exclude when running with index server, as pruning info for explain command
+  // not set with index server.
   test("rename index table fail, revert success, insert new record success" +
-       " and query hit old index table") {
+       " and query hit old index table", true) {
     val mock: MockUp[MockClassForAlterRevertTests] = new MockUp[MockClassForAlterRevertTests]() {
       @Mock
       @throws[ProcessMetaDataException]


### PR DESCRIPTION
 ### Why is this PR needed?
1.  When the path is empty in Carbon add segments then `StringIndexOutOfBoundsException `is thrown.
2.  Index server UT failures fix.
3. Update fails with dataload fail error if set bad records action is specified to force with spark 3.1v.

 ### What changes were proposed in this PR?
1. Added check to see if the path is empty and then throw a valid error message.
2. Used `checkAnswer `instead of `assert `in test cases so that the order of rows returned would be same with or without index server. Excluded 2 test cases where explain with query statistics is used, as we are not setting any pruning info from index server. 
3.  On update command, dataframe.persist is called and with latest 3.1 spark changes, spark returns a cloned SparkSession from cacheManager with all specified configurations disabled. As now it's using a different sparkSession for 3.1 which is not initialized in CarbonEnv. So `CarbonEnv.init` is called where new CarbonSessionInfo is created with no sessionParams. So, the properties set were not accessible. When a new carbonSessionInfo object is getting created, made changes to set existing sessionparams from `currentThreadSessionInfo`.

 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
