### PR TITLE
[CARBONDATA-4303] Columns mismatch when insert into table with static partition

### DIFF
--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/booleantype/BooleanDataTypesInsertTest.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/booleantype/BooleanDataTypesInsertTest.scala
@@ -81,22 +81,6 @@ class BooleanDataTypesInsertTest extends QueryTest with BeforeAndAfterEach with 
     )
   }
 
-  test("Inserting and selecting table: create one column boolean table and insert two columns") {
-    // send to old flow, as for one column two values are inserted.
-    CarbonProperties.getInstance()
-      .addProperty(CarbonCommonConstants.CARBON_ENABLE_BAD_RECORD_HANDLING_FOR_INSERT, "true")
-    sql("insert into boolean_one_column values(true,false)")
-    sql("insert into boolean_one_column values(True)")
-    sql("insert into boolean_one_column values(false,true)")
-    checkAnswer(
-      sql("select * from boolean_one_column"),
-      Seq(Row(true), Row(true), Row(false))
-    )
-    CarbonProperties.getInstance()
-      .addProperty(CarbonCommonConstants.CARBON_ENABLE_BAD_RECORD_HANDLING_FOR_INSERT,
-        CarbonCommonConstants.CARBON_ENABLE_BAD_RECORD_HANDLING_FOR_INSERT_DEFAULT)
-  }
-
   test("Inserting and selecting table: two columns boolean and many rows, should support") {
     sql("CREATE TABLE if not exists boolean_table2(" +
         "col1 BOOLEAN, col2 BOOLEAN) STORED AS carbondata")
@@ -441,7 +425,7 @@ class BooleanDataTypesInsertTest extends QueryTest with BeforeAndAfterEach with 
       sql("insert into boolean_table2 select * from boolean_table")
     }
     assert(exception_insert.getMessage.contains(
-      "Cannot insert into target table because number of columns mismatch"))
+      "requires that the data to be inserted have the same number of columns as the target table"))
   }
 
   test("Inserting into Hive table from carbon table: support boolean data type and other format") {
@@ -641,26 +625,6 @@ class BooleanDataTypesInsertTest extends QueryTest with BeforeAndAfterEach with 
       sql("select * from boolean_one_column"),
       Seq(Row(true))
     )
-  }
-
-  test("Inserting overwrite: create one column boolean table and insert two columns") {
-    // send to old flow, as for one column two values are inserted.
-    CarbonProperties.getInstance()
-      .addProperty(CarbonCommonConstants.CARBON_ENABLE_BAD_RECORD_HANDLING_FOR_INSERT, "true")
-    sql("insert overwrite table boolean_one_column values(true,false)")
-    checkAnswer(
-      sql("select * from boolean_one_column"),
-      Seq(Row(true))
-    )
-    sql("insert overwrite table boolean_one_column values(True)")
-    sql("insert overwrite table boolean_one_column values(false,true)")
-    checkAnswer(
-      sql("select * from boolean_one_column"),
-      Seq(Row(false))
-    )
-    CarbonProperties.getInstance()
-      .addProperty(CarbonCommonConstants.CARBON_ENABLE_BAD_RECORD_HANDLING_FOR_INSERT,
-        CarbonCommonConstants.CARBON_ENABLE_BAD_RECORD_HANDLING_FOR_INSERT_DEFAULT)
   }
 
   test("Inserting overwrite: two columns boolean and many rows, should support") {

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/iud/DeleteCarbonTableTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/iud/DeleteCarbonTableTestCase.scala
@@ -383,7 +383,7 @@ class DeleteCarbonTableTestCase extends QueryTest with BeforeAndAfterAll {
     sql(
       """insert overwrite table deleteinpartition
         | partition (dtm=20200908)
-        | select * from deleteinpartition
+        | select id, sales from deleteinpartition
         | where dtm = 20200907""".stripMargin)
     checkAnswer(
       sql("""select count(1), dtm from deleteinpartition group by dtm"""),
@@ -395,7 +395,7 @@ class DeleteCarbonTableTestCase extends QueryTest with BeforeAndAfterAll {
     sql(
       """insert overwrite table deleteinpartition
         | partition (dtm=20200909)
-        | select * from deleteinpartition
+        | select id, sales from deleteinpartition
         | where dtm = 20200907""".stripMargin)
     checkAnswer(
       sql("""select count(1), dtm from deleteinpartition group by dtm"""),

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/iud/UpdateCarbonTableTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/iud/UpdateCarbonTableTestCase.scala
@@ -127,7 +127,7 @@ class UpdateCarbonTableTestCase extends QueryTest with BeforeAndAfterAll {
     sql(
       """insert overwrite table iud.updateinpartition
         | partition (dtm=20200908)
-        | select * from iud.updateinpartition where dtm = 20200907""".stripMargin)
+        | select id, sales from iud.updateinpartition where dtm = 20200907""".stripMargin)
     checkAnswer(
       sql(
         """select sales from iud.updateinpartition

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/merge/MergeTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/merge/MergeTestCase.scala
@@ -772,7 +772,7 @@ class MergeTestCase extends QueryTest with BeforeAndAfterAll {
     sql(
       """insert overwrite table target
         | partition (value=3)
-        | select * from target where value = 100""".stripMargin)
+        | select key from target where value = 100""".stripMargin)
     checkAnswer(sql("select * from target order by key"),
       Seq(Row("c", "200"), Row("e", "100"), Row("e", "3")))
     sql("""alter table target drop partition (value=3)""")

--- a/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/standardpartition/StandardPartitionTableDropTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/carbondata/spark/testsuite/standardpartition/StandardPartitionTableDropTestCase.scala
@@ -172,13 +172,13 @@ class StandardPartitionTableDropTestCase extends QueryTest with BeforeAndAfterAl
     sql(
       """insert overwrite table droppartition
         | partition (dtm=20200908)
-        | select * from droppartition
+        | select id, sales from droppartition
         | where dtm = 20200907""".stripMargin)
     // insert overwrite an non-existing partition
     sql(
       """insert overwrite table droppartition
         | partition (dtm=20200909)
-        | select * from droppartition
+        | select id, sales from droppartition
         | where dtm = 20200907""".stripMargin)
 
     // make sure drop one partition won't effect other partitions


### PR DESCRIPTION
 ### Why is this PR needed?
When insert into table with static partition, source projects should not contain static partition column, target table will have all columns, the columns number comparison between source table and target table is: source table column number = target table column number - static partition column number.
 
 ### What changes were proposed in this PR?
Before do the column number comparison, remove the static partition column from target table.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
