### PR TITLE
[CARBONDATA-4286] Fixed measure comparator

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletIndex.java
+++ b/core/src/main/java/org/apache/carbondata/core/indexstore/blockletindex/BlockletIndex.java
@@ -158,13 +158,15 @@ public class BlockletIndex extends BlockIndex implements Serializable {
       row.setRow(addMinMax(schema[ordinal], minValuesForColumnsToBeCached), ordinal);
       // compute and set task level min values
       addTaskMinMaxValues(summaryRow, taskSummarySchema, taskMinMaxOrdinal,
-          minValuesForColumnsToBeCached, TASK_MIN_VALUES_INDEX, true);
+          minValuesForColumnsToBeCached, TASK_MIN_VALUES_INDEX,
+              true, fileFooter.getColumnInTable());
       ordinal++;
       taskMinMaxOrdinal++;
       row.setRow(addMinMax(schema[ordinal], maxValuesForColumnsToBeCached), ordinal);
       // compute and set task level max values
       addTaskMinMaxValues(summaryRow, taskSummarySchema, taskMinMaxOrdinal,
-          maxValuesForColumnsToBeCached, TASK_MAX_VALUES_INDEX, false);
+          maxValuesForColumnsToBeCached, TASK_MAX_VALUES_INDEX,
+              false, fileFooter.getColumnInTable());
       ordinal++;
       row.setInt(blockletInfo.getNumberOfRows(), ordinal++);
       // add file name

--- a/core/src/main/java/org/apache/carbondata/core/segmentmeta/SegmentMetaDataInfoStats.java
+++ b/core/src/main/java/org/apache/carbondata/core/segmentmeta/SegmentMetaDataInfoStats.java
@@ -19,10 +19,12 @@ package org.apache.carbondata.core.segmentmeta;
 
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.carbondata.core.constants.CarbonCommonConstants;
 import org.apache.carbondata.core.indexstore.blockletindex.BlockIndex;
+import org.apache.carbondata.core.metadata.schema.table.column.ColumnSchema;
 import org.apache.carbondata.core.util.ByteUtil;
 
 /**
@@ -84,7 +86,7 @@ public class SegmentMetaDataInfoStats {
   }
 
   public synchronized void setBlockMetaDataInfo(String tableName, String segmentId,
-      BlockColumnMetaDataInfo currentBlockColumnMetaInfo) {
+      BlockColumnMetaDataInfo currentBlockColumnMetaInfo, List<ColumnSchema> columnSchemaList) {
     // check if tableName is present in tableSegmentMetaDataInfoMap
     if (!this.tableSegmentMetaDataInfoMap.isEmpty() && null != this.tableSegmentMetaDataInfoMap
         .get(tableName) && !this.tableSegmentMetaDataInfoMap.get(tableName).isEmpty()
@@ -94,9 +96,9 @@ public class SegmentMetaDataInfoStats {
           this.tableSegmentMetaDataInfoMap.get(tableName).get(segmentId);
       // compare and get updated min and max values
       byte[][] updatedMin = BlockIndex.compareAndUpdateMinMax(previousBlockColumnMetaInfo.getMin(),
-          currentBlockColumnMetaInfo.getMin(), true);
+          currentBlockColumnMetaInfo.getMin(), true, columnSchemaList);
       byte[][] updatedMax = BlockIndex.compareAndUpdateMinMax(previousBlockColumnMetaInfo.getMax(),
-          currentBlockColumnMetaInfo.getMax(), false);
+          currentBlockColumnMetaInfo.getMax(), false, columnSchemaList);
       // update the segment
       this.tableSegmentMetaDataInfoMap.get(tableName).get(segmentId)
           .setMinMax(updatedMin, updatedMax);

--- a/core/src/main/java/org/apache/carbondata/core/util/AbstractDataFileFooterConverter.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/AbstractDataFileFooterConverter.java
@@ -231,7 +231,8 @@ public abstract class AbstractDataFileFooterConverter {
    * @param blockletIndexList
    * @return blocklet index
    */
