### PR TITLE
[CARBONDATA-4288][CARBONDATA-4289] Fix various issues with Index Server caching mechanism.

### DIFF
--- a/integration/spark/src/main/scala/org/apache/carbondata/indexserver/DistributedRDDUtils.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/indexserver/DistributedRDDUtils.scala
@@ -357,13 +357,11 @@ object DistributedRDDUtils {
     val existingExecutorMapping = executorToCacheSizeMapping.get(host)
     if (existingExecutorMapping != null) {
       val existingSize = existingExecutorMapping.get(executor)
+      var totalSize = segment.getIndexSize
       if (existingSize != null) {
-        existingExecutorMapping.put(executor, existingSize + segment.getIndexSize
-          .toInt)
-      } else {
-        existingExecutorMapping.put(executor, segment.getIndexSize
-          .toInt)
+        totalSize += existingSize
       }
+      existingExecutorMapping.put(executor, totalSize.toInt)
     } else {
       val newExecutorMapping = new ConcurrentHashMap[String, Long]()
       newExecutorMapping.put(executor, segment.getIndexSize)

--- a/integration/spark/src/main/scala/org/apache/carbondata/indexserver/DistributedRDDUtils.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/indexserver/DistributedRDDUtils.scala
@@ -32,7 +32,7 @@ import org.apache.carbondata.core.indexstore.ExtendedBlockletWrapper
 import org.apache.carbondata.core.metadata.AbsoluteTableIdentifier
 import org.apache.carbondata.core.metadata.schema.table.CarbonTable
 import org.apache.carbondata.core.readcommitter.{LatestFilesReadCommittedScope, TableStatusReadCommittedScope}
-import org.apache.carbondata.core.statusmanager.SegmentUpdateStatusManager
+import org.apache.carbondata.core.statusmanager.{SegmentStatus, SegmentUpdateStatusManager}
 import org.apache.carbondata.core.util.CarbonProperties
 import org.apache.carbondata.events.{IndexServerLoadEvent, OperationContext, OperationListenerBus}
 import org.apache.carbondata.hadoop.api.{CarbonInputFormat, CarbonTableInputFormat}
@@ -108,7 +108,20 @@ object DistributedRDDUtils {
           val wrapper: IndexInputSplit = legacySegment
             .asInstanceOf[IndexInputSplitWrapper].getDistributable
           val executor = validExecutorIds(index % validExecutorIds.length)
-          wrapper.setLocations(Array("executor_" + executor))
+          tableToExecutorMapping.putIfAbsent(tableUniqueName,
+            new ConcurrentHashMap[String, String]())
+          val existingSegmentMapping = tableToExecutorMapping.get(tableUniqueName)
+          val oldMapping = existingSegmentMapping.putIfAbsent(wrapper.getSegment.getSegmentNo,
+            s"${executor}")
+          if (oldMapping == null) {
+            val newSegmentMapping = new ConcurrentHashMap[String, String]()
+            newSegmentMapping.put(wrapper.getSegment.getSegmentNo, s"${executor}")
+            tableToExecutorMapping.putIfAbsent(tableUniqueName, newSegmentMapping)
+            wrapper.setLocations(Array("executor_" + executor))
+          } else {
+            wrapper.setLocations(Array("executor_" + existingSegmentMapping
+              .get(wrapper.getSegment.getSegmentNo)))
+          }
           legacySegment
       }
     } else { Seq() }
@@ -161,6 +174,14 @@ object DistributedRDDUtils {
           invalidateTableMapping(tableUniqueName)
         }
       }
+    }
+  }
+
+  def isSegmentInProgress(request: IndexInputFormat, segment: String): Boolean = {
+    request.getReadCommittedScope.getSegmentList.find(_.getLoadName
+      .equalsIgnoreCase(segment)) match {
+      case Some(value) => value.getSegmentStatus.equals(SegmentStatus.INSERT_IN_PROGRESS)
+      case None => false
     }
   }
 
@@ -313,31 +334,34 @@ object DistributedRDDUtils {
           case None => throw new RuntimeException("Could not find any alive executors.")
         }
       }
