### PR TITLE
[CARBONDATA-4277] geo instance compatability fix

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/util/CustomIndex.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CustomIndex.java
@@ -35,6 +35,8 @@ import java.util.Map;
  * @param <ReturnType>
  */
 public abstract class CustomIndex<ReturnType> implements Serializable {
+
+  private static final long serialVersionUID = 6529685098267757692L;
   /**
    * Initialize the custom index instance.
    * @param indexName

--- a/docs/spatial-index-guide.md
+++ b/docs/spatial-index-guide.md
@@ -78,6 +78,8 @@ Note:
    * `mygeohash` in the above example represent the index name.
    * Columns present in spatial_index table properties cannot be altered
     i.e., sourcecolumns: `longitude, latitude` and index column: `mygeohash` in the above example.
+   * To make the spatial instance compatible with previous versions, trigger refresh table command.
+     In direct upgrade scenario, if spatial table already exists then refresh command fails but updates the instance property in metadata.
 
 #### List of spatial index table properties
 

--- a/integration/spark/src/main/scala/org/apache/spark/util/AlterTableUtil.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/util/AlterTableUtil.scala
@@ -485,7 +485,9 @@ object AlterTableUtil {
         // with the newly added/modified comment since thriftTable also holds comment as its
         // direct property.
         lowerCasePropertiesMap.foreach { property =>
-          if (validateTableProperties(property._1)) {
+          if (validateTableProperties(property._1) ||
+              (property._1.startsWith(CarbonCommonConstants.SPATIAL_INDEX) &&
+               property._1.endsWith("instance"))) {
             tblPropertiesMap.put(property._1, property._2)
           } else {
             val errorMessage = "Error: Invalid option(s): " + property._1.toString()


### PR DESCRIPTION
 ### Why is this PR needed?
 The `CustomIndex `interface extends Serializable and for different version store, if the serialization id doesn't match, it throws `java.io.InvalidClassException` during load/update/query operations.
 
 ### What changes were proposed in this PR?
As the instance is stored in table properties, made changes to initialize and update instance while refresh table. Also added static serialId for the CustomIndex interface.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No, tested in cluster

    
