### PR TITLE
[CARBONDATA-4328] Load parquet table with options error message fix.

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/parser/CarbonExtensionSpark2SqlParser.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/parser/CarbonExtensionSpark2SqlParser.scala
@@ -19,8 +19,10 @@ package org.apache.spark.sql.parser
 
 import scala.language.implicitConversions
 
+import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.execution.command.management.RefreshCarbonTableCommand
+import org.apache.spark.sql.execution.strategy.CarbonPlanHelper
 
 /**
  * Parser for All Carbon DDL, DML cases in Unified context
@@ -51,7 +53,8 @@ class CarbonExtensionSpark2SqlParser extends CarbonSpark2SqlParser {
     (INTO ~> TABLE ~> (ident <~ ".").? ~ ident) ~
     (PARTITION ~> "(" ~> repsep(partitions, ",") <~ ")").? ~
     (OPTIONS ~> "(" ~> repsep(options, ",") <~ ")") <~ opt(";") ^^ {
-      case filePath ~ isOverwrite ~ table ~ partitions ~ optionsList =>
+      case filePath ~ isOverwrite ~ table ~ partitions ~ optionsList
+        if CarbonPlanHelper.isCarbonTable(TableIdentifier(table._2, table._1)) =>
         val (databaseNameOp, tableName) = table match {
           case databaseName ~ tableName => (databaseName, tableName.toLowerCase())
         }

--- a/integration/spark/src/main/scala/org/apache/spark/sql/parser/CarbonSpark2SqlParser.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/parser/CarbonSpark2SqlParser.scala
@@ -495,7 +495,8 @@ class CarbonSpark2SqlParser extends CarbonDDLSqlParser {
     (INTO ~> TABLE ~> (ident <~ ".").? ~ ident) ~
     (PARTITION ~> "(" ~> repsep(partitions, ",") <~ ")").? ~
     (OPTIONS ~> "(" ~> repsep(options, ",") <~ ")").? <~ opt(";") ^^ {
-      case filePath ~ isOverwrite ~ table ~ partitions ~ optionsList =>
+      case filePath ~ isOverwrite ~ table ~ partitions ~ optionsList
+        if CarbonPlanHelper.isCarbonTable(TableIdentifier(table._2, table._1)) =>
         val (databaseNameOp, tableName) = table match {
           case databaseName ~ tableName => (databaseName, tableName.toLowerCase())
         }


### PR DESCRIPTION
 ### Why is this PR needed?
 If parquet table is created and load statement with options is triggerred, then its failing with `NoSuchTableException: Table ${tableIdentifier.table} does not exist`.
 
 ### What changes were proposed in this PR?
As parquet table load is not handled, added a check to filter out non-carbon tables in the parser. So that, the spark parser can handle the statement.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
