### PR TITLE
[CARBONDATA-4300] Clean files command supports specify segment ids

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
+++ b/core/src/main/java/org/apache/carbondata/core/constants/CarbonCommonConstants.java
@@ -1996,6 +1996,8 @@ public final class CarbonCommonConstants {
    */
   public static final long SEGMENT_LOAD_TIME_DEFAULT = -1;
 
+  public static final String SEGMENT_ID_PATTERN = "^\\d+(\\.\\d+)?$";
+
   /**
    * default name of data base
    */

--- a/docs/clean-files.md
+++ b/docs/clean-files.md
@@ -102,3 +102,11 @@ clean files operation, the user can disable that option by using ```statistics =
    CLEAN FILES FOR TABLE TABLE_NAME options('statistics'='false')
    ```
   
+### SEGMENT_IDS
+Clean files operation can specify segments to be deleted instead of delete all the Marked For Delete and Compacted segments after the number of theses segments reaches carbon.invisible.segments.preserve.count.
+User can specify segments with option ```segment_ids```. Value of this option is the segment ids user wants to delete. Only Marked for Delete and Compacted segment ids are valid. If invalid ids are given, operation will fail directly.
+If segments are specified, ```force``` option will be ignored.
+
+   ```
+   CLEAN FILES FOR TABLE TABLE_NAME options('segment_ids'='0,1,2')
+   ```

--- a/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/TestCleanFilesWithSI.scala
+++ b/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/TestCleanFilesWithSI.scala
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.carbondata.spark.testsuite.secondaryindex
+
+import java.io.File
+
+import org.apache.spark.sql.CarbonEnv
+import org.apache.spark.sql.test.util.QueryTest
+import org.scalatest.BeforeAndAfterEach
+
+import org.apache.carbondata.core.metadata.schema.table.CarbonTable
+import org.apache.carbondata.core.statusmanager.{LoadMetadataDetails, SegmentStatusManager}
+import org.apache.carbondata.core.util.path.CarbonTablePath
+
+
+/**
+ * test cases for testing clean files command on table with SI
+ */
+class TestCleanFilesWithSI extends QueryTest with BeforeAndAfterEach {
+
+  var mainTable : CarbonTable = _
+  var mainTablePath : String = _
+  var indexTable : CarbonTable = _
+  var indexTablePath : String = _
+
+  override protected def beforeEach(): Unit = {
+    sql("drop table if exists test.maintable")
+    sql("drop database if exists test cascade")
+    sql("create database test")
+    sql("CREATE TABLE test.maintable(a INT, b STRING, c STRING) stored as carbondata")
+    sql("CREATE INDEX indextable1 on table test.maintable(c) as 'carbondata'")
+    sql("INSERT INTO test.maintable SELECT 1,'string1', 'string2'")
+    sql("INSERT INTO test.maintable SELECT 1,'string1', 'string2'")
+    sql("INSERT INTO test.maintable SELECT 1,'string1', 'string2'")
+    sql("DELETE FROM TABLE test.maintable WHERE SEGMENT.ID IN(0,1,2)")
+
+    mainTable =
+      CarbonEnv.getCarbonTable(Option("test"), "maintable")(sqlContext.sparkSession)
+    mainTablePath =
+      CarbonTablePath.getPartitionDir(mainTable.getTablePath)
+    indexTable =
+      CarbonEnv.getCarbonTable(Option("test"), "indextable1")(sqlContext.sparkSession)
+    indexTablePath =
+      CarbonTablePath.getPartitionDir(indexTable.getTablePath)
+  }
+
+  test("Test clean files on table with secondary index and si missing segment 0") {
+    // simulate main table and SI table segment inconsistent scenario
+    sql("CLEAN FILES FOR TABLE test.indextable1 options('segment_ids'='0')")
+    sql("CLEAN FILES FOR TABLE test.maintable options('segment_ids'='0,1')")
+
+    var mainTableSegmentCount = sql("SHOW SEGMENTS FOR TABLE test.maintable").count()
+    // main table segment 2
+    assert(mainTableSegmentCount == 1)
+    var siTableSegmentCount = sql("SHOW SEGMENTS FOR TABLE test.indextable1").count()
+    // si table segment 2
+    assert(siTableSegmentCount == 1)
+
+    var segmentFolders = new File(mainTablePath).listFiles()
+    assert(segmentFolders.length == 1)
+    segmentFolders = new File(indexTablePath).listFiles()
+    assert(segmentFolders.length == 1)
+
+    sql("CLEAN FILES FOR TABLE test.maintable options('segment_ids'='2')")
+    mainTableSegmentCount = sql("SHOW SEGMENTS FOR TABLE test.maintable").count()
+    // main table has no segment left
+    assert(mainTableSegmentCount == 0)
+    siTableSegmentCount = sql("SHOW SEGMENTS FOR TABLE test.indextable1").count()
+    // si table has no segment left
+    assert(siTableSegmentCount == 0)
+
+    segmentFolders = new File(mainTablePath).listFiles()
+    assert(segmentFolders.length == 0)
+    segmentFolders = new File(indexTablePath).listFiles()
+    assert(segmentFolders.length == 0)
+  }
+
+  test("Test clean files on table with secondary index and si missing segment 1") {
+    // simulate main table and SI table segment inconsistent scenario
+    sql("CLEAN FILES FOR TABLE test.indextable1 options('segment_ids'='1')")
+    sql("CLEAN FILES FOR TABLE test.maintable options('segment_ids'='0,1')")
+
+    var mainTableSegmentCount = sql("SHOW SEGMENTS FOR TABLE test.maintable").count()
+    // main table segment 2
+    assert(mainTableSegmentCount == 1)
+    var siTableSegmentCount = sql("SHOW SEGMENTS FOR TABLE test.indextable1").count()
+    // si table segment 2
+    assert(siTableSegmentCount == 1)
+
+    var segmentFolders = new File(mainTablePath).listFiles()
+    assert(segmentFolders.length == 1)
+    segmentFolders = new File(indexTablePath).listFiles()
+    assert(segmentFolders.length == 1)
+
+    sql("CLEAN FILES FOR TABLE test.maintable options('segment_ids'='2')")
+    mainTableSegmentCount = sql("SHOW SEGMENTS FOR TABLE test.maintable").count()
+    // main table has no segment left
+    assert(mainTableSegmentCount == 0)
+    siTableSegmentCount = sql("SHOW SEGMENTS FOR TABLE test.indextable1").count()
+    // si table has no segment left
+    assert(siTableSegmentCount == 0)
+
+    segmentFolders = new File(mainTablePath).listFiles()
+    assert(segmentFolders.length == 0)
+    segmentFolders = new File(indexTablePath).listFiles()
+    assert(segmentFolders.length == 0)
+  }
+
+  test("Test clean files on table with secondary index" +
+       " and si metadata and physical files is not consistent") {
+    // simulate SI table metadata and physical files not consistent, remove segment 1 from si
+    // tablestatus
+    val siLoadDetails = SegmentStatusManager.readLoadMetadata(indexTable.getMetadataPath)
+    val modifiedLoadDetails = new Array[LoadMetadataDetails](siLoadDetails.length - 1)
+    modifiedLoadDetails(0) = siLoadDetails(0)
+    modifiedLoadDetails(1) = siLoadDetails(2)
+    SegmentStatusManager.writeLoadDetailsIntoFile(
+      CarbonTablePath.getTableStatusFilePath(indexTable.getTablePath), modifiedLoadDetails)
+
+    sql("CLEAN FILES FOR TABLE test.maintable options('segment_ids'='0,1')")
+    var mainTableSegmentCount = sql("SHOW SEGMENTS FOR TABLE test.maintable").count()
+    // main table segment 2
+    assert(mainTableSegmentCount == 1)
+    var siTableSegmentCount = sql("SHOW SEGMENTS FOR TABLE test.indextable1").count()
+    // si table segment 2
+    assert(siTableSegmentCount == 1)
+
+    var segmentFolders = new File(mainTablePath).listFiles()
+    assert(segmentFolders.length == 1)
+    segmentFolders = new File(indexTablePath).listFiles()
+    // si table Segment_1 folder is not cleaned because segment 1 is not presented in tablestatus
+    assert(segmentFolders.length == 2)
+
+    sql("CLEAN FILES FOR TABLE test.maintable options('segment_ids'='2')")
+    mainTableSegmentCount = sql("SHOW SEGMENTS FOR TABLE test.maintable").count()
+    // main table has no segment left
+    assert(mainTableSegmentCount == 0)
+    siTableSegmentCount = sql("SHOW SEGMENTS FOR TABLE test.indextable1").count()
+    // si table has no segment left
+    assert(siTableSegmentCount == 0)
+
+    segmentFolders = new File(mainTablePath).listFiles()
+    assert(segmentFolders.length == 0)
+    segmentFolders = new File(indexTablePath).listFiles()
+    // si table Segment_1 folder is not cleaned because segment 1 is not presented in tablestatus
+    assert(segmentFolders.length == 1)
+    assert(segmentFolders.head.getName.equalsIgnoreCase("Segment_1"))
+  }
+}

--- a/integration/spark/src/main/scala/org/apache/carbondata/events/CleanFilesEvents.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/events/CleanFilesEvents.scala
@@ -25,6 +25,7 @@ case class CleanFilesPreEvent(carbonTable: CarbonTable, sparkSession: SparkSessi
 
 case class CleanFilesPostEvent(
     carbonTable: CarbonTable,
+    filterSegmentList: java.util.List[String],
     sparkSession: SparkSession,
     options: Map[String, String])
   extends Event with CleanFilesEventInfo

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/util/CommonUtil.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/util/CommonUtil.scala
@@ -1067,4 +1067,8 @@ object CommonUtil {
       }
     }
   }
