### PR TITLE
[CARBONDATA-4271] Support DPP for carbon

### DIFF
--- a/integration/spark/src/main/common2.3and2.4/org/apache/spark/sql/CarbonDataSourceScanHelper.scala
+++ b/integration/spark/src/main/common2.3and2.4/org/apache/spark/sql/CarbonDataSourceScanHelper.scala
@@ -20,6 +20,7 @@ package org.apache.spark.sql
 import org.apache.spark.CarbonInputMetrics
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.catalog.CatalogTablePartition
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression => SparkExpression}
 import org.apache.spark.sql.catalyst.plans.QueryPlan
 import org.apache.spark.sql.execution.{ColumnarBatchScan, DataSourceScanExec}
@@ -40,6 +41,8 @@ abstract class  CarbonDataSourceScanHelper(relation: CarbonDatasourceHadoopRelat
     pushedDownProjection: CarbonProjection,
     directScanSupport: Boolean,
     extraRDD: Option[(RDD[InternalRow], Boolean)],
+    selectedCatalogPartitions: Seq[CatalogTablePartition],
+    partitionFilterWithDpp: Seq[SparkExpression],
     segmentIds: Option[String])
   extends DataSourceScanExec with ColumnarBatchScan {
 

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDeltaRowScanRDD.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDeltaRowScanRDD.scala
@@ -44,7 +44,7 @@ class CarbonDeltaRowScanRDD[T: ClassTag](
     @transient private val spark: SparkSession,
     @transient private val serializedTableInfo: Array[Byte],
     @transient private val tableInfo: TableInfo,
-    @transient override val partitionNames: Seq[PartitionSpec],
+    @transient private val newPartitionNames: Seq[PartitionSpec],
     override val columnProjection: CarbonProjection,
     var filter: IndexFilter,
     identifier: AbsoluteTableIdentifier,
@@ -62,7 +62,7 @@ class CarbonDeltaRowScanRDD[T: ClassTag](
     serializedTableInfo,
     tableInfo,
     inputMetricsStats,
-    partitionNames,
+    newPartitionNames,
     dataTypeConverterClz,
     readSupportClz) {
   override def internalGetPartitions: Array[Partition] = {

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonScanRDD.scala
@@ -83,7 +83,7 @@ class CarbonScanRDD[T: ClassTag](
     @transient private val serializedTableInfo: Array[Byte],
     @transient private val tableInfo: TableInfo,
     inputMetricsStats: InitInputMetrics,
-    @transient val partitionNames: Seq[PartitionSpec],
+    @transient var partitionNames: Seq[PartitionSpec],
     val dataTypeConverterClz: Class[_ <: DataTypeConverter] = classOf[SparkDataTypeConverterImpl],
     val readSupportClz: Class[_ <: CarbonReadSupport[_]] = SparkReadSupport.readSupportClass,
     @transient var splits: java.util.List[InputSplit] = null,

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonInsertIntoHadoopFsRelationCommand.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/management/CarbonInsertIntoHadoopFsRelationCommand.scala
@@ -198,8 +198,6 @@ case class CarbonInsertIntoHadoopFsRelationCommand(
 
       // refresh cached files in FileIndex
       fileIndex.foreach(_.refresh())
-      // refresh data cache if table is cached
-      sparkSession.catalog.refreshByPath(outputPath.toString)
 
       if (catalogTable.nonEmpty) {
         CommandUtils.updateTableStats(sparkSession, catalogTable.get)

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonCreateTableAsSelectCommand.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/table/CarbonCreateTableAsSelectCommand.scala
@@ -81,7 +81,7 @@ case class CarbonCreateTableAsSelectCommand(
         tableName = carbonDataSourceHadoopRelation.carbonRelation.tableName,
         options = scala.collection.immutable
           .Map("fileheader" ->
-               carbonDataSourceHadoopRelation.tableSchema.get.fields.map(_.name).mkString(",")),
+               carbonDataSourceHadoopRelation.getTableSchema.get.fields.map(_.name).mkString(",")),
         isOverwriteTable = false,
         logicalPlan = query,
         tableInfo = tableInfo)

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/strategy/DMLStrategy.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/strategy/DMLStrategy.scala
@@ -374,9 +374,10 @@ object DMLStrategy extends SparkStrategy {
     def pushLimit(limit: Int, plan: LogicalPlan): LogicalPlan = {
       val newPlan = plan transform {
         case lr: LogicalRelation =>
-          val newRelation = lr.copy(relation = lr.relation
+          val relation = lr.relation
             .asInstanceOf[CarbonDatasourceHadoopRelation]
-            .copy(limit = limit))
+          relation.setLimit(limit)
+          val newRelation = lr.copy(relation = relation)
           newRelation
         case other => other
       }

--- a/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonFileMetastore.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonFileMetastore.scala
@@ -559,7 +559,7 @@ class CarbonFileMetastore extends CarbonMetaStore {
           case None =>
             CarbonEnv.getTablePath(tableIdentifier.database, tableIdentifier.table)(sparkSession)
         }
-        CarbonDatasourceHadoopRelation(sparkSession,
+        new CarbonDatasourceHadoopRelation(sparkSession,
           Array(tableLocation.asInstanceOf[String]),
           catalogTable.storage.properties,
           Option(catalogTable.schema))

--- a/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/CarbonFilters.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/CarbonFilters.scala
@@ -675,11 +675,11 @@ object CarbonFilters {
     if (!carbonTable.isHivePartitionTable) {
       return (null, null, partitionFilters)
     }
-    val partititions = getCatalogTablePartitions(partitionFilters, sparkSession, carbonTable)
-    if (partititions.isEmpty) {
+    val partitions = getCatalogTablePartitions(partitionFilters, sparkSession, carbonTable)
+    if (partitions.isEmpty) {
       (Seq.empty, Seq.empty, partitionFilters)
     } else {
-      (partititions, convertToPartitionSpec(partititions), partitionFilters)
+      (partitions, convertToPartitionSpec(partitions), partitionFilters)
     }
   }
 }

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/dblocation/DBLocationCarbonTableTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/dblocation/DBLocationCarbonTableTestCase.scala
@@ -268,7 +268,7 @@ class DBLocationCarbonTableTestCase extends QueryTest with BeforeAndAfterEach {
   }
 
   test("Alter table drop column test") {
-    sql(s"create database carbon location '$dbLocation'")
+    sql(s"create database carbon location '$dbLocation/newdb/'")
     sql("use carbon")
     sql(
       """create table carbon.carbontable (

--- a/integration/spark/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/spark/sql/DynamicPartitionPruningTestCase.scala
@@ -1,0 +1,235 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql
+
+import org.apache.spark.SPARK_VERSION
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.execution.strategy.CarbonDataSourceScan
+import org.apache.spark.sql.test.util.QueryTest
+import org.apache.spark.util.SparkUtil
+import org.scalatest.BeforeAndAfterEach
+
+import org.apache.carbondata.spark.rdd.CarbonScanRDD
+
+class DynamicPartitionPruningTestCase extends QueryTest with BeforeAndAfterEach {
+
+  override protected def beforeEach(): Unit = {
+    sql("drop table if exists dpp_table1")
+    sql("drop table if exists dpp_table2")
+  }
+
+  override protected def afterEach(): Unit = {
+    sql("drop table if exists dpp_table1")
+    sql("drop table if exists dpp_table2")
+  }
+
+  test("test partition pruning: carbon join other format table") {
+    sql("create table dpp_table1(col1 int) partitioned by (col2 string) stored as carbondata")
+    sql("insert into dpp_table1 values(1, 'a'),(2, 'b'),(3, 'c'),(4, 'd')")
+    sql("create table dpp_table2(col1 int, col2 string) ")
+    sql("insert into dpp_table2 values(1, 'a'),(2, 'b'),(3, 'c'),(4, 'd')")
+
+    // partition table without filter
+    verifyPartitionPruning(
+      "select t1.col1 from dpp_table1 t1, dpp_table2 t2 " +
+      "where t1.col2=t2.col2 and t2.col1 in (1,2)",
+      "dpp_table1",
+      2,
+      4)
+
+    // partition table with filter on partition column
+    verifyPartitionPruning(
+      "select t1.col1 from dpp_table1 t1, dpp_table2 t2 " +
+      "where t1.col2=t2.col2 and t2.col2 in ('b','c') and t2.col1 in (1,2)",
+      "dpp_table1",
+      1,
+      2)
+
+    // partition table with filter on normal column
+    verifyPartitionPruning(
+      "select t1.col1 from dpp_table1 t1, dpp_table2 t2 " +
+      "where t1.col2=t2.col2 and t1.col1 in (2, 3) and t2.col1 in (1,2)",
+      "dpp_table1",
+      2,
+      4)
+
+    // partition table with filter on normal column and partition column
+    verifyPartitionPruning(
+      "select t1.col1 from dpp_table1 t1, dpp_table2 t2 " +
+      "where t1.col2=t2.col2 and t1.col1 in (2, 3) and t1.col2 in ('b', 'c') and t2.col1 in (1,2)",
+      "dpp_table1",
+      1,
+      2)
+  }
+
+  test("test partition pruning: carbon join format table") {
+    sql("create table dpp_table1(col1 int) partitioned by (col2 string) stored as carbondata")
+    sql("insert into dpp_table1 values(1, 'a'),(2, 'b'),(3, 'c'),(4, 'd')")
+    sql("create table dpp_table2(col1 int, col2 string) stored as carbondata")
+    sql("insert into dpp_table2 values(1, 'a'),(2, 'b'),(3, 'c'),(4, 'd')")
+
+    // partition table without filter
+    verifyPartitionPruning(
+      "select t1.col1 from dpp_table1 t1, dpp_table2 t2 " +
+      "where t1.col2=t2.col2 and t2.col1 in (1,2)",
+      "dpp_table1",
+      2,
+      4)
+
+    // partition table with filter on partition column
+    verifyPartitionPruning(
+      "select t1.col1 from dpp_table1 t1, dpp_table2 t2 " +
+      "where t1.col2=t2.col2 and t2.col2 in ('b','c') and t2.col1 in (1,2)",
+      "dpp_table1",
+      1,
+      2)
+
+    // partition table with filter on normal column
+    verifyPartitionPruning(
+      "select t1.col1 from dpp_table1 t1, dpp_table2 t2 " +
+      "where t1.col2=t2.col2 and t1.col1 in (2, 3) and t2.col1 in (1,2)",
+      "dpp_table1",
+      2,
+      4)
+
+    // partition table with filter on normal column and partition column
+    verifyPartitionPruning(
+      "select t1.col1 from dpp_table1 t1, dpp_table2 t2 " +
+      "where t1.col2=t2.col2 and t1.col1 in (2, 3) and t1.col2 in ('b', 'c') and t2.col1 in (1,2)",
+      "dpp_table1",
+      1,
+      2)
+  }
+
+  test("test partition pruning: partitioned table join partitioned table") {
+    sql("create table dpp_table1(col1 int) partitioned by (col2 string) stored as carbondata")
+    sql("insert into dpp_table1 values(1, 'a'),(2, 'b'),(3, 'c'),(4, 'd')")
+    sql("create table dpp_table2(col1 int) partitioned by (col2 string) stored as carbondata")
+    sql("insert into dpp_table2 values(1, 'a'),(2, 'b'),(3, 'c'),(4, 'd')")
+
+    // partition table without filter
+    verifyPartitionPruning(
+      "select t1.col1 from dpp_table1 t1, dpp_table2 t2 " +
+      "where t1.col2=t2.col2 and t2.col1 in (1,2)",
+      "dpp_table1",
+      2,
+      4)
+
+    // right table without filter
+    verifyPartitionPruning(
+      "select /** BROADCAST(t1) */ t1.col1 from dpp_table1 t1, dpp_table2 t2 " +
+      "where t1.col2=t2.col2 and t1.col1 in (1,2)",
+      "dpp_table2",
+      4,
+      4)
+
+    // left table with filter on partition column
+    verifyPartitionPruning(
+      "select t1.col1 from dpp_table1 t1, dpp_table2 t2 " +
+      "where t1.col2=t2.col2 and t1.col2 in ('b', 'c') and t2.col1 in (1,2)",
+      "dpp_table1",
+      1,
+      2)
+
+    // right table with filter on partition column
+    verifyPartitionPruning(
+      "select t1.col1 from dpp_table1 t1, dpp_table2 t2 " +
+      "where t1.col2=t2.col2 and t2.col2 in ('b', 'c') and t1.col1 in (1,2)",
+      "dpp_table2",
+      2,
+      2,
+      false)
+
+    // left table with filter on normal column
+    verifyPartitionPruning(
+      "select t1.col1 from dpp_table1 t1, dpp_table2 t2 " +
+      "where t1.col2=t2.col2 and t1.col1 in (2, 3) and t2.col1 in (1,2)",
+      "dpp_table1",
+      2,
+      4)
+
+    // right table with filter on normal column
+    verifyPartitionPruning(
+      "select t1.col1 from dpp_table1 t1, dpp_table2 t2 " +
+      "where t1.col2=t2.col2 and t2.col1 in (2, 3) and t1.col1 in (1,2)",
+      "dpp_table2",
+      4,
+      4,
+      false)
+
+    // left table with filter on normal column and partition column
+    verifyPartitionPruning(
+      "select t1.col1 from dpp_table1 t1, dpp_table2 t2 " +
+      "where t1.col2=t2.col2 and t1.col1 in (2, 3) and t1.col2 in ('b', 'c') and t2.col1 in (1,2)",
+      "dpp_table1",
+      1,
+      2)
+
+    // right table with filter on normal column and partition column
+    verifyPartitionPruning(
+      "select t1.col1 from dpp_table1 t1, dpp_table2 t2 " +
+      "where t1.col2=t2.col2 and t2.col1 in (2, 3) and t2.col2 in ('b', 'c') and t1.col1 in (1,2)",
+      "dpp_table2",
+      2,
+      2,
+      false)
+
+    // both tables with filter on normal column and partition column
+    verifyPartitionPruning(
+      "select t1.col1 from dpp_table1 t1, dpp_table2 t2 " +
+      "where t1.col2=t2.col2 and  t1.col1 in (2, 3) and t1.col2 in ('a', 'b', 'c') and " +
+      "t2.col1 = 2 and t2.col2 in ('a', 'b')",
+      "dpp_table1",
+      1,
+      2)
+
+    verifyPartitionPruning(
+      "select t1.col1 from dpp_table1 t1, dpp_table2 t2 " +
+      "where t1.col2=t2.col2 and  t2.col1 in (2, 3) and t2.col2 in ('a', 'b', 'c') and " +
+      "t1.col1 = 2 and t2.col2 in ('a', 'b')",
+      "dpp_table2",
+      2,
+      2,
+      false)
+  }
+
+  private def verifyPartitionPruning(sqlText: String,
+      tableName: String,
+      dynamicPartitionPruning: Int,
+      staticPartitionPruning: Int,
+      hasDynamicPruning: Boolean = true): Unit = {
+    if (SPARK_VERSION.startsWith("3")) {
+      val df = sql(sqlText)
+      df.collect()
+      val ds = df.queryExecution.executedPlan.find { plan =>
+        plan.isInstanceOf[CarbonDataSourceScan] &&
+        plan.asInstanceOf[CarbonDataSourceScan].tableIdentifier.get.table.equals(tableName)
+      }
+      val carbonDs = ds.get.asInstanceOf[CarbonDataSourceScan]
+      val carbonRdd = carbonDs.inputRDDs().head.asInstanceOf[CarbonScanRDD[InternalRow]]
+      assert(carbonDs.metadata.contains("PartitionFilters"))
+      if (SparkUtil.isSparkVersionXAndAbove("2.4")) {
+        if (hasDynamicPruning) {
+          assert(carbonDs.metadata("PartitionFilters").contains("dynamicpruning"))
+        }
+        assertResult(dynamicPartitionPruning)(carbonRdd.partitionNames.size)
+      } else {
+        assertResult(staticPartitionPruning)(carbonRdd.partitionNames.size)
+      }
+    }
+  }
+}


### PR DESCRIPTION
 ### Why is this PR needed?
 This PR enables Dynamic Partition Pruning for carbon.
 
 ### What changes were proposed in this PR?
1. CarbonDatasourceHadoopRelation has to extend HadoopFsRelation, because spark has added a check to use DPP only for relation matching HadoopFsRelation
2. Apply Dynamic filter and get runtimePartitions and set this to CarbonScanRDD for pruning
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
