### PR TITLE
[CARBONDATA-4282] Fix issues with table having complex columns related to long string, SI, local dictionary

### DIFF
--- a/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/TestSIWithComplexArrayType.scala
+++ b/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/TestSIWithComplexArrayType.scala
@@ -425,11 +425,19 @@ class TestSIWithComplexArrayType extends QueryTest with BeforeAndAfterEach {
   }
 
   test("test si creation with array") {
-    sql("create table complextable (id int, name string, country array<array<string>>, add array<int>) stored as carbondata")
+    sql("create table complextable (id int, name string, country array<array<string>>," +
+        " add array<map<int,int>>, code array<struct<a:string,b:int>>) stored as carbondata")
     sql("drop index if exists index_1 on complextable")
+    val errorMessage = "SI creation with nested array complex type is not supported yet"
     assert(intercept[RuntimeException] {
       sql("create index index_1 on table complextable(country) as 'carbondata'")
-    }.getMessage.contains("SI creation with nested array complex type is not supported yet"))
+    }.getMessage.contains(errorMessage))
+    assert(intercept[RuntimeException] {
+      sql("create index index_1 on table complextable(add) as 'carbondata'")
+    }.getMessage.contains(errorMessage))
+    assert(intercept[RuntimeException] {
+      sql("create index index_1 on table complextable(code) as 'carbondata'")
+    }.getMessage.contains(errorMessage))
   }
 
   test("test complex with null and empty data") {

--- a/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/command/SICreationCommand.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/command/SICreationCommand.scala
@@ -497,7 +497,9 @@ private[sql] case class CarbonCreateSecondaryIndexCommand(
         }
         if (dimension.getNumberOfChild > 0) {
           val complexChildDims = dimension.getListOfChildDimensions.asScala
-          if (complexChildDims.exists(col => DataTypes.isArrayType(col.getDataType))) {
+          // For complex columns, SI creation on only array of primitive types is allowed.
+          // Check if child column is of complex type and throw exception.
+          if (complexChildDims.exists(col => col.isComplex)) {
             throw new ErrorMessage(
               "SI creation with nested array complex type is not supported yet")
           }

--- a/integration/spark/src/main/scala/org/apache/spark/util/AlterTableUtil.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/util/AlterTableUtil.scala
@@ -992,10 +992,7 @@ object AlterTableUtil {
                                      .equalsIgnoreCase("STRING") &&
                                    !col.getDataType.toString
                                      .equalsIgnoreCase("VARCHAR") &&
-                                   !col.getDataType.toString
-                                     .equalsIgnoreCase("STRUCT") &&
-                                   !col.getDataType.toString
-                                     .equalsIgnoreCase("ARRAY"))) {
+                                   !col.getDataType.isComplexType)) {
         val errMsg = "LOCAL_DICTIONARY_INCLUDE/LOCAL_DICTIONARY_EXCLUDE column: " + dictCol.trim +
                      " is not a string/complex/varchar datatype column. LOCAL_DICTIONARY_INCLUDE" +
                      "/LOCAL_DICTIONARY_EXCLUDE should be no " +

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/alterTable/TestAlterTableAddColumns.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/alterTable/TestAlterTableAddColumns.scala
@@ -237,9 +237,10 @@ class TestAlterTableAddColumns extends QueryTest with BeforeAndAfterAll {
   }
 
 
-  test("Test alter add complex type and compaction") {
+  test("Test alter add complex type with long string column and compaction") {
     sql("DROP TABLE IF EXISTS alter_com")
-    sql("create table alter_com (a int, b string, arr1 array<string>) stored as carbondata")
+    sql("create table alter_com (a int, b string, arr1 array<string>) stored as carbondata" +
+        " tblproperties('long_string_columns'='b')")
     sql("insert into alter_com select 1,'a',array('hi')")
     sql("insert into alter_com select 2,'b',array('hello','world')")
     sql("ALTER TABLE alter_com ADD COLUMNS(struct1 STRUCT<a:int, b:string>)")


### PR DESCRIPTION
 ### Why is this PR needed?
 1. Insert/load fails after alter add complex column if table contains long string columns.
 2. create index on array of complex column (map/struct) throws null pointer exception instead of correct error message.
 3. alter table property local dictionary inlcude/exclude with newly added map column is failing.
 
 ### What changes were proposed in this PR?
1. The datatypes array and data row are of different order leading to `ClassCastException`. Made changes to add newly added complex columns after the long string columns and other dimensions in `carbonTableSchemaCommon.scala`
2. For complex columns, SI creation on only array of primitive types is allowed. Check if the child column is of complex type and throw an exception. Changes made in `SICreationCommand.scala`
3. In `AlterTableUtil.scala`, while validating local dictionary columns, array and struct type are present but map type is missed. Added check for complex types.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
