### PR TITLE
[CARBONDATA-4316]Fix horizontal compaction failure for partition tables

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/mutation/HorizontalCompaction.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/mutation/HorizontalCompaction.scala
@@ -112,9 +112,7 @@ object HorizontalCompaction {
     val db = carbonTable.getDatabaseName
     val table = carbonTable.getTableName
     val deletedBlocksList = CarbonDataMergerUtil.getSegListIUDCompactionQualified(segLists,
-      absTableIdentifier,
-      segmentUpdateStatusManager,
-      compactionTypeIUD)
+      segmentUpdateStatusManager)
     if (LOG.isDebugEnabled) {
       LOG.debug(s"The segment list for Horizontal Update Compaction is $deletedBlocksList")
     }

--- a/processing/src/main/java/org/apache/carbondata/processing/merger/CarbonDataMergerUtil.java
+++ b/processing/src/main/java/org/apache/carbondata/processing/merger/CarbonDataMergerUtil.java
@@ -875,13 +875,11 @@ public final class CarbonDataMergerUtil {
   /**
    * method gets the segments list which get qualified for IUD compaction.
    * @param segments
-   * @param absoluteTableIdentifier
-   * @param compactionTypeIUD
    * @return
    */
   public static List<String> getSegListIUDCompactionQualified(List<Segment> segments,
-      AbsoluteTableIdentifier absoluteTableIdentifier,
-      SegmentUpdateStatusManager segmentUpdateStatusManager, CompactionType compactionTypeIUD) {
+      SegmentUpdateStatusManager segmentUpdateStatusManager)
+      throws IOException {
 
     List<String> validSegments = new ArrayList<>();
 
@@ -906,7 +904,8 @@ public final class CarbonDataMergerUtil {
    * @return block list of the segment
    */
   private static List<String> checkDeleteDeltaFilesInSeg(Segment seg,
-      SegmentUpdateStatusManager segmentUpdateStatusManager, int numberDeltaFilesThreshold) {
+      SegmentUpdateStatusManager segmentUpdateStatusManager, int numberDeltaFilesThreshold)
+      throws IOException {
 
     List<String> blockLists = new ArrayList<>();
     Set<String> uniqueBlocks = new HashSet<String>();


### PR DESCRIPTION
 ### Why is this PR needed?
 Horizontal compaction fails for partition table leading to many delete delta files for a single block, leading to slower query performance. This is happening because during horizontal compaction the delta file path prepared for the partition table is wrong which fails to identify the path and fails the operation.
 
 ### What changes were proposed in this PR?
If it is a partition table, read the segment file and identity the partition where the block is present to prepare a proper partition path.
    
 ### Does this PR introduce any user interface change?
 - No


 ### Is any new testcase added?
 - Yes

    
