### PR TITLE
[CARBONDATA-4253] Optimize Rename Table Performance

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/schema/CarbonAlterTableRenameCommand.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/schema/CarbonAlterTableRenameCommand.scala
@@ -124,11 +124,6 @@ private[sql] case class CarbonAlterTableRenameCommand(
       val newCarbonTableIdentifier = new CarbonTableIdentifier(oldDatabaseName,
         newTableName, carbonTable.getCarbonTableIdentifier.getTableId)
       metastore.removeTableFromMetadata(oldDatabaseName, oldTableName)
-      var partitions: Seq[CatalogTablePartition] = Seq.empty
-      if (carbonTable.isHivePartitionTable) {
-        partitions =
-          sparkSession.sessionState.catalog.listPartitions(oldTableIdentifier)
-      }
       sparkSession.catalog.refreshTable(oldTableIdentifier.quotedString)
       CarbonSessionCatalogUtil.alterTableRename(
         oldTableIdentifier,


### PR DESCRIPTION
 ### Why is this PR needed?
  The rename command will list partitions for the table, but the partitions information is not actually used. If the table has hundreds of thousands partitions, the performance of rename table will degrade a lot
 
 ### What changes were proposed in this PR?
 avoid list partitions in RENAMETO command.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No

    
