### PR TITLE
[CARBONDATA-4256] Fixed parsing failure on SI creation for complex column

### DIFF
--- a/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/TestSIWithComplexArrayType.scala
+++ b/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/TestSIWithComplexArrayType.scala
@@ -351,6 +351,9 @@ class TestSIWithComplexArrayType extends QueryTest with BeforeAndAfterEach {
       sql("create index index_1 on table complextable(country) as 'carbondata'")
     }.getMessage.contains(errMsg))
     assert(intercept[RuntimeException] {
+      sql("create index index_1 on table complextable(country.b) as 'carbondata'")
+    }.getMessage.contains(errMsg))
+    assert(intercept[RuntimeException] {
       sql("create index index_1 on table complextable(id) as 'carbondata'")
     }.getMessage.contains(errMsg))
     assert(intercept[RuntimeException] {

--- a/integration/spark/src/main/scala/org/apache/spark/sql/parser/CarbonSpark2SqlParser.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/parser/CarbonSpark2SqlParser.scala
@@ -192,7 +192,7 @@ class CarbonSpark2SqlParser extends CarbonDDLSqlParser {
   protected lazy val createIndex: Parser[LogicalPlan] =
     CREATE ~> INDEX ~> opt(IF ~> NOT ~> EXISTS) ~ ident ~
     ontable ~
-    ("(" ~> repsep(ident, ",") <~ ")") ~
+    ("(" ~> repsep(element, ",") <~ ")") ~
     (AS ~> stringLit) ~
     (WITH ~> DEFERRED ~> REFRESH).? ~
     (PROPERTIES ~> "(" ~> repsep(options, ",") <~ ")").? <~ opt(";") ^^ {


### PR DESCRIPTION
 ### Why is this PR needed?
 Currently, SI creation on a complex column that includes child column with a dot(.) fails with parse exception.
 
 ### What changes were proposed in this PR?
Handled parsing for create index on complex column.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
