### PR TITLE
[CARBONDATA-4330] Incremental‌ ‌Dataload‌ ‌of Average aggregate in ‌MV‌‌

### DIFF
--- a/core/src/main/java/org/apache/carbondata/core/view/MVSchema.java
+++ b/core/src/main/java/org/apache/carbondata/core/view/MVSchema.java
@@ -57,6 +57,12 @@ public class MVSchema implements Serializable, Writable {
   private String query;
 
   /**
+   * SQL modified query string.
+   * In case of MV with avg incremental mode, the original query is modified.
+   */
+  private String modifiedQuery;
+
+  /**
    * Properties provided by user
    */
   protected Map<String, String> properties;
@@ -99,8 +105,16 @@ public class MVSchema implements Serializable, Writable {
     return query;
   }
 
+  public String getModifiedQuery() {
+    return modifiedQuery;
+  }
+
   public void setQuery(String query) {
     this.query = query;
+  }
+
+  public void setModifiedQuery(String modifiedQuery) {
+    this.modifiedQuery = modifiedQuery;
   }
 
   public Map<String, String> getProperties() {

--- a/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/TestCreateIndexForCleanAndDeleteSegment.scala
+++ b/index/secondary-index/src/test/scala/org/apache/carbondata/spark/testsuite/secondaryindex/TestCreateIndexForCleanAndDeleteSegment.scala
@@ -73,7 +73,7 @@ class TestCreateIndexForCleanAndDeleteSegment extends QueryTest with BeforeAndAf
     assert(preDeleteSegmentsByDate == postDeleteSegmentsByDate)
     val result = sql("show materialized views on table delete_segment_by_id").collectAsList()
     assert(result.get(0).get(2).toString.equalsIgnoreCase("ENABLED"))
-    assert(result.get(0).get(3).toString.equalsIgnoreCase("full"))
+    assert(result.get(0).get(3).toString.equalsIgnoreCase("incremental"))
     assert(result.get(0).get(4).toString.equalsIgnoreCase("on_commit"))
     dryRun = sql("clean files for table delete_segment_by_id" +
       " OPTIONS('dryrun'='true', 'force'='true')").collect()

--- a/integration/spark/src/main/scala/org/apache/carbondata/view/MVRefresher.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/view/MVRefresher.scala
@@ -166,11 +166,15 @@ object MVRefresher {
                                newLoadName: String,
                                segmentMap: java.util.Map[String, java.util.List[String]],
                                session: SparkSession): Boolean = {
-    val query = viewSchema.getQuery
+    val isFullRefresh = !viewSchema.isRefreshIncremental
+    var query = viewSchema.getQuery
+    if (!isFullRefresh) {
+      // query is modified internally if average aggregate is used with incremental load.
+      query = viewSchema.getModifiedQuery
+    }
     if (query != null) {
       val viewIdentifier = viewSchema.getIdentifier
       val updatedQuery = MVQueryParser.getQuery(query, session)
-      val isFullRefresh = !viewSchema.isRefreshIncremental
       // Set specified segments for incremental load
       val segmentMapIterator = segmentMap.entrySet().iterator()
       while (segmentMapIterator.hasNext) {

--- a/integration/spark/src/main/scala/org/apache/carbondata/view/MVSchemaWrapper.scala
+++ b/integration/spark/src/main/scala/org/apache/carbondata/view/MVSchemaWrapper.scala
@@ -27,4 +27,5 @@ case class MVSchemaWrapper(
     viewSignature: Option[Signature],
     viewSchema: MVSchema,
     logicalPlan: LogicalPlan,
+    modifiedLogicalPlan: LogicalPlan,
     modularPlan: ModularPlan)

--- a/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/MVRewrite.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/optimizer/MVRewrite.scala
@@ -28,20 +28,22 @@ import scala.util.control.Breaks.{break, breakable}
 import org.apache.log4j.Logger
 import org.apache.spark.sql.{CarbonToSparkAdapter, SparkSession}
 import org.apache.spark.sql.catalyst.catalog.HiveTableRelation
-import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeMap, AttributeReference, Expression, Literal, NamedExpression, ScalaUDF, SortOrder}
+import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeMap, AttributeReference, Cast, Divide, Expression, Literal, NamedExpression, ScalaUDF, SortOrder}
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.plans.logical.{Filter, Join, LogicalPlan}
 import org.apache.spark.sql.catalyst.trees.{CurrentOrigin, TreeNode}
 import org.apache.spark.sql.execution.datasources.LogicalRelation
-import org.apache.spark.sql.types.{DataType, DataTypes}
+import org.apache.spark.sql.parser.MVQueryParser
+import org.apache.spark.sql.types.{DataTypes, DoubleType}
 import org.apache.spark.unsafe.types.UTF8String
 
 import org.apache.carbondata.common.logging.LogServiceFactory
+import org.apache.carbondata.core.constants.CarbonCommonConstants
 import org.apache.carbondata.core.preagg.TimeSeriesFunctionEnum
 import org.apache.carbondata.mv.expressions.modular.{ModularSubquery, ScalarModularSubquery}
 import org.apache.carbondata.mv.plans.modular.{ExpressionHelper, GroupBy, HarmonizedRelation, LeafNode, Matchable, ModularPlan, ModularRelation, Select, SimpleModularizer}
 import org.apache.carbondata.mv.plans.util.BirdcageOptimizer
-import org.apache.carbondata.view.{MVCatalogInSpark, MVPlanWrapper, MVTimeGranularity, TimeSeriesFunction}
+import org.apache.carbondata.view.{MVCatalogInSpark, MVHelper, MVPlanWrapper, MVSchemaWrapper, MVTimeGranularity, TimeSeriesFunction}
 
 /**
  * The primary workflow for rewriting relational queries using Spark libraries.
@@ -408,8 +410,8 @@ class MVRewrite(catalog: MVCatalogInSpark, logicalPlan: LogicalPlan,
           LOGGER.info("Query matching has been initiated with available mv schema's")
           val rewrittenPlans =
             for {schemaWrapper <- catalog.lookupFeasibleSchemas(plan).toStream
-                 subsumer <- SimpleModularizer.modularize(
-                   BirdcageOptimizer.execute(schemaWrapper.logicalPlan)).map(_.semiHarmonized)
+                 subsumer <- SimpleModularizer.modularize(BirdcageOptimizer.execute(
+                   getLogicalPlan(schemaWrapper, plan))).map(_.semiHarmonized)
                  subsumee <- unifySubsumee(plan)
                  rewrittenPlan <- rewriteWithSchemaWrapper0(
                    unifySubsumer2(
@@ -431,6 +433,23 @@ class MVRewrite(catalog: MVCatalogInSpark, logicalPlan: LogicalPlan,
       getRolledUpModularPlan(rewrittenPlan)
     } else {
       Some(rewrittenPlan)
+    }
+  }
+
+  // Currently, the user query is modified if it contains avg aggregate.
+  // modifiedLogicalPlan is created from modified query which can be used to derive sum or count
+  // columns from MV in case avg is not present.
+  private def getLogicalPlan(schemaWrapper: MVSchemaWrapper,
+      plan: ModularPlan): LogicalPlan = {
+    val queryOutput = plan.output
+    val sumOrCountCol = queryOutput.find(x => x.sql.contains(CarbonCommonConstants.SUM + "(") ||
+                                              x.sql.contains(CarbonCommonConstants.COUNT + "("))
+    if (!schemaWrapper.logicalPlan.equals(schemaWrapper.modifiedLogicalPlan) &&
+        !queryOutput.exists(x => x.sql.contains(CarbonCommonConstants.AVERAGE + "("))
+        && sumOrCountCol.isDefined) {
+      schemaWrapper.modifiedLogicalPlan
+    } else {
+      schemaWrapper.logicalPlan
     }
   }
 
@@ -734,10 +753,10 @@ class MVRewrite(catalog: MVCatalogInSpark, logicalPlan: LogicalPlan,
         case Seq(groupBy: GroupBy) if groupBy.modularPlan.isDefined =>
           val planWrapper = groupBy.modularPlan.get.asInstanceOf[MVPlanWrapper]
           val plan = planWrapper.modularPlan.asInstanceOf[Select]
-          val aliasMap = getAliasMap(plan.outputList, groupBy.outputList)
-          // Update the flagSpec as per the mv table attributes.
-          val updatedFlagSpec = updateFlagSpec(select, plan, aliasMap, keepAlias = false)
           if (!planWrapper.viewSchema.isRefreshIncremental) {
+            val aliasMap = getAliasMap(plan.outputList, groupBy.outputList)
+            // Update the flagSpec as per the mv table attributes.
+            val updatedFlagSpec = updateFlagSpec(select, plan, aliasMap, keepAlias = false)
             val updatedPlanOutputList = getUpdatedOutputList(plan.outputList, groupBy.modularPlan)
             val outputList =
               for ((output1, output2) <- groupBy.outputList zip updatedPlanOutputList) yield {
@@ -786,6 +805,9 @@ class MVRewrite(catalog: MVCatalogInSpark, logicalPlan: LogicalPlan,
                       other
                   }
               }
+            val aliasMap = getAliasMap(child.outputList, groupBy.outputList)
+            // Update the flagSpec as per the mv table attributes.
+            val updatedFlagSpec = updateFlagSpec(select, plan, aliasMap, keepAlias = false)
             // TODO Remove the unnecessary columns from selection.
             // Only keep columns which are required by parent.
             select.copy(
@@ -800,7 +822,62 @@ class MVRewrite(catalog: MVCatalogInSpark, logicalPlan: LogicalPlan,
         val planWrapper = groupBy.modularPlan.get.asInstanceOf[MVPlanWrapper]
         val plan = planWrapper.modularPlan.asInstanceOf[Select]
         val updatedPlanOutputList = getUpdatedOutputList(plan.outputList, groupBy.modularPlan)
-        val outputListMapping = groupBy.outputList zip updatedPlanOutputList
+        var columnIndex = -1
+
+        def getColumnName(expression: Expression): String = {
+          if (expression.isInstanceOf[AttributeReference]) {
+            expression.asInstanceOf[AttributeReference].name
+          } else if (expression.isInstanceOf[Literal]) {
+            expression.asInstanceOf[Literal].value.toString
+          } else {
+            ""
+          }
+        }
+        // get column from list having the given aggregate and column name.
+        def getColumnFromOutputList(updatedPlanOutputList: Seq[NamedExpression], aggregate: String,
+            colName: String): NamedExpression = {
+          val nextIndex = columnIndex + 1
+          if ((nextIndex) < updatedPlanOutputList.size &&
+              updatedPlanOutputList(nextIndex).name.contains(aggregate) &&
+              updatedPlanOutputList(nextIndex).name.contains(colName)) {
+            columnIndex += 1
+            updatedPlanOutputList(columnIndex)
+          } else {
+            updatedPlanOutputList.find(x => x.name.contains(aggregate) &&
+                                            x.name.contains(colName)).get
+          }
+        }
+        val outputListMapping = if (groupBy.outputList.exists(_.sql.contains("avg("))) {
+          // for each avg attribute, updatedPlanOutputList has 2 attributes (sum and count),
+          // so direct mapping of groupBy.outputList and updatedPlanOutputList is not possible.
+          // If query has avg, then get the sum, count attributes in the list and map accordingly.
+          for (exp <- groupBy.outputList) yield {
+            exp match {
+              case Alias(aggregateExpression: AggregateExpression, _)
+                if aggregateExpression.aggregateFunction.isInstanceOf[Average] =>
+                val colName = getColumnName(aggregateExpression.collectLeaves().head)
+                val sumAttr = getColumnFromOutputList(updatedPlanOutputList, "sum", colName)
+                val countAttr = getColumnFromOutputList(updatedPlanOutputList, "count", colName)
+                (exp, sumAttr, Some(countAttr))
+              case Alias(aggregateExpression: AggregateExpression, _)
+                if aggregateExpression.aggregateFunction.isInstanceOf[Sum] ||
+                   aggregateExpression.aggregateFunction.isInstanceOf[Count] =>
+                // If query contains avg aggregate and also sum or count of column,
+                // duplicate column creation is avoided. The column might have already mapped
+                // with avg, so search from output list to find the column and map.
+                val colName = getColumnName(aggregateExpression.collectLeaves().head)
+                val colAttr = getColumnFromOutputList(updatedPlanOutputList,
+                  aggregateExpression.aggregateFunction.prettyName, colName)
+                (exp, colAttr, None)
+              case _ =>
+                columnIndex += 1
+                (exp, updatedPlanOutputList(columnIndex), None)
+            }
+          }
+        } else {
+          (groupBy.outputList, updatedPlanOutputList, List.fill(updatedPlanOutputList.size)(None))
+            .zipped.toList
+        }
         val (outputList: Seq[NamedExpression], updatedPredicates: Seq[Expression]) =
           getUpdatedOutputAndPredicateList(
           groupBy,
@@ -816,7 +893,8 @@ class MVRewrite(catalog: MVCatalogInSpark, logicalPlan: LogicalPlan,
           val planWrapper = select.modularPlan.get.asInstanceOf[MVPlanWrapper]
           val plan = planWrapper.modularPlan.asInstanceOf[Select]
           val updatedPlanOutputList = getUpdatedOutputList(plan.outputList, select.modularPlan)
-          val outputListMapping = groupBy.outputList zip updatedPlanOutputList
+          val outputListMapping = (groupBy.outputList, updatedPlanOutputList, List.fill(
+            updatedPlanOutputList.size)(None)).zipped.toList
           val (outputList: Seq[NamedExpression], updatedPredicates: Seq[Expression]) =
             getUpdatedOutputAndPredicateList(
               groupBy,
@@ -834,9 +912,9 @@ class MVRewrite(catalog: MVCatalogInSpark, logicalPlan: LogicalPlan,
   }
 
   private def getUpdatedOutputAndPredicateList(groupBy: GroupBy,
-      outputListMapping: Seq[(NamedExpression, NamedExpression)]):
+      outputListMapping: Seq[(NamedExpression, NamedExpression, Option[NamedExpression])]):
   (Seq[NamedExpression], Seq[Expression]) = {
-    val outputList = for ((output1, output2) <- outputListMapping) yield {
+    val outputList = for ((output1, output2, output3) <- outputListMapping) yield {
       output1 match {
         case Alias(aggregateExpression: AggregateExpression, _)
           if aggregateExpression.aggregateFunction.isInstanceOf[Sum] =>
@@ -844,6 +922,13 @@ class MVRewrite(catalog: MVCatalogInSpark, logicalPlan: LogicalPlan,
           val uFun = aggregate.copy(child = output2)
           Alias(aggregateExpression.copy(aggregateFunction = uFun),
             output1.name)(exprId = output1.exprId)
+        case Alias(aggregateExpression: AggregateExpression, _)
+          if aggregateExpression.aggregateFunction.isInstanceOf[Average] =>
+          val uFunSum = Sum(output2)
+          val uFunCount = Sum(output3.get)
+          val uFunDivide = Divide(Cast(uFunSum, DoubleType), Cast(uFunCount, DoubleType))
+          Alias(Cast(uFunDivide, DoubleType), output1.name)(exprId = output1.exprId)
+
         case Alias(aggregateExpression: AggregateExpression, _)
           if aggregateExpression.aggregateFunction.isInstanceOf[Max] =>
           val max = aggregateExpression.aggregateFunction.asInstanceOf[Max]
@@ -881,7 +966,7 @@ class MVRewrite(catalog: MVCatalogInSpark, logicalPlan: LogicalPlan,
     val updatedPredicates = groupBy.predicateList.map {
       predicate =>
         outputListMapping.find {
-          case (output1, _) =>
+          case (output1, _, _) =>
             output1 match {
               case alias: Alias if predicate.isInstanceOf[Alias] =>
                 alias.child.semanticEquals(predicate.children.head)
@@ -891,7 +976,7 @@ class MVRewrite(catalog: MVCatalogInSpark, logicalPlan: LogicalPlan,
                 other.semanticEquals(predicate)
             }
         } match {
-          case Some((_, output2)) => output2
+          case Some((_, output2, _)) => output2
           case _ => predicate
         }
     }


### PR DESCRIPTION
 ### Why is this PR needed?
 Currently, whenever MV is created with average aggregate, a full refresh is done meaning it reloads the whole MV for any newly added segments. This will slow down the loading. With incremental data load, only the segments that are newly added can be loaded to the MV.
 
 ### What changes were proposed in this PR?
If avg is present, rewrite the query with the sum and count of the columns to create MV and use them to derive avg.
Refer: https://docs.google.com/document/d/1kPEMCX50FLZcmyzm6kcIQtUH9KXWDIqh-Hco7NkTp80/edit

    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
