### PR TITLE
[CARBONDATA-4250] Ignoring presto random test cases

### DIFF
--- a/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/mergeindex/CarbonIndexFileMergeTestCaseWithSI.scala
+++ b/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/mergeindex/CarbonIndexFileMergeTestCaseWithSI.scala
@@ -98,7 +98,7 @@ class CarbonIndexFileMergeTestCaseWithSI
       sql("""Select count(*) from indexmerge"""))
   }
 
-  test("Verify command of index merge") {
+  ignore("Verify command of index merge") {
     CarbonProperties.getInstance()
       .addProperty(CarbonCommonConstants.CARBON_MERGE_INDEX_IN_SEGMENT, "false")
     sql("DROP TABLE IF EXISTS nonindexmerge")

--- a/integration/presto/src/test/scala/org/apache/carbondata/presto/integrationtest/PrestoTestUsingSparkStore.scala
+++ b/integration/presto/src/test/scala/org/apache/carbondata/presto/integrationtest/PrestoTestUsingSparkStore.scala
@@ -21,7 +21,7 @@ import java.io.{File}
 import java.util
 
 import org.apache.commons.io.FileUtils
-import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, FunSuiteLike}
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, FunSuiteLike, Ignore}
 
 import org.apache.carbondata.common.logging.LogServiceFactory
 import org.apache.carbondata.core.constants.CarbonCommonConstants
@@ -29,6 +29,7 @@ import org.apache.carbondata.core.datastore.impl.FileFactory
 import org.apache.carbondata.core.util.{CarbonProperties, CarbonUtil}
 import org.apache.carbondata.presto.server.{PrestoServer, PrestoTestUtil}
 
+@Ignore
 class PrestoTestUsingSparkStore
   extends FunSuiteLike with BeforeAndAfterAll with BeforeAndAfterEach {
 

--- a/integration/spark/src/test/scala/org/apache/carbondata/integration/spark/testsuite/dataload/SparkStoreCreatorForPresto.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/integration/spark/testsuite/dataload/SparkStoreCreatorForPresto.scala
@@ -25,7 +25,7 @@ import scala.util.Random
 import org.apache.commons.io.FileUtils
 import org.apache.spark.sql.CarbonEnv
 import org.apache.spark.sql.test.util.QueryTest
-import org.scalatest.BeforeAndAfterAll
+import org.scalatest.{BeforeAndAfterAll, Ignore}
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.datastore.impl.FileFactory
@@ -33,6 +33,7 @@ import org.apache.carbondata.core.util.{CarbonProperties, CarbonUtil}
 import org.apache.carbondata.core.util.path.CarbonTablePath
 import org.apache.carbondata.sdk.file.{CarbonSchemaReader, CarbonWriterBuilder}
 
+@Ignore
 class SparkStoreCreatorForPresto extends QueryTest with BeforeAndAfterAll{
 
   private val timestampFormat = CarbonProperties.getInstance()

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/alterTable/TestAlterTableAddColumns.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/alterTable/TestAlterTableAddColumns.scala
@@ -337,7 +337,7 @@ class TestAlterTableAddColumns extends QueryTest with BeforeAndAfterAll {
     assert(c(0)(2) == null)
   }
 
-  test("Test alter add for structs enabling local dictionary") {
+  ignore("Test alter add for structs enabling local dictionary") {
     createTableForComplexTypes("LOCAL_DICTIONARY_INCLUDE", "STRUCT")
     // For the previous segments the default value for newly added struct column is null
     insertIntoTableForStructType
@@ -347,7 +347,7 @@ class TestAlterTableAddColumns extends QueryTest with BeforeAndAfterAll {
     sql("DROP TABLE IF EXISTS alter_struct")
   }
 
-  test("Test alter add for structs, disabling local dictionary") {
+  ignore("Test alter add for structs, disabling local dictionary") {
     createTableForComplexTypes("LOCAL_DICTIONARY_EXCLUDE", "STRUCT")
     // For the previous segments the default value for newly added struct column is null
     insertIntoTableForStructType


### PR DESCRIPTION
 ### Why is this PR needed?
 Presto test cases failing randomly and taking more time in CI verification for other PRs.
 
 ### What changes were proposed in this PR?
Currently presto random test cases will be ignored and will be fixed with other JIRA raised.
1) JIRA [CARBONDATA-4250] raised for ignoring presto test cases currently as this random failures causing PR CI failures.
2) JIRA [CARBONDATA-4249] raised for fixing **presto random tests** in concurrent scenario. We can get more details on this JIRA about issue reproduce and problem snippet.
3) [CARBONDATA-4254] raised to fix   **Test alter add for structs enabling local dictionary** and **CarbonIndexFileMergeTestCaseWithSI.Verify command of index merge**
 ### Does this PR introduce any user interface change?
 - No


 ### Is any new testcase added?
 - No


    
