### PR TITLE
[CARBONDATA-4285] Fix alter add complex columns with global sort compaction failure

### DIFF
--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableOutputFormat.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonTableOutputFormat.java
@@ -365,11 +365,16 @@ public class CarbonTableOutputFormat extends FileOutputFormat<NullWritable, Obje
     if (null == complexDelim) {
       complexDelim = ComplexDelimitersEnum.COMPLEX_DELIMITERS_LEVEL_1.value() + ","
           + ComplexDelimitersEnum.COMPLEX_DELIMITERS_LEVEL_2.value() + ","
-          + ComplexDelimitersEnum.COMPLEX_DELIMITERS_LEVEL_3.value();
+          + ComplexDelimitersEnum.COMPLEX_DELIMITERS_LEVEL_3.value() + ","
+          + ComplexDelimitersEnum.COMPLEX_DELIMITERS_LEVEL_4.value();
     }
     String[] split = complexDelim.split(",");
     model.setComplexDelimiter(split[0]);
-    if (split.length > 2) {
+    if (split.length > 3) {
+      model.setComplexDelimiter(split[1]);
+      model.setComplexDelimiter(split[2]);
+      model.setComplexDelimiter(split[3]);
+    } else if (split.length > 2) {
       model.setComplexDelimiter(split[1]);
       model.setComplexDelimiter(split[2]);
     } else if (split.length > 1) {

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/load/DataLoadProcessorStepOnSpark.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/load/DataLoadProcessorStepOnSpark.scala
@@ -221,10 +221,11 @@ object DataLoadProcessorStepOnSpark {
       modelBroadcast: Broadcast[CarbonLoadModel],
       partialSuccessAccum: LongAccumulator,
       rowCounter: LongAccumulator,
-      keepActualData: Boolean = false): Iterator[CarbonRow] = {
+      keepActualData: Boolean = false,
+      isCompactionFlow: Boolean = false): Iterator[CarbonRow] = {
     val model: CarbonLoadModel = modelBroadcast.value.getCopyWithTaskNo(index.toString)
     val conf = DataLoadProcessBuilder.createConfiguration(model)
-    val badRecordLogger = BadRecordsLoggerProvider.createBadRecordLogger(conf)
+    val badRecordLogger = BadRecordsLoggerProvider.createBadRecordLogger(conf, isCompactionFlow)
     if (keepActualData) {
       conf.getDataFields.foreach(_.setUseActualData(keepActualData))
     }

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonTableCompactor.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonTableCompactor.scala
@@ -507,7 +507,8 @@ class CarbonTableCompactor(
         Option(dataFrame),
         outputModel,
         SparkSQLUtil.sessionState(sparkSession).newHadoopConf(),
-        segmentMetaDataAccumulator)
+        segmentMetaDataAccumulator,
+        isCompactionFlow = true)
         .map { row =>
           (row._1, FailureCauses.NONE == row._2._2.failureCauses)
         }

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/BadRecordsLogger.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/BadRecordsLogger.java
@@ -88,11 +88,13 @@ public class BadRecordsLogger {
 
   private boolean isDataLoadFail;
 
+  private boolean isCompactionFlow;
+
   // private final Object syncObject =new Object();
 
   public BadRecordsLogger(String key, String fileName, String storePath,
       boolean badRecordsLogRedirect, boolean badRecordLoggerEnable,
-      boolean badRecordConvertNullDisable, boolean isDataLoadFail) {
+      boolean badRecordConvertNullDisable, boolean isDataLoadFail, boolean isCompactionFlow) {
     // Initially no bad rec
     taskKey = key;
     this.fileName = fileName;
@@ -101,6 +103,11 @@ public class BadRecordsLogger {
     this.badRecordLoggerEnable = badRecordLoggerEnable;
     this.badRecordConvertNullDisable = badRecordConvertNullDisable;
     this.isDataLoadFail = isDataLoadFail;
+    this.isCompactionFlow = isCompactionFlow;
+  }
+
+  public boolean isCompFlow() {
+    return isCompactionFlow;
   }
 
   /**

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/BadRecordsLoggerProvider.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/BadRecordsLoggerProvider.java
@@ -33,6 +33,16 @@ public class BadRecordsLoggerProvider {
    * @return
    */
   public static BadRecordsLogger createBadRecordLogger(CarbonDataLoadConfiguration configuration) {
+    return createBadRecordLogger(configuration, false);
+  }
+
+  /**
+   * method returns the BadRecordsLogger instance
+   * @param configuration
+   * @return
+   */
+  public static BadRecordsLogger createBadRecordLogger(CarbonDataLoadConfiguration configuration,
+      Boolean isCompactionFlow) {
     boolean badRecordsLogRedirect = false;
     boolean badRecordConvertNullDisable = false;
     boolean isDataLoadFail = false;
@@ -72,7 +82,7 @@ public class BadRecordsLoggerProvider {
     return new BadRecordsLogger(identifier.getBadRecordLoggerKey(),
         identifier.getTableName() + '_' + System.currentTimeMillis(),
         getBadLogStoreLocation(configuration), badRecordsLogRedirect,
-        badRecordsLoggerEnable, badRecordConvertNullDisable, isDataLoadFail);
+        badRecordsLoggerEnable, badRecordConvertNullDisable, isDataLoadFail, isCompactionFlow);
   }
 
   public static String getBadLogStoreLocation(CarbonDataLoadConfiguration configuration) {

--- a/processing/src/main/java/org/apache/carbondata/processing/loading/converter/impl/RowConverterImpl.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/loading/converter/impl/RowConverterImpl.java
@@ -134,13 +134,15 @@ public class RowConverterImpl implements RowConverter {
         if (reason.equalsIgnoreCase(CarbonCommonConstants.STRING_LENGTH_EXCEEDED_MESSAGE)) {
           reason = String.format(reason, this.fields[i].getColumn().getColName());
         }
-        badRecordLogger.addBadRecordsToBuilder(row.getRawData(), reason);
-        if (badRecordLogger.isDataLoadFail()) {
-          String error = "Data load failed due to bad record: " + reason;
-          if (!badRecordLogger.isBadRecordLoggerEnable()) {
-            error += "Please enable bad record logger to know the detail reason.";
+        if (!badRecordLogger.isCompFlow()) {
+          badRecordLogger.addBadRecordsToBuilder(row.getRawData(), reason);
+          if (badRecordLogger.isDataLoadFail()) {
+            String error = "Data load failed due to bad record: " + reason;
+            if (!badRecordLogger.isBadRecordLoggerEnable()) {
+              error += "Please enable bad record logger to know the detail reason.";
+            }
+            throw new BadRecordFoundException(error);
           }
-          throw new BadRecordFoundException(error);
         }
         logHolder.clear();
         logHolder.setLogged(true);


### PR DESCRIPTION
 ### Why is this PR needed?
 Alter add complex columns with global sort compaction is failing due to 
1) AOI exception : Currently creating default complex delimiter list in global sort compaction with size of 3. For map case need extra complex delimiter for handling the key-value
2) bad record handling: When we  add complex columns after insert the data, complex columns has null data for previously loaded segments. this null value is going to treat as bad record and compaction is failed.
 
 ### What changes were proposed in this PR?
1) In Global sort compaction flow create default complex delimiter with 4, as already doing in load flow. 
2)  Bad records handling pruned for compaction case. No need to check bad records for compaction as they are already checked while loading. previously loaded segments data we are inserting again in compaction case
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
