### PR TITLE
[CARBONDATA-4319] Fixed clean files not deleteting stale delete delta files after horizontal compaction

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/statusmanager/SegmentStatusManager.java
+++ b/core/src/main/java/org/apache/carbondata/core/statusmanager/SegmentStatusManager.java
@@ -855,6 +855,26 @@ public class SegmentStatusManager {
     }
   }
 
+  /**
+   * This API will return the update status file name.
+   * @param segmentList
+   * @return
+   */
+  public String getUpdateStatusFileName(LoadMetadataDetails[] segmentList) {
+    if (segmentList.length == 0) {
+      return "";
+    }
+    else {
+      for (LoadMetadataDetails eachSeg : segmentList) {
+        // file name stored in 0th segment.
+        if (eachSeg.getLoadName().equalsIgnoreCase("0")) {
+          return eachSeg.getUpdateStatusFileName();
+        }
+      }
+    }
+    return "";
+  }
+
   public static class ValidAndInvalidSegmentsInfo {
     private final List<Segment> listOfValidSegments;
     private final List<Segment> listOfValidUpdatedSegments;

--- a/docs/clean-files.md
+++ b/docs/clean-files.md
@@ -45,13 +45,15 @@ The above clean files command will clean Marked For Delete and Compacted segment
   * In trash folder, the retention time is "carbon.trash.retention.days"
   * Outside trash folder(Segment Directories in table path), the retention time is Max("carbon.trash.retention.days", "max.query.execution.time")
 ### FORCE OPTION
-The force option with clean files command deletes all the files and folders from the trash folder and delete the Marked for Delete and Compacted segments immediately. Since Clean Files operation with force option will delete data that can never be recovered, the force option by default is disabled. Clean files with force option is only allowed when the carbon property ```carbon.clean.file.force.allowed``` is set to true. The default value of this property is false.
+The force option with clean files command deletes all the files and folders from the trash folder and delete the Marked for Delete and Compacted segments immediately. This option will also delete all the stale delete delta files that are present in the segment folder or the partition folder after a successful horizontal compaction. Since Clean Files operation with force option will delete data that can never be recovered, the force option by default is disabled. Clean files with force option is only allowed when the carbon property ```carbon.clean.file.force.allowed``` is set to true. The default value of this property is false.
                                                                                                                                                                        
-
 
   ```
   CLEAN FILES FOR TABLE TABLE_NAME options('force'='true')
   ```
+
+**NOTE**:
+  * Since clean files with force option also deletes the stale delete delta files immediately, do not run this operation concurrently with other delete/update operation as it can lead to query failures.
 
 ### STALE_INPROGRESS OPTION
 The stale_inprogress option deletes the stale Insert In Progress segments after the expiration of the property    ```carbon.trash.retention.days``` 


### PR DESCRIPTION
 ### Why is this PR needed?
 After horizontal compaction was performed on partition and non partition tables, the clean files operation was not deleting the stale delete delta files. the code was removed as the part of clean files refactoring done previously. 
 
 ### What changes were proposed in this PR?
Clean files with force option now handles removal of these stale delta files as well as the stale tableupdatestatus file for both partition and non partition table. 
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes. 2 test cases have been added.

This PR is dependent on   #4240 . That needs to be merged to the master code before merging this.
    
