### PR TITLE
[CARBONDATA-4342] Fix Desc Columns shows New Column added, even though ALter ADD column query failed

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonHiveMetaStore.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonHiveMetaStore.scala
@@ -156,11 +156,7 @@ class CarbonHiveMetaStore extends CarbonFileMetastore {
     val dbName = newTableIdentifier.getDatabaseName
     val tableName = newTableIdentifier.getTableName
     val schemaParts = CarbonUtil.convertToMultiGsonStrings(wrapperTableInfo, "=", "'", "")
-    val hiveClient = sparkSession
-      .sessionState
-      .catalog
-      .externalCatalog.asInstanceOf[HiveExternalCatalog]
-      .client
+    val hiveClient = CarbonSessionCatalogUtil.getClient(sparkSession)
     hiveClient.runSqlHive(s"ALTER TABLE `$dbName`.`$tableName` SET SERDEPROPERTIES($schemaParts)")
 
     sparkSession.catalog.refreshTable(TableIdentifier(tableName, Some(dbName)).quotedString)

--- a/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonSessionCatalogUtil.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/hive/CarbonSessionCatalogUtil.scala
@@ -159,4 +159,7 @@ object CarbonSessionCatalogUtil {
 class MockClassForAlterRevertTests {
   def mockForAlterRevertTest(): Unit = {
   }
+
+  def mockForAlterAddColRevertTest(): Unit = {
+  }
 }

--- a/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/events/AlterTableColumnRenameEventListener.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/events/AlterTableColumnRenameEventListener.scala
@@ -136,8 +136,7 @@ class AlterTableColumnRenameEventListener extends OperationEventListener with Lo
               val evolutionEntryList = thriftTable.fact_table.schema_evolution
                 .schema_evolution_history
               AlterTableUtil
-                .revertColumnRenameAndDataTypeChanges(indexCarbonTable.getDatabaseName,
-                  indexCarbonTable.getTableName,
+                .revertColumnRenameAndDataTypeChanges(indexCarbonTable,
                   evolutionEntryList.get(evolutionEntryList.size() - 1).time_stamp)(
                   alterTableColRenameAndDataTypeChangePostEvent.sparkSession)
             }


### PR DESCRIPTION
 ### Why is this PR needed?
 1. When spark.carbon.hive.schema.store property is enabled, alter operations fails with Class Cast Exception.
 2. When Alter add/drop/rename column operation failed due to the issue mentioned above, the revert schema operation is not reverting back to the old schema
 
 ### What changes were proposed in this PR?
1. Use `org.apache.spark.sql.hive.CarbonSessionCatalogUtil#getClient` to get HiveClient to avoid ClassCast Exception
2. Revert the schema in the spark Catalog table also, in case of failure 
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
