### PR TITLE
[CARBONDATA-4326] MV not hitting with multiple sessions issue fix

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/view/CarbonCreateMVCommand.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/view/CarbonCreateMVCommand.scala
@@ -93,7 +93,7 @@ case class CarbonCreateMVCommand(
     withEvents(CreateMVPreExecutionEvent(session, systemDirectoryPath, identifier),
       CreateMVPostExecutionEvent(session, systemDirectoryPath, identifier)) {
       // get mv catalog
-      val viewCatalog = MVManagerInSpark.getOrReloadMVCatalog(session)
+      val viewCatalog = MVManagerInSpark.getMVCatalog(session)
       val schema = doCreate(session, identifier, viewManager, viewCatalog)
 
       // Update the related mv tables property to mv fact tables

--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/view/CarbonRefreshMVCommand.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/command/view/CarbonRefreshMVCommand.scala
@@ -48,7 +48,7 @@ case class CarbonRefreshMVCommand(
         throw new MalformedMVCommandException(
           s"Materialized view $databaseName.$mvName does not exist")
       }
-      val viewCatalog = MVManagerInSpark.getOrReloadMVCatalog(session)
+      val viewCatalog = MVManagerInSpark.getMVCatalog(session)
       if (!viewCatalog.getAllSchemas.exists(_.viewSchema.getIdentifier.getTableName
           .equals(schema.getIdentifier.getTableName))) {
         try {

--- a/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/MVRewriteRule.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/MVRewriteRule.scala
@@ -50,6 +50,7 @@ class MVRewriteRule(session: SparkSession) extends Rule[LogicalPlan] {
     logicalPlan match {
       case _: Command => return logicalPlan
       case _: LocalRelation => return logicalPlan
+      case _: DeserializeToObject => return logicalPlan
       case _ =>
     }
     try {
@@ -105,7 +106,7 @@ class MVRewriteRule(session: SparkSession) extends Rule[LogicalPlan] {
     if (!canApply) {
       return logicalPlan
     }
-    val viewCatalog = MVManagerInSpark.getOrReloadMVCatalog(session)
+    val viewCatalog = MVManagerInSpark.getMVCatalog(session)
     if (viewCatalog != null && hasSuitableMV(logicalPlan, viewCatalog)) {
       LOGGER.debug(s"Query Rewrite has been initiated for the plan: " +
                    s"${ logicalPlan.toString().trim }")


### PR DESCRIPTION
 ### Why is this PR needed?
MV created in beeline not hitting in sql/shell and vice versa if both beeline and sql/shell are running in parallel.
Currently, If the view catalog for a particular session is already initialized then the schemas are not reloaded each time. So when mv is created in another session and queried from the currently open session, mv is not hit.
 
 ### What changes were proposed in this PR?

- Reload mv catalog every time to `getSchemas `from the path. Register the schema if not present in the catalog and deregister the schema if it's dropped.
- When create SI is triggered, no need to try rewriting the plan and check for mv schemas. So, returning plan if `DeserializeToObject` is present.

    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No, tested in cluster

    
