### PR TITLE
[CARBONDATA-4341] Drop Index Fails after TABLE RENAME

### DIFF
--- a/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/events/AlterTableRenameEventListener.scala
+++ b/integration/spark/src/main/scala/org/apache/spark/sql/secondaryindex/events/AlterTableRenameEventListener.scala
@@ -51,11 +51,13 @@ class AlterTableRenameEventListener extends OperationEventListener with Logging 
           .lookupRelation(Some(oldDatabaseName), newTableName)(sparkSession)
           .asInstanceOf[CarbonRelation].carbonTable
         table.getIndexTableNames(IndexType.SI.getIndexProviderName)
-          .asScala.map {
+          .asScala.foreach {
           entry =>
             CarbonSessionCatalogUtil.getClient(sparkSession).runSqlHive(
               s"ALTER TABLE $oldDatabaseName.${ entry } " +
               s"SET SERDEPROPERTIES ('parentTableName'='$newTableName')")
+            CarbonEnv.getInstance(sparkSession).carbonMetaStore
+              .removeTableFromMetadata(oldDatabaseName, entry)
         }
     }
   }

--- a/integration/spark/src/test/scala/org/apache/spark/carbondata/restructure/vectorreader/AlterTableColumnRenameTestCase.scala
+++ b/integration/spark/src/test/scala/org/apache/spark/carbondata/restructure/vectorreader/AlterTableColumnRenameTestCase.scala
@@ -780,6 +780,21 @@ class AlterTableColumnRenameTestCase extends QueryTest with BeforeAndAfterAll {
     sql("DROP TABLE IF EXISTS test_alter")
   }
 
+  test("test alter rename table and drop index") {
+    sql("drop table if exists test_rename")
+    sql("drop index if exists si on test_rename1")
+    sql("CREATE TABLE test_rename (name string,id int) STORED AS carbondata")
+    sql("insert into test_rename values('a',1)")
+    sql("insert into test_rename values('v',2)")
+    sql(s"create index si on test_rename(name) as 'carbondata'")
+    // only rename operation
+    sql("alter table test_rename rename to test_rename1")
+    checkAnswer(sql("select id from test_rename1"),
+      Seq(Row(1), Row(2)))
+    sql("drop index if exists si on test_rename1")
+    sql("drop table if exists test_rename1")
+  }
+
   override def afterAll(): Unit = {
     dropTable()
   }
@@ -788,6 +803,7 @@ class AlterTableColumnRenameTestCase extends QueryTest with BeforeAndAfterAll {
     sql("DROP TABLE IF EXISTS rename")
     sql("DROP TABLE IF EXISTS rename_partition")
     sql("DROP TABLE IF EXISTS test_rename")
+    sql("drop table if exists test_rename1")
     sql("DROP TABLE IF EXISTS test_rename_compact")
     sql("DROP TABLE IF EXISTS test_alter")
     sql("DROP TABLE IF EXISTS simple_table")


### PR DESCRIPTION
 ### Why is this PR needed?
 Drop Index Fails after TABLE RENAME
 
 ### What changes were proposed in this PR?
After table rename, its si tables property - `parentTableName` is updated with latest name and index metadata gets updated. Dropping the table from the metadata cache so that it would be reloaded and gets updated property when fetched next time.
    
 ### Does this PR introduce any user interface change?
 - No

 ### Is any new testcase added?
 - Yes

    
