### PR TITLE
[CARBONDATA-4317] Fix TPCDS performance issues

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/strategy/CarbonSourceStrategy.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/strategy/CarbonSourceStrategy.scala
@@ -158,9 +158,10 @@ private[sql] object CarbonSourceStrategy extends SparkStrategy {
         SparkSession.getActiveSession.get,
         relation.catalogTable.get.identifier
       )
-      // remove dynamic partition filter from predicates
-      filterPredicates = CarbonToSparkAdapter.getDataFilter(partitionSet, allPredicates)
     }
+    // remove dynamic partition filter from predicates
+    filterPredicates = CarbonToSparkAdapter.getDataFilter(partitionSet,
+      allPredicates, partitionsFilter)
     val table = relation.relation.asInstanceOf[CarbonDatasourceHadoopRelation]
     val projects = rawProjects.map {p =>
       p.transform {
@@ -232,7 +233,6 @@ private[sql] object CarbonSourceStrategy extends SparkStrategy {
       output,
       partitionsFilter.filterNot(SubqueryExpression.hasSubquery),
       handledPredicates,
-      readCommittedScope,
       getCarbonProjection(relationPredicates, requiredColumns, projects),
       pushedFilters,
       directScanSupport,

--- a/integration/spark/src/main/spark2.3/org/apache/spark/sql/CarbonToSparkAdapter.scala
+++ b/integration/spark/src/main/spark2.3/org/apache/spark/sql/CarbonToSparkAdapter.scala
@@ -173,7 +173,9 @@ object CarbonToSparkAdapter extends SparkVersionAdapter {
       }
   }
 
-  def getDataFilter(partitionSet: AttributeSet, filter: Seq[Expression]): Seq[Expression] = {
+  def getDataFilter(partitionSet: AttributeSet,
+      filter: Seq[Expression],
+      partitionFilter: Seq[Expression]): Seq[Expression] = {
     filter
   }
 

--- a/integration/spark/src/main/spark2.4/org/apache/spark/sql/CarbonToSparkAdapter.scala
+++ b/integration/spark/src/main/spark2.4/org/apache/spark/sql/CarbonToSparkAdapter.scala
@@ -207,7 +207,9 @@ object CarbonToSparkAdapter extends SparkVersionAdapter {
       }
   }
 
-  def getDataFilter(partitionSet: AttributeSet, filter: Seq[Expression]): Seq[Expression] = {
+  def getDataFilter(partitionSet: AttributeSet,
+      filter: Seq[Expression],
+      partitionFilter: Seq[Expression]): Seq[Expression] = {
     filter
   }
 

--- a/integration/spark/src/main/spark3.1/org/apache/spark/sql/CarbonToSparkAdapter.scala
+++ b/integration/spark/src/main/spark3.1/org/apache/spark/sql/CarbonToSparkAdapter.scala
@@ -180,9 +180,12 @@ object CarbonToSparkAdapter extends SparkVersionAdapter {
       }
   }
 
-  def getDataFilter(partitionSet: AttributeSet, filter: Seq[Expression]): Seq[Expression] = {
+  def getDataFilter(partitionSet: AttributeSet, filter: Seq[Expression],
+      partitionFilter: Seq[Expression]): Seq[Expression] = {
     filter.filter {
-      case _: DynamicPruningSubquery => false
+      case dp: DynamicPruningSubquery =>
+        // if filter does not exists in partition filter, then push down the filter to spark
+        !partitionFilter.exists(_.semanticEquals(dp))
       case _ => true
     }
   }


### PR DESCRIPTION
 ### Why is this PR needed?
The following issues has degraded the TPCDS query performance
 1. If dynamic filters is not present in partitionFilters Set, then that filter is skipped, to pushdown to spark. 
 2. In some cases, some nodes like Exchange / Shuffle is not reused, because the CarbonDataSourceSCan plan is not mached
 3. While accessing the metadata on the canonicalized plan throws NPE
 
 ### What changes were proposed in this PR?
1. Check if dynamic filters is present in PartitionFilters set. If not, pushdown the filter
2. Match the plans, by converting them to canonicalized and by normalising the expressions
3. Move variables used in metadata(), to avoid NPE while comparing plans

    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No
    
