### PR TITLE
[CARBONDATA-4227] SDK CarbonWriterBuilder cannot execute `build()` several times with different output path

### DIFF
--- a/sdk/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonWriterBuilder.java
+++ b/sdk/sdk/src/main/java/org/apache/carbondata/sdk/file/CarbonWriterBuilder.java
@@ -958,6 +958,7 @@ public class CarbonWriterBuilder {
         }
       }
     }
+    CarbonTable carbonTable = this.carbonTable;
     if (carbonTable == null) {
       // if carbonTable is not set by user, build it using schema
       carbonTable = buildCarbonTable();

--- a/sdk/sdk/src/test/java/org/apache/carbondata/sdk/file/CarbonReaderTest.java
+++ b/sdk/sdk/src/test/java/org/apache/carbondata/sdk/file/CarbonReaderTest.java
@@ -2990,7 +2990,7 @@ public class CarbonReaderTest extends TestCase {
       }
       writer1.close();
       CarbonWriter writer2 = builder.outputPath(path2).build();
-      for (int i = 0; i < 10; i++) {
+      for (int i = 0; i < numRows; i++) {
         writer2.write(json);
       }
       writer2.close();


### PR DESCRIPTION
## Why is this PR needed?

Sometimes we want to reuse the CarbonWriterBuilder object to build CarbonWriter with different output paths, but it does not work.

For example:

```kotlin
val builder = CarbonWriter.builder().withCsvInput(...).writtenBy(...)

// 1. first writing with path1
val writer1 = builder.outputPath(path1).build()
// write data, it works 

// 2. second writing with path2
val writer2 = builder.outputPath(path2).build()
// write data, it does not work. It still writes data to path1
```

## What changes were proposed in this PR?

## Does this PR introduce any user interface change?
No

## Is any new testcase added?
Yes
