### PR TITLE
[CARBONDATA-4248] Fixed upper case column name in explain command

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/CarbonFilters.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/CarbonFilters.scala
@@ -347,7 +347,7 @@ object CarbonFilters {
   }
 
   def translateDataType(name: String, columnTypes: Map[String, SparkDataType]): DataType = {
-    CarbonSparkDataSourceUtil.convertSparkToCarbonDataType(columnTypes(name))
+    CarbonSparkDataSourceUtil.convertSparkToCarbonDataType(columnTypes(name.toLowerCase()))
   }
 
   def translateColumn(name: String, dataType: SparkDataType): ColumnExpression = {


### PR DESCRIPTION
 ### Why is this PR needed?
 Explain command with upper case column name fails with key not found exception.
 
 ### What changes were proposed in this PR?
Changed column name to lower case before conversion of spark data type to carbon data type.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
