### PR TITLE
[CARBONDATA-4255] Prohibit Create/Drop Database when databaselocation is inconsistent

### DIFF
--- a/conf/carbon.properties.template
+++ b/conf/carbon.properties.template
@@ -17,9 +17,6 @@
 #
 
 #################### System Configuration ##################
-##Optional. Location where CarbonData will create the store, and write the data in its own format.
-##If not specified then it takes spark.sql.warehouse.dir path.
-#carbon.storelocation
 #Base directory for Data files
 #carbon.ddl.base.hdfs.url
 #Path where the bad records are stored

--- a/conf/dataload.properties.template
+++ b/conf/dataload.properties.template
@@ -16,10 +16,6 @@
 # limitations under the License.
 #
 
-#carbon store path
-# you should change to the code path of your local machine
-carbon.storelocation=/home/david/Documents/carbondata/examples/spark/target/store
-
 #csv delimiter character
 delimiter=,
 

--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -37,6 +37,7 @@ public final class CarbonCommonConstants {
   /**
    * location of the carbon member, hierarchy and fact files
    */
+  @Deprecated
   @CarbonProperty
   public static final String STORE_LOCATION = "carbon.storelocation";
 

--- a/docs/ddl-of-carbondata.md
+++ b/docs/ddl-of-carbondata.md
@@ -638,7 +638,12 @@ CarbonData DDL statements are documented here,which includes:
 
 
 ## CREATE DATABASE 
-  This function creates a new database. By default the database is created in Carbon store location, but you can also specify custom location.
+  This function creates a new database. By default the database is created in location 'spark.sql.warehouse.dir', but you can also specify custom location by configuring 'spark.sql.warehouse.dir', the configuration 'carbon.storelocation' has been deprecated.
+
+  **Note:**
+    For simplicity, we recommended you remove the configuration of carbon.storelocation. If carbon.storelocaiton and spark.sql.warehouse.dir are configured to different paths, exception will be thrown when CREATE DATABASE and DROP DATABASE to avoid inconsistent database location.
+
+
   ```
   CREATE DATABASE [IF NOT EXISTS] database_name [LOCATION path];
   ```

--- a/docs/file-structure-of-carbondata.md
+++ b/docs/file-structure-of-carbondata.md
@@ -42,7 +42,7 @@ This document describes the what a CarbonData table looks like in a HDFS directo
 
 ## File Directory Structure
 
-The CarbonData files are stored in the location specified by the ***carbon.storelocation*** configuration (configured in carbon.properties; if not configured, the default is ../carbon.store).
+The CarbonData files are stored in the location specified by the ***spark.sql.warehouse.dir*** configuration (configured in carbon.properties; if not configured, the default is ../carbon.store).
 
   The file directory structure is as below: 
 

--- a/docs/s3-guide.md
+++ b/docs/s3-guide.md
@@ -28,12 +28,12 @@ Carbondata relies on Hadoop provided S3 filesystem APIs to access Object stores.
 
 # Writing to Object Storage
 
-To store carbondata files onto Object Store, `carbon.storelocation` property will have 
-to be configured with Object Store path in CarbonProperties file. 
+To store carbondata files onto Object Store, `spark.sql.warehouse.dir` property will have 
+to be configured with Object Store path in spark-default.conf. 
 
 For example:
 ```
-carbon.storelocation=s3a://mybucket/carbonstore
+spark.sql.warehouse.dir=s3a://mybucket/carbonstore
 ```
 
 If the existing store location cannot be changed or only specific tables need to be stored 

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/strategy/DDLStrategy.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/strategy/DDLStrategy.scala
@@ -183,8 +183,7 @@ object DDLStrategy extends SparkStrategy {
       // database
       case createDb: CreateDatabaseCommand =>
         ExecutedCommandExec(DDLHelper.createDatabase(createDb, sparkSession)) :: Nil
-      case drop@DropDatabaseCommand(dbName, ifExists, _)
-        if CarbonEnv.databaseLocationExists(dbName, sparkSession, ifExists) =>
+      case drop@DropDatabaseCommand(dbName, ifExists, _) =>
         ExecutedCommandExec(CarbonDropDatabaseCommand(drop)) :: Nil
       // explain
       case explain: ExplainCommand =>


### PR DESCRIPTION
 ### Why is this PR needed?
When carbon.storelocation and spark.sql.warehouse.dir are configured to different values, the databaselocation maybe inconsistent. When DROP DATABASE command is executed, maybe both location (carbon dblcation and hive dblocation) will be cleared, which may confuses the users
 
 
 ### What changes were proposed in this PR?
Drop database is prohibited when database locaton is inconsistent    
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes