### PR TITLE
[CARBONDATA-4247][CARBONDATA-4241] Fix Wrong timestamp value query results for data before 1900 years with Spark 3.1

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -123,6 +123,16 @@ public final class CarbonCommonConstants {
   public static final String CARBON_TIMESTAMP_MILLIS = "dd-MM-yyyy HH:mm:ss:SSS";
 
   /**
+   * CARBON Default format - time segment
+   */
+  public static final String CARBON_TIME_SEGMENT_DEFAULT_FORMAT = " HH:mm:ss";
+
+  /**
+   * CARBON Default data - time segment
+   */
+  public static final String CARBON_TIME_SEGMENT_DATA_DEFAULT_FORMAT = " 00:00:00";
+
+  /**
    * Property for specifying the format of DATE data type column.
    * e.g. yyyy/MM/dd , or using default value
    */
@@ -2647,5 +2657,17 @@ public final class CarbonCommonConstants {
   public static final String CARBON_MAP_ORDER_PUSHDOWN = "carbon.mapOrderPushDown";
 
   public static final String CARBON_SDK_EMPTY_METADATA_PATH = "emptyMetadataFolder";
+
+  /**
+   * Property to identify if the spark version is above 3.x version
+   */
+  public static final String CARBON_SPARK_VERSION_SPARK3 = "carbon.spark.version.spark3";
+
+  public static final String CARBON_SPARK_VERSION_SPARK3_DEFAULT = "false";
+
+  /**
+   * Carbon Spark 3.x supported data file written version
+   */
+  public static final String CARBON_SPARK3_VERSION = "2.2.0";
 
 }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/block/AbstractIndex.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/block/AbstractIndex.java
@@ -17,6 +17,7 @@
 
 package org.apache.carbondata.core.datastore.block;
 
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -50,6 +51,12 @@ public abstract class AbstractIndex implements Cacheable {
    * last fetch delete deltaFile timestamp
    */
   private long deleteDeltaTimestamp;
+
+  public List<TableBlockInfo> getBlockInfos() {
+    return blockInfos;
+  }
+
+  protected List<TableBlockInfo> blockInfos;
 
   /**
    * map of blockletIdAndPageId to deleted rows

--- a/core/src/main/java/org/apache/carbondata/core/datastore/block/TableBlockInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/block/TableBlockInfo.java
@@ -88,6 +88,11 @@ public class TableBlockInfo implements Distributable, Serializable {
   private transient DataFileFooter dataFileFooter;
 
   /**
+   * Carbon Data file written version
+   */
+  private String carbonDataFileWrittenVersion = null;
+
+  /**
    * comparator to sort by block size in descending order.
    * Since each line is not exactly the same, the size of a InputSplit may differs,
    * so we allow some deviation for these splits.
@@ -132,6 +137,7 @@ public class TableBlockInfo implements Distributable, Serializable {
     info.deletedDeltaFilePath = deletedDeltaFilePath;
     info.detailInfo = detailInfo.copy();
     info.indexWriterPath = indexWriterPath;
+    info.carbonDataFileWrittenVersion = carbonDataFileWrittenVersion;
     return info;
   }
 
@@ -353,4 +359,13 @@ public class TableBlockInfo implements Distributable, Serializable {
     sb.append('}');
     return sb.toString();
   }
+
+  public String getCarbonDataFileWrittenVersion() {
+    return carbonDataFileWrittenVersion;
+  }
+
+  public void setCarbonDataFileWrittenVersion(String carbonDataFileWrittenVersion) {
+    this.carbonDataFileWrittenVersion = carbonDataFileWrittenVersion;
+  }
+
 }

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/reader/dimension/v3/DimensionChunkReaderV3.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/reader/dimension/v3/DimensionChunkReaderV3.java
@@ -256,6 +256,7 @@ public class DimensionChunkReaderV3 extends AbstractDimensionChunkReader {
     if (vectorInfo != null) {
       // set encodings of current page in the vectorInfo, used for decoding the complex child page
       vectorInfo.encodings = encodings;
+      vectorInfo.vector.setCarbonDataFileWrittenVersion(vectorInfo.carbonDataFileWrittenVersion);
       decoder
           .decodeAndFillVector(pageData.array(), offset, pageMetadata.data_page_length, vectorInfo,
               nullBitSet, isLocalDictEncodedPage, pageMetadata.numberOfRowsInpage,

--- a/core/src/main/java/org/apache/carbondata/core/datastore/chunk/reader/measure/v3/MeasureChunkReaderV3.java
+++ b/core/src/main/java/org/apache/carbondata/core/datastore/chunk/reader/measure/v3/MeasureChunkReaderV3.java
@@ -245,6 +245,7 @@ public class MeasureChunkReaderV3 extends AbstractMeasureChunkReader {
     ColumnPageDecoder codec =
         encodingFactory.createDecoder(encodings, encoderMetas, compressorName, vectorInfo != null);
     if (vectorInfo != null) {
+      vectorInfo.vector.setCarbonDataFileWrittenVersion(vectorInfo.carbonDataFileWrittenVersion);
       codec.decodeAndFillVector(pageData.array(), offset, pageMetadata.data_page_length, vectorInfo,
           nullBitSet, false, pageMetadata.numberOfRowsInpage, reusableDataBuffer);
       return null;

--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/IndexWrapper.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/IndexWrapper.java
@@ -31,8 +31,6 @@ import org.apache.carbondata.core.datastore.impl.FileFactory;
  */
 public class IndexWrapper extends AbstractIndex {
 
-  private List<TableBlockInfo> blockInfos;
-
   public IndexWrapper(List<TableBlockInfo> blockInfos, SegmentProperties segmentProperties) {
     this.blockInfos = blockInfos;
     this.segmentProperties = segmentProperties;

--- a/core/src/main/java/org/apache/carbondata/core/metadata/blocklet/DataFileFooter.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/blocklet/DataFileFooter.java
@@ -76,6 +76,11 @@ public class DataFileFooter implements Serializable {
   private Boolean isSorted = true;
 
   /**
+   * carbon data file written version
+   */
+  private String carbonDataFileWrittenVersion = null;
+
+  /**
    * @return the versionId
    */
   public ColumnarFormatVersion getVersionId() {
@@ -173,5 +178,13 @@ public class DataFileFooter implements Serializable {
 
   public Boolean isSorted() {
     return isSorted;
+  }
+
+  public String getCarbonDataFileWrittenVersion() {
+    return carbonDataFileWrittenVersion;
+  }
+
+  public void setCarbonDataFileWrittenVersion(String carbonDataFileWrittenVersion) {
+    this.carbonDataFileWrittenVersion = carbonDataFileWrittenVersion;
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/scan/collector/impl/DictionaryBasedVectorResultCollector.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/collector/impl/DictionaryBasedVectorResultCollector.java
@@ -259,6 +259,8 @@ public class DictionaryBasedVectorResultCollector extends AbstractScannedResultC
       BitSet deltaBitSet) {
     for (int i = 0; i < allColumnInfo.length; i++) {
       allColumnInfo[i].vectorOffset = columnarBatch.getRowCounter();
+      allColumnInfo[i].carbonDataFileWrittenVersion =
+          columnarBatch.getCarbonDataFileWrittenVersion();
       allColumnInfo[i].vector = columnarBatch.columnVectors[i];
       allColumnInfo[i].deletedRows = deltaBitSet;
       if (null != allColumnInfo[i].dimension) {

--- a/core/src/main/java/org/apache/carbondata/core/scan/executor/impl/AbstractQueryExecutor.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/executor/impl/AbstractQueryExecutor.java
@@ -224,6 +224,7 @@ public abstract class AbstractQueryExecutor<E> implements QueryExecutor<E> {
           if (null == blockletDetailInfo) {
             blockletDetailInfo = QueryUtil.getBlockletDetailInfo(fileFooter, blockInfo);
           }
+          blockInfo.setCarbonDataFileWrittenVersion(fileFooter.getCarbonDataFileWrittenVersion());
           blockInfo.setDetailInfo(blockletDetailInfo);
         }
         if (null == segmentProperties) {

--- a/core/src/main/java/org/apache/carbondata/core/scan/processor/DataBlockIterator.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/processor/DataBlockIterator.java
@@ -244,6 +244,9 @@ public class DataBlockIterator extends CarbonIterator<List<Object[]>> {
   }
 
   public void processNextBatch(CarbonColumnarBatch columnarBatch) {
+    columnarBatch.setCarbonDataFileWrittenVersion(
+        this.blockExecutionInfo.getDataBlock().getDataRefNode().getTableBlockInfo()
+            .getCarbonDataFileWrittenVersion());
     if (updateScanner()) {
       this.scannerResultAggregator.collectResultInColumnarBatch(scannedResult, columnarBatch);
     }

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/RowBatch.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/RowBatch.java
@@ -38,6 +38,11 @@ public class RowBatch extends CarbonIterator<Object[]> {
    */
   protected int counter;
 
+  /**
+   * Carbon data file written version
+   */
+  private String carbonDataFileWrittenVersion = null;
+
   public RowBatch() {
     this.rows = new ArrayList<>();
   }
@@ -114,5 +119,13 @@ public class RowBatch extends CarbonIterator<Object[]> {
     }
     counter = counter + rows.size();
     return rows;
+  }
+
+  public String getCarbonDataFileWrittenVersion() {
+    return carbonDataFileWrittenVersion;
+  }
+
+  public void setCarbonDataFileWrittenVersion(String carbonDataFileWrittenVersion) {
+    this.carbonDataFileWrittenVersion = carbonDataFileWrittenVersion;
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/iterator/AbstractDetailQueryResultIterator.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/iterator/AbstractDetailQueryResultIterator.java
@@ -87,6 +87,8 @@ public abstract class AbstractDetailQueryResultIterator<E> extends CarbonIterato
    */
   private QueryStatisticsModel queryStatisticsModel;
 
+  String carbonDataFileWrittenVersion;
+
   AbstractDetailQueryResultIterator(List<BlockExecutionInfo> infos, QueryModel queryModel,
       ExecutorService execService) {
     batchSize = CarbonProperties.getQueryBatchSize();
@@ -222,6 +224,8 @@ public abstract class AbstractDetailQueryResultIterator<E> extends CarbonIterato
     }
     if (blockExecutionInfos.size() > 0) {
       BlockExecutionInfo executionInfo = blockExecutionInfos.get(0);
+      carbonDataFileWrittenVersion = executionInfo.getDataBlock().getDataRefNode()
+          .getTableBlockInfo().getCarbonDataFileWrittenVersion();
       blockExecutionInfos.remove(executionInfo);
       return new DataBlockIterator(executionInfo, fileReader, batchSize, queryStatisticsModel,
           execService);

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/iterator/ChunkRowIterator.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/iterator/ChunkRowIterator.java
@@ -69,6 +69,10 @@ public class ChunkRowIterator extends CarbonIterator<Object[]> {
     return currentChunk.next();
   }
 
+  public String getCarbonDataFileWrittenVersion() {
+    return currentChunk.getCarbonDataFileWrittenVersion();
+  }
+
   /**
    * read next batch
    *

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/iterator/DetailQueryResultIterator.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/iterator/DetailQueryResultIterator.java
@@ -56,6 +56,7 @@ public class DetailQueryResultIterator extends AbstractDetailQueryResultIterator
       updateDataBlockIterator();
       if (dataBlockIterator != null) {
         rowBatch.setRows(dataBlockIterator.next());
+        rowBatch.setCarbonDataFileWrittenVersion(carbonDataFileWrittenVersion);
       }
     }
     return rowBatch;

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/vector/CarbonColumnVector.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/vector/CarbonColumnVector.java
@@ -116,6 +116,8 @@ public interface CarbonColumnVector {
 
   void setLazyPage(LazyPageLoader lazyPage);
 
+  void setCarbonDataFileWrittenVersion(String carbonDataFileWrittenVersion);
+
   // Added default implementation for interface,
   // to avoid implementing presto required functions for spark or core module.
   default List<CarbonColumnVector> getChildrenVector() {

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/vector/CarbonColumnarBatch.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/vector/CarbonColumnarBatch.java
@@ -33,6 +33,11 @@ public class CarbonColumnarBatch {
 
   private int rowsFiltered;
 
+  /**
+   * Carbon Data file written version
+   */
+  private String carbonDataFileWrittenVersion = null;
+
   public CarbonColumnarBatch(CarbonColumnVector[] columnVectors, int batchSize,
       boolean[] filteredRows) {
     this.columnVectors = columnVectors;
@@ -91,5 +96,13 @@ public class CarbonColumnarBatch {
         columnVectors[i].setFilteredRowsExist(true);
       }
     }
+  }
+
+  public String getCarbonDataFileWrittenVersion() {
+    return carbonDataFileWrittenVersion;
+  }
+
+  public void setCarbonDataFileWrittenVersion(String carbonDataFileWrittenVersion) {
+    this.carbonDataFileWrittenVersion = carbonDataFileWrittenVersion;
   }
 }

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/vector/ColumnVectorInfo.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/vector/ColumnVectorInfo.java
@@ -35,6 +35,7 @@ public class ColumnVectorInfo implements Comparable<ColumnVectorInfo> {
   public int size;
   public CarbonColumnVector vector;
   public int vectorOffset;
+  public String carbonDataFileWrittenVersion;
   public ProjectionDimension dimension;
   public ProjectionMeasure measure;
   public int ordinal;

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/vector/impl/CarbonColumnVectorImpl.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/vector/impl/CarbonColumnVectorImpl.java
@@ -501,6 +501,11 @@ public class CarbonColumnVectorImpl implements CarbonColumnVector {
   }
 
   @Override
+  public void setCarbonDataFileWrittenVersion(String carbonDataFileWrittenVersion) {
+   // do nothing here
+  }
+
+  @Override
   public void putAllByteArray(byte[] data, int offset, int length) {
     byteArr = data;
   }

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/vector/impl/directread/ColumnarVectorWrapperDirectWithDeleteDelta.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/vector/impl/directread/ColumnarVectorWrapperDirectWithDeleteDelta.java
@@ -246,4 +246,9 @@ class ColumnarVectorWrapperDirectWithDeleteDelta extends AbstractCarbonColumnarV
   public CarbonColumnVector getColumnVector() {
     return this.columnVector;
   }
+
+  @Override
+  public void setCarbonDataFileWrittenVersion(String carbonDataFileWrittenVersion) {
+    this.columnVector.setCarbonDataFileWrittenVersion(carbonDataFileWrittenVersion);
+  }
 }

--- a/core/src/main/java/org/apache/carbondata/core/scan/result/vector/impl/directread/ColumnarVectorWrapperDirectWithInvertedIndex.java
+++ b/core/src/main/java/org/apache/carbondata/core/scan/result/vector/impl/directread/ColumnarVectorWrapperDirectWithInvertedIndex.java
@@ -105,6 +105,11 @@ public class ColumnarVectorWrapperDirectWithInvertedIndex extends AbstractCarbon
   }
 
   @Override
+  public void setCarbonDataFileWrittenVersion(String carbonDataFileWrittenVersion) {
+    this.columnVector.setCarbonDataFileWrittenVersion(carbonDataFileWrittenVersion);
+  }
+
+  @Override
   public void putFloats(int rowId, int count, float[] src, int srcIndex) {
     for (int i = srcIndex; i < count; i++) {
       columnVector.putFloat(invertedIndex[rowId++], src[i]);

--- a/core/src/main/java/org/apache/carbondata/core/util/DataFileFooterConverterV3.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/DataFileFooterConverterV3.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.datastore.block.TableBlockInfo;
 import org.apache.carbondata.core.datastore.impl.FileFactory;
 import org.apache.carbondata.core.metadata.ColumnarFormatVersion;
@@ -73,6 +74,10 @@ public class DataFileFooterConverterV3 extends AbstractDataFileFooterConverter {
     DataFileFooter dataFileFooter = new DataFileFooter();
     dataFileFooter.setVersionId(ColumnarFormatVersion.valueOf((short) fileHeader.getVersion()));
     dataFileFooter.setNumberOfRows(footer.getNum_rows());
+    if (null != footer.getExtra_info()) {
+      dataFileFooter.setCarbonDataFileWrittenVersion(
+          footer.getExtra_info().get(CarbonCommonConstants.CARBON_WRITTEN_VERSION));
+    }
     dataFileFooter.setSchemaUpdatedTimeStamp(fileHeader.getTime_stamp());
     if (footer.isSetIs_sort()) {
       dataFileFooter.setSorted(footer.isIs_sort());

--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/CarbonRecordReader.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/CarbonRecordReader.java
@@ -141,6 +141,11 @@ public class CarbonRecordReader<T> extends AbstractRecordReader<T> {
     return readSupport.readRow(carbonIterator.next());
   }
 
+  public String getCarbonDataFileWrittenVersion() {
+    ChunkRowIterator iterator = (ChunkRowIterator) carbonIterator;
+    return iterator.getCarbonDataFileWrittenVersion();
+  }
+
   /**
    * get batch result
    *

--- a/integration/presto/src/main/java/org/apache/carbondata/presto/ColumnarVectorWrapperDirect.java
+++ b/integration/presto/src/main/java/org/apache/carbondata/presto/ColumnarVectorWrapperDirect.java
@@ -220,6 +220,11 @@ public class ColumnarVectorWrapperDirect implements CarbonColumnVector, Sequenti
   }
 
   @Override
+  public void setCarbonDataFileWrittenVersion(String carbonDataFileWrittenVersion) {
+    // do nothing here
+  }
+
+  @Override
   public Object getData(int rowId) {
     throw new UnsupportedOperationException(
         "Not supported this opeartion from " + this.getClass().getName());

--- a/integration/spark/src/main/common2.3and2.4/org/apache/spark/sql/SparkVersionAdapter.scala
+++ b/integration/spark/src/main/common2.3and2.4/org/apache/spark/sql/SparkVersionAdapter.scala
@@ -83,6 +83,12 @@ trait SparkVersionAdapter {
     DateTimeUtils.timestampToString(timeStamp)
   }
 
+  def rebaseTime(timestamp: Long, carbonWrittenVersion: String = null): Long = {
+    // From spark 3.1, spark will store gregorian micros value for timestamp, hence
+    // rebase is required. For 2.x versions, no need rebase
+    timestamp
+  }
+
   def stringToTime(value: String): java.util.Date = {
     DateTimeUtils.stringToTime(value)
   }

--- a/integration/spark/src/main/java/org/apache/carbondata/spark/vectorreader/ColumnarVectorWrapper.java
+++ b/integration/spark/src/main/java/org/apache/carbondata/spark/vectorreader/ColumnarVectorWrapper.java
@@ -24,6 +24,7 @@ import org.apache.carbondata.core.scan.result.vector.CarbonColumnVector;
 import org.apache.carbondata.core.scan.result.vector.CarbonDictionary;
 import org.apache.carbondata.core.scan.scanner.LazyPageLoader;
 
+import org.apache.spark.sql.CarbonToSparkAdapter;
 import org.apache.spark.sql.CarbonVectorProxy;
 import org.apache.spark.sql.carbondata.execution.datasources.CarbonSparkDataSourceUtil;
 import org.apache.spark.sql.types.Decimal;
@@ -47,6 +48,8 @@ class ColumnarVectorWrapper implements CarbonColumnVector {
   private DataType blockDataType;
 
   private CarbonColumnVector dictionaryVector;
+
+  private String carbonDataFileWrittenVersion;
 
   ColumnarVectorWrapper(CarbonVectorProxy writableColumnVector, boolean[] filteredRows,
       int ordinal) {
@@ -119,7 +122,8 @@ class ColumnarVectorWrapper implements CarbonColumnVector {
   @Override
   public void putLong(int rowId, long value) {
     if (!filteredRows[rowId]) {
-      sparkColumnVectorProxy.putLong(counter++, value);
+      sparkColumnVectorProxy
+          .putLong(counter++, CarbonToSparkAdapter.rebaseTime(value, carbonDataFileWrittenVersion));
     }
   }
 
@@ -294,6 +298,11 @@ class ColumnarVectorWrapper implements CarbonColumnVector {
   @Override
   public void setFilteredRowsExist(boolean filteredRowsExist) {
     this.filteredRowsExist = filteredRowsExist;
+  }
+
+  @Override
+  public void setCarbonDataFileWrittenVersion(String carbonDataFileWrittenVersion) {
+    this.carbonDataFileWrittenVersion = carbonDataFileWrittenVersion;
   }
 
   @Override

--- a/integration/spark/src/main/java/org/apache/carbondata/spark/vectorreader/ColumnarVectorWrapperDirect.java
+++ b/integration/spark/src/main/java/org/apache/carbondata/spark/vectorreader/ColumnarVectorWrapperDirect.java
@@ -24,6 +24,7 @@ import org.apache.carbondata.core.scan.result.vector.CarbonColumnVector;
 import org.apache.carbondata.core.scan.result.vector.CarbonDictionary;
 import org.apache.carbondata.core.scan.scanner.LazyPageLoader;
 
+import org.apache.spark.sql.CarbonToSparkAdapter;
 import org.apache.spark.sql.CarbonVectorProxy;
 import org.apache.spark.sql.carbondata.execution.datasources.CarbonSparkDataSourceUtil;
 import org.apache.spark.sql.types.Decimal;
@@ -50,6 +51,8 @@ class ColumnarVectorWrapperDirect implements CarbonColumnVector {
   private DataType blockDataType;
 
   private CarbonColumnVector dictionaryVector;
+
+  private String carbonDataFileWrittenVersion;
 
   ColumnarVectorWrapperDirect(CarbonVectorProxy writableColumnVector, int ordinal) {
     this.sparkColumnVectorProxy = writableColumnVector.getColumnVector(ordinal);
@@ -93,7 +96,8 @@ class ColumnarVectorWrapperDirect implements CarbonColumnVector {
 
   @Override
   public void putLong(int rowId, long value) {
-    sparkColumnVectorProxy.putLong(rowId, value);
+    sparkColumnVectorProxy
+        .putLong(rowId, CarbonToSparkAdapter.rebaseTime(value, carbonDataFileWrittenVersion));
   }
 
   @Override
@@ -232,6 +236,11 @@ class ColumnarVectorWrapperDirect implements CarbonColumnVector {
   @Override
   public void setFilteredRowsExist(boolean filteredRowsExist) {
 
+  }
+
+  @Override
+  public void setCarbonDataFileWrittenVersion(String carbonDataFileWrittenVersion) {
+    this.carbonDataFileWrittenVersion = carbonDataFileWrittenVersion;
   }
 
   @Override

--- a/integration/spark/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/CarbonEnv.scala
@@ -138,6 +138,10 @@ class CarbonEnv {
       .addNonSerializableProperty(CarbonCommonConstants.IS_DRIVER_INSTANCE, "true")
     Profiler.initialize(sparkSession.sparkContext)
     CarbonToSparkAdapter.addSparkSessionListener(sparkSession)
+    if(sparkSession.sparkContext.version.startsWith("3.1")) {
+      CarbonProperties.getInstance().addProperty(CarbonCommonConstants
+        .CARBON_SPARK_VERSION_SPARK3, "true")
+    }
     initialized = true
     LOGGER.info("Initialize CarbonEnv completed...")
   }

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/directdictionary/TimestampNoDictionaryColumnTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/directdictionary/TimestampNoDictionaryColumnTestCase.scala
@@ -51,47 +51,35 @@ class TimestampNoDictionaryColumnTestCase extends QueryTest with BeforeAndAfterA
   }
 
   test("select projectjoindate, projectenddate from timestamp_nodictionary") {
-    if (!sqlContext.sparkContext.version.startsWith("3.1")) {
-      checkAnswer(
-        sql("select projectjoindate, projectenddate from timestamp_nodictionary"),
-        Seq(Row(Timestamp.valueOf("2000-01-29 00:00:00.0"),
-          Timestamp.valueOf("2016-06-29 00:00:00.0")),
-          Row(Timestamp.valueOf("1800-02-17 00:00:00.0"),
-            Timestamp.valueOf("1900-11-29 00:00:00.0")),
-          Row(null, Timestamp.valueOf("2016-05-29 00:00:00.0")),
-          Row(null, Timestamp.valueOf("2016-11-30 00:00:00.0")),
-          Row(Timestamp.valueOf("3000-10-22 00:00:00.0"),
-            Timestamp.valueOf("3002-11-15 00:00:00.0")),
-          Row(Timestamp.valueOf("1802-06-29 00:00:00.0"),
-            Timestamp.valueOf("1902-12-30 00:00:00.0")),
-          Row(null, Timestamp.valueOf("2016-12-30 00:00:00.0")),
-          Row(Timestamp.valueOf("2038-11-14 00:00:00.0"),
-            Timestamp.valueOf("2041-12-29 00:00:00.0")),
-          Row(null, null),
-          Row(Timestamp.valueOf("2014-09-15 00:00:00.0"),
-            Timestamp.valueOf("2016-05-29 00:00:00.0"))
-        )
+    checkAnswer(
+      sql("select projectjoindate, projectenddate from timestamp_nodictionary"),
+      Seq(Row(Timestamp.valueOf("2000-01-29 00:00:00.0"),
+        Timestamp.valueOf("2016-06-29 00:00:00.0")),
+        Row(Timestamp.valueOf("1800-02-17 00:00:00.0"), Timestamp.valueOf("1900-11-29 00:00:00.0")),
+        Row(null, Timestamp.valueOf("2016-05-29 00:00:00.0")),
+        Row(null, Timestamp.valueOf("2016-11-30 00:00:00.0")),
+        Row(Timestamp.valueOf("3000-10-22 00:00:00.0"), Timestamp.valueOf("3002-11-15 00:00:00.0")),
+        Row(Timestamp.valueOf("1802-06-29 00:00:00.0"), Timestamp.valueOf("1902-12-30 00:00:00.0")),
+        Row(null, Timestamp.valueOf("2016-12-30 00:00:00.0")),
+        Row(Timestamp.valueOf("2038-11-14 00:00:00.0"), Timestamp.valueOf("2041-12-29 00:00:00.0")),
+        Row(null, null),
+        Row(Timestamp.valueOf("2014-09-15 00:00:00.0"), Timestamp.valueOf("2016-05-29 00:00:00.0"))
       )
-    }
+    )
   }
-
 
   test("select projectjoindate, projectenddate from timestamp_nodictionary where in filter") {
-    if (!sqlContext.sparkContext.version.startsWith("3.1")) {
-      checkAnswer(
-        sql("select projectjoindate, projectenddate from timestamp_nodictionary " +
+    checkAnswer(
+      sql("select projectjoindate, projectenddate from timestamp_nodictionary " +
           "where projectjoindate in ('1800-02-17 00:00:00','3000-10-22 00:00:00') or " +
           "projectenddate in ('1900-11-29 00:00:00','3002-11-15 00:00:00','2041-12-29 00:00:00')"),
-        Seq(Row(Timestamp.valueOf("1800-02-17 00:00:00.0"),
-          Timestamp.valueOf("1900-11-29 00:00:00.0")),
-          Row(Timestamp.valueOf("3000-10-22 00:00:00.0"),
-            Timestamp.valueOf("3002-11-15 00:00:00.0")),
-          Row(Timestamp.valueOf("2038-11-14 00:00:00.0"),
-            Timestamp.valueOf("2041-12-29 00:00:00.0")))
-      )
-    }
-  }
+      Seq(Row(Timestamp.valueOf("1800-02-17 00:00:00.0"),
+        Timestamp.valueOf("1900-11-29 00:00:00.0")),
+        Row(Timestamp.valueOf("3000-10-22 00:00:00.0"), Timestamp.valueOf("3002-11-15 00:00:00.0")),
+        Row(Timestamp.valueOf("2038-11-14 00:00:00.0"), Timestamp.valueOf("2041-12-29 00:00:00.0")))
+    )
 
+  }
 
   override def afterAll {
     CarbonProperties.getInstance()

--- a/streaming/src/main/scala/org/apache/carbondata/streaming/parser/FieldConverter.scala
+++ b/streaming/src/main/scala/org/apache/carbondata/streaming/parser/FieldConverter.scala
@@ -24,6 +24,7 @@ import java.util.Base64
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.util.CarbonProperties
+import org.apache.carbondata.util.SparkStreamingUtil
 
 object FieldConverter {
 
@@ -125,7 +126,7 @@ object FieldConverter {
             i += 1
           }
           builder.substring(0, builder.length - delimiter.length())
-        case other => other.toString
+        case other => SparkStreamingUtil.checkInstant(other, timeStampFormat)
       }
     }
   }

--- a/streaming/src/main/spark2.x/org.apache.carbondata.util/SparkStreamingUtil.scala
+++ b/streaming/src/main/spark2.x/org.apache.carbondata.util/SparkStreamingUtil.scala
@@ -17,6 +17,8 @@
 
 package org.apache.carbondata.util
 
+import java.text.SimpleDateFormat
+
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
@@ -25,5 +27,9 @@ object SparkStreamingUtil {
 
   def convertInternalRowToRow(expressionEncoder: ExpressionEncoder[Row]): InternalRow => Row = {
     expressionEncoder.fromRow
+  }
+
+  def checkInstant(value: Any, timeStampFormat: SimpleDateFormat): String = {
+    value.toString
   }
 }

--- a/streaming/src/main/spark3.1/org/apache/carbondata/util/SparkStreamingUtil.scala
+++ b/streaming/src/main/spark3.1/org/apache/carbondata/util/SparkStreamingUtil.scala
@@ -17,13 +17,26 @@
 
 package org.apache.carbondata.util
 
+import java.text.SimpleDateFormat
+import java.time.Instant
+
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
+import org.apache.spark.sql.catalyst.util.DateTimeUtils
 
 object SparkStreamingUtil {
 
   def convertInternalRowToRow(expressionEncoder: ExpressionEncoder[Row]): InternalRow => Row = {
     expressionEncoder.createDeserializer().apply
+  }
+
+  def checkInstant(value: Any, timeStampFormat: SimpleDateFormat): String = {
+    value match {
+      case instant: Instant =>
+        // if value is instant, convert instant time to java timestamp
+        timeStampFormat format DateTimeUtils.toJavaTimestamp(DateTimeUtils.instantToMicros(instant))
+      case other => other.toString
+    }
   }
 }


### PR DESCRIPTION

 ### Why is this PR needed?
1.  Spark 3.1, will store timestamp value as julian micros and rebase timestamp value from JulianToGregorianMicros during query.
    -> Since carbon parse and formats timestamp value with SimpleDateFormatter, query gives incorrect results, when rebased with JulianToGregorianMicros by spark.

2. CARBONDATA-4241 -> Global sort load and compaction fails on table having timestamp column
 
 ### What changes were proposed in this PR?
1. Use Java Instant to parse new timestamp values. 2. For old stores and query with Spark 3.1, Rebase the timestamp value from Julian to Gregorian Micros
2. If timestamp value is of type Instant, then convert value to java timestamp.
    
 ### Does this PR introduce any user interface change?
 - No
 - 
 ### Is any new testcase added?
 - No (Existing testcase is sufficient)

    