-      val existingExecutorMapping = executorToCacheSizeMapping.get(newHost)
-      if (existingExecutorMapping != null) {
-        val existingSize = existingExecutorMapping.get(newExecutor)
-        if (existingSize != null) {
-          existingExecutorMapping.put(newExecutor, existingSize + segment.getIndexSize
-            .toInt)
-        } else {
-          existingExecutorMapping.put(newExecutor, segment.getIndexSize
-            .toInt)
-        }
-      } else {
-        val newExecutorMapping = new ConcurrentHashMap[String, Long]()
-        newExecutorMapping.put(newExecutor, segment.getIndexSize)
-        executorToCacheSizeMapping.put(newHost, newExecutorMapping)
-      }
+      tableToExecutorMapping.putIfAbsent(tableUniqueName, new ConcurrentHashMap[String, String]())
       val existingSegmentMapping = tableToExecutorMapping.get(tableUniqueName)
-      if (existingSegmentMapping == null) {
-        val newSegmentMapping = new ConcurrentHashMap[String, String]()
-        newSegmentMapping.put(segment.getSegmentNo, s"${newHost}_$newExecutor")
-        tableToExecutorMapping.putIfAbsent(tableUniqueName, newSegmentMapping)
+      val oldMapping = existingSegmentMapping.putIfAbsent(segment.getSegmentNo,
+        s"${ newHost }_$newExecutor")
+      if (oldMapping == null) {
+        updateCacheSize(newHost, newExecutor, segment)
+        s"executor_${newHost}_$newExecutor"
       } else {
-        existingSegmentMapping.putIfAbsent(segment.getSegmentNo, s"${newHost}_$newExecutor")
-        tableToExecutorMapping.putIfAbsent(tableUniqueName, existingSegmentMapping)
+        s"executor_$oldMapping"
       }
-      s"executor_${newHost}_$newExecutor"
+    }
+  }
+
+  private def updateCacheSize(host: String, executor: String, segment: Segment) = {
+    val existingExecutorMapping = executorToCacheSizeMapping.get(host)
+    if (existingExecutorMapping != null) {
+      val existingSize = existingExecutorMapping.get(executor)
+      if (existingSize != null) {
+        existingExecutorMapping.put(executor, existingSize + segment.getIndexSize
+          .toInt)
+      } else {
+        existingExecutorMapping.put(executor, segment.getIndexSize
+          .toInt)
+      }
+    } else {
+      val newExecutorMapping = new ConcurrentHashMap[String, Long]()
+      newExecutorMapping.put(executor, segment.getIndexSize)
+      executorToCacheSizeMapping.put(host, newExecutorMapping)
     }
   }
 


### PR DESCRIPTION
 ### Why is this PR needed?
 There are 2 issues in the Index Server flow:
1. In case when there is a main table with a SI table with prepriming disabled and index serve enabled, new load to main table and SI table put the cache for the main table in the index server. Cache is also getting again when a select query is fired. This issue happens because during load to SI table, getSplits is called on the main table segment which is in Insert In Progress state. Index server considers this segment as a legacy segment because it's index size = 0 and does not put it's entry in the tableToExecutor mapping. In the getsplits method isRefreshneeded is false the first time getSplits is called. During the select query, in getSplits method isRefreshNeeded is true and the previous loaded entry is removed from the driver but since there is no entry for that table in tableToExecutor mapping, the previous cache value becomes dead cache and always stays in the index server. The newly loaded cache is loaded to a new executor and 2 copies of cache for the same segment is being mantained.
2. Concurrent select queries to the index server shows wrong cache values in the Index server.
 
 ### What changes were proposed in this PR?
The following changes are proposed to the index server code:
1. Removing cache object from the index server in case the segment is INSERT IN PROGRESS and in the case of legacy segment adding the value in tabeToExecutor mappping so that the cache is also removed from the executor side.
2. Concurrent queries were able adding duplicate cache values to other executors. Changed logic of assign executors method so that concurrent queries are not able to add cache for same segment in other executors
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes. Test case added to check assignExecutors method using multiple threads.

    
