### PR TITLE
[CARBONDATA-4268][Doc][summer-2021] Add new dev mailing list (website) link and update the Nabble address. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,9 @@ This guide document introduces [how to contribute to CarbonData](https://github.
 To get involved in CarbonData:
 
 * First join by emailing to [dev-subscribe@carbondata.apache.org](mailto:dev-subscribe@carbondata.apache.org), then you can discuss issues by emailing to [dev@carbondata.apache.org](mailto:dev@carbondata.apache.org). 
-  Or you can directly visit [Apache CarbonData Dev Mailing List archive](http://apache-carbondata-mailing-list-archive.1130556.n5.nabble.com/). If you do not already have an account, sign up [here](http://apache-carbondata-mailing-list-archive.1130556.n5.nabble.com/template/NamlServlet.jtp?macro=start_registration_page).
-
+  You can also directly visit [dev@carbondata.apache.org](https://lists.apache.org/list.html?dev@carbondata.apache.org). 
+  Or you can visit [Apache CarbonData Dev Mailing List archive](http://apache-carbondata-dev-mailing-list-archive.168.s1.nabble.com/). 
+  
 * Report issues on [Apache Jira](https://issues.apache.org/jira/browse/CARBONDATA). If you do not already have an Apache JIRA account, sign up [here](https://issues.apache.org/jira/).
 
 * You can also slack to get in touch with the community. After we invite you, you can use this [Slack Link](https://carbondataworkspace.slack.com/) to sign in to CarbonData.


### PR DESCRIPTION
 ### Why is this PR needed?
1. The Nabble updated their service, so did the address of  our mailing list website.
2. Add new link of dev@carbondata.apache.org (https://lists.apache.org/list.html?dev@carbondata.apache.org), which is based on Pony Mail!.
 
 ### What changes were proposed in this PR?

    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No

    
JIRA Issue: https://issues.apache.org/jira/browse/CARBONDATA-4268