-  protected BlockletIndex getBlockletIndexForDataFileFooter(List<BlockletIndex> blockletIndexList) {
+  protected BlockletIndex getBlockletIndexForDataFileFooter(List<BlockletIndex> blockletIndexList,
+        List<ColumnSchema> columnSchemaList) {
     BlockletIndex blockletIndex = new BlockletIndex();
     BlockletBTreeIndex blockletBTreeIndex = new BlockletBTreeIndex();
     blockletBTreeIndex.setStartKey(blockletIndexList.get(0).getBtreeIndex().getStartKey());
@@ -257,11 +258,22 @@ public abstract class AbstractDataFileFooterConverter {
           currentMinValue[j] = new byte[0];
           continue;
         }
-        if (ByteUtil.UnsafeComparer.INSTANCE.compareTo(currentMinValue[j], minValue[j]) > 0) {
-          currentMinValue[j] = minValue[j].clone();
-        }
-        if (ByteUtil.UnsafeComparer.INSTANCE.compareTo(currentMaxValue[j], maxValue[j]) < 0) {
-          currentMaxValue[j] = maxValue[j].clone();
+        if (columnSchemaList.get(j).isDimensionColumn()) {
+          if (ByteUtil.UnsafeComparer.INSTANCE.compareTo(currentMinValue[j], minValue[j]) > 0) {
+            currentMinValue[j] = minValue[j].clone();
+          }
+          if (ByteUtil.UnsafeComparer.INSTANCE.compareTo(currentMaxValue[j], maxValue[j]) < 0) {
+            currentMaxValue[j] = maxValue[j].clone();
+          }
+        } else {
+          if (CarbonUtil.compareMeasureData(currentMinValue[j], minValue[j],
+                  columnSchemaList.get(j).getDataType()) > 0) {
+            currentMinValue[j] = minValue[j].clone();
+          }
+          if (CarbonUtil.compareMeasureData(currentMaxValue[j], maxValue[j],
+                  columnSchemaList.get(j).getDataType()) < 0) {
+            currentMaxValue[j] = maxValue[j].clone();
+          }
         }
       }
     }

--- a/core/src/main/java/org/apache/carbondata/core/util/ByteUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/ByteUtil.java
@@ -200,6 +200,9 @@ public final class ByteUtil {
      * @param buffer1 value to compare
      * @param buffer2 value to compare
      * @return compare result
+     * Please be careful while using this method as this is valid only for dimension columns.
+     * In case of measure column and for negative and positive buffer values
+     * it will return incorrect result.
      */
     public int compareTo(byte[] buffer1, byte[] buffer2) {
 

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonMetadataUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonMetadataUtil.java
@@ -33,8 +33,6 @@ import org.apache.carbondata.core.datastore.page.encoding.EncodedColumnPage;
 import org.apache.carbondata.core.datastore.page.statistics.SimpleStatsResult;
 import org.apache.carbondata.core.datastore.page.statistics.TablePageStatistics;
 import org.apache.carbondata.core.metadata.ColumnarFormatVersion;
-import org.apache.carbondata.core.metadata.datatype.DataType;
-import org.apache.carbondata.core.metadata.datatype.DataTypes;
 import org.apache.carbondata.core.metadata.index.BlockIndexInfo;
 import org.apache.carbondata.core.metadata.schema.table.column.CarbonMeasure;
 import org.apache.carbondata.format.BlockIndex;
@@ -267,12 +265,12 @@ public class CarbonMetadataUtil {
             getEncodedColumnPages(encodedBlocklet, false, i));
         minVal = stats.getMeasureMinValue()[j];
         maxVal = stats.getMeasureMaxValue()[j];
-        if (compareMeasureData(measureMaxValue[j], maxVal, carbonMeasureList.get(j).getDataType())
-            < 0) {
+        if (CarbonUtil.compareMeasureData(measureMaxValue[j], maxVal,
+                carbonMeasureList.get(j).getDataType()) < 0) {
           measureMaxValue[j] = maxVal.clone();
         }
-        if (compareMeasureData(measureMinValue[j], minVal, carbonMeasureList.get(j).getDataType())
-            > 0) {
+        if (CarbonUtil.compareMeasureData(measureMinValue[j], minVal,
+                carbonMeasureList.get(j).getDataType()) > 0) {
           measureMinValue[j] = minVal.clone();
         }
       }
@@ -491,51 +489,6 @@ public class CarbonMetadataUtil {
       dataChunksList.add(encodedColumnPage.getPageMetadata());
     }
     return CarbonMetadataUtil.getDataChunk3(dataChunksList, null);
-  }
-
-  private static int compareMeasureData(byte[] first, byte[] second, DataType dataType) {
-    ByteBuffer firstBuffer = null;
-    ByteBuffer secondBuffer = null;
-    if (dataType == DataTypes.BOOLEAN || dataType == DataTypes.BYTE) {
-      if (first[0] > second[0]) {
-        return 1;
-      } else if (first[0] < second[0]) {
-        return -1;
-      }
-      return 0;
-    } else if (dataType == DataTypes.DOUBLE) {
-      double firstValue = ((ByteBuffer) (ByteBuffer.allocate(8).put(first).flip())).getDouble();
-      double secondValue = ((ByteBuffer) (ByteBuffer.allocate(8).put(second).flip())).getDouble();
-      if (firstValue > secondValue) {
-        return 1;
-      } else if (firstValue < secondValue) {
-        return -1;
-      }
-      return 0;
-    } else if (dataType == DataTypes.FLOAT) {
-      float firstValue = ((ByteBuffer) (ByteBuffer.allocate(8).put(first).flip())).getFloat();
-      float secondValue = ((ByteBuffer) (ByteBuffer.allocate(8).put(second).flip())).getFloat();
-      if (firstValue > secondValue) {
-        return 1;
-      } else if (firstValue < secondValue) {
-        return -1;
-      }
-      return 0;
-    } else if (dataType == DataTypes.LONG || dataType == DataTypes.INT
-        || dataType == DataTypes.SHORT) {
-      long firstValue = ((ByteBuffer) (ByteBuffer.allocate(8).put(first).flip())).getLong();
-      long secondValue = ((ByteBuffer) (ByteBuffer.allocate(8).put(second).flip())).getLong();
-      if (firstValue > secondValue) {
-        return 1;
-      } else if (firstValue < secondValue) {
-        return -1;
-      }
-      return 0;
-    } else if (DataTypes.isDecimal(dataType)) {
-      return DataTypeUtil.byteToBigDecimal(first).compareTo(DataTypeUtil.byteToBigDecimal(second));
-    } else {
-      throw new IllegalArgumentException("Invalid data type:" + dataType);
-    }
   }
 
   /**

--- a/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/CarbonUtil.java
@@ -1024,6 +1024,51 @@ public final class CarbonUtil {
         .toPrimitive(isDictionaryDimensions.toArray(new Boolean[isDictionaryDimensions.size()]));
   }
 
+  public static int compareMeasureData(byte[] first, byte[] second, DataType dataType) {
+    ByteBuffer firstBuffer = null;
+    ByteBuffer secondBuffer = null;
+    if (dataType == DataTypes.BOOLEAN || dataType == DataTypes.BYTE) {
+      if (first[0] > second[0]) {
+        return 1;
+      } else if (first[0] < second[0]) {
+        return -1;
+      }
+      return 0;
+    } else if (dataType == DataTypes.DOUBLE) {
+      double firstValue = ((ByteBuffer) (ByteBuffer.allocate(8).put(first).flip())).getDouble();
+      double secondValue = ((ByteBuffer) (ByteBuffer.allocate(8).put(second).flip())).getDouble();
+      if (firstValue > secondValue) {
+        return 1;
+      } else if (firstValue < secondValue) {
+        return -1;
+      }
+      return 0;
+    } else if (dataType == DataTypes.FLOAT) {
+      float firstValue = ((ByteBuffer) (ByteBuffer.allocate(8).put(first).flip())).getFloat();
+      float secondValue = ((ByteBuffer) (ByteBuffer.allocate(8).put(second).flip())).getFloat();
+      if (firstValue > secondValue) {
+        return 1;
+      } else if (firstValue < secondValue) {
+        return -1;
+      }
+      return 0;
+    } else if (dataType == DataTypes.LONG || dataType == DataTypes.INT
+            || dataType == DataTypes.SHORT) {
+      long firstValue = ((ByteBuffer) (ByteBuffer.allocate(8).put(first).flip())).getLong();
+      long secondValue = ((ByteBuffer) (ByteBuffer.allocate(8).put(second).flip())).getLong();
+      if (firstValue > secondValue) {
+        return 1;
+      } else if (firstValue < secondValue) {
+        return -1;
+      }
+      return 0;
+    } else if (DataTypes.isDecimal(dataType)) {
+      return DataTypeUtil.byteToBigDecimal(first).compareTo(DataTypeUtil.byteToBigDecimal(second));
+    } else {
+      throw new IllegalArgumentException("Invalid data type:" + dataType);
+    }
+  }
+
   /**
    * This method will form one single byte [] for all the high card dims.
    * First it will add all the indexes of variable length byte[] and then the

--- a/core/src/main/java/org/apache/carbondata/core/util/DataFileFooterConverter.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/DataFileFooterConverter.java
@@ -85,7 +85,8 @@ public class DataFileFooterConverter extends AbstractDataFileFooterConverter {
         blockletInfoList.add(blockletInfo);
       }
       dataFileFooter.setBlockletList(blockletInfoList);
-      dataFileFooter.setBlockletIndex(getBlockletIndexForDataFileFooter(blockletIndexList));
+      dataFileFooter.setBlockletIndex(getBlockletIndexForDataFileFooter(blockletIndexList,
+          dataFileFooter.getColumnInTable()));
     } finally {
       if (null != fileReader) {
         fileReader.finish();

--- a/core/src/main/java/org/apache/carbondata/core/util/DataFileFooterConverterV3.java
+++ b/core/src/main/java/org/apache/carbondata/core/util/DataFileFooterConverterV3.java
@@ -103,7 +103,8 @@ public class DataFileFooterConverterV3 extends AbstractDataFileFooterConverter {
       blockletInfoList.add(blockletInfo);
     }
     dataFileFooter.setBlockletList(blockletInfoList);
-    dataFileFooter.setBlockletIndex(getBlockletIndexForDataFileFooter(blockletIndexList));
+    dataFileFooter.setBlockletIndex(getBlockletIndexForDataFileFooter(blockletIndexList,
+        dataFileFooter.getColumnInTable()));
     return dataFileFooter;
   }
 

--- a/core/src/test/java/org/apache/carbondata/core/util/CarbonMetadataUtilTest.java
+++ b/core/src/test/java/org/apache/carbondata/core/util/CarbonMetadataUtilTest.java
@@ -209,7 +209,7 @@ public class CarbonMetadataUtilTest {
     buffer.flip();
     byte[] r = buffer.array().clone();
 
-    Method method = CarbonMetadataUtil.class
+    Method method = CarbonUtil.class
         .getDeclaredMethod("compareMeasureData", l.getClass(), r.getClass(),
             org.apache.carbondata.core.metadata.datatype.DataType.class);
     method.setAccessible(true);

--- a/processing/src/main/java/org/apache/carbondata/processing/store/writer/AbstractFactDataWriter.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/store/writer/AbstractFactDataWriter.java
@@ -428,7 +428,7 @@ public abstract class AbstractFactDataWriter implements CarbonFactDataWriter {
             new BlockColumnMetaDataInfo(thriftColumnSchemaList, min, max);
         SegmentMetaDataInfoStats.getInstance()
             .setBlockMetaDataInfo(model.getTableName(), model.getSegmentId(),
-                blockColumnMetaDataInfo);
+                blockColumnMetaDataInfo, this.model.getWrapperColumnSchema());
       }
     }
     String indexFileName;


### PR DESCRIPTION
 ### Why is this PR needed?
 Select query on a table with and filter condition returns an empty result while valid data present in the table.

**Root cause:** Currently when we are building the min-max index at block level that time we are using unsafe byte comparator for either dimension or measure column which returns incorrect result for measure columns. 
 
 ### What changes were proposed in this PR?
We should use different comparators for dimensions and measure columns which we are already doing at time of writing the min-max index at blocklet level.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No

    
