### PR TITLE
[CARBONDATA-4318]Improve load overwrite performance for partition tables

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/metadata/SegmentFileStore.java
+++ b/core/src/main/java/org/apache/carbondata/core/metadata/SegmentFileStore.java
@@ -1005,10 +1005,9 @@ public class SegmentFileStore {
    * @param uniqueId
    * @throws IOException
    */
-  public void dropPartitions(Segment segment, List<PartitionSpec> partitionSpecs,
+  public void dropPartitions(String segmentNo, List<String> partitionLocations,
       String uniqueId, List<String> toBeDeletedSegments, List<String> toBeUpdatedSegments)
       throws IOException {
-    readSegment(tablePath, segment.getSegmentFileName());
     boolean updateSegment = false;
     for (Map.Entry<String, FolderDetails> entry : segmentFile.getLocationMap().entrySet()) {
       String location = entry.getKey();
@@ -1017,9 +1016,9 @@ public class SegmentFileStore {
       }
       Path path = new Path(location);
       // Update the status to delete if path equals
-      if (null != partitionSpecs) {
-        for (PartitionSpec spec : partitionSpecs) {
-          if (path.equals(spec.getLocation())) {
+      if (null != partitionLocations) {
+        for (String partitionLocation : partitionLocations) {
+          if (path.toString().equals(partitionLocation)) {
             entry.getValue().setStatus(SegmentStatus.MARKED_FOR_DELETE.getMessage());
             updateSegment = true;
             break;
@@ -1031,7 +1030,7 @@ public class SegmentFileStore {
       String writePath = CarbonTablePath.getSegmentFilesLocation(tablePath);
       writePath =
           writePath + CarbonCommonConstants.FILE_SEPARATOR +
-              SegmentFileStore.genSegmentFileName(segment.getSegmentNo(),  String.valueOf(uniqueId))
+              SegmentFileStore.genSegmentFileName(segmentNo,  String.valueOf(uniqueId))
               + CarbonTablePath.SEGMENT_EXT;
       writeSegmentFile(segmentFile, writePath);
     }
@@ -1044,10 +1043,10 @@ public class SegmentFileStore {
       }
     }
     if (deleteSegment) {
-      toBeDeletedSegments.add(segment.getSegmentNo());
+      toBeDeletedSegments.add(segmentNo);
     }
     if (updateSegment) {
-      toBeUpdatedSegments.add(segment.getSegmentNo());
+      toBeUpdatedSegments.add(segmentNo);
     }
   }
 

--- a/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDropPartitionRDD.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/spark/rdd/CarbonDropPartitionRDD.scala
@@ -46,7 +46,7 @@ class CarbonDropPartitionRDD(
     @transient private val ss: SparkSession,
     tablePath: String,
     segments: Seq[Segment],
-    partitions: util.List[PartitionSpec],
+    partitionLocations: util.List[String],
     uniqueId: String)
   extends CarbonRDD[(String, String)](ss, Nil) {
 
@@ -67,8 +67,8 @@ class CarbonDropPartitionRDD(
       new SegmentFileStore(
         tablePath,
         split.segment.getSegmentFileName).dropPartitions(
-        split.segment,
-        partitions,
+        split.segment.getSegmentNo,
+        partitionLocations,
         uniqueId,
         toBeDeletedSegments,
         toBeUpdateSegments)

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/management/CommonLoadUtils.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/management/CommonLoadUtils.scala
@@ -1078,11 +1078,6 @@ object CommonLoadUtils {
       CarbonThreadUtil.threadUnset("partition.operationcontext")
       if (loadParams.isOverwriteTable) {
         IndexStoreManager.getInstance().clearIndex(table.getAbsoluteTableIdentifier)
-        // Clean the overwriting segments if any.
-        SegmentFileStore.cleanSegments(
-          table,
-          null,
-          false)
       }
       if (partitionsLen > 1) {
         // clean cache only if persisted and keeping unpersist non-blocking as non-blocking call


### PR DESCRIPTION
 ### Why is this PR needed?
 With the increase in the number of overwrite loads for the partition table, the time takes for each load keeps on increasing over time. This is because,

1. whenever a load overwrite for partition table is fired, it basically means that we need to overwrite or drop the partitions if anything overlaps with current partitions getting loaded. Since carbondata stores the partition information in the segments file, to identify and drop partitions, it's reading all the previous segment files to identify and drop the overwriting partitions, which leads to a decrease in performance.
2. After partition load is completed, a `cleanSegments` method is called which again reads segment file and table status file to identify MArked for delete segments to clean. But Since the force clean is false and timeout also is more than a day by default, it's not necessary to call this method. Clean files should handle this part.

 
 ### What changes were proposed in this PR?
1. we already have the information about current partitions, so with that first identify if there are any partitions to overwrite, if yes then only we read segment files to call `dropParitition`, else we don't read the segment files unnecessarily. It also contains other refactoring to avoid reading table status file also.
2. no need to call clean segments after every load. Clean files will take care to delete the expired ones.
    
 ### Does this PR introduce any user interface change?
 - No


 ### Is any new testcase added?
 - No


    
