### PR TITLE
[CARBONDATA-4333][Doc] Update the declaration of supported String data types

### DIFF
--- a/docs/supported-data-types-in-carbondata.md
+++ b/docs/supported-data-types-in-carbondata.md
@@ -36,8 +36,6 @@
 
   * String Types
     * STRING
-    * CHAR
-    * VARCHAR
 
     **NOTE**: For string longer than 32000 characters, use `LONG_STRING_COLUMNS` in table property.
     Please refer to TBLProperties in [CreateTable](./ddl-of-carbondata.md#create-table) for more information.


### PR DESCRIPTION
Why is this PR needed?
CHAR and VARCHAR as String data types are no longer supported in Carbon. They should be deleted from doc's desc.

What changes were proposed in this PR?
CHAR and VARCHAR stop appearing as two String data types in doc.

Does this PR introduce any user interface change?
No

Is any new testcase added?
No