### PR TITLE
[CARBONDATA-4273] Fix Cannot create external table with partitions

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/parser/CarbonSparkSqlParserUtil.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/parser/CarbonSparkSqlParserUtil.scala
@@ -215,10 +215,6 @@ object CarbonSparkSqlParserUtil {
       table.identifier.table.toLowerCase()
     )
     val tableInfo = if (isExternal) {
-      if (partitionColumnNames.nonEmpty) {
-        throw new MalformedCarbonCommandException(
-          "Partition is not supported for external table")
-      }
       // read table info from schema file in the provided table path
       val tableInfo = {
         try {


### PR DESCRIPTION
 ### Why is this PR needed?
 Create partition table with location fails with unsupported message.
 
 ### What changes were proposed in this PR?
This scenario works in cluster mode. This check can be moved in local mode also and partition table can be created with table with location
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
