### PR TITLE
[CARBONDATA-4306] Fix Query Performance issue for Spark 3.1

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/execution/strategy/CarbonSourceStrategy.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/execution/strategy/CarbonSourceStrategy.scala
@@ -158,10 +158,10 @@ private[sql] object CarbonSourceStrategy extends SparkStrategy {
         SparkSession.getActiveSession.get,
         relation.catalogTable.get.identifier
       )
+      // remove dynamic partition filter from predicates
+      filterPredicates = CarbonToSparkAdapter.getDataFilter(partitionSet,
+        allPredicates, partitionsFilter)
     }
-    // remove dynamic partition filter from predicates
-    filterPredicates = CarbonToSparkAdapter.getDataFilter(partitionSet,
-      allPredicates, partitionsFilter)
     val table = relation.relation.asInstanceOf[CarbonDatasourceHadoopRelation]
     val projects = rawProjects.map {p =>
       p.transform {


### PR DESCRIPTION
 ### Why is this PR needed?
 Some non-partition filters, which cannot be handled by carbon, is not pushed down to spark.
 
 ### What changes were proposed in this PR?
 If partition filters is non empty, then the filter column is not partition column, then push the filter to spark
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - No


    