+
+  def isSegmentId(str: String): Boolean = {
+    CarbonCommonConstants.SEGMENT_ID_PATTERN.r.pattern.matcher(str).matches();
+  }
 }

--- a/integration/spark/src/main/scala/org/apache/spark/util/CleanFiles.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/util/CleanFiles.scala
@@ -38,6 +38,7 @@ object CleanFiles {
     val carbonTable = CarbonEnv.getCarbonTable(Some(dbName), tableName)(spark)
     DataTrashManager.cleanGarbageData(
       carbonTable,
+      null,
       isForceDeletion,
       cleanStaleInProgress,
       false,

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/cleanfiles/TestCleanFileCommand.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/cleanfiles/TestCleanFileCommand.scala
@@ -73,7 +73,7 @@ class TestCleanFileCommand extends QueryTest with BeforeAndAfterAll {
     val path = CarbonEnv.getCarbonTable(Some("default"), "cleantest")(sqlContext.sparkSession)
       .getTablePath
     val trashFolderPath = CarbonTablePath.getTrashFolderPath(path)
-    editTableStatusFile(path)
+    assert(editTableStatusFile(path))
     assert(!FileFactory.isFileExist(trashFolderPath))
 
     val segmentNumber1 = sql(s"""show segments for table cleantest""").count()
@@ -531,7 +531,7 @@ class TestCleanFileCommand extends QueryTest with BeforeAndAfterAll {
   }
 
 
-  def editTableStatusFile(carbonTablePath: String) : Unit = {
+  def editTableStatusFile(carbonTablePath: String) : Boolean = {
     // original table status file
     val f1 = new File(CarbonTablePath.getTableStatusFilePath(carbonTablePath))
     val f2 = new File(CarbonTablePath.getMetadataPath(carbonTablePath) + CarbonCommonConstants
@@ -547,6 +547,7 @@ class TestCleanFileCommand extends QueryTest with BeforeAndAfterAll {
     // scalastyle:on println
     bufferedSource.close()
     w.close()
+    f1.delete();
     f2.renameTo(f1)
   }
 

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/cleanfiles/TestCleanFilesCommandPartitionTable.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/cleanfiles/TestCleanFilesCommandPartitionTable.scala
@@ -41,7 +41,7 @@ class TestCleanFilesCommandPartitionTable extends QueryTest with BeforeAndAfterA
     val path = CarbonEnv.getCarbonTable(Some("default"), "cleantest")(sqlContext.sparkSession)
       .getTablePath
     val trashFolderPath = path + CarbonCommonConstants.FILE_SEPARATOR + CarbonTablePath.TRASH_DIR
-    editTableStatusFile(path)
+    assert(editTableStatusFile(path))
     assert(!FileFactory.isFileExist(trashFolderPath))
     val segmentNumber1 = sql(s"""show segments for table cleantest""").count()
     assert(segmentNumber1 == 4)
@@ -291,7 +291,7 @@ class TestCleanFilesCommandPartitionTable extends QueryTest with BeforeAndAfterA
     sql("""DROP TABLE IF EXISTS CLEANTEST""")
   }
 
-  def editTableStatusFile(carbonTablePath: String) : Unit = {
+  def editTableStatusFile(carbonTablePath: String) : Boolean = {
     // Original Table status file
     val f1 = new File(CarbonTablePath.getTableStatusFilePath(carbonTablePath))
     // duplicate
@@ -308,6 +308,7 @@ class TestCleanFilesCommandPartitionTable extends QueryTest with BeforeAndAfterA
     // scalastyle:on println
     bufferedSource.close
     w.close()
+    f1.delete();
     f2.renameTo(f1)
   }
 

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/cleanfiles/TestCleanFilesCommandPartitionTableWithSegmentIds.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/cleanfiles/TestCleanFilesCommandPartitionTableWithSegmentIds.scala
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.spark.testsuite.cleanfiles
+
+import java.io.File
+
+import org.apache.spark.sql.CarbonEnv
+import org.apache.spark.sql.test.util.QueryTest
+import org.scalatest.BeforeAndAfterEach
+
+import org.apache.carbondata.core.constants.CarbonCommonConstants
+import org.apache.carbondata.core.util.CarbonProperties
+import org.apache.carbondata.core.util.path.CarbonTablePath.DataFileUtil
+
+class TestCleanFilesCommandPartitionTableWithSegmentIds extends QueryTest with BeforeAndAfterEach {
+
+  override protected def beforeEach(): Unit = {
+    createPartitionTable()
+    loadData()
+  }
+
+  test("Test clean files after delete command") {
+    sql(s"""Delete from table cleantest where segment.id in(0, 1, 2, 3)""")
+    var showSegments = sql("show segments for table cleantest").collect().map {
+      a => (a.get(0), a.get(1))
+    }
+    assert(showSegments.length == 4)
+    assert(showSegments.count(_._2 == "Marked for Delete") == 4)
+    sql("CLEAN FILES FOR TABLE cleantest OPTIONS('segment_ids'='0, 1,\t2,3')")
+    showSegments = sql("show segments for table cleantest").collect().map {
+      a => (a.get(0), a.get(1))
+    }
+    assert(showSegments.isEmpty)
+    showSegments = sql("show history segments for table cleantest").collect().map {
+      a => (a.get(0), a.get(1))
+    }
+    assert(showSegments.length == 4)
+    assert(showSegments.count(_._2 == "Marked for Delete") == 4)
+
+    // check all segments data are deleted successfully
+    val table = CarbonEnv.getCarbonTable(None, "cleantest")(sqlContext.sparkSession)
+    val tableFolder = new File(table.getTablePath).listFiles()
+    assert(!tableFolder.exists(f =>
+      f.getName.contains("add=abc") || f.getName.contains("add=adc")))
+  }
+
+  test("Test clean files after compaction command with segment_ids option") {
+    sql(s"""alter table cleantest compact 'custom' where segment.id in(0, 1, 2, 3)""")
+    var showSegments = sql("show segments for table cleantest").collect().map {
+      a => (a.get(0), a.get(1))
+    }
+    assert(showSegments.length == 5)
+    assert(showSegments.count(_._2 == "Compacted") == 4)
+    assert(showSegments.count(_._2 == "Success") == 1)
+    sql("CLEAN FILES FOR TABLE cleantest OPTIONS('segment_ids'='0, 1,\t2,3')")
+    showSegments = sql("show segments for table cleantest").collect().map {
+      a => (a.get(0), a.get(1))
+    }
+    assert(showSegments.length == 1)
+
+    // check all segments data before compaction are deleted successfully
+    val table = CarbonEnv.getCarbonTable(None, "cleantest")(sqlContext.sparkSession)
+    val abcFiles = new File(
+      table.getTablePath + CarbonCommonConstants.FILE_SEPARATOR + "add=abc").listFiles()
+    val adcFiles = new File(
+      table.getTablePath + CarbonCommonConstants.FILE_SEPARATOR + "add=adc").listFiles()
+    for (file <- abcFiles) {
+      if (file.getPath.endsWith("carbondata")) {
+        assert(DataFileUtil.getSegmentNo(file.getName).equals("0.1"))
+      }
+    }
+    for (file <- adcFiles) {
+      if (file.getPath.endsWith("carbondata")) {
+        assert(DataFileUtil.getSegmentNo(file.getName).equals("0.1"))
+      }
+    }
+  }
+
+  test("Test clean files after compaction command without segment_ids option") {
+    sql(s"""alter table cleantest compact 'custom' where segment.id in(0, 1, 2, 3)""")
+    var showSegments = sql("show segments for table cleantest").collect().map {
+      a => (a.get(0), a.get(1))
+    }
+    assert(showSegments.length == 5)
+    assert(showSegments.count(_._2 == "Compacted") == 4)
+    assert(showSegments.count(_._2 == "Success") == 1)
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.CARBON_CLEAN_FILES_FORCE_ALLOWED, "true")
+    sql("CLEAN FILES FOR TABLE cleantest OPTIONS('force'='true')")
+    CarbonProperties.getInstance()
+      .removeProperty(CarbonCommonConstants.CARBON_CLEAN_FILES_FORCE_ALLOWED)
+    showSegments = sql("show segments for table cleantest").collect().map {
+      a => (a.get(0), a.get(1))
+    }
+    assert(showSegments.length == 1)
+
+    // check all segments data before compaction are deleted successfully
+    val table = CarbonEnv.getCarbonTable(None, "cleantest")(sqlContext.sparkSession)
+    val abcFiles = new File(
+      table.getTablePath + CarbonCommonConstants.FILE_SEPARATOR + "add=abc").listFiles()
+    val adcFiles = new File(
+      table.getTablePath + CarbonCommonConstants.FILE_SEPARATOR + "add=adc").listFiles()
+    for (file <- abcFiles) {
+      if (file.getPath.endsWith("carbondata")) {
+        assert(DataFileUtil.getSegmentNo(file.getName).equals("0.1"))
+      }
+    }
+    for (file <- adcFiles) {
+      if (file.getPath.endsWith("carbondata")) {
+        assert(DataFileUtil.getSegmentNo(file.getName).equals("0.1"))
+      }
+    }
+  }
+
+  override protected def afterEach(): Unit = {
+    sql("drop table if exists cleantest")
+  }
+
+  def createPartitionTable() : Unit = {
+    sql("""DROP TABLE IF EXISTS CLEANTEST""")
+    sql(
+      """
+        | CREATE TABLE CLEANTEST (id Int, id1 INT, name STRING ) PARTITIONED BY (add String)
+        | STORED AS carbondata
+      """.stripMargin)
+  }
+
+  def loadData() : Unit = {
+    sql(s"""INSERT INTO CLEANTEST SELECT 1, 2,"bob","abc"""")
+    sql(s"""INSERT INTO CLEANTEST SELECT 1, 2,"jack","abc"""")
+    sql(s"""INSERT INTO CLEANTEST SELECT 1, 2,"johnny","adc"""")
+    sql(s"""INSERT INTO CLEANTEST SELECT 1, 2,"Reddit","adc"""")
+  }
+}

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/cleanfiles/TestCleanFilesCommandWithSegmentIds.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/cleanfiles/TestCleanFilesCommandWithSegmentIds.scala
@@ -1,0 +1,227 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.carbondata.spark.testsuite.cleanfiles
+
+import java.io.{File, IOException}
+
+import org.apache.spark.sql.CarbonEnv
+import org.apache.spark.sql.test.util.QueryTest
+import org.scalatest.BeforeAndAfterEach
+
+import org.apache.carbondata.common.exceptions.sql.MalformedCarbonCommandException
+import org.apache.carbondata.core.constants.CarbonCommonConstants
+import org.apache.carbondata.core.util.CarbonProperties
+import org.apache.carbondata.core.util.path.CarbonTablePath
+import org.apache.carbondata.spark.util.CommonUtil
+
+class TestCleanFilesCommandWithSegmentIds extends QueryTest with BeforeAndAfterEach {
+  override protected def beforeEach(): Unit = {
+    sql(
+      """
+        | CREATE TABLE if not exists cleantest (empname String, designation String, doj Timestamp,
+        |  workgroupcategory int, workgroupcategoryname String, deptno int, deptname String,
+        |  projectcode int, projectjoindate Timestamp, projectenddate Date,attendance int,
+        |  utilization int,salary int, empno int)
+        | STORED AS carbondata
+      """.stripMargin)
+    loadData()
+  }
+
+  test("Test clean files after delete command") {
+    sql(s"""Delete from table cleantest where segment.id in(0, 1, 2, 3)""")
+    var showSegments = sql("show segments for table cleantest").collect().map {
+      a => (a.get(0), a.get(1))
+    }
+    assert(showSegments.length == 4)
+    assert(showSegments.count(_._2 == "Marked for Delete") == 4)
+    sql("CLEAN FILES FOR TABLE cleantest OPTIONS('segment_ids'='0, 1,\t2,3')")
+    showSegments = sql("show segments for table cleantest").collect().map {
+      a => (a.get(0), a.get(1))
+    }
+    assert(showSegments.isEmpty)
+    showSegments = sql("show history segments for table cleantest").collect().map {
+      a => (a.get(0), a.get(1))
+    }
+    assert(showSegments.length == 4)
+    assert(showSegments.count(_._2 == "Marked for Delete") == 4)
+
+    // check all segments data are deleted successfully
+    val table = CarbonEnv.getCarbonTable(None, "cleantest")(sqlContext.sparkSession)
+    val path = CarbonTablePath.getPartitionDir(table.getTablePath)
+    val segmentFolders = new File(path).listFiles()
+    assert(segmentFolders.isEmpty)
+  }
+
+  test("Test clean files after delete command with empty segment_ids option") {
+    sql(s"""Delete from table cleantest where segment.id in(0, 1, 2, 3)""")
+    var showSegments = sql("show segments for table cleantest").collect().map {
+      a => (a.get(0), a.get(1))
+    }
+    assert(showSegments.length == 4)
+    assert(showSegments.count(_._2 == "Marked for Delete") == 4)
+    sql("CLEAN FILES FOR TABLE cleantest OPTIONS('segment_ids'='')")
+    showSegments = sql("show segments for table cleantest").collect().map {
+      a => (a.get(0), a.get(1))
+    }
+    assert(showSegments.length == 4)
+    assert(showSegments.count(_._2 == "Marked for Delete") == 4)
+
+    // check no segment data are deleted
+    val table = CarbonEnv.getCarbonTable(None, "cleantest")(sqlContext.sparkSession)
+    val path = CarbonTablePath.getPartitionDir(table.getTablePath)
+    val segmentFolders = new File(path).listFiles()
+    assert(segmentFolders.length == 4)
+  }
+
+  test("Test clean files after compaction command with segment_ids option") {
+    sql(s"""alter table cleantest compact 'custom' where segment.id in(0, 1, 2, 3)""")
+    var showSegments = sql("show segments for table cleantest").collect().map {
+      a => (a.get(0), a.get(1))
+    }
+    assert(showSegments.length == 5)
+    assert(showSegments.count(_._2 == "Compacted") == 4)
+    assert(showSegments.count(_._2 == "Success") == 1)
+    sql("CLEAN FILES FOR TABLE cleantest OPTIONS('segment_ids'='0, 1,\t2,3')")
+    showSegments = sql("show segments for table cleantest").collect().map {
+      a => (a.get(0), a.get(1))
+    }
+    assert(showSegments.length == 1)
+
+    // check all segments data are deleted successfully
+    val table = CarbonEnv.getCarbonTable(None, "cleantest")(sqlContext.sparkSession)
+    val path = CarbonTablePath.getPartitionDir(table.getTablePath)
+    val segmentFolders = new File(path).listFiles()
+    assert(segmentFolders.length == 1)
+    assert(segmentFolders.head.getName.contains("Segment_0.1"))
+  }
+
+  test("Test clean files after compaction command with segment_ids option with 1 segment") {
+    sql(s"""alter table cleantest compact 'custom' where segment.id in(0, 1, 2, 3)""")
+    var showSegments = sql("show segments for table cleantest").collect().map {
+      a => (a.get(0), a.get(1))
+    }
+    assert(showSegments.length == 5)
+    assert(showSegments.count(_._2 == "Compacted") == 4)
+    assert(showSegments.count(_._2 == "Success") == 1)
+    sql("CLEAN FILES FOR TABLE cleantest OPTIONS('segment_ids'='0')")
+    showSegments = sql("show segments for table cleantest").collect().map {
+      a => (a.get(0), a.get(1))
+    }
+    assert(showSegments.length == 4)
+
+    // check all segments data are deleted successfully
+    val table = CarbonEnv.getCarbonTable(None, "cleantest")(sqlContext.sparkSession)
+    val path = CarbonTablePath.getPartitionDir(table.getTablePath)
+    val segmentFolders = new File(path).listFiles()
+    assert(segmentFolders.length == 4)
+  }
+
+  test("Test clean files after compaction command without segment_ids option") {
+    sql(s"""alter table cleantest compact 'custom' where segment.id in(0, 1, 2, 3)""")
+    var showSegments = sql("show segments for table cleantest").collect().map {
+      a => (a.get(0), a.get(1))
+    }
+    assert(showSegments.length == 5)
+    assert(showSegments.count(_._2 == "Compacted") == 4)
+    assert(showSegments.count(_._2 == "Success") == 1)
+    CarbonProperties.getInstance()
+      .addProperty(CarbonCommonConstants.CARBON_CLEAN_FILES_FORCE_ALLOWED, "true")
+    sql("CLEAN FILES FOR TABLE cleantest OPTIONS('force'='true')")
+    CarbonProperties.getInstance()
+      .removeProperty(CarbonCommonConstants.CARBON_CLEAN_FILES_FORCE_ALLOWED)
+    showSegments = sql("show segments for table cleantest").collect().map {
+      a => (a.get(0), a.get(1))
+    }
+    assert(showSegments.length == 1)
+
+    // check all segments data are deleted successfully
+    val table = CarbonEnv.getCarbonTable(None, "cleantest")(sqlContext.sparkSession)
+    val path = CarbonTablePath.getPartitionDir(table.getTablePath)
+    val segmentFolders = new File(path).listFiles()
+    assert(segmentFolders.length == 1)
+    assert(segmentFolders.head.getName.contains("Segment_0.1"))
+  }
+
+  test("Test clean files on Success segment") {
+    // clean files on all segments
+    val ex = intercept[IOException] {
+      sql("CLEAN FILES FOR TABLE cleantest OPTIONS('segment_ids'='0, 1, 2, 3')")
+    }
+    assert(ex.getMessage.contains(
+      "Clean files request is failed for default.cleantest. Segment 0,1,2,3"))
+
+    // check no segment data are deleted
+    val table = CarbonEnv.getCarbonTable(None, "cleantest")(sqlContext.sparkSession)
+    val path = CarbonTablePath.getPartitionDir(table.getTablePath)
+    val segmentFolders = new File(path).listFiles()
+    assert(segmentFolders.length == 4)
+  }
+
+  test("Test clean files on non exists segment") {
+    // clean files on non exists segments
+    val ex = intercept[IOException] {
+      sql("CLEAN FILES FOR TABLE cleantest OPTIONS('segment_ids'='4')")
+    }
+    assert(ex.getMessage.contains(
+      "Clean files request is failed for default.cleantest. Segment 4 are not exists"))
+    val showSegments = sql("show segments for table cleantest").collect().map {
+      a => (a.get(0), a.get(1))
+    }
+    assert(showSegments.length == 4)
+    assert(showSegments.count(_._2 == "Success") == 4)
+
+    // check no segment data are deleted
+    val table = CarbonEnv.getCarbonTable(None, "cleantest")(sqlContext.sparkSession)
+    val path = CarbonTablePath.getPartitionDir(table.getTablePath)
+    val segmentFolders = new File(path).listFiles()
+    assert(segmentFolders.length == 4)
+  }
+
+  test("Test clean files with incorrect segment_ids option") {
+    val ex = intercept[MalformedCarbonCommandException] {
+      sql("CLEAN FILES FOR TABLE cleantest OPTIONS('segment_ids'='s, d, e, f')")
+    }
+    assert(ex.getMessage.contains("Invalid segment id in clean files command."))
+  }
+
+  test("Test CommonUtil.isSegmentId") {
+    val segmentIds = List("0", "1", "2", "0.1", "1.1")
+    val nonSegmentIds = List("1.", "1..", ".0", "1..1", "a", "1.a")
+    assert(segmentIds.count(CommonUtil.isSegmentId) == 5)
+    assert(!nonSegmentIds.exists(CommonUtil.isSegmentId))
+  }
+
+  override protected def afterEach(): Unit = {
+    sql("drop table if exists cleantest")
+  }
+
+  def loadData() : Unit = {
+    sql(
+      s"""LOAD DATA local inpath '$resourcesPath/data.csv' INTO TABLE cleantest OPTIONS
+         |('DELIMITER'= ',', 'QUOTECHAR'= '"')""".stripMargin)
+    sql(
+      s"""LOAD DATA local inpath '$resourcesPath/data.csv' INTO TABLE cleantest OPTIONS
+         |('DELIMITER'= ',', 'QUOTECHAR'= '"')""".stripMargin)
+    sql(
+      s"""LOAD DATA local inpath '$resourcesPath/data.csv' INTO TABLE cleantest OPTIONS
+         |('DELIMITER'= ',', 'QUOTECHAR'= '"')""".stripMargin)
+    sql(
+      s"""LOAD DATA local inpath '$resourcesPath/data.csv' INTO TABLE cleantest OPTIONS
+         |('DELIMITER'= ',', 'QUOTECHAR'= '"')""".stripMargin)
+  }
+}


### PR DESCRIPTION
 ### Why is this PR needed?
Currently clean files command will delete all the Marked for Delete and Compacted segments after the number of theses segments reaches carbon.invisible.segments.preserve.count, this delete operation may take lots of time and user cannot decide to only delete some of these segments. It is better to enhance clean files command to allow specify the segments to be deleted.
 
 ### What changes were proposed in this PR?
1. Clean files command supports specify segment ids, syntax is "clean files for table table_name options("segment_ids"="id1,id2,id3...")". If specified segment ids, then only the segment with these ids will be delete physically.
2. Refactoring lock taken: during clean files, take the tablestatus lock at the begining and release the lock at the end, and during lock taken period, only read tablestatus file one time(before there could be 10+) and all operations are done on it like change the visibility of segment, move visibility = false segment to tablestatus.history file.
    
 ### Does this PR introduce any user interface change?
 - Yes. One more option is added for clean files command: segment_ids. Value is the segment ids user wants to delete. Only Marked for Delete and Compacted segment ids are valid. If invalid ids are given, operation will fail directly. If segments are specified, force option will be ignored.
CLEAN FILES FOR TABLE TABLE_NAME options('segment_ids'='0,1,2')

 ### Is any new testcase added?
 - Yes

    
