### PR TITLE
[CARBONDATA-4339]Fix NullPointerException in load overwrite on partition table

### DIFF
--- a/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonOutputCommitter.java
+++ b/hadoop/src/main/java/org/apache/carbondata/hadoop/api/CarbonOutputCommitter.java
@@ -336,9 +336,11 @@ public class CarbonOutputCommitter extends FileOutputCommitter {
           .filter(partitionList::contains).collect(Collectors.toList());
       if (!overlappingPartitions.isEmpty()) {
         List<LoadMetadataDetails> validLoadMetadataDetails =
-            loadModel.getLoadMetadataDetails().stream().filter(
-                loadMetadataDetail -> !loadMetadataDetail.getLoadName()
-                    .equalsIgnoreCase(newMetaEntry.getLoadName())).collect(Collectors.toList());
+            loadModel.getLoadMetadataDetails().stream().filter(loadMetadataDetail ->
+                !loadMetadataDetail.getLoadName().equalsIgnoreCase(newMetaEntry.getLoadName()) && (
+                    loadMetadataDetail.getSegmentStatus().equals(SegmentStatus.SUCCESS)
+                        || loadMetadataDetail.getSegmentStatus()
+                        .equals(SegmentStatus.LOAD_PARTIAL_SUCCESS))).collect(Collectors.toList());
         String uniqueId = String.valueOf(System.currentTimeMillis());
         List<String> toBeUpdatedSegments = new ArrayList<>(validLoadMetadataDetails.size());
         List<String> toBeDeletedSegments = new ArrayList<>(validLoadMetadataDetails.size());


### PR DESCRIPTION
 ### Why is this PR needed?
 After delete segment and clean files with force option true, the load overwrite operation throws nullpointer exception. This is because when clean files with force is done, except the 0th segment and last segment remaining marked for delete will be moved to tablestatus.history file irrespective of the status of the 0th and last segment. During overwrite load, the overwritten partition will be dropped. Since all the segments are physically deleted with clean files, and load model's load metadata details list contains 0th segment which is marked for delete also leading to failure.
 
 ### What changes were proposed in this PR?
When the valid segments are collected, filter using the segment's status to avoid the failure.
    
 ### Does this PR introduce any user interface change?
 - No


 ### Is any new testcase added?
 - Yes

    